### PR TITLE
Moving '/workflows' to '/api/workflows'.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization := "org.broadinstitute"
 
 scalaVersion := "2.11.7"
 
-val lenthallV = "0.13"
+val lenthallV = "0.14-2ce072a-SNAPSHOT"
 
 val sprayV = "1.3.2"
 
@@ -125,4 +125,3 @@ testOptions in NoDockerTest += Tests.Argument("-l", "DockerTest")
 test in assembly := {}
 
 parallelExecution := false
-

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,11 +8,6 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
 
-swagger {
-  docsPath = "swagger/cromwell.yaml"
-  uiVersion = "2.1.1"
-}
-
 spray.can {
   server {
     request-timeout = 40s

--- a/src/main/resources/swagger/cromwell.yaml
+++ b/src/main/resources/swagger/cromwell.yaml
@@ -10,6 +10,7 @@ info:
   termsOfService: 'http://www.github.com/broadinstitute/cromwell'
 produces:
   - application/json
+basePath: /api
 paths:
   '/workflows/{version}/{id}/abort':
     post:
@@ -22,7 +23,7 @@ paths:
           in: path
           default: v1
         - name: id
-          description: workflow identifier
+          description: Workflow ID
           required: true
           type: string
           in: path
@@ -132,8 +133,9 @@ paths:
           required: true
           type: string
           in: path
+          default: v1
         - name: id
-          description: Workflow Identifier
+          description: Workflow ID
           required: true
           type: string
           in: path
@@ -151,7 +153,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{workflowId}/outputs/{callFqn}':
+  '/workflows/{version}/{id}/outputs/{callFqn}':
     get:
       summary: Query for call outputs based on workflow id and call fully qualified name
       parameters:
@@ -161,7 +163,7 @@ paths:
           type: string
           in: path
           default: v1
-        - name: workflowId
+        - name: id
           description: Workflow ID
           required: true
           type: string
@@ -196,7 +198,7 @@ paths:
           in: path
           default: v1
         - name: id
-          description: Workflow Identifier
+          description: Workflow ID
           required: true
           type: string
           in: path
@@ -216,7 +218,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{workflowId}/logs/{callFqn}':
+  '/workflows/{version}/{id}/logs/{callFqn}':
     get:
       summary: Query standard output and error of a call from its fully qualified name
       parameters:
@@ -226,7 +228,7 @@ paths:
           type: string
           in: path
           default: v1
-        - name: workflowId
+        - name: id
           description: Workflow ID
           required: true
           type: string
@@ -250,7 +252,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{workflowId}/logs':
+  '/workflows/{version}/{id}/logs':
     get:
       summary: Query for the standard output and error of all calls in a workflow
       parameters:
@@ -260,7 +262,7 @@ paths:
           type: string
           in: path
           default: v1
-        - name: workflowId
+        - name: id
           description: Workflow ID
           required: true
           type: string
@@ -279,7 +281,7 @@ paths:
       security:
         - google_oauth:
             - openid
-  '/workflows/{version}/{workflowId}/metadata':
+  '/workflows/{version}/{id}/metadata':
     get:
       summary: Query for workflow and call-level metadata for a specified workflow
       parameters:
@@ -289,7 +291,7 @@ paths:
           type: string
           in: path
           default: v1
-        - name: workflowId
+        - name: id
           description: Workflow ID
           required: true
           type: string

--- a/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/src/main/scala/cromwell/server/CromwellServer.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 object CromwellServer extends DefaultWorkflowManagerSystem {
   val conf = ConfigFactory.load()
 
-  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, SwaggerService.from(conf)), "cromwell-service")
+  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf), "cromwell-service")
 
   implicit val timeout = Timeout(5.seconds)
 


### PR DESCRIPTION
Added config option 'api.routeUnwrapped' to optionally allow still serving '/workflows'.