### PR TITLE
Add a default-application authentication mode that uses Application D…

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -76,6 +76,10 @@ backend {
 google {
   // Used by cromwell to make calls to JES and to perform GCS reads/writes.
   // The latter can be overriden if the "User Mode" is used (see below).
+  // Use "application-default" to use the default service account credentials.
+  // This is useful if you are running on a GCE VM and if you don't need
+  // user level access. See https://developers.google.com/identity/protocols/application-default-credentials
+  // for more info.
   // authScheme = "user"
 
   // If authScheme is "user"

--- a/src/main/scala/cromwell/engine/backend/jes/authentication/JesAuthMode.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/authentication/JesAuthMode.scala
@@ -4,6 +4,7 @@ object JesAuthMode {
   def fromString(name: String): JesAuthMode = name match {
     case "service" => ServiceAccountMode
     case "user" => UserMode
+    case "application-default" => ApplicationDefaultMode
     case nop => throw new IllegalArgumentException(s"$nop is not a recognized authentication mode")
   }
 }
@@ -12,3 +13,4 @@ object JesAuthMode {
 sealed trait JesAuthMode
 object ServiceAccountMode extends JesAuthMode
 object UserMode extends JesAuthMode
+object ApplicationDefaultMode extends JesAuthMode

--- a/src/main/scala/cromwell/util/google/GoogleCredentialFactory.scala
+++ b/src/main/scala/cromwell/util/google/GoogleCredentialFactory.scala
@@ -11,6 +11,7 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.JsonFactory
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.store.FileDataStoreFactory
+import com.google.api.services.genomics.GenomicsScopes
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.LoggerFactory
 
@@ -27,6 +28,7 @@ object GoogleCredentialFactory {
   lazy val fromAuthScheme: Credential = GoogleAuthScheme match {
     case "user" => forUser(GoogleConf.getConfig("userAuth"))
     case "service" => forServiceAccount(GoogleConf.getConfig("serviceAuth"))
+    case "application-default" => forApplicationDefaultCredentials()
   }
 
   lazy val forRefreshToken: (ClientSecrets, String) => Credential = forClientSecrets
@@ -75,5 +77,9 @@ object GoogleCredentialFactory {
       .setClientSecrets(secrets.clientId, secrets.clientSecret)
       .build()
       .setRefreshToken(token))
+  }
+
+  private def forApplicationDefaultCredentials(): Credential = {
+    validateCredentials(GoogleCredential.getApplicationDefault().createScoped(GenomicsScopes.all()))
   }
 }


### PR DESCRIPTION
…efault Credentials. This is especially useful when running on a GCE VM when you want to

authenticate with the standard compute service account.