### PR TITLE
Scatter Gather Database schema changes

### DIFF
--- a/src/main/migrations/changelog.xml
+++ b/src/main/migrations/changelog.xml
@@ -11,4 +11,6 @@
     <include file="changesets/symbol_iteration_not_null.xml" relativeToChangelogFile="true" />
     <include file="changesets/add_unique_constraints.xml" relativeToChangelogFile="true" />
     <include file="changesets/lengthen_wdl_value.xml" relativeToChangelogFile="true" />
+    <include file="changesets/add_index_in_execution.xml" relativeToChangelogFile="true" />
+    <include file="changesets/rename_iteration_to_index.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/migrations/changesets/add_index_in_execution.xml
+++ b/src/main/migrations/changesets/add_index_in_execution.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="tjeandet" id="add-index-in-execution">
+        <addColumn
+            tableName="EXECUTION">
+            <column name="INDEX" type="INT" />
+        </addColumn>
+        <addNotNullConstraint
+                tableName="EXECUTION" columnName="INDEX"
+                columnDataType="INT" defaultNullValue="-1"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/migrations/changesets/rename_iteration_to_index.xml
+++ b/src/main/migrations/changesets/rename_iteration_to_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="tjeandet" id="rename-iteration-to-index">
+        <renameColumn columnDataType="INT"
+                      newColumnName="INDEX"
+                      oldColumnName="ITERATION"
+                      tableName="SYMBOL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/scala/cromwell/engine/db/slick/ExecutionComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/ExecutionComponent.scala
@@ -4,6 +4,7 @@ case class Execution
 (
   workflowExecutionId: Int,
   callFqn: String,
+  index: Int,
   status: String,
   executionId: Option[Int] = None
   )
@@ -20,9 +21,11 @@ trait ExecutionComponent {
 
     def callFqn = column[String]("CALL_FQN")
 
+    def index = column[Int]("INDEX")
+
     def status = column[String]("STATUS")
 
-    override def * = (workflowExecutionId, callFqn, status, executionId.?) <>
+    override def * = (workflowExecutionId, callFqn, index, status, executionId.?) <>
       (Execution.tupled, Execution.unapply)
 
     def workflowExecution = foreignKey(

--- a/src/main/scala/cromwell/engine/db/slick/SymbolComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/SymbolComponent.scala
@@ -7,7 +7,7 @@ case class Symbol
   workflowExecutionId: Int,
   scope: String,
   name: String,
-  iteration: Int, // https://bugs.mysql.com/bug.php?id=8173
+  index: Int, // https://bugs.mysql.com/bug.php?id=8173
   io: String,
   wdlType: String,
   wdlValue: Option[Clob],
@@ -28,7 +28,7 @@ trait SymbolComponent {
 
     def name = column[String]("NAME")
 
-    def iteration = column[Int]("ITERATION")
+    def index = column[Int]("INDEX")
 
     def io = column[String]("IO")
 
@@ -36,14 +36,14 @@ trait SymbolComponent {
 
     def wdlValue = column[Option[Clob]]("WDL_VALUE")
 
-    override def * = (workflowExecutionId, scope, name, iteration, io, wdlType, wdlValue, symbolId.?) <>
+    override def * = (workflowExecutionId, scope, name, index, io, wdlType, wdlValue, symbolId.?) <>
       (Symbol.tupled, Symbol.unapply)
 
     def workflowExecution = foreignKey(
       "FK_SYMBOL_WORKFLOW_EXECUTION_ID", workflowExecutionId, workflowExecutions)(_.workflowExecutionId)
 
     def uniqueKey = index("UK_SYM_WORKFLOW_EXECUTION_ID_SCOPE_NAME_ITERATION_IO",
-      (workflowExecutionId, scope, name, iteration, io), unique = true)
+      (workflowExecutionId, scope, name, index, io), unique = true)
   }
 
   protected val symbols = TableQuery[Symbols]

--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -82,7 +82,7 @@ package object engine {
 
     def apply(fullyQualifiedName: FullyQualifiedName, wdlValue: WdlValue, input: Boolean): SymbolStoreEntry = {
       val (scope, name) = splitFqn(fullyQualifiedName)
-      val key = SymbolStoreKey(scope, name, iteration = None, input)
+      val key = SymbolStoreKey(scope, name, index = None, input)
       SymbolStoreEntry(key, wdlValue.wdlType, Some(wdlValue))
     }
 
@@ -95,7 +95,7 @@ package object engine {
     }.toMap
   }
 
-  case class SymbolStoreKey(scope: String, name: String, iteration: Option[Int], input: Boolean)
+  case class SymbolStoreKey(scope: String, name: String, index: Option[Int], input: Boolean)
 
   case class SymbolStoreEntry(key: SymbolStoreKey, wdlType: WdlType, wdlValue: Option[WdlValue]) {
     def isInput: Boolean = key.input

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -11,7 +11,7 @@ import cromwell.binding.values.{WdlArray, WdlString}
 import cromwell.engine._
 import cromwell.engine.backend.Backend.RestartableWorkflow
 import cromwell.engine.backend.local.LocalBackend
-import cromwell.engine.backend.{TaskExecutionContext, Backend, StdoutStderr}
+import cromwell.engine.backend.{Backend, StdoutStderr, TaskExecutionContext}
 import cromwell.engine.db.DataAccess.WorkflowInfo
 import cromwell.engine.db.{DataAccess, LocalCallBackendInfo}
 import cromwell.parser.BackendType
@@ -288,7 +288,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           val resultSymbolStoreKey = resultSymbol.key
           resultSymbolStoreKey.scope should be("call.fully.qualified.scope")
           resultSymbolStoreKey.name should be("symbol.fully.qualified.scope")
-          resultSymbolStoreKey.iteration should be(None)
+          resultSymbolStoreKey.index should be(None)
           resultSymbolStoreKey.input should be(right = true) // IntelliJ highlighting
           resultSymbol.wdlType should be(WdlStringType)
           resultSymbol.wdlValue shouldNot be(empty)
@@ -319,7 +319,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           val resultSymbolStoreKey = resultSymbol.key
           resultSymbolStoreKey.scope should be("call.fully.qualified.scope")
           resultSymbolStoreKey.name should be("symbol.fully.qualified.scope")
-          resultSymbolStoreKey.iteration should be(None)
+          resultSymbolStoreKey.index should be(None)
           resultSymbolStoreKey.input should be(right = true) // IntelliJ highlighting
           resultSymbol.wdlType should be(WdlArrayType(WdlStringType))
           resultSymbol.wdlValue shouldNot be(empty)
@@ -359,7 +359,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           val resultSymbolStoreKey = resultSymbol.key
           resultSymbolStoreKey.scope should be("call.fully.qualified.scope")
           resultSymbolStoreKey.name should be("symbol")
-          resultSymbolStoreKey.iteration should be(None)
+          resultSymbolStoreKey.index should be(None)
           resultSymbolStoreKey.input should be(right = false) // IntelliJ highlighting
           resultSymbol.wdlType should be(WdlStringType)
           resultSymbol.wdlValue shouldNot be(empty)
@@ -387,7 +387,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           val resultSymbolStoreKey = resultSymbol.key
           resultSymbolStoreKey.scope should be("call.fully.qualified.scope")
           resultSymbolStoreKey.name should be("symbol")
-          resultSymbolStoreKey.iteration should be(None)
+          resultSymbolStoreKey.index should be(None)
           resultSymbolStoreKey.input should be(right = false) // IntelliJ highlighting
           resultSymbol.wdlType should be(WdlStringType)
           resultSymbol.wdlValue shouldNot be(empty)
@@ -454,7 +454,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
           val resultSymbolStoreKey = resultSymbol.key
           resultSymbolStoreKey.scope should be("call.fully.qualified.scope")
           resultSymbolStoreKey.name should be("symbol")
-          resultSymbolStoreKey.iteration should be(None)
+          resultSymbolStoreKey.index should be(None)
           resultSymbolStoreKey.input should be(right = false) // IntelliJ highlighting
           resultSymbol.wdlType should be(WdlStringType)
           resultSymbol.wdlValue shouldNot be(empty)


### PR DESCRIPTION
Based on the current description of the story I think that's about it.
I splitted it into 2 different changesets, one for adding `index` in `EXECUTION` and the other for renaming `iteration` to `index` in `SYMBOL`, but they could be merged into one file I guess.
This probably shouldn't be merged yet though until we figure out if we need a parent column. Although it doesn't matter if we don't support nested scatter.