### PR TITLE
Redirect default java tmp directory to cromwell directory

### DIFF
--- a/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
@@ -329,6 +329,8 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
     val fileContent =
       s"""
          |#!/bin/bash
+         |export _JAVA_OPTIONS=-Djava.io.tmpdir=$JesCromwellRoot/tmp
+         |export TMPDIR=$JesCromwellRoot/tmp
          |cd $JesCromwellRoot
          |$monitoring
          |$command


### PR DESCRIPTION
This is needed so tools don't write their temporary files to /tmp or /var/tmp which are not on the same disk as cromwell_root in JES.