### PR TITLE
Fix broken Jenkins tests by changing from a Future in CallActor to a VassalCallActor.

### DIFF
--- a/src/main/scala/cromwell/engine/CallExecutionActor.scala
+++ b/src/main/scala/cromwell/engine/CallExecutionActor.scala
@@ -1,0 +1,42 @@
+package cromwell.engine
+
+import akka.actor.{Actor, Props}
+import akka.event.{Logging, LoggingReceive}
+import cromwell.binding.WdlExpression.ScopedLookupFunction
+import cromwell.binding.{Call, CallInputs, WorkflowDescriptor}
+import cromwell.engine.backend.Backend
+
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
+
+
+object CallExecutionActor {
+  def props(backend: Backend, command: String, workflowDescriptor: WorkflowDescriptor, call: Call, callInputs: CallInputs, lookup: ScopedLookupFunction): Props =
+    Props(new CallExecutionActor(backend, command, workflowDescriptor, call, callInputs, lookup))
+}
+
+/** Actor to manage the execution of a single call. */
+class CallExecutionActor(backend: Backend, command: String, workflowDescriptor: WorkflowDescriptor, call: Call, callInputs: CallInputs, lookup: ScopedLookupFunction) extends Actor with CromwellActor {
+  private val log = Logging(context.system, classOf[CallExecutionActor])
+  val tag = s"CallExecutionActor [UUID(${workflowDescriptor.shortId}):${call.name}]"
+
+  log.info(s"$tag: starting.")
+  backend.executeCommand(command, workflowDescriptor, call, callInputs, lookup) match {
+    case Success(callOutputs) =>
+      log.info(s"$tag: successful execution.")
+      context.parent ! CallActor.ExecutionFinished(callOutputs)
+    case Failure(e) =>
+      log.error(s"$tag: failed execution.")
+      context.parent ! CallActor.ExecutionFailed(e)
+  }
+
+  /**
+   * The `CallExecutionActor` is not meant to respond to messages, it just starts up, does its work,
+   * and shuts down.
+   */
+  override def receive = LoggingReceive {
+    case badMessage =>
+      val diagnostic = s"$tag: unexpected message $badMessage."
+      log.error(diagnostic)
+  }
+}

--- a/src/main/scala/cromwell/engine/db/slick/SlickDataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/slick/SlickDataAccess.scala
@@ -116,8 +116,6 @@ class SlickDataAccess(databaseConfig: Config, val dataAccess: DataAccessComponen
     //
     // Otherwise, create one DataAccess and hold on to the reference.
     if (databaseConfig.getBooleanOr("slick.createSchema")) {
-      //noinspection SqlNoDataSourceInspection
-      Await.result(database.run(sqlu"SET DATABASE TRANSACTION CONTROL MVCC"), Duration.Inf)
       Await.result(database.run(dataAccess.schema.create), Duration.Inf)
     }
   }

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -69,13 +69,13 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
    * state, otherwise remain in `WorkflowRunning`.  If not successful, go to `WorkflowFailed`.
    */
   private def startRunnableCalls() = {
-      tryStartingRunnableCalls() match {
-        case Success(_) =>
-          goto(WorkflowRunning)
-        case Failure(e) =>
-          log.error(e, e.getMessage)
-          goto(WorkflowFailed)
-      }
+    tryStartingRunnableCalls() match {
+      case Success(_) =>
+        goto(WorkflowRunning)
+      case Failure(e) =>
+        log.error(e, e.getMessage)
+        goto(WorkflowFailed)
+    }
   }
 
   when(WorkflowSubmitted) {


### PR DESCRIPTION
Supersedes the work on sfrazer_bugs.  Non-Docker tests pass on gce-ces-build, I don't know how to run  Docker tests there from the CLI.  This does not include @kshakir's MVCC database changes as those don't appear to be strictly necessary to solve these problems, though they might be desirable on their own merits.