### PR TITLE
Stabilize tests

### DIFF
--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -18,6 +18,7 @@ import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.util.SampleWdl
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, Matchers, OneInstancePerTest, WordSpecLike}
 
 import scala.concurrent.Await
@@ -107,6 +108,8 @@ object CromwellTestkitSpec {
 
 abstract class CromwellTestkitSpec(name: String) extends TestKit(ActorSystem(name, ConfigFactory.parseString(ConfigText)))
 with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures with OneInstancePerTest {
+
+  implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
 
   def startingCallsFilter[T](callNames: String*)(block: => T): T =
     waitForPattern(s"starting calls: ${callNames.mkString(", ")}$$") {

--- a/src/test/scala/cromwell/InputLocalizationWorkflowSpec.scala
+++ b/src/test/scala/cromwell/InputLocalizationWorkflowSpec.scala
@@ -7,7 +7,7 @@ import cromwell.binding.values.{WdlArray, WdlFile, WdlString}
 import cromwell.util.SampleWdl
 
 
-class InputLocalizationWorkflowSpec extends CromwellTestkitSpec("InputLocalisationWorkflowSpec") {
+class InputLocalizationWorkflowSpec extends CromwellTestkitSpec("InputLocalizationWorkflowSpec") {
   "a workflow running on a SharedFileSystem" should {
 
     val expectedOutputs = Map(

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -107,6 +107,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       import dataAccess.dataAccess.driver.api._
 
       val getProduct = SimpleDBIO[String](_.connection.getMetaData.getDatabaseProductName)
+      //noinspection SqlDialectInspection
       val getHsqldbTx = sql"""SELECT PROPERTY_VALUE
                               FROM INFORMATION_SCHEMA.SYSTEM_PROPERTIES
                               WHERE PROPERTY_NAME = 'hsqldb.tx'""".as[String].head
@@ -392,7 +393,6 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
     it should "insert a call in execution table" in {
       assume(canConnect || testRequired)
       val callFqn = "call.fully.qualified.scope"
-      val symbolFqn = "symbol.fully.qualified.scope"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = new WorkflowDescriptor(workflowId, testSources)
       val task = new Task("taskName", Nil, Nil, Nil, null, BackendType.LOCAL)
@@ -525,7 +525,6 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
       assume(canConnect || testRequired)
       val callFqn1 = "call.fully.qualified.scope$s1"
       val callFqn2 = "call.fully.qualified.scope$s2"
-      val symbolLqn = "symbol"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = new WorkflowDescriptor(workflowId, testSources)
       val task = new Task("taskName", Nil, Nil, Nil, null, BackendType.LOCAL)


### PR DESCRIPTION
Lots of changes to `SingleWorkflowRunnerActor`:

* Clients communicate with SWRA via an ask, giving callers like `Main` a `Future` whose success status can be used to generate an exit code.
* SWRA no longer manages shutting down the actor system, that becomes the responsibility of the caller.  This allows tests that want to see certain error messages to shut down the system only after the error messages are seen by an event filter.  The previous structure allowed for a race condition where messages that filters wanted to see were produced, but the actor system was torn down before the messages were delivered to the filters.
* SWRA is now an FSM.

Also increased the default patience in `CromwellTestkitSpec` for `InputLocalizationWorkflowSpec` and friends.

Does *not* include any changes to address MySQL connection issues sporadically seen in SlickDataAccessSpec; per discussion with Jeff I'll ticket that separately.