### PR TITLE
Allow users to specify workflow options.

### DIFF
--- a/src/main/migrations/changelog.xml
+++ b/src/main/migrations/changelog.xml
@@ -16,4 +16,5 @@
     <include file="changesets/sge.xml" relativeToChangelogFile="true" />
     <include file="changesets/change_execution_unique_constraint.xml" relativeToChangelogFile="true" />
     <include file="changesets/rc.xml" relativeToChangelogFile="true" />
+    <include file="changesets/workflow_options.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/main/migrations/changesets/workflow_options.xml
+++ b/src/main/migrations/changesets/workflow_options.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+    <property name="clob.type" value="LONGTEXT" dbms="mysql"/>
+    <property name="clob.type" value="LONGVARCHAR" dbms="hsqldb"/>
+    <changeSet author="sfrazer" id="workflow-options">
+        <addColumn tableName="WORKFLOW_EXECUTION_AUX">
+            <column name="WORKFLOW_OPTIONS" type="${clob.type}" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/swagger/cromwell.yaml
+++ b/src/main/resources/swagger/cromwell.yaml
@@ -62,8 +62,13 @@ paths:
           type: file
           in: formData
         - name: workflowInputs
-          description: WDL JSON
-          required: true
+          description: WDL Inputs JSON
+          required: false
+          type: file
+          in: formData
+        - name: workflowOptions
+          description: Workflow Options JSON
+          required: false
           type: file
           in: formData
       tags:

--- a/src/main/scala/cromwell/binding/AstTools.scala
+++ b/src/main/scala/cromwell/binding/AstTools.scala
@@ -157,7 +157,10 @@ object AstTools {
     would have its own MemberAccess - "a.b.c" and "a.b.d"
   */
   def findTopLevelMemberAccesses(expr: AstNode): Iterable[Ast] = expr.findAstsWithTrail("MemberAccess").filterNot {
-    case(k, v) => v.exists{case a:Ast => a.getName == "MemberAccess"}
+    case(k, v) => v exists {
+      case a: Ast => a.getName == "MemberAccess"
+      case _ => false
+    }
   }.keys
 
   /**

--- a/src/main/scala/cromwell/binding/package.scala
+++ b/src/main/scala/cromwell/binding/package.scala
@@ -1,7 +1,12 @@
 package cromwell
 
+import com.typesafe.config.ConfigFactory
+import cromwell.engine.backend.Backend
+import spray.json._
+import scala.util.{Try, Success, Failure}
 import cromwell.binding.values.WdlValue
 import cromwell.engine.WorkflowId
+import cromwell.parser.BackendType
 
 /**
  * ==WDL Bindings for Scala==
@@ -16,6 +21,8 @@ import cromwell.engine.WorkflowId
 package object binding {
   type WdlSource = String
   type WdlJson = String
+  type WorkflowOptionsJson = String
+  type WorkflowOptions = Map[String, String]
   type WorkflowRawInputs = Map[FullyQualifiedName, Any]
   type WorkflowCoercedInputs = Map[FullyQualifiedName, WdlValue]
   type WorkflowOutputs = Map[FullyQualifiedName, WdlValue]
@@ -24,16 +31,40 @@ package object binding {
   type CallInputs = Map[String, WdlValue]
   type CallOutputs = Map[LocallyQualifiedName, WdlValue]
   type HostInputs = Map[String, WdlValue]
-
   type ImportResolver = String => WdlSource
 
   /**
-   * Core data identifying a workflow including its unique ID, its namespace, and strongly typed inputs.
+   * Constructs a representation of a particular workflow invocation.  As with other
+   * case classes and apply() methods, this will throw an exception if it cannot be
+   * created
    */
-  case class WorkflowDescriptor(id: WorkflowId, namespace: NamespaceWithWorkflow, wdlSource: WdlSource, wdlJson: WdlJson, actualInputs: WorkflowCoercedInputs) {
+  case class WorkflowDescriptor(id: WorkflowId, sourceFiles: WorkflowSourceFiles) {
+    val workflowOptions = Try(sourceFiles.workflowOptionsJson.parseJson) match {
+      case Success(JsObject(options)) =>
+        if (options.values.nonEmpty && !options.values.exists(_.isInstanceOf[JsString])) {
+          throw new Throwable(s"Workflow ${id.toString} options JSON is not a String -> String map: ${sourceFiles.workflowOptionsJson}")
+        }
+        options map { case (k, v) => k -> v.asInstanceOf[JsString].value }
+      case _ => throw new Throwable(s"Workflow ${id.toString} contains bad workflow options JSON: ${sourceFiles.inputsJson}")
+    }
+
+    val backendType = Backend.from(workflowOptions.getOrElse("default_backend", ConfigFactory.load.getConfig("backend").getString("backend")))
+    val namespace = NamespaceWithWorkflow.load(sourceFiles.wdlSource, backendType.backendType)
     val name = namespace.workflow.name
     val shortId = id.toString.split("-")(0)
+
+    val rawInputs = Try(sourceFiles.inputsJson.parseJson) match {
+      case Success(JsObject(inputs)) => inputs
+      case _ => throw new Throwable(s"Workflow ${id.toString} contains bad inputs JSON: ${sourceFiles.inputsJson}")
+    }
+
+    // Currently we are throwing an exception if construction of the workflow descriptor fails, hence .get on the Trys
+    val coercedInputs = namespace.coerceRawInputs(rawInputs).get
+    val declarations = namespace.staticDeclarationsRecursive(coercedInputs).get
+    val actualInputs: WorkflowCoercedInputs = coercedInputs ++ declarations
   }
+
+  case class WorkflowSourceFiles(wdlSource: WdlSource, inputsJson: WdlJson, workflowOptionsJson: WorkflowOptionsJson)
 
   implicit class EnhancedFullyQualifiedName(val fqn: FullyQualifiedName) extends AnyVal {
     def isScatter = fqn.contains(Scatter.FQNIdentifier)

--- a/src/main/scala/cromwell/binding/types/WdlArrayType.scala
+++ b/src/main/scala/cromwell/binding/types/WdlArrayType.scala
@@ -13,8 +13,9 @@ case class WdlArrayType(memberType: WdlType) extends WdlType {
 
   override protected def coercion = {
     case s: Seq[Any] if s.nonEmpty => coerceIterable(s)
-    case s: Seq[Any] if s.isEmpty => WdlArray(WdlArrayType(memberType), Seq())
+    case s: Seq[Any] => WdlArray(WdlArrayType(memberType), Seq())
     case js: JsArray if js.elements.nonEmpty => coerceIterable(js.elements)
+    case js: JsArray => WdlArray(WdlArrayType(memberType), Seq())
     case wdlArray: WdlArray => wdlArray.wdlType.memberType match {
       case WdlStringType if memberType == WdlFileType =>
         // Coerce Array[String] -> Array[File]

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -23,16 +23,14 @@ import scala.util.{Failure, Success, Try}
 
 object Backend {
   class StdoutStderrException(message: String) extends RuntimeException(message)
-  def from(backendConf: Config): Backend = {
-    backendConf.getString("backend").toLowerCase match {
-      case "local" => new LocalBackend
-      case "jes" => new JesBackend
-      case "sge" => new SgeBackend
-      case doh => throw new IllegalArgumentException(s"$doh is not a recognized backend")
-    }
+  def from(backendConf: Config): Backend = from(backendConf.getString("backend"))
+  def from(name: String) = name.toLowerCase match {
+    case "local" => new LocalBackend
+    case "jes" => new JesBackend
+    case "sge" => new SgeBackend
+    case doh => throw new IllegalArgumentException(s"$doh is not a recognized backend")
   }
-
-  case class RestartableWorkflow(id: WorkflowId, source: WdlSource, json: WdlJson, inputs: binding.WorkflowRawInputs)
+  case class RestartableWorkflow(id: WorkflowId, source: WorkflowSourceFiles)
 }
 
 /**
@@ -78,7 +76,7 @@ trait Backend {
   /**
    * Return CallStandardOutput which contains the stdout/stderr of the particular call
    */
-  def stdoutStderr(workflowId: WorkflowId, workflowName: String, callName: String, index: ExecutionIndex): StdoutStderr
+  def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): StdoutStderr
 
   def backendType: BackendType
 

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -12,7 +12,7 @@ case class JesBackendCall(backend: JesBackend,
                           key: CallKey,
                           locallyQualifiedInputs: CallInputs,
                           callAbortRegistrationFunction: AbortRegistrationFunction) extends BackendCall {
-  val callGcsPath = JesBackend.callGcsPath(workflowDescriptor.id.toString, workflowDescriptor.name, call.name, key.index)
+  val callGcsPath = JesBackend.callGcsPath(workflowDescriptor, call.name, key.index)
   val callDir = GoogleCloudStoragePath(callGcsPath)
   val gcsExecPath = GoogleCloudStoragePath(callGcsPath + "/exec.sh")
   val jesConnection = JesBackend.JesConnection

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -84,8 +84,8 @@ trait SharedFileSystem {
 
   def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs
 
-  def stdoutStderr(workflowId: WorkflowId, workflowName: String, callName: String, index: ExecutionIndex): StdoutStderr = {
-    val dir = LocalBackend.hostCallPath(workflowName, workflowId, callName, index)
+  def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): StdoutStderr = {
+    val dir = LocalBackend.hostCallPath(descriptor.namespace.workflow.name, descriptor.id, callName, index)
     StdoutStderr(
       stdout = WdlFile(dir.resolve("stdout").toAbsolutePath.toString),
       stderr = WdlFile(dir.resolve("stderr").toAbsolutePath.toString)

--- a/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -30,26 +30,23 @@ object DataAccess {
       Await.ready(dataAccess.shutdown(), Duration.Inf)
     }
   }
-
-  // TODO PLEASE RENAME ME
-  case class WorkflowInfo(workflowId: WorkflowId, wdlSource: WdlSource, wdlJson: WdlJson)
 }
 
 trait DataAccess {
-
-  import DataAccess._
   /**
    * Creates a row in each of the backend-info specific tables for each call in `calls` corresponding to the backend
    * `backend`.  Or perhaps defer this?
    */
-  def createWorkflow(workflowInfo: WorkflowInfo,
+  def createWorkflow(workflowDescriptor: WorkflowDescriptor,
                      workflowInputs: Traversable[SymbolStoreEntry],
                      calls: Traversable[Scope],
                      backend: Backend): Future[Unit]
 
   def getWorkflowState(workflowId: WorkflowId): Future[Option[WorkflowState]]
 
-  def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowInfo]]
+  def getWorkflow(workflowId: WorkflowId): Future[WorkflowDescriptor]
+
+  def getWorkflowsByState(states: Traversable[WorkflowState]): Future[Traversable[WorkflowDescriptor]]
 
   def getExecutionBackendInfo(workflowId: WorkflowId, call: Call): Future[CallBackendInfo]
 

--- a/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/WorkflowExecutionAuxComponent.scala
@@ -9,6 +9,7 @@ case class WorkflowExecutionAux
   workflowExecutionId: Int,
   wdlSource: Clob,
   jsonInputs: Clob,
+  workflowOptions: Clob,
   workflowExecutionAuxId: Option[Int] = None
 )
 
@@ -22,8 +23,9 @@ trait WorkflowExecutionAuxComponent {
     def workflowExecutionId = column[Int]("WORKFLOW_EXECUTION_ID")
     def wdlSource = column[Clob]("WDL_SOURCE")
     def jsonInputs = column[Clob]("JSON_INPUTS")
+    def workflowOptions = column[Clob]("WORKFLOW_OPTIONS")
 
-    override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowExecutionAuxId.?) <>
+    override def * = (workflowExecutionId, wdlSource, jsonInputs, workflowOptions, workflowExecutionAuxId.?) <>
       (WorkflowExecutionAux.tupled, WorkflowExecutionAux.unapply)
 
     def workflowExecution = foreignKey(

--- a/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -1,6 +1,5 @@
 package cromwell.engine.workflow
 
-
 import akka.actor.FSM.{SubscribeTransitionCallBack, Transition}
 import akka.actor.{Actor, ActorRef, Props}
 import akka.event.{Logging, LoggingReceive}
@@ -13,24 +12,21 @@ import cromwell.engine.ExecutionStatus.ExecutionStatus
 import cromwell.engine._
 import cromwell.engine.backend.Backend.RestartableWorkflow
 import cromwell.engine.backend.{Backend, StdoutStderr}
-import cromwell.engine.db.DataAccess.WorkflowInfo
 import cromwell.engine.db.{DataAccess, ExecutionDatabaseKey}
 import cromwell.engine.workflow.WorkflowActor.{Restart, Start}
 import cromwell.util.WriteOnceStore
-import spray.json._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
-
 object WorkflowManagerActor {
   class WorkflowNotFoundException(message: String) extends RuntimeException(message)
   class CallNotFoundException(message: String) extends RuntimeException(message)
 
   sealed trait WorkflowManagerActorMessage
-  case class SubmitWorkflow(wdlSource: WdlSource, wdlJson: WdlJson, inputs: binding.WorkflowRawInputs) extends WorkflowManagerActorMessage
+  case class SubmitWorkflow(source: WorkflowSourceFiles) extends WorkflowManagerActorMessage
   case class WorkflowStatus(id: WorkflowId) extends WorkflowManagerActorMessage
   case class WorkflowOutputs(id: WorkflowId) extends WorkflowManagerActorMessage
   case class CallOutputs(id: WorkflowId, callFqn: FullyQualifiedName) extends WorkflowManagerActorMessage
@@ -67,8 +63,8 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
   }
 
   def receive = LoggingReceive {
-    case SubmitWorkflow(wdlSource, wdlJson, inputs) =>
-      submitWorkflow(wdlSource, wdlJson, inputs, maybeWorkflowId = None) pipeTo sender
+    case SubmitWorkflow(source) =>
+      submitWorkflow(source, maybeWorkflowId = None) pipeTo sender
     case WorkflowStatus(id) => dataAccess.getWorkflowState(id) pipeTo sender
     case WorkflowAbort(id) =>
       workflowStore.toMap.get(id) match {
@@ -137,12 +133,9 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
     }
   }
 
-  /* Return value here is a tuple: (workflow name, call name)
-   * TODO: This should use a more sophisticated way of resolving FQNs.  See DSDEEPB-986
-   */
-  private def assertCallFqnWellFormed(callFqn: FullyQualifiedName): Try[(String, String)] = {
-    callFqn.split("\\.").toSeq match {
-      case s: Seq[String] if s.size >= 2 => Success(s.head, s.last)
+  private def assertCallFqnWellFormed(descriptor: WorkflowDescriptor, callFqn: FullyQualifiedName): Try[String] = {
+    descriptor.namespace.resolve(callFqn) match {
+      case Some(c: Call) => Success(c.name)
       case _ => Failure(new UnsupportedOperationException("Expected a fully qualified name to have at least two parts"))
     }
   }
@@ -160,23 +153,22 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
 
   private def callStdoutStderr(workflowId: WorkflowId, callFqn: String): Future[Any] = {
     for {
-      _ <- assertWorkflowExistence(workflowId)
-      _ <- assertCallExistence(workflowId, callFqn)
-      (wf, call) <- Future.fromTry(assertCallFqnWellFormed(callFqn))
-      callLogKeys <- getCallLogKeys(workflowId, callFqn)
-      callStandardOutput <- Future.successful( callLogKeys map { key => backend.stdoutStderr(workflowId, wf, call, key.index) })
-    } yield callStandardOutput
+        _ <- assertWorkflowExistence(workflowId)
+        descriptor <- dataAccess.getWorkflow(workflowId)
+        callName <- Future.fromTry(assertCallFqnWellFormed(descriptor, callFqn))
+        callLogKeys <- getCallLogKeys(workflowId, callFqn)
+        callStandardOutput <- Future.successful(callLogKeys map { key => backend.stdoutStderr(descriptor, callName, key.index) })
+      } yield callStandardOutput
   }
 
-
   private def workflowStdoutStderr(workflowId: WorkflowId): Future[Map[FullyQualifiedName, Seq[StdoutStderr]]] = {
-    def logMapFromStatusMap(statusMap: Map[ExecutionDatabaseKey, ExecutionStatus]): Try[Map[FullyQualifiedName, Seq[StdoutStderr]]] = {
+    def logMapFromStatusMap(descriptor: WorkflowDescriptor, statusMap: Map[ExecutionDatabaseKey, ExecutionStatus]): Try[Map[FullyQualifiedName, Seq[StdoutStderr]]] = {
       Try {
         val sortedMap = statusMap.toSeq.sortBy(_._1.index)
         val callsToPaths = for {
           (key, status) <- sortedMap if status.isTerminal && hasLogs(statusMap.keys)(key)
-          (wf, callLqn) = assertCallFqnWellFormed(key.fqn).get
-          callStandardOutput = backend.stdoutStderr(workflowId, wf, callLqn, key.index)
+          callName = assertCallFqnWellFormed(descriptor, key.fqn).get
+          callStandardOutput = backend.stdoutStderr(descriptor, callName, key.index)
         } yield key.fqn -> callStandardOutput
 
         callsToPaths groupBy { _._1 } mapValues { v => v map { _._2 } }
@@ -185,21 +177,19 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
 
     for {
       _ <- assertWorkflowExistence(workflowId)
+      descriptor <- dataAccess.getWorkflow(workflowId)
       callToStatusMap <- dataAccess.getExecutionStatuses(workflowId)
-      callToLogsMap <- Future.fromTry(logMapFromStatusMap(callToStatusMap mapValues { _.executionStatus }))
+      x = callToStatusMap mapValues { _.executionStatus }
+      callToLogsMap <- Future.fromTry(logMapFromStatusMap(descriptor, callToStatusMap mapValues { _.executionStatus }))
     } yield callToLogsMap
   }
 
-  private def submitWorkflow(wdlSource: WdlSource, wdlJson: WdlJson, inputs: WorkflowRawInputs,
+  private def submitWorkflow(source: WorkflowSourceFiles,
                              maybeWorkflowId: Option[WorkflowId]): Future[WorkflowId] = {
     val workflowId: WorkflowId = maybeWorkflowId.getOrElse(WorkflowId.randomId())
     log.info(s"$tag submitWorkflow input id = $maybeWorkflowId, effective id = $workflowId")
     val futureId = for {
-      eventualNamespace <- Future(NamespaceWithWorkflow.load(wdlSource, BackendType))
-      coercedInputs <- Future.fromTry(eventualNamespace.coerceRawInputs(inputs))
-      declarations <- Future.fromTry(eventualNamespace.staticDeclarationsRecursive(coercedInputs))
-      inputs = coercedInputs ++ declarations
-      descriptor = new WorkflowDescriptor(workflowId, eventualNamespace, wdlSource, wdlJson, inputs)
+      descriptor <- Future.fromTry(Try(new WorkflowDescriptor(workflowId, source)))
       workflowActor = context.actorOf(WorkflowActor.props(descriptor, backend, dataAccess), s"WorkflowActor-$workflowId")
       _ <- Future.fromTry(workflowStore.insert(workflowId, workflowActor))
     } yield {
@@ -218,9 +208,8 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
     futureId
   }
 
-  private def restartWorkflow(restartableWorkflow: RestartableWorkflow): Unit = {
-    submitWorkflow(restartableWorkflow.source, restartableWorkflow.json, restartableWorkflow.inputs, Option(restartableWorkflow.id))
-  }
+  private def restartWorkflow(restartableWorkflow: RestartableWorkflow): Unit =
+    submitWorkflow(restartableWorkflow.source, Option(restartableWorkflow.id))
 
   private def updateWorkflowState(workflow: WorkflowActorRef, state: WorkflowState): Future[Unit] = {
     val id = idByWorkflow(workflow)
@@ -232,33 +221,20 @@ class WorkflowManagerActor(dataAccess: DataAccess, backend: Backend) extends Act
   }
 
   private def restartIncompleteWorkflows(): Unit = {
-    // If the clob inputs for this workflow can be converted to JSON, return the JSON
-    // version of those inputs in a Some().  Otherwise return None.
-    def clobToJsonInputs(workflowInfo: WorkflowInfo): Option[binding.WorkflowRawInputs] = {
-      workflowInfo.wdlJson.parseJson match {
-        case JsObject(rawInputs) => Option(rawInputs)
-        case x =>
-          log.error(s"$tag Error restarting workflow ${workflowInfo.workflowId}: expected JSON inputs, got '$x'.")
-          None
-      }
-    }
-
     type QuantifierAndPlural = (String, String)
     def pluralize(num: Int): QuantifierAndPlural = {
       (if (num == 0) "no" else num.toString, if (num == 1) "" else "s")
     }
 
-    def buildRestartableWorkflows(workflowInfos: Traversable[WorkflowInfo]): Seq[RestartableWorkflow] = {
+    def buildRestartableWorkflows(workflowDescriptors: Traversable[WorkflowDescriptor]): Seq[RestartableWorkflow] = {
       (for {
-        workflowInfo <- workflowInfos
-        jsonInputs = clobToJsonInputs(workflowInfo)
-        if jsonInputs.isDefined
-      } yield RestartableWorkflow(workflowInfo.workflowId, workflowInfo.wdlSource, workflowInfo.wdlJson, jsonInputs.get)).toSeq
+        workflowDescriptor <- workflowDescriptors
+      } yield RestartableWorkflow(workflowDescriptor.id, workflowDescriptor.sourceFiles)).toSeq
     }
 
     val result = for {
-      workflowInfos <- dataAccess.getWorkflowsByState(Seq(WorkflowSubmitted, WorkflowRunning))
-      restartableWorkflows = buildRestartableWorkflows(workflowInfos)
+      workflowDescriptors <- dataAccess.getWorkflowsByState(Seq(WorkflowSubmitted, WorkflowRunning))
+      restartableWorkflows = buildRestartableWorkflows(workflowDescriptors)
       _ <- backend.handleCallRestarts(restartableWorkflows, dataAccess)
     } yield {
         val num = restartableWorkflows.length

--- a/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -5,6 +5,7 @@ import javax.ws.rs.Path
 import akka.actor.{Actor, ActorRef, ActorRefFactory, Props}
 import com.typesafe.config.Config
 import com.wordnik.swagger.annotations._
+import cromwell.binding.WorkflowSourceFiles
 import cromwell.engine.WorkflowId
 import cromwell.engine.workflow.ValidateActor
 import spray.http.StatusCodes
@@ -87,16 +88,30 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
   def submitRoute =
     path("workflows" / Segment) { version =>
       post {
-        formFields("wdlSource", "workflowInputs") { (wdlSource, workflowInputs) =>
-
-          val tryMap = Try(workflowInputs.parseJson)
-          tryMap match {
-            case Success(JsObject(json)) =>
-              requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.WorkflowSubmit(wdlSource, workflowInputs, json))
-            case Success(o) =>
-              complete(StatusCodes.BadRequest, "Expecting JSON object as workflow inputs")
-            case Failure(ex) =>
+        formFields("wdlSource", "workflowInputs".?, "workflowOptions".?) { (wdlSource, workflowInputs, workflowOptions) =>
+          val tryInputsMap = Try(workflowInputs.getOrElse("{}").parseJson)
+          val tryOptionsMap = Try(workflowOptions.getOrElse("{}").parseJson)
+          (tryInputsMap, tryOptionsMap) match {
+            case (Success(JsObject(inputs)), Success(JsObject(options))) =>
+              if (!options.values.exists(_.isInstanceOf[JsString])) {
+                complete(StatusCodes.BadRequest, "Workflow options must be a string -> string map")
+              }
+              val parsedWorkflowOptions = options map {
+                case (k, v) => k -> v.asInstanceOf[JsString].value
+              }
+              requestContext => perRequest(
+                requestContext,
+                CromwellApiHandler.props(workflowManager),
+                CromwellApiHandler.WorkflowSubmit(
+                  WorkflowSourceFiles(wdlSource, workflowInputs.getOrElse("{}"), workflowOptions.getOrElse("{}"))
+                )
+              )
+            case (Success(_), _) | (_, Success(_)) =>
+              complete(StatusCodes.BadRequest, "Expecting JSON object for workflowInputs and workflowOptions fields")
+            case (Failure(ex), _) =>
               complete(StatusCodes.BadRequest, "workflowInput JSON was malformed")
+            case (_, Failure(ex)) =>
+              complete(StatusCodes.BadRequest, "workflowOptions JSON was malformed")
           }
         }
       }

--- a/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -27,7 +27,8 @@ class SimpleWorkflowActorSpec extends CromwellTestkitSpec("SimpleWorkflowActorSp
     val namespace = NamespaceWithWorkflow.load(sampleWdl.wdlSource(), BackendType.LOCAL)
     val rawInputs = rawInputsOverride.getOrElse(sampleWdl.rawInputs)
     val coercedInputs = namespace.coerceRawInputs(rawInputs).get
-    val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), namespace, sampleWdl.wdlSource(), sampleWdl.wdlJson, coercedInputs)
+    val workflowSources = WorkflowSourceFiles(sampleWdl.wdlSource(), sampleWdl.wdlJson, "{}")
+    val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), workflowSources)
     TestFSMRef(new WorkflowActor(descriptor, new LocalBackend, dataAccess))
   }
 

--- a/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -7,7 +7,7 @@ import scala.language.postfixOps
 
 class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec("SingleWorkflowRunnerActorSpec") {
   val workflowManagerActor = system.actorOf(WorkflowManagerActor.props(dataAccess, CromwellSpec.BackendInstance))
-  val props = SingleWorkflowRunnerActor.props(ThreeStep.wdlSource(), ThreeStep.wdlJson, ThreeStep.rawInputs, workflowManagerActor)
+  val props = SingleWorkflowRunnerActor.props(ThreeStep.asWorkflowSources(), ThreeStep.rawInputs, workflowManagerActor)
 
   "A SingleWorkflowRunnerActor" should {
     "successfully run a workflow" in {

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -1,19 +1,33 @@
 package cromwell.util
 
 import java.io.{File, FileWriter}
-import java.nio.file.{Path, Files}
+import java.nio.file.{Files, Path}
 
 import cromwell.binding._
-import cromwell.binding.values.WdlFile
+import spray.json._
+import scala.language.postfixOps
 
 trait SampleWdl {
   def wdlSource(runtime: String = ""): WdlSource
-
+  def asWorkflowSources(runtime: String = "") = WorkflowSourceFiles(wdlSource(runtime), wdlJson, "{}")
   val rawInputs: WorkflowRawInputs
 
-  def wdlJson: WdlJson = {
-    "{" + rawInputs.collect { case (k, v) => s""" "$k": "$v"""" }.mkString(",\n") + "}"
+  implicit object AnyJsonFormat extends JsonFormat[Any] {
+    def write(x: Any) = x match {
+      case n: Int => JsNumber(n)
+      case s: String => JsString(s)
+      case b: Boolean => if(b) JsTrue else JsFalse
+      case s: Seq[Any] => JsArray(s map {_.toJson} toVector)
+    }
+    def read(value: JsValue) = ???
   }
+
+  implicit object RawInputsJsonFormat extends JsonFormat[WorkflowRawInputs] {
+    def write(inputs: WorkflowRawInputs) = JsObject(inputs map { case (k, v) => k -> v.toJson })
+    def read(value: JsValue) = ???
+  }
+
+  def wdlJson: WdlJson = rawInputs.toJson.prettyPrint
 
   private def write(file: File, contents: String) = {
     val writer = new FileWriter(file)
@@ -807,7 +821,7 @@ object SampleWdl {
         |    input: files=files
         |  }
         |  call count_lines {
-        |    input: files=concat.concatenated
+        |    input: files=[concat.concatenated]
         |  }
         |  call find
         |  call count_lines as count_lines_array {

--- a/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -39,7 +39,7 @@ object MockWorkflowManagerActor {
 class MockWorkflowManagerActor extends Actor  {
 
   def receive = {
-    case SubmitWorkflow(wdlSource, wdlJson, rawInputs) =>
+    case SubmitWorkflow(sources) =>
       sender ! MockWorkflowManagerActor.submittedWorkflowId
 
     case WorkflowStatus(id) =>
@@ -240,14 +240,27 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
       }
   }
 
-  it should "return 400 for a malformed JSON " in {
+  it should "return 400 for a malformed workflow inputs JSON " in {
     Post("/workflows/$version", FormData(Seq("wdlSource" -> HelloWorld.wdlSource(), "workflowInputs" -> CromwellApiServiceSpec.MalformedInputsJson))) ~>
       submitRoute ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
         }
-        assertResult("workflowInput JSON was malformed") {
+        assertResult("Expecting JSON object for workflowInputs and workflowOptions fields") {
+          responseAs[String]
+        }
+      }
+  }
+
+  it should "return 400 for a malformed workflow options JSON " in {
+    Post("/workflows/$version", FormData(Seq("wdlSource" -> HelloWorld.wdlSource(), "workflowInputs" -> HelloWorld.rawInputs.toJson.toString(), "workflowOptions" -> CromwellApiServiceSpec.MalformedInputsJson))) ~>
+      submitRoute ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+        assertResult("Expecting JSON object for workflowInputs and workflowOptions fields") {
           responseAs[String]
         }
       }


### PR DESCRIPTION
* Users specify `workflowOptions` from the HTTP API.  It is formatted as a JSON object, currently as a String to String map.  Users can also specify it at the command line
* Allow users to specify `jes_gcs_root` in this JSON file, honored in JesBackend
* Remove `WorkflowInfo`, replace with `WorkflowDescriptor`