### PR TITLE
WMA now reads directly read from dataAccess

### DIFF
--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -62,6 +62,10 @@ package object engine {
       val key = SymbolStoreKey(scope, name, iteration = None, input)
       SymbolStoreEntry(key, wdlValue.wdlType, Some(wdlValue))
     }
+
+    def toWorkflowOutputs(t: Traversable[SymbolStoreEntry]): WorkflowOutputs = t.map { e =>
+      s"${e.key.scope}.${e.key.name}" -> e.wdlValue.get
+    }.toMap
   }
 
   case class SymbolStoreKey(scope: String, name: String, iteration: Option[Int], input: Boolean)

--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -14,7 +14,7 @@ import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.db.DataAccess
 import cromwell.engine.workflow.WorkflowActor
 import cromwell.engine.workflow.WorkflowActor._
-import cromwell.engine.{WorkflowRunning, WorkflowSubmitted, WorkflowSucceeded}
+import cromwell.engine.{WorkflowFailed, WorkflowRunning, WorkflowSubmitted, WorkflowSucceeded}
 import cromwell.util.SampleWdl
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -123,7 +123,8 @@ with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with Bef
       fsm ! Start
       within(5 seconds) {
         awaitCond(fsm.stateName == WorkflowRunning)
-        awaitCond(fsm.stateName == WorkflowSucceeded)
+        awaitCond(fsm.stateName.isTerminal)
+        fsm.stateData should be(NoFailureMessage)
         val outputs = fsm.ask(GetOutputs).mapTo[WorkflowOutputs].futureValue
 
         expectedOutputs foreach { case (outputFqn, expectedValue) =>

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -564,7 +564,7 @@ object SampleWdl {
       """
         |task cat {
         |  command {
-        |    cat ${File file} ${flags?}
+        |    cat ${flags?} ${File file}
         |  }
         |  output {
         |    File procs = stdout()


### PR DESCRIPTION
Previously only returned outputs for in-memory workflows.
With DSDEEPB-364 storing outputs for JES in the db, this should satisfy DSDEEPB-393
Also added slightly faster debugging of failed workflow tests, with the `fsm.stateData` of why the test actually failed, instead of just timing out.
TODO: For even more helpful debugging, print stderr during tests, or capture tail of stderr to `fsm.stateData` object.