### PR TITLE
Updates to scatter-gather fully qualified names.

### DIFF
--- a/src/main/scala/cromwell/binding/Scatter.scala
+++ b/src/main/scala/cromwell/binding/Scatter.scala
@@ -17,6 +17,7 @@ object Scatter {
  * @param index Index of the scatter block. The index is computed during tree generation to reflect wdl scatter blocks structure.
  * @param item Item which this block is scattering over
  * @param collection Wdl Expression corresponding to the collection this scatter is looping through
+ * @param parent Parent of this scatter
  */
 case class Scatter(index: Int, item: String, collection: WdlExpression, parent: Option[Scope]) extends Scope {
 

--- a/src/main/scala/cromwell/binding/Workflow.scala
+++ b/src/main/scala/cromwell/binding/Workflow.scala
@@ -7,7 +7,7 @@ import cromwell.parser.WdlParser.{Ast, SyntaxError, Terminal}
 
 object Workflow {
 
-  def apply(ast: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter, parent: Option[Scope]): Workflow = {
+  def apply(ast: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Workflow = {
     val name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
     val declarations = ast.findAsts(AstNodeName.Declaration).map(Declaration(_, name, wdlSyntaxErrorFormatter))
     val callNames = ast.findAsts(AstNodeName.Call).map {call =>
@@ -24,7 +24,7 @@ object Workflow {
       case _ =>
     }
 
-    new Workflow(name, declarations, parent, workflowOutputsDecls)
+    new Workflow(name, declarations, workflowOutputsDecls)
   }
 }
 
@@ -35,7 +35,12 @@ object Workflow {
  *
  * @param name The name of the workflow
  */
-case class Workflow(name: String, declarations: Seq[Declaration], parent: Option[Scope], workflowOutputDecls: Seq[WorkflowOutputDeclaration]) extends Executable with Scope {
+case class Workflow(name: String,
+                    declarations: Seq[Declaration],
+                    workflowOutputDecls: Seq[WorkflowOutputDeclaration]) extends Executable with Scope {
+
+
+  override val parent: Option[Scope] = None
 
   /* Calls and scatters are accessed frequently so this avoids traversing the whole children tree every time.
    * Lazy because children are not provided at instantiation but rather later during tree building process.

--- a/src/main/scala/cromwell/engine/workflow/ExecutionStoreKey.scala
+++ b/src/main/scala/cromwell/engine/workflow/ExecutionStoreKey.scala
@@ -1,0 +1,54 @@
+package cromwell.engine.workflow
+
+import cromwell.binding._
+import cromwell.engine.ExecutionStatus
+import cromwell.engine.workflow.WorkflowActor.ExecutionStore
+
+sealed trait ExecutionStoreKey {
+  val scope: Scope
+
+  val index: Option[Int]
+
+  val parent: Option[ExecutionStoreKey]
+}
+
+case class CallKey(scope: Call, index: Option[Int], parent: Option[ExecutionStoreKey]) extends ExecutionStoreKey
+
+case class ScatterKey(scope: Scatter, index: Option[Int], parent: Option[ExecutionStoreKey]) extends ExecutionStoreKey {
+
+  /**
+   * Creates a sub-ExecutionStore with Starting entries for each of the scoped children.
+   * @param count Number of ways to scatter the children.
+   * @return ExecutionStore of scattered children.
+   */
+  def populate(count: Int): ExecutionStore = {
+    val keys = for {
+      childScope <- this.scope.children
+      collector = collectorForChild(childScope, count)
+      entry <- collector +: collector.keys
+    } yield entry
+
+    (keys map {
+      _ -> ExecutionStatus.NotStarted
+    }).toMap
+  }
+
+  private def collectorForChild(scope: Scope, count: Int): CollectorKey = {
+    val parent = Option(this)
+    val indexed = (0 until count) map { i =>
+      val index = Option(i)
+      scope match {
+        case call: Call =>
+          CallKey(call, index, parent)
+        case scatter: Scatter =>
+          ScatterKey(scatter, index, parent)
+      }
+    }
+    CollectorKey(scope, parent, indexed)
+  }
+}
+
+case class CollectorKey(scope: Scope, parent: Option[ExecutionStoreKey], keys: Seq[ExecutionStoreKey])
+  extends ExecutionStoreKey {
+  override val index = None
+}

--- a/src/test/scala/cromwell/binding/ScopeSpec.scala
+++ b/src/test/scala/cromwell/binding/ScopeSpec.scala
@@ -69,7 +69,7 @@ class ScopeSpec extends FlatSpec with Matchers {
   }
 
   it should "throw an exception if trying to re-assign children on a scope" in {
-    the [UnsupportedOperationException] thrownBy { namespace.workflow.setChildren(Seq.empty) } should have message "children is write-once"
+    the [UnsupportedOperationException] thrownBy { namespace.workflow.children = Seq.empty } should have message "children is write-once"
   }
 
   it should "throw an exception if trying to generate a workflow from a non-workflow ast" in {

--- a/src/test/scala/cromwell/engine/ScatterPopulateSpec.scala
+++ b/src/test/scala/cromwell/engine/ScatterPopulateSpec.scala
@@ -1,0 +1,165 @@
+package cromwell.engine
+
+import cromwell.binding._
+import cromwell.engine.workflow.WorkflowActor._
+import cromwell.engine.workflow._
+import cromwell.parser.BackendType
+import cromwell.util.SampleWdl
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ScatterPopulateSpec extends FlatSpec with Matchers {
+
+  import ScatterPopulateSpec._
+
+  behavior of "ScatterPopulate"
+
+  it should "populate WDL from our conversation" in {
+    val namespace = NamespaceWithWorkflow.load(SampleWdl.ScatterConversationWdl.wdlSource(), BackendType.LOCAL)
+
+    val workflowEntries = WorkflowActor.populate(namespace.workflow)
+    workflowEntries.size should be(3)
+
+    val workflowEntriesExpected = Table(
+      ("fqn", "type"),
+      ("w.A", classOf[CallKey]),
+      ("w.$scatter_0", classOf[ScatterKey]),
+      ("w.D", classOf[CallKey]))
+
+    forAll(workflowEntriesExpected) {
+      (fqn: FullyQualifiedName, clazz: Class[_]) =>
+        validateWorkflow(workflowEntries, fqn, clazz)
+    }
+
+    val scatter0 = workflowEntries.findScatterKey("w.$scatter_0")
+    val scatter0Entries = scatter0.populate(3)
+    scatter0Entries.size should be(12)
+
+    Seq("w.B", "w.C", "w.E") foreach { fqn =>
+      validateScatter(scatter0Entries, fqn, classOf[CallKey], scatter0, 3)
+    }
+  }
+
+  it should "populate scatter WDL example" in {
+    val namespace = NamespaceWithWorkflow.load(SampleWdl.ScatterWdl.wdlSource(), BackendType.LOCAL)
+
+    // Workflow: Populate the workflow entries
+    val workflowEntries = WorkflowActor.populate(namespace.workflow)
+    workflowEntries.size should be(4)
+
+    val workflowEntriesExpected = Table(
+      ("fqn", "type"),
+      ("w.A", classOf[CallKey]),
+      ("w.$scatter_0", classOf[ScatterKey]),
+      ("w.$scatter_3", classOf[ScatterKey]),
+      ("w.D", classOf[CallKey]))
+
+    forAll(workflowEntriesExpected) {
+      (fqn: FullyQualifiedName, clazz: Class[_]) =>
+        validateWorkflow(workflowEntries, fqn, clazz)
+    }
+
+    // From the workflow entries, populate the first w.$scatter_0
+
+    val scatter0 = workflowEntries.findScatterKey("w.$scatter_0")
+    val scatter0Entries = scatter0.populate(3)
+    scatter0Entries.size should be(20)
+
+    val scatter0EntriesExpected = Table(
+      ("fqn", "type"),
+      ("w.B", classOf[CallKey]),
+      ("w.C", classOf[CallKey]),
+      ("w.E", classOf[CallKey]),
+      ("w.$scatter_1", classOf[ScatterKey]),
+      ("w.$scatter_2", classOf[ScatterKey]))
+
+    forAll(scatter0EntriesExpected) {
+      (fqn: FullyQualifiedName, clazz: Class[_]) =>
+        validateScatter(scatter0Entries, fqn, clazz, scatter0, 3)
+    }
+
+    // From Scatter 0 entries, find Scatter 2.
+    // Scatter 0 created three instances of all children, including Scatter 2.
+    // Get the child at Index 1, and populate four entries
+
+    val scatter2 = scatter0Entries.findScatterKey("w.$scatter_2", Option(1))
+    val scatter2Entries = scatter2.populate(4)
+    scatter2Entries.size should be(5)
+    validateScatter(scatter2Entries, "w.H", classOf[CallKey], scatter2, 4)
+  }
+
+  def validateWorkflow(entries: ExecutionStore, fqn: FullyQualifiedName, clazz: Class[_]): Unit = {
+    val key = entries.findKey(fqn, None)
+    key.getClass should be(clazz)
+    key.parent should be(empty)
+    entries.map(_.status) should contain only ExecutionStatus.NotStarted
+  }
+
+  def validateScatter(entries: ExecutionStore, fqn: FullyQualifiedName, clazz: Class[_],
+                      parent: ScatterKey, count: Int): Unit = {
+    val collectorKey = entries.findKey(fqn, None)
+    collectorKey shouldBe a[CollectorKey]
+    collectorKey.parent shouldNot be(empty)
+    collectorKey.parent.get should be(parent)
+
+    (0 until count) foreach { i =>
+      val index = Option(i)
+      val key = entries.findKey(fqn, index)
+      key.getClass should be(clazz)
+      key.parent shouldNot be(empty)
+      key.parent.get should be(parent)
+    }
+    entries.map(_.status) should contain only ExecutionStatus.NotStarted
+  }
+}
+
+object ScatterPopulateSpec {
+
+  implicit class ExecutionStoreWrapper(val entries: ExecutionStore) extends AnyVal {
+    def findKeyOption(fqn: FullyQualifiedName, index: Option[Int] = None): Option[ExecutionStoreKey] = {
+      entries map {
+        _.key
+      } find { key =>
+        key.scope.fullyQualifiedName == fqn && key.index == index
+      }
+    }
+
+    def findKey(fqn: FullyQualifiedName, index: Option[Int] = None) = {
+      val findOption = findKeyOption(fqn, index)
+      if (findOption.isDefined) {
+        findOption.get
+      } else {
+        val keys = entries map { entry =>
+          s"${entry.key.scope.fullyQualifiedName} || ${entry.key.index}"
+        }
+        val msg = keys.mkString(s"$fqn || $index not found in:\n", "\n", "")
+        throw new NoSuchElementException(msg)
+      }
+    }
+
+    def findScatterKey(fqn: FullyQualifiedName, index: Option[Int] = None): ScatterKey = {
+      findKey(fqn, index).asInstanceOf[ScatterKey]
+    }
+  }
+
+  implicit class ExecutionStoreEntryWrapper(val entry: ExecutionStoreEntry) extends AnyVal {
+    def key = entry._1
+
+    def status = entry._2
+
+    override def toString = s"ExecutionStoreEntry(key=$key,status=$status)"
+  }
+
+  implicit class ExecutionStoreKeyWrapper(val key: ExecutionStoreKey) extends AnyVal {
+    def scope = key.scope
+
+    def index = key.index
+
+    def parent = key.parent
+
+    def typeName = key.getClass.getSimpleName.stripSuffix("Key")
+
+    override def toString = s"ExecutionStoreKey(scope=$scope,index=$index,parent=$parent)"
+  }
+
+}

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -975,4 +975,68 @@ object SampleWdl {
 
     override val rawInputs =  Map.empty[String, String]
   }
+
+  object ScatterConversationWdl extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """task A {
+        |  command {
+        |    echo -n -e "jeff\nchris\nmiguel\nthibault\nkhalid\nscott"
+        |  }
+        |  output {
+        |    Array[String] A_out = read_lines(stdout())
+        |  }
+        |}
+        |
+        |task B {
+        |  String B_in
+        |  command {
+        |    python -c "print(len('${B_in}'))"
+        |  }
+        |  output {
+        |    Int B_out = read_int(stdout())
+        |  }
+        |}
+        |
+        |task C {
+        |  Int C_in
+        |  command {
+        |    python -c "print(${C_in}*100)"
+        |  }
+        |  output {
+        |    Int C_out = read_int(stdout())
+        |  }
+        |}
+        |
+        |task D {
+        |  Array[Int] D_in
+        |  command {
+        |    python -c "print(${sep='+' D_in})"
+        |  }
+        |  output {
+        |    Int D_out = read_int(stdout())
+        |  }
+        |}
+        |
+        |task E {
+        |  command {
+        |    python -c "import random; print(random.randint(1,100))"
+        |  }
+        |  output {
+        |    Int E_out = read_int(stdout())
+        |  }
+        |}
+        |
+        |workflow w {
+        |  call A
+        |  scatter (item in A.A_out) {
+        |    call B {input: B_in=item}
+        |    call C {input: C_in=B.B_out}
+        |    call E
+        |  }
+        |  call D {input: D_in=B.B_out}
+        |}
+      """.stripMargin
+    override lazy val rawInputs = Map("" -> "...")
+  }
+
 }


### PR DESCRIPTION
`ExecutionStore` was keyed by a `Call`. Now uses a `ExecutionStoreKey` trait.
`binding.Workflow` initialization from `Ast` now separates top level `Scope` from `Call` and `Scatter`.
Using a scala mutator instead of a java setter for `Scope.children`.