### PR TITLE
Fixed issue with using wdl source/json >254 chars. DSDEEPB-717

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -25,6 +25,8 @@
       <root level="INFO">
         <appender-ref ref="CONSOLE_APPENDER" />
       </root>
+      <logger name="com.zaxxer.hikari" level="ERROR"/>
+      <logger name="HikariPool" level="ERROR"/>
     </else>
   </if>
 </configuration>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -34,10 +34,6 @@ database {
       driver = "org.hsqldb.jdbcDriver"
       slick.driver = "slick.driver.HsqldbDriver"
       slick.createSchema = true
-      // TODO: Running into a travis error. Should only disable via command line in travis.
-      //   [error] Could not run test cromwell.engine.db.slick.DataAccessControllerSpec: java.lang.ExceptionInInitializerError
-      //   [HikariCP connection filler (pool )] DEBUG com.zaxxer.hikari.pool.PoolUtilities -  - Connection.setNetworkTimeout() not supported
-      connectionPool = disabled
     }
   }
 
@@ -50,8 +46,6 @@ database {
         changelog = "src/main/migrations/changelog.xml"
         connection = "liquibase.database.jvm.HsqlConnection"
       }
-      // TODO: Should only disable via command line in travis.
-      connectionPool = disabled
     }
 
     mysql {

--- a/src/main/scala/cromwell/binding/WdlExpression.scala
+++ b/src/main/scala/cromwell/binding/WdlExpression.scala
@@ -1,5 +1,6 @@
 package cromwell.binding
 
+import cromwell.binding.WdlExpression.ScopedLookupFunction
 import cromwell.binding.formatter.{NullSyntaxHighlighter, SyntaxHighlighter}
 import cromwell.binding.types.WdlExpressionType
 import cromwell.binding.values._
@@ -126,7 +127,7 @@ object WdlExpression {
 
 case class WdlExpression(ast: AstNode) extends WdlValue {
   override val wdlType = WdlExpressionType
-  def evaluate(lookup: String => WdlValue, functions: WdlFunctions): Try[WdlValue] =
+  def evaluate(lookup: ScopedLookupFunction, functions: WdlFunctions): Try[WdlValue] =
     WdlExpression.evaluate(ast, lookup, functions)
   def toString(highlighter: SyntaxHighlighter): String = {
     WdlExpression.toString(ast, highlighter)

--- a/src/main/scala/cromwell/engine/db/slick/JesJobComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/JesJobComponent.scala
@@ -32,14 +32,20 @@ trait JesJobComponent {
       executionId, unique = true)
   }
 
-  val jesJobs = TableQuery[JesJobs]
+  protected val jesJobs = TableQuery[JesJobs]
 
   val jesJobsAutoInc = jesJobs returning jesJobs.
     map(_.jesJobId) into ((a, id) => a.copy(jesJobId = Some(id)))
 
-  val jesJobByID = Compiled(
-    (id: Rep[Int]) => for {
+  val jesJobsByExecutionId = Compiled(
+    (executionId: Rep[Int]) => for {
       jesJob <- jesJobs
-      if jesJob.jesJobId === id
+      if jesJob.executionId === executionId
     } yield jesJob)
+
+  val jesJobIdsAndJesStatusesByExecutionId = Compiled(
+    (executionId: Rep[Int]) => for {
+      jesJob <- jesJobs
+      if jesJob.executionId === executionId
+    } yield (jesJob.jesJobId, jesJob.jesStatus))
 }

--- a/src/main/scala/cromwell/engine/db/slick/LocalJobComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/LocalJobComponent.scala
@@ -32,14 +32,20 @@ trait LocalJobComponent {
       executionId, unique = true)
   }
 
-  val localJobs = TableQuery[LocalJobs]
+  protected val localJobs = TableQuery[LocalJobs]
 
   val localJobsAutoInc = localJobs returning localJobs.
     map(_.localJobId) into ((a, id) => a.copy(localJobId = Some(id)))
 
-  val localJobByID = Compiled(
-    (id: Rep[Int]) => for {
+  val localJobsByExecutionId = Compiled(
+    (executionId: Rep[Int]) => for {
       localJob <- localJobs
-      if localJob.localJobId === id
+      if localJob.executionId === executionId
     } yield localJob)
+
+  val localJobPidsAndRcsByExecutionId = Compiled(
+    (executionId: Rep[Int]) => for {
+      localJob <- localJobs
+      if localJob.executionId === executionId
+    } yield (localJob.pid, localJob.rc))
 }

--- a/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
@@ -1,12 +1,14 @@
 package cromwell.engine.db.slick
 
+import java.sql.Clob
+
 // TODO switch to UUID on WorkflowExecution rather than synthetic PK, update this to reference that.
 // TODO probably don't need a synthetic PK on this table as the WorkflowExecution ID serves that purpose.
 case class WorkflowExecutionAux
 (
   workflowExecutionId: Int,
-  wdlSource: String,
-  jsonInputs: String,
+  wdlSource: Clob,
+  jsonInputs: Clob,
   workflowExecutionAuxId: Option[Int] = None
 )
 
@@ -18,8 +20,8 @@ trait WorkflowExecutionAuxComponent {
   class WorkflowExecutionAuxes(tag: Tag) extends Table[WorkflowExecutionAux](tag, "WORKFLOW_EXECUTION_AUX") {
     def workflowExecutionAuxId = column[Int]("WORKFLOW_EXECUTION_AUX_ID", O.PrimaryKey, O.AutoInc)
     def workflowExecutionId = column[Int]("WORKFLOW_EXECUTION_ID")
-    def wdlSource = column[String]("WDL_SOURCE")
-    def jsonInputs = column[String]("JSON_INPUTS")
+    def wdlSource = column[Clob]("WDL_SOURCE")
+    def jsonInputs = column[Clob]("JSON_INPUTS")
 
     override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowExecutionAuxId.?) <>
       (WorkflowExecutionAux.tupled, WorkflowExecutionAux.unapply)

--- a/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
@@ -26,16 +26,21 @@ trait WorkflowExecutionAuxComponent {
     override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowExecutionAuxId.?) <>
       (WorkflowExecutionAux.tupled, WorkflowExecutionAux.unapply)
 
-    def workflow = foreignKey(
+    def workflowExecution = foreignKey(
       "FK_WE_AUX_WORKFLOW_EXECUTION_ID", workflowExecutionId, workflowExecutions)(_.workflowExecutionId)
 
     def uniqueKey = index("UK_WE_AUX_WORKFLOW_EXECUTION_ID",
       workflowExecutionId, unique = true)
   }
 
-  val workflowExecutionAuxes = TableQuery[WorkflowExecutionAuxes]
+  protected val workflowExecutionAuxes = TableQuery[WorkflowExecutionAuxes]
 
   val workflowExecutionAuxesAutoInc = workflowExecutionAuxes returning workflowExecutionAuxes.
     map(_.workflowExecutionAuxId) into ((a, id) => a.copy(workflowExecutionAuxId = Some(id)))
 
+  val workflowExecutionAuxesByWorkflowExecutionId = Compiled(
+    (workflowExecutionId: Rep[Int]) => for {
+      workflowExecutionAux <- workflowExecutionAuxes
+      if workflowExecutionAux.workflowExecutionId === workflowExecutionId
+    } yield workflowExecutionAux)
 }

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -12,15 +12,42 @@ import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.db.DataAccess.WorkflowInfo
 import cromwell.engine.db.LocalCallBackendInfo
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Future, ExecutionContext}
+import scala.io.Source
 
 class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
+
+  import TableDrivenPropertyChecks._
+
   implicit val ec = ExecutionContext.global
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+
+  lazy val wdlSource3Step = {
+    val resourcePath = "/3step.wdl"
+    val stream = getClass.getResourceAsStream(resourcePath)
+    stream shouldNot be(null)
+    try {
+      Source.fromInputStream(stream).mkString
+    } finally {
+      stream.close()
+    }
+  }
+
+  lazy val wdlJson3Step = {
+    // NOTE: You may need to move back any intellij reformatted lines
+    // due to the macro usage and an issue similar to these old bugs:
+    //   https://youtrack.jetbrains.com/issue/SCL-4142
+    //   https://youtrack.jetbrains.com/issue/SCL-6499
+    s"""{
+       |  "three_step.cgrep.pattern": "${"." * 10000}"
+       |}
+       | """.stripMargin
+  }
 
   // Tests against main database used for command line
   "SlickDataAccess (main.hsqldb)" should behave like databaseWithConfig("main.hsqldb", testRequired = true)
@@ -61,6 +88,26 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           workflowResult.workflowId should be(workflowId)
           workflowResult.wdlSource should be("source")
           workflowResult.wdlJson should be("{}")
+        }
+      } yield ()).futureValue
+    }
+
+    it should "create and retrieve 3step.wdl with a 10,000 char pattern" in {
+      assume(canConnect || testRequired)
+      val workflowId = UUID.randomUUID()
+      val workflowInfo = new WorkflowInfo(workflowId, wdlSource3Step, wdlJson3Step)
+
+      (for {
+        _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq.empty, new LocalBackend)
+        _ <- dataAccess.getWorkflowsByState(Seq(WorkflowSubmitted)) map { results =>
+          results shouldNot be(empty)
+
+          val workflowResultOption = results.find(_.workflowId == workflowId)
+          workflowResultOption shouldNot be(empty)
+          val workflowResult = workflowResultOption.get
+          workflowResult.workflowId should be(workflowId)
+          workflowResult.wdlSource should be(wdlSource3Step)
+          workflowResult.wdlJson should be(wdlJson3Step)
         }
       } yield ()).futureValue
     }
@@ -145,43 +192,56 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       } yield ()).futureValue
     }
 
-    it should "get initial execution status" in {
-      assume(canConnect || testRequired)
-      val workflowId = UUID.randomUUID()
-      val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, "fully.qualified.name", task, Map.empty, null)
+    // We were using call.taskFqn instead of call.fullyQualifiedName.
+    // Make sure all permutations of aliases, nested calls, & updates are working correctly.
+    val executionStatusPermutations = Table(
+      ("updateStatus", "useAlias", "setCallParent", "expectedFqn"),
+      (false, false, false, "call.name"),
+      (false, true, false, "call.alias"),
+      (true, false, false, "call.name"),
+      (true, true, false, "call.alias"),
+      (false, false, true, "workflow.name.call.name"),
+      (false, true, true, "workflow.name.call.alias"),
+      (true, false, true, "workflow.name.call.name"),
+      (true, true, true, "workflow.name.call.alias"))
 
-      (for {
-        _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call), new LocalBackend)
-        _ <- dataAccess.updateWorkflowState(workflowId, WorkflowRunning)
-        _ <- dataAccess.getExecutionStatuses(workflowId) map { result =>
-          result.size should be(1)
-          val (fqn, status) = result.head
-          fqn should be("fully.qualified.name")
-          status should be(ExecutionStatus.NotStarted)
-        }
-      } yield ()).futureValue
-    }
+    forAll(executionStatusPermutations) { (updateStatus, useAlias, setCallParent, expectedFqn) =>
 
-    it should "get updated execution status" in {
-      assume(canConnect || testRequired)
-      val workflowId = UUID.randomUUID()
-      val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, "fully.qualified.name", task, Map.empty, null)
+      val spec = "%s execution status for a call%s%s".format(
+        if (updateStatus) "updated" else "initial",
+        if (setCallParent) " in workflow" else "",
+        if (useAlias) " with alias" else "")
 
-      (for {
-        _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call), new LocalBackend)
-        _ <- dataAccess.updateWorkflowState(workflowId, WorkflowRunning)
-        _ <- dataAccess.setStatus(workflowId, Seq(call.fullyQualifiedName), ExecutionStatus.Running)
-        _ <- dataAccess.getExecutionStatuses(workflowId) map { result =>
-          result.size should be(1)
-          val (fqn, status) = result.head
-          fqn should be("fully.qualified.name")
-          status should be(ExecutionStatus.Running)
-        }
-      } yield ()).futureValue
+      val callAlias = if (useAlias) Some("call.alias") else None
+
+      it should s"get $spec" in {
+        assume(canConnect || testRequired)
+        val workflowId = UUID.randomUUID()
+        val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
+        val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
+        val call = new Call(callAlias, "call.name", task, Map.empty, null)
+        if (setCallParent)
+          call.setParent(new Workflow("workflow.name", Seq(call)))
+
+        def optionallyUpdateExecutionStatus() =
+          if (updateStatus)
+            dataAccess.setStatus(workflowId, Seq(call.fullyQualifiedName), ExecutionStatus.Running)
+          else
+            Future.successful(())
+
+        (for {
+          _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call), new LocalBackend)
+          _ <- dataAccess.updateWorkflowState(workflowId, WorkflowRunning)
+          _ <- optionallyUpdateExecutionStatus()
+          _ <- dataAccess.getExecutionStatuses(workflowId) map { result =>
+            result.size should be(1)
+            val (fqn, status) = result.head
+            fqn should be(expectedFqn)
+            status should be(if (updateStatus) ExecutionStatus.Running else ExecutionStatus.NotStarted)
+          }
+        } yield ()).futureValue
+      }
+
     }
 
     it should "fail to get an non-existent execution status" in {

--- a/src/test/scala/cromwell/engine/db/slick/TestSlickDatabase.scala
+++ b/src/test/scala/cromwell/engine/db/slick/TestSlickDatabase.scala
@@ -42,7 +42,11 @@ class TestSlickDatabase(configPath: String) {
     }
   }
 
-  lazy val slickDataAccess = new SlickDataAccess(databaseConfig, dataAccessComponent)
+  lazy val slickDataAccess =
+    if (this.databaseConfig == DatabaseConfig.databaseConfig)
+      new SlickDataAccess() // Test the no-args constructor
+    else
+      new SlickDataAccess(databaseConfig, dataAccessComponent)
 
   def useLiquibase = databaseConfig.hasPath("liquibase")
 

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -5,11 +5,11 @@ import java.io.{File, FileWriter}
 import cromwell.binding._
 
 trait SampleWdl {
-  def wdlSource(runtime: String = ""): String
+  def wdlSource(runtime: String = ""): WdlSource
 
-  val rawInputs: Map[String, Any]
+  val rawInputs: WorkflowRawInputs
 
-  def wdlJson: String = {
+  def wdlJson: WdlJson = {
     "{" + rawInputs.collect { case (k, v) => s""" "$k": "$v"""" }.mkString(",\n") + "}"
   }
 }
@@ -126,6 +126,11 @@ object SampleWdl {
 
     val PatternKey = "three_step.cgrep.pattern"
     override val rawInputs = Map(PatternKey -> "...")
+  }
+
+  object ThreeStepLargeJson extends SampleWdl {
+    override def wdlSource(runtime: String = "") = ThreeStep.wdlSource(runtime)
+    override lazy val rawInputs = Map(ThreeStep.PatternKey -> "." * 10000)
   }
 
   object CannedThreeStep extends SampleWdl {


### PR DESCRIPTION
Switched `WorkflowExecutionAux` Slick columns from `String` to `Clob`.
Added a test to store/retrieve the 441 char `/3step.wdl` resource paired with a ~10K generated json.
Fixed bug where workflow creation was storing `Call`s using `.taskFqn` instead of `.fullyQualifiedName`.
Added a set of permuted tests for regression checking fully qualified name inserts and updates.
Fixed typo in `to*Worfk*low` utility method.
Re-enabling connection pool for main and tests.
Switched off command line Hikari info & warning logging via logback.xml.