### PR TITLE
Trusty Tahr Tames Testy Travis?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
+sudo: required
+dist: trusty
 language: scala
 scala:
-  - 2.11.6
+  - 2.11.7
 jdk:
   - oraclejdk8
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
+  - docker pull ubuntu:latest
 before_script:
-  - mysql -e "create database IF NOT EXISTS cromwell_test;"
-
-script: sbt -Dbackend.shared-filesystem.localization.0=copy clean coverage nodocker:test assembly
+  - mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
+  - mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY '';"
+  - mysql -u root -e "GRANT ALL PRIVILEGES ON cromwell_test . * TO 'travis'@'localhost';"
+script: sbt -Dbackend.shared-filesystem.localization.0=copy clean coverage test assembly
 after_success: sbt coveralls

--- a/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -187,7 +187,7 @@ with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with Bef
   def runWdl(sampleWdl: SampleWdl,
              eventFilter: EventFilter,
              runtime: String = "",
-             terminalState: WorkflowState = WorkflowSucceeded): (TestActorRef[WorkflowManagerActor], WorkflowId) = {
+             terminalState: WorkflowState = WorkflowSucceeded): WorkflowOutputs = {
     val wma = buildWorkflowManagerActor(sampleWdl, runtime)
     val workflowSources = WorkflowSourceFiles(sampleWdl.wdlSource(runtime), sampleWdl.wdlJson, "{}")
     val submitMessage = WorkflowManagerActor.SubmitWorkflow(workflowSources)
@@ -199,8 +199,6 @@ with DefaultTimeout with ImplicitSender with WordSpecLike with Matchers with Bef
         wma.ask(WorkflowManagerActor.WorkflowOutputs(workflowId)).mapTo[WorkflowOutputs].futureValue
       }
     }
-
-    (wma, workflowId)
   }
 
   def runWdlAndAssertOutputs(sampleWdl: SampleWdl,

--- a/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -178,9 +178,8 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec("WorkflowManagerActor
     }
 
     "run workflows in the correct directory" in {
-      val (wma, workflowId) = runWdl(sampleWdl = SampleWdl.CurrentDirectory,
+      val outputs = runWdl(sampleWdl = SampleWdl.CurrentDirectory,
         EventFilter.info(pattern = s"starting calls: whereami.whereami", occurrences = 1))
-      val outputs = wma.ask(WorkflowManagerActor.WorkflowOutputs(workflowId)).mapTo[binding.WorkflowOutputs].futureValue
       val outputName = "whereami.whereami.pwd"
       val salutation = outputs.get(outputName).get
       val actualOutput = salutation.asInstanceOf[WdlString].value.trim


### PR DESCRIPTION
After this morning's discussion of Cromwell's memory usage I poked around the Travis docs and found the container infrastructure on which we were running gave us only 4 GB:

https://docs.travis-ci.com/user/ci-environment

Also on this page is mentioned the new Trusty Tahr beta environment which offers 7.5 GB.  I've tried this and have seen no intermittent SlickDataAccess or other failures.  As a bonus this is a real VM (not a container) and can run all of our Docker tests.  The one gotcha I've found is that these builds don't start as quickly as the container builds, but if this delay remains reasonable it may be worth trading some lag for stability and Docker coverage.

There were some additional changes required to the Travis YAML to add MySQL as that's not baked into Trusty, and I also had to pull the ubuntu:latest image in advance to keep the first Docker test from timing out.  There was also a bit of weirdness with files not globbing in alphabetical order which broke a test.