### PR TITLE
Rename server logging to file logging since we don't seem to use serv…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1176,10 +1176,10 @@ Defaults to "false".
 Cromwell accepts three Java Properties for controlling logging:
 
 * `LOG_ROOT` - Specifies the directory where logs will be written (default `.`)
-* `LOG_MODE` - Accepts either `server`, `console`, or `server,console` (default `console`).  In `server` mode, logs will be written to `LOG_ROOT`
+* `LOG_MODE` - Accepts either `file`, `console`, or `file,console` (default `console`).  In `file` mode, logs will be written to `LOG_ROOT`
 * `LOG_LEVEL` - Level at which to log (default `info`)
 
-If the command `java -DLOG_MODE=server,console -DLOG_ROOT=log -jar cromwell.jar run my_workflow.wdl my_workflow.json` were run three times, we'd see this in the `log` directory:
+If the command `java -DLOG_MODE=file,console -DLOG_ROOT=log -jar cromwell.jar run my_workflow.wdl my_workflow.json` were run three times, we'd see this in the `log` directory:
 
 ```
 log

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
-  <if condition='property("LOG_MODE").toUpperCase().contains("SERVER")'>
+  <if condition='property("LOG_MODE").toUpperCase().contains("FILE")'>
     <then>
-      <appender name="SERVER_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
+      <appender name="FILE_APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <!-- Support multiple-JVM writing to the same log file -->
         <prudent>true</prudent>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -14,7 +14,7 @@
       </appender>
     </then>
     <else>
-      <appender name="SERVER_APPENDER" class="ch.qos.logback.core.helpers.NOPAppender" />
+      <appender name="FILE_APPENDER" class="ch.qos.logback.core.helpers.NOPAppender" />
     </else>
   </if>
 
@@ -32,7 +32,7 @@
   </if>
 
   <root level="${LOG_LEVEL}">
-    <appender-ref ref="SERVER_APPENDER" />
+    <appender-ref ref="FILE_APPENDER" />
     <appender-ref ref="CONSOLE_APPENDER" />
   </root>
   <logger name="com.zaxxer.hikari" level="ERROR"/>

--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -70,7 +70,7 @@ package object engine {
 
     val props = sys.props
     val workflowLogger = props.get("LOG_MODE") match {
-      case Some(x) if x.toUpperCase.contains("SERVER") => makeFileLogger(
+      case Some(x) if x.toUpperCase.contains("FILE") => makeFileLogger(
         Paths.get(props.getOrElse("LOG_ROOT", ".")),
         s"workflow.$id.log",
         Level.toLevel(props.getOrElse("LOG_LEVEL", "debug"))

--- a/src/main/scala/cromwell/logging/TerminalLayout.scala
+++ b/src/main/scala/cromwell/logging/TerminalLayout.scala
@@ -24,7 +24,7 @@ class TerminalLayout extends LayoutBase[ILoggingEvent] {
       .replaceAll("UUID\\((.*?)\\)", TerminalUtil.highlight(2, "$1"))
       .replaceAll("`([^`]*?)`", TerminalUtil.highlight(5, "$1"))
 
-    s"[$timestamp] [$level] $highlightedMessage\n${event.toStackTrace}"
+    s"[$timestamp] ${java.lang.Thread.currentThread.getName} [$level] $highlightedMessage\n${event.toStackTrace}"
   }
 }
 


### PR DESCRIPTION
…er logging for server mode

Make console logging report the thread name like the ex-server logging since console is now default for server mode