### PR TITLE
Fix JES log naming

### DIFF
--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -35,7 +35,7 @@ object JesBackendCall {
   val RcFilename = "job.rc.txt"
 
   val JesLogBasename = "jes"
-  private val JesLog = s"$JesLogBasename.log"
+  private [jes] val JesLog = s"$JesLogBasename.log"
   private val JesStdout = s"$JesLogBasename-stdout.log"
   private val JesStderr = s"$JesLogBasename-stderr.log"
 

--- a/src/main/scala/cromwell/engine/backend/jes/Run.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/Run.scala
@@ -50,7 +50,7 @@ object Run  {
       logger.info(s"Outputs:\n${stringifyMap(rpr.getOutputs.asScala.toMap)}")
 
       val logging = new Logging()
-      logging.setGcsPath(s"${pipeline.gcsPath}/${JesBackendCall.JesLogBasename}")
+      logging.setGcsPath(s"${pipeline.gcsPath}/${JesBackendCall.JesLog}")
       rpr.setLogging(logging)
 
       // Currently, some resources (specifically disk) need to be specified both at pipeline creation and pipeline run time


### PR DESCRIPTION
Probably mixed up the name while refactoring, the log path needs to be a file path (ie gs://balblabl/jes.log) for JES to use it as a filename when delocalizing its logs.