### PR TITLE
Allow parameters with duplicated name under some circumstances

### DIFF
--- a/src/main/scala/cromwell/binding/WdlSyntaxErrorFormatter.scala
+++ b/src/main/scala/cromwell/binding/WdlSyntaxErrorFormatter.scala
@@ -186,4 +186,20 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WdlSource]) extend
        |${pointToSource(location)}
      """.stripMargin
   }
+
+  def parametersWithSameNameMustHaveSameDefinition(taskName: Terminal, firstParam: Terminal, secondParam: Terminal) = {
+    s"""ERROR: Task ${taskName.getSourceString} has input '${firstParam.getSourceString}' which is defined twice
+        |with conficting definitions:
+        |
+        |${pointToSource(secondParam)}
+        |
+        |first definition of parameter is here:
+        |
+        |${pointToSource(firstParam)}
+        |
+        |Task defined here (line ${taskName.getLine}, col ${taskName.getColumn}):
+        |
+        |${pointToSource(taskName)}
+     """.stripMargin
+  }
 }

--- a/src/main/scala/cromwell/binding/command/Command.scala
+++ b/src/main/scala/cromwell/binding/command/Command.scala
@@ -54,13 +54,18 @@ object Command {
 case class Command(parts: Seq[CommandPart]) {
   val ws = Pattern.compile("[\\ \\t]+")
   def inputs: Seq[TaskInput] = {
-    parts.collect {case p: ParameterCommandPart => p}.map {p =>
+    val collectedInputs = parts.collect {case p: ParameterCommandPart => p}.map {p =>
       // TODO: if postfix quantifier is + or *, then the type must be a primitive.
       val wdlType = p.postfixQuantifier match {
         case Some(x) if ParameterCommandPart.PostfixQuantifiersThatAcceptArrays.contains(x) => WdlArrayType(p.wdlType)
         case _ => p.wdlType
       }
       TaskInput(p.name, wdlType, p.postfixQuantifier)
+    }
+
+    /* It is assumed here that all TaskInputs with the same name are identically defined, this filters out duplicates by name */
+    collectedInputs.map {_.name}.distinct.map {name =>
+      collectedInputs.filter {_.name == name}.head
     }
   }
 

--- a/src/test/scala/cromwell/binding/SameNameParametersSpec.scala
+++ b/src/test/scala/cromwell/binding/SameNameParametersSpec.scala
@@ -1,0 +1,24 @@
+package cromwell.binding
+
+import cromwell.binding.types.WdlStringType
+import cromwell.binding.values.WdlString
+import org.scalatest.{FlatSpec, Matchers}
+
+class SameNameParametersSpec extends FlatSpec with Matchers {
+  val namespace1 = NamespaceWithWorkflow.load(
+    """
+       |task test {
+       |  command { ./script ${String x} ${String x} ${x} }
+       |}
+       |workflow wf { call test }
+     """.stripMargin
+  )
+
+  "A task with command that uses the same parameter more than once" should "only count it as one input" in {
+    namespace1.findTask("test").get.inputs shouldEqual Seq(TaskInput(name="x", wdlType=WdlStringType))
+  }
+
+  it should "instantiate the command with duplicated parameter names properly" in {
+    namespace1.findTask("test").get.command.instantiate(Map("x" -> WdlString("foo"))).get shouldEqual "./script foo foo foo"
+  }
+}

--- a/src/test/scala/cromwell/binding/SyntaxErrorSpec.scala
+++ b/src/test/scala/cromwell/binding/SyntaxErrorSpec.scala
@@ -169,13 +169,21 @@ class SyntaxErrorSpec extends FlatSpec with Matchers {
         |}
         |""".stripMargin)
   }
-  it should "detect if a task has duplicated inputs" in {
+  it should "detect incompatible types for same input" in {
     expectError("""
-        |task ps {command{ps ${bad} ${bad}}}
-        |workflow three_step {
-        |  call ps
-        |}
-        |""".stripMargin)
+      |task test {
+      |  command { ./script ${String x} ${File x} ${x} }
+      |}
+      |workflow wf { call test }
+    """.stripMargin)
+  }
+  it should "detect when an input is defined differently at least once" in {
+    expectError("""
+      |task test {
+      |  command { ./script ${default="bar" String x?} ${String x} ${x} }
+      |}
+      |workflow wf { call test }
+    """.stripMargin)
   }
   it should "detect unexpected EOF" in {
     expectError("workflow")


### PR DESCRIPTION
This will ensure that if you use a variable declaration twice that they must be identical definitions.  Not perfect, but handles the majority case easily.