### PR TITLE
Auto delete docker container when call completes

### DIFF
--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -112,11 +112,12 @@ class LocalBackend extends Backend with LocalFileSystemOperations with LazyLoggi
   }
 
   /**
+   * --rm automatically deletes the container upon exit
    * -v maps the host workflow executions directory to /root/<workflow id> on the container.
    * -i makes the run interactive, required for the cat and <&0 shenanigans that follow.
    */
   private def buildDockerRunCommand(backendCall: BackendCall, image: String): String =
-    s"docker run -v ${backendCall.workflowRootPath.toAbsolutePath}:${backendCall.dockerContainerExecutionDir} -i $image"
+    s"docker run --rm -v ${backendCall.workflowRootPath.toAbsolutePath}:${backendCall.dockerContainerExecutionDir} -i $image"
 
   private def runSubprocess(backendCall: BackendCall): Try[CallOutputs] = {
     val tag = makeTag(backendCall)


### PR DESCRIPTION
I think we can add this `--rm` option to the docker command so it cleans up after itself once it's finished.
Like Lukas said it doesn't take much space so it's not a big deal, but as the container is not a daemon it can delete itself so I don't see any reason not to do it ?