### PR TITLE
Fix HandleTerminalWorkflow call condition

### DIFF
--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -205,7 +205,7 @@ case class WorkflowActor(workflow: WorkflowDescriptor,
         // the message is logged.
         _ <- globalDataAccess.updateWorkflowState(workflow.id, toState)
         _ = log.info(s"$tag transitioning from $fromState to $toState.")
-        _ <- handleTerminalWorkflow if toState.isTerminal
+        _ <- if (toState.isTerminal) handleTerminalWorkflow else Future.successful({})
       } yield ()
   }
 


### PR DESCRIPTION
`_ <- handleTerminalWorkflow if toState.isTerminal` actually causes `handleTerminalWorkflow` to be called even if `toState.isTerminal` is false.