### PR TITLE
Allow users to specify workflow options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,13 @@ inputs <WDL file>
   workflow.  Fill in the values in this JSON document and
   pass it in to the 'run' subcommand.
 
-run <WDL file> <JSON inputs file>
+run <WDL file> [<JSON inputs file> [<JSON workflow options]]
 
   Given a WDL file and JSON file containing the value of the
   workflow inputs, this will run the workflow locally and
-  print out the outputs in JSON format.
+  print out the outputs in JSON format.  The workflow
+  options file specifies some runtime configuration for the
+  workflow (see README for details)
 
 parse <WDL file>
 
@@ -226,14 +228,39 @@ Given a WDL file and a JSON inputs file (see `inputs` subcommand), Run the workf
 
 ```
 $ java -jar cromwell.jar run 3step.wdl inputs.json
-[INFO] [06/10/2015 09:20:19.945] [ForkJoinPool-2-worker-13] [akka://cromwell-system/user/$b] Workflow ID: bdcc70e6-e6d7-4483-949b-7c3c2199e26c
-[INFO] [06/10/2015 09:20:19.968] [cromwell-system-akka.actor.default-dispatcher-5] [akka://cromwell-system/user/$a/$a] Starting calls: ps
-[INFO] [06/10/2015 09:20:20.094] [cromwell-system-akka.actor.default-dispatcher-5] [akka://cromwell-system/user/$a/$a] Starting calls: cgrep, wc
-[INFO] [06/10/2015 09:20:20.123] [cromwell-system-akka.actor.default-dispatcher-2] [akka://cromwell-system/user/$b] Workflow complete: Succeeded
+... play-by-play output ...
 {
   "three_step.ps.procs": "/var/folders/kg/c7vgxnn902lc3qvc2z2g81s89xhzdz/T/stdout1272284837004786003.tmp",
   "three_step.cgrep.count": 0,
   "three_step.wc.count": 13
+}
+```
+
+The JSON inputs can be left off if there's a file with the same name as the WDL file but with a `.json` extension.  For example, this will assume that `3step.json` exists:
+
+```
+$ java -jar cromwell.jar run 3step.wdl
+```
+
+If your workflow has no inputs, you can specify `-` as the value for the inputs parameter:
+
+```
+$ java -jar cromwell.jar run my_workflow.wdl -
+```
+
+The final optinal parameter to the 'run' subcommand is a JSON file of workflow options.  By default, the command line will look for a file with the same name as the WDL file but with the extension `.options.json`.  But one can also specify a value of `-` manually to specify that there are no workflow inputs.
+
+The only workflow input that has any meaning currently is the `jes_gcs_root`, which will be used in the JES backend.  See the section on the [JES backend](#google-jes) for more details.
+
+```
+$ java -jar cromwell.jar run my_jes_wf.wdl my_jes_wf.json wf_options.json
+```
+
+Where `wf_options.json` would contain:
+
+```
+{
+  "jes_gcs_root": "gs://my-bucket/workflows"
 }
 ```
 
@@ -262,11 +289,17 @@ test.wdl
 ```
 task abc {
   String in
-  command { echo ${in} }
-  output {String out = read_string(stdout())}
+  command {
+    echo ${in}
+  }
+  output {
+    String out = read_string(stdout())
+  }
 }
 
-workflow wf { call abc }
+workflow wf {
+  call abc
+}
 ```
 
 This WDL file can be formatted in HTML as follows:
@@ -770,7 +803,11 @@ All web server requests include an API version in the url. The current version i
 
 ## POST /workflows/:version
 
-This endpoint accepts a POST request with a `multipart/form-data` encoded body.  The two elements in the body must be named `wdl` and `inputs`.  The `wdl` element contains the WDL file to run while the `inputs` contains a JSON file of the inputs to the workflow.
+This endpoint accepts a POST request with a `multipart/form-data` encoded body.  The form fields that must be included are:
+
+* `wdlSource` - Contains the WDL file to submit for execution.
+* `workflowInputs` - JSON file containing the inputs.  A skeleton file can be generated from the CLI with the [inputs](#inputs) sub-command.
+* `workflowOptions` - *Optional* JSON file containing options for this workflow execution.  See the [run](#run) CLI sub-command for some more information about this.
 
 cURL:
 
@@ -859,6 +896,65 @@ Server: spray-can/1.3.3
     "id": "69d1d92f-3895-4a7b-880a-82535e9a096e",
     "status": "Submitted"
 }
+```
+
+To specify workflow options as well:
+
+
+cURL:
+
+```
+$ curl -v "localhost:8000/workflows/v1" -F wdlSource=@wdl/jes0.wdl -F workflowInputs=@wdl/jes0.json -F workflowOptions=@options.json
+```
+
+HTTPie:
+
+```
+http --print=HBhb --form POST http://localhost:8000/workflows/v1 wdlSource=@wdl/jes0.wdl workflowInputs@wdl/jes0.json workflowOptions@options.json
+```
+
+Request (some parts truncated for brevity):
+
+```
+POST /workflows/v1 HTTP/1.1
+Accept: */*
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Length: 1472
+Content-Type: multipart/form-data; boundary=f3fd038395644de596c460257626edd7
+Host: localhost:8000
+User-Agent: HTTPie/0.9.2
+
+--f3fd038395644de596c460257626edd7
+Content-Disposition: form-data; name="wdlSource"
+
+task x { ... }
+task y { ... }
+task z { ... }
+
+workflow sfrazer {
+  call x
+  call y
+  call z {
+    input: example="gs://my-bucket/cromwell-executions/sfrazer/example.txt", int=3000
+  }
+}
+
+--f3fd038395644de596c460257626edd7
+Content-Disposition: form-data; name="workflowInputs"; filename="jes0.json"
+
+{
+  "sfrazer.x.x": "100"
+}
+
+--f3fd038395644de596c460257626edd7
+Content-Disposition: form-data; name="workflowOptions"; filename="options.json"
+
+{
+  "jes_gcs_root": "gs://sfrazer-dev/workflows"
+}
+
+--f3fd038395644de596c460257626edd7--
 ```
 
 ## GET /workflows/:version/:id/status

--- a/src/main/migrations/changelog.xml
+++ b/src/main/migrations/changelog.xml
@@ -15,4 +15,5 @@
     <include file="changesets/rename_iteration_to_index.xml" relativeToChangelogFile="true" />
     <include file="changesets/sge.xml" relativeToChangelogFile="true" />
     <include file="changesets/change_execution_unique_constraint.xml" relativeToChangelogFile="true" />
+    <include file="changesets/workflow_options.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/migrations/changesets/workflow_options.xml
+++ b/src/main/migrations/changesets/workflow_options.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <property name="clob.type" value="LONGTEXT" dbms="mysql"/>
+    <property name="clob.type" value="LONGVARCHAR" dbms="hsqldb"/>
+    <changeSet author="sfrazer" id="workflow-options">
+        <addColumn tableName="WORKFLOW_EXECUTION_AUX">
+            <column name="WORKFLOW_OPTIONS" type="${clob.type}" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -1,7 +1,7 @@
 package cromwell
 
 import java.io.File
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 
 import cromwell.binding.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
 import cromwell.binding.{AstTools, _}
@@ -11,6 +11,8 @@ import cromwell.server.{CromwellServer, DefaultWorkflowManagerSystem, WorkflowMa
 import cromwell.util.FileUtil.EnhancedPath
 import org.slf4j.LoggerFactory
 import spray.json._
+
+import scala.util.{Try, Success, Failure}
 
 object Actions extends Enumeration {
   val Parse, Validate, Highlight, Run, Inputs, Server = Value
@@ -77,18 +79,50 @@ object Main extends App {
   }
 
   def run(args: Array[String], workflowManagerSystem: WorkflowManagerSystem): Unit = {
-    if (args.length != 2) usageAndExit()
+    if (args.length < 1 || args.length > 3) usageAndExit()
 
-    Log.info(s"Backend is: ${WorkflowManagerActor.BackendType}")
+    args foreach {arg =>
+      val path = Paths.get(arg)
+      if (arg != "-") {
+        if (!Files.exists(path)) {
+          System.err.println(s"ERROR: file does not exist: $arg")
+          System.exit(1)
+        }
+        if (!Files.isReadable(path)) {
+          System.err.println(s"ERROR: file is not readable: $arg")
+          System.exit(1)
+        }
+      }
+    }
 
+    val wdlFile = args(0)
+    val inputsJsonFile = Try(args(1)).getOrElse(wdlFile.replaceAll("\\.wdl$", ".json"))
+    val workflowOptionsFile = Try(args(2)).getOrElse(wdlFile.replace("\\.wdl$", ".options.json"))
+
+    Log.info(s"Default backend: ${WorkflowManagerActor.BackendType}")
     Log.info(s"RUN sub-command")
     Log.info(s"  WDL file: ${args(0)}")
-    Log.info(s"  Inputs: ${args(1)}")
 
     try {
       val wdlSource = Paths.get(args(0)).slurp
-      val wdlJson = Paths.get(args(1)).slurp
-      val jsValue = wdlJson.parseJson
+      val inputsJson = inputsJsonFile match {
+        case "-" => "{}"
+        case path if path != args(0) && Files.exists(Paths.get(path)) =>
+          Log.info(s"  Inputs: $path")
+          Paths.get(path).slurp
+        case _ =>
+          System.err.println(s"ERROR: No workflow inputs specified")
+          System.exit(1)
+          ""
+      }
+      val workflowOptions = workflowOptionsFile match {
+        case "-" => "{}"
+        case path if path != args(0) && Files.exists(Paths.get(path)) =>
+          Log.info(s"  Workflow Options: $path")
+          Paths.get(path).slurp
+        case _ => "{}"
+      }
+      val jsValue = inputsJson.parseJson
 
       val inputs: binding.WorkflowRawInputs = jsValue match {
         case JsObject(rawInputs) => rawInputs
@@ -96,7 +130,8 @@ object Main extends App {
       }
 
       inputs foreach { case (k, v) => Log.info(s"input: $k => $v") }
-      val singleWorkflowRunner = SingleWorkflowRunnerActor.props(wdlSource, wdlJson, inputs, workflowManagerSystem.workflowManagerActor)
+      val sources = WorkflowSourceFiles(wdlSource, inputsJson, workflowOptions)
+      val singleWorkflowRunner = SingleWorkflowRunnerActor.props(sources, inputs, workflowManagerSystem.workflowManagerActor)
       workflowManagerSystem.actorSystem.actorOf(singleWorkflowRunner, "SingleWorkflowRunnerActor")
       workflowManagerSystem.actorSystem.awaitTermination()
       // And now we just wait for the magic to happen
@@ -132,11 +167,13 @@ object Main extends App {
         |  workflow.  Fill in the values in this JSON document and
         |  pass it in to the 'run' subcommand.
         |
-        |run <WDL file> <JSON inputs file>
+        |run <WDL file> [<JSON inputs file> [<JSON workflow options]]
         |
         |  Given a WDL file and JSON file containing the value of the
         |  workflow inputs, this will run the workflow locally and
-        |  print out the outputs in JSON format.
+        |  print out the outputs in JSON format.  The workflow
+        |  options file specifies some runtime configuration for the
+        |  workflow (see README for details)
         |
         |parse <WDL file>
         |

--- a/src/main/scala/cromwell/binding/AstTools.scala
+++ b/src/main/scala/cromwell/binding/AstTools.scala
@@ -157,7 +157,10 @@ object AstTools {
     would have its own MemberAccess - "a.b.c" and "a.b.d"
   */
   def findTopLevelMemberAccesses(expr: AstNode): Iterable[Ast] = expr.findAstsWithTrail("MemberAccess").filterNot {
-    case(k, v) => v.exists{case a:Ast => a.getName == "MemberAccess"}
+    case(k, v) => v exists {
+      case a:Ast => a.getName == "MemberAccess"
+      case _ => false
+    }
   }.keys
 
   /**

--- a/src/main/scala/cromwell/binding/package.scala
+++ b/src/main/scala/cromwell/binding/package.scala
@@ -1,7 +1,12 @@
 package cromwell
 
+import com.typesafe.config.ConfigFactory
+import cromwell.engine.backend.Backend
+import spray.json._
+import scala.util.{Try, Success, Failure}
 import cromwell.binding.values.WdlValue
 import cromwell.engine.WorkflowId
+import cromwell.parser.BackendType
 
 /**
  * ==WDL Bindings for Scala==
@@ -16,6 +21,8 @@ import cromwell.engine.WorkflowId
 package object binding {
   type WdlSource = String
   type WdlJson = String
+  type WorkflowOptionsJson = String
+  type WorkflowOptions = Map[String, String]
   type WorkflowRawInputs = Map[FullyQualifiedName, Any]
   type WorkflowCoercedInputs = Map[FullyQualifiedName, WdlValue]
   type WorkflowOutputs = Map[FullyQualifiedName, WdlValue]
@@ -24,16 +31,37 @@ package object binding {
   type CallInputs = Map[String, WdlValue]
   type CallOutputs = Map[LocallyQualifiedName, WdlValue]
   type HostInputs = Map[String, WdlValue]
-
   type ImportResolver = String => WdlSource
 
   /**
-   * Core data identifying a workflow including its unique ID, its namespace, and strongly typed inputs.
+   * Constructs a representation of a particular workflow invocation
    */
-  case class WorkflowDescriptor(id: WorkflowId, namespace: NamespaceWithWorkflow, wdlSource: WdlSource, wdlJson: WdlJson, actualInputs: WorkflowCoercedInputs) {
+  case class WorkflowDescriptor(id: WorkflowId, sourceFiles: WorkflowSourceFiles) {
+    val workflowOptions = Try(sourceFiles.workflowOptionsJson.parseJson) match {
+      case Success(JsObject(options)) =>
+        if (options.values.nonEmpty && !options.values.exists(_.isInstanceOf[JsString])) {
+          throw new Throwable(s"Workflow ${id.toString} options JSON is not a String -> String map: ${sourceFiles.workflowOptionsJson}")
+        }
+        options map { case (k, v) => k -> v.asInstanceOf[JsString].value }
+      case _ => throw new Throwable(s"Workflow ${id.toString} contains bad workflow options JSON: ${sourceFiles.inputsJson}")
+    }
+
+    val backendType = Backend.from(workflowOptions.getOrElse("default_backend", ConfigFactory.load.getConfig("backend").getString("backend")))
+    val namespace = NamespaceWithWorkflow.load(sourceFiles.wdlSource, backendType.backendType)
     val name = namespace.workflow.name
     val shortId = id.toString.split("-")(0)
+
+    val rawInputs = Try(sourceFiles.inputsJson.parseJson) match {
+      case Success(JsObject(inputs)) => inputs
+      case _ => throw new Throwable(s"Workflow ${id.toString} contains bad inputs JSON: ${sourceFiles.inputsJson}")
+    }
+
+    val coercedInputs = namespace.coerceRawInputs(rawInputs).get
+    val declarations = namespace.staticDeclarationsRecursive(coercedInputs).get
+    val actualInputs: WorkflowCoercedInputs = coercedInputs ++ declarations
   }
+
+  case class WorkflowSourceFiles(wdlSource: WdlSource, inputsJson: WdlJson, workflowOptionsJson: WorkflowOptionsJson)
 
   implicit class EnhancedFullyQualifiedName(val fqn: FullyQualifiedName) extends AnyVal {
     def isScatter = fqn.contains(Scatter.FQNIdentifier)

--- a/src/main/scala/cromwell/binding/types/WdlArrayType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlArrayType.scala
@@ -15,6 +15,7 @@ case class WdlArrayType(memberType: WdlType) extends WdlType {
     case s: Seq[Any] if s.nonEmpty => coerceIterable(s)
     case s: Seq[Any] if s.isEmpty => WdlArray(WdlArrayType(memberType), Seq())
     case js: JsArray if js.elements.nonEmpty => coerceIterable(js.elements)
+    case js: JsArray if js.elements.isEmpty => WdlArray(WdlArrayType(memberType), Seq())
     case wdlArray: WdlArray => wdlArray.wdlType.memberType match {
       case WdlStringType if memberType == WdlFileType =>
         // Coerce Array[String] -> Array[File]

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -23,16 +23,14 @@ import scala.util.{Failure, Success, Try}
 
 object Backend {
   class StdoutStderrException(message: String) extends RuntimeException(message)
-  def from(backendConf: Config): Backend = {
-    backendConf.getString("backend").toLowerCase match {
-      case "local" => new LocalBackend
-      case "jes" => new JesBackend
-      case "sge" => new SgeBackend
-      case doh => throw new IllegalArgumentException(s"$doh is not a recognized backend")
-    }
+  def from(backendConf: Config): Backend = from(backendConf.getString("backend"))
+  def from(name: String) = name.toLowerCase match {
+    case "local" => new LocalBackend
+    case "jes" => new JesBackend
+    case "sge" => new SgeBackend
+    case doh => throw new IllegalArgumentException(s"$doh is not a recognized backend")
   }
-
-  case class RestartableWorkflow(id: WorkflowId, source: WdlSource, json: WdlJson, inputs: binding.WorkflowRawInputs)
+  case class RestartableWorkflow(id: WorkflowId, source: WorkflowSourceFiles)
 }
 
 /**
@@ -78,7 +76,7 @@ trait Backend {
   /**
    * Return CallStandardOutput which contains the stdout/stderr of the particular call
    */
-  def stdoutStderr(workflowId: WorkflowId, workflowName: String, callName: String, index: ExecutionIndex): StdoutStderr
+  def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): StdoutStderr
 
   def backendType: BackendType
 

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -14,7 +14,7 @@ case class JesBackendCall(backend: JesBackend,
                           key: CallKey,
                           locallyQualifiedInputs: CallInputs,
                           callAbortRegistrationFunction: AbortRegistrationFunction) extends BackendCall {
-  val callGcsPath = JesBackend.callGcsPath(workflowDescriptor.id.toString, workflowDescriptor.name, call.name, key.index)
+  val callGcsPath = JesBackend.callGcsPath(workflowDescriptor, call.name, key.index)
   val callDir = GoogleCloudStoragePath(callGcsPath)
   val gcsExecPath = GoogleCloudStoragePath(callGcsPath + "/exec.sh")
   val jesConnection = JesBackend.JesConnection

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -83,8 +83,8 @@ trait SharedFileSystem {
 
   def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs
 
-  def stdoutStderr(workflowId: WorkflowId, workflowName: String, callName: String, index: ExecutionIndex): StdoutStderr = {
-    val dir = LocalBackend.hostCallPath(workflowName, workflowId, callName, index)
+  def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): StdoutStderr = {
+    val dir = LocalBackend.hostCallPath(descriptor.namespace.workflow.name, descriptor.id, callName, index)
     StdoutStderr(
       stdout = WdlFile(dir.resolve("stdout").toAbsolutePath.toString),
       stderr = WdlFile(dir.resolve("stderr").toAbsolutePath.toString)

--- a/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -30,26 +30,23 @@ object DataAccess {
       Await.ready(dataAccess.shutdown(), Duration.Inf)
     }
   }
-
-  // TODO PLEASE RENAME ME
-  case class WorkflowInfo(workflowId: WorkflowId, wdlSource: WdlSource, wdlJson: WdlJson)
 }
 
 trait DataAccess {
-
-  import DataAccess._
   /**
    * Creates a row in each of the backend-info specific tables for each call in `calls` corresponding to the backend
    * `backend`.  Or perhaps defer this?
    */
-  def createWorkflow(workflowInfo: WorkflowInfo,
+  def createWorkflow(workflowDescriptor: WorkflowDescriptor,
                      workflowInputs: Traversable[SymbolStoreEntry],
                      calls: Traversable[Scope],
                      backend: Backend): Future[Unit]
 
   def getWorkflowState(workflowId: WorkflowId): Future[Option[WorkflowState]]
 
-  def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowInfo]]
+  def getWorkflow(workflowId: WorkflowId): Future[WorkflowDescriptor]
+
+  def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowDescriptor]]
 
   def getExecutionBackendInfo(workflowId: WorkflowId, call: Call): Future[CallBackendInfo]
 

--- a/src/main/scala/cromwell/engine/db/slick/SlickDataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/slick/SlickDataAccess.scala
@@ -15,9 +15,8 @@ import cromwell.engine.backend.Backend
 import cromwell.engine.backend.jes.JesBackend
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.backend.sge.SgeBackend
-import cromwell.engine.db.DataAccess.WorkflowInfo
 import cromwell.engine.db._
-import cromwell.engine.workflow.{ScatterKey, ExecutionStoreKey, CallKey, OutputKey}
+import cromwell.engine.workflow.{CallKey, ExecutionStoreKey, OutputKey, ScatterKey}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.Duration
@@ -145,7 +144,7 @@ class SlickDataAccess(databaseConfig: Config, val dataAccess: DataAccessComponen
    * Creates a row in each of the backend-info specific tables for each key in `keys` corresponding to the backend
    * `backend`.  Or perhaps defer this?
    */
-  override def createWorkflow(workflowInfo: WorkflowInfo,
+  override def createWorkflow(workflowDescriptor: WorkflowDescriptor,
                               workflowInputs: Traversable[SymbolStoreEntry],
                               scopes: Traversable[Scope],
                               backend: Backend): Future[Unit] = {
@@ -159,14 +158,16 @@ class SlickDataAccess(databaseConfig: Config, val dataAccess: DataAccessComponen
 
       workflowExecutionInsert <- dataAccess.workflowExecutionsAutoInc +=
         new WorkflowExecution(
-          workflowInfo.workflowId.toString,
+          workflowDescriptor.id.toString,
           WorkflowSubmitted.toString,
           new Date().toTimestamp)
 
       _ <- dataAccess.workflowExecutionAuxesAutoInc += new WorkflowExecutionAux(
         workflowExecutionInsert.workflowExecutionId.get,
-        workflowInfo.wdlSource.toClob,
-        workflowInfo.wdlJson.toClob)
+        workflowDescriptor.sourceFiles.wdlSource.toClob,
+        workflowDescriptor.sourceFiles.inputsJson.toClob,
+        workflowDescriptor.sourceFiles.workflowOptionsJson.toClob
+      )
 
       symbolInsert <- dataAccess.symbolsAutoInc ++= toSymbols(workflowExecutionInsert, workflowInputs)
 
@@ -307,28 +308,45 @@ class SlickDataAccess(databaseConfig: Config, val dataAccess: DataAccessComponen
     runTransaction(action)
   }
 
-  override def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowInfo]] = {
+  override def getWorkflow(workflowId: WorkflowId): Future[WorkflowDescriptor] = {
+    val action = for {
+      workflowExecutionResult <- dataAccess.workflowExecutionsByWorkflowExecutionUuid(workflowId.toString).result.head
+      workflowAux <- dataAccess.workflowExecutionAuxesByWorkflowExecutionId(workflowExecutionResult.workflowExecutionId.get).result.head
+      workflowDescriptor = WorkflowDescriptor(
+        workflowId,
+        WorkflowSourceFiles(workflowAux.wdlSource.toRawString, workflowAux.jsonInputs.toRawString, workflowAux.workflowOptions.toRawString)
+      )
+    } yield workflowDescriptor
+
+    runTransaction(action)
+  }
+
+  override def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowDescriptor]] = {
 
     val action = for {
 
       workflowExecutionResults <- dataAccess.workflowExecutionsByStatuses(states.map(_.toString)).result
 
-      workflowInfos <- DBIO.sequence(
+      workflowDescriptors <- DBIO.sequence(
         workflowExecutionResults map { workflowExecutionResult =>
 
           val workflowExecutionAuxResult = dataAccess.workflowExecutionAuxesByWorkflowExecutionId(
             workflowExecutionResult.workflowExecutionId.get).result.head
 
           workflowExecutionAuxResult map { workflowExecutionAux =>
-            new WorkflowInfo(
+            new WorkflowDescriptor(
               WorkflowId.fromString(workflowExecutionResult.workflowExecutionUuid),
-              workflowExecutionAux.wdlSource.toRawString,
-              workflowExecutionAux.jsonInputs.toRawString)
+              WorkflowSourceFiles(
+                workflowExecutionAux.wdlSource.toRawString,
+                workflowExecutionAux.jsonInputs.toRawString,
+                workflowExecutionAux.workflowOptions.toRawString
+              )
+            )
           }
         }
       )
 
-    } yield workflowInfos
+    } yield workflowDescriptors
 
     runTransaction(action)
   }

--- a/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
@@ -9,6 +9,7 @@ case class WorkflowExecutionAux
   workflowExecutionId: Int,
   wdlSource: Clob,
   jsonInputs: Clob,
+  workflowOptions: Clob,
   workflowExecutionAuxId: Option[Int] = None
 )
 
@@ -22,8 +23,9 @@ trait WorkflowExecutionAuxComponent {
     def workflowExecutionId = column[Int]("WORKFLOW_EXECUTION_ID")
     def wdlSource = column[Clob]("WDL_SOURCE")
     def jsonInputs = column[Clob]("JSON_INPUTS")
+    def workflowOptions = column[Clob]("WORKFLOW_OPTIONS")
 
-    override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowExecutionAuxId.?) <>
+    override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowOptions, workflowExecutionAuxId.?) <>
       (WorkflowExecutionAux.tupled, WorkflowExecutionAux.unapply)
 
     def workflowExecution = foreignKey(

--- a/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -27,7 +27,8 @@ class SimpleWorkflowActorSpec extends CromwellTestkitSpec("SimpleWorkflowActorSp
     val namespace = NamespaceWithWorkflow.load(sampleWdl.wdlSource(), BackendType.LOCAL)
     val rawInputs = rawInputsOverride.getOrElse(sampleWdl.rawInputs)
     val coercedInputs = namespace.coerceRawInputs(rawInputs).get
-    val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), namespace, sampleWdl.wdlSource(), sampleWdl.wdlJson, coercedInputs)
+    val workflowSources = WorkflowSourceFiles(sampleWdl.wdlSource(), sampleWdl.wdlJson, "{}")
+    val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), workflowSources)
     TestFSMRef(new WorkflowActor(descriptor, new LocalBackend, dataAccess))
   }
 

--- a/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -7,7 +7,7 @@ import scala.language.postfixOps
 
 class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec("SingleWorkflowRunnerActorSpec") {
   val workflowManagerActor = system.actorOf(WorkflowManagerActor.props(dataAccess, CromwellSpec.BackendInstance))
-  val props = SingleWorkflowRunnerActor.props(ThreeStep.wdlSource(), ThreeStep.wdlJson, ThreeStep.rawInputs, workflowManagerActor)
+  val props = SingleWorkflowRunnerActor.props(ThreeStep.asWorkflowSources(), ThreeStep.rawInputs, workflowManagerActor)
 
   "A SingleWorkflowRunnerActor" should {
     "successfully run a workflow" in {

--- a/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -39,7 +39,7 @@ object MockWorkflowManagerActor {
 class MockWorkflowManagerActor extends Actor  {
 
   def receive = {
-    case SubmitWorkflow(wdlSource, wdlJson, rawInputs) =>
+    case SubmitWorkflow(sources) =>
       sender ! MockWorkflowManagerActor.submittedWorkflowId
 
     case WorkflowStatus(id) =>
@@ -240,14 +240,27 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
       }
   }
 
-  it should "return 400 for a malformed JSON " in {
+  it should "return 400 for a malformed workflow inputs JSON " in {
     Post("/workflows/$version", FormData(Seq("wdlSource" -> HelloWorld.wdlSource(), "workflowInputs" -> CromwellApiServiceSpec.MalformedInputsJson))) ~>
       submitRoute ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
         }
-        assertResult("workflowInput JSON was malformed") {
+        assertResult("Expecting JSON object for workflowInputs and workflowOptions fields") {
+          responseAs[String]
+        }
+      }
+  }
+
+  it should "return 400 for a malformed workflow options JSON " in {
+    Post("/workflows/$version", FormData(Seq("wdlSource" -> HelloWorld.wdlSource(), "workflowInputs" -> HelloWorld.rawInputs.toJson.toString(), "workflowOptions" -> CromwellApiServiceSpec.MalformedInputsJson))) ~>
+      submitRoute ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+        assertResult("Expecting JSON object for workflowInputs and workflowOptions fields") {
           responseAs[String]
         }
       }


### PR DESCRIPTION
* Users specify `workflowOptions` from the HTTP API.  It is formatted as a JSON object, currently as a String to String map.  Users can also specify it at the command line
* Allow users to specify `jes_gcs_root` in this JSON file, honored in JesBackend
* Remove `WorkflowInfo`, replace with `WorkflowDescriptor`