### PR TITLE
Scatter/Gather shards respected by updateExecutionBackendInfo

### DIFF
--- a/src/main/scala/cromwell/engine/backend/jes/JesAttributes.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesAttributes.scala
@@ -2,7 +2,7 @@ package cromwell.engine.backend.jes
 
 import java.net.URL
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.ConfigFactory
 import cromwell.util.ConfigUtil._
 
 import scala.language.postfixOps
@@ -23,6 +23,7 @@ object JesAttributes {
     "baseExecutionBucket",
     "endpointUrl",
     "authenticationMode",
+    "maximumPollingInterval",
     "dockerAccount",
     "dockerToken"
   )

--- a/src/main/scala/cromwell/engine/backend/jes/Pipeline.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/Pipeline.scala
@@ -3,7 +3,6 @@ package cromwell.engine.backend.jes
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.CreatePipelineRequest
 import com.typesafe.scalalogging.LazyLogging
-import cromwell.binding.Call
 import cromwell.engine.WorkflowDescriptor
 import cromwell.engine.backend.jes.JesBackend._
 import cromwell.engine.workflow.CallKey
@@ -35,8 +34,8 @@ object Pipeline extends LazyLogging {
                  pipelineId, 
                  projectId, 
                  gcsPath, 
-                 workflow, 
-                 call, 
+                 workflow,
+                 key,
                  jesParameters, 
                  runtimeInfo, 
                  jesConnection.genomics)
@@ -49,7 +48,7 @@ case class Pipeline(command: String,
                     projectId: String,
                     gcsPath: String,
                     workflow: WorkflowDescriptor,
-                    call: Call,
+                    key: CallKey,
                     jesParameters: Seq[JesParameter],
                     runtimeInfo: JesRuntimeInfo,
                     genomicsService: Genomics) {

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
@@ -7,8 +7,9 @@ import cromwell.binding.{Call, CallInputs}
 import cromwell.engine.backend.Backend.RestartableWorkflow
 import cromwell.engine.backend._
 import cromwell.engine.backend.local.{LocalBackend, SharedFileSystem}
-import cromwell.engine.db.{CallStatus, SgeCallBackendInfo}
-import cromwell.engine.workflow.{CallKey, WorkflowOptions}
+import cromwell.engine.db.DataAccess._
+import cromwell.engine.db.SgeCallBackendInfo
+import cromwell.engine.workflow.CallKey
 import cromwell.engine.{AbortRegistrationFunction, _}
 import cromwell.parser.BackendType
 import cromwell.util.FileUtil._
@@ -72,10 +73,8 @@ class SgeBackend extends Backend with SharedFileSystem with LazyLogging {
   }
 
   private def updateSgeJobTable(call: BackendCall, status: String, rc: Option[Int], sgeJobId: Option[Int]): Future[Unit] = {
-    val backendInfo = SgeCallBackendInfo(CallStatus(status, rc), sgeJobId)
-    // TODO: re-add
-    //globalDataAccess.updateExecutionBackendInfo(call.workflowDescriptor.id, call.call, backendInfo)
-    Future.successful(())
+    val backendInfo = SgeCallBackendInfo(sgeJobId)
+    globalDataAccess.updateExecutionBackendInfo(call.workflowDescriptor.id, CallKey(call.call, call.key.index), backendInfo)
   }
 
   // TODO: Not much thought was given to this function

--- a/src/main/scala/cromwell/engine/db/CallBackendInfo.scala
+++ b/src/main/scala/cromwell/engine/db/CallBackendInfo.scala
@@ -1,11 +1,9 @@
 package cromwell.engine.db
 
-sealed trait CallBackendInfo {
-  val status: CallStatus
-}
+sealed trait CallBackendInfo
 
-final case class LocalCallBackendInfo(status: CallStatus, processId: Option[Int]) extends CallBackendInfo
+final case class LocalCallBackendInfo(processId: Option[Int]) extends CallBackendInfo
 
-final case class JesCallBackendInfo(status: CallStatus, jesId: Option[JesId], jesStatus: Option[JesStatus]) extends CallBackendInfo
+final case class JesCallBackendInfo(jesId: Option[JesId], jesStatus: Option[JesStatus]) extends CallBackendInfo
 
-final case class SgeCallBackendInfo(status: CallStatus, sgeJobNumber: Option[Int]) extends CallBackendInfo
+final case class SgeCallBackendInfo(sgeJobNumber: Option[Int]) extends CallBackendInfo

--- a/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -5,7 +5,7 @@ import cromwell.binding.values.WdlValue
 import cromwell.engine.ExecutionStatus.ExecutionStatus
 import cromwell.engine.backend.Backend
 import cromwell.engine.db.slick._
-import cromwell.engine.workflow.{ExecutionStoreKey, OutputKey}
+import cromwell.engine.workflow.{CallKey, ExecutionStoreKey, OutputKey}
 import cromwell.engine.{SymbolStoreEntry, WorkflowDescriptor, WorkflowId, WorkflowState}
 
 import scala.concurrent.Future
@@ -32,7 +32,7 @@ trait DataAccess {
 
   def getExecutionBackendInfo(workflowId: WorkflowId, call: Call): Future[CallBackendInfo]
 
-  def updateExecutionBackendInfo(workflowId: WorkflowId, call: Call, backendInfo: CallBackendInfo): Future[Unit]
+  def updateExecutionBackendInfo(workflowId: WorkflowId, callKey: CallKey, backendInfo: CallBackendInfo): Future[Unit]
 
   def updateWorkflowState(workflowId: WorkflowId, workflowState: WorkflowState): Future[Unit]
 

--- a/src/main/scala/cromwell/engine/db/slick/ExecutionComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/ExecutionComponent.scala
@@ -66,6 +66,15 @@ trait ExecutionComponent {
       if execution.callFqn === callFqn
     } yield (execution.callFqn, execution.index, execution.status, execution.rc))
 
+  val executionsByWorkflowExecutionUuidAndCallFqnAndShardIndex = Compiled(
+    (workflowExecutionUuid: Rep[String], callFqn: Rep[String], index: Rep[Int]) => for {
+      execution <- executions
+      if execution.callFqn === callFqn
+      if execution.index === index
+      workflowExecution <- execution.workflowExecution
+      if workflowExecution.workflowExecutionUuid === workflowExecutionUuid
+    } yield execution)
+
   val executionsByWorkflowExecutionUuidAndCallFqn = Compiled(
     (workflowExecutionUuid: Rep[String], callFqn: Rep[String]) => for {
       execution <- executions

--- a/src/main/scala/cromwell/engine/workflow/ExecutionStoreKey.scala
+++ b/src/main/scala/cromwell/engine/workflow/ExecutionStoreKey.scala
@@ -9,17 +9,16 @@ import scala.language.postfixOps
 sealed trait ExecutionStoreKey {
   def scope: Scope
   def index: Option[Int]
-  def parent: Option[ExecutionStoreKey]
 }
 
 trait OutputKey extends ExecutionStoreKey
 
-case class CallKey(scope: Call, index: Option[Int], parent: Option[ExecutionStoreKey]) extends OutputKey
-case class CollectorKey(scope: Call, parent: Option[ExecutionStoreKey]) extends OutputKey {
+case class CallKey(scope: Call, index: Option[Int]) extends OutputKey
+case class CollectorKey(scope: Call) extends OutputKey {
   override val index: Option[Int] = None
 }
 
-case class ScatterKey(scope: Scatter, index: Option[Int], parent: Option[ExecutionStoreKey]) extends ExecutionStoreKey {
+case class ScatterKey(scope: Scatter, index: Option[Int]) extends ExecutionStoreKey {
 
   /**
    * Creates a sub-ExecutionStore with Starting entries for each of the scoped children.
@@ -35,8 +34,8 @@ case class ScatterKey(scope: Scatter, index: Option[Int], parent: Option[Executi
     val parent = Option(this)
     scope match {
       case call: Call =>
-        val shards = (0 until count) map { i => CallKey(call, Option(i), parent) }
-        shards :+ CollectorKey(call, parent)
+        val shards = (0 until count) map { i => CallKey(call, Option(i)) }
+        shards :+ CollectorKey(call)
       case scatter: Scatter =>
         throw new UnsupportedOperationException("Nested Scatters are not supported (yet).")
       case e =>

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -489,10 +489,10 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
     globalDataAccess.getExecutionStatuses(workflow.id) map { statuses =>
       statuses map { case (k, v) =>
         val key: ExecutionStoreKey = (workflow.namespace.resolve(k.fqn), k.index) match {
-          case (Some(c: Call), Some(i)) => CallKey(c, Some(i), None)
-          case (Some(c: Call), None) if isInScatterBlock(c) => CollectorKey(c, None)
-          case (Some(c: Call), None) => CallKey(c, None, None)
-          case (Some(s: Scatter), None) => ScatterKey(s, None, None)
+          case (Some(c: Call), Some(i)) => CallKey(c, Some(i))
+          case (Some(c: Call), None) if isInScatterBlock(c) => CollectorKey(c)
+          case (Some(c: Call), None) => CallKey(c, None)
+          case (Some(s: Scatter), None) => ScatterKey(s, None)
           case _ => throw new UnsupportedOperationException(s"Execution entry invalid: $k -> $v")
         }
         key -> v.executionStatus

--- a/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
@@ -37,7 +37,7 @@ class LocalBackendSpec extends CromwellTestkitSpec("LocalBackendSpec") {
   def testFailOnStderr(descriptor: WorkflowDescriptor, expectSuccess: Boolean): Unit = {
     val call = descriptor.namespace.workflow.calls.head
     val backend = new LocalBackend()
-    val backendCall = backend.bindCall(descriptor, CallKey(call, None, None), Map.empty[String, WdlValue], AbortRegistrationFunction(_ => ()))
+    val backendCall = backend.bindCall(descriptor, CallKey(call, None), Map.empty[String, WdlValue], AbortRegistrationFunction(_ => ()))
     backendCall.execute match {
       case FailedExecution(e, _) => if (expectSuccess) fail("A call in a failOnStderr test which should have succeeded has failed ", e)
       case SuccessfulExecution(_) => if (!expectSuccess) fail("A call in a failOnStderr test which should have failed has succeeded")


### PR DESCRIPTION
This change does two things:

* updateExecutionBackendInfo now works correctly with sharded input
* The function no longer updates the EXECUTION table - this turned out to be unnecessary as other hooks are already updating this in full.