### PR TITLE
Dual auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ $ java -jar cromwell.jar run my_workflow.wdl -
 
 The final optinal parameter to the 'run' subcommand is a JSON file of workflow options.  By default, the command line will look for a file with the same name as the WDL file but with the extension `.options.json`.  But one can also specify a value of `-` manually to specify that there are no workflow options.
 
-The only workflow option that has any meaning currently is the `jes_gcs_root`, which will be used in the JES backend.  See the section on the [JES backend](#google-jes) for more details.
+Only a few workflow options are available currently and are all to be used with the JES backend. See the section on the [JES backend](#google-jes) for more details.
 
 ```
 $ java -jar cromwell.jar run my_jes_wf.wdl my_jes_wf.json wf_options.json
@@ -269,6 +269,8 @@ Where `wf_options.json` would contain:
 ```
 {
   "jes_gcs_root": "gs://my-bucket/workflows"
+  "account_name": "my.google.account@gmail.com"
+  "refresh_token": "1/Fjf8gfJr5fdfNf9dk26fdn23FDm4x"
 }
 ```
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -43,11 +43,15 @@ backend {
   //  project = ""
   //  baseExecutionBucket = ""
   //  endpointUrl = ""
-  //  dockerhubCredentialsPath = "gs://...."
   //
   //  * Polling for completion backs-off gradually for slower-running jobs. This is the maximum polling
   //  * interval (in seconds):
   //  maximumPollingInterval = 600
+  //  authenticationMode = "" //("service_account" | "refresh_token")
+  //
+  // **** OPTIONAL ***
+  //  dockerAccount = ""
+  //  dockerToken = ""
   //}
 
   // For any backend that assumes a local filesystem (local, sge)

--- a/src/main/scala/cromwell/engine/backend/jes/GcsAuth.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/GcsAuth.scala
@@ -1,0 +1,57 @@
+package cromwell.engine.backend.jes
+
+
+import spray.json._
+
+object GcsAuth {
+
+  /**
+   * Generates a json containing auth information based on the parameters provided.
+   * @return a string representation of the json
+   */
+  def generateJson(dockerAuth: Option[DockerAuthInformation], userAuth: Option[GcsUserAuthInformation]) = {
+    Seq(dockerAuth, userAuth).flatten map { _.toMap } match {
+      case Nil => None
+      case jsons =>
+        val authsValues = jsons.reduce(_ ++ _) mapValues JsObject.apply
+        Option(JsObject("auths" -> JsObject(authsValues)).prettyPrint)
+    }
+  }
+}
+
+object GcsAuthMode {
+  def fromString(name: String): GcsAuthMode = name match {
+    case "service_account" => ServiceAccountMode
+    case "refresh_token" => RefreshTokenMode
+    case nop => throw new IllegalArgumentException(s"$nop is not a recognized authentication mode")
+  }
+}
+
+// Authentication modes supported
+sealed trait GcsAuthMode
+object ServiceAccountMode extends GcsAuthMode
+object RefreshTokenMode extends GcsAuthMode
+
+sealed trait AuthInformation {
+  val account: String
+  val token: String
+  val context: String
+
+  def toMap = Map(
+    context -> Map(
+      "account" -> JsString(account),
+      "token" -> JsString(token)
+    )
+  )
+}
+
+// User Authentication coming from the workflow options
+case class GcsUserAuthInformation(account: String, token: String) extends AuthInformation {
+  override val context = "gcloud"
+}
+
+// Docker Authentication coming from the configuration file
+// TODO (discussed with Miguel): Change to be read from workflow options too ?
+case class DockerAuthInformation(account: String, token: String) extends AuthInformation {
+  override val context = "docker"
+}

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -184,4 +184,10 @@ class LocalBackend extends Backend with SharedFileSystem with LazyLogging {
       }
     }
   }
+
+  // Nothing to do currently
+  override def cleanUpForWorkflow(workflow: WorkflowDescriptor)(implicit ec: ExecutionContext) = Future.successful({})
+
+  // No workflow options for local backend yet
+  override def assertWorkflowOptions(options: Map[String, String]): Unit = {}
 }

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -9,8 +9,8 @@ import cromwell.binding._
 import cromwell.binding.types.{WdlArrayType, WdlFileType, WdlMapType}
 import cromwell.binding.values.{WdlValue, _}
 import cromwell.engine.ExecutionIndex._
-import cromwell.engine.WorkflowId
 import cromwell.engine.backend.{LocalFileSystemBackendCall, StdoutStderr}
+import cromwell.engine.db.DataAccess
 import org.apache.commons.io.FileUtils
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
@@ -3,7 +3,7 @@ package cromwell.engine.backend.sge
 import java.nio.file.Files
 
 import com.typesafe.scalalogging.LazyLogging
-import cromwell.binding.{CallInputs, CallOutputs, WorkflowDescriptor}
+import cromwell.binding.{CallInputs, WorkflowDescriptor}
 import cromwell.engine.backend.Backend.RestartableWorkflow
 import cromwell.engine.backend._
 import cromwell.engine.backend.local.{LocalBackend, SharedFileSystem}
@@ -151,4 +151,10 @@ class SgeBackend extends Backend with SharedFileSystem with LazyLogging {
         }
     }
   }
+
+  // Nothing to do currently
+  override def cleanUpForWorkflow(workflow: WorkflowDescriptor)(implicit ec: ExecutionContext) = Future.successful({})
+
+  // No workflow options for sge yet
+  override def assertWorkflowOptions(options: Map[String, String]): Unit = {}
 }

--- a/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -5,6 +5,8 @@ import cromwell.binding.values.WdlValue
 import cromwell.engine.ExecutionStatus.ExecutionStatus
 import cromwell.engine.backend.Backend
 import cromwell.engine.db.slick._
+import cromwell.engine.backend.jes.GcsUserAuthInformation
+
 import cromwell.engine.workflow.{ExecutionStoreKey, OutputKey}
 import cromwell.engine.{SymbolStoreEntry, WorkflowId, WorkflowState}
 

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -196,7 +196,10 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
         Send a message to self to trigger an actor shutdown. Run on a short timer to help enable some
         unit test instrumentation
        */
-      if (toState.isTerminal) setTimer(s"WorkflowActor termination message: $tag", Terminate, AkkaTimeout, DontRepeatTimer)
+      if (toState.isTerminal) {
+        backend.cleanUpForWorkflow(workflow)
+        setTimer(s"WorkflowActor termination message: $tag", Terminate, AkkaTimeout, DontRepeatTimer)
+      }
   }
 
   private def persistStatus(key: ExecutionStoreKey, status: ExecutionStatus, rc: Option[Int] = None): Future[Unit] = {

--- a/src/main/scala/cromwell/util/google/GoogleCloudStorage.scala
+++ b/src/main/scala/cromwell/util/google/GoogleCloudStorage.scala
@@ -35,14 +35,22 @@ case class GoogleCloudStorage(client: Storage) {
   // See comment in uploadObject re small files. Here, define small as 2MB or lower:
   private val smallFileSizeLimit: Long = 2000000
 
-  def uploadObject(gcsPath: GoogleCloudStoragePath, fileContent: String): Unit = {
+  private def uploadFile(gcsPath: GoogleCloudStoragePath, fileContent: String, contentType: String) = {
     val fileBytes = fileContent.getBytes
     val bais = new ByteArrayInputStream(fileBytes)
-    uploadObject(gcsPath, bais, fileBytes.length)
+    uploadObject(gcsPath, bais, fileBytes.length, contentType)
   }
 
-  def uploadObject(gcsPath: GoogleCloudStoragePath, inputStream: InputStream, byteCount: Long): Unit = {
-    val mediaContent: InputStreamContent = new InputStreamContent("application/octet-stream", inputStream)
+  def uploadObject(gcsPath: GoogleCloudStoragePath, fileContent: String): Unit = {
+    uploadFile(gcsPath, fileContent, "application/octet-stream")
+  }
+
+  def uploadJson(gcsPath: GoogleCloudStoragePath, fileContent: String): Unit = {
+    uploadFile(gcsPath, fileContent, "application/json")
+  }
+
+  def uploadObject(gcsPath: GoogleCloudStoragePath, inputStream: InputStream, byteCount: Long, contentType: String): Unit = {
+    val mediaContent: InputStreamContent = new InputStreamContent(contentType, inputStream)
     mediaContent.setLength(byteCount)
 
     val insertObject = client.objects.insert(gcsPath.bucket, null, mediaContent)
@@ -55,6 +63,10 @@ case class GoogleCloudStorage(client: Storage) {
     }
 
     insertObject.execute()
+  }
+
+  def deleteObject(gcsPath: GoogleCloudStoragePath): Unit = {
+    client.objects.delete(gcsPath.bucket, gcsPath.objectName).execute()
   }
 
   def downloadObject(gcsPath: GoogleCloudStoragePath): Array[Byte] = {

--- a/src/test/scala/cromwell/engine/backend/jes/GcsAuthSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/GcsAuthSpec.scala
@@ -1,0 +1,68 @@
+package cromwell.engine.backend.jes
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+import spray.json._
+
+
+class GcsAuthSpec extends FlatSpec with Matchers with MockitoSugar {
+
+  def normalize(str: String) = {
+    str.parseJson.prettyPrint
+  }
+
+  "GcsAuthMode" should "parse AuthenticationMode" in {
+    GcsAuthMode.fromString("refresh_token") shouldBe RefreshTokenMode
+    GcsAuthMode.fromString("service_account") shouldBe ServiceAccountMode
+    an [IllegalArgumentException] should be thrownBy GcsAuthMode.fromString("unrecognized_value")
+  }
+
+  "generateJson" should "generate the correct json content depending on the available configuration" in {
+    val dockerAuth = Option(DockerAuthInformation("my@docker.account", "mydockertoken"))
+    val userAuth = Option(GcsUserAuthInformation("my@email.com", "myrefreshtoken"))
+
+    GcsAuth.generateJson(None, None) shouldBe None
+
+    GcsAuth.generateJson(dockerAuth, None) shouldBe
+      Some(normalize("""
+        |{
+        |    "auths": {
+        |        "docker": {
+        |            "account": "my@docker.account",
+        |            "token": "mydockertoken"
+        |        }
+        |    }
+        |}
+      """.stripMargin))
+
+    GcsAuth.generateJson(None, userAuth) shouldBe
+    Some(normalize("""
+           |{
+           |    "auths": {
+           |        "gcloud": {
+           |            "account": "my@email.com",
+           |            "token": "myrefreshtoken"
+           |        }
+           |    }
+           |}
+         """.stripMargin))
+
+    GcsAuth.generateJson(dockerAuth, userAuth) shouldBe
+    Some(normalize("""
+           |{
+           |    "auths": {
+           |        "docker": {
+           |            "account": "my@docker.account",
+           |            "token": "mydockertoken"
+           |        },
+           |        "gcloud": {
+           |            "account": "my@email.com",
+           |            "token": "myrefreshtoken"
+           |        }
+           |    }
+           |}
+         """.stripMargin))
+
+  }
+
+}

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -65,6 +65,10 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
 
     override def backendType: BackendType =
       throw new NotImplementedError
+
+    override def cleanUpForWorkflow(workflow: WorkflowDescriptor)(implicit ec: ExecutionContext) = Future.successful({})
+
+    override def assertWorkflowOptions(options: Map[String, String]): Unit = {}
   }
 
   // Tests against main database used for command line


### PR DESCRIPTION
The way this works for now is:
In JES configuration you need to specify an `authenticationMode` parameter which can take one of those 2 values: `service_account` or `refresh_token`
`service_account` works exactly the same way as it did before
`refresh_token` will require 2 fields to be passed as workflow options:
    `account_name` and `refresh_token`

Depending on what is available, the JES backend will create, only if necessary and at workflow initialization time, a json file (gcloudauth.json) and upload it to the root directory of the workflow.
Currently this json file can contain 2 types of information:

- Docker credentials: These are optional and can be specified in the `jes` section in application.conf. They look like this:
```
dockerAccount = "my.docker@account.com"
dockerToken = "mydockertoken"
```
If they are specified a "docker" value will be added to gcloudauth.json containing those values.
This will allow using a private docker image that would not be accessible otherwise.
This functionality was mostly already there from Kristian PR, I just moved the credential location from gcs to conf.

- User credentials: These need to be added as workflow options : 
```
{
"account_name": "myaccount@broadinstitute.org",
"refresh_token": "refresh_token"
}
```
Again if in RefreshToken mode, they need to be there for every workflow call or an exception will be thrown at initialization time.
If they are there they will be added to the gcloudauth.json in the same way docker crednetials are, under a "gcloud" value. You should then get permission to localize input files that are only accessible to this user.

So depending on what is provided (docker info, user info), you can get a gcloudauth.json with both credentials, only one, or no file at all. In any case the JES backend will try to delete this file when the workflow reaches a terminal state.