### PR TITLE
Namespace resolution fixes

### DIFF
--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import cromwell.binding._
 import cromwell.engine.{WorkflowManagerActor, SingleWorkflowRunner}
-import cromwell.binding.formatter.{TerminalSyntaxHighlighter, SyntaxFormatter}
+import cromwell.binding.formatter.{AnsiSyntaxHighlighter, SyntaxFormatter}
 import cromwell.parser.WdlParser.SyntaxError
 import cromwell.server.CromwellServer
 import spray.json._
@@ -39,7 +39,7 @@ object Main extends App {
 
   def highlight(args: Array[String]) {
     val binding = WdlBinding.process(new File(args(0)))
-    val formatter = new SyntaxFormatter(TerminalSyntaxHighlighter)
+    val formatter = new SyntaxFormatter(AnsiSyntaxHighlighter)
     println(formatter.format(binding))
   }
 

--- a/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
+++ b/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
@@ -21,15 +21,16 @@ trait SyntaxHighlighter {
 
 object NullSyntaxHighlighter extends SyntaxHighlighter
 
-object TerminalSyntaxHighlighter extends SyntaxHighlighter {
-  override def keyword(s: String): String = s"\033[38;5;214m$s\033[0m"
-  override def name(s: String): String = s"\033[38;5;253m$s\033[0m"
+object AnsiSyntaxHighlighter extends SyntaxHighlighter {
+  def highlight(string: String, color: Int) = s"\033[38;5;${color}m${string}\033[0m"
+  override def keyword(s: String): String = highlight(s, 214)
+  override def name(s: String): String = highlight(s, 253)
   override def section(s: String): String = s
-  override def wdlType(t: WdlType): String = s"\033[38;5;33m${t.toWdlString}\033[0m"
-  override def variable(s: String): String = s"\033[38;5;112m$s\033[0m"
+  override def wdlType(t: WdlType): String = highlight(t.toWdlString, 33)
+  override def variable(s: String): String = highlight(s, 112)
   override def alias(s: String): String = s
-  override def command(s: String): String = s //s"\033[48;5;243m$s\033[0m"
-  override def function(s: String): String = s"\033[38;5;13m$s\033[0m"
+  override def command(s: String): String = s
+  override def function(s: String): String = highlight(s, 13)
 }
 
 object HtmlSyntaxHighlighter extends SyntaxHighlighter {
@@ -62,10 +63,7 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
     s"$imports${definitions.mkString("\n\n")}"
   }
   private def formatImport(imp: Import): String = {
-    val namespace = imp.namespace match {
-      case Some(ns) => s" as $ns"
-      case None => ""
-    }
+    val namespace = imp.namespace.map{ns => s" as $ns"}.getOrElse("")
     s"${highlighter.keyword("import")} '${imp.uri}'$namespace"
   }
   private def formatTask(task: Task): String = {
@@ -98,13 +96,12 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
     indentText(section.stripMargin, level)
   }
   private def formatOutput(output: TaskOutput, level:Int): String = {
-    s"${in(level)}${highlighter.wdlType(output.wdlType)} ${highlighter.variable(output.name)} = ${output.expression.toString(highlighter)}"
+    indentText(s"${highlighter.wdlType(output.wdlType)} ${highlighter.variable(output.name)} = ${output.expression.toString(highlighter)}", level)
   }
   private def formatWorkflow(workflow: Workflow): String = {
-    val section = s"""${highlighter.keyword("workflow")} ${highlighter.name(workflow.name)} {
+    s"""${highlighter.keyword("workflow")} ${highlighter.name(workflow.name)} {
         |${workflow.calls.map{formatCall(_, 1)}.mkString("\n")}
-        |}"""
-    section.stripMargin
+        |}""".stripMargin
   }
   private def formatCall(call: Call, level:Int): String = {
     val header = s"${highlighter.keyword("call")} ${highlighter.name(call.task.name)}${formatCallAlias(call)}"
@@ -120,14 +117,10 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
     }
   }
   private def formatCallAlias(call: Call): String = {
-    call.alias match {
-      case Some(s:String) => s" as ${highlighter.alias(s)}"
-      case None => ""
-    }
+    call.alias.map {a => s" as ${highlighter.alias(a)}"}.getOrElse("")
   }
   private def text(astNode: AstNode) = astNode.asInstanceOf[Terminal].getSourceString
   private def indentText(s: String, i: Int): String = {
-    s.split("\n").map {in(i) + _}.mkString("\n")
+    s.split("\n").map {" " * (i * indent) + _}.mkString("\n")
   }
-  private def in(i: Int): String = " " * (i * indent)
 }

--- a/src/main/scala/cromwell/binding/types/WdlNamespaceType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlNamespaceType.scala
@@ -1,0 +1,6 @@
+package cromwell.binding.types
+
+case object WdlNamespaceType extends WdlType {
+  override def toWdlString: String = "Namespace"
+  override protected def coercion = ???
+}

--- a/src/main/scala/cromwell/engine/CallActor.scala
+++ b/src/main/scala/cromwell/engine/CallActor.scala
@@ -68,7 +68,6 @@ class CallActor(call: Call, backend: Backend, storeActor: ActorRef) extends Acto
       commandLine <- Future.fromTry(call.task.command.instantiate(inputs))
     } yield {
       originalSender ! CallActor.Started(call)
-      log.info(s"Launching: $commandLine")
       val tryOutputs = backend.executeCommand(commandLine, call, call.task.outputs, s => inputs.get(s).get)
       val (successes, failures) = tryOutputs.partition {
         _._2.isSuccess

--- a/src/main/scala/cromwell/engine/ExecutionStore.scala
+++ b/src/main/scala/cromwell/engine/ExecutionStore.scala
@@ -27,10 +27,13 @@ class ExecutionStore(binding: WdlBinding) {
     for {
       callEntry <- table if callEntry._2 == ExecutionStatus.NotStarted
       call = callEntry._1
-      if call.prerequisiteCalls().forall(table.get(_).get == ExecutionStatus.Done)
+      if call.prerequisiteCalls().forall {
+        case c:Call => table.get(c).get == ExecutionStatus.Done
+        case _ => false
+      }
     } yield call
   }
   override def toString: String = {
-    table.map{case(k, v) => s"${k.fullyQualifiedName}\t$v"}.mkString("\n")
+    table.map {case(k, v) => s"${k.fullyQualifiedName}\t$v"}.mkString("\n")
   }
 }

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -5,7 +5,7 @@ import java.io.Writer
 import cromwell.binding.WdlExpression.ScopedLookupFunction
 import cromwell.binding.types.WdlFileType
 import cromwell.binding.values.{WdlFile, WdlString, WdlValue}
-import cromwell.binding.{Call, TaskOutput}
+import cromwell.binding.{WdlExpression, Call, TaskOutput}
 import cromwell.engine.backend.Backend
 import cromwell.util.FileUtil
 import cromwell.util.FileUtil._
@@ -70,8 +70,8 @@ class LocalBackend extends Backend {
     taskOutputs.map { taskOutput =>
       val rawValue = taskOutput.expression.evaluate(
         scopedLookupFunction,
-        new LocalEngineFunctions(TaskExecutionContext(stdoutFile, stderrFile)))
-
+        new LocalEngineFunctions(TaskExecutionContext(stdoutFile, stderrFile))
+      )
       taskOutput.name -> rawValue.map { possiblyAutoConvertedValue(taskOutput, _) }
     }.toMap
   }

--- a/src/test/scala/cromwell/binding/SyntaxHighlightTest.scala
+++ b/src/test/scala/cromwell/binding/SyntaxHighlightTest.scala
@@ -1,6 +1,6 @@
 package cromwell.binding
 
-import cromwell.binding.formatter.{HtmlSyntaxHighlighter, TerminalSyntaxHighlighter, SyntaxFormatter}
+import cromwell.binding.formatter.{HtmlSyntaxHighlighter, AnsiSyntaxHighlighter, SyntaxFormatter}
 import org.scalatest.{FlatSpec, Matchers}
 
 class SyntaxHighlightTest extends FlatSpec with Matchers {
@@ -34,7 +34,7 @@ class SyntaxHighlightTest extends FlatSpec with Matchers {
   }
 
   it should "produce ANSI terminal output" in {
-    val formatter = new SyntaxFormatter(TerminalSyntaxHighlighter)
+    val formatter = new SyntaxFormatter(AnsiSyntaxHighlighter)
     val actual = formatter.format(binding)
     val expected = s"""\u001b[38;5;214mtask\u001b[0m \u001b[38;5;253mt\u001b[0m {
       |  command {

--- a/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
@@ -41,10 +41,10 @@ class ThreeStepImportNamespaceAliasSpec extends FlatSpec with Matchers {
     |workflow three_step {
     |  call ns1.ps as a1
     |  call ns2.cgrep as a2 {
-    |    input: in_file=ns1.ps.procs
+    |    input: in_file=a1.procs
     |  }
     |  call ns3.wc {
-    |    input: in_file=ns1.ps.procs
+    |    input: in_file=a1.procs
     |  }
     |}""".stripMargin
 
@@ -96,7 +96,7 @@ class ThreeStepImportNamespaceAliasSpec extends FlatSpec with Matchers {
     binding.importedBindings flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Have 3 calls in the workflow, 2 of them aliased" in {
-    binding.workflows flatMap {_.calls} map {_.name} shouldEqual Seq("a1", "a2", "wc")
+    binding.workflows flatMap {_.calls} map {_.name} shouldEqual Seq("a1", "a2", "ns3.wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
     def badResolver(s: String): String = {


### PR DESCRIPTION
This fixes some oddities that I noticed with how namespaces are evaluated.

1)  Determining a Call's upstream Calls is now more sophisticated and actually does a partial evaluation on all the input expressions, instead of assuming all MemberAccess ASTs are of the form "call.output"

2)  `partialEvalMemberAccess(ast: Ast)` will now treat MemberAccess ASTs that contain other MemberAccess ASTs (e.g. "ns.task.output")

3) WdlBinding is now a WdlValue.  For example, when evaluating the expression `ns.task.output`, there are two MemberAccess ASTs: `(ns.task).output`.  When evaluating the inner AST, `ns` will try to be evaluated but `ns` refers to a namespace.

4) Lookup function was modified to return WdlBindings

Also I think WdlBinding should be renamed to WdlNamespace, but I'll do that later.