### PR TITLE
"Emulate" JES Localization process in SharedFileSystem

### DIFF
--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -43,8 +43,9 @@ trait Backend {
    * Return a possibly altered copy of inputs reflecting any localization of input file paths that might have
    * been performed for this `Backend` implementation.
    */
-  def adjustInputPaths(call: Call, inputs: CallInputs): CallInputs
+  def adjustInputPaths(callKey: CallKey, inputs: CallInputs, workflowDescriptor: WorkflowDescriptor): CallInputs
 
+  // FIXME: This is never called...
   def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs
 
   /**

--- a/src/main/scala/cromwell/engine/backend/BackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/BackendCall.scala
@@ -86,7 +86,7 @@ trait BackendCall {
    * which is why it returns a Try[String]
    */
   def instantiateCommand: Try[String] = {
-    val backendInputs = backend.adjustInputPaths(call, locallyQualifiedInputs)
+    val backendInputs = backend.adjustInputPaths(key, locallyQualifiedInputs, workflowDescriptor)
     call.instantiateCommandLine(backendInputs, engineFunctions)
   }
 

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
@@ -114,7 +114,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
 
   type BackendCall = JesBackendCall
 
-  override def adjustInputPaths(call: Call, inputs: CallInputs): CallInputs = inputs map { case (k, v) => (k, gcsPathToLocal(v)) }
+  override def adjustInputPaths(callKey: CallKey, inputs: CallInputs, workflowDescriptor: WorkflowDescriptor): CallInputs = inputs mapValues gcsPathToLocal
   override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs map { case (k,v) => (k, gcsPathToLocal(v)) }
 
   private def writeAuthenticationFile(workflow: WorkflowDescriptor) = authenticated { connection =>
@@ -219,7 +219,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
    * Creates a set of JES inputs for a backend call.
    */
   def generateJesInputs(backendCall: BackendCall): Iterable[JesInput] = {
-    val adjustedPaths = adjustInputPaths(backendCall.call, backendCall.locallyQualifiedInputs)
+    val adjustedPaths = adjustInputPaths(backendCall.key, backendCall.locallyQualifiedInputs, backendCall.workflowDescriptor)
     def mkInput(locallyQualifiedInputName: String, location: WdlFile) = JesInput(locallyQualifiedInputName, backendCall.lookupFunction(locallyQualifiedInputName).valueString, Paths.get(location.valueString))
     adjustedPaths collect {
       case (locallyQualifiedInputName: String, location: WdlFile) =>

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -143,8 +143,11 @@ class LocalBackend extends Backend with SharedFileSystem with LazyLogging {
    * -v maps the host workflow executions directory to /root/<workflow id> on the container.
    * -i makes the run interactive, required for the cat and <&0 shenanigans that follow.
    */
-  private def buildDockerRunCommand(backendCall: BackendCall, image: String): String =
-    s"docker run --rm -v ${backendCall.workflowRootPath.toAbsolutePath}:${backendCall.dockerContainerExecutionDir} -i $image"
+  private def buildDockerRunCommand(backendCall: BackendCall, image: String): String = {
+    val callPath = containerCallPath(backendCall.workflowDescriptor, backendCall.call.name, backendCall.key.index)
+    s"docker run --rm -v ${backendCall.callRootPath.toAbsolutePath}:$callPath -i $image"
+  }
+
 
   private def runSubprocess(backendCall: BackendCall): ExecutionResult = {
     val tag = makeTag(backendCall)

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -2,26 +2,31 @@ package cromwell.engine.backend.local
 
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
-import java.security.MessageDigest
 
 import com.typesafe.config.ConfigFactory
 import cromwell.binding._
 import cromwell.binding.expression.WdlStandardLibraryFunctions
-import cromwell.binding.types.WdlFileType
+import cromwell.binding.types.{WdlArrayType, WdlFileType, WdlMapType}
 import cromwell.binding.values.{WdlValue, _}
 import cromwell.engine.ExecutionIndex._
 import cromwell.engine.WorkflowDescriptor
 import cromwell.engine.backend.{LocalFileSystemBackendCall, StdoutStderr}
+import cromwell.engine.workflow.CallKey
+import cromwell.util.TryUtil
 import org.apache.commons.io.FileUtils
+import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 object SharedFileSystem {
+  type LocalizationStrategy = (Path, Path) => Try[Unit]
+
   val SharedFileSystemConf = ConfigFactory.load.getConfig("backend").getConfig("shared-filesystem")
   val CromwellExecutionRoot = SharedFileSystemConf.getString("root")
   val LocalizationStrategies = SharedFileSystemConf.getStringList("localization").asScala
+
   val Localizers = localizePathAlreadyLocalized _ +: (LocalizationStrategies map {
     case "hard-link" => localizePathViaHardLink _
     case "soft-link" => localizePathViaSymbolicLink _
@@ -29,14 +34,20 @@ object SharedFileSystem {
     case unsupported => throw new UnsupportedOperationException(s"Localization strategy $unsupported is not recognized")
   })
 
+  // Note that any unrecognized configuration will be raised when Localizers (just above) gets resolved.
+  val DockerLocalizers = localizePathAlreadyLocalized _ +: (LocalizationStrategies collect {
+    case "hard-link" => localizePathViaHardLink _
+    case "copy" => localizePathViaCopy _
+  })
+
   /**
    * Return a `Success` result if the file has already been localized, otherwise `Failure`.
    */
-  private def localizePathAlreadyLocalized(call: Option[Call], originalPath: Path, executionPath: Path): Try[Unit] = {
+  private def localizePathAlreadyLocalized(originalPath: Path, executionPath: Path): Try[Unit] = {
     if (Files.exists(executionPath)) Success(()) else Failure(new Throwable)
   }
 
-  private def localizePathViaCopy(call: Option[Call], originalPath: Path, executionPath: Path): Try[Unit] = {
+  private def localizePathViaCopy(originalPath: Path, executionPath: Path): Try[Unit] = {
     if (Files.isDirectory(originalPath)) {
       Try(FileUtils.copyDirectory(originalPath.toFile, executionPath.toFile))
     } else {
@@ -44,7 +55,7 @@ object SharedFileSystem {
     }
   }
 
-  private def localizePathViaHardLink(call: Option[Call], originalPath: Path, executionPath: Path): Try[Unit] =
+  private def localizePathViaHardLink(originalPath: Path, executionPath: Path): Try[Unit] =
     Try(Files.createLink(executionPath, originalPath))
 
   /**
@@ -55,11 +66,10 @@ object SharedFileSystem {
    * The symbolic link will only fail in the Docker case if a Call uses the file directly and not
    * indirectly through one of its input expressions
    */
-  private def localizePathViaSymbolicLink(call: Option[Call], originalPath: Path, executionPath: Path): Try[Unit] = {
-    call.flatMap(_.docker) match {
-      case Some(_) => Failure(new UnsupportedOperationException("Cannot localize with symbolic links with Docker"))
-      case _ => Try(Files.createSymbolicLink(executionPath, originalPath.toAbsolutePath))
-    }
+  private def localizePathViaSymbolicLink(originalPath: Path, executionPath: Path): Try[Unit] = {
+    if (originalPath.toFile.isDirectory)
+      Failure(new UnsupportedOperationException("Cannot localize directory with symbolic links"))
+    else Try(Files.createSymbolicLink(executionPath, originalPath.toAbsolutePath))
   }
 }
 
@@ -101,102 +111,97 @@ trait SharedFileSystem {
       stderr = WdlFile(dir.resolve("stderr").toAbsolutePath.toString)
     )
   }
-
   /**
-   * Creates host execution directory, inputs path, and outputs path.  Stages any input files into the workflow-inputs
-   * directory and localizes their paths relative to the container.
+   * Creates host execution directory.
    */
   def initializeForWorkflow(descriptor: WorkflowDescriptor): Try[HostInputs] = {
     val hostExecutionDirectory = LocalBackend.hostExecutionPath(descriptor).toFile
     hostExecutionDirectory.mkdirs()
-    val hostExecutionAbsolutePath = hostExecutionDirectory.getAbsolutePath
-    Array("workflow-inputs", "workflow-outputs") foreach { Paths.get(hostExecutionAbsolutePath, _).toFile.mkdir() }
-    stageWorkflowInputs(descriptor)
+    Success(descriptor.actualInputs)
   }
 
   /**
    * Return a possibly altered copy of inputs reflecting any localization of input file paths that might have
    * been performed for this `Backend` implementation.
    */
-  def adjustInputPaths(call: Call, inputs: CallInputs): CallInputs = {
-    def containerPath(path: String): WdlFile = {
+  def adjustInputPaths(callKey: CallKey, inputs: CallInputs, workflowDescriptor: WorkflowDescriptor): CallInputs = {
+    val call = callKey.scope
+    val strategies = if (call.docker.isDefined) DockerLocalizers else Localizers
+
+    def toDockerPath(path: Path): Path = {
       // Host path would look like cromwell-executions/three-step/f00ba4/call-ps/stdout.txt
       // Container path should look like /root/f00ba4/call-ps/stdout.txt
-      val fullPath = Paths.get(path).toFile.getAbsolutePath
+      val fullPath = path.toFile.getAbsolutePath
       // Strip out everything before cromwell-executions.
       val pathUnderCromwellExecutions = fullPath.substring(fullPath.indexOf(CromwellExecutionRoot) + CromwellExecutionRoot.length)
       // Strip out the workflow name (the first component under cromwell-executions).
       val pathWithWorkflowName = Paths.get(pathUnderCromwellExecutions)
-      WdlFile(WdlFile.appendPathsWithSlashSeparators("/root", pathWithWorkflowName.subpath(1, pathWithWorkflowName.getNameCount).toString))
+      Paths.get(WdlFile.appendPathsWithSlashSeparators("/root", pathWithWorkflowName.subpath(1, pathWithWorkflowName.getNameCount).toString))
     }
 
-    // If this call is using Docker, adjust input paths, otherwise return unaltered input paths.
-    def adjustPath(nameAndValue: (String, WdlValue)): (String, WdlValue) = {
-      val (name, value) = nameAndValue
-      val adjusted = value match {
-        case WdlFile(path) => containerPath(path)
-        case WdlArray(t, values) => new WdlArray(t, values map { adjustPath(name, _)._2 })
-        case WdlMap(t, values) => new WdlMap(t, values mapValues { adjustPath(name, _)._2 })
-        case x => x
-      }
-      name -> adjusted
+    /**
+     * Transform an original input path to a path in the call directory.
+     * The new path matches the original path, it only "moves" the root to be the call directory.
+     */
+    def toCallPath(path: Path): Path = {
+      val callDirectory = LocalBackend.hostCallPath(workflowDescriptor, call.name, callKey.index)
+      // Concatenate call directory with absolute input path
+      Paths.get(callDirectory.toAbsolutePath.toString, path.toAbsolutePath.toString)
     }
 
-    // If this call is using Docker, adjust input paths, otherwise return unaltered input paths.
-    if (call.docker.isDefined) inputs map adjustPath else inputs
+    // Optional function to adjust the path to "docker path" if the call runs in docker
+    val postProcessor: Option[Path => Path] = call.docker map { _ => toDockerPath _ }
+    val localizeFunction = localizeWdlValue(toCallPath, strategies.toStream, postProcessor) _
+    val localizedValues = inputs.toSeq map {
+      case (name, value) => localizeFunction(value) map { name -> _ }
+    }
+
+    TryUtil.sequence(localizedValues, "Failures during localization").get toMap
   }
 
   /**
-   * Given the specified workflow descriptor and inputs, stage any WdlFiles into the workflow-inputs subdirectory
-   * of the workflow execution directory.  Return a Map of the input values with any input WdlFiles adjusted to
-   * reflect host paths.
-   *
-   * Original input path: /could/be/anywhere/input.bam
-   * Host inputs path: $PWD/cromwell-executions/some-workflow-name/0f00-ba4/workflow-inputs/input.bam
+   * Try to localize a WdlValue if it is or contains a WdlFile.
+   * @param toDestPath function specifying how to generate the destination path from the source path
+   * @param strategies strategies to use for localization
+   * @param postProcessor optional function to be applied to the path after the file it points to has been localized (defaults to noop)
+   * @param wdlValue WdlValue to localize
+   * @return localized wdlValue
    */
-  private def stageWorkflowInputs(descriptor: WorkflowDescriptor): Try[HostInputs] = {
-    val hostInputsPath = Paths.get(LocalBackend.hostExecutionPath(descriptor).toFile.getAbsolutePath, "workflow-inputs")
-    val attemptedStagedInputs = descriptor.actualInputs map { case(name, value) =>
-      val call = descriptor.namespace.resolve(name.split("\\.").dropRight(1).mkString(".")) match {
-        case Some(c: Call) => Some(c)
-        case _ => None
+  def localizeWdlValue(toDestPath: (Path => Path), strategies: Stream[LocalizationStrategy], postProcessor: Option[Path => Path] = None)(wdlValue: WdlValue): Try[WdlValue] = {
+
+    def localize(source: Path, dest: Path) = strategies map { _(source, dest) } find { _.isSuccess } getOrElse {
+      Failure(new UnsupportedOperationException(s"Could not localize $source -> $dest"))
+    }
+
+    def adjustArray(t: WdlArrayType, inputArray: Seq[WdlValue]): Try[WdlArray] = {
+      val tryAdjust = inputArray map localizeWdlValue(toDestPath, strategies, postProcessor)
+
+      TryUtil.sequence(tryAdjust, s"Failed to localize files in input Array ${wdlValue.valueString}") map { adjusted =>
+        new WdlArray(t, adjusted)
       }
-      name -> stageWdlValue(call, value, hostInputsPath)
     }
-    attemptedStagedInputs.values collect { case f: Failure[_] => f } match {
-      case Nil =>
-        Success(attemptedStagedInputs map { case (k, v) => k -> v.get })
-      case failedInputs =>
-        val errors = failedInputs map { _.exception.getMessage } mkString "\n"
-        Failure(new UnsupportedOperationException(s"Failures during localization:\n\n$errors"))
+
+    def adjustMap(t: WdlMapType, inputMap: Map[WdlValue, WdlValue]): Try[WdlMap] = {
+      val tryAdjust = inputMap mapValues { localizeWdlValue(toDestPath, strategies, postProcessor) }
+
+      TryUtil.sequenceMap(tryAdjust, s"Failed to localize files in input Map ${wdlValue.valueString}") map { adjusted =>
+        new WdlMap(t, adjusted)
+      }
     }
-  }
 
-  private def stageInputArray(call: Option[Call], array: WdlArray, hostInputsPath: Path): Try[WdlArray] = {
-    val attemptedStagedArray = array.value.map(stageWdlValue(call, _, hostInputsPath))
-    attemptedStagedArray collect { case f: Failure[_] => f } match {
-      case s: Seq[Failure[_]] if s.nonEmpty =>
-        val errors = s map { _.exception.getMessage } mkString "\n"
-        Failure(new UnsupportedOperationException(s"Failures during localization of array $array:\n\n$errors"))
-      case _ => Success(WdlArray(array.wdlType, attemptedStagedArray.map(_.get)))
+    def adjustFile(path: Path) = {
+      val adjustedPath = toDestPath(path)
+      localize(path, adjustedPath) map { Unit =>
+        val finalPath = postProcessor map { _(adjustedPath) } getOrElse adjustedPath
+        new WdlFile(finalPath.toAbsolutePath.toString)
+      }
     }
-  }
 
-  private def stageWdlValue(call: Option[Call], value: WdlValue, hostInputsPath: Path): Try[WdlValue] = value match {
-    case w: WdlFile => stageWdlFile(call, w, hostInputsPath)
-    case a: WdlArray => stageInputArray(call, a, hostInputsPath)
-    case x => Success(x)
-  }
-
-  private def stageWdlFile(call: Option[Call], wdlFile: WdlFile, hostInputsPath: Path): Try[WdlFile] = {
-    val originalPath = Paths.get(wdlFile.value)
-    val directoryIdentifier = MessageDigest.getInstance("MD5").digest(originalPath.toAbsolutePath.getParent.toString.getBytes) map {byte => f"$byte%02x"} mkString
-    val executionPath = hostInputsPath.resolve(s"${directoryIdentifier.substring(0,8)}-${originalPath.getFileName.toString}")
-
-    val attemptedLocalization = Stream(Localizers: _*) map { _(call, originalPath, executionPath) } find { _.isSuccess }
-    attemptedLocalization match {
-      case Some(_) => Success(WdlFile(executionPath.toString))
-      case None => Failure(throw new UnsupportedOperationException(s"Could not localize $wdlFile -> $executionPath"))
+    wdlValue match {
+      case WdlFile(path) => adjustFile(Paths.get(path))
+      case WdlArray(t, values) => adjustArray(t, values)
+      case WdlMap(t, values) => adjustMap(t, values)
+      case x => Success(x)
     }
   }
 

--- a/src/test/scala/cromwell/InputLocalizationWorkflowSpec.scala
+++ b/src/test/scala/cromwell/InputLocalizationWorkflowSpec.scala
@@ -1,0 +1,40 @@
+package cromwell
+
+import akka.testkit.EventFilter
+import cromwell.CromwellSpec.DockerTest
+import cromwell.binding.types.{WdlFileType, WdlStringType, WdlArrayType}
+import cromwell.binding.values.{WdlArray, WdlFile, WdlString}
+import cromwell.util.SampleWdl
+
+
+class InputLocalizationWorkflowSpec extends CromwellTestkitSpec("InputLocalisationWorkflowSpec") {
+  "a workflow running on a SharedFileSystem" should {
+
+    val expectedOutputs = Map(
+      "wf.fromDifferentDirectories.ls" -> WdlString("1"),
+      "wf.echo_int.out" -> WdlArray(WdlArrayType(WdlFileType), Seq(WdlFile("out"), WdlFile("out"))),
+      "wf.fromSameDirectory.ls" -> WdlString("2")
+    )
+
+    "ensure task inputs isolation" in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.InputIsolationWdl,
+        eventFilter = EventFilter.info(pattern = s"starting calls: wf.echo_int", occurrences = 1),
+        expectedOutputs = expectedOutputs
+      )
+    }
+
+    "ensure task inputs isolation in a docker container"  taggedAs DockerTest in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.InputIsolationWdl,
+        eventFilter = EventFilter.info(pattern = s"starting calls: wf.echo_int", occurrences = 1),
+        runtime = """
+                    |runtime {
+                    |  docker: "ubuntu:latest"
+                    |}
+                  """.stripMargin,
+        expectedOutputs = expectedOutputs
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
@@ -1,11 +1,12 @@
 package cromwell.engine.backend.jes
 
 import java.net.URL
+
+import cromwell.binding.CallInputs
 import cromwell.binding.values.{WdlFile, WdlString}
-import cromwell.binding.{Call, CallInputs}
 import cromwell.engine.WorkflowDescriptor
 import cromwell.engine.backend.jes.authentication._
-import cromwell.engine.workflow.WorkflowOptions
+import cromwell.engine.workflow.{CallKey, WorkflowOptions}
 import cromwell.util.EncryptionSpec
 import cromwell.util.google.SimpleClientSecrets
 import org.scalatest.{FlatSpec, Matchers}
@@ -23,7 +24,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito {
       project = anyString,
       executionBucket = anyString,
       endpointUrl = anyURL,
-      authMode = ServiceAccountMode,
+      authMode = JesAuthMode.fromString("service"),
       dockerCredentials = None,
       googleSecrets = Some(SimpleClientSecrets("myclientId", "myclientSecret"))) {
       override val localizeWithRefreshToken = true
@@ -32,7 +33,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito {
   }
 
   "adjustInputPaths" should "map GCS paths and *only* GCS paths to local" in {
-    val ignoredCall = mock[Call]
+    val ignoredCall = mock[CallKey]
     val stringKey = "abc"
     val stringVal = WdlString("abc")
     val localFileKey = "lf"
@@ -47,7 +48,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito {
       gcsFileKey -> gcsFileVal
     )
 
-    val mappedInputs: CallInputs  = new JesBackend().adjustInputPaths(ignoredCall, inputs)
+    val mappedInputs: CallInputs  = new JesBackend().adjustInputPaths(ignoredCall, inputs, mock[WorkflowDescriptor])
 
     mappedInputs.get(stringKey).get match {
       case WdlString(v) => assert(v.equalsIgnoreCase(stringVal.value))

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -39,7 +39,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
   object UnknownBackend extends Backend {
     type BackendCall = LocalBackendCall
 
-    override def adjustInputPaths(call: Call, inputs: CallInputs) =
+    override def adjustInputPaths(callKey: CallKey, inputs: CallInputs, workflowDescriptor: WorkflowDescriptor) =
       throw new NotImplementedError
 
     override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs =

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -168,7 +168,7 @@ object SampleWdl {
         |workflow wf {
         |  call a
         |  call b {
-        |    input: message=a.message, integer=a.constant - 75
+        |    input: message = a.message, integer = a.constant - 75
         |  }
         |}
       """.stripMargin
@@ -196,7 +196,7 @@ object SampleWdl {
         |
         |workflow test1 {
         |  call summary {
-        |     input: bfile=bfile
+        |     input: bfile = bfile
         |  }
         |}
       """.stripMargin
@@ -242,10 +242,10 @@ object SampleWdl {
         |workflow three_step {
         |  call ps
         |  call cgrep {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |  call wc {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |}
         |
@@ -290,7 +290,7 @@ object SampleWdl {
         |task D {
         |  Array[Int] D_in
         |  command {
-        |    python -c "print(${sep='+' D_in})"
+        |    python -c "print(${sep = '+' D_in})"
         |  }
         |  output {
         |    Int D_out = read_int(stdout())
@@ -309,8 +309,8 @@ object SampleWdl {
         |workflow w {
         |  call A
         |  scatter (item in A.A_out) {
-        |    call B {input: B_in=item}
-        |    call C {input: C_in=B.B_out}
+        |    call B {input: B_in = item}
+        |    call C {input: C_in = B.B_out}
         |    call E
         |    scatter (itemB in B.B_out) {
         |     call E as G
@@ -322,7 +322,7 @@ object SampleWdl {
         |  scatter (item in A.A_out) {
         |    call E as F
         |  }
-        |  call D {input: D_in=B.B_out}
+        |  call D {input: D_in = B.B_out}
         |}
       """.stripMargin
     override lazy val rawInputs = Map("" -> "...")
@@ -350,7 +350,7 @@ object SampleWdl {
       |  call hello
       |  call hello as hello2
       |  call hello as hello_person {
-      |    input: person="world"
+      |    input: person = "world"
       |  }
       |}
     """.stripMargin.replaceAll("RUNTIME", runtime)
@@ -367,7 +367,7 @@ object SampleWdl {
         |task hello {
         |  Array[String] person
         |  command {
-        |    echo "hello ${sep="," person}"
+        |    echo "hello ${sep = "," person}"
         |  }
         |  output {
         |    String greeting = read_string(stdout())
@@ -398,7 +398,7 @@ object SampleWdl {
         |task hello {
         |  Array[String]+ person
         |  command {
-        |    echo "hello ${sep="," person}"
+        |    echo "hello ${sep = "," person}"
         |  }
         |  output {
         |    String greeting = read_string(stdout())
@@ -425,7 +425,7 @@ object SampleWdl {
         |task hello {
         |  String? person
         |  command {
-        |    echo "hello ${default="default value" person}"
+        |    echo "hello ${default = "default value" person}"
         |  }
         |  output {
         |    String greeting = read_string(stdout())
@@ -497,10 +497,10 @@ object SampleWdl {
         |  call ps as ps2
         |  call ps as ps3
         |  call cgrep {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |  call wc {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |}
       """.stripMargin.replaceAll("RUNTIME", runtime)
@@ -569,10 +569,10 @@ object SampleWdl {
         |workflow three_step {
         |  call ps
         |  call cgrep {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |  call wc {
-        |    input: in_file=ps.procs
+        |    input: in_file = ps.procs
         |  }
         |}
         |
@@ -681,10 +681,10 @@ object SampleWdl {
         |  String flags = "-" + flags_suffix
         |  String static_string = "foobarbaz"
         |  call cat {
-        |    input: flags=flags
+        |    input: flags = flags
         |  }
         |  call cgrep {
-        |    input: in_file=cat.procs
+        |    input: in_file = cat.procs
         |  }
         |}
       """.stripMargin
@@ -735,7 +735,7 @@ object SampleWdl {
         |  String? flags
         |  Array[File]+ files
         |  command {
-        |    cat ${default="-s" flags} ${sep=" " files}
+        |    cat ${default = "-s" flags} ${sep = " " files}
         |  }
         |  output {
         |    File concatenated = stdout()
@@ -756,7 +756,7 @@ object SampleWdl {
         |task count_lines {
         |  Array[File]+ files
         |  command {
-        |    cat ${sep=' ' files} | wc -l
+        |    cat ${sep = ' ' files} | wc -l
         |  }
         |  output {
         |    Int count = read_int(stdout())
@@ -777,24 +777,24 @@ object SampleWdl {
         |  Array[File] files
         |  Array[String] strings = ["str1", "str2", "str3"]
         |  call serialize {
-        |    input: strs=strings
+        |    input: strs = strings
         |  }
         |  call concat_files as concat {
-        |    input: files=files
+        |    input: files = files
         |  }
         |  call count_lines {
-        |    input: files=[concat.concatenated]
+        |    input: files = [concat.concatenated]
         |  }
         |  call find
         |  call count_lines as count_lines_array {
-        |    input: files=find.results
+        |    input: files = find.results
         |  }
         |}
       """.stripMargin
 
     val tempDir = Files.createTempDirectory("ArrayIO")
-    val firstFile = createCannedFile(prefix="first", contents="foo\n", dir=Some(tempDir))
-    val secondFile = createCannedFile(prefix="second", contents="bar\nbaz\n", dir=Some(tempDir))
+    val firstFile = createCannedFile(prefix = "first", contents = "foo\n", dir = Some(tempDir))
+    val secondFile = createCannedFile(prefix = "second", contents = "bar\nbaz\n", dir = Some(tempDir))
 
     override val rawInputs = Map(
       "wf.find.root" -> tempDir.toAbsolutePath.toString,
@@ -819,7 +819,7 @@ object SampleWdl {
         |task cat {
         |  Array[File]+ files
         |  command {
-        |    cat -s ${sep=' ' files}
+        |    cat -s ${sep = ' ' files}
         |  }
         |  output {
         |    Array[String] lines = read_lines(stdout())
@@ -828,7 +828,7 @@ object SampleWdl {
         |
         |workflow wf {
         |  Array[File] arr = ["f1", "f2", "f3"]
-        |  call cat {input: files=arr}
+        |  call cat {input: files = arr}
         |}
       """.stripMargin
 
@@ -862,7 +862,7 @@ object SampleWdl {
         |
         |workflow wf {
         |  Map[File, String] map = {"f1": "alice", "f2": "bob", "f3": "chuck"}
-        |  call write_map {input: file_to_name=map}
+        |  call write_map {input: file_to_name = map}
         |  call read_map
         |}
       """.stripMargin
@@ -894,6 +894,51 @@ object SampleWdl {
       """.stripMargin
 
     override val rawInputs = Map.empty[String, String]
+  }
+
+  object InputIsolationWdl extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """
+        |task localize {
+        |    Array[File] array
+        |    command {
+        |        ls -1 "$(dirname ${array[0]})" | wc -l | tr -d '[[:space:]]'
+        |    }
+        |    output {
+        |        String ls = read_string(stdout())
+        |    }
+        |    RUNTIME
+        |}
+        |
+        |task echo_int {
+        |  Int int
+        |  command {echo ${int} > out }
+        |  output {File out = "out"}
+        |   RUNTIME
+        |}
+        |
+        |workflow wf {
+        |    Array[File] files
+        |    Array[Int] ints = [1,2]
+        |
+        |   scatter(i in ints) {
+        |    call echo_int {
+        |      input: int = i
+        |    }
+        |  }
+        |
+        |  call localize as fromDifferentDirectories { input: array = echo_int.out }
+        |  call localize as fromSameDirectory { input: array = files }
+        |}
+      """.stripMargin.replaceAll("RUNTIME", runtime)
+
+    val tempDir = Files.createTempDirectory("InputFiles")
+    val file1 = createCannedFile(prefix = "file1", contents = "", dir = Some(tempDir))
+    val file2 = createCannedFile(prefix = "file1", contents = "", dir = Some(tempDir))
+
+    override val rawInputs = Map(
+      "wf.files" -> Seq(file1.getAbsolutePath, file2.getAbsolutePath)
+    )
   }
 
   object TripleSleep extends SampleWdl {
@@ -1017,7 +1062,7 @@ object SampleWdl {
       |task D {
       |  Array[Int] D_in
       |  command {
-      |    python -c "print(${sep='+' D_in})"
+      |    python -c "print(${sep = '+' D_in})"
       |  }
       |  output {
       |    Int D_out = read_int(stdout())
@@ -1040,11 +1085,11 @@ object SampleWdl {
         |workflow w {
         |  call A
         |  scatter (item in A.A_out) {
-        |    call B {input: B_in=item}
-        |    call C {input: C_in=B.B_out}
+        |    call B {input: B_in = item}
+        |    call C {input: C_in = B.B_out}
         |    call E
         |  }
-        |  call D {input: D_in=B.B_out}
+        |  call D {input: D_in = B.B_out}
         |}
       """.stripMargin
 
@@ -1058,14 +1103,14 @@ object SampleWdl {
         |workflow w {
         |  call A
         |  scatter (item in A.A_out) {
-        |    call B {input: B_in=item}
-        |    call C {input: C_in=B.B_out}
+        |    call B {input: B_in = item}
+        |    call C {input: C_in = B.B_out}
         |    call E
         |  }
         |  scatter (item in A.A_out) {
-        |    call B as F {input: B_in=item}
+        |    call B as F {input: B_in = item}
         |  }
-        |  call D {input: D_in=B.B_out}
+        |  call D {input: D_in = B.B_out}
         |}
       """.stripMargin
 
@@ -1082,10 +1127,10 @@ object SampleWdl {
         |
         |workflow scatter0 {
         |  Array[Int] ints = [1,2,3,4,5]
-        |  call echo_int as outside_scatter {input: int=8000}
+        |  call echo_int as outside_scatter {input: int = 8000}
         |  scatter(i in ints) {
         |    call echo_int as inside_scatter {
-        |      input: int=i
+        |      input: int = i
         |    }
         |  }
         |}
@@ -1127,7 +1172,7 @@ object SampleWdl {
         |task do_gather {
         |    Array[File] input_files
         |    command <<<
-        |        cat ${sep=' ' input_files} | awk '{s+=$1} END {print s}'
+        |        cat ${sep = ' ' input_files} | awk '{s+=$1} END {print s}'
         |    >>>
         |    output {
         |        Int sum = read_int(stdout())
@@ -1138,11 +1183,11 @@ object SampleWdl {
         |    call do_prepare
         |    scatter(f in do_prepare.split_files) {
         |        call do_scatter {
-        |            input: input_file=f
+        |            input: input_file = f
         |        }
         |    }
         |    call do_gather {
-        |        input: input_files=do_scatter.count_file
+        |        input: input_files = do_scatter.count_file
         |    }
         |}
       """.stripMargin.replaceAll("RUNTIME", runtime)
@@ -1174,8 +1219,8 @@ object SampleWdl {
 
     val tempDir1 = Files.createTempDirectory("FileClobber1")
     val tempDir2 = Files.createTempDirectory("FileClobber2")
-    val firstFile = createFile(name="file.txt", contents="first file.txt", dir=tempDir1)
-    val secondFile = createFile(name="file.txt", contents="second file.txt", dir=tempDir2)
+    val firstFile = createFile(name = "file.txt", contents = "first file.txt", dir = tempDir1)
+    val secondFile = createFile(name = "file.txt", contents = "second file.txt", dir = tempDir2)
 
     override val rawInputs = Map(
       "two.x.in" -> firstFile.getAbsolutePath,
@@ -1206,7 +1251,7 @@ object SampleWdl {
         |
         |workflow w {
         |  call A
-        |  call B {input: B_in=A.A_out}
+        |  call B {input: B_in = A.A_out}
         |}
       """.stripMargin.replaceAll("RUNTIME", runtime)
     override lazy val rawInputs = Map("" -> "...")
@@ -1232,8 +1277,8 @@ object SampleWdl {
         |workflow file_passing {
         |  File f
         |
-        |  call a {input: in=f}
-        |  call a as b {input: in=a.out}
+        |  call a {input: in = f}
+        |  call a as b {input: in = a.out}
         |}
       """.stripMargin.replaceAll("RUNTIME", runtime)
 
@@ -1266,7 +1311,7 @@ object SampleWdl {
         |  Map[String, String] map
         |
         |  command {
-        |    echo ${sep=' ' array} > concat
+        |    echo ${sep = ' ' array} > concat
         |  }
         |  output {
         |    String x = read_string("concat")
@@ -1280,8 +1325,8 @@ object SampleWdl {
         |  Array[String] in_array = read_lines(array_file)
         |  Map[String, String] in_map = read_map(map_file)
         |  call a {input:
-        |    array=in_array,
-        |    map=in_map
+        |    array = in_array,
+        |    map = in_map
         |  }
         |}
       """.stripMargin.replaceAll("RUNTIME", runtime)
@@ -1299,7 +1344,7 @@ object SampleWdl {
       """task subtask {
         |  Array[File] a
         |  command {
-        |    cat ${sep=" " a}
+        |    cat ${sep = " " a}
         |  }
         |  output {
         |    String concatenated = read_string(stdout())
@@ -1311,17 +1356,17 @@ object SampleWdl {
         |
         |  scatter(n in nested_file) {
         |    call subtask {
-        |      input: a=n
+        |      input: a = n
         |    }
         |  }
         |}
       """.stripMargin
 
     val tempDir = Files.createTempDirectory("ArrayOfArray")
-    val firstFile = createCannedFile(prefix="first", contents="foo\n", dir=Some(tempDir))
-    val secondFile = createCannedFile(prefix="second", contents="bar\nbaz\n", dir=Some(tempDir))
-    val thirdFile = createCannedFile(prefix="third", contents="third\n", dir=Some(tempDir))
-    val fourthFile = createCannedFile(prefix="fourth", contents="fourth\n", dir=Some(tempDir))
+    val firstFile = createCannedFile(prefix = "first", contents = "foo\n", dir = Some(tempDir))
+    val secondFile = createCannedFile(prefix = "second", contents = "bar\nbaz\n", dir = Some(tempDir))
+    val thirdFile = createCannedFile(prefix = "third", contents = "third\n", dir = Some(tempDir))
+    val fourthFile = createCannedFile(prefix = "fourth", contents = "fourth\n", dir = Some(tempDir))
 
     override val rawInputs = Map(
       "wf.nested_file" ->


### PR DESCRIPTION
Now localize directly all call inputs into the call directory, following the path structure of the original path.
Ex: if a workflow input is defined at `/Users/tjeandet/inputs/myfile.txt` it will be localized at 
`cromwell-executions/workflow/UUID/call-mycall/Users/tjeandet/inputs/myfile.txt`. Same for inputs coming from other calls.
`workflow-inputs` no longer exists.