### PR TITLE
Better logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,18 +370,6 @@ Contains implementations of an interface to launch jobs.  `cromwell.engine` will
 
 ### cromwell.engine
 
-![Engine Actors](http://i.imgur.com/ByFUakW.png)
+![Engine Actors](http://i.imgur.com/sF9vMt2.png)
 
 Contains the Akka code and actor system to execute a workflow.  This layer should operate entirely on objects returned from the `cromwell.binding` layer.
-
-|Start|End|Message|Parameters|State Change|
-|-----|---|-------|----------|------------|
-|![WMA](http://i.imgur.com/98ugXkZ.png)|![WA](http://i.imgur.com/eJxn3wu.png)|Start||
-|![WMA](http://i.imgur.com/98ugXkZ.png)|![WA](http://i.imgur.com/eJxn3wu.png)|SubscribeTransitionCallback|WorkflowManagerActor|
-|![WA](http://i.imgur.com/eJxn3wu.png)|![SA](http://i.imgur.com/JzNNe64.png)|UpdateStatus|Call,status|
-|![WA](http://i.imgur.com/eJxn3wu.png)|![SA](http://i.imgur.com/JzNNe64.png)|CallCompleted|Call,outputs|
-|![WA](http://i.imgur.com/eJxn3wu.png)|![SA](http://i.imgur.com/JzNNe64.png)|GetOutputs||
-|![WA](http://i.imgur.com/eJxn3wu.png)|![CA](http://i.imgur.com/Nyoln74.png)|Start||
-
-> **TODO**: This table is not complete.
-

--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,11 @@ libraryDependencies ++= Seq(
   "io.spray" %% "spray-http" % sprayV,
   "io.spray" %% "spray-json" % DowngradedSprayV,
   "com.typesafe.akka" %% "akka-actor" % akkaV,
+  "com.typesafe.akka" %% "akka-slf4j" % akkaV,
   "commons-codec" % "commons-codec" % "1.10",
   "ch.qos.logback" % "logback-classic" % "1.1.3",
-  //---------- Test libraries -------------------//
+  "ch.qos.logback" % "logback-access" % "1.1.3",
+  "org.codehaus.janino" % "janino" % "2.7.8",
   "io.spray" %% "spray-testkit" % sprayV % Test,
   "org.scalatest" %% "scalatest" % "2.2.5" % Test,
   "com.typesafe.akka" %% "akka-testkit" % akkaV % Test

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,12 @@
+akka {
+  event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  actor {
+    debug {
+      receive = on
+      event-stream = on
+      fsm = on
+    }
+  }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,30 @@
+<configuration>
+  <if condition='property("CROMWELL_LOGGER").equals("SERVER")'>
+    <then>
+      <appender name="SERVER_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- Support multiple-JVM writing to the same log file -->
+        <prudent>true</prudent>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+          <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
+          <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+          <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+      </appender>
+      <root level="TRACE">
+        <appender-ref ref="SERVER_APPENDER" />
+      </root>
+    </then>
+    <else>
+      <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+          <layout class="cromwell.logging.TerminalLayout" />
+        </encoder>
+      </appender>
+      <root level="INFO">
+        <appender-ref ref="CONSOLE_APPENDER" />
+      </root>
+    </else>
+  </if>
+</configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,8 +1,6 @@
 webservice.port = 8000
 webservice.interface = 0.0.0.0
 instance.name = "reference"
-#vault.url = "https://api-ci.vault.broadinstitute.org/api"
-#ces.url = "https://snoop-dev.broadinstitute.org"
 
 swagger {
   apiDocs = "api-docs"

--- a/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
+++ b/src/main/scala/cromwell/binding/formatter/SyntaxFormatter.scala
@@ -4,6 +4,7 @@ import cromwell.binding._
 import cromwell.binding.command.{Command, ParameterCommandPart, StringCommandPart}
 import cromwell.binding.types.WdlType
 import cromwell.parser.WdlParser.{Ast, AstList, AstNode, Terminal}
+import cromwell.util.TerminalUtil
 
 import scala.collection.JavaConverters._
 
@@ -21,15 +22,14 @@ trait SyntaxHighlighter {
 object NullSyntaxHighlighter extends SyntaxHighlighter
 
 object AnsiSyntaxHighlighter extends SyntaxHighlighter {
-  def highlight(string: String, color: Int) = s"\033[38;5;${color}m${string}\033[0m"
-  override def keyword(s: String): String = highlight(s, 214)
-  override def name(s: String): String = highlight(s, 253)
+  override def keyword(s: String): String = TerminalUtil.highlight(214, s)
+  override def name(s: String): String = TerminalUtil.highlight(253, s)
   override def section(s: String): String = s
-  override def wdlType(t: WdlType): String = highlight(t.toWdlString, 33)
-  override def variable(s: String): String = highlight(s, 112)
+  override def wdlType(t: WdlType): String = TerminalUtil.highlight(33, t.toWdlString)
+  override def variable(s: String): String = TerminalUtil.highlight(112, s)
   override def alias(s: String): String = s
   override def command(s: String): String = s
-  override def function(s: String): String = highlight(s, 13)
+  override def function(s: String): String = TerminalUtil.highlight(13, s)
 }
 
 object HtmlSyntaxHighlighter extends SyntaxHighlighter {

--- a/src/main/scala/cromwell/binding/package.scala
+++ b/src/main/scala/cromwell/binding/package.scala
@@ -40,6 +40,7 @@ package object binding {
    */
   case class WorkflowDescriptor(namespace: WdlNamespace, actualInputs: WorkflowCoercedInputs) {
     val id = UUID.randomUUID()
+    val shortId = id.toString.split("-")(0)
     val name = namespace.workflows.head.name
   }
 }

--- a/src/main/scala/cromwell/engine/SymbolStore.scala
+++ b/src/main/scala/cromwell/engine/SymbolStore.scala
@@ -20,7 +20,6 @@ case class SymbolStoreEntry(key: SymbolStoreKey, wdlType: WdlType, wdlValue: Opt
 }
 
 class SymbolStore(namespace: WdlNamespace, inputs: HostInputs) {
-
   private val store = mutable.Set[SymbolStoreEntry]()
 
   inputs.foreach { case (fullyQualifiedName, value) =>

--- a/src/main/scala/cromwell/engine/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/WorkflowActor.scala
@@ -1,6 +1,7 @@
 package cromwell.engine
 
 import akka.actor.{FSM, LoggingFSM, Props}
+import akka.event.Logging
 import akka.pattern.{ask, pipe}
 import cromwell.binding._
 import cromwell.engine.WorkflowActor._
@@ -27,9 +28,11 @@ object WorkflowActor {
   case class FailureMessage(msg: String) extends WorkflowFailure with WorkflowActorMessage
 }
 
-case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend) extends LoggingFSM[WorkflowState, WorkflowFailure] with CromwellActor {
+case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend) extends FSM[WorkflowState, WorkflowFailure] with CromwellActor {
 
-  private val storeActor = context.actorOf(StoreActor.props(workflow.namespace, backend.initializeForWorkflow(workflow)))
+  private val storeActor = context.actorOf(StoreActor.props(workflow, backend.initializeForWorkflow(workflow)))
+  val tag: String = s"WorkflowActor [UUID(${workflow.shortId})]"
+  override val log = Logging(context.system, classOf[WorkflowActor])
 
   startWith(WorkflowSubmitted, NoFailureMessage)
 
@@ -38,22 +41,11 @@ case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend) extends
   }
 
   when(WorkflowRunning) {
-    case Event(CallStarted(call), NoFailureMessage) =>
-      storeActor ! StoreActor.UpdateStatus(call, ExecutionStatus.Running)
-      stay()
-    case Event(CallCompleted(call, callOutputs), NoFailureMessage) =>
-      storeActor ! StoreActor.CallCompleted(call, callOutputs)
-      stay()
-    case Event(RunnableCalls(runnableCalls), NoFailureMessage) =>
-      if (runnableCalls.nonEmpty) {
-        log.info("Starting calls: " + runnableCalls.map {_.name}.toSeq.sorted.mkString(", "))
-      }
-      runnableCalls foreach startCallActor
-      stay()
-    case Event(CallFailed(call, failure), NoFailureMessage) =>
-      storeActor ! StoreActor.UpdateStatus(call, ExecutionStatus.Failed)
-      goto(WorkflowFailed) using FailureMessage(failure)
-    case Event(Complete, NoFailureMessage) => goto(WorkflowSucceeded)
+    case Event(CallStarted(call), NoFailureMessage) => updateCallStatusToRunning(call)
+    case Event(CallCompleted(completedCall, callOutputs), NoFailureMessage) => updateCallStatusToCompleted(completedCall, callOutputs)
+    case Event(RunnableCalls(runnableCalls), NoFailureMessage) => receiveRunnableCalls(runnableCalls)
+    case Event(CallFailed(call, failure), NoFailureMessage) => updateCallStatusToFailed(call, failure)
+    case Event(WorkflowActor.Complete, NoFailureMessage) => goto(WorkflowSucceeded)
   }
 
   when(WorkflowFailed) {
@@ -78,10 +70,38 @@ case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend) extends
     case WorkflowSubmitted -> WorkflowRunning => storeActor ! StoreActor.StartRunnableCalls
   }
 
-  /** Create a per-call `CallActor` for the specified `Call` and send it a `Start` message to
-    * begin execution. */
-  private def startCallActor(call: Call): Unit = {
-    val callActorProps = CallActor.props(call, backend, workflow, storeActor, "CallActor-" + call.name)
-    context.actorOf(callActorProps) ! CallActor.Start
+  private def updateCallStatusToRunning(call: Call) = {
+    log.info(s"$tag: call '${call.name}' running")
+    storeActor ! StoreActor.UpdateStatus(call, ExecutionStatus.Running)
+    stay()
+  }
+
+  private def updateCallStatusToCompleted(call: Call, outputs: WorkflowOutputs) = {
+    log.info(s"$tag: call '${call.name}' completed")
+    storeActor ! StoreActor.CallCompleted(call, outputs)
+    stay()
+  }
+
+  private def updateCallStatusToFailed(call: Call, failure: String) = {
+    log.info(s"$tag: call '${call.name}' failed ($failure)")
+    storeActor ! StoreActor.UpdateStatus(call, ExecutionStatus.Failed)
+    goto(WorkflowFailed) using FailureMessage(failure)
+  }
+
+  private def unknownMessage(e: Any) = {
+    log.warning(s"$tag: Unexpected message: $e")
+    stay()
+  }
+
+  private def receiveRunnableCalls(calls: Iterable[Call]) = {
+    if (calls.nonEmpty) {
+      log.info(s"$tag: starting " + calls.map {_.name}.toSeq.sorted.mkString(", "))
+    }
+    calls foreach { call =>
+      log.info(s"$tag: launching CallActor for '${call.name}'")
+      val callActorProps = CallActor.props(call, backend, workflow, storeActor)
+      context.actorOf(callActorProps) ! CallActor.Start
+    }
+    stay()
   }
 }

--- a/src/main/scala/cromwell/logging/CromwellLogger.scala
+++ b/src/main/scala/cromwell/logging/CromwellLogger.scala
@@ -1,0 +1,31 @@
+package cromwell.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.{ConsoleAppender, LayoutBase}
+import cromwell.util.TerminalUtil
+
+import scala.collection.JavaConverters._
+
+class TerminalLayout extends LayoutBase[ILoggingEvent] {
+  def doLayout(event: ILoggingEvent): String = {
+    val level = event.getLevel match {
+      case Level.WARN => TerminalUtil.highlight(220, "warn")
+      case Level.ERROR => TerminalUtil.highlight(1, "error")
+      case x => x.toString.toLowerCase
+    }
+
+    val highlightedMessage = event.getFormattedMessage
+      .replaceAll("UUID\\((.*?)\\)", TerminalUtil.highlight(2, "$1"))
+      .replaceAll("`(.*?)`", TerminalUtil.highlight(9, "$1"))
+
+    /* For some reason a '{}' is the value of getMessage only for Actors.
+       This prepends a highlighted asterisk to messages that come from actors.
+     */
+    val prefix = if (event.getMessage == "{}") s"[${TerminalUtil.highlight(129, "*")}] " else ""
+
+    s"$prefix[$level] $highlightedMessage\n"
+  }
+}
+
+class TerminalAppender extends ConsoleAppender

--- a/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/src/main/scala/cromwell/server/CromwellServer.scala
@@ -15,7 +15,7 @@ import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success}
 
 // Note that as per the language specification, this is instiated lazily and only used when necessary (i.e. server mode)
-object CromwellServer extends WorkflowManagerSystem {
+object CromwellServer extends DefaultWorkflowManagerSystem {
   val conf = ConfigFactory.parseFile(new File("/etc/cromwell.conf"))
 
   val swaggerConfig = conf.getConfig("swagger")

--- a/src/main/scala/cromwell/server/DefaultWorkflowManagerSystem.scala
+++ b/src/main/scala/cromwell/server/DefaultWorkflowManagerSystem.scala
@@ -1,13 +1,18 @@
 package cromwell.server
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
+import com.typesafe.config.ConfigFactory
 import cromwell.engine.WorkflowManagerActor
 
 trait WorkflowManagerSystem {
+  val systemName: String
+  implicit val actorSystem: ActorSystem
+  val workflowManagerActor: ActorRef
+}
+  
+case class DefaultWorkflowManagerSystem() extends WorkflowManagerSystem {
   val systemName = "cromwell-system"
   implicit val actorSystem = ActorSystem(systemName)
-
   actorSystem.registerOnTermination {actorSystem.log.info(s"$systemName shutting down")}
-
   val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props)
 }

--- a/src/main/scala/cromwell/util/TerminalUtil.scala
+++ b/src/main/scala/cromwell/util/TerminalUtil.scala
@@ -1,0 +1,5 @@
+package cromwell.util
+
+object TerminalUtil {
+  def highlight(colorCode:Int, string:String) = s"\033[38;5;${colorCode}m${string}\033[0m"
+}

--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -2,14 +2,31 @@ package cromwell
 
 import akka.actor.ActorSystem
 import akka.testkit.{DefaultTimeout, EventFilter, ImplicitSender, TestKit}
+import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 
-abstract class CromwellTestkitSpec(actorSystem: ActorSystem) extends TestKit(actorSystem) with DefaultTimeout
-with ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
+object CromwellTestkitSpec {
+  val akkaConfigString =
+    """
+      |akka {
+      |  loggers = ["akka.event.slf4j.Slf4jLogger", "akka.testkit.TestEventListener"]
+      |  loglevel = "DEBUG"
+      |  actor {
+      |    debug {
+      |       receive = on
+      |    }
+      |  }
+      |}
+    """.stripMargin
+}
+
+abstract class CromwellTestkitSpec(name: String)
+  extends TestKit(ActorSystem(name, ConfigFactory.parseString(CromwellTestkitSpec.akkaConfigString)))
+  with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   def startingCallsFilter(callNames: String*): EventFilter =
-    EventFilter.info(message = s"Starting calls: ${callNames.mkString(", ")}", occurrences = 1)
+    EventFilter.info(pattern = s"starting ${callNames.mkString(", ")}", occurrences = 1)
 
   def waitForHandledMessage[T](named: String)(block: => T): T = {
     waitForHandledMessagePattern(s"^received handled message $named")(block)
@@ -20,6 +37,4 @@ with ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with 
       block
     }
   }
-
-  protected def getActorSystem = actorSystem
 }

--- a/src/test/scala/cromwell/engine/ActorWorkflowManagerSpec.scala
+++ b/src/test/scala/cromwell/engine/ActorWorkflowManagerSpec.scala
@@ -1,21 +1,16 @@
 package cromwell.engine
 
-import akka.actor.ActorSystem
 import akka.testkit.TestActorRef
-import com.typesafe.config.ConfigFactory
-import cromwell.{binding, CromwellTestkitSpec}
-import cromwell.HelloWorldActorSpec._
-import cromwell.binding.FullyQualifiedName
-import cromwell.binding.values.{WdlString, WdlValue}
+import cromwell.CromwellTestkitSpec
+import cromwell.binding.values.WdlString
 import cromwell.engine.WorkflowManagerActor.{SubmitWorkflow, WorkflowOutputs, WorkflowStatus}
 import cromwell.util.ActorTestUtil
 import cromwell.util.SampleWdl.HelloWorld
+import cromwell.{CromwellSpec, binding}
 
 import scala.language.{higherKinds, postfixOps, reflectiveCalls}
 
-
-class ActorWorkflowManagerSpec extends CromwellTestkitSpec(ActorSystem("ActorWorkflowManagerSpec", ConfigFactory.parseString(Config))) {
-
+class ActorWorkflowManagerSpec extends CromwellTestkitSpec("ActorWorkflowManagerSpec") {
   "An ActorWorkflowManager" should {
     "run the Hello World workflow" in {
       implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props, self, "Test the ActorWorkflowManager")
@@ -28,7 +23,6 @@ class ActorWorkflowManagerSpec extends CromwellTestkitSpec(ActorSystem("ActorWor
       status shouldEqual WorkflowSucceeded
 
       val outputs = ActorTestUtil.messageAndWait(WorkflowOutputs(workflowId), _.mapTo[binding.WorkflowOutputs])
-
       val actual = outputs.map { case (k, WdlString(string)) => k -> string }
       actual shouldEqual Map(HelloWorld.OutputKey -> HelloWorld.OutputValue)
     }

--- a/src/test/scala/cromwell/engine/SingleWorkflowRunnerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/SingleWorkflowRunnerActorSpec.scala
@@ -1,22 +1,19 @@
 package cromwell.engine
 
-import cromwell.HelloWorldActorSpec._
-import cromwell.util.SampleWdl.ThreeStep
-import akka.actor.ActorSystem
 import akka.testkit.EventFilter
-import com.typesafe.config.ConfigFactory
 import cromwell.CromwellTestkitSpec
+import cromwell.util.SampleWdl.ThreeStep
+
 import scala.language.postfixOps
 
-class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec(ActorSystem("ActorWorkflowManagerSpec", ConfigFactory.parseString(Config))) {
-  val actorSystem = super.getActorSystem
-  val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props)
+class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec("SingleWorkflowRunnerActorSpec") {
+  val workflowManagerActor = this.system.actorOf(WorkflowManagerActor.props)
   val props = SingleWorkflowRunnerActor.props(ThreeStep.WdlSource, ThreeStep.RawInputs, workflowManagerActor)
 
   "A SingleWorkflowRunnerActor" should {
     "successfully run a workflow" in {
-      EventFilter.info(message = "Workflow complete: Succeeded", occurrences = 1) intercept {
-        actorSystem.actorOf(props)
+      EventFilter.info(message = "SingleWorkflowRunnerActor: workflow finished with status 'Succeeded'", occurrences = 1) intercept {
+        system.actorOf(props)
       }
     }
   }


### PR DESCRIPTION
![screen shot 2015-06-14 at 8 36 19 am](https://cloud.githubusercontent.com/assets/58551/8148606/0f7b94f6-1273-11e5-8f6e-8fb7b23aa935.png)


No rush to review this.  This is ancillary to the sprint but it'd be nice if we could get it in by the end of the sprint.

Changes:

1)  SLF4J logging hooked in with the actor system too.

2)  Two modes of logging, set by the Java Property `CROMWELL_LOGGER=[SERVER|CONSOLE]`:

  * In SERVER mode, it logs to a rolling file appender with all the bells and whistles.  This will default to DEBUG level.
  * In CONSOLE mode, there's code in `cromwell.logging` that handles these messages from SLF4J and prints them out to the console is as human-readable way as possible.  I welcome comments about how to make it more readable.  Though, if you are going to do that make sure you first run it so you can see the colors, which are an important aspect of this!  CONSOLE logs on INFO, WARN, ERROR.
  * The modes are toggled either by explicitly setting CROMWELL_LOGGER, or based on the CLI sub-command you chose:  `server` will do SERVER logging and every other sub-command uses CONSOLE logging.

3)  I've tried to establish some conventions for logging:

  * INFO, WARN, ERROR is meant to be read by *users* to debug their WDL executions.  It should equally be helpful for *developers* to debug many issues.  We must keep in mind that these are also show up in the server logs so they could also help us add context to debugging an issue easier if we're used to these messages from the command line.
  * Messages should contain the workflow UUID wherever appropriate.  Anything that exists only in a context of a workflow execution: CallActors, WorkflowActors, SymbolStores, etc.
  * Messages should be chosen to craft a story about how a workflow is progressing.  Highlight the big points (something starts, something finishes, something is launched, symbol store entry is updated, etc)