### PR TITLE
Per-workflow logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Workflow engine using [WDL](https://github.com/broadinstitute/wdl/blob/wdl2/SPEC
   * [cpu](#cpu)
   * [defaultDisks](#defaultdisks)
   * [defaultZones](#defaultzones)
-  * [failOnStderr](#failonstderr)
   * [docker](#docker)
+  * [failOnStderr](#failonstderr)
   * [memory](#memory)
   * [preemptible](#preemptible)
+* [Logging](#logging)
 * [REST API](#rest-api)
   * [REST API Versions](#rest-api-versions)
   * [POST /api/workflows/:version](#post-apiworkflowsversion)
@@ -1129,6 +1130,28 @@ runtime {
 ```
 
 Defaults to "false".
+
+# Logging
+
+Cromwell accepts three Java Properties for controlling logging:
+
+* `LOG_ROOT` - Specifies the directory where logs will be written (default `.`)
+* `LOG_MODE` - Accepts either `server`, `console`, or `server,console` (default `console`).  In `server` mode, logs will be written to `LOG_ROOT`
+* `LOG_LEVEL` - Level at which to log (default `info`)
+
+If the command `java -DLOG_MODE=server,console -DLOG_ROOT=log -jar cromwell.jar run my_workflow.wdl my_workflow.json` were run three times, we'd see this in the `log` directory:
+
+```
+log
+├── cromwell.2015-10-26.log
+├── workflow.319df202-a60f-47c8-b886-bd4821747c68.log
+├── workflow.36e07688-9e47-45bd-9930-aff58471541e.log
+└── workflow.7dad065d-9d7a-4450-91c8-1f7ece184851.log
+```
+
+There would also be logging to the standard out stream as well.
+
+The `cromwell.<date>.log` file contains an aggregate of every log message, while the `workflow.<uuid>.log` files contain only log messages that pertain to that particular workflow.
 
 # REST API
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,34 +1,40 @@
 <configuration>
-  <if condition='property("CROMWELL_LOGGER").equals("SERVER")'>
+  <if condition='property("LOG_MODE").toUpperCase().contains("SERVER")'>
     <then>
       <appender name="SERVER_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- Support multiple-JVM writing to the same log file -->
         <prudent>true</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-          <fileNamePattern>cromwell.%d{yyyy-MM-dd}.log</fileNamePattern>
+          <fileNamePattern>${LOG_ROOT}/cromwell.%d{yyyy-MM-dd}.log</fileNamePattern>
           <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-          <pattern>%date [%thread] %-5level %logger{35} - %msg%n</pattern>
+          <pattern>%date %thread %-5level - %msg%n</pattern>
         </encoder>
       </appender>
-      <root level="INFO">
-        <appender-ref ref="SERVER_APPENDER" />
-      </root>
-      <logger name="com.zaxxer.hikari" level="ERROR"/>
-      <logger name="HikariPool" level="ERROR"/>
     </then>
     <else>
+      <appender name="SERVER_APPENDER" class="ch.qos.logback.core.helpers.NOPAppender" />
+    </else>
+  </if>
+
+  <if condition='property("LOG_MODE").toUpperCase().contains("CONSOLE")'>
+    <then>
       <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
           <layout class="cromwell.logging.TerminalLayout" />
         </encoder>
       </appender>
-      <root level="INFO">
-        <appender-ref ref="CONSOLE_APPENDER" />
-      </root>
-      <logger name="com.zaxxer.hikari" level="ERROR"/>
-      <logger name="HikariPool" level="ERROR"/>
+    </then>
+    <else>
+      <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.helpers.NOPAppender" />
     </else>
   </if>
+
+  <root level="${LOG_LEVEL}">
+    <appender-ref ref="SERVER_APPENDER" />
+    <appender-ref ref="CONSOLE_APPENDER" />
+  </root>
+  <logger name="com.zaxxer.hikari" level="ERROR"/>
+  <logger name="HikariPool" level="ERROR"/>
 </configuration>

--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -1,13 +1,20 @@
 package cromwell
 
+import java.nio.file.{Paths, Path}
 import java.util.UUID
 
+import ch.qos.logback.classic.{LoggerContext, Level}
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.FileAppender
 import com.typesafe.config.ConfigFactory
 import cromwell.binding._
 import cromwell.binding.types.WdlType
 import cromwell.binding.values.WdlValue
 import cromwell.engine.backend.Backend
 import cromwell.engine.workflow.WorkflowOptions
+import org.slf4j.{LoggerFactory, Logger}
+import org.slf4j.helpers.NOPLogger
 import spray.json._
 
 import scala.language.implicitConversions
@@ -60,6 +67,36 @@ package object engine {
     val coercedInputs = namespace.coerceRawInputs(rawInputs).get
     val declarations = namespace.staticDeclarationsRecursive(coercedInputs, backend.engineFunctions).get
     val actualInputs: WorkflowCoercedInputs = coercedInputs ++ declarations
+
+    val workflowLogger = Option(System.getProperty("LOG_MODE")) match {
+      case Some(x) if x.toUpperCase.contains("SERVER") => makeFileLogger(
+        Paths.get(Option(System.getProperty("LOG_ROOT")).getOrElse(".")),
+        s"workflow.$id.log"
+      )
+      case _ => NOPLogger.NOP_LOGGER
+    }
+
+    private def makeFileLogger(root: Path, name: String): Logger = {
+      val ctx = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+      val encoder = new PatternLayoutEncoder()
+      encoder.setPattern("%date %-5level - %msg%n")
+      encoder.setContext(ctx)
+      encoder.start()
+
+      val path = root.resolve(name).toAbsolutePath.toString
+      val appender = new FileAppender[ILoggingEvent]()
+      appender.setFile(path)
+      appender.setEncoder(encoder)
+      appender.setName(name)
+      appender.setContext(ctx)
+      appender.start()
+
+      val fileLogger = ctx.getLogger(name)
+      fileLogger.addAppender(appender)
+      fileLogger.setAdditive(false)
+      fileLogger.setLevel(Level.toLevel(Option(System.getProperty("LOG_LEVEL")).getOrElse("debug")))
+      fileLogger
+    }
   }
 
   /**

--- a/src/main/scala/cromwell/logging/WorkflowLogger.scala
+++ b/src/main/scala/cromwell/logging/WorkflowLogger.scala
@@ -1,0 +1,98 @@
+package cromwell.logging
+
+import akka.event.LoggingAdapter
+import cromwell.engine.WorkflowDescriptor
+import org.slf4j.Logger
+
+/**
+ * This sets up two loggers for a given workflow, specified by the
+ * WorkflowDescriptor.
+ *
+ * 1) akkaLogger - the Akka event logger (optional).  The log
+ *    messages sent to the Akka logger will propagate to the root
+ *    logger (see logback.xml)
+ *
+ * 2) A logger that writes to a file that only has log messages
+ *    for this particular workflow.  This makes it easier to debug
+ *    a particular workflow if the messages aren't interleaved with
+ *    other workflows.  This logger does NOT propagate to the root
+ *    logger
+ *
+ * 3) otherLoggers - any org.slf4j.Logger instances to also log to.
+ *    (defaults to Seq.empty)
+ *
+ * Each log method called (e.g. warn(), error()) will log to all the
+ * above locations
+ */
+case class WorkflowLogger(caller: String,
+                          descriptor: WorkflowDescriptor,
+                          akkaLogger: Option[LoggingAdapter] = None,
+                          otherLoggers: Seq[Logger] = Seq.empty[Logger],
+                          callTag: Option[String] = None) {
+  val workflowFileLogger = descriptor.workflowLogger
+
+  val tag: String = {
+    val subtag = callTag.map(c => s":$c").getOrElse("")
+    s"$caller [UUID(${descriptor.shortId})$subtag]"
+  }
+
+  private def format(msg: String): String = s"$tag: $msg"
+
+  def warn(msg: String): Unit = {
+    workflowFileLogger.warn(format(msg))
+    akkaLogger.foreach(_.warning(format(msg)))
+    otherLoggers.foreach(_.warn(format(msg)))
+  }
+
+  def warn(msg: String, t: Throwable): Unit = {
+    workflowFileLogger.warn(format(msg), t)
+    akkaLogger.foreach(_.warning(format(msg), t))
+    otherLoggers.foreach(_.warn(format(msg), t))
+  }
+
+  def error(msg: String): Unit = {
+    workflowFileLogger.error(format(msg))
+    akkaLogger.foreach(_.error(format(msg)))
+    otherLoggers.foreach(_.error(format(msg)))
+  }
+
+  def error(msg: String, t: Throwable): Unit = {
+    workflowFileLogger.error(format(msg), t)
+    akkaLogger.foreach(_.error(format(msg), t))
+    otherLoggers.foreach(_.error(format(msg), t))
+  }
+
+  def debug(msg: String): Unit = {
+    workflowFileLogger.debug(format(msg))
+    akkaLogger.foreach(_.debug(format(msg)))
+    otherLoggers.foreach(_.debug(format(msg)))
+  }
+
+  def debug(msg: String, t: Throwable): Unit = {
+    workflowFileLogger.debug(format(msg), t)
+    akkaLogger.foreach(_.debug(format(msg), t))
+    otherLoggers.foreach(_.debug(format(msg), t))
+  }
+
+  def trace(msg: String): Unit = {
+    workflowFileLogger.trace(format(msg))
+    otherLoggers.foreach(_.trace(format(msg)))
+  }
+
+  def trace(msg: String, t: Throwable): Unit = {
+    workflowFileLogger.trace(format(msg), t)
+    otherLoggers.foreach(_.trace(format(msg), t))
+  }
+
+  def info(msg: String): Unit = {
+    workflowFileLogger.info(format(msg))
+    akkaLogger.foreach(_.info(format(msg)))
+    otherLoggers.foreach(_.info(format(msg)))
+  }
+
+  def info(msg: String, t: Throwable): Unit = {
+    workflowFileLogger.info(format(msg), t)
+    akkaLogger.foreach(_.info(format(msg), t))
+    otherLoggers.foreach(_.info(format(msg), t))
+  }
+}

--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -32,7 +32,7 @@ object CromwellTestkitSpec {
   val ConfigText =
     """
       |akka {
-      |  loggers = ["akka.event.slf4j.Slf4jLogger", "akka.testkit.TestEventListener"]
+      |  loggers = ["akka.testkit.TestEventListener"]
       |  loglevel = "INFO"
       |  actor {
       |    debug {

--- a/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
@@ -63,12 +63,5 @@ class LocalBackendSpec extends CromwellTestkitSpec("LocalBackendSpec") with Mock
     "allow stderr if failOnStderr is not set" in {
       testFailOnStderr(stderrDescriptor("runtime {failOnStderr: false}"), expectSuccess = true)
     }
-
-    "make a log tag from a workflowDescriptor" in {
-      val wd = mock[WorkflowDescriptor]
-      wd.shortId returns "SHORTID"
-      val backend = new LocalBackend()
-      backend.makeTag(wd) shouldBe "LocalBackend [UUID(SHORTID)]"
-    }
   }
 }

--- a/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
+++ b/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
@@ -1,0 +1,36 @@
+package cromwell.logging
+
+import java.util.UUID
+
+import cromwell.binding.values.WdlValue
+import cromwell.engine.backend.local.{LocalBackend, LocalBackendCall}
+import cromwell.engine.workflow.CallKey
+import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor, WorkflowId, WorkflowSourceFiles}
+import org.scalatest.{FlatSpec, Matchers}
+
+class WorkflowLoggerSpec extends FlatSpec with Matchers {
+  val descriptor = WorkflowDescriptor(
+    WorkflowId(UUID.fromString("fc6cfad9-65e9-4eb7-853f-7e08c1c8cf8e")),
+    WorkflowSourceFiles(
+      "task x {command {ps}} workflow w {call x}",
+      "{}",
+      "{}"
+    )
+  )
+  val backend = new LocalBackend()
+  val backendCall = LocalBackendCall(
+    backend,
+    descriptor,
+    CallKey(descriptor.namespace.workflow.calls.find(_.name == "x").head, None),
+    Map.empty[String, WdlValue],
+    AbortRegistrationFunction(_ => ())
+  )
+
+  "WorkflowLogger" should "create a valid tag" in {
+    backend.workflowLogger(descriptor).tag shouldBe "LocalBackend [UUID(fc6cfad9)]"
+  }
+
+  it should "create a valid tag for backend call" in {
+    backend.workflowLoggerWithCall(backendCall).tag shouldBe "LocalBackend [UUID(fc6cfad9):x]"
+  }
+}

--- a/src/test/scala/cromwell/util/TryUtilSpec.scala
+++ b/src/test/scala/cromwell/util/TryUtilSpec.scala
@@ -1,5 +1,9 @@
 package cromwell.util
 
+import java.util.UUID
+
+import cromwell.engine.{WorkflowId, WorkflowSourceFiles, WorkflowDescriptor}
+import cromwell.logging.WorkflowLogger
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.language.postfixOps
@@ -19,6 +23,17 @@ class TryUtilSpec extends FlatSpec with Matchers {
     func
   }
 
+  val descriptor = WorkflowDescriptor(
+    WorkflowId(UUID.randomUUID()),
+    WorkflowSourceFiles(
+      "workflow w {}",
+      "{}",
+      "{}"
+    )
+  )
+
+  val logger = WorkflowLogger("Test", descriptor)
+
   it should "Retry a function until it works" in {
     val value = TryUtil.retryBlock(
       fn = failNTimes(4),
@@ -26,6 +41,7 @@ class TryUtilSpec extends FlatSpec with Matchers {
       pollingInterval = 50 milliseconds,
       pollingBackOffFactor = 1,
       maxPollingInterval = 10 seconds,
+      logger = logger,
       failMessage = Some(s"failed attempt (on purpose)")
     )
     value shouldEqual Success(9)
@@ -38,6 +54,7 @@ class TryUtilSpec extends FlatSpec with Matchers {
       pollingInterval = 50 milliseconds,
       pollingBackOffFactor = 1,
       maxPollingInterval = 10 seconds,
+      logger = logger,
       failMessage = Some(s"failed attempt (on purpose)")
     )
     value.isFailure shouldEqual true


### PR DESCRIPTION
This allows for a log file per workflow, as well as the ability to specify the log root.  This also allows for both stdout and file-logging simultaneously.  This will allow us to have an API endpoint which just reads this the particular file for the workflow and sends it back over HTTP

Cromwell now accepts three Java Properties:

* `LOG_ROOT` - location where log files go (default `.`)
* `LOG_MODE` - `server`, `console`, or `server,console` (default `console`)
* `LOG_LEVEL` - info, debug, etc (default `info`)

**Standard out logging and the main Cromwell log were not changed by this PR**

If the command `sbt -DLOG_MODE=server,console -DLOG_ROOT=log "run run 3step.wdl 3step.json"` were run three times, we'd see this in the `log` directory:

```
log
├── cromwell.2015-10-26.log
├── workflow.319df202-a60f-47c8-b886-bd4821747c68.log
├── workflow.36e07688-9e47-45bd-9930-aff58471541e.log
└── workflow.7dad065d-9d7a-4450-91c8-1f7ece184851.log
```

FAQ:

> Scott, why did you not use the `application.conf` file for things like log root, log mode?  Seems obvious, right?

Glad you asked.  I tried, for a very long time, to allow for the values to be set in `application.conf`.  However, I was unable to get it to work.  It seems that by querying for a value in `application.conf`, it causes the `logback.xml` to be read and processed.  The logback.xml file does not recognize values in `application.conf` natively, it must have Java Properties set.

> What the hell were you thinking with the `WorkflowLogger` class?

I'd be very happy to discuss how to do this better.  The problem is this:

* We need to log to the Akka logger whenever we can because the tests depend on it
* Akka logger descends from the root logger (`logback.xml`)
* A new logger needs to be created for each workflow.
* Both the Akka logger and the workflow logger descend from the root logger so they both can't propagate  messages or we'll get doubles of everything in the root logger.
* Workflow logger is set to not propagate messages (`setAdditive(false)`)