### PR TITLE
DSDEEPB-1158 Make Workflow.inputs return a Map

### DIFF
--- a/src/main/scala/cromwell/binding/WdlNamespace.scala
+++ b/src/main/scala/cromwell/binding/WdlNamespace.scala
@@ -75,9 +75,7 @@ case class NamespaceWithWorkflow(importedAs: Option[String],
         }
     }
 
-    val tryCoercedValues = workflow.inputs.map {input =>
-      input.fqn -> coerceRawInput(input)
-    }.toMap
+    val tryCoercedValues = workflow.inputs map { case (fqn, input) => fqn -> coerceRawInput(input) }
 
     val (successes, failures) = tryCoercedValues.partition { case (_, tryValue) => tryValue.isSuccess }
     if (failures.isEmpty) {

--- a/src/main/scala/cromwell/binding/Workflow.scala
+++ b/src/main/scala/cromwell/binding/Workflow.scala
@@ -4,6 +4,8 @@ import cromwell.binding.AstTools.{AstNodeName, EnhancedAstNode}
 import cromwell.binding.types.WdlType
 import cromwell.parser.WdlParser.{Ast, SyntaxError, Terminal}
 
+import scala.language.postfixOps
+
 
 object Workflow {
 
@@ -45,15 +47,15 @@ case class Workflow(name: String, declarations: Seq[Declaration], parent: Option
   lazy val scatters: Seq[Scatter] = collectAllScatters
 
   /**
-   * All inputs for this workflow and their associated types.
+   * FQNs for all inputs to this workflow and their associated types and possible postfix quantifiers.
    *
-   * @return a Seq[WorkflowInput] representing the
+   * @return a Map[FullyQualifiedName, WorkflowInput] representing the
    *         inputs that the user needs to provide to this workflow
    */
-  def inputs: Seq[WorkflowInput] = {
+  def inputs: Map[FullyQualifiedName, WorkflowInput] = {
     val callInputs = for { call <- calls; input <- call.unsatisfiedInputs } yield input
     val declarationInputs = for { declaration <- declarations; input <- declaration.asWorkflowInput } yield input
-    callInputs ++ declarationInputs
+    (callInputs ++ declarationInputs) map { input => input.fqn -> input } toMap
   }
 
   /**

--- a/src/main/scala/cromwell/binding/types/WdlTypeJsonFormatter.scala
+++ b/src/main/scala/cromwell/binding/types/WdlTypeJsonFormatter.scala
@@ -1,6 +1,6 @@
 package cromwell.binding.types
 
-import cromwell.binding.WorkflowInput
+import cromwell.binding.{FullyQualifiedName, WorkflowInput}
 import spray.json._
 
 object WdlTypeJsonFormatter extends DefaultJsonProtocol {
@@ -9,12 +9,12 @@ object WdlTypeJsonFormatter extends DefaultJsonProtocol {
     def read(value: JsValue) = ???
   }
 
-  implicit object WorkflowInputJsonFormat extends RootJsonFormat[Seq[WorkflowInput]] {
-    def write(input: Seq[WorkflowInput]) = {
-      JsObject(input.map {input =>
+  implicit object WorkflowInputJsonFormat extends RootJsonFormat[Map[FullyQualifiedName, WorkflowInput]] {
+    def write(inputs: Map[FullyQualifiedName, WorkflowInput]) = {
+      JsObject(inputs map { case (fqn, input) =>
         val optional = if (input.optional) "(optional) " else ""
-        input.fqn -> JsString(s"$optional${input.wdlType.toWdlString}")
-      }.toMap)
+        fqn -> JsString(s"$optional${input.wdlType.toWdlString}")
+      })
     }
     def read(value: JsValue) = ???
   }

--- a/src/test/scala/cromwell/DeclarationWorkflowSpec.scala
+++ b/src/test/scala/cromwell/DeclarationWorkflowSpec.scala
@@ -18,11 +18,11 @@ class DeclarationWorkflowSpec extends CromwellTestkitSpec("DeclarationWorkflowSp
 
   "A workflow with declarations in it" should {
     "compute inputs properly" in {
-      NamespaceWithWorkflow.load(SampleWdl.DeclarationsWorkflow.wdlSource(runtime=""), BackendType.LOCAL).workflow.inputs shouldEqual Seq(
-        WorkflowInput("two_step.cat.file", WdlFileType, postfixQuantifier = None),
-        WorkflowInput("two_step.cgrep.str_decl", WdlStringType, postfixQuantifier = None),
-        WorkflowInput("two_step.cgrep.pattern", WdlStringType, postfixQuantifier = None),
-        WorkflowInput("two_step.flags_suffix", WdlStringType, postfixQuantifier = None)
+      NamespaceWithWorkflow.load(SampleWdl.DeclarationsWorkflow.wdlSource(runtime=""), BackendType.LOCAL).workflow.inputs shouldEqual Map(
+        "two_step.cat.file" -> WorkflowInput("two_step.cat.file", WdlFileType, postfixQuantifier = None),
+        "two_step.cgrep.str_decl" -> WorkflowInput("two_step.cgrep.str_decl", WdlStringType, postfixQuantifier = None),
+        "two_step.cgrep.pattern" -> WorkflowInput("two_step.cgrep.pattern", WdlStringType, postfixQuantifier = None),
+        "two_step.flags_suffix" -> WorkflowInput("two_step.flags_suffix", WdlStringType, postfixQuantifier = None)
       )
     }
     "honor the declarations" in {


### PR DESCRIPTION
Make `Workflow.inputs` return a `Map [FullyQualifiedName, WorkflowInput]` instead of `Seq [WorkflowInput]`.  The `Seq` return type caused some confusion in Rawlsville with the implication that  inputs are ordered in a particular way and that there could be duplicate keys. 