### PR TITLE
Adding some Array features that were missing

### DIFF
--- a/src/main/scala/cromwell/binding/WdlNamespace.scala
+++ b/src/main/scala/cromwell/binding/WdlNamespace.scala
@@ -137,7 +137,11 @@ case class NamespaceWithWorkflow(importedAs: Option[String],
     val evaluatedDeclarations = allDeclarations.filter {_.expression.isDefined}.map {decl =>
       val value = decl.expression.get.evaluate(declarationLookupFunction(decl, collected.toMap ++ userInputs), new NoFunctions)
       collected += (decl.fullyQualifiedName -> value.get)
-      decl.fullyQualifiedName -> value
+      val coercedValue = value match {
+        case Success(s) => decl.wdlType.coerceRawValue(s)
+        case f => f
+      }
+      decl.fullyQualifiedName -> coercedValue
     }.toMap
 
     val (successes, failures) = evaluatedDeclarations.partition {case (_, tryValue) => tryValue.isSuccess}

--- a/src/main/scala/cromwell/binding/types/WdlArrayType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlArrayType.scala
@@ -1,6 +1,6 @@
 package cromwell.binding.types
 
-import cromwell.binding.values.WdlArray
+import cromwell.binding.values.{WdlFile, WdlString, WdlArray}
 import spray.json.JsArray
 
 case class WdlArrayType(memberType: WdlType) extends WdlType {
@@ -14,5 +14,10 @@ case class WdlArrayType(memberType: WdlType) extends WdlType {
   override protected def coercion = {
     case s: Seq[Any] if s.nonEmpty => coerceIterable(s)
     case js: JsArray if js.elements.nonEmpty => coerceIterable(js.elements)
+    case wdlArray: WdlArray => wdlArray.wdlType.memberType match {
+      case WdlStringType if memberType == WdlFileType =>
+        // Coerce Array[String] -> Array[File]
+        WdlArray(WdlArrayType(WdlFileType), wdlArray.value.map(str => WdlFile(str.asInstanceOf[WdlString].value)).toList)
+    }
   }
 }

--- a/src/main/scala/cromwell/binding/types/WdlBooleanType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlBooleanType.scala
@@ -13,6 +13,7 @@ case object WdlBooleanType extends WdlPrimitiveType {
     case s: JsString if s.value.equalsIgnoreCase("true") => WdlBoolean.True
     case s: JsString if s.value.equalsIgnoreCase("false") => WdlBoolean.False
     case s: JsBoolean => WdlBoolean(s.value)
+    case b: WdlBoolean => b
   }
 
   override def fromWdlString(rawString: String) = WdlBoolean(rawString.toBoolean)

--- a/src/main/scala/cromwell/binding/types/WdlFileType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlFileType.scala
@@ -9,5 +9,6 @@ case object WdlFileType extends WdlPrimitiveType {
   override protected def coercion = {
     case s: String => WdlFile(s)
     case s: JsString => WdlFile(s.value)
+    case f: WdlFile => f
   }
 }

--- a/src/main/scala/cromwell/binding/types/WdlFloatType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlFloatType.scala
@@ -9,6 +9,7 @@ case object WdlFloatType extends WdlPrimitiveType {
   override protected def coercion = {
     case d: Double => WdlFloat(d)
     case n: JsNumber => WdlFloat(n.value.doubleValue())
+    case f: WdlFloat => f
   }
 
   override def fromWdlString(rawString: String) = WdlFloat(rawString.toFloat)

--- a/src/main/scala/cromwell/binding/types/WdlIntegerType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlIntegerType.scala
@@ -9,6 +9,7 @@ case object WdlIntegerType extends WdlPrimitiveType {
   override protected def coercion = {
     case i: Integer => WdlInteger(i)
     case n: JsNumber => WdlInteger(n.value.intValue())
+    case i: WdlInteger => i
   }
 
   override def fromWdlString(rawString: String) = WdlInteger(rawString.toInt)

--- a/src/main/scala/cromwell/binding/types/WdlStringType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlStringType.scala
@@ -9,5 +9,6 @@ case object WdlStringType extends WdlPrimitiveType {
   override protected def coercion = {
     case s: String => WdlString(s)
     case s: JsString => WdlString(s.value)
+    case s: WdlString => s
   }
 }

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -221,12 +221,19 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
   /* Return a Markdown table of all entries in the database */
   private def symbolsMarkdownTable(): Option[String] = {
     val header = Seq("SCOPE","NAME","I/O","TYPE","VALUE")
+    val max_col_chars = 100
     val rows = fetchAllEntries.map { entry =>
       val valueString = entry.wdlValue match {
         case Some(value) => s"(${value.wdlType.toWdlString}) " + value.valueString
         case _ => ""
       }
-      Seq(entry.key.scope, entry.key.name, if (entry.key.input) "INPUT" else "OUTPUT", entry.wdlType.toWdlString, valueString)
+      Seq(
+        entry.key.scope,
+        entry.key.name,
+        if (entry.key.input) "INPUT" else "OUTPUT",
+        entry.wdlType.toWdlString,
+        if (valueString.length > max_col_chars) valueString.substring(0, max_col_chars) else valueString
+      )
     }.toSeq
     rows match {
       case r:Seq[Seq[String]] if r.isEmpty => None

--- a/src/test/scala/cromwell/ArrayWorkflowSpec.scala
+++ b/src/test/scala/cromwell/ArrayWorkflowSpec.scala
@@ -1,13 +1,24 @@
 package cromwell
 
+import java.nio.file.{Paths, Files}
+import java.util.UUID
+
 import akka.testkit._
-import cromwell.binding.types.{WdlFileType, WdlArrayType}
-import cromwell.binding.values.{WdlInteger, WdlFile, WdlArray, WdlString}
+import cromwell.CromwellSpec.DockerTest
+import cromwell.binding.{WdlFunctions, NamespaceWithWorkflow, WdlNamespace}
+import cromwell.binding.types.{WdlStringType, WdlFileType, WdlArrayType}
+import cromwell.binding.values.{WdlInteger, WdlArray, WdlFile, WdlString}
+import cromwell.engine.backend.local.LocalBackend
+import cromwell.parser.BackendType
 import cromwell.util.SampleWdl
 
 import scala.language.postfixOps
 
 class ArrayWorkflowSpec extends CromwellTestkitSpec("ArrayWorkflowSpec") {
+  val tmpDir = Files.createTempDirectory("ArrayWorkflowSpec")
+  val ns = NamespaceWithWorkflow.load(SampleWdl.ArrayLiteral(tmpDir).wdlSource(""), BackendType.LOCAL)
+  val expectedArray = WdlArray(WdlArrayType(WdlFileType), Seq(WdlFile("f1"), WdlFile("f2"), WdlFile("f3")))
+
   "A task which contains a parameter " should {
     "accept an array for the value" in {
       runWdlAndAssertOutputs(
@@ -18,6 +29,54 @@ class ArrayWorkflowSpec extends CromwellTestkitSpec("ArrayWorkflowSpec") {
           "wf.count_lines_array.count" -> WdlInteger(3)
         )
       )
+    }
+  }
+
+  "A static Array[File] declaration" should {
+    "be a valid declaration" in {
+      val declaration = ns.workflow.declarations.find {_.name == "arr"}.getOrElse {
+        fail("Expected declaration 'arr' to be found")
+      }
+      val expression = declaration.expression.getOrElse {
+        fail("Expected an expression for declaration 'arr'")
+      }
+      class NoFunctions extends WdlFunctions {
+        def getFunction(name: String): WdlFunction = fail("No functions should be called in this test")
+      }
+      val value = expression.evaluate((s:String) => fail("No lookups"), new NoFunctions()).getOrElse {
+        fail("Expected expression for 'arr' to evaluate")
+      }
+      value shouldEqual WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("f1"), WdlString("f2"), WdlString("f3")))
+    }
+    "be usable as an input" in {
+      val catTask = ns.findTask("cat").getOrElse {
+        fail("Expected to find task 'cat'")
+      }
+      val command = catTask.command.instantiate(Map("files" -> expectedArray)).getOrElse {
+        fail("Expected instantiation to work")
+      }
+      command shouldEqual "cat -s f1 f2 f3"
+    }
+    "Coerce Array[String] to Array[File] when running the workflow" in {
+      val outputs = Map(
+        "wf.cat.lines" -> WdlArray(WdlArrayType(WdlStringType), Seq(
+            WdlString("line1"),
+            WdlString("line2"),
+            WdlString("line3"),
+            WdlString("line4"),
+            WdlString("line5")
+          )
+        )
+      )
+      val uuid = UUID.randomUUID()
+      val sampleWdl = SampleWdl.ArrayLiteral(Paths.get("."))
+      val descriptor = buildWorkflowDescriptor(sampleWdl, runtime="", uuid=uuid)
+      runWdlAndAssertOutputs(
+        descriptor,
+        eventFilter = EventFilter.info(pattern = s"starting calls: wf.cat", occurrences = 1),
+        expectedOutputs = outputs
+      )
+      sampleWdl.cleanup()
     }
   }
 }


### PR DESCRIPTION
I forgot to make the expression evaluator understand `ArrayLiteral` ASTs.  Without it, users cannot create WDL array literals within WDL source code.  For example:

```
Array[String] strs = ["x", "y", "z"]
```

The `["x", "y", "z"]` part is an `ArrayLiteral` AST.

Coercions also had to be specified so that the following declaration

```
Array[File] files = ["x", "y", "z"]
```

means: `x`, `y`, and `z` are WdlFiles, which in this case because of no trailing `/`, they are treated as relative to VM.  This is very useful for analysts running with the JAR file locally.  With WDL files meant for the cloud, file arrays would likely be defined as:

```
Array[File] files = ["gs://bucket/x", "gs://bucket/y", "gs://bucket/z"]
```

Also added a tests:
* Test the `Array[String] -> Array[File]` auto conversion
* Test Array literals in WDL