### PR TITLE
WdlBinding -> WdlNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ Contains implementations of an interface to launch jobs.  `cromwell.engine` will
 
 Contains the Akka code and actor system to execute a workflow.  This layer should operate entirely on objects returned from the `cromwell.binding` layer.
 
+Scala API Usage
+---------------
+
+The main entry point into the parser is the `WdlNamespace` object.  A WDL file is considered a namespace, and other namespaces can be included by using the `import` statement (but only with an `as` clause).
+
+```scala
+val ns = WdlNamespace.load(new File("test.wdl"))
+val ns2 = WdlNamespace.load("workflow wf {}")
+val workflows = ns.workflows
+val tasks = ns.tasks
+val commands = ns.tasks.map{_.command}
+```
+
 Web Server
 ----------
 
@@ -164,7 +177,7 @@ Server: spray-can/1.3.3
 
 {
     "id": "69d1d92f-3895-4a7b-880a-82535e9a096e",
-    "status": "WorkflowSucceeded"
+    "status": "Succeeded"
 }
 ```
 

--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -3,8 +3,8 @@ package cromwell
 import java.io.File
 
 import cromwell.binding._
-import cromwell.engine.{WorkflowManagerActor, SingleWorkflowRunner}
 import cromwell.binding.formatter.{AnsiSyntaxHighlighter, SyntaxFormatter}
+import cromwell.engine.{SingleWorkflowRunner, WorkflowManagerActor}
 import cromwell.parser.WdlParser.SyntaxError
 import cromwell.server.CromwellServer
 import spray.json._
@@ -31,24 +31,24 @@ object Main extends App {
   def validate(args: Array[String]): Unit = {
     if (args.length != 1) usageAndExit()
     try {
-      WdlBinding.process(new File(args(0)))
+      WdlNamespace.load(new File(args(0)))
     } catch {
       case e:SyntaxError => println(e)
     }
   }
 
   def highlight(args: Array[String]) {
-    val binding = WdlBinding.process(new File(args(0)))
+    val namespace = WdlNamespace.load(new File(args(0)))
     val formatter = new SyntaxFormatter(AnsiSyntaxHighlighter)
-    println(formatter.format(binding))
+    println(formatter.format(namespace))
   }
 
   def inputs(args: Array[String]): Unit = {
     if (args.length != 1) usageAndExit()
     try {
       import cromwell.binding.types.WdlTypeJsonFormatter._
-      val binding = WdlBinding.process(new File(args(0)))
-      println(binding.workflows.head.inputs.toJson.prettyPrint)
+      val namespace = WdlNamespace.load(new File(args(0)))
+      println(namespace.workflows.head.inputs.toJson.prettyPrint)
     } catch {
       case e:SyntaxError => println(e)
     }
@@ -70,7 +70,7 @@ object Main extends App {
 
   def parse(args: Array[String]): Unit = {
     if (args.length != 1) usageAndExit()
-    else println(WdlBinding.getAst(new File(args(0))).toPrettyString)
+    else println(AstTools.getAst(new File(args(0))).toPrettyString)
   }
 
   def usageAndExit(exit: Boolean = true): Unit = {

--- a/src/main/scala/cromwell/binding/AstTools.scala
+++ b/src/main/scala/cromwell/binding/AstTools.scala
@@ -1,0 +1,87 @@
+package cromwell.binding
+
+import java.io.File
+import scala.collection.JavaConverters._
+import cromwell.parser.WdlParser
+import cromwell.parser.WdlParser.{AstList, AstNode, Ast, Terminal}
+import cromwell.util.FileUtil
+
+object AstTools {
+  object AstNodeName {
+    val Task = "Task"
+    val Workflow = "Workflow"
+    val Command = "RawCommand"
+    val Output = "Output"
+    val CommandParameter = "CommandParameter"
+    val Call = "Call"
+    val IOMapping = "IOMapping"
+    val Inputs = "Inputs"
+    val MemberAccess = "MemberAccess"
+  }
+
+  def getAst(wdlSource: WdlSource, resource: String): Ast = {
+    val parser = new WdlParser()
+    val tokens = parser.lex(wdlSource, resource)
+    val terminalMap = (tokens.asScala.toVector map {(_, wdlSource)}).toMap
+    val syntaxErrorFormatter = new WdlSyntaxErrorFormatter(terminalMap)
+    parser.parse(tokens, syntaxErrorFormatter).toAst.asInstanceOf[Ast]
+  }
+
+  /**
+   * Given a WDL file, this will simply parse it and return the syntax tree
+   * @param wdlFile The file to parse
+   * @return an Abstract Syntax Tree (WdlParser.Ast) representing the structure of the code
+   * @throws WdlParser.SyntaxError if there was a problem parsing the source code
+   */
+  def getAst(wdlFile: File): Ast = getAst(FileUtil.slurp(wdlFile), wdlFile.getName)
+
+  def findAsts(ast: AstNode, name: String): Seq[Ast] = {
+    ast match {
+      case x: Ast =>
+        val thisAst = if (x.getName.equals(name)) Seq(x) else Seq.empty[Ast]
+        x.getAttributes.values.asScala.flatMap(findAsts(_, name)).toSeq ++ thisAst
+      case x: AstList => x.asScala.toVector.flatMap(findAsts(_, name)).toSeq
+      case x: Terminal => Seq.empty[Ast]
+      case _ => Seq.empty[Ast]
+    }
+  }
+
+  def findAstsWithTrail(ast: AstNode, name: String, trail: Seq[AstNode] = Seq.empty): Map[Ast, Seq[AstNode]] = {
+    ast match {
+      case x: Ast =>
+        val thisAst = if (x.getName.equals(name)) Map(x -> trail) else Map.empty[Ast, Seq[AstNode]]
+        combine(x.getAttributes.values.asScala.flatMap{y => findAstsWithTrail(y, name, trail :+ x)}.toMap, thisAst)
+      case x: AstList => x.asScala.toVector.flatMap{y => findAstsWithTrail(y, name, trail :+ x)}.toMap
+      case x: Terminal => Map.empty[Ast, Seq[AstNode]]
+      case _ => Map.empty[Ast, Seq[AstNode]]
+    }
+  }
+
+  def findTerminals(ast: AstNode): Seq[Terminal] = {
+    ast match {
+      case x: Ast => x.getAttributes.values.asScala.flatMap(findTerminals).toSeq
+      case x: AstList => x.asScala.toVector.flatMap(findTerminals).toSeq
+      case x: Terminal => Seq(x)
+      case _ => Seq.empty[Terminal]
+    }
+  }
+
+  /* All MemberAccess ASTs that are not contained in other MemberAccess ASTs */
+  def findTopLevelMemberAccesses(expr: AstNode): Iterable[Ast] = AstTools.findAstsWithTrail(expr, "MemberAccess").filter {
+    case(k, v) => !v.exists{case a:Ast => a.getName == "MemberAccess"}
+  }.keys
+
+  def getCallInputAsts(ast: Ast): Seq[Ast] = {
+    findAsts(ast, AstNodeName.Inputs) match {
+      case x: Seq[Ast] if x.size == 1 => AstTools.findAsts(x.head.getAttribute("map"), AstNodeName.IOMapping)
+      case _ => Seq.empty[Ast]
+    }
+  }
+
+  def terminalMap(ast: Ast, source: WdlSource) = (findTerminals(ast) map {(_, source)}).toMap
+
+  private def combine[T, U](map1: Map[T, Seq[U]], map2: Map[T, Seq[U]]): Map[T, Seq[U]] = {
+    map1 ++ map2.map{ case (k,v) => k -> (v ++ map1.getOrElse(k, Seq.empty)) }
+  }
+}
+

--- a/src/main/scala/cromwell/binding/Call.scala
+++ b/src/main/scala/cromwell/binding/Call.scala
@@ -1,7 +1,6 @@
 package cromwell.binding
 
 import cromwell.binding.types.WdlType
-import cromwell.parser.WdlParser.Terminal
 
 import scala.util.Success
 
@@ -18,7 +17,7 @@ import scala.util.Success
  *                      value of those inputs
  * @todo Validate that the keys in inputMappings correspond to actual parameters in the task
  */
-case class Call(alias: Option[String], taskFqn: FullyQualifiedName, task: Task, inputMappings: Map[String, WdlExpression], binding: WdlBinding) extends Scope {
+case class Call(alias: Option[String], taskFqn: FullyQualifiedName, task: Task, inputMappings: Map[String, WdlExpression], namespace: WdlNamespace) extends Scope {
   val name: String = alias getOrElse taskFqn
 
   private var _parent: Option[Scope] = None
@@ -60,8 +59,8 @@ case class Call(alias: Option[String], taskFqn: FullyQualifiedName, task: Task, 
   def prerequisiteCalls(): Iterable[Call] = {
     for {
       expr <- inputMappings.values
-      ast <- WdlBinding.findTopLevelMemberAccesses(expr.ast)
-      call <- binding.getCallFromMemberAccessAst(ast) match {
+      ast <- AstTools.findTopLevelMemberAccesses(expr.ast)
+      call <- namespace.getCallFromMemberAccessAst(ast) match {
         case Success(c:Call) => Vector(c)
         case _ => Vector()
       }

--- a/src/main/scala/cromwell/binding/WdlExpression.scala
+++ b/src/main/scala/cromwell/binding/WdlExpression.scala
@@ -66,7 +66,7 @@ object WdlExpression {
         }
         evaluate(a.getAttribute("lhs"), lookup, functions).map {
           case o: WdlObject => o.value.getOrElse(rhs, throw new WdlExpressionException(s"Could not find key $rhs"))
-          case ns: WdlBinding => lookup(ns.namespace.map {n => s"$n.$rhs"}.getOrElse(rhs))
+          case ns: WdlNamespace => lookup(ns.namespace.map {n => s"$n.$rhs"}.getOrElse(rhs))
           case _ => throw new WdlExpressionException("Left-hand side of expression must be a WdlObject or Namespace")
         }
       case a: Ast if a.getName == "FunctionCall" =>

--- a/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
+++ b/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
@@ -1,12 +1,11 @@
 package cromwell.binding.formatter
 
-import cromwell.binding.command.{ParameterCommandPart, StringCommandPart, Command}
+import cromwell.binding._
+import cromwell.binding.command.{Command, ParameterCommandPart, StringCommandPart}
 import cromwell.binding.types.WdlType
+import cromwell.parser.WdlParser.{Ast, AstList, AstNode, Terminal}
 
 import scala.collection.JavaConverters._
-
-import cromwell.binding._
-import cromwell.parser.WdlParser.{Terminal, AstList, AstNode, Ast}
 
 trait SyntaxHighlighter {
   def keyword(s: String): String = s
@@ -47,15 +46,15 @@ object HtmlSyntaxHighlighter extends SyntaxHighlighter {
 
 class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
   val indent = 2
-  def format(binding: WdlBinding): String = {
-    val imports = binding.imports.map(formatImport) match {
+  def format(namespace: WdlNamespace): String = {
+    val imports = namespace.imports.map(formatImport) match {
       case v if v.size > 0 => v.mkString("\n") + "\n\n"
       case v => ""
     }
-    val definitions = for(node <- binding.ast.getAttribute("definitions").asInstanceOf[AstList].asScala.toVector) yield {
+    val definitions = for(node <- namespace.ast.getAttribute("definitions").asInstanceOf[AstList].asScala.toVector) yield {
       node match {
-        case a:Ast if a.getName == "Workflow" => formatWorkflow(binding.workflows.head)
-        case a:Ast if a.getName == "Task" => formatTask(binding.findTask(text(a.getAttribute("name"))).getOrElse {
+        case a:Ast if a.getName == "Workflow" => formatWorkflow(namespace.workflows.head)
+        case a:Ast if a.getName == "Task" => formatTask(namespace.findTask(text(a.getAttribute("name"))).getOrElse {
           throw new UnsupportedOperationException("Shouldn't happen")
         })
       }

--- a/src/main/scala/cromwell/binding/types/WdlBooleanType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlBooleanType.scala
@@ -4,7 +4,7 @@ import cromwell.binding.values.WdlBoolean
 import spray.json.{JsBoolean, JsString}
 
 case object WdlBooleanType extends WdlType {
-  override def toWdlString: String = "Boolean"
+  val toWdlString: String = "Boolean"
 
   override protected def coercion = {
     case b: Boolean => WdlBoolean(b)

--- a/src/main/scala/cromwell/binding/types/WdlFileType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlFileType.scala
@@ -4,7 +4,7 @@ import cromwell.binding.values.WdlFile
 import spray.json.JsString
 
 case object WdlFileType extends WdlType {
-  override def toWdlString: String = "File"
+  val toWdlString: String = "File"
 
   override protected def coercion = {
     case s: String => WdlFile(s)

--- a/src/main/scala/cromwell/binding/types/WdlFloatType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlFloatType.scala
@@ -4,7 +4,7 @@ import cromwell.binding.values.WdlFloat
 import spray.json.JsNumber
 
 case object WdlFloatType extends WdlType {
-  override def toWdlString: String = "Float"
+  val toWdlString: String = "Float"
 
   override protected def coercion = {
     case d: Double => WdlFloat(d)

--- a/src/main/scala/cromwell/binding/types/WdlIntegerType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlIntegerType.scala
@@ -4,7 +4,7 @@ import cromwell.binding.values.WdlInteger
 import spray.json.JsNumber
 
 case object WdlIntegerType extends WdlType {
-  override def toWdlString: String = "Int"
+  val toWdlString: String = "Int"
 
   override protected def coercion = {
     case i: Integer => WdlInteger(i)

--- a/src/main/scala/cromwell/binding/types/WdlObjectType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlObjectType.scala
@@ -1,7 +1,7 @@
 package cromwell.binding.types
 
 case object WdlObjectType extends WdlType {
-  override def toWdlString: String = "Object"
+  val toWdlString: String = "Object"
 
   override protected def coercion = ???
 }

--- a/src/main/scala/cromwell/binding/types/WdlStringType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlStringType.scala
@@ -4,7 +4,7 @@ import cromwell.binding.values.WdlString
 import spray.json.JsString
 
 case object WdlStringType extends WdlType {
-  override def toWdlString: String = "String"
+  val toWdlString: String = "String"
 
   override protected def coercion = {
     case s: String => WdlString(s)

--- a/src/main/scala/cromwell/engine/ExecutionStore.scala
+++ b/src/main/scala/cromwell/engine/ExecutionStore.scala
@@ -1,6 +1,6 @@
 package cromwell.engine
 
-import cromwell.binding.{Call, WdlBinding}
+import cromwell.binding.{Call, WdlNamespace}
 
 object ExecutionStatus extends Enumeration {
   type ExecutionStatus = Value
@@ -11,13 +11,13 @@ object ExecutionStatus extends Enumeration {
 /**
  * Corresponds to the "execution table" of our discussions.
  */
-class ExecutionStore(binding: WdlBinding) {
+class ExecutionStore(namespace: WdlNamespace) {
 
   def isWorkflowDone: Boolean = table.forall(_._2 == ExecutionStatus.Done)
 
   def updateStatus(call: Call, status: ExecutionStatus.Value): Unit = table += (call -> status)
 
-  var table = binding.workflows.head.calls.map { call => call -> ExecutionStatus.NotStarted }.toMap
+  var table = namespace.workflows.head.calls.map { call => call -> ExecutionStatus.NotStarted }.toMap
 
   /**
    * Return all calls which are currently in state `NotStarted` and whose prerequisites are all `Done`,

--- a/src/main/scala/cromwell/engine/StoreActor.scala
+++ b/src/main/scala/cromwell/engine/StoreActor.scala
@@ -3,10 +3,9 @@ package cromwell.engine
 import akka.actor.{Actor, Props}
 import akka.event.{Logging, LoggingReceive}
 import akka.util.Timeout
+import cromwell.binding._
 import cromwell.binding.values.WdlValue
-import cromwell.binding.{WdlBinding, _}
 import cromwell.engine.StoreActor._
-import cromwell.parser.WdlParser.{Ast, Terminal}
 import cromwell.util.TryUtil
 
 import scala.concurrent.duration._
@@ -15,8 +14,8 @@ import scala.util.Try
 
 
 object StoreActor {
-  def props(binding: WdlBinding, inputs: WorkflowCoercedInputs) =
-    Props(new StoreActor(binding, inputs))
+  def props(namespace: WdlNamespace, inputs: WorkflowCoercedInputs) =
+    Props(new StoreActor(namespace, inputs))
 
   sealed trait StoreActorMessage
   case class CallCompleted(call: Call, callOutputs: Map[String, WdlValue]) extends StoreActorMessage
@@ -31,9 +30,9 @@ object StoreActor {
  * Actor to hold symbol and execution status data for a single workflow.  This actor
  * guards mutable state over the symbol and execution stores, and must therefore not
  * pass back `Future`s over updates or reads of those stores. */
-class StoreActor(binding: WdlBinding, inputs: WorkflowCoercedInputs) extends Actor {
-  private val symbolStore = new SymbolStore(binding, inputs)
-  private val executionStore = new ExecutionStore(binding)
+class StoreActor(namespace: WdlNamespace, inputs: WorkflowCoercedInputs) extends Actor {
+  private val symbolStore = new SymbolStore(namespace, inputs)
+  private val executionStore = new ExecutionStore(namespace)
   private val log = Logging(context.system, this)
 
   override def receive: Receive = LoggingReceive {

--- a/src/test/scala/cromwell/HelloWorldActorSpec.scala
+++ b/src/test/scala/cromwell/HelloWorldActorSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit._
 import com.typesafe.config.ConfigFactory
 import cromwell.HelloWorldActorSpec._
 import cromwell.binding.values.WdlString
-import cromwell.binding.{UnsatisfiedInputsException, WdlBinding}
+import cromwell.binding.{UnsatisfiedInputsException, WdlNamespace}
 import cromwell.engine.WorkflowActor
 import cromwell.engine.WorkflowActor._
 import cromwell.engine.backend.local.LocalBackend
@@ -34,9 +34,9 @@ class HelloWorldActorSpec extends CromwellSpec(ActorSystem("HelloWorldActorSpec"
 
   def buildWorkflowActor(name: String = UUID.randomUUID().toString,
                          rawInputs: binding.WorkflowRawInputs = HelloWorld.RawInputs): TestActorRef[WorkflowActor] = {
-    val binding = WdlBinding.process(HelloWorld.WdlSource)
-    val coercedInputs = binding.coerceRawInputs(rawInputs).get
-    val props = WorkflowActor.props(UUID.randomUUID(), binding, coercedInputs, new LocalBackend)
+    val namespace = WdlNamespace.load(HelloWorld.WdlSource)
+    val coercedInputs = namespace.coerceRawInputs(rawInputs).get
+    val props = WorkflowActor.props(UUID.randomUUID(), namespace, coercedInputs, new LocalBackend)
     TestActorRef(props, self, "Workflow-" + name)
   }
 

--- a/src/test/scala/cromwell/MainSpec.scala
+++ b/src/test/scala/cromwell/MainSpec.scala
@@ -1,10 +1,7 @@
 package cromwell
 
-import java.io.File
-
-import cromwell.binding.WdlBinding
+import cromwell.util.FileUtil
 import cromwell.util.SampleWdl.ThreeStep
-import cromwell.util.{FileUtil, SampleWdl}
 import org.scalatest.{FlatSpec, Matchers}
 
 class MainSpec extends FlatSpec with Matchers {

--- a/src/test/scala/cromwell/ThreeStepActorSpec.scala
+++ b/src/test/scala/cromwell/ThreeStepActorSpec.scala
@@ -96,7 +96,7 @@ object ThreeStepActorSpec {
 
 class ThreeStepActorSpec extends CromwellSpec(ActorSystem("ThreeStepActorSpec", ConfigFactory.parseString(ThreeStepActorSpec.Config))) {
 
-  val binding = WdlBinding.process(ThreeStepActorSpec.WdlSource)
+  val namespace = WdlNamespace.load(ThreeStepActorSpec.WdlSource)
 
   private def buildWorkflowActor: TestActorRef[WorkflowActor] = {
     import ThreeStepActorSpec._
@@ -104,10 +104,9 @@ class ThreeStepActorSpec extends CromwellSpec(ActorSystem("ThreeStepActorSpec", 
       Inputs.Pattern ->"joeblaux",
       Inputs.DummyPsFileName -> createDummyPsFile.getAbsolutePath)
 
-    val binding = WdlBinding.process(ThreeStepActorSpec.WdlSource)
     // This is a test and is okay with just throwing if coerceRawInputs returns a Failure.
-    val coercedInputs = binding.coerceRawInputs(workflowInputs).get
-    val props = WorkflowActor.props(UUID.randomUUID(), binding, coercedInputs, new LocalBackend)
+    val coercedInputs = namespace.coerceRawInputs(workflowInputs).get
+    val props = WorkflowActor.props(UUID.randomUUID(), namespace, coercedInputs, new LocalBackend)
     TestActorRef(props, self, "ThreeStep")
   }
 

--- a/src/test/scala/cromwell/binding/AstSpec.scala
+++ b/src/test/scala/cromwell/binding/AstSpec.scala
@@ -4,19 +4,19 @@ import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpec, Matchers}
 
 class AstSpec extends FlatSpec with Matchers {
-  val binding = WdlBinding.process(SampleWdl.ThreeStep.WdlSource)
+  val namespace = WdlNamespace.load(SampleWdl.ThreeStep.WdlSource)
 
   "Parser" should "produce AST with 3 Task nodes" in {
-    WdlBinding.findAsts(binding.ast, "Task").size shouldEqual 3
+    AstTools.findAsts(namespace.ast, "Task").size shouldEqual 3
   }
 
   it should "produce AST with 1 Workflow node" in {
-    WdlBinding.findAsts(binding.ast, "Workflow").size shouldEqual 1
+    AstTools.findAsts(namespace.ast, "Workflow").size shouldEqual 1
   }
 
   it should "produce AST with 3 Call nodes in the Workflow node" in {
-    WdlBinding.findAsts(
-      WdlBinding.findAsts(binding.ast, "Workflow").head,
+    AstTools.findAsts(
+      AstTools.findAsts(namespace.ast, "Workflow").head,
       "Call"
     ).size shouldEqual 3
   }

--- a/src/test/scala/cromwell/binding/SyntaxErrorSpec.scala
+++ b/src/test/scala/cromwell/binding/SyntaxErrorSpec.scala
@@ -35,7 +35,7 @@ class SyntaxErrorSpec extends FlatSpec with Matchers {
 
   private def expectError(wdl: String) = {
     try {
-      val binding = WdlBinding.process(wdl, resolver _)
+      val namespace = WdlNamespace.load(wdl, resolver _)
       fail("Exception expected")
     } catch {
       case x: SyntaxError => // expected

--- a/src/test/scala/cromwell/binding/SyntaxHighlightTest.scala
+++ b/src/test/scala/cromwell/binding/SyntaxHighlightTest.scala
@@ -1,10 +1,10 @@
 package cromwell.binding
 
-import cromwell.binding.formatter.{HtmlSyntaxHighlighter, AnsiSyntaxHighlighter, SyntaxFormatter}
+import cromwell.binding.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
 import org.scalatest.{FlatSpec, Matchers}
 
 class SyntaxHighlightTest extends FlatSpec with Matchers {
-  val binding = WdlBinding.process(
+  val namespace = WdlNamespace.load(
     s"""task t {command{./cmd $${f} $${Int p}}}
        |workflow w {
        |  call t
@@ -17,7 +17,7 @@ class SyntaxHighlightTest extends FlatSpec with Matchers {
 
   "SyntaxFormatter" should "produce tagged HTML" in {
     val formatter = new SyntaxFormatter(HtmlSyntaxHighlighter)
-    val actual = formatter.format(binding)
+    val actual = formatter.format(namespace)
     val expected = s"""<span class="keyword">task</span> <span class="name">t</span> {
       |  <span class="section">command</span> {
       |    <span class="command">./cmd $${<span class="type">String</span> <span class="variable">f</span>} $${<span class="type">Int</span> <span class="variable">p</span>}</span>
@@ -35,7 +35,7 @@ class SyntaxHighlightTest extends FlatSpec with Matchers {
 
   it should "produce ANSI terminal output" in {
     val formatter = new SyntaxFormatter(AnsiSyntaxHighlighter)
-    val actual = formatter.format(binding)
+    val actual = formatter.format(namespace)
     val expected = s"""\u001b[38;5;214mtask\u001b[0m \u001b[38;5;253mt\u001b[0m {
       |  command {
       |    ./cmd $${\u001b[38;5;33mString\u001b[0m \u001b[38;5;112mf\u001b[0m} $${\u001b[38;5;33mInt\u001b[0m \u001b[38;5;112mp\u001b[0m}

--- a/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
@@ -57,53 +57,53 @@ class ThreeStepImportNamespaceAliasSpec extends FlatSpec with Matchers {
     }
   }
 
-  val binding = WdlBinding.process(workflowWdl, resolver _)
+  val namespace = WdlNamespace.load(workflowWdl, resolver _)
 
   "WDL file with imports" should "Have 1 executable (1 workflow)" in {
-    binding.executables.size shouldEqual 1
+    namespace.executables.size shouldEqual 1
   }
   it should "Have 0 tasks (3 tasks are in separate namespace)" in {
-    binding.tasks.size shouldEqual 0
+    namespace.tasks.size shouldEqual 0
   }
   it should "Have 0 task ASTs" in {
-    binding.taskAsts.size shouldEqual 0
+    namespace.taskAsts.size shouldEqual 0
   }
   it should "Have 0 local tasks" in {
-    binding.localTasks.size shouldEqual 0
+    namespace.localTasks.size shouldEqual 0
   }
   it should "Have 0 local task ASTs" in {
-    binding.localTaskAsts.size shouldEqual 0
+    namespace.localTaskAsts.size shouldEqual 0
   }
   it should "Have 0 imported tasks" in {
-    binding.importedTasks.size shouldEqual 0
+    namespace.importedTasks.size shouldEqual 0
   }
   it should "Have 0 imported task ASTs" in {
-    binding.importedTaskAsts.size shouldEqual 0
+    namespace.importedTaskAsts.size shouldEqual 0
   }
   it should "Have 1 workflow" in {
-    binding.workflows.size shouldEqual 1
+    namespace.workflows.size shouldEqual 1
   }
   it should "Have 1 local workflow" in {
-    binding.localWorkflows.size shouldEqual 1
+    namespace.localWorkflows.size shouldEqual 1
   }
   it should "Have 0 imported workflow" in {
-    binding.importedWorkflows.size shouldEqual 0
+    namespace.importedWorkflows.size shouldEqual 0
   }
   it should "Have 3 imported WdlBindings" in {
-    binding.importedBindings.size shouldEqual 3
+    namespace.namespaces.size shouldEqual 3
   }
   it should "Have 3 imported WdlBindings with tasks 'ps', 'cgrep', and 'wc'" in {
-    binding.importedBindings flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
+    namespace.namespaces flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Have 3 calls in the workflow, 2 of them aliased" in {
-    binding.workflows flatMap {_.calls} map {_.name} shouldEqual Seq("a1", "a2", "ns3.wc")
+    namespace.workflows flatMap {_.calls} map {_.name} shouldEqual Seq("a1", "a2", "ns3.wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
     def badResolver(s: String): String = {
       throw new RuntimeException(s"Can't Resolve")
     }
     try {
-      val badBinding = WdlBinding.process(workflowWdl, badResolver _)
+      val badBinding = WdlNamespace.load(workflowWdl, badResolver _)
       fail("Expecting an exception to be thrown when using badResolver")
     } catch {
       case _: RuntimeException =>

--- a/src/test/scala/cromwell/binding/ThreeStepImportNamespaceSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportNamespaceSpec.scala
@@ -57,50 +57,50 @@ class ThreeStepImportNamespaceSpec extends FlatSpec with Matchers {
     }
   }
 
-  val binding = WdlBinding.process(workflowWdl, resolver _)
+  val namespace = WdlNamespace.load(workflowWdl, resolver _)
 
   "WDL file with imports" should "Have 1 executable (1 workflow)" in {
-    binding.executables.size shouldEqual 1
+    namespace.executables.size shouldEqual 1
   }
   it should "Have 0 tasks (3 tasks are in separate namespace)" in {
-    binding.tasks.size shouldEqual 0
+    namespace.tasks.size shouldEqual 0
   }
   it should "Have 0 task ASTs" in {
-    binding.taskAsts.size shouldEqual 0
+    namespace.taskAsts.size shouldEqual 0
   }
   it should "Have 0 local tasks" in {
-    binding.localTasks.size shouldEqual 0
+    namespace.localTasks.size shouldEqual 0
   }
   it should "Have 0 local task ASTs" in {
-    binding.localTaskAsts.size shouldEqual 0
+    namespace.localTaskAsts.size shouldEqual 0
   }
   it should "Have 0 imported tasks" in {
-    binding.importedTasks.size shouldEqual 0
+    namespace.importedTasks.size shouldEqual 0
   }
   it should "Have 0 imported task ASTs" in {
-    binding.importedTaskAsts.size shouldEqual 0
+    namespace.importedTaskAsts.size shouldEqual 0
   }
   it should "Have 1 workflow" in {
-    binding.workflows.size shouldEqual 1
+    namespace.workflows.size shouldEqual 1
   }
   it should "Have 1 local workflow" in {
-    binding.localWorkflows.size shouldEqual 1
+    namespace.localWorkflows.size shouldEqual 1
   }
   it should "Have 0 imported workflow" in {
-    binding.importedWorkflows.size shouldEqual 0
+    namespace.importedWorkflows.size shouldEqual 0
   }
   it should "Have 3 imported WdlBindings" in {
-    binding.importedBindings.size shouldEqual 3
+    namespace.namespaces.size shouldEqual 3
   }
   it should "Have 3 imported WdlBindings with tasks 'ps', 'cgrep', and 'wc'" in {
-    binding.importedBindings flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
+    namespace.namespaces flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
     def badResolver(s: String): String = {
       throw new RuntimeException(s"Can't Resolve")
     }
     try {
-      val badBinding = WdlBinding.process(workflowWdl, badResolver _)
+      val badBinding = WdlNamespace.load(workflowWdl, badResolver _)
       fail("Expecting an exception to be thrown when using badResolver")
     } catch {
       case _: RuntimeException =>

--- a/src/test/scala/cromwell/binding/ThreeStepImportSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportSpec.scala
@@ -57,50 +57,50 @@ class ThreeStepImportSpec extends FlatSpec with Matchers {
     }
   }
 
-  val binding = WdlBinding.process(workflowWdl, resolver _)
+  val namespace = WdlNamespace.load(workflowWdl, resolver _)
 
   "WDL file with imports" should "Have 4 executables (3 tasks, 1 workflow)" in {
-    binding.executables.size shouldEqual 4
+    namespace.executables.size shouldEqual 4
   }
   it should "Have 3 tasks" in {
-    binding.tasks.size shouldEqual 3
+    namespace.tasks.size shouldEqual 3
   }
   it should "Have 3 task ASTs" in {
-    binding.taskAsts.size shouldEqual 3
+    namespace.taskAsts.size shouldEqual 3
   }
   it should "Have 0 local tasks" in {
-    binding.localTasks.size shouldEqual 0
+    namespace.localTasks.size shouldEqual 0
   }
   it should "Have 0 local task ASTs" in {
-    binding.localTaskAsts.size shouldEqual 0
+    namespace.localTaskAsts.size shouldEqual 0
   }
   it should "Have 3 imported tasks" in {
-    binding.importedTasks.size shouldEqual 3
+    namespace.importedTasks.size shouldEqual 3
   }
   it should "Have 3 imported task ASTs" in {
-    binding.importedTaskAsts.size shouldEqual 3
+    namespace.importedTaskAsts.size shouldEqual 3
   }
   it should "Have 1 workflow" in {
-    binding.workflows.size shouldEqual 1
+    namespace.workflows.size shouldEqual 1
   }
   it should "Have 1 local workflow" in {
-    binding.localWorkflows.size shouldEqual 1
+    namespace.localWorkflows.size shouldEqual 1
   }
   it should "Have 0 imported workflow" in {
-    binding.importedWorkflows.size shouldEqual 0
+    namespace.importedWorkflows.size shouldEqual 0
   }
   it should "Have 3 imported WdlBindings" in {
-    binding.importedBindings.size shouldEqual 3
+    namespace.namespaces.size shouldEqual 3
   }
   it should "Have tasks with the names 'ps', 'cgrep' and 'wc'" in {
-    binding.tasks map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
+    namespace.tasks map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
     def badResolver(s: String): String = {
       throw new RuntimeException(s"Can't Resolve")
     }
     try {
-      val badBinding = WdlBinding.process(workflowWdl, badResolver _)
+      val badBinding = WdlNamespace.load(workflowWdl, badResolver _)
       fail("Expecting an exception to be thrown when using badResolver")
     } catch {
       case _: RuntimeException =>

--- a/src/test/scala/cromwell/binding/ThreeStepSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepSpec.scala
@@ -6,38 +6,38 @@ import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpec, Matchers}
 
 class ThreeStepSpec extends FlatSpec with Matchers {
-  val binding = WdlBinding.process(SampleWdl.ThreeStep.WdlSource)
+  val namespace = WdlNamespace.load(SampleWdl.ThreeStep.WdlSource)
 
   "Binding Workflow" should "Have one workflow definition" in {
-    binding.workflows.size shouldEqual 1
+    namespace.workflows.size shouldEqual 1
   }
   it should "Have zero imported workflow definition" in {
-    binding.importedWorkflows.size shouldEqual 0
+    namespace.importedWorkflows.size shouldEqual 0
   }
   it should "Have correct name for workflow" in {
-    binding.workflows.head.name shouldEqual "three_step"
+    namespace.workflows.head.name shouldEqual "three_step"
   }
   it should "Have correct FQN" in {
-    binding.workflows.head.fullyQualifiedName shouldEqual "three_step"
+    namespace.workflows.head.fullyQualifiedName shouldEqual "three_step"
   }
   it should "Have no parent" in {
-    binding.workflows.head.parent shouldEqual None
+    namespace.workflows.head.parent shouldEqual None
   }
   it should "Have three 'Call' objects" in {
-    binding.workflows.head.calls.size shouldEqual 3
+    namespace.workflows.head.calls.size shouldEqual 3
   }
   it should "Have three outputs" in {
-    binding.workflows.head.outputs.size shouldEqual 3
+    namespace.workflows.head.outputs.size shouldEqual 3
   }
 
   "Binding Tasks" should "Have three task definitions" in {
-    binding.tasks.size shouldEqual 3
+    namespace.tasks.size shouldEqual 3
   }
   it should "Have zero imported tasks" in {
-    binding.importedTasks.size shouldEqual 0
+    namespace.importedTasks.size shouldEqual 0
   }
   it should "Have a task with name 'wc'" in {
-    val task = binding.findTask("wc") getOrElse fail("No 'wc' task found")
+    val task = namespace.findTask("wc") getOrElse fail("No 'wc' task found")
     task.name shouldEqual "wc"
     task.inputs shouldEqual Map("in_file" -> WdlFileType)
     task.command.instantiate(Map("in_file" -> WdlFile("/path/to/file"))).get shouldEqual "cat /path/to/file | wc -l"
@@ -46,7 +46,7 @@ class ThreeStepSpec extends FlatSpec with Matchers {
     task.outputs.head.wdlType shouldEqual WdlIntegerType
   }
   it should "Have a task with name 'cgrep'" in {
-    val task = binding.findTask("cgrep") getOrElse fail("No 'cgrep' task found")
+    val task = namespace.findTask("cgrep") getOrElse fail("No 'cgrep' task found")
     task.name shouldEqual "cgrep"
     task.inputs shouldEqual Map("pattern" -> WdlStringType, "in_file" -> WdlFileType)
     task.command.instantiate(
@@ -57,7 +57,7 @@ class ThreeStepSpec extends FlatSpec with Matchers {
     task.outputs.head.wdlType shouldEqual WdlIntegerType
   }
   it should "Have a task with name 'ps'" in {
-    val task = binding.findTask("ps") getOrElse fail("No 'ps' task found")
+    val task = namespace.findTask("ps") getOrElse fail("No 'ps' task found")
     task.name shouldEqual "ps"
     task.inputs shouldEqual Map()
     task.command.instantiate(Map()).get shouldEqual "ps"

--- a/src/test/scala/cromwell/engine/SymbolStoreTest.scala
+++ b/src/test/scala/cromwell/engine/SymbolStoreTest.scala
@@ -1,7 +1,7 @@
 package cromwell.engine
 
-import cromwell.binding.WdlBinding
-import cromwell.binding.types.{WdlIntegerType, WdlExpressionType, WdlStringType}
+import cromwell.binding.WdlNamespace
+import cromwell.binding.types.{WdlIntegerType, WdlStringType}
 import cromwell.binding.values.{WdlInteger, WdlString}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -27,15 +27,15 @@ class SymbolStoreSpec extends FlatSpec with Matchers {
       |}
     """.stripMargin
 
-  val binding = WdlBinding.process(wdl)
+  val namespace = WdlNamespace.load(wdl)
   "A SymbolStore" should "acquire local inputs for a task" in {
     val inputs = Map("wf.a.message" -> WdlString("hello"))
-    val store = new SymbolStore(binding, inputs)
-    val callAInputs = store.locallyQualifiedInputs(binding.workflows.head.calls.find{c => c.name == "a"}.get)
+    val store = new SymbolStore(namespace, inputs)
+    val callAInputs = store.locallyQualifiedInputs(namespace.workflows.head.calls.find{c => c.name == "a"}.get)
     callAInputs.mapValues{v => v.wdlType} shouldEqual Map("message" -> WdlStringType)
     store.addOutputValue("wf.a", "constant", Some(WdlInteger(5)), WdlIntegerType)
     store.addOutputValue("wf.a", "message", Some(WdlString("hello")), WdlStringType)
-    val callBInputs = store.locallyQualifiedInputs(binding.workflows.head.calls.find{c => c.name == "b"}.get)
+    val callBInputs = store.locallyQualifiedInputs(namespace.workflows.head.calls.find{c => c.name == "b"}.get)
     callBInputs.mapValues{v => v.wdlType} shouldEqual Map("message" -> WdlStringType, "integer" -> WdlIntegerType)
   }
 }


### PR DESCRIPTION
The high level overview:

1.  Rename `WdlBinding` to `WdlNamespace`
2.  Move AST specific functions into `AstTools`

In more detail:

1.  `WdlBinding` was feeling poorly named since the import statement was introduced.  All of a sudden this object became recursive and started to really resemble how namespaces worked in WDL.  And that's not on accident because the object structure is laid out exactly like the lexical structure of WDL.  So naturally we would call "the thing that holds workflows and tasks" as a "namespace".

2.  The main entry point into the binding layer is the `WdlNamespace` object, in which users call `WdlNamespace.load(...)` with either String or File parameters.  Client code now looks like this:

```scala
val namespace = WdlNamespace.load(new File(args(0)))
namespace.workflows
namespace.namespaces
namespace.tasks
```

3.  All `Ast => Workflow | Call | Task | ...` functions are in `class WdlNamespace`.  All AST related tools are now in `AstTools` (things like `findAsts`, `terminalMap`).  `object WdlNamespace` only contains various `load()` functions.

4.  Changed all variable references to 'binding' in any way to reference 'namespace' instead.