### PR TITLE
Enforce the constraint that a WdlNamespace must have a local Workflow…

### DIFF
--- a/src/main/scala/cromwell/binding/Import.scala
+++ b/src/main/scala/cromwell/binding/Import.scala
@@ -1,3 +1,17 @@
 package cromwell.binding
 
-case class Import(uri: String, namespace: Option[String])
+import cromwell.parser.WdlParser.{AstNode, Ast}
+import cromwell.parser.AstTools.EnhancedAstNode
+
+object Import {
+  def apply(astNode: AstNode): Import = {
+    val uri = astNode.asInstanceOf[Ast].getAttribute("uri").sourceString()
+    val importNamespace = Option(astNode.asInstanceOf[Ast].getAttribute("namespace"))
+    Import(uri, importNamespace)
+  }
+}
+
+// FIXME: I dislike dragging the AST along but it's necessary for "compile" time error syntax highlighting, argh
+case class Import(uri: String, namespaceAst: Option[AstNode]) {
+  val namespace: Option[String] = namespaceAst map {_.sourceString()}
+}

--- a/src/main/scala/cromwell/binding/Scope.scala
+++ b/src/main/scala/cromwell/binding/Scope.scala
@@ -1,5 +1,6 @@
 package cromwell.binding
 
+// FIXME: It'd be nice to have a notion of a parented and a not-parented Scope, see FIXME in Call about this
 trait Scope {
   def name: String
 

--- a/src/main/scala/cromwell/binding/Task.scala
+++ b/src/main/scala/cromwell/binding/Task.scala
@@ -1,7 +1,45 @@
 package cromwell.binding
 
-import cromwell.binding.command.Command
-import cromwell.binding.types.WdlType
+import cromwell.binding.command.{ParameterCommandPart, StringCommandPart, Command}
+import cromwell.binding.types._
+import cromwell.parser.AstTools.AstNodeName
+import cromwell.parser.WdlParser._
+import cromwell.parser.AstTools.{EnhancedAstNode, EnhancedAstSeq}
+import scala.collection.JavaConverters._
+import scala.language.postfixOps
+
+object Task {
+  def apply(ast: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Task = {
+    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
+
+    val dupeParamAsts = ast.findAsts(AstNodeName.CommandParameter).duplicatesByName
+    if (dupeParamAsts.nonEmpty) {
+      throw new SyntaxError(wdlSyntaxErrorFormatter.taskHasDuplicatedInputs(ast, dupeParamAsts))
+    }
+
+    val commandAsts = ast.findAsts(AstNodeName.Command)
+    if (commandAsts.size != 1) throw new UnsupportedOperationException("Expecting only one Command AST")
+    val command = Command(commandAsts.head)
+    val outputs = ast.findAsts(AstNodeName.Output) map {TaskOutput(_)}
+    new Task(name, command, outputs, buildRuntimeAttributes(ast), ast)
+  }
+
+  // TODO/FIXME: If RuntimeAttributes turned into a real type (i.e. case class) the following crap could go into its construction
+  private def buildRuntimeAttributes(ast: Ast): RuntimeAttributes = {
+    val asts = ast.findAsts(AstNodeName.Runtime)
+    if (asts.size > 1) throw new UnsupportedOperationException("Only one runtime block may be defined per task")
+    val astList = asts.headOption map {_.getAttribute("map").asInstanceOf[AstList]}
+    astList map processRuntimeAttributes getOrElse Map.empty[String, String]
+  }
+
+  private def processRuntimeAttributes(astList: AstList): RuntimeAttributes = {
+    astList.asScala.toVector map {a => processRuntimeAttribute(a.asInstanceOf[Ast])} toMap
+  }
+
+  private def processRuntimeAttribute(ast: Ast): RuntimeAttribute = {
+    (ast.getAttribute("key").sourceString(), ast.getAttribute("value").sourceString())
+  }
+}
 
 /**
  * Represents a `task` declaration in a WDL file
@@ -13,7 +51,8 @@ import cromwell.binding.types.WdlType
 case class Task(name: String,
                 command: Command,
                 outputs: Seq[TaskOutput],
-                runtimeAttributes: RuntimeAttributes) extends Executable {
+                runtimeAttributes: RuntimeAttributes,
+                ast: Ast) extends Executable { // FIXME: I dislike bundling AST here, it's only used at WdlNamespace construction time, but for now ...
   /**
    * Inputs to this task, as task-local names (i.e. not fully-qualified)
    *

--- a/src/main/scala/cromwell/binding/TaskOutput.scala
+++ b/src/main/scala/cromwell/binding/TaskOutput.scala
@@ -1,6 +1,16 @@
 package cromwell.binding
 
 import cromwell.binding.types.WdlType
-import cromwell.binding.values.WdlValue
+import cromwell.parser.AstTools.EnhancedAstNode
+import cromwell.parser.WdlParser.Ast
+
+object TaskOutput {
+  def apply(ast: Ast): TaskOutput = {
+    val wdlType = ast.getAttribute("type").wdlType
+    val name = ast.getAttribute("var").sourceString()
+    val expression = ast.getAttribute("expression")
+    new TaskOutput(name, wdlType, new WdlExpression(expression))
+  }
+}
 
 case class TaskOutput(name: String, wdlType: WdlType, expression: WdlExpression)

--- a/src/main/scala/cromwell/binding/WdlExpression.scala
+++ b/src/main/scala/cromwell/binding/WdlExpression.scala
@@ -67,7 +67,7 @@ object WdlExpression {
         }
         evaluate(a.getAttribute("lhs"), lookup, functions).map {
           case o: WdlObject => o.value.getOrElse(rhs, throw new WdlExpressionException(s"Could not find key $rhs"))
-          case ns: WdlNamespace => lookup(ns.namespace.map {n => s"$n.$rhs"}.getOrElse(rhs))
+          case ns: WdlNamespace => lookup(ns.importedAs.map {n => s"$n.$rhs"}.getOrElse(rhs))
           case _ => throw new WdlExpressionException("Left-hand side of expression must be a WdlObject or Namespace")
         }
       case a: Ast if a.getName == "FunctionCall" =>

--- a/src/main/scala/cromwell/binding/WdlNamespace.scala
+++ b/src/main/scala/cromwell/binding/WdlNamespace.scala
@@ -2,293 +2,68 @@ package cromwell.binding
 
 import java.io.File
 
-import cromwell.binding.WdlNamespace.ImportResolver
-import cromwell.binding.command._
+import cromwell.binding.command.ParameterCommandPart
 import cromwell.binding.types._
 import cromwell.binding.values.{WdlArray, WdlValue}
 import cromwell.parser.{AstTools, WdlParser}
 import cromwell.parser.WdlParser._
 import cromwell.util.FileUtil
-import AstTools.EnhancedAstNode
+import cromwell.parser.AstTools.{AstNodeName, EnhancedAstNode, EnhancedAstSeq}
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 import scala.language.postfixOps
 
 /**
- * Main interface into the `cromwell.binding` package.
- *
- * Example usage:
- *
- * {{{
- * val namespace = WdlNamespace.process(new File("/path/to/file.wdl"))
- * binding.workflow.calls foreach { call =>
- *      println(call)
- * }
- * }}}
+ * Define WdlNamespace as a sum type w/ two states - one containing a local workflow and one without.
+ * The latter is a valid state for a WDL file, however only the former can be requested to be run, so
+ * any constructs (e.g. WorkflowManagerActor) expecting to run a workflow should only take the `NamespaceWithWorkflow`
  */
+sealed trait WdlNamespace extends WdlValue {
+  final val wdlType = WdlNamespaceType
 
-object WdlNamespace {
-  type ImportResolver = String => WdlSource
-  def localImportResolver(path: String): WdlSource = readFile(new File(path))
+  def ast: Ast // FIXME: I think this is only used by the syntax highlighting, can it go away once we're built?
+  def importedAs: Option[String] // Used when imported with `as` 
+  def imports: Seq[Import] // FIXME: Change to Set?
+  def namespaces: Seq[WdlNamespace] // FIXME: Change to Set? FIXME: Rename to importedNamespaces?
+  def tasks: Seq[Task] // FIXME: Change to Set?
+  def terminalMap: Map[Terminal, WdlSource]
 
-  /**
-   * Given a pointer to a WDL file, parse the text and build Workflow and Task
-   * objects.
-   *
-   * @param wdlFile The file to parse/process
-   * @return WdlBinding object with the parsed results
-   * @throws WdlParser.SyntaxError if there was a problem parsing the source code
-   * @throws UnsupportedOperationException if an error occurred constructing the
-   *                                       Workflow and Task objects
-   *
-   */
-  def load(wdlFile: File): WdlNamespace =
-    load(readFile(wdlFile), wdlFile.toString, localImportResolver, None)
+  // Convenience method for findTask in the context of this namespace
+  def findTask(name: String): Option[Task] = WdlNamespace.findTask(name, namespaces, tasks)
 
-  def load(wdlFile: File, importResolver: ImportResolver): WdlNamespace =
-    load(readFile(wdlFile), wdlFile.toString, importResolver, None)
-
-  def load(wdlSource: WdlSource): WdlNamespace =
-    load(wdlSource, "string", localImportResolver, None)
-
-  def load(wdlSource: WdlSource, importResolver: ImportResolver): WdlNamespace =
-    load(wdlSource, "string", importResolver, None)
-
-  def load(wdlSource: WdlSource, resource: String): WdlNamespace =
-    load(wdlSource, resource, localImportResolver, None)
-
-  def load(wdlSource: WdlSource, resource: String, importResolver: ImportResolver): WdlNamespace =
-    load(wdlSource, resource, importResolver, None)
-
-  private def load(wdlSource: WdlSource, resource: String, importResolver: ImportResolver, namespace: Option[String]): WdlNamespace =
-    new WdlNamespace(AstTools.getAst(wdlSource, resource), wdlSource, importResolver, namespace)
-
-  def readFile(wdlFile: File): WdlSource = FileUtil.slurp(wdlFile)
+  override def toRawString = ???
+  override def toWdlString = ???
 }
 
-case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResolver, namespace: Option[String]) extends WdlValue {
-  val wdlType = WdlNamespaceType
-
-  import AstTools.AstNodeName
-
-  val invalidTask = Task("INVALID", Command(Seq.empty[CommandPart]), Seq.empty[TaskOutput], Map.empty[String, String])
-
-  /**
-   * All `import` statement strings at the top of the document
-   */
-  val imports = ast.getAttribute("imports").asInstanceOf[AstList].asScala.toVector.map { i =>
-    val uri = i.asInstanceOf[Ast].getAttribute("uri").sourceString()
-    val namespaceAst = i.asInstanceOf[Ast].getAttribute("namespace")
-    val namespace = if (namespaceAst == null) None else Option(namespaceAst.sourceString())
-    Import(uri, namespace)
-  }
-
-  /* WdlBinding objects for each import statement */
-  val namespaces = for {
-    i <- imports
-    source = importResolver(i.uri)
-    if source.length > 0
-  } yield WdlNamespace.load(source, i.uri, importResolver, i.namespace)
-
-  /* Create a map of Terminal -> WdlBinding */
-  val terminalMap = AstTools.terminalMap(ast, source)
-  val combinedTerminalMap = ((namespaces map {x => x.terminalMap}) ++ Seq(terminalMap)) reduce (_ ++ _)
-  val wdlSyntaxErrorFormatter = new WdlSyntaxErrorFormatter(combinedTerminalMap)
-
-  /**
-   * All imported `task` definitions for `import` statements without a namespace (e.g. no `as` clause)
-   * These tasks are considered to be in this current workspace
-   */
-  val importedTaskAsts: Seq[Ast] = namespaces flatMap { b =>
-    b.namespace match {
-      case None => b.taskAsts
-      case _ => Seq.empty[Ast]
-    }
-  }
-  val importedTasks: Seq[Task] = namespaces flatMap { b =>
-    b.namespace match {
-      case None => b.tasks
-      case _ => Seq.empty[Task]
-    }
-  }
-
-  /**
-   * All `task` definitions defined in the WDL file (i.e. not imported)
-   */
-  val localTaskAsts = ast.findAsts(AstNodeName.Task)
-  val localTasks = localTaskAsts.map(processTask)
-
-  /**
-   * All `task` definitions, including local and imported ones
-   */
-  val taskAsts = localTaskAsts ++ importedTaskAsts
-  val tasks = localTasks ++ importedTasks
-
-  /**
-   * All imported `Workflow`s
-   */
-  val importedWorkflows: Seq[Workflow] = namespaces flatMap { b =>
-    b.namespace match {
-      case None => b.workflows
-      case _ => Seq.empty[Workflow]
-    }
-  }
-
-  /**
-   * All `Workflow`s defined in the WDL file (i.e. not imported)
-   */
-  val localWorkflows = ast.findAsts(AstNodeName.Workflow).map(processWorkflow)
-
-  /**
-   * All `Workflow` definitions, including local and imported ones
-   */
-  val workflows = importedWorkflows ++ localWorkflows
-
-  lazy val workflow = workflows.head
-
-  lazy val calls = workflow.calls
-
-  /* All `Task`s and `Workflow`s */
-  val executables = workflows ++ tasks
-
-  workflows foreach { workflow =>
-    workflow.calls.foreach {
-      _.setParent(workflow)
-    }
-  }
-
-  def findTaskAst(name: String): Option[Ast] = {
-    if (name.contains(".")) {
-      val parts = name.split("\\.", 2)
-      namespaces find {_.namespace == Some(parts(0))} flatMap {_.findTaskAst(parts(1))}
-    } else {
-      taskAsts.find{t => t.getAttribute("name").sourceString == name}
-    }
-  }
-
-  def findTask(name: String): Option[Task] = {
-    if (name.contains(".")) {
-      val parts = name.split("\\.", 2)
-      namespaces find {_.namespace == Some(parts(0))} flatMap {_.findTask(parts(1))}
-    } else {
-      tasks.find(_.name == name)
-    }
-  }
-
-  private def processWorkflow(ast: Ast): Workflow = {
-    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
-    val calls = ast.findAsts(AstNodeName.Call) map processCall
-    new Workflow(name, calls)
-  }
-
-  private def processTask(ast: Ast): Task = {
-    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
-    val commandAsts = ast.findAsts(AstNodeName.Command)
-    if (commandAsts.size != 1) throw new UnsupportedOperationException("Expecting only one Command AST")
-    val command = processCommand(commandAsts.head.getAttribute("parts").asInstanceOf[AstList])
-    val outputs = ast.findAsts(AstNodeName.Output) map processTaskOutput
-    new Task(name, command, outputs, buildRuntimeAttributes(ast))
-  }
-
-  private def buildRuntimeAttributes(ast: Ast): RuntimeAttributes = {
-    val asts = ast.findAsts(AstNodeName.Runtime)
-    if (asts.size > 1) throw new UnsupportedOperationException("Only one runtime block may be defined per task")
-    val astList = asts.headOption map {_.getAttribute("map").asInstanceOf[AstList]}
-    astList map processRuntimeAttributes getOrElse Map.empty[String, String]
-  }
-
-  private def processRuntimeAttributes(astList: AstList): RuntimeAttributes = {
-    astList.asScala.toVector map {a => processRuntimeAttribute(a.asInstanceOf[Ast])} toMap
-  }
-
-  private def processRuntimeAttribute(ast: Ast): RuntimeAttribute = {
-    (ast.getAttribute("key").sourceString(), ast.getAttribute("value").sourceString())
-  }
-
-  private def processCommand(astList: AstList): Command = {
-    val parts = astList.asScala.toVector.map {
-      case x: Terminal => new StringCommandPart(x.getSourceString)
-      case x: Ast => processCommandParameter(x)
-    }
-    new Command(parts)
-  }
-
-  private def processCommandParameter(ast: Ast): ParameterCommandPart = {
-    val wdlType = processWdlType(ast.getAttribute("type"))
-    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
-    val prefix = Option(ast.getAttribute("prefix")) map { case t:Terminal => t.sourceString() }
-    val attributes = ast.getAttribute("attributes").asInstanceOf[AstList].asScala.toSeq.map { a =>
-      processCommandParameterAttr(a.asInstanceOf[Ast])
-    }.toMap
-    val postfixQuantifier = ast.getAttribute("postfix") match {
-      case t:Terminal => Some(t.sourceString())
-      case _ => None
-    }
-    new ParameterCommandPart(wdlType, name, prefix, attributes, postfixQuantifier)
-  }
-
-  private def processCommandParameterAttr(ast: Ast): (String, String) = {
-    (ast.getAttribute("key").sourceString(), ast.getAttribute("value").sourceString())
-  }
-
-  private def processTaskOutput(ast: Ast): TaskOutput = {
-    val wdlType = processWdlType(ast.getAttribute("type"))
-    val name = ast.getAttribute("var").sourceString()
-    val expression = ast.getAttribute("expression")
-    new TaskOutput(name, wdlType, new WdlExpression(expression))
-  }
-
-  private def processCall(ast: Ast): Call = {
-    val alias: Option[String] = ast.getAttribute("alias") match {
-      case x: Terminal => Option(x.getSourceString)
-      case _ => None
-    }
-    val taskName = ast.getAttribute("task").sourceString()
-    val task = findTask(taskName) getOrElse invalidTask
-    val inputs = processCallInput(ast)
-    new Call(alias, taskName, task, inputs.toMap, this)
-  }
-
-  private def processCallInput(ast: Ast): Map[String, WdlExpression] = AstTools.callInputAsts(ast).map {a =>
-    val key = a.getAttribute("key").sourceString()
-    val expression = new WdlExpression(a.getAttribute("value"))
-    (key, expression)
-  }.toMap
-
-  private def processWdlType(ast: AstNode): WdlType = {
-    ast match {
-      case t: Terminal =>
-        t.getSourceString match {
-          case WdlFileType.toWdlString => WdlFileType
-          case WdlStringType.toWdlString => WdlStringType
-          case WdlIntegerType.toWdlString => WdlIntegerType
-          case WdlFloatType.toWdlString => WdlFloatType
-          case WdlBooleanType.toWdlString => WdlBooleanType
-          case WdlObjectType.toWdlString => WdlObjectType
-        }
-      case a: Ast =>
-        val subtypes = a.getAttribute("subtype").asInstanceOf[AstList].asScala.toSeq
-        val typeTerminal = a.getAttribute("name").asInstanceOf[Terminal]
-        a.getAttribute("name").sourceString() match {
-          case "Array" =>
-            if (subtypes.size != 1) {
-              throw new SyntaxError(wdlSyntaxErrorFormatter.arrayHasOneTypeParameter(typeTerminal))
-            }
-            val member = processWdlType(subtypes.head)
-            WdlArrayType(member)
-        }
-      case null => WdlStringType
-      case t => throw new UnsupportedOperationException(s"Type not supported: $t")
-    }
-  }
-
+/**
+ * A valid Namespace which doesn't have a locally defined Workflow. This should pass any validity checking but is not
+ * directly runnable by `WorkflowManagerActor`
+ */
+case class NamespaceWithoutWorkflow(importedAs: Option[String],
+                                    imports: Seq[Import],
+                                    namespaces: Seq[WdlNamespace],
+                                    tasks: Seq[Task],
+                                    terminalMap: Map[Terminal, WdlSource],
+                                    ast: Ast) extends WdlNamespace
+/**
+ * Represents a WdlNamespace which has a local workflow, i.e. a directly runnable namespace
+ *
+ * FIXME: getCallFromMemberAccessAst was being doubly used as validator *and* runtime fetcher, thus needs that formatter. We shouldn't be doing syntax checks at runtime
+ */
+case class NamespaceWithWorkflow(importedAs: Option[String],
+                                 workflow: Workflow,
+                                 imports: Seq[Import],
+                                 namespaces: Seq[WdlNamespace],
+                                 tasks: Seq[Task],
+                                 terminalMap: Map[Terminal, WdlSource],
+                                 wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter,
+                                 ast: Ast) extends WdlNamespace {
   /**
    * Confirm all required inputs are present and attempt to coerce raw inputs to `WdlValue`s.
    * This can fail if required raw inputs are missing or if the values for a specified raw input
    * cannot be coerced to the target type of the input as specified in the namespace.
    */
   def coerceRawInputs(rawInputs: WorkflowRawInputs): Try[WorkflowCoercedInputs] = {
-
     def coerceRawInput(input: WorkflowInput): Try[Option[WdlValue]] = input.fqn match {
       case _ if rawInputs.contains(input.fqn) =>
         val rawValue = rawInputs.get(input.fqn).get
@@ -303,9 +78,9 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
             }
           case _ => coercionFailure
         }
-        /* TODO: if coercion fails above, it might be because you tried passing a single value to a parameter that can
-         * take multiple values (e.g. `${sep=" " String var+}`).  If this is the case, coerce to
-         */
+      /* TODO: if coercion fails above, it might be because you tried passing a single value to a parameter that can
+       * take multiple values (e.g. `${sep=" " String var+}`).  If this is the case, coerce to
+       */
       case _ =>
         input.optional match {
           case true => Success(None)
@@ -313,7 +88,7 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
         }
     }
 
-    val tryCoercedValues = workflows.head.inputs.map {input =>
+    val tryCoercedValues = workflow.inputs.map {input =>
       input.fqn -> coerceRawInput(input)
     }.toMap
 
@@ -329,99 +104,229 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
     }
   }
 
-  /**
-   * Validate the following things about the AST:
-   *
-   * 1) All `Call` blocks reference tasks that exist
-   * 2) All `Call` inputs reference actual variables on the corresponding task
-   * 3) Tasks do not have duplicate inputs
-   * 4) Calls do not reference the same task input more than once
-   * 5) Tasks in this namespace have unique names
-   * 6) Tasks and namespaces don't have overlapping names
-   * 7) `Call` input expressions (right-hand side) should only use the MemberAccess
-   * syntax (e.g: x.y) on WdlObjects (which include other `Call` invocations)
-   * 8) `Call` input expressions (right-hand side) should only reference identifiers
-   * that will resolve when evaluated
+  /*
+    FIXME: Originally this was called 2x - in validation and in WorkflowManagerActor. In the first case, the scaladoc
+    comment makes sense. In the latter case it doesn't seem to be a check. Is the validating circumstance checking via
+    side effect? Or the other way around?
+
+    TODO/FIXME: Is this really the right thing to be running here anyways? WTF should syntax be checked at runtime? We could get rid of the formatter
    */
-  private def validate(): Unit = {
-    val workflowAsts = ast.findAsts(AstNodeName.Workflow)
+  /** Partially evaluate MemberAccess ASTs to make sure they make sense at compile time */
+  def getCallFromMemberAccessAst(ast: Ast): Try[Call] = {
+    NamespaceWithWorkflow.getCallFromMemberAccessAst(ast, workflow, wdlSyntaxErrorFormatter)
+  }
+}
 
-    if (workflowAsts.size > 1) {
-      throw new SyntaxError(wdlSyntaxErrorFormatter.tooManyWorkflows(workflowAsts.asJava))
+/**
+ * Main interface into the `cromwell.binding` package.
+ *
+ * Example usage:
+ *
+ * {{{
+ * val namespace = WdlNamespace.process(new File("/path/to/file.wdl"))
+ * binding.workflow.calls foreach { call =>
+ *      println(call)
+ * }
+ * }}}
+ */
+object WdlNamespace {
+  /**
+   * Given a pointer to a WDL file, parse the text and build Workflow and Task
+   * objects.
+   *
+   * @param wdlFile The file to parse/process
+   * @return WdlBinding object with the parsed results
+   * @throws WdlParser.SyntaxError if there was a problem parsing the source code
+   * @throws UnsupportedOperationException if an error occurred constructing the
+   *                                       Workflow and Task objects
+   *
+   */
+  def load(wdlFile: File): WdlNamespace = {
+    load(readFile(wdlFile), wdlFile.toString, localImportResolver, None)
+  }
+
+  def load(wdlFile: File, importResolver: ImportResolver): WdlNamespace = {
+    load(readFile(wdlFile), wdlFile.toString, importResolver, None)
+  }
+
+  def load(wdlSource: WdlSource): WdlNamespace = load(wdlSource, "string", localImportResolver, None)
+
+  def load(wdlSource: WdlSource, importResolver: ImportResolver): WdlNamespace = {
+    load(wdlSource, "string", importResolver, None)
+  }
+
+  def load(wdlSource: WdlSource, resource: String): WdlNamespace = load(wdlSource, resource, localImportResolver, None)
+
+  def load(wdlSource: WdlSource, resource: String, importResolver: ImportResolver): WdlNamespace = {
+    load(wdlSource, resource, importResolver, None)
+  }
+
+  private def load(wdlSource: WdlSource, resource: String, importResolver: ImportResolver,
+                   importedAs: Option[String]): WdlNamespace = {
+    WdlNamespace(AstTools.getAst(wdlSource, resource), wdlSource, importResolver, importedAs)
+  }
+
+  /**
+   * Validates the following things about the AST:
+   *
+   * 1) Tasks do not have duplicate inputs
+   * 2) Tasks in this namespace have unique names
+   * 3) Tasks and namespaces don't have overlapping names (FIXME: Likely has to do w/ DSDEEPB-726)
+   */
+  def apply(ast: Ast, source: WdlSource, importResolver: ImportResolver, namespace: Option[String]): WdlNamespace = {
+    /**
+     * All `import` statement strings at the top of the document
+     */
+    val imports = ast.getAttribute("imports").asInstanceOf[AstList].asScala map {x => Import(x)}
+
+    /* WdlBinding objects for each import statement */
+    val namespaces: Seq[WdlNamespace] = {for {
+      i <- imports
+      source = importResolver(i.uri) if source.length > 0
+    } yield WdlNamespace.load(source, i.uri, importResolver, i.namespace)}.toSeq
+
+    /* Create a map of Terminal -> WdlBinding */
+    val terminalMap = AstTools.terminalMap(ast, source)
+    val combinedTerminalMap = ((namespaces map {x => x.terminalMap}) ++ Seq(terminalMap)) reduce (_ ++ _)
+    val wdlSyntaxErrorFormatter = new WdlSyntaxErrorFormatter(combinedTerminalMap)
+
+    /**
+     * All imported `task` definitions for `import` statements without a namespace (e.g. no `as` clause)
+     * These tasks are considered to be in this current workspace
+     */
+    val importedTasks: Seq[Task] = namespaces flatMap { b =>
+      b.importedAs match {
+        case None => b.tasks
+        case _ => Seq.empty[Task]
+      }
     }
 
-    tasks foreach {task =>
-      val taskAstsWithSameName = taskAsts filter {_.getAttribute("name").sourceString == task.name}
-      /* No two tasks can have the same name */
-      if (taskAstsWithSameName.size > 1) {
-        throw new SyntaxError(wdlSyntaxErrorFormatter.duplicateTask(taskAstsWithSameName))
-      }
-      /* A task can not have duplicated inputs */
-      val commandLineInputs = taskAstsWithSameName.head.findAsts(AstNodeName.CommandParameter)
-      commandLineInputs foreach {input =>
-        val inputName = input.getAttribute("name").sourceString()
-        val inputsWithSameName = commandLineInputs filter {_.getAttribute("name").sourceString == inputName}
-        if (inputsWithSameName.size > 1) {
-          throw new SyntaxError(wdlSyntaxErrorFormatter.taskHasDuplicatedInputs(taskAstsWithSameName.head, inputsWithSameName))
-        }
-      }
+    /**
+     * All `task` definitions defined in the WDL file (i.e. not imported)
+     */
+    val localTasks: Seq[Task] = ast.findAsts(AstNodeName.Task) map {Task(_, wdlSyntaxErrorFormatter)}
+
+    /**
+     * All `task` definitions, including local and imported ones
+     */
+    val tasks: Seq[Task] = localTasks ++ importedTasks
+
+    /* 
+     * Ensure that no namespaces collide with task names. 
+     * 
+     * It'd be simpler to get this via the `namespaces` themselves but don't have access to the correct AST, which is
+     * required by the error syntax highlighter :/ (FIXME: Or do I?)
+     */
+    for {
+      i <- imports
+      namespaceAst <- i.namespaceAst
+      task <- findTask(namespaceAst.sourceString(), namespaces, tasks)
+    } yield {throw new SyntaxError(wdlSyntaxErrorFormatter.taskAndNamespaceHaveSameName(task.ast, namespaceAst.asInstanceOf[Terminal]))}
+
+    // Detect duplicated task names
+    val dupeTaskAstsByName = tasks.map(_.ast).duplicatesByName
+    if (dupeTaskAstsByName.nonEmpty) {
+      throw new SyntaxError(wdlSyntaxErrorFormatter.duplicateTask(dupeTaskAstsByName))
     }
 
-    /* Ensure that no namespaces collide with task/workflow names */
-    ast.getAttribute("imports").asInstanceOf[AstList].asScala.toVector.foreach {i =>
-      val namespaceAst = i.asInstanceOf[Ast].getAttribute("namespace").asInstanceOf[Terminal]
-      if (namespaceAst != null) {
-        findTaskAst(namespaceAst.sourceString()) match {
-          case Some(taskAst) =>
-            throw new SyntaxError(wdlSyntaxErrorFormatter.taskAndNamespaceHaveSameName(taskAst, namespaceAst))
-          case _ =>
-        }
-        workflowAsts foreach {workflowAst =>
-          if (namespaceAst.sourceString == workflowAst.getAttribute("name").sourceString) {
-            throw new SyntaxError(wdlSyntaxErrorFormatter.workflowAndNamespaceHaveSameName(workflowAst, namespaceAst))
-          }
-        }
-      }
-    }
-
-    workflowAsts foreach { workflowAst =>
-      val workflow = localWorkflows.head
-      workflowAst.findAsts(AstNodeName.Call) foreach { callAst =>
-        val taskName = callAst.getAttribute("task").sourceString()
-        val taskAst = findTaskAst(taskName) getOrElse {
-          throw new SyntaxError(wdlSyntaxErrorFormatter.callReferencesBadTaskName(callAst, taskName))
-        }
-        val task = findTask(taskName) getOrElse {
-          throw new SyntaxError(wdlSyntaxErrorFormatter.callReferencesBadTaskName(callAst, taskName))
-        }
-
-        val callName = Option(callAst.getAttribute("alias")).getOrElse(callAst.getAttribute("task")).sourceString()
-
-        val call = workflow.calls.find{_.name == callName} getOrElse {
-          throw new SyntaxError(s"Cannot find call with name $callName")
-        }
-
-        call.inputMappings foreach { inputKv =>
-          task.inputs find { taskInput => taskInput.name == inputKv._1 } getOrElse {
-            val callInput = AstTools.callInputAsts(callAst) find {
-              _.getAttribute("key").sourceString == inputKv._1
-            } getOrElse {
-              throw new SyntaxError(s"Can't find call input: ${inputKv._1}")
-            }
-            throw new SyntaxError(wdlSyntaxErrorFormatter.callReferencesBadTaskInput(callInput, taskAst))
-          }
-
-          /* All MemberAccess ASTs that are not contained in other MemberAccess ASTs */
-          inputKv._2.ast.findTopLevelMemberAccesses().map(getCallFromMemberAccessAst).map {_.get}
-        }
-      }
+    // FIXME: Here's where I'd toSet stuff after duplications are detected
+    ast.findAsts(AstNodeName.Workflow) match {
+      case Nil => NamespaceWithoutWorkflow(namespace, imports, namespaces, tasks, terminalMap, ast)
+      case Seq(x) => NamespaceWithWorkflow(ast, x, namespace, imports, namespaces, tasks, terminalMap, wdlSyntaxErrorFormatter)
+      case doh => throw new SyntaxError(wdlSyntaxErrorFormatter.tooManyWorkflows(doh.asJava))
     }
   }
 
-  /* Partially evaluate MemberAccess ASTs to make sure they're not nonsense at compile time */
-  def getCallFromMemberAccessAst(ast: Ast): Try[Call] = {
+
+  /**
+   * Given a name, a collection of WdlNamespaces and a collection of Tasks will attempt to find a Task
+   * with that name within the WdlNamespaces
+   */
+  def findTask(name: String, namespaces: Seq[WdlNamespace], tasks: Seq[Task]): Option[Task] = {
+    if (name.contains(".")) {
+      val parts = name.split("\\.", 2)
+      /*
+        FIXME: From Scott, re more explanation:
+
+        I think this is supposed to resolve a dot-notation name by traversing into the namespaces until it finds the task... for example
+          a.b.c would first find namespace a and then findTasks(b.c) in the a namespace context
+          b.c would find namespace b inside of the a namespace context, then findtasks(c)
+          c would find task c in the b namespace context
+       */
+      namespaces find {_.importedAs == Some(parts(0))} flatMap {x => findTask(parts(1), x.namespaces, x.tasks)}
+    } else tasks.find(_.name == name)
+  }
+
+  private def localImportResolver(path: String): WdlSource = readFile(new File(path))
+  private def readFile(wdlFile: File): WdlSource = FileUtil.slurp(wdlFile)
+}
+
+object NamespaceWithWorkflow {
+  def load(wdlSource: WdlSource): NamespaceWithWorkflow = from(WdlNamespace.load(wdlSource))
+  def load(wdlSource: WdlSource, importResolver: ImportResolver): NamespaceWithWorkflow = NamespaceWithWorkflow.from(WdlNamespace.load(wdlSource, importResolver))
+  /**
+   * Used to safely cast a WdlNamespace to a NamespaceWithWorkflow. Throws an IllegalArgumentException if another
+   * form of WdlNamespace is passed to it
+   */
+  private def from(namespace: WdlNamespace): NamespaceWithWorkflow = {
+    namespace match {
+      case n: NamespaceWithWorkflow => n
+      case _ => throw new IllegalArgumentException("Namespace does not have a local workflow to run")
+    }
+  }
+
+  /**
+   * Validates:
+   * 1) All `Call` blocks reference tasks that exist
+   * 2) All `Call` inputs reference actual variables on the corresponding task
+   * 3) Calls do not reference the same task input more than once
+   * 4) `Call` input expressions (right-hand side) should only use the MemberAccess
+   * syntax (e.g: x.y) on WdlObjects (which include other `Call` invocations)
+   * 5) `Call` input expressions (right-hand side) should only reference identifiers
+   * that will resolve when evaluated
+   */
+  def apply(ast: Ast, workflowAst: Ast, namespace: Option[String], imports: Seq[Import],
+            namespaces: Seq[WdlNamespace], tasks: Seq[Task], terminalMap: Map[Terminal, WdlSource],
+            wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): NamespaceWithWorkflow = {
+    /*
+     * Ensure that no namespaces collide with workflow names.
+     *
+     * It'd be simpler to get this via the `namespaces` themselves but don't have access to the correct AST, which is
+     * required by the error syntax highlighter :/ (FIXME: Or do I?)
+     */
+    for {
+      i <- imports
+      namespaceAst <- i.namespaceAst
+      if namespaceAst.sourceString() == workflowAst.getAttribute("name").sourceString()
+    } yield {throw new SyntaxError(wdlSyntaxErrorFormatter.workflowAndNamespaceHaveSameName(workflowAst, namespaceAst.asInstanceOf[Terminal]))}
+
+    val calls = workflowAst.findAsts(AstNodeName.Call) map {Call(_, namespaces, tasks, wdlSyntaxErrorFormatter)}
+    val workflow: Workflow = Workflow(workflowAst, calls)
+
+    // FIXME: This block is run for its side effect of blowing up on the .get (I believe!) - Should there be a real syntax error?
+    // FIXME: It took me a while to understand the logic of the original code & I'm not sure this comment is correct?
+    // FIXME: Also, it'd be nice to move this validity check into Workflow if possible
+    // All MemberAccess ASTs that are not contained in other MemberAccess ASTs
+   for {
+      call <- workflow.calls
+      (name, expression) <- call.inputMappings
+      memberAccess <- expression.ast.findTopLevelMemberAccesses()
+    } yield {
+      getCallFromMemberAccessAst(memberAccess, workflow, wdlSyntaxErrorFormatter).get
+    }
+
+    new NamespaceWithWorkflow(namespace, workflow, imports, namespaces, tasks, terminalMap, wdlSyntaxErrorFormatter, ast)
+  }
+
+  // FIXME/TODO: Depending on how things work w/ the related FIXME's in the actual case class this might change. This is also being used as a validity check. I had another FIXME about this up above
+  /*
+   * Partially evaluate MemberAccess ASTs to make sure they're not nonsense at compile time
+   *
+   * MemberAccess ASTs are of the form lhs.rhs
+   */
+  def getCallFromMemberAccessAst(ast: Ast, workflow: Workflow, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Try[Call] = {
     def callFromName(name: String): Try[Call] = {
-      workflows.head.calls.find(_.name == name) match {
+      workflow.calls.find(_.name == name) match {
         case Some(c:Call) => Success(c)
         case _ => Failure(new SyntaxError(wdlSyntaxErrorFormatter.undefinedMemberAccess(ast)))
       }
@@ -429,7 +334,7 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
     val rhs = ast.getAttribute("rhs").sourceString()
 
     /**
-     * The left-hand side of a member-access AST should always be interpreted as a String
+     * The right-hand side of a member-access AST should always be interpreted as a String
      * Sometimes, the left-hand side is itself a MemberAccess AST, like in the expression
      * for `call t1` below.  In that example, callFromName("ns.ns2.task_name") would be
      * called.  In the `call t2` example, callFromName("alias") is called
@@ -449,7 +354,7 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
      */
     val lhs = callFromName(ast.getAttribute("lhs") match {
       case a: Ast => WdlExpression.toString(a)
-      case terminal: Terminal => terminal.sourceString
+      case terminal: Terminal => terminal.sourceString()
     })
 
     lhs match {
@@ -461,9 +366,4 @@ case class WdlNamespace(ast: Ast, source: WdlSource, importResolver: ImportResol
       case f => f
     }
   }
-
-  override def toRawString = ???
-  override def toWdlString = ???
-
-  validate()
 }

--- a/src/main/scala/cromwell/binding/Workflow.scala
+++ b/src/main/scala/cromwell/binding/Workflow.scala
@@ -1,6 +1,14 @@
 package cromwell.binding
 
 import cromwell.binding.types.WdlType
+import cromwell.parser.WdlParser.{Terminal, Ast}
+
+object Workflow {
+  def apply(ast: Ast, calls: Seq[Call]): Workflow = {
+    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
+    new Workflow(name, calls)
+  }
+}
 
 /**
  * Represents a `workflow` definition in WDL which currently
@@ -11,6 +19,8 @@ import cromwell.binding.types.WdlType
  * @param calls The set of `call` declarations
  */
 case class Workflow(name: String, calls: Seq[Call]) extends Executable with Scope {
+  calls foreach {c => c.setParent(this)}
+
   /** Parent node for this workflow.  Since we do not support nested
     * workflows currently, this is always `None`
     */

--- a/src/main/scala/cromwell/binding/command/Command.scala
+++ b/src/main/scala/cromwell/binding/command/Command.scala
@@ -2,11 +2,24 @@ package cromwell.binding.command
 
 import java.util.regex.Pattern
 
-import cromwell.binding.types.WdlArrayType
 import cromwell.binding.{CallInputs, TaskInput}
+import cromwell.binding.types.WdlArrayType
+import cromwell.parser.WdlParser.{Ast, AstList, Terminal}
 
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 import scala.util.Try
+
+object Command {
+  def apply(ast: Ast): Command = {
+    val parts = ast.getAttribute("parts").asInstanceOf[AstList].asScala.toVector.map {
+      case x: Terminal => new StringCommandPart(x.getSourceString)
+      case x: Ast => ParameterCommandPart(x)
+    }
+
+    new Command(parts)
+  }
+}
 
 /**
  * Represents the `command` section of a `task` definition in a WDL file.
@@ -50,6 +63,7 @@ case class Command(parts: Seq[CommandPart]) {
       TaskInput(p.name, wdlType, p.postfixQuantifier)
     }
   }
+
   /**
    * Given a map of task-local parameter names and WdlValues,
    * create a command String.

--- a/src/main/scala/cromwell/binding/command/ParameterCommandPart.scala
+++ b/src/main/scala/cromwell/binding/command/ParameterCommandPart.scala
@@ -2,11 +2,29 @@ package cromwell.binding.command
 
 import cromwell.binding.WdlExpression
 import cromwell.binding.types.WdlType
-import cromwell.binding.values.{WdlArray, WdlPrimitive, WdlString, WdlValue}
+import cromwell.binding.values.{WdlArray, WdlString, WdlPrimitive, WdlValue}
+import cromwell.parser.WdlParser.{AstList, Terminal, Ast}
+import cromwell.parser.AstTools.EnhancedAstNode
+import scala.collection.JavaConverters._
 
 object ParameterCommandPart {
   val PostfixQuantifiersThatAcceptArrays = Set("+", "*")
   val OptionalPostfixQuantifiers = Set("?", "*")
+
+  def apply(ast: Ast): ParameterCommandPart = {
+    val wdlType = ast.getAttribute("type").wdlType
+    val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
+    val prefix = Option(ast.getAttribute("prefix")) map { case t:Terminal => t.sourceString() }
+    val attributes = ast.getAttribute("attributes").asInstanceOf[AstList].asScala.toSeq.map { a =>
+      val ast = a.asInstanceOf[Ast]
+      (ast.getAttribute("key").sourceString(), ast.getAttribute("value").sourceString())
+    }.toMap
+    val postfixQuantifier = ast.getAttribute("postfix") match {
+      case t:Terminal => Some(t.sourceString())
+      case _ => None
+    }
+    new ParameterCommandPart(wdlType, name, prefix, attributes, postfixQuantifier)
+  }
 }
 
 /**

--- a/src/main/scala/cromwell/binding/package.scala
+++ b/src/main/scala/cromwell/binding/package.scala
@@ -27,8 +27,12 @@ package object binding {
   type CallOutputs = Map[FullyQualifiedName, WdlValue]
   type HostInputs = Map[String, WdlValue]
 
+  type ImportResolver = String => WdlSource
+
   /**
    * Provides a few convenience methods for specific runtime attribute keys which were defined in the WDL spec
+   *
+   * FIXME: If we made RuntimeAttributes into a proper class w/ the attr map as it's field we'd A: get better typing and B: Not need the implicit class
    */
   implicit class EnhancedRuntimeAttributes(val runtimeAttributes: RuntimeAttributes) extends AnyVal {
     def docker: Option[String] = attribute("docker")
@@ -40,8 +44,8 @@ package object binding {
   /**
    * Core data identifying a workflow including its unique ID, its namespace, and strongly typed inputs.
    */
-  case class WorkflowDescriptor(id: UUID, namespace: WdlNamespace, wdlSource: WdlSource, wdlJson: WdlJson, actualInputs: WorkflowCoercedInputs) {
-    val name = namespace.workflows.head.name
+  case class WorkflowDescriptor(id: UUID, namespace: NamespaceWithWorkflow, wdlSource: WdlSource, wdlJson: WdlJson, actualInputs: WorkflowCoercedInputs) {
+    val name = namespace.workflow.name
     val shortId = id.toString.split("-")(0)
   }
 }

--- a/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -83,9 +83,9 @@ class WorkflowManagerActor(dataAccess: DataAccess) extends Actor with CromwellAc
     val workflowId = maybeWorkflowId.getOrElse(UUID.randomUUID())
     log.info(s"$tag submitWorkflow input id = $maybeWorkflowId, effective id = $workflowId")
     val futureId = for {
-      namespace <- Future(WdlNamespace.load(wdlSource))
-      coercedInputs <- Future.fromTry(namespace.coerceRawInputs(inputs))
-      descriptor = new WorkflowDescriptor(workflowId, namespace, wdlSource, wdlJson, coercedInputs)
+      eventualNamespace <- Future(NamespaceWithWorkflow.load(wdlSource))
+      coercedInputs <- Future.fromTry(eventualNamespace.coerceRawInputs(inputs))
+      descriptor = new WorkflowDescriptor(workflowId, eventualNamespace, wdlSource, wdlJson, coercedInputs)
       workflowActor = context.actorOf(WorkflowActor.props(descriptor, backend, dataAccess))
       _ <- Future.fromTry(workflowStore.insert(workflowId, workflowActor))
     } yield {

--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -91,7 +91,7 @@ with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with Bef
   }
 
   private def buildFsmWorkflowActor(sampleWdl: SampleWdl, runtime: String) = {
-    val namespace = WdlNamespace.load(sampleWdl.wdlSource(runtime))
+    val namespace = NamespaceWithWorkflow.load(sampleWdl.wdlSource(runtime))
     // This is a test and is okay with just throwing if coerceRawInputs returns a Failure.
     val coercedInputs = namespace.coerceRawInputs(sampleWdl.rawInputs).get
     val descriptor = WorkflowDescriptor(UUID.randomUUID(), namespace, sampleWdl.wdlSource(runtime), sampleWdl.wdlJson, coercedInputs)

--- a/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -24,7 +24,7 @@ class SimpleWorkflowActorSpec extends CromwellTestkitSpec("SimpleWorkflowActorSp
   private def buildWorkflowFSMRef(sampleWdl: SampleWdl, rawInputsOverride: Option[WorkflowRawInputs] = None):
   TestFSMRef[WorkflowState, WorkflowFailure, WorkflowActor] = {
 
-    val namespace = WdlNamespace.load(sampleWdl.wdlSource())
+    val namespace = NamespaceWithWorkflow.load(sampleWdl.wdlSource())
     val rawInputs = rawInputsOverride.getOrElse(sampleWdl.rawInputs)
     val coercedInputs = namespace.coerceRawInputs(rawInputs).get
     val descriptor = WorkflowDescriptor(UUID.randomUUID(), namespace, sampleWdl.wdlSource(), sampleWdl.wdlJson, coercedInputs)

--- a/src/test/scala/cromwell/ThreeStepActorSpec.scala
+++ b/src/test/scala/cromwell/ThreeStepActorSpec.scala
@@ -17,6 +17,7 @@ object ThreeStepActorSpec {
 
 class ThreeStepActorSpec extends CromwellTestkitSpec("ThreeStepActorSpec") {
   import ThreeStepActorSpec._
+
   "A three step workflow" should {
     "best get to (three) steppin'" in {
       runWdlAndAssertOutputs(

--- a/src/test/scala/cromwell/binding/RuntimeAttributeSpec.scala
+++ b/src/test/scala/cromwell/binding/RuntimeAttributeSpec.scala
@@ -69,20 +69,20 @@ object RuntimeAttributeSpec {
                                  |}
                                """.stripMargin
 
-  val NamespaceWithRuntime = WdlNamespace.load(WorkflowWithRuntime)
-  val NamespaceWithoutRuntime = WdlNamespace.load(WorkflowWithoutRuntime)
+  val NamespaceWithRuntime = NamespaceWithWorkflow.load(WorkflowWithRuntime)
+  val NamespaceWithoutRuntime = NamespaceWithWorkflow.load(WorkflowWithoutRuntime)
 }
 
 class RuntimeAttributeSpec extends FlatSpec with Matchers {
   "WDL file with runtime" should "have runtime information" in {
-    assert(NamespaceWithRuntime.workflows.head.calls.forall {_.task.runtimeAttributes.nonEmpty})
+    assert(NamespaceWithRuntime.workflow.calls.forall {_.task.runtimeAttributes.nonEmpty})
   }
 
   it should "have docker information" in {
-    assert(NamespaceWithRuntime.workflows.head.calls forall {_.task.runtimeAttributes.docker.get == "ubuntu:latest"})
+    assert(NamespaceWithRuntime.workflow.calls forall {_.task.runtimeAttributes.docker.get == "ubuntu:latest"})
   }
 
   "WDL file without runtime" should "not have imported runtime information" in {
-    assert(NamespaceWithoutRuntime.workflows.head.calls.forall {_.task.runtimeAttributes.isEmpty})
+    assert(NamespaceWithoutRuntime.workflow.calls.forall {_.task.runtimeAttributes.isEmpty})
   }
 }

--- a/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportNamespaceAliasSpec.scala
@@ -57,38 +57,12 @@ class ThreeStepImportNamespaceAliasSpec extends FlatSpec with Matchers {
     }
   }
 
-  val namespace = WdlNamespace.load(workflowWdl, resolver _)
+  val namespace = NamespaceWithWorkflow.load(workflowWdl, resolver _)
 
-  "WDL file with imports" should "Have 1 executable (1 workflow)" in {
-    namespace.executables.size shouldEqual 1
-  }
-  it should "Have 0 tasks (3 tasks are in separate namespace)" in {
+  "WDL file with imports" should "Have 0 tasks (3 tasks are in separate namespace)" in {
     namespace.tasks.size shouldEqual 0
   }
-  it should "Have 0 task ASTs" in {
-    namespace.taskAsts.size shouldEqual 0
-  }
-  it should "Have 0 local tasks" in {
-    namespace.localTasks.size shouldEqual 0
-  }
-  it should "Have 0 local task ASTs" in {
-    namespace.localTaskAsts.size shouldEqual 0
-  }
-  it should "Have 0 imported tasks" in {
-    namespace.importedTasks.size shouldEqual 0
-  }
-  it should "Have 0 imported task ASTs" in {
-    namespace.importedTaskAsts.size shouldEqual 0
-  }
-  it should "Have 1 workflow" in {
-    namespace.workflows.size shouldEqual 1
-  }
-  it should "Have 1 local workflow" in {
-    namespace.localWorkflows.size shouldEqual 1
-  }
-  it should "Have 0 imported workflow" in {
-    namespace.importedWorkflows.size shouldEqual 0
-  }
+
   it should "Have 3 imported WdlBindings" in {
     namespace.namespaces.size shouldEqual 3
   }
@@ -96,7 +70,7 @@ class ThreeStepImportNamespaceAliasSpec extends FlatSpec with Matchers {
     namespace.namespaces flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Have 3 calls in the workflow, 2 of them aliased" in {
-    namespace.workflows flatMap {_.calls} map {_.name} shouldEqual Seq("a1", "a2", "ns3.wc")
+    namespace.workflow.calls map {_.name} shouldEqual Seq("a1", "a2", "ns3.wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
     def badResolver(s: String): String = {

--- a/src/test/scala/cromwell/binding/ThreeStepImportNamespaceSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportNamespaceSpec.scala
@@ -57,37 +57,11 @@ class ThreeStepImportNamespaceSpec extends FlatSpec with Matchers {
     }
   }
 
-  val namespace = WdlNamespace.load(workflowWdl, resolver _)
+  val namespace = NamespaceWithWorkflow.load(workflowWdl, resolver _)
 
-  "WDL file with imports" should "Have 1 executable (1 workflow)" in {
-    namespace.executables.size shouldEqual 1
-  }
-  it should "Have 0 tasks (3 tasks are in separate namespace)" in {
+
+  "WDL file with imports" should "Have 0 tasks (3 tasks are in separate namespace)" in {
     namespace.tasks.size shouldEqual 0
-  }
-  it should "Have 0 task ASTs" in {
-    namespace.taskAsts.size shouldEqual 0
-  }
-  it should "Have 0 local tasks" in {
-    namespace.localTasks.size shouldEqual 0
-  }
-  it should "Have 0 local task ASTs" in {
-    namespace.localTaskAsts.size shouldEqual 0
-  }
-  it should "Have 0 imported tasks" in {
-    namespace.importedTasks.size shouldEqual 0
-  }
-  it should "Have 0 imported task ASTs" in {
-    namespace.importedTaskAsts.size shouldEqual 0
-  }
-  it should "Have 1 workflow" in {
-    namespace.workflows.size shouldEqual 1
-  }
-  it should "Have 1 local workflow" in {
-    namespace.localWorkflows.size shouldEqual 1
-  }
-  it should "Have 0 imported workflow" in {
-    namespace.importedWorkflows.size shouldEqual 0
   }
   it should "Have 3 imported WdlBindings" in {
     namespace.namespaces.size shouldEqual 3

--- a/src/test/scala/cromwell/binding/ThreeStepImportSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepImportSpec.scala
@@ -57,38 +57,12 @@ class ThreeStepImportSpec extends FlatSpec with Matchers {
     }
   }
 
-  val namespace = WdlNamespace.load(workflowWdl, resolver _)
+  val namespace = NamespaceWithWorkflow.load(workflowWdl, resolver _)
 
-  "WDL file with imports" should "Have 4 executables (3 tasks, 1 workflow)" in {
-    namespace.executables.size shouldEqual 4
-  }
-  it should "Have 3 tasks" in {
+  "WDL file with imports" should "Have 3 tasks" in {
     namespace.tasks.size shouldEqual 3
   }
-  it should "Have 3 task ASTs" in {
-    namespace.taskAsts.size shouldEqual 3
-  }
-  it should "Have 0 local tasks" in {
-    namespace.localTasks.size shouldEqual 0
-  }
-  it should "Have 0 local task ASTs" in {
-    namespace.localTaskAsts.size shouldEqual 0
-  }
-  it should "Have 3 imported tasks" in {
-    namespace.importedTasks.size shouldEqual 3
-  }
-  it should "Have 3 imported task ASTs" in {
-    namespace.importedTaskAsts.size shouldEqual 3
-  }
-  it should "Have 1 workflow" in {
-    namespace.workflows.size shouldEqual 1
-  }
-  it should "Have 1 local workflow" in {
-    namespace.localWorkflows.size shouldEqual 1
-  }
-  it should "Have 0 imported workflow" in {
-    namespace.importedWorkflows.size shouldEqual 0
-  }
+
   it should "Have 3 imported WdlBindings" in {
     namespace.namespaces.size shouldEqual 3
   }

--- a/src/test/scala/cromwell/binding/ThreeStepSpec.scala
+++ b/src/test/scala/cromwell/binding/ThreeStepSpec.scala
@@ -6,36 +6,28 @@ import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpec, Matchers}
 
 class ThreeStepSpec extends FlatSpec with Matchers {
-  val namespace = WdlNamespace.load(SampleWdl.ThreeStep.wdlSource())
+  val namespace = NamespaceWithWorkflow.load(SampleWdl.ThreeStep.wdlSource())
 
-  "Binding Workflow" should "Have one workflow definition" in {
-    namespace.workflows.size shouldEqual 1
-  }
-  it should "Have zero imported workflow definition" in {
-    namespace.importedWorkflows.size shouldEqual 0
-  }
-  it should "Have correct name for workflow" in {
-    namespace.workflows.head.name shouldEqual "three_step"
+  "Binding Workflow" should "Have correct name for workflow" in {
+    namespace.workflow.name shouldEqual "three_step"
   }
   it should "Have correct FQN" in {
-    namespace.workflows.head.fullyQualifiedName shouldEqual "three_step"
+    namespace.workflow.fullyQualifiedName shouldEqual "three_step"
   }
   it should "Have no parent" in {
-    namespace.workflows.head.parent shouldEqual None
+    namespace.workflow.parent shouldEqual None
   }
   it should "Have three 'Call' objects" in {
-    namespace.workflows.head.calls.size shouldEqual 3
+    namespace.workflow.calls.size shouldEqual 3
   }
   it should "Have three outputs" in {
-    namespace.workflows.head.outputs.size shouldEqual 3
+    namespace.workflow.outputs.size shouldEqual 3
   }
 
   "Binding Tasks" should "Have three task definitions" in {
     namespace.tasks.size shouldEqual 3
   }
-  it should "Have zero imported tasks" in {
-    namespace.importedTasks.size shouldEqual 0
-  }
+
   it should "Have a task with name 'wc'" in {
     val task = namespace.findTask("wc") getOrElse fail("No 'wc' task found")
     task.name shouldEqual "wc"

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -191,10 +191,9 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
         assume(canConnect || testRequired)
         val workflowId = UUID.randomUUID()
         val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-        val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-        val call = new Call(callAlias, "call.name", task, Map.empty, null)
-        if (setCallParent)
-          call.setParent(new Workflow("workflow.name", Seq(call)))
+        val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+        val call = new Call(callAlias, "call.name", task, Map.empty)
+        if (setCallParent) new Workflow("workflow.name", Seq(call))
 
         def optionallyUpdateExecutionStatus() =
           if (updateStatus)
@@ -230,8 +229,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = true)
       val entry = new SymbolStoreEntry(key, WdlStringType, Option(new WdlString("testStringValue")))
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq(entry), Seq.empty, localBackend)
@@ -269,8 +268,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val symbolLqn = "symbol"
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq.empty, localBackend)
@@ -297,8 +296,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val symbolLqn = "symbol"
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq.empty, localBackend)
@@ -336,8 +335,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val callFqn = "call.fully.qualified.scope"
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call),
         UnknownBackend).failed.futureValue should be(an[IllegalArgumentException])
@@ -348,8 +347,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val callFqn = "call.fully.qualified.scope"
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call),
         null).failed.futureValue should be(an[IllegalArgumentException])
@@ -364,8 +363,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = true)
       val entry = new SymbolStoreEntry(key, WdlStringType, Option(new WdlString("testStringValue")))
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq(entry), Seq.empty, localBackend)
@@ -395,8 +394,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = false)
       val entry = new SymbolStoreEntry(key, WdlStringType, Option(new WdlString("testStringValue")))
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, callFqn, task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, callFqn, task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq(entry), Seq.empty, localBackend)
@@ -409,8 +408,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       assume(canConnect || testRequired)
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, "fully.qualified.name", task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, "fully.qualified.name", task, Map.empty)
       val backendInfo = new LocalCallBackendInfo(ExecutionStatus.Running, Option(123), Option(456))
 
       (for {
@@ -436,8 +435,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       val workflowId2 = UUID.randomUUID()
       val workflowInfo1 = new WorkflowInfo(workflowId1, "source", "{}")
       val workflowInfo2 = new WorkflowInfo(workflowId2, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, "fully.qualified.name", task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, "fully.qualified.name", task, Map.empty)
       val backendInfo1 = new LocalCallBackendInfo(ExecutionStatus.Running, Option(123), Option(456))
       val backendInfo2 = new LocalCallBackendInfo(ExecutionStatus.Failed, Option(321), Option(654))
 
@@ -473,8 +472,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       assume(canConnect || testRequired)
       val workflowId = UUID.randomUUID()
       val workflowInfo = new WorkflowInfo(workflowId, "source", "{}")
-      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty)
-      val call = new Call(None, "fully.qualified.name", task, Map.empty, null)
+      val task = new Task("taskName", new Command(Seq.empty), Seq.empty, Map.empty, null)
+      val call = new Call(None, "fully.qualified.name", task, Map.empty)
 
       (for {
         _ <- dataAccess.createWorkflow(workflowInfo, Seq.empty, Seq(call), localBackend)

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -39,6 +39,25 @@ object SampleWdl {
     val OutputValue = "Hello world!\n"
   }
 
+  object HelloWorldWithoutWorkflow extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """
+        |task hello {
+        |  command {
+        |    echo "Hello ${addressee}!"
+        |  }
+        |  output {
+        |    String salutation = read_string(stdout())
+        |  }
+        |}
+      """.stripMargin
+
+    val Addressee = "hello.hello.addressee"
+    val rawInputs = Map(Addressee -> "world")
+    val OutputKey = "hello.hello.salutation"
+    val OutputValue = "Hello world!\n"
+  }
+
   object GoodbyeWorld extends SampleWdl {
     override def wdlSource(runtime: String = "") =
       """


### PR DESCRIPTION
… if it'll be run.

- Convert WdlNamespace into a sum type w/ a worfklowless and workflowed version
- Workflowless namespaces are valid but not runnable
- Decompose monolithic WdlNamespace constructor to separate local workflow logic into workflowed namespaces only
- Decompose validation logic of a Namespace's component parts into the construction of those parts
- Minor refactorings
- Many FIXMEs posing as TODOs and TODOs as well
- Some commentary on old stuff I found particularly confusing in an attempt to work through them