### PR TITLE
build updates

### DIFF
--- a/assembly.sbt
+++ b/assembly.sbt
@@ -1,1 +1,0 @@
-assemblySettings

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
-import sbtassembly.Plugin.AssemblyKeys._
-import sbtassembly.Plugin._
+import sbtassembly.MergeStrategy
 import sbtrelease.ReleasePlugin._
 
 name := "cromwell"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 


### PR DESCRIPTION
it fixes the issue where "sbt assembly" on newer versions of sbt and docker will ignore the `test in assembly := {}` in the build.sbt