### PR TITLE
DataAccessObject trait to be mixed in wherever needed

### DIFF
--- a/src/main/scala/cromwell/server/DataAccessObject.scala
+++ b/src/main/scala/cromwell/server/DataAccessObject.scala
@@ -1,0 +1,7 @@
+package cromwell.server
+
+import cromwell.engine.db.DataAccess
+
+trait DataAccessObject {
+  lazy val dataAccess: DataAccess = DataAccess()
+}

--- a/src/main/scala/cromwell/server/DefaultWorkflowManagerSystem.scala
+++ b/src/main/scala/cromwell/server/DefaultWorkflowManagerSystem.scala
@@ -1,3 +1,3 @@
 package cromwell.server
 
-case class DefaultWorkflowManagerSystem() extends WorkflowManagerSystem
+case class DefaultWorkflowManagerSystem() extends WorkflowManagerSystem with DataAccessObject

--- a/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
+++ b/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
@@ -2,10 +2,9 @@ package cromwell.server
 
 import akka.actor.ActorSystem
 import cromwell.engine.backend.Backend
-import cromwell.engine.db.DataAccess
 import cromwell.engine.workflow.WorkflowManagerActor
 
-trait WorkflowManagerSystem {
+trait WorkflowManagerSystem { self: DataAccessObject =>
   lazy val backend: Backend = WorkflowManagerActor.BackendInstance
 
   val systemName = "cromwell-system"
@@ -13,9 +12,6 @@ trait WorkflowManagerSystem {
 
   // For now there's only one WorkflowManagerActor so no need to dynamically name it
   lazy val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props(dataAccess, backend), "WorkflowManagerActor")
-
-  // Lazily created as the primary consumer is the workflowManagerActor.
-  private lazy val dataAccess: DataAccess = DataAccess()
 
   /**
    * Should be called after the system is no longer in use.

--- a/src/test/scala/cromwell/MainSpec.scala
+++ b/src/test/scala/cromwell/MainSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.EventFilter
 import com.typesafe.config.ConfigFactory
 import cromwell.engine.backend.local.LocalBackend
-import cromwell.server.WorkflowManagerSystem
+import cromwell.server.{DataAccessObject, WorkflowManagerSystem}
 import cromwell.util.SampleWdl.ThreeStep
 import cromwell.util.{FileUtil, SampleWdl}
 import org.scalatest.{FlatSpec, Matchers}
@@ -14,7 +14,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class TestWorkflowManagerSystem extends WorkflowManagerSystem {
+class TestWorkflowManagerSystem extends WorkflowManagerSystem with DataAccessObject {
   override lazy val backend = new LocalBackend
   override implicit val actorSystem = ActorSystem(systemName, ConfigFactory.parseString(CromwellTestkitSpec.ConfigText))
 }


### PR DESCRIPTION
This is just a suggestion:

I was poking at the 1333 ticket and it made me realize that we pass around the slick `dataAccess` value as a function parameter anywhere it's needed, from the very top in `WorkflowManagerSystem` where it's created to the very bottom of `Backend` implementations where we need to make DB updates etc...
I was thinking we could pull it away from `WorkflowManagerSystem` and use it in a "cake pattern" way by mixing it to whatever class needs it.