### PR TITLE
Fix file clobbering in local/sge backend

### DIFF
--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -2,6 +2,7 @@ package cromwell.engine.backend.local
 
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
+import java.security.MessageDigest
 
 import com.typesafe.config.ConfigFactory
 import cromwell.binding._
@@ -179,7 +180,8 @@ trait SharedFileSystem {
 
   private def stageWdlFile(call: Option[Call], wdlFile: WdlFile, hostInputsPath: Path): Try[WdlFile] = {
     val originalPath = Paths.get(wdlFile.value)
-    val executionPath = hostInputsPath.resolve(originalPath.getFileName.toString)
+    val directoryIdentifier = MessageDigest.getInstance("MD5").digest(originalPath.toAbsolutePath.getParent.toString.getBytes) map {byte => f"$byte%02x"} mkString
+    val executionPath = hostInputsPath.resolve(s"${directoryIdentifier.substring(0,8)}-${originalPath.getFileName.toString}")
 
     val attemptedLocalization = Stream(Localizers: _*) map { _(call, originalPath, executionPath) } find { _.isSuccess }
     attemptedLocalization match {

--- a/src/test/scala/cromwell/MultipleFilesWithSameNameWorkflowSpec.scala
+++ b/src/test/scala/cromwell/MultipleFilesWithSameNameWorkflowSpec.scala
@@ -1,0 +1,22 @@
+package cromwell
+
+import akka.testkit._
+import cromwell.binding.values.{WdlString, WdlFile}
+import cromwell.util.SampleWdl
+
+import scala.language.postfixOps
+
+class MultipleFilesWithSameNameWorkflowSpec extends CromwellTestkitSpec("MultipleFilesWithSameNameWorkflowSpec") {
+  "A workflow with two file inputs that have the same name" should {
+    "not clobber one file with the contents of another" in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.FileClobber,
+        EventFilter.info(pattern = s"starting calls: two.x, two.y", occurrences = 1),
+        expectedOutputs = Map(
+          "two.x.out" -> WdlString("first file.txt"),
+          "two.y.out" -> WdlString("second file.txt")
+        )
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -1181,4 +1181,29 @@ object SampleWdl {
 
     override lazy val rawInputs = Map("sc_test.do_prepare.input_file" -> createCannedFile("scatter",contents).getAbsolutePath)
   }
+
+  object FileClobber extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """task read_line {
+        |  File in
+        |  command { cat ${in} }
+        |  output { String out = read_string(stdout()) }
+        |}
+        |
+        |workflow two {
+        |  call read_line as x
+        |  call read_line as y
+        |}
+      """.stripMargin
+
+    val tempDir1 = Files.createTempDirectory("FileClobber1")
+    val tempDir2 = Files.createTempDirectory("FileClobber2")
+    val firstFile = createFile(name="file.txt", contents="first file.txt", dir=tempDir1)
+    val secondFile = createFile(name="file.txt", contents="second file.txt", dir=tempDir2)
+
+    override val rawInputs = Map(
+      "two.x.in" -> firstFile.getAbsolutePath,
+      "two.y.in" -> secondFile.getAbsolutePath
+    )
+  }
 }


### PR DESCRIPTION
I just realized that this may break for files like `.bam` and `.bai` files...