### PR TITLE
Add a default-application authentication mode that uses Application D…

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -93,6 +93,10 @@ backend {
 google {
   // Used by cromwell to make calls to JES and to perform GCS reads/writes.
   // The latter can be overriden if the "User Mode" is used (see below).
+  // Use "application-default" to use the default service account credentials.
+  // This is useful if you are running on a GCE VM and if you don't need
+  // user level access. See https://developers.google.com/identity/protocols/application-default-credentials
+  // for more info.
   // authScheme = "user"
 
   // If authScheme is "user"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -95,7 +95,7 @@ google {
   // The latter can be overriden if the "User Mode" is used (see below).
   // Use "application-default" to use the default service account credentials.
   // This is useful if you are running on a GCE VM and if you don't need
-  // user level access. See https://developers.google.com/identity/protocols/application-default-credentials
+  // user level access. See https://developers.google.com/accounts/docs/application-default-credentials
   // for more info.
   // authScheme = "user"
 

--- a/src/main/scala/cromwell/engine/backend/jes/authentication/JesAuthMode.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/authentication/JesAuthMode.scala
@@ -4,6 +4,7 @@ object JesAuthMode {
   def fromString(name: String): JesAuthMode = name match {
     case "service" => ServiceAccountMode
     case "user" => UserMode
+    case "application-default" => ApplicationDefaultMode
     case nop => throw new IllegalArgumentException(s"$nop is not a recognized authentication mode")
   }
 }
@@ -12,3 +13,4 @@ object JesAuthMode {
 sealed trait JesAuthMode
 object ServiceAccountMode extends JesAuthMode
 object UserMode extends JesAuthMode
+object ApplicationDefaultMode extends JesAuthMode

--- a/src/main/scala/cromwell/util/google/GoogleCredentialFactory.scala
+++ b/src/main/scala/cromwell/util/google/GoogleCredentialFactory.scala
@@ -10,6 +10,7 @@ import com.google.api.client.googleapis.extensions.java6.auth.oauth2.GooglePromp
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.store.FileDataStoreFactory
+import com.google.api.services.genomics.GenomicsScopes
 import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.collection.JavaConverters._
@@ -55,6 +56,7 @@ object GoogleCredentialFactory {
     config.getString("google.authScheme").toLowerCase match {
       case "user" => new UserCredentialFactory(config)
       case "service" => new ServiceAccountCredentialFactory(config)
+      case "application-default" => new ApplicationDefaultCredentialFactory()
     }
   }
 
@@ -146,5 +148,17 @@ class RefreshTokenCredentialFactory(clientId: String, clientSecret: String,
       .setClientSecrets(clientId, clientSecret)
       .build()
       .setRefreshToken(refreshToken)
+  }
+}
+
+/**
+  * Creates a credential using the default service account credentials. This is useful if you are running on a GCE VM
+  * and if you don't need user level access.
+  *
+  * See https://developers.google.com/identity/protocols/application-default-credentials for more info.
+  */
+class ApplicationDefaultCredentialFactory() extends GoogleCredentialFactory {
+  protected def initCredential(): Credential = {
+    GoogleCredential.getApplicationDefault().createScoped(GenomicsScopes.all())
   }
 }

--- a/src/main/scala/cromwell/util/google/GoogleScopes.scala
+++ b/src/main/scala/cromwell/util/google/GoogleScopes.scala
@@ -1,12 +1,17 @@
 package cromwell.util.google
 
+import com.google.api.services.genomics.GenomicsScopes
 import com.google.api.services.storage.StorageScopes
+import scala.collection.JavaConverters._
 
 object GoogleScopes {
-  val Scopes = Vector(
-    StorageScopes.DEVSTORAGE_FULL_CONTROL,
-    StorageScopes.DEVSTORAGE_READ_WRITE,
-    "https://www.googleapis.com/auth/genomics",
-    "https://www.googleapis.com/auth/compute"
-  )
+  val Scopes = {
+    val scopes = Vector(
+      StorageScopes.DEVSTORAGE_FULL_CONTROL,
+      StorageScopes.DEVSTORAGE_READ_WRITE,
+      "https://www.googleapis.com/auth/genomics",
+      "https://www.googleapis.com/auth/compute"
+    ) ++ GenomicsScopes.all().asScala
+    scopes.sorted.distinct
+  }
 }

--- a/src/test/scala/cromwell/util/google/GoogleCredentialFactorySpec.scala
+++ b/src/test/scala/cromwell/util/google/GoogleCredentialFactorySpec.scala
@@ -6,71 +6,41 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{Assertions, FlatSpec, Matchers}
 
+import scala.util.Try
+
 class GoogleCredentialFactorySpec extends FlatSpec with Matchers {
 
   behavior of "GoogleCredentialFactory"
+
+  it should "refresh a token using the default application credential" in {
+    GoogleCredentialFactorySpec.assumeApplicationDefaultCredentialExists()
+
+    val credentialFactory = new ApplicationDefaultCredentialFactory()
+    testFactory(credentialFactory)
+  }
 
   it should "refresh a token using user credentials" in {
     GoogleCredentialFactorySpec.assumeUserConfigExists()
 
     val credentialFactory = GoogleCredentialFactory.fromAuthScheme(GoogleCredentialFactorySpec.UserConfig)
-    val firstCredentialTry = credentialFactory.freshCredential
-    assert(firstCredentialTry.isSuccess)
-    val firstCredential = firstCredentialTry.get
-    firstCredential.getAccessToken shouldNot be(empty)
-
-    firstCredential.setExpiresInSeconds(59L)
-
-    val secondCredentialTry = credentialFactory.freshCredential
-    assert(secondCredentialTry.isSuccess)
-
-    val secondCredential = secondCredentialTry.get
-    secondCredential.getAccessToken shouldNot be(empty)
-    secondCredential.getExpiresInSeconds shouldNot be(null)
-    secondCredential.getExpiresInSeconds.longValue should be > 60L
+    testFactory(credentialFactory)
   }
 
   it should "refresh a token using a service account" in {
     GoogleCredentialFactorySpec.assumeAccountConfigExists()
 
     val credentialFactory = GoogleCredentialFactory.fromAuthScheme(GoogleCredentialFactorySpec.AccountConfig)
-    val firstCredentialTry = credentialFactory.freshCredential
-    assert(firstCredentialTry.isSuccess)
-    val firstCredential = firstCredentialTry.get
-    firstCredential.getAccessToken shouldNot be(empty)
-
-    firstCredential.setExpiresInSeconds(59L)
-
-    val secondCredentialTry = credentialFactory.freshCredential
-    assert(secondCredentialTry.isSuccess)
-
-    val secondCredential = secondCredentialTry.get
-    secondCredential.getAccessToken shouldNot be(empty)
-    secondCredential.getExpiresInSeconds shouldNot be(null)
-    secondCredential.getExpiresInSeconds.longValue should be > 60L
+    testFactory(credentialFactory)
   }
 
   it should "refresh a token using a refresh token" in {
     GoogleCredentialFactorySpec.assumeRefreshConfigExists()
 
-    val refreshToken =
-      GoogleCredentialFactory.fromAuthScheme(GoogleCredentialFactorySpec.RefreshConfig).freshCredential.get.getRefreshToken
+    val refreshTokenFactory = GoogleCredentialFactory.fromAuthScheme(GoogleCredentialFactorySpec.RefreshConfig)
+    val refreshToken = refreshTokenFactory.freshCredential.get.getRefreshToken
 
     val credentialFactory = new RefreshTokenCredentialFactory(GoogleCredentialFactorySpec.RefreshConfig, refreshToken)
-    val firstCredentialTry = credentialFactory.freshCredential
-    assert(firstCredentialTry.isSuccess)
-    val firstCredential = firstCredentialTry.get
-    firstCredential.getAccessToken shouldNot be(empty)
-
-    firstCredential.setExpiresInSeconds(59L)
-
-    val secondCredentialTry = credentialFactory.freshCredential
-    assert(secondCredentialTry.isSuccess)
-
-    val secondCredential = secondCredentialTry.get
-    secondCredential.getAccessToken shouldNot be(empty)
-    secondCredential.getExpiresInSeconds shouldNot be(null)
-    secondCredential.getExpiresInSeconds.longValue should be > 60L
+    testFactory(credentialFactory)
   }
 
   it should "not refresh an empty token" in {
@@ -81,9 +51,29 @@ class GoogleCredentialFactorySpec extends FlatSpec with Matchers {
     val exception = factory.freshCredential.failed.get
     exception.getMessage should be("Unable to refresh token")
   }
+
+  private[this] def testFactory(credentialFactory: GoogleCredentialFactory) {
+    val firstCredentialTry = credentialFactory.freshCredential
+    assert(firstCredentialTry.isSuccess)
+    val firstCredential = firstCredentialTry.get
+    firstCredential.getAccessToken shouldNot be(empty)
+
+    firstCredential.setExpiresInSeconds(59L)
+
+    val secondCredentialTry = credentialFactory.freshCredential
+    assert(secondCredentialTry.isSuccess)
+
+    val secondCredential = secondCredentialTry.get
+    secondCredential.getAccessToken shouldNot be(empty)
+    secondCredential.getExpiresInSeconds shouldNot be(null)
+    secondCredential.getExpiresInSeconds.longValue should be > 60L
+  }
 }
 
 object GoogleCredentialFactorySpec {
+  val ApplicationDefaultCredentialTry = Try(new ApplicationDefaultCredentialFactory().rawCredential)
+  lazy val ApplicationDefaultCredentialExists = ApplicationDefaultCredentialTry.isSuccess
+
   val AccountConfigPath = Paths.get("cromwell-account.conf")
   val AccountConfigExists = Files.exists(AccountConfigPath)
   lazy val AccountConfig = ConfigFactory.parseFile(AccountConfigPath.toFile)
@@ -97,6 +87,15 @@ object GoogleCredentialFactorySpec {
   lazy val RefreshConfig = ConfigFactory.parseFile(RefreshConfigPath.toFile)
 
   import Assertions._
+
+  def assumeApplicationDefaultCredentialExists() = assume(ApplicationDefaultCredentialExists,
+    // Use fold to defer execution of the failed message.
+    ApplicationDefaultCredentialTry.toOption.fold(
+      s"""
+         |Error getting default application credential. Please see this link for more info:
+         |https://developers.google.com/accounts/docs/application-default-credentials
+         |
+         |${ApplicationDefaultCredentialTry.failed.get.getMessage}""".stripMargin)(_ => "aok"))
 
   def assumeAccountConfigExists() = assume(AccountConfigExists, s"\nConfig not found $AccountConfigPath")
 


### PR DESCRIPTION
…efault Credentials. This is especially useful when running on a GCE VM when you want to

authenticate with the standard compute service account.