### PR TITLE
Adding retries and proper failures to the creation of JES runs

### DIFF
--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -85,6 +85,10 @@ trait Backend {
   @throws[IllegalArgumentException]("if a value is missing / incorrect")
   def assertWorkflowOptions(options: WorkflowOptions): Unit = {}
 
-  def makeTag(backendCall: BackendCall): String =
-    s"${this.getClass.getSimpleName} [UUID(${backendCall.workflowDescriptor.shortId}):${backendCall.call.name}]"
+  def makeTag(backendCall: BackendCall): String = {
+    // Sometimes the class name is `anon$1`.  In cases like that, don't print it in the log because it's not adding value
+    val cls = this.getClass.getSimpleName
+    val clsString = if (cls.startsWith("anon")) "" else s"$cls "
+    s"$clsString[UUID(${backendCall.workflowDescriptor.shortId}):${backendCall.call.name}]"
+  }
 }

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -10,6 +10,8 @@ import cromwell.engine.workflow.CallKey
 import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
 import cromwell.util.google.GoogleCloudStoragePath
 
+import scala.util.Try
+
 
 object JesBackendCall {
   
@@ -49,5 +51,5 @@ case class JesBackendCall(backend: JesBackend,
   def standardParameters = Seq(stderrJesOutput, stdoutJesOutput, rcJesOutput) 
   def rcGcsPath = rcJesOutput.gcs
   def execute: ExecutionResult = backend.execute(this)
-  def downloadRcFile = jesConnection.storage.slurpFile(GoogleCloudStoragePath(callGcsPath, RcFilename))
+  def downloadRcFile: Try[String] = GoogleCloudStoragePath.parse(callGcsPath + "/" + RcFilename).map(jesConnection.storage.slurpFile)
 }

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -634,14 +634,14 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
   private def executionsAsTable: Seq[Seq[String]] = {
     val futureRows = globalDataAccess.getExecutionStatuses(workflow.id) map { entries =>
       entries.map({ case(k, v) =>
-        Seq(k.fqn.toString, k.index.getOrElse("").toString, v.toString)
+        Seq(k.fqn.toString, k.index.getOrElse("").toString, v.executionStatus.toString, v.returnCode.getOrElse("").toString)
       })
     }
     Await.result(futureRows, AkkaTimeout).toSeq
   }
 
   private def executionsMarkdownTable: Option[String] = {
-    val header = Seq("SCOPE", "INDEX", "STATUS")
+    val header = Seq("SCOPE", "INDEX", "STATUS", "RETURN CODE")
     executionsAsTable match {
       case rows: Seq[Seq[String]] if rows.isEmpty => None
       case rows => Some(TerminalUtil.mdTable(rows.toSeq, header))

--- a/src/test/scala/cromwell/util/TryUtilSpec.scala
+++ b/src/test/scala/cromwell/util/TryUtilSpec.scala
@@ -1,0 +1,45 @@
+package cromwell.util
+
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+import scala.concurrent.duration._
+import scala.util.Success
+
+class TryUtilSpec extends FlatSpec with Matchers {
+  def failNTimes(n: Int): Option[Int] => Int = {
+    var counter = n
+    def func(prior: Option[Int]): Int = {
+      if (counter > 0) {
+        counter -= 1
+        throw new Exception("Failed")
+      }
+      9
+    }
+    func
+  }
+
+  it should "Retry a function until it works" in {
+    val value = TryUtil.retryBlock(
+      fn = failNTimes(4),
+      retries = Some(5),
+      pollingInterval = 50 milliseconds,
+      pollingBackOffFactor = 1,
+      maxPollingInterval = 10 seconds,
+      failMessage = Some(s"failed attempt (on purpose)")
+    )
+    value shouldEqual Success(9)
+  }
+
+  it should "Fail if it hits the max retry count" in {
+    val value = TryUtil.retryBlock(
+      fn = failNTimes(4),
+      retries = Some(4),
+      pollingInterval = 50 milliseconds,
+      pollingBackOffFactor = 1,
+      maxPollingInterval = 10 seconds,
+      failMessage = Some(s"failed attempt (on purpose)")
+    )
+    value.isFailure shouldEqual true
+  }
+}


### PR DESCRIPTION
* Retries the creation of the `Pipeline` and `Run`
* If all retries fail, a proper failure is propagated and the call will fail