### PR TITLE
JES Auth rework for Firecloud

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -74,6 +74,8 @@ backend {
 // If authenticating with Google (e.g. if backend is 'JES') you must supply a top level stanza 'google':
 // This defines how all requests to JES/GCS performed by Cromwell will be authenticated.
 google {
+  // Used by cromwell to make calls to JES and to perform GCS reads/writes.
+  // The latter can be overriden if the "User Mode" is used (see below).
   // authScheme = "user"
 
   // If authScheme is "user"
@@ -89,9 +91,9 @@ google {
     // serviceAccountId = ""
   }
 
-  // [Optional]
-  // If defined, data localization and delocalization in GoogleCloudStorage will be done on behalf of another entity (typically a user).
-  // This allows cromwell to localize data that wouldn't be accessible using whatever "authScheme" has been defined.
+  // User Mode [Optional]
+  // If defined, most of the operations in GoogleCloudStorage will be done on behalf of another entity (typically a user).
+  // In particular this allows cromwell to work with a bucket that wouldn't be accessible using whatever "authScheme" has been defined.
   // It requires a user refresh token to be passed upon every workflow submission (see "workflow options" in cromwell documentation).
   // client_id and client_secrets must be the ones that have been used to generate the above-mentioned refresh token.
   // localizeWithRefreshToken = {

--- a/src/main/scala/cromwell/binding/IOInterface.scala
+++ b/src/main/scala/cromwell/binding/IOInterface.scala
@@ -1,0 +1,16 @@
+package cromwell.binding
+
+/**
+  * Defines the set of IO methods needed by the WdlStandardLibrary to execute IO engine functions (read_*, write_*, glob, ...).
+  * Implementation is Backend specific. Authentication might be workflow specific.
+  * An instance of this is expected to be created when a WorkflowDescriptor is instantiated.
+  * It will then hold a reference to an IOInterface that can be used throughout the workflow execution to evaluate expressions with IO engine functions.
+  */
+trait IOInterface {
+  def readFile(path: String): String
+  def writeFile(path: String, content: String): Unit
+  def writeTempFile(path: String, prefix: String, suffix: String, content: String): String
+  def exists(path: String): Boolean
+  def listContents(path: String): Iterable[String]
+  def glob(path: String, pattern: String): Seq[String]
+}

--- a/src/main/scala/cromwell/binding/expression/WdlFunctions.scala
+++ b/src/main/scala/cromwell/binding/expression/WdlFunctions.scala
@@ -1,7 +1,5 @@
 package cromwell.binding.expression
 
-import cromwell.binding.values.WdlValue
-
 import scala.language.postfixOps
 import scala.util.{Failure, Try}
 
@@ -18,11 +16,9 @@ trait WdlFunctions[T] {
   }
 
   /**
-    * Given a WDL value that represents a file, return the contents
-    * of that file.  Not all WdlValues can be interpreted as files
-    * In which case this method should throw an exception
-    *
-    * @param value - WDL Value that represents a file
+    * Given a path to a file, return the contents
+    * of that file.
+    * @param path - path to the file
     * @return - Contents of the file
     * @throws UnsupportedOperationException if the WDL value can
     *         not be interpreted as a file

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -44,6 +44,7 @@ trait JobKey
 trait Backend {
 
   type BackendCall <: backend.BackendCall
+  type IOInterface <: cromwell.binding.IOInterface
 
   /**
    * Return a possibly altered copy of inputs reflecting any localization of input file paths that might have
@@ -77,7 +78,12 @@ trait Backend {
   /**
    * Engine functions that don't need a Call context (e.g. read_lines(), read_float(), etc)
    */
-  def engineFunctions: WdlStandardLibraryFunctions
+  def engineFunctions(interface: IOInterface): WdlStandardLibraryFunctions
+
+  /**
+    * Interface to be used primarily by engine functions requiring IO capabilities.
+    */
+  def ioInterface(workflowOptions: WorkflowOptions): IOInterface
 
   /**
    * Do any work that needs to be done <b>before</b> attempting to restart a workflow.

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
@@ -11,7 +11,6 @@ import cromwell.binding.expression.{NoFunctions, WdlStandardLibraryFunctions}
 import cromwell.binding.values._
 import cromwell.engine.ExecutionIndex.{ExecutionIndex, IndexEnhancedInt}
 import cromwell.engine.ExecutionStatus.ExecutionStatus
-import cromwell.engine._
 import cromwell.engine.backend._
 import cromwell.engine.backend.jes.JesBackend._
 import cromwell.engine.backend.jes.Run.RunStatus
@@ -25,7 +24,7 @@ import cromwell.logging.WorkflowLogger
 import cromwell.parser.BackendType
 import cromwell.util.StringDigestion._
 import cromwell.util.TryUtil
-import cromwell.util.google.GoogleCloudStoragePath
+import cromwell.util.google.{GoogleCloudStorage, GoogleCloudStoragePath, GoogleCredentialFactory}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -52,7 +51,9 @@ object JesBackend {
   val RefreshTokenOptionKey = "refresh_token"
   val GcsRootOptionKey = "jes_gcs_root"
   val MonitoringScriptOptionKey = "monitoring_script"
-  val OptionKeys = Set(RefreshTokenOptionKey, GcsRootOptionKey, MonitoringScriptOptionKey)
+  val GoogleProjectOptionKey = "google_project"
+  val AuthFilePathOptionKey = "auth_bucket"
+  val OptionKeys = Set(RefreshTokenOptionKey, GcsRootOptionKey, MonitoringScriptOptionKey, GoogleProjectOptionKey, AuthFilePathOptionKey)
 
   lazy val monitoringScriptLocalPath = localFilePathFromRelativePath(JesMonitoringScript)
   lazy val monitoringLogFileLocalPath = localFilePathFromRelativePath(JesMonitoringLogFile)
@@ -130,6 +131,8 @@ object JesBackend {
     def isScatter: Boolean = execution.callFqn.contains(Scatter.FQNIdentifier)
     def executionStatus: ExecutionStatus = ExecutionStatus.withName(execution.status)
   }
+
+  type IOInterface = GoogleCloudStorage
 }
 
 final case class JesJobKey(operationId: String) extends JobKey
@@ -151,15 +154,16 @@ case class JesPendingExecutionHandle(backendCall: JesBackendCall,
 class JesBackend extends Backend with LazyLogging with ProductionJesAuthentication with ProductionJesConfiguration {
 
   type BackendCall = JesBackendCall
+  type IOInterface = JesBackend.IOInterface
 
   override def adjustInputPaths(callKey: CallKey, inputs: CallInputs, workflowDescriptor: WorkflowDescriptor): CallInputs = inputs mapValues gcsPathToLocal
   override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs mapValues gcsPathToLocal
 
-  private def writeAuthenticationFile(workflow: WorkflowDescriptor) = authenticated { connection =>
-    val path = GoogleCloudStoragePath(gcsAuthFilePath(workflow))
+  private def writeAuthenticationFile(workflow: WorkflowDescriptor) = authenticateAsCromwell { connection =>
     val log = workflowLogger(workflow)
 
     generateAuthJson(jesConf.dockerCredentials, getGcsAuthInformation(workflow)) foreach { content =>
+      val path = GoogleCloudStoragePath(gcsAuthFilePath(workflow))
       def upload(prev: Option[Unit]) = connection.storage.uploadJson(path, content)
 
       log.info(s"Creating authentication file for workflow ${workflow.id} at \n ${path.toString}")
@@ -208,24 +212,31 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
    * First queries for the existence of the auth file, then deletes it if it exists.
    * If either of these operations fails, then a Future.failure is returned
    */
-  override def cleanUpForWorkflow(workflow: WorkflowDescriptor)(implicit ec: ExecutionContext): Future[Unit] = authenticated { connection =>
-    val gcsAuthFile = GoogleCloudStoragePath(gcsAuthFilePath(workflow))
-    val log = workflowLogger(workflow)
-    def gcsCheckAuthFileExists(prior: Option[Boolean]): Boolean = connection.storage.exists(gcsAuthFile)
-    def gcsAttemptToDeleteObject(prior: Option[Unit]): Unit = connection.storage.deleteObject(gcsAuthFile)
-    withRetry(gcsCheckAuthFileExists, log, s"Failed to query for auth file: $gcsAuthFile") match {
-      case Success(exists) if exists =>
-        withRetry(gcsAttemptToDeleteObject, log, s"Failed to delete auth file: $gcsAuthFile") match {
-          case Success(_) => Future.successful(Unit)
-          case Failure(ex) =>
-            log.error(s"Could not delete the auth file $gcsAuthFile", ex)
-            Future.failed(ex)
-        }
-      case Failure(ex) =>
-        log.error(s"Could not query for the existence of the auth file $gcsAuthFile", ex)
-        Future.failed(ex)
-      case _ => Future.successful(Unit)
+  override def cleanUpForWorkflow(workflow: WorkflowDescriptor)(implicit ec: ExecutionContext): Future[Unit] = {
+    Future(gcsAuthFilePath(workflow)) map { path =>
+      deleteAuthFile(path, workflowLogger(workflow))
+      ()
+    } recover {
+      case e: UnsatisfiedInputsException =>  // No need to fail here, it just means that we didn't have an auth file in the first place so no need to delete it.
     }
+  }
+
+  private def deleteAuthFile(authFilePath: String, log: WorkflowLogger): Future[Unit] = authenticateAsCromwell { connection =>
+      def gcsCheckAuthFileExists(prior: Option[Boolean]): Boolean = connection.storage.exists(authFilePath)
+      def gcsAttemptToDeleteObject(prior: Option[Unit]): Unit = connection.storage.deleteObject(authFilePath)
+      withRetry(gcsCheckAuthFileExists, log, s"Failed to query for auth file: $authFilePath") match {
+        case Success(exists) if exists =>
+          withRetry(gcsAttemptToDeleteObject, log, s"Failed to delete auth file: $authFilePath") match {
+            case Success(_) => Future.successful(Unit)
+            case Failure(ex) =>
+              log.error(s"Could not delete the auth file $authFilePath", ex)
+              Future.failed(ex)
+          }
+        case Failure(ex) =>
+          log.error(s"Could not query for the existence of the auth file $authFilePath", ex)
+          Future.failed(ex)
+        case _ => Future.successful(Unit)
+      }
   }
 
   override def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): StdoutStderr = {
@@ -239,7 +250,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
     new JesBackendCall(this, workflowDescriptor, key, locallyQualifiedInputs, abortRegistrationFunction)
   }
 
-  override def engineFunctions: WdlStandardLibraryFunctions = new JesEngineFunctionsWithoutCallContext()
+  override def engineFunctions(interface: IOInterface): WdlStandardLibraryFunctions = new JesEngineFunctionsWithoutCallContext(interface)
 
   private def executeOrResume(backendCall: BackendCall, runIdForResumption: Option[String])(implicit ec: ExecutionContext): Future[ExecutionHandle] = Future {
     val log = workflowLoggerWithCall(backendCall)
@@ -319,7 +330,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
     if (referenceName.length <= 127) referenceName else referenceName.md5Sum
   }
 
-  private def uploadCommandScript(backendCall: BackendCall, command: String, withMonitoring: Boolean): Try[Unit] = authenticated { implicit connection =>
+  private def uploadCommandScript(backendCall: BackendCall, command: String, withMonitoring: Boolean): Try[Unit] = {
     val monitoring = if (withMonitoring) {
       s"""|touch $JesMonitoringLogFile
           |chmod u+x $JesMonitoringScript
@@ -335,14 +346,14 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
          |echo $$? > ${JesBackendCall.RcFilename}
        """.stripMargin.trim
 
-    def attemptToUploadObject(priorAttempt: Option[Unit]) = authenticated { _.storage.uploadObject(backendCall.gcsExecPath, fileContent) }
+    def attemptToUploadObject(priorAttempt: Option[Unit]) = authenticateAsUser(backendCall) { _.uploadObject(backendCall.gcsExecPath, fileContent) }
 
     val log = workflowLogger(backendCall.workflowDescriptor)
     withRetry(attemptToUploadObject, log, s"${workflowLoggerWithCall(backendCall).tag} Exception occurred while uploading script to ${backendCall.gcsExecPath}")
   }
 
   private def createJesRun(backendCall: BackendCall, jesParameters: Seq[JesParameter], runIdForResumption: Option[String]): Try[Run] =
-    authenticated { connection =>
+    authenticateAsCromwell { connection =>
       def attemptToCreateJesRun(priorAttempt: Option[Run]): Run = Pipeline(
         backendCall.jesCommandLine,
         backendCall.workflowDescriptor,
@@ -402,7 +413,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
     }
   }
 
-  def executionResult(status: RunStatus, handle: JesPendingExecutionHandle): ExecutionHandle = authenticated { connection =>
+  def executionResult(status: RunStatus, handle: JesPendingExecutionHandle): ExecutionHandle = {
     val log = workflowLoggerWithCall(handle.backendCall)
 
     try {
@@ -427,7 +438,7 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
         taskOutput.name -> attemptedValue
       } toMap
 
-      lazy val stderrLength: BigInteger = connection.storage.objectSize(GoogleCloudStoragePath(backendCall.stderrJesOutput.gcs))
+      lazy val stderrLength: BigInteger = authenticateAsUser(backendCall) { _.objectSize(GoogleCloudStoragePath(backendCall.stderrJesOutput.gcs)) }
       lazy val returnCodeContents = backendCall.downloadRcFile
       lazy val returnCode = returnCodeContents map { _.trim.toInt }
       lazy val continueOnReturnCode = backendCall.call.continueOnReturnCode
@@ -571,8 +582,11 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
   override def backendType = BackendType.JES
 
   def gcsAuthFilePath(descriptor: WorkflowDescriptor): String = {
-    val wfPath = workflowGcsPath(descriptor)
-    s"$wfPath/auth.json"
+    // If we are going to upload an auth file we need a valid GCS path passed via workflow options.
+    val bucket = descriptor.workflowOptions.get(AuthFilePathOptionKey) getOrElse {
+      throw new UnsatisfiedInputsException(s"$AuthFilePathOptionKey has not been found in workflow options.")
+    }
+    s"$bucket/${descriptor.id}_auth.json"
   }
 
   def callGcsPath(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): String = {
@@ -587,17 +601,29 @@ class JesBackend extends Backend with LazyLogging with ProductionJesAuthenticati
   }
 
   def googleProject(descriptor: WorkflowDescriptor): String = {
-    descriptor.workflowOptions.getOrElse("google_project", jesConf.project)
+    descriptor.workflowOptions.getOrElse(GoogleProjectOptionKey, jesConf.project)
   }
 
   // Create an input parameter containing the path to this authentication file, if needed
   def gcsAuthParameter(descriptor: WorkflowDescriptor): Option[JesInput] = {
-    if (jesConf.localizeWithRefreshToken || jesConf.isDockerAuthenticated)
+    if ((jesConf.localizeWithRefreshToken || jesConf.isDockerAuthenticated) && descriptor.workflowOptions.get(AuthFilePathOptionKey).isSuccess)
       Option(authGcsCredentialsPath(gcsAuthFilePath(descriptor)))
     else None
   }
 
   override def findResumableExecutions(id: WorkflowId)(implicit ec: ExecutionContext): Future[Map[ExecutionDatabaseKey, JobKey]] = {
     globalDataAccess.findResumableJesExecutions(id)
+  }
+
+  /**
+    * Will try to instantiate a user authenticated IOInterface if possible.
+    * If not, will default back to the Cromwell authenticated IOInterface.
+    */
+  override def ioInterface(workflowOptions: WorkflowOptions): GoogleCloudStorage = {
+    val userCredentials = for {
+      secrets <- jesConf.googleSecrets
+      token <- workflowOptions.get(RefreshTokenOptionKey).toOption
+    } yield GoogleCredentialFactory.forRefreshToken(secrets, token)
+    userCredentials map { GcsFactory(jesConf.applicationName, _) } getOrElse jesCromwellConnection.storage
   }
 }

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -58,10 +58,10 @@ class JesBackendCall(val backend: JesBackend,
   lazy val rcJesOutput = jesOutput(callGcsPath, RcFilename)
   lazy val cmdInput = JesInput(ExecParamName, gcsExecPath.toString, localFilePathFromRelativePath(JesExecScript))
   lazy val diskInput = JesInput(WorkingDiskParamName, LocalWorkingDiskValue, Paths.get(JesCromwellRoot))
-  
+
   def standardParameters = Seq(stderrJesOutput, stdoutJesOutput, rcJesOutput, diskInput)
 
-  def downloadRcFile = authenticated { connection => GoogleCloudStoragePath.parse(callGcsPath + "/" + RcFilename).map(connection.storage.slurpFile) }
+  def downloadRcFile = authenticateAsUser(this) { storage => Try(storage.readFile(s"$callGcsPath/$RcFilename")) }
 
   /**
    * Determine the output directory for the files matching a particular glob.

--- a/src/main/scala/cromwell/engine/backend/jes/JesInterface.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesInterface.scala
@@ -3,25 +3,22 @@ package cromwell.engine.backend.jes
 import java.net.URL
 
 import com.google.api.client.auth.oauth2.Credential
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.HttpTransport
 import com.google.api.client.json.JsonFactory
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.genomics.Genomics
-import cromwell.engine.backend.jes.JesInterface.GoogleGenomics
-import cromwell.util.google.{GoogleCredentialFactory, GoogleCloudStorage}
+import cromwell.util.google.{GoogleCloudStorage, GoogleCredentialFactory}
 
+case class JesInterface(storage: GoogleCloudStorage, genomics: Genomics)
 
-object JesInterface {
-  val jsonFactory = JacksonFactory.getDefaultInstance
-  val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+object GcsFactory {
+  def apply(appName: String, credential: Credential): GoogleCloudStorage = {
+    GoogleCloudStorage(appName, credential, GoogleCredentialFactory.jsonFactory, GoogleCredentialFactory.httpTransport)
+  }
+}
 
-  def apply(appName: String, endpointUrl: URL): JesInterface = {
-    val credential = GoogleCredentialFactory.from(jsonFactory, httpTransport)
-    val genomics = GoogleGenomics.from(appName, endpointUrl, credential, jsonFactory, httpTransport)
-    val storage = GoogleCloudStorage(appName, credential, jsonFactory, httpTransport)
-
-    JesInterface(credential, genomics, storage)
+object GenomicsFactory {
+  def apply(appName: String, endpointUrl: URL, credential: Credential): Genomics = {
+    GoogleGenomics.from(appName, endpointUrl, credential, GoogleCredentialFactory.jsonFactory, GoogleCredentialFactory.httpTransport)
   }
 
   // Wrapper object around Google's Genomics class providing a convenience 'from' "method"
@@ -31,5 +28,3 @@ object JesInterface {
     }
   }
 }
-
-case class JesInterface(credential: Credential, genomics: Genomics, storage: GoogleCloudStorage)

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
@@ -24,7 +24,7 @@ case class LocalBackendCall(backend: LocalBackend,
   val stdout = callRootPath.resolve("stdout")
   val stderr = callRootPath.resolve("stderr")
   val script = callRootPath.resolve("script")
-  val engineFunctions: LocalEngineFunctions = new LocalEngineFunctions(callRootPath, stdout, stderr)
+  val engineFunctions: LocalEngineFunctions = new LocalEngineFunctions(callRootPath, stdout, stderr, workflowDescriptor.IOInterface)
   callRootPath.toFile.mkdirs
 
   override def execute(implicit ec: ExecutionContext) = backend.execute(this)

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -11,7 +11,7 @@ import cromwell.binding.values.{WdlValue, _}
 import cromwell.engine.ExecutionIndex._
 import cromwell.engine.WorkflowDescriptor
 import cromwell.engine.backend.{LocalFileSystemBackendCall, StdoutStderr}
-import cromwell.engine.workflow.CallKey
+import cromwell.engine.workflow.{WorkflowOptions, CallKey}
 import cromwell.util.TryUtil
 import org.apache.commons.io.FileUtils
 
@@ -72,11 +72,37 @@ object SharedFileSystem {
   }
 }
 
+class SharedFileSystemIOInterface extends IOInterface {
+  import better.files._
+
+  override def readFile(path: String): String = Paths.get(path).contentAsString
+
+  override def writeFile(path: String, content: String): Unit = Paths.get(path).write(content)
+
+  override def listContents(path: String): Iterable[String] = Paths.get(path).list map { _.path.toAbsolutePath.toString } toIterable
+
+  override def exists(path: String): Boolean = Paths.get(path).exists
+
+  override def writeTempFile(path: String, prefix: String, suffix: String, content: String): String = {
+    val file = Files.createTempFile(Paths.get(path), prefix, suffix)
+    file.write(content)
+    file.fullPath
+  }
+
+  override def glob(path: String, pattern: String): Seq[String] = {
+    Paths.get(path).glob(pattern) map { _.path.fullPath } toSeq
+  }
+}
+
 trait SharedFileSystem {
 
   import SharedFileSystem._
 
-  val engineFunctions: WdlStandardLibraryFunctions = new LocalEngineFunctionsWithoutCallContext
+  type IOInterface = SharedFileSystemIOInterface
+
+  def engineFunctions(interface: IOInterface): WdlStandardLibraryFunctions = new LocalEngineFunctionsWithoutCallContext(interface)
+
+  def ioInterface(workflowOptions: WorkflowOptions): IOInterface = new SharedFileSystemIOInterface
 
   def postProcess(backendCall: LocalFileSystemBackendCall): Try[CallOutputs] = {
     // Evaluate output expressions, performing conversions from String -> File where required.

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
@@ -20,7 +20,7 @@ case class SgeBackendCall(backend: SgeBackend,
   val stderr = callRootPath.resolve("stderr")
   val script = callRootPath.resolve("script.sh")
   val returnCode = callRootPath.resolve("rc")
-  val engineFunctions: SgeEngineFunctions = new SgeEngineFunctions(callRootPath, stdout, stderr)
+  val engineFunctions: SgeEngineFunctions = new SgeEngineFunctions(callRootPath, stdout, stderr, workflowDescriptor.IOInterface)
   callRootPath.toFile.mkdirs
 
   override def execute(implicit ec: ExecutionContext) = backend.execute(this)

--- a/src/main/scala/cromwell/engine/backend/sge/SgeEngineFunctions.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeEngineFunctions.scala
@@ -2,6 +2,7 @@ package cromwell.engine.backend.sge
 
 import java.nio.file.Path
 
+import cromwell.binding.IOInterface
 import cromwell.engine.backend.local.LocalEngineFunctions
 
-class SgeEngineFunctions(cwd: Path, stdout: Path, stderr: Path) extends LocalEngineFunctions(cwd, stdout, stderr)
+class SgeEngineFunctions(cwd: Path, stdout: Path, stderr: Path, interface: IOInterface) extends LocalEngineFunctions(cwd, stdout, stderr, interface)

--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -1,11 +1,11 @@
 package cromwell
 
-import java.nio.file.{Paths, Path}
+import java.nio.file.{Path, Paths}
 import java.util.UUID
 
-import ch.qos.logback.classic.{LoggerContext, Level}
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.FileAppender
 import com.typesafe.config.ConfigFactory
 import cromwell.binding._
@@ -13,8 +13,8 @@ import cromwell.binding.types.WdlType
 import cromwell.binding.values.WdlValue
 import cromwell.engine.backend.Backend
 import cromwell.engine.workflow.WorkflowOptions
-import org.slf4j.{LoggerFactory, Logger}
 import org.slf4j.helpers.NOPLogger
+import org.slf4j.{Logger, LoggerFactory}
 import spray.json._
 
 import scala.language.implicitConversions
@@ -63,9 +63,11 @@ package object engine {
       case _ => throw new Throwable(s"Workflow ${id.toString} contains bad inputs JSON: ${sourceFiles.inputsJson}")
     }
 
+    val IOInterface = backend.ioInterface(workflowOptions)
+
     // Currently we are throwing an exception if construction of the workflow descriptor fails, hence .get on the Trys
     val coercedInputs = namespace.coerceRawInputs(rawInputs).get
-    val declarations = namespace.staticDeclarationsRecursive(coercedInputs, backend.engineFunctions).get
+    val declarations = namespace.staticDeclarationsRecursive(coercedInputs, backend.engineFunctions(IOInterface)).get
     val actualInputs: WorkflowCoercedInputs = coercedInputs ++ declarations
 
     val props = sys.props

--- a/src/main/scala/cromwell/util/ConfigUtil.scala
+++ b/src/main/scala/cromwell/util/ConfigUtil.scala
@@ -1,14 +1,15 @@
 package cromwell.util
 
-import java.net.{MalformedURLException, URL}
+import java.net.URL
 
-import com.typesafe.config.{ConfigValue, Config, ConfigException, ConfigFactory}
-import org.slf4j.{LoggerFactory, Logger}
-import scala.reflect.{ClassTag, classTag}
+import com.typesafe.config.{Config, ConfigException, ConfigValue}
+import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConversions._
+import scala.reflect.{ClassTag, classTag}
 import scala.util.Try
+import scalaz.Scalaz._
 import scalaz._
-import Scalaz._
 
 object ConfigUtil {
 
@@ -60,14 +61,14 @@ object ConfigUtil {
     def validateString(key: String): ValidationNel[String, String] = try {
       config.getString(key).successNel
     } catch {
-      case e: ConfigException.Missing => "Could not find key: $key".failureNel
+      case e: ConfigException.Missing => s"Could not find key: $key".failureNel
     }
 
     def validateConfig(key: String): ValidationNel[String, Config] = try {
       config.getConfig(key).successNel
     } catch {
       case e: ConfigException.Missing => "Could not find key: $key".failureNel
-      case e: ConfigException.WrongType => "key $key cannot be parsed to a Config".failureNel
+      case e: ConfigException.WrongType => s"key $key cannot be parsed to a Config".failureNel
     }
 
   }

--- a/src/main/scala/cromwell/util/google/GoogleCloudStoragePath.scala
+++ b/src/main/scala/cromwell/util/google/GoogleCloudStoragePath.scala
@@ -1,6 +1,7 @@
 package cromwell.util.google
 
 import scala.util.{Failure, Success, Try}
+import scala.language.implicitConversions
 
 case class GoogleCloudStoragePath(bucket: String, objectName: String) {
   override def toString = {
@@ -9,6 +10,9 @@ case class GoogleCloudStoragePath(bucket: String, objectName: String) {
 }
 
 object GoogleCloudStoragePath {
+
+  implicit def toGcsPath(str: String): GoogleCloudStoragePath = GoogleCloudStoragePath(str)
+
   def apply(value: String): GoogleCloudStoragePath = {
     parse(value) match {
       case Success(gcsPath) => gcsPath
@@ -20,7 +24,15 @@ object GoogleCloudStoragePath {
     val gsUriRegex = """gs://([^/]*)/(.*)""".r
     value match {
       case gsUriRegex(bucket, objectName) => Success(GoogleCloudStoragePath(bucket, objectName))
-      case _ => Failure(new IllegalArgumentException(s"Not a valid Google Cloud Storage URI: ${value}"))
+      case _ => Failure(new IllegalArgumentException(s"Not a valid Google Cloud Storage URI: $value"))
+    }
+  }
+
+  def parseBucket(value: String): Try[String] = {
+    val gsUriRegex = """gs://([^/]*)""".r
+    value match {
+      case gsUriRegex(bucket) => Success(bucket)
+      case _ => Failure(new IllegalArgumentException(s"Not a valid Google Cloud Storage URI: $value"))
     }
   }
 }

--- a/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
@@ -7,7 +7,7 @@ import cromwell.binding.CallInputs
 import cromwell.binding.types.{WdlArrayType, WdlFileType, WdlMapType, WdlStringType}
 import cromwell.binding.values.{WdlArray, WdlFile, WdlMap, WdlString}
 import cromwell.engine.WorkflowDescriptor
-import cromwell.engine.backend.jes.JesBackend.{JesInput, JesOutput}
+import cromwell.engine.backend.jes.JesBackend.{JesWorkflowDescriptor, JesInput, JesOutput}
 import cromwell.engine.backend.jes.authentication._
 import cromwell.engine.workflow.{CallKey, WorkflowOptions}
 import cromwell.util.EncryptionSpec
@@ -32,7 +32,8 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito {
       googleSecrets = Some(SimpleClientSecrets("myclientId", "myclientSecret"))) {
       override val localizeWithRefreshToken = true
     }
-    override lazy val jesConnection = null
+    override lazy val jesCromwellConnection = null
+    override def jesUserConnection(backendCall: JesBackendCall) = null
   }
 
   "adjustInputPaths" should "map GCS paths and *only* GCS paths to local" in {

--- a/src/test/scala/cromwell/engine/backend/jes/JesVMAuthenticationSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/JesVMAuthenticationSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.backend.jes
 
+import cromwell.engine.backend.jes.JesBackend.JesWorkflowDescriptor
 import cromwell.engine.backend.jes.authentication._
 import cromwell.util.google.SimpleClientSecrets
 import org.scalatest.{FlatSpec, Matchers}
@@ -8,7 +9,8 @@ import spray.json._
 
 class JesVMAuthenticationSpec extends FlatSpec with Matchers with ProductionJesAuthentication {
   // Prevent production jesConnection to be resolved (and trigger prod configuration resolving)
-  override lazy val jesConnection = null
+  override lazy val jesCromwellConnection = null
+  override def jesUserConnection(backendCall: JesBackendCall) = null
 
   def normalize(str: String) = {
     str.parseJson.prettyPrint

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -13,7 +13,7 @@ import cromwell.engine.backend.local.{LocalBackend, LocalBackendCall}
 import cromwell.engine.backend.{ExecutionHandle, Backend, ExecutionResult, StdoutStderr}
 import cromwell.engine.backend.{JobKey, Backend, ExecutionResult, StdoutStderr}
 import cromwell.engine.db.{CallStatus, ExecutionDatabaseKey, LocalCallBackendInfo}
-import cromwell.engine.workflow.CallKey
+import cromwell.engine.workflow.{WorkflowOptions, CallKey}
 import cromwell.parser.BackendType
 import cromwell.util.SampleWdl
 import org.scalactic.StringNormalizations._
@@ -60,11 +60,13 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
                           abortRegistrationFunction: AbortRegistrationFunction): BackendCall =
       throw new NotImplementedError
 
-    override def engineFunctions: WdlStandardLibraryFunctions =
+    override def engineFunctions(interface: IOInterface): WdlStandardLibraryFunctions =
       throw new NotImplementedError
 
     override def backendType: BackendType =
       throw new NotImplementedError
+
+    override def ioInterface(workflowOptions: WorkflowOptions): IOInterface = throw new NotImplementedError
   }
 
   // Tests against main database used for command line


### PR DESCRIPTION
This reworks the JES Authentication schema in such a way that:

- All JES calls (launching a VM) are requested using the Cromwell Service Account (CSA) passed in through the configuration.
- The upload / delete of the authentication file to GCS is also done using CSA.
- All other GCS interactions are done using the user's credentials (with refresh token coming from WF options + clientID/secrets in the conf).
- a `billing_bucket` workflow option has been added that sets the gcs path where cromwell will write the auth.json file