### PR TITLE
Cleanup of Main

### DIFF
--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -3,7 +3,7 @@ package cromwell
 import java.io.{File => JFile}
 import java.nio.file.{Files, Path, Paths}
 
-import akka.actor.{Actor, ActorRef, Props, Status}
+import akka.actor.{Actor, Props, Status}
 import better.files._
 import wdl4s.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
 import wdl4s.{AstTools, _}
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 import spray.json._
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Promise}
+import scala.concurrent.{Future, Await, Promise}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
@@ -43,7 +43,7 @@ object Main extends App {
    * Also now passing args to runAction instead of the constructor, as even sbt seemed to have issues with the args
    * array becoming null in "new Main(args)" when used with: sbt 'run run ...'
    */
-  new Main().runAction(args)
+  sys.exit(new Main().runAction(args))
 
   /**
     * If a cromwell server is going to be run, makes adjustments to the default logback configuration.
@@ -55,48 +55,55 @@ object Main extends App {
     * @param args The command line arguments.
     */
   private def setupServerLogging(args: Array[String]): Unit = {
-    args.headOption.map(_.capitalize) match {
-      case Some("Server") => sys.props.getOrElseUpdate("LOG_MODE", "STANDARD")
+    getAction(args) match {
+      case Some(Actions.Server) => sys.props.getOrElseUpdate("LOG_MODE", "STANDARD")
       case _ =>
     }
   }
+
+  private def getAction(args: Seq[String]): Option[Actions.Value] = for {
+    arg <- args.headOption
+    argCapitalized = arg.capitalize
+    action <- Actions.values find (_.toString == argCapitalized)
+  } yield action
 }
 
 /** A simplified version of the Akka `PromiseActorRef` that doesn't time out. */
-private class PromiseWorkflowActor(promise: Promise[Any], runner: ActorRef) extends Actor {
-  runner ! RunWorkflow
-
+private class PromiseActor(promise: Promise[Any]) extends Actor {
   override def receive = {
-    case Status.Failure(f) => promise.tryFailure(f)
-    case success => promise.trySuccess(success)
+    case Status.Failure(f) =>
+      promise.tryFailure(f)
+      context.stop(self)
+    case success =>
+      promise.trySuccess(success)
+      context.stop(self)
   }
 }
 
-
-class Main private[cromwell](enableTermination: Boolean, managerSystem: () => WorkflowManagerSystem) {
+class Main private[cromwell](managerSystem: WorkflowManagerSystem) {
   private[cromwell] val initLoggingReturnCode = initLogging()
 
   lazy val Log = LoggerFactory.getLogger("cromwell")
   Monitor.start()
 
-  def this() = this(enableTermination = true, managerSystem = () => new WorkflowManagerSystem {})
+  def this() = this(managerSystem = new WorkflowManagerSystem {})
 
   // CromwellServer still doesn't clean up... so => Any
-  def runAction(args: Seq[String]): Any = {
-    getAction(args.headOption) match {
+  def runAction(args: Seq[String]): Int = {
+    Main.getAction(args) match {
       case Some(x) if x == Actions.Validate => validate(args.tail)
       case Some(x) if x == Actions.Highlight => highlight(args.tail)
       case Some(x) if x == Actions.Inputs => inputs(args.tail)
       case Some(x) if x == Actions.Run => run(args.tail)
       case Some(x) if x == Actions.Parse => parse(args.tail)
-      case Some(x) if x == Actions.Server => CromwellServer
+      case Some(x) if x == Actions.Server => runServer(args.tail)
       case _ => usageAndExit()
     }
   }
 
   def validate(args: Seq[String]): Int = {
     continueIf(args.length == 1) {
-      loadWdl(args.head) { _ => exit(0) }
+      loadWdl(args.head) { _ => 0 }
     }
   }
 
@@ -105,7 +112,7 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
       loadWdl(args.head) { namespace =>
         val formatter = new SyntaxFormatter(if (args(1) == "html") HtmlSyntaxHighlighter else AnsiSyntaxHighlighter)
         println(formatter.format(namespace))
-        exit(0)
+        0
       }
     }
   }
@@ -118,9 +125,13 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
           case x: NamespaceWithWorkflow => println(x.workflow.inputs.toJson.prettyPrint)
           case _ => println("WDL does not have a local workflow")
         }
-        exit(0)
+        0
       }
     }
+  }
+
+  def runServer(args: Seq[String]): Int = {
+    continueIf(args.isEmpty)(waitAndExit(CromwellServer.run(), CromwellServer))
   }
 
   /* Begin .run() method and utilities */
@@ -147,7 +158,7 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
         case Success(workflowSourceFiles) => runWorkflow(workflowSourceFiles, metadataPath)
         case Failure(ex) =>
           Console.err.println(ex.getMessage)
-          exit(1)
+          1
       }
     }
   }
@@ -176,23 +187,27 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
   }
 
   private[this] def runWorkflow(workflowSourceFiles: WorkflowSourceFiles, metadataPath: Option[Path]): Int = {
-    val workflowManagerSystem = managerSystem()
+    val workflowManagerSystem = managerSystem
     val runnerProps = SingleWorkflowRunnerActor.props(workflowSourceFiles, metadataPath,
       workflowManagerSystem.workflowManagerActor)
     val runner = workflowManagerSystem.actorSystem.actorOf(runnerProps, "SingleWorkflowRunnerActor")
 
     val promise = Promise[Any]()
-    workflowManagerSystem.actorSystem.actorOf(Props(classOf[PromiseWorkflowActor], promise, runner))
-    val futureResult = promise.future
+    val promiseActor = workflowManagerSystem.actorSystem.actorOf(Props(classOf[PromiseActor], promise))
+    runner.tell(RunWorkflow, promiseActor)
+    waitAndExit(promise.future, workflowManagerSystem)
+  }
+
+  private[this] def waitAndExit(futureResult: Future[Any], workflowManagerSystem: WorkflowManagerSystem): Int = {
     Await.ready(futureResult, Duration.Inf)
 
-    if (enableTermination) workflowManagerSystem.actorSystem.shutdown()
+    workflowManagerSystem.shutdownActorSystem()
 
     futureResult.value.get match {
-      case Success(_) => exit(0)
+      case Success(_) => 0
       case Failure(e) =>
         Console.err.println(e.getMessage)
-        exit(1)
+        1
     }
   }
 
@@ -260,7 +275,7 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
   def parse(args: Seq[String]): Int = {
     continueIf(args.length == 1) {
       println(AstTools.getAst(new JFile(args.head)).toPrettyString)
-      exit(0)
+      0
     }
   }
 
@@ -314,7 +329,7 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
         |  will output colorized text to the terminal
         |
       """.stripMargin)
-    exit(-1)
+    -1
   }
 
   private[this] def initLogging(): Int = {
@@ -337,33 +352,18 @@ class Main private[cromwell](enableTermination: Boolean, managerSystem: () => Wo
       case e: Throwable =>
         Console.err.println(s"Could not create log directory: $logRoot")
         e.printStackTrace()
-        exit(1)
+        1
     }
   }
 
   private[this] def continueIf(valid: => Boolean)(block: => Int): Int = if (valid) block else usageAndExit()
-
-  private[this] def getAction(firstArg: Option[String]): Option[Actions.Value] = for {
-    arg <- firstArg
-    argCapitalized = arg.capitalize
-    a <- Actions.values find (_.toString == argCapitalized)
-  } yield a
 
   private[this] def loadWdl(path: String)(f: WdlNamespace => Int): Int = {
     Try(WdlNamespace.load(new JFile(path))) match {
       case Success(namespace) => f(namespace)
       case Failure(t) =>
         println(t.getMessage)
-        exit(1)
+        1
     }
-  }
-
-  private[this] def exit(returnCode: Int): Int = {
-    if (enableTermination) {
-      // $COVERAGE-OFF$Exit not allowed during tests
-      sys.exit(returnCode)
-      // $COVERAGE-ON$
-    }
-    returnCode
   }
 }

--- a/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/src/main/scala/cromwell/server/CromwellServer.scala
@@ -5,7 +5,9 @@ import com.typesafe.config.ConfigFactory
 import cromwell.webservice.CromwellApiServiceActor
 import lenthall.spray.SprayCanHttpService._
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 // Note that as per the language specification, this is instantiated lazily and only used when necessary (i.e. server mode)
 object CromwellServer extends WorkflowManagerSystem {
@@ -15,7 +17,25 @@ object CromwellServer extends WorkflowManagerSystem {
   val conf = ConfigFactory.load()
   val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf), "cromwell-service")
   val webserviceConf = conf.getConfig("webservice")
-  service.bindOrShutdown(interface = webserviceConf.getString("interface"), port = webserviceConf.getInt("port")) onSuccess {
-    case _ => actorSystem.log.info("Cromwell service started...")
+
+  def run(): Future[Any] = {
+    val interface = webserviceConf.getString("interface")
+    val port = webserviceConf.getInt("port")
+    val futureBind = service.bind(interface = interface, port = port)
+    futureBind andThen {
+      case Success(_) =>
+        actorSystem.log.info("Cromwell service started...")
+        actorSystem.awaitTermination()
+      case Failure(throwable) =>
+        /*
+        TODO:
+        If/when CromwellServer behaves like a better async citizen, we may be less paranoid about our async log messages
+        not appearing due to the actor system shutdown. For now, synchronously print to the stderr so that the user has
+        some idea of why the server failed to start up.
+         */
+        Console.err.println(s"Binding failed interface $interface port $port")
+        throwable.printStackTrace(Console.err)
+        shutdownActorSystem()
+    }
   }
 }

--- a/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
+++ b/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
@@ -2,15 +2,22 @@ package cromwell.server
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import cromwell.engine.backend.{CromwellBackend, Backend}
+import cromwell.engine.backend.{Backend, CromwellBackend}
 import cromwell.engine.workflow.WorkflowManagerActor
-import cromwell.engine.backend.BackendType
 
 trait WorkflowManagerSystem {
   protected def systemName = "cromwell-system"
+
   protected def newActorSystem(): ActorSystem = ActorSystem(systemName)
-  implicit final val actorSystem = newActorSystem()
+
+  implicit final lazy val actorSystem = newActorSystem()
+
+  def shutdownActorSystem(): Unit = {
+    actorSystem.shutdown()
+  }
+
   def backendType: String = ConfigFactory.load.getConfig("backend").getString("backend")
+
   lazy val backend: Backend = CromwellBackend.initBackend(backendType, actorSystem)
   // For now there's only one WorkflowManagerActor so no need to dynamically name it
   lazy val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props(backend), "WorkflowManagerActor")

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -27,8 +27,9 @@ import org.scalactic.StringNormalizations._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.PartialFunctionValues._
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
 import scala.concurrent.{ExecutionContext, Future}
 import Hashing._
 
@@ -37,11 +38,16 @@ object SlickDataAccessSpec {
   val AllowTrue = Seq(webservice.QueryParameter("allow", "true"))
 }
 
-class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures {
+class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
 
   import TableDrivenPropertyChecks._
 
   val workflowManagerSystem = new TestWorkflowManagerSystem
+
+  override protected def afterAll() = {
+    workflowManagerSystem.shutdownTestActorSystem()
+    super.afterAll()
+  }
 
   implicit val ec = ExecutionContext.global
 

--- a/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
+++ b/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
@@ -7,10 +7,15 @@ import wdl4s.values.WdlValue
 import cromwell.engine.backend.local.{LocalBackend, LocalBackendCall}
 import cromwell.engine.workflow.CallKey
 import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor, WorkflowId, WorkflowSourceFiles}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-class WorkflowLoggerSpec extends FlatSpec with Matchers {
+class WorkflowLoggerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   val testWorkflowManagerSystem = new CromwellTestkitSpec.TestWorkflowManagerSystem()
+
+  override protected def afterAll() = {
+    testWorkflowManagerSystem.shutdownTestActorSystem()
+    super.afterAll()
+  }
 
   val descriptor = WorkflowDescriptor(
     WorkflowId(UUID.fromString("fc6cfad9-65e9-4eb7-853f-7e08c1c8cf8e")),

--- a/src/test/scala/cromwell/webservice/CromwellApiServiceIntegrationSpec.scala
+++ b/src/test/scala/cromwell/webservice/CromwellApiServiceIntegrationSpec.scala
@@ -17,6 +17,11 @@ class CromwellApiServiceIntegrationSpec extends FlatSpec with CromwellApiService
   override val workflowManager = TestActorRef(new WorkflowManagerActor(new LocalBackend(actorRefFactory)))
   val version = "v1"
 
+  override protected def afterAll() = {
+    testWorkflowManagerSystem.shutdownTestActorSystem()
+    super.afterAll()
+  }
+
   it should "return 400 for a malformed WDL " in {
     Post(s"/workflows/$version", FormData(Seq("wdlSource" -> CromwellApiServiceSpec.MalformedWdl, "workflowInputs" -> HelloWorld.rawInputs.toJson.toString()))) ~>
       submitRoute ~>


### PR DESCRIPTION
`CromwellServer` now exits with a 1 if the server does not start up. Still could use clean termination handling (via lenthall?).
Refactored the `WorkflowManagerSystem` passing into `Main`, including ensuring that during tests the internal actor system does get shut down, but not prematurely.
Made the `PromiseActor` more generic. TODO: Could move to lenthall, and possibly make it even easier to use, as right now it requires using `tell` instead of `!` to ensure the `sender` is set correctly.
`sys.exit()` is only called in the `object Main`, not conditionally in the `class Main`.
Moved `getAction()` from the `Main` class to the object.