### PR TITLE
Don't run tests as part of assembly.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,3 +83,5 @@ lazy val root = (project in file("."))
 testOptions in DockerTest := Seq(Tests.Argument("-n", "DockerTest"))
 
 testOptions in NoDockerTest := Seq(Tests.Argument("-l", "DockerTest"))
+
+test in assembly := {}


### PR DESCRIPTION
They already run once as part of the release process and the second run trips up the Dockerized container-building process.