### PR TITLE
added a default local SSD disk to be used for localization, also need…

### DIFF
--- a/src/main/scala/cromwell/binding/RuntimeAttributes.scala
+++ b/src/main/scala/cromwell/binding/RuntimeAttributes.scala
@@ -22,7 +22,7 @@ object RuntimeAttributes {
   /** Fallback values if values for these keys are not specified in a task "runtime" stanza. */
   object Defaults {
     val Cpu = 1
-    val Disk = Seq(LocalDisk("local-disk", 100L, "LOCAL_SSD").toDisk)
+    val LocalizationDisk = LocalDisk("local-disk", 100L, "LOCAL_SSD").toDisk
     val FailOnStderr = false
     val MemoryInBytes = MemorySize.GB.toBytes(2)
     val Preemptible = false
@@ -109,7 +109,8 @@ case class RuntimeAttributes private(attributes: Map[String, String], warnings: 
         Array(name, sizeGb, diskType) = diskString.split("\\s+")
       } yield LocalDisk(name, sizeGb.toLong, diskType).toDisk
 
-    if (taskSpecifiedAttributes.isEmpty) Defaults.Disk else taskSpecifiedAttributes
+    // additional disks will be added to the default localization disk
+    taskSpecifiedAttributes :+ Defaults.LocalizationDisk
   }
 
   val memoryGB: Double = {

--- a/src/main/scala/cromwell/engine/backend/jes/Run.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/Run.scala
@@ -27,6 +27,11 @@ object Run  {
     logging.setGcsPath(pipeline.gcsPath)
     rpr.setLogging(logging)
 
+    // Currently, disk resources need to be specified both at pipeline creation and pipeline run time
+    val resources = new Resources()
+    resources.setDisks( scala.collection.JavaConversions.seqAsJavaList(pipeline.call.task.runtimeAttributes.defaultDisks))
+    rpr.setResources(resources)
+
     val id = pipeline.genomicsService.pipelines().run(rpr).execute().getName
     Log.info(s"$tag JES ID is $id")
     new Run(id, pipeline, tag)

--- a/src/test/scala/cromwell/binding/RuntimeAttributeSpec.scala
+++ b/src/test/scala/cromwell/binding/RuntimeAttributeSpec.scala
@@ -180,7 +180,7 @@ class RuntimeAttributeSpec extends FlatSpec with Matchers {
     attributes.cpu shouldBe 3
     val firstDisk = new Disk().setName("Disk1").setSizeGb(3L).setType("SSD")
     val secondDisk = new Disk().setName("Disk2").setSizeGb(500L).setType("OldSpinnyKind")
-    attributes.defaultDisks shouldEqual Seq(firstDisk, secondDisk)
+    attributes.defaultDisks shouldEqual Seq(firstDisk, secondDisk, RuntimeAttributes.Defaults.LocalizationDisk)
     attributes.defaultZones shouldEqual Seq("US_Metro", "US_Backwater")
     attributes.memoryGB shouldBe 4
   }
@@ -194,7 +194,7 @@ class RuntimeAttributeSpec extends FlatSpec with Matchers {
     val googlyCall = calls(callIndex)
     val attributes = googlyCall.task.runtimeAttributes
     attributes.cpu shouldBe RuntimeAttributes.Defaults.Cpu
-    attributes.defaultDisks shouldBe RuntimeAttributes.Defaults.Disk
+    attributes.defaultDisks shouldEqual Seq(RuntimeAttributes.Defaults.LocalizationDisk)
     attributes.defaultZones shouldBe RuntimeAttributes.Defaults.Zones
     attributes.memoryGB shouldBe MemorySize.GB.fromBytes(RuntimeAttributes.Defaults.MemoryInBytes)
   }


### PR DESCRIPTION
…ed to mount that into the docker image by using JES disk input parameters, which it turns out you have to specify both at pipeline time and runtime (question out to Garrick).

This is important because currently if you try to localize or produce more than 10gb of input your pipeline will die.  This bumps that up to 100G of local ssd.  Eventually, after getting some road time, we might want to think about how to parameterize this so users could specify/override