### PR TITLE
Fix output file handing in JES

### DIFF
--- a/src/main/scala/cromwell/binding/command/ParameterCommandPart.scala
+++ b/src/main/scala/cromwell/binding/command/ParameterCommandPart.scala
@@ -24,10 +24,7 @@ case class ParameterCommandPart(attributes: Map[String, String], expression: Wdl
   override def toString: String = "${" + s"$attributesToString${expression.toWdlString}" + "}"
 
   override def instantiate(declarations: Seq[Declaration], parameters: Map[String, WdlValue], functions: WdlFunctions[WdlValue] = new NoFunctions): String = {
-    case class VariableNotFoundException(variable: String) extends RuntimeException(s"Could not find variable: $variable")
-    def lookup(key: String) = parameters.getOrElse(key, throw new VariableNotFoundException(key))
-
-    val value = expression.evaluate(lookup, functions) match {
+    val value = expression.evaluate(WdlExpression.standardLookupFunction(parameters, declarations, functions), functions) match {
       case Success(v) => v
       case Failure(f) => f match {
         case v: VariableNotFoundException => declarations.find(_.name == v.variable) match {

--- a/src/main/scala/cromwell/engine/backend/BackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/BackendCall.scala
@@ -78,7 +78,7 @@ trait BackendCall {
    * expression `read_lines(my_file_var)` would have to call lookupFunction()("my_file_var")
    * during expression evaluation
    */
-  def lookupFunction: String => WdlValue
+  def lookupFunction: String => WdlValue = WdlExpression.standardLookupFunction(locallyQualifiedInputs, key.scope.task.declarations, engineFunctions)
 
   /**
    * Attempt to evaluate all the ${...} tags in a command and return a String representation

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -1,7 +1,6 @@
 package cromwell.engine.backend.jes
 
 import cromwell.binding._
-import cromwell.binding.values.WdlValue
 import cromwell.engine.backend.{BackendCall, ExecutionResult}
 import cromwell.engine.workflow.CallKey
 import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
@@ -17,6 +16,5 @@ case class JesBackendCall(backend: JesBackend,
   val gcsExecPath = GoogleCloudStoragePath(callGcsPath + "/exec.sh")
   val jesConnection = JesBackend.JesConnection
   val engineFunctions = new JesEngineFunctions(this)
-  val lookupFunction: String => WdlValue = inputName => locallyQualifiedInputs.get(inputName).get
   def execute: ExecutionResult = backend.execute(this)
 }

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
@@ -1,7 +1,6 @@
 package cromwell.engine.backend.local
 
 import cromwell.binding.CallInputs
-import cromwell.binding.values.WdlValue
 import cromwell.engine.backend.{BackendCall, ExecutionResult, LocalFileSystemBackendCall}
 import cromwell.engine.workflow.CallKey
 import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
@@ -23,7 +22,6 @@ case class LocalBackendCall(backend: LocalBackend,
   val stderr = callRootPath.resolve("stderr")
   val script = callRootPath.resolve("script")
   val engineFunctions: LocalEngineFunctions = new LocalEngineFunctions(callRootPath, stdout, stderr)
-  val lookupFunction: String => WdlValue = inputName => locallyQualifiedInputs.get(inputName).get
   callRootPath.toFile.mkdirs
   def execute: ExecutionResult = backend.execute(this)
 }

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
@@ -1,7 +1,6 @@
 package cromwell.engine.backend.sge
 
 import cromwell.binding.CallInputs
-import cromwell.binding.values.WdlValue
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.backend.{BackendCall, ExecutionResult, LocalFileSystemBackendCall}
 import cromwell.engine.workflow.CallKey
@@ -19,7 +18,6 @@ case class SgeBackendCall(backend: SgeBackend,
   val script = callRootPath.resolve("script.sh")
   val returnCode = callRootPath.resolve("rc")
   val engineFunctions: SgeEngineFunctions = new SgeEngineFunctions(callRootPath, stdout, stderr)
-  val lookupFunction: String => WdlValue = inputName => locallyQualifiedInputs.get(inputName).get
   callRootPath.toFile.mkdirs
   def execute: ExecutionResult = backend.execute(this)
 }

--- a/src/test/scala/cromwell/FilePassingWorkflowSpec.scala
+++ b/src/test/scala/cromwell/FilePassingWorkflowSpec.scala
@@ -1,0 +1,26 @@
+package cromwell
+
+import akka.testkit._
+import cromwell.binding.values.{WdlFile, WdlString}
+import cromwell.util.SampleWdl
+
+import scala.language.postfixOps
+
+class FilePassingWorkflowSpec extends CromwellTestkitSpec("FilePassingWorkflowSpec") {
+  "A workflow that passes files between tasks" should {
+    "pass files properly" in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.FilePassingWorkflow,
+        EventFilter.info(pattern = s"starting calls: file_passing.a", occurrences = 1),
+        expectedOutputs = Map(
+          "file_passing.a.out" -> WdlFile("out"),
+          "file_passing.a.out_interpolation" -> WdlFile("out"),
+          "file_passing.a.contents" -> WdlString("foo bar baz"),
+          "file_passing.b.out" -> WdlFile("out"),
+          "file_passing.b.out_interpolation" -> WdlFile("out"),
+          "file_passing.b.contents" -> WdlString("foo bar baz")
+        )
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -1205,4 +1205,36 @@ object SampleWdl {
       """.stripMargin.replaceAll("RUNTIME", runtime)
     override lazy val rawInputs = Map("" -> "...")
   }
+
+  object FilePassingWorkflow extends SampleWdl {
+    override def wdlSource(runtime: String): WdlSource =
+      """task a {
+        |  File in
+        |  String out_name = "out"
+        |
+        |  command {
+        |    cat ${in} > ${out_name}
+        |  }
+        |  RUNTIME
+        |  output {
+        |    File out = "out"
+        |    File out_interpolation = "${out_name}"
+        |    String contents = read_string("${out_name}")
+        |  }
+        |}
+        |
+        |workflow file_passing {
+        |  File f
+        |
+        |  call a {input: in=f}
+        |  call a as b {input: in=a.out}
+        |}
+      """.stripMargin.replaceAll("RUNTIME", runtime)
+
+    private val fileContents = s"foo bar baz"
+
+    override val rawInputs: WorkflowRawInputs = Map(
+      "file_passing.f" -> createCannedFile("canned", fileContents).getAbsolutePath
+    )
+  }
 }


### PR DESCRIPTION
This will allow this WDL file to run:

```
task a {
  File in
  String out_name = "out"

  command {
    cat ${in} > ${out_name}
  }
  runtime {
    docker: "kcibul/picard"
  }
  output {
    File out = "out"
    File out_interpolation = "${out_name}"
    String contents = read_string("${out_name}")
  }
}

workflow file_passing {
  File f

  call a {input: in=f}
  call a as b {input: in=a.out}
}
```

This also fixes a bug where static declarations weren't being honored when resolving variables in all cases.  This lead to some frustrating bugs with Yossi