### PR TITLE
Correct input symbols in metadata

### DIFF
--- a/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -60,6 +60,9 @@ trait DataAccess {
   /** Should fail if a value is already set.  The keys in the Map are locally qualified names. */
   def setOutputs(workflowId: WorkflowId, key: OutputKey, callOutputs: WorkflowOutputs, workflowOutputFqns: Seq[ReportableSymbol]): Future[Unit]
 
+  /** Updates the existing input symbols to replace expressions with real values **/
+  def updateCallInputs(workflowId: WorkflowId, key: CallKey, callInputs: CallInputs): Future[Int]
+
   def setExecutionEvents(workflowId: WorkflowId, callFqn: String, shardIndex: Option[Int], events: Seq[ExecutionEventEntry]): Future[Unit]
 
   /** Gets a mapping from call FQN to an execution event entry list */

--- a/src/main/scala/cromwell/engine/db/slick/SymbolComponent.scala
+++ b/src/main/scala/cromwell/engine/db/slick/SymbolComponent.scala
@@ -100,6 +100,19 @@ trait SymbolComponent {
       if workflowExecution.workflowExecutionUuid === workflowExecutionUuid
     } yield symbol)
 
+  def symbolsFilterByWorkflowAndScopeAndNameAndIndex(workflowExecutionId: Int, scope: String, name: String, index: Int) = {
+    val workflowFilteredQuery = for {
+      symbol <- symbols
+      if symbol.workflowExecutionId === workflowExecutionId
+    } yield symbol
+
+    workflowFilteredQuery filter { s =>
+      s.scope === scope &&
+      s.name === name &&
+      s.index === index
+    }
+  }
+
   val symbolsForWorkflowOutput = Compiled(
     (workflowExecutionUuid: Rep[String]) => for {
       symbol <- symbols

--- a/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -12,10 +12,10 @@ import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
 import cromwell.util.SampleWdl
-import cromwell.util.SampleWdl.{GoodbyeWorld, ThreeStep}
+import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
 import cromwell.webservice.WorkflowJsonSupport._
 import cromwell.webservice.WorkflowMetadataResponse
-import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.prop.{TableFor3, TableDrivenPropertyChecks}
 import spray.json._
 
 import scala.concurrent.Await
@@ -75,53 +75,69 @@ SingleWorkflowRunnerActorSpec("SingleWorkflowRunnerActorWithMetadataSpec") with 
 
   override protected def afterAll() = metadataFile.delete(ignoreIOExceptions = true)
 
+  private def doTheTest(wdlFile: SampleWdl, expectedCalls: TableFor3[String, Int, Int], workflowInputs: Int, workflowOutputs: Int) = {
+    val testStart = System.currentTimeMillis
+    within(timeoutDuration) {
+      singleWorkflowActor(
+        sampleWdl = wdlFile,
+        outputFile = Option(metadataFile))
+    }
+    TestKit.shutdownActorSystem(system, timeoutDuration)
+
+    val metadata = metadataFile.contentAsString.parseJson.convertTo[WorkflowMetadataResponse]
+    metadata.id shouldNot be(empty)
+    metadata.status should be("Succeeded")
+    metadata.submission.getMillis should be >= testStart
+    metadata.start shouldNot be(empty)
+    metadata.start.get.getMillis should be >= metadata.submission.getMillis
+    metadata.end shouldNot be(empty)
+    metadata.end.get.getMillis should be >= metadata.start.get.getMillis
+    metadata.inputs.fields should have size workflowInputs
+    metadata.outputs shouldNot be(empty)
+    metadata.outputs.get should have size workflowOutputs
+    metadata.calls shouldNot be(empty)
+
+    forAll(expectedCalls) { (callName, numInputs, numOutputs) =>
+      val callSeq = metadata.calls(callName)
+      callSeq should have size 1
+      val call = callSeq.head
+      call.inputs should have size numInputs
+      call.inputs foreach { case (name, value) =>
+        value.wdlType.toWdlString should not be "Expression"
+      }
+      call.executionStatus should be("Done")
+      call.backend should be(Option("Local"))
+      call.backendStatus should be(empty)
+      call.outputs shouldNot be(empty)
+      call.outputs.get should have size numOutputs
+      call.start shouldNot be(empty)
+      call.start.get.getMillis should be >= metadata.start.get.getMillis
+      call.end shouldNot be(empty)
+      call.end.get.getMillis should be >= call.start.get.getMillis
+      call.end.get.getMillis should be <= metadata.end.get.getMillis
+      call.jobId should be(empty)
+      call.returnCode should be(Option(0))
+      call.stdout shouldNot be(empty)
+      call.stderr shouldNot be(empty)
+    }
+  }
+
   "A SingleWorkflowRunnerActor" should {
     "successfully run a workflow outputting metadata" in {
-      val testStart = System.currentTimeMillis
-      within(timeoutDuration) {
-        singleWorkflowActor(outputFile = Option(metadataFile))
-      }
-      TestKit.shutdownActorSystem(system, timeoutDuration)
-
-      val metadata = metadataFile.contentAsString.parseJson.convertTo[WorkflowMetadataResponse]
-      metadata.id shouldNot be(empty)
-      metadata.status should be("Succeeded")
-      metadata.submission.getMillis should be >= testStart
-      metadata.start shouldNot be(empty)
-      metadata.start.get.getMillis should be >= metadata.submission.getMillis
-      metadata.end shouldNot be(empty)
-      metadata.end.get.getMillis should be >= metadata.start.get.getMillis
-      metadata.inputs.fields should have size 1
-      metadata.outputs shouldNot be(empty)
-      metadata.outputs.get should have size 3
-      metadata.calls shouldNot be(empty)
-
       val expectedCalls = Table(
         ("callName", "numInputs", "numOutputs"),
         ("three_step.wc", 1, 1),
         ("three_step.ps", 0, 1),
         ("three_step.cgrep", 2, 1))
 
-      forAll(expectedCalls) { (callName, numInputs, numOutputs) =>
-        val callSeq = metadata.calls(callName)
-        callSeq should have size 1
-        val call = callSeq.head
-        call.inputs should have size numInputs
-        call.executionStatus should be("Done")
-        call.backend should be(Option("Local"))
-        call.backendStatus should be(empty)
-        call.outputs shouldNot be(empty)
-        call.outputs.get should have size numOutputs
-        call.start shouldNot be(empty)
-        call.start.get.getMillis should be >= metadata.start.get.getMillis
-        call.end shouldNot be(empty)
-        call.end.get.getMillis should be >= call.start.get.getMillis
-        call.end.get.getMillis should be <= metadata.end.get.getMillis
-        call.jobId should be(empty)
-        call.returnCode should be(Option(0))
-        call.stdout shouldNot be(empty)
-        call.stderr shouldNot be(empty)
-      }
+      doTheTest(ThreeStep, expectedCalls, 1, 3)
+    }
+    "run a workflow outputting metadata with no remaining input expressions" in {
+      val expectedCalls = Table(
+        ("callName", "numInputs", "numOutputs"),
+        ("wf.echo", 1, 1),
+        ("wf.echo2", 1, 1))
+      doTheTest(ExpressionsInInputs, expectedCalls, 2, 2)
     }
   }
 }

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -1609,4 +1609,34 @@ object SampleWdl {
       "w.t.d" -> WdlFile(cannedFile.getAbsolutePath)
     )
   }
+
+  object ExpressionsInInputs extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """task echo {
+        |  String inString
+        |  command {
+        |    echo ${inString}
+        |  }
+        |
+        |  output {
+        |    String outString = read_string(stdout())
+        |  }
+        |}
+        |
+        |workflow wf {
+        |  String a1
+        |  String a2
+        |  call echo {
+        |   input: inString = a1 + " " + a2
+        |  }
+        |  call echo as echo2 {
+        |    input: inString = a1 + " " + echo.outString + " " + a2
+        |  }
+        |}
+      """.stripMargin
+    override val rawInputs = Map(
+      "wf.a1" -> WdlString("hello"),
+      "wf.a2" -> WdlString("world")
+    )
+  }
 }


### PR DESCRIPTION
A quick explanation of the strategy - I did this with a database update at (actually just after) evaluation time. This has a few benefits (as I see it):

* The database is as easy to read and interpret as the metadata.
* We don't need to rehydrate the various data structures required by the expression evaluation logic just to perform a metadata query.
* We know that the evaluated expression in the database is the **exact** expression used in the call. There's no possibility of it being re-calculated incorrectly at a later time (maybe expression logic changes, etc)
* I got to re-learn slick database update operations :-D