### PR TITLE
Allow for multiple lines in the command, don't strip newlines.

### DIFF
--- a/src/main/scala/cromwell/binding/command/Command.scala
+++ b/src/main/scala/cromwell/binding/command/Command.scala
@@ -131,7 +131,7 @@ case class Command(parts: Seq[CommandPart]) {
     val trimmed = stripAll(s, "\r\n", "\r\n \t")
     val parts = trimmed.split("[\\r\\n]+")
     val indent = parts.map(leadingWhitespaceCount).min
-    parts.map(_.substring(indent)).mkString("")
+    parts.map(_.substring(indent)).mkString("\n")
   }
 
   private def leadingWhitespaceCount(s: String): Int = {

--- a/src/main/scala/cromwell/logging/CromwellLogger.scala
+++ b/src/main/scala/cromwell/logging/CromwellLogger.scala
@@ -17,7 +17,7 @@ class TerminalLayout extends LayoutBase[ILoggingEvent] {
 
     val highlightedMessage = event.getFormattedMessage
       .replaceAll("UUID\\((.*?)\\)", TerminalUtil.highlight(2, "$1"))
-      .replaceAll("`(.*?)`", TerminalUtil.highlight(5, "$1"))
+      .replaceAll("`([^`]*?)`", TerminalUtil.highlight(5, "$1"))
 
     /* For some reason a '{}' is the value of getMessage only for Actors.
        This prepends a highlighted asterisk to messages that come from actors.

--- a/src/test/scala/cromwell/MultiLineCommandWorkflowSpec.scala
+++ b/src/test/scala/cromwell/MultiLineCommandWorkflowSpec.scala
@@ -1,0 +1,32 @@
+package cromwell
+
+import akka.testkit._
+import cromwell.CromwellSpec.DockerTest
+import cromwell.binding.values.WdlString
+import cromwell.util.SampleWdl
+
+import scala.language.postfixOps
+
+class MultiLineCommandWorkflowSpec extends CromwellTestkitSpec("MultiLineCommandWorkflowSpec") {
+  "A workflow that calls a task with a multi-line command" should {
+    "honor the newlines in the command" in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.MultiLineCommandWorkflowWdl,
+        eventFilter = EventFilter.info(pattern = s"starting calls: wf.blah", occurrences = 1),
+        expectedOutputs = Map("wf.blah.ab" -> WdlString("ab"))
+      )
+    }
+    "honor the newlines in the command in a Docker environment" taggedAs DockerTest in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.MultiLineCommandWorkflowWdl,
+        eventFilter = EventFilter.info(pattern = s"starting calls: wf.blah", occurrences = 1),
+        runtime =
+          """runtime {
+            |  docker: "ubuntu:latest"
+            |}
+          """.stripMargin,
+        expectedOutputs = Map("wf.blah.ab" -> WdlString("ab"))
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -734,4 +734,30 @@ object SampleWdl {
 
     override val rawInputs = Map.empty[String, String]
   }
+
+  object MultiLineCommandWorkflowWdl extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """task blah {
+        |  command <<<
+        |    python <<CODE
+        |    def a():
+        |      return "a"
+        |    def b():
+        |      return "b"
+        |    print('{}{}'.format(a(),b()))
+        |    CODE
+        |  >>>
+        |
+        |  output {
+        |    String ab = read_string(stdout())
+        |  }
+        |}
+        |
+        |workflow wf {
+        |  call blah
+        |}
+      """.stripMargin
+
+    override val rawInputs = Map.empty[String, String]
+  }
 }


### PR DESCRIPTION
What's happening here is that we're breaking the command on newlines, specifically `[\r\n]+` and then reassembling the pieces with `.mkString("")` effectively removing all newlines from a user's command.

This not a problem for one line commands and also many multi-line commands, but it is a problem for commands that are whitespace dependent (see the test case for an example).