### PR TITLE
Convert util cruft to enhanced implicit classes

### DIFF
--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -2,7 +2,7 @@ package cromwell
 
 import java.io.File
 import java.nio.file.Paths
-
+import cromwell.util.FileUtil.{EnhancedFile, EnhancedPath}
 import cromwell.binding.formatter.{AnsiSyntaxHighlighter, SyntaxFormatter}
 import cromwell.binding.{AstTools, _}
 import cromwell.engine.workflow.SingleWorkflowRunnerActor
@@ -77,8 +77,8 @@ object Main extends App {
     Log.info(s"  Inputs: ${args(1)}")
 
     try {
-      val wdlSource = FileUtil.slurp(Paths.get(args(0)))
-      val wdlJson = FileUtil.slurp(Paths.get(args(1)))
+      val wdlSource = Paths.get(args(0)).slurp
+      val wdlJson = Paths.get(args(1)).slurp
       val jsValue = wdlJson.parseJson
 
       val inputs: binding.WorkflowRawInputs = jsValue match {

--- a/src/main/scala/cromwell/binding/AstTools.scala
+++ b/src/main/scala/cromwell/binding/AstTools.scala
@@ -6,7 +6,7 @@ import cromwell.binding.types._
 import cromwell.binding.values._
 import cromwell.parser.WdlParser
 import cromwell.parser.WdlParser._
-import cromwell.util.FileUtil
+import cromwell.util.FileUtil._
 
 import scala.collection.JavaConverters._
 
@@ -98,7 +98,7 @@ object AstTools {
    * @return an Abstract Syntax Tree (WdlParser.Ast) representing the structure of the code
    * @throws WdlParser.SyntaxError if there was a problem parsing the source code
    */
-  def getAst(wdlFile: File): Ast = getAst(FileUtil.slurp(wdlFile), wdlFile.getName)
+  def getAst(wdlFile: File): Ast = getAst(wdlFile.slurp, wdlFile.getName)
 
   def findAsts(ast: AstNode, name: String): Seq[Ast] = {
     ast match {

--- a/src/main/scala/cromwell/binding/WdlNamespace.scala
+++ b/src/main/scala/cromwell/binding/WdlNamespace.scala
@@ -8,6 +8,8 @@ import cromwell.binding.types._
 import cromwell.binding.values._
 import cromwell.parser.WdlParser
 import cromwell.parser.WdlParser._
+import cromwell.util.FileUtil.EnhancedFile
+import AstTools.{AstNodeName, EnhancedAstNode, EnhancedAstSeq}
 import cromwell.util.FileUtil
 
 import scala.collection.JavaConverters._
@@ -95,7 +97,7 @@ case class NamespaceWithWorkflow(importedAs: Option[String],
       Try(for {
         (key, tryValue) <- successes
         optionValue = tryValue.get if tryValue.get.isDefined
-      } yield (key -> optionValue.get))
+      } yield key -> optionValue.get)
     } else {
       val message = failures.values.collect { case f: Failure[_] => f.exception.getMessage }.mkString("\n")
       Failure(new UnsatisfiedInputsException(s"The following errors occurred while processing your inputs:\n\n$message"))
@@ -301,7 +303,7 @@ object WdlNamespace {
   }
 
   private def localImportResolver(path: String): WdlSource = readFile(new File(path))
-  private def readFile(wdlFile: File): WdlSource = FileUtil.slurp(wdlFile)
+  private def readFile(wdlFile: File): WdlSource = wdlFile.slurp
 }
 
 object NamespaceWithWorkflow {

--- a/src/main/scala/cromwell/engine/backend/local/LocalEngineFunctions.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalEngineFunctions.scala
@@ -5,9 +5,8 @@ import java.nio.file.Paths
 import cromwell.binding.types.{WdlArrayType, WdlStringType}
 import cromwell.binding.values._
 import cromwell.engine.EngineFunctions
-import cromwell.util.FileUtil
-
-import scala.util.{Failure, Success, Try}
+import cromwell.util.FileUtil.EnhancedPath
+import scala.util.{Success, Failure, Try}
 
 class LocalEngineFunctions(executionContext: TaskExecutionContext) extends EngineFunctions {
 
@@ -30,8 +29,8 @@ class LocalEngineFunctions(executionContext: TaskExecutionContext) extends Engin
    */
   private def fileContentsToString(value: WdlValue): String = {
     value match {
-      case f: WdlFile => FileUtil.slurp(f.value)
-      case s: WdlString => FileUtil.slurp(executionContext.cwd.resolve(s.value))
+      case f: WdlFile => f.value.slurp
+      case s: WdlString => executionContext.cwd.resolve(s.value).slurp
       case e => throw new UnsupportedOperationException("Unsupported argument " + e)
     }
   }

--- a/src/main/scala/cromwell/util/FileUtil.scala
+++ b/src/main/scala/cromwell/util/FileUtil.scala
@@ -4,18 +4,10 @@ import java.io.{BufferedWriter, File, FileWriter, Writer}
 import java.nio.file.Path
 
 object FileUtil {
-
-  /** Build a `Writer` for the specified `File`, return the tuple of both. */
-  def fileAndWriter(file: Path): (Path, Writer) = {
-    val writer = new BufferedWriter(new FileWriter(file.toFile))
-    (file, writer)
-  }
-
   /** Build a temp file with the specified base name and an associated writer,
     * return the tuple of both. */
   def tempFileAndWriter(baseName: String, directory: File = null): (Path, Writer) = {
-    val file = File.createTempFile(baseName, ".tmp", directory).toPath
-    fileAndWriter(file)
+    File.createTempFile(baseName, ".tmp", directory).toPath.fileAndWriter
   }
 
   implicit class FlushingAndClosingWriter(writer: Writer) {
@@ -26,12 +18,20 @@ object FileUtil {
     }
   }
 
-  /** Read an entire file into a string, closing the underlying stream. */
-  def slurp(path: Path): String = slurp(path.toFile)
+  implicit class EnhancedFile(val file: File) extends AnyVal {
+    /** Read an entire file into a string, closing the underlying stream. */
+    def slurp: String = {
+      val source = io.Source.fromFile(file)
+      try source.mkString finally source.close()
+    }
+  }
 
-  /** Read an entire file into a string, closing the underlying stream. */
-  def slurp(file: File): String = {
-    val source = io.Source.fromFile(file)
-    try source.mkString finally source.close()
+  implicit class EnhancedPath(val path: Path) extends AnyVal {
+    def slurp = path.toFile.slurp
+
+    def fileAndWriter: (Path, Writer) = {
+      val writer = new BufferedWriter(new FileWriter(path.toFile))
+      (path, writer)
+    }
   }
 }


### PR DESCRIPTION
Minor change to FileUtil to convert to an enhanced class pattern instead of util functions.

Reviewable now, but hold off on merging until the end of the sprint.