### PR TITLE
Localization strategies for backends using a "shared filesystem"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ jdk:
 before_script:
   - mysql -e "create database IF NOT EXISTS cromwell_test;"
 
-script: sbt clean coverage nodocker:test
+script: sbt -Dbackend.shared-filesystem.localization.0=copy clean coverage nodocker:test
 after_success: sbt coveralls

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -44,6 +44,27 @@ backend {
   //  baseExecutionBucket = ""
   //  endpointUrl = ""
   //}
+
+  // For any backend that assumes a local filesystem (local, sge)
+  shared-filesystem {
+    // Root directory where Cromwell writes job results to.  This directory must be
+    // visible and writeable to the Cromwell process as well as the jobs that Cromwell
+    // launches
+    root: "cromwell-executions"
+
+    // Cromwell makes a link to your input files within <root>/<workflow UUID>/workflow-inputs
+    // The following are strategies used to make those links.  They are ordered.  If one fails
+    // The next one is tried:
+    //
+    // hard-link: attempt to create a hard-link to the file
+    // copy: copy the file
+    // soft-link: create a symbolic link to the file
+    //
+    // NOTE: soft-link will be skipped for Docker jobs
+    localization: [
+      "hard-link", "soft-link", "copy"
+    ]
+  }
 }
 
 // If authenticating with Google (e.g. if backend is 'JES') you must supply a top level stanza 'google':

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -52,7 +52,7 @@ trait Backend {
    * the coerced inputs present in the `WorkflowDescriptor` with any input `WdlFile`s
    * adjusted for the host workflow execution path.
    */
-  def initializeForWorkflow(workflow: WorkflowDescriptor): HostInputs
+  def initializeForWorkflow(workflow: WorkflowDescriptor): Try[HostInputs]
 
   /**
    * Execute the Call (wrapped in a BackendCall), return the outputs if it is

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
@@ -116,7 +116,7 @@ class JesBackend extends Backend with LazyLogging {
   override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs
 
   // No need to copy GCS inputs for the workflow we should be able to directly reference them
-  override def initializeForWorkflow(workflow: WorkflowDescriptor): HostInputs = workflow.actualInputs
+  override def initializeForWorkflow(workflow: WorkflowDescriptor): Try[HostInputs] = Success(workflow.actualInputs)
 
   def taskOutputToJesOutput(taskOutput: TaskOutput, callGcsPath: String, scopedLookupFunction: ScopedLookupFunction, engineFunctions: JesEngineFunctions): Try[Option[JesOutput]] = {
     // If the output isn't a file then it's not a file to be retrieved by the JES run! (but NB: see anonymous task output below)

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -18,9 +18,6 @@ import scala.sys.process._
 import scala.util.{Failure, Success, Try}
 
 object LocalBackend {
-
-  val CromwellExecutions = "cromwell-executions"
-
   /**
    * Simple utility implicit class adding a method that writes a line and appends a newline in one shot.
    */
@@ -38,7 +35,7 @@ object LocalBackend {
     hostExecutionPath(workflow.name, workflow.id)
 
   def hostExecutionPath(workflowName: String, workflowUuid: WorkflowId): Path =
-    Paths.get(CromwellExecutions, workflowName, workflowUuid.id.toString)
+    Paths.get(SharedFileSystem.CromwellExecutionRoot, workflowName, workflowUuid.id.toString)
 
   def hostCallPath(workflow: WorkflowDescriptor, callName: String): Path =
     Paths.get(hostExecutionPath(workflow).toFile.getAbsolutePath, s"call-$callName")
@@ -51,7 +48,7 @@ object LocalBackend {
 /**
  * Handles both local Docker runs as well as local direct command line executions.
  */
-class LocalBackend extends Backend with LocalFileSystemOperations with LazyLogging {
+class LocalBackend extends Backend with SharedFileSystem with LazyLogging {
   type BackendCall = LocalBackendCall
 
   import LocalBackend._

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
@@ -5,7 +5,7 @@ import java.nio.file.Files
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.binding.{Call, CallInputs, CallOutputs, WorkflowDescriptor}
 import cromwell.engine.backend.Backend.RestartableWorkflow
-import cromwell.engine.backend.local.{LocalBackend, LocalFileSystemOperations}
+import cromwell.engine.backend.local.{LocalBackend, SharedFileSystem}
 import cromwell.engine.backend.{Backend, TaskAbortedException}
 import cromwell.engine.db.DataAccess
 import cromwell.engine.{AbortRegistrationFunction, _}
@@ -18,7 +18,7 @@ import scala.language.postfixOps
 import scala.sys.process._
 import scala.util.{Failure, Success, Try}
 
-class SgeBackend extends Backend with LocalFileSystemOperations with LazyLogging {
+class SgeBackend extends Backend with SharedFileSystem with LazyLogging {
   type BackendCall = SgeBackendCall
 
   import LocalBackend.WriteWithNewline

--- a/src/test/scala/cromwell/ArrayWorkflowSpec.scala
+++ b/src/test/scala/cromwell/ArrayWorkflowSpec.scala
@@ -1,14 +1,12 @@
 package cromwell
 
-import java.nio.file.{Paths, Files}
+import java.nio.file.{Files, Paths}
 import java.util.UUID
 
 import akka.testkit._
-import cromwell.CromwellSpec.DockerTest
-import cromwell.binding.{NoFunctions, WdlFunctions, NamespaceWithWorkflow, WdlNamespace}
-import cromwell.binding.types.{WdlStringType, WdlFileType, WdlArrayType}
-import cromwell.binding.values.{WdlInteger, WdlArray, WdlFile, WdlString}
-import cromwell.engine.backend.local.LocalBackend
+import cromwell.binding.types.{WdlArrayType, WdlFileType, WdlStringType}
+import cromwell.binding.values.{WdlArray, WdlFile, WdlInteger, WdlString}
+import cromwell.binding.{NamespaceWithWorkflow, NoFunctions}
 import cromwell.parser.BackendType
 import cromwell.util.SampleWdl
 

--- a/src/test/scala/cromwell/StdoutStderrWorkflowSpec.scala
+++ b/src/test/scala/cromwell/StdoutStderrWorkflowSpec.scala
@@ -10,13 +10,21 @@ import scala.language.postfixOps
 
 class StdoutStderrWorkflowSpec extends CromwellTestkitSpec("StdoutStderrWorkflowSpec") {
   "A workflow with tasks that produce stdout/stderr" should {
-    "have correct contents in stdout/stderr files" in {
+    "have correct contents in stdout/stderr files for a call" in {
       runWdlAndAssertStdoutStderr(
         sampleWdl = SampleWdl.HelloWorld,
         eventFilter = EventFilter.info(pattern = s"persisting status of calls hello.hello to Done", occurrences = 1),
         fqn = "hello.hello",
         stdout = Some("Hello world!\n"),
         stderr = Some("")
+      )
+    }
+    "have correct contents in stdout/stderr files for a workflow" in {
+      runWdlAndAssertWorkflowStdoutStderr(
+        sampleWdl = SampleWdl.HelloWorld,
+        eventFilter = EventFilter.info(pattern = s"persisting status of calls hello.hello to Done", occurrences = 1),
+        stdout = Map("hello.hello" -> "Hello world!\n"),
+        stderr = Map("hello.hello" -> "")
       )
     }
     "have correct contents in stdout/stderr files in a Docker environment" taggedAs DockerTest in {

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -40,7 +40,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
     override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs
     override def stdoutStderr(workflowId: WorkflowId, workflowName: String, callName: String): StdoutStderr = ???
 
-    override def initializeForWorkflow(workflow: WorkflowDescriptor) = Map.empty
+    override def initializeForWorkflow(workflow: WorkflowDescriptor) = Success(Map.empty)
 
     override def handleCallRestarts(restartableWorkflows: Seq[RestartableWorkflow],
                                     dataAccess: DataAccess)(implicit ec: ExecutionContext) = Future.successful(())


### PR DESCRIPTION
This will localization strategies in order until one works.  The localization strategies are aware of their context.  For example, we fail the "symbolic link" strategy if the particular Call will run with Docker because Docker won't be able to read those files.