### PR TITLE
added stanza related to workflow option encryption

### DIFF
--- a/src/main/config/cromwell.conf.ctmpl
+++ b/src/main/config/cromwell.conf.ctmpl
@@ -13,6 +13,14 @@ backend {
   }
 }
 
+workflow-options {
+  // These workflow options will be encrypted when stored in the database
+  encrypted-fields: ["refresh_token"]
+
+  // AES-256 key to use to encrypt the values in `encrypted-fields`
+  base64-encryption-key: "{{.Data.workflow_options_encryption_key}}"
+}
+
 docker {
   dockerAccount = "{{.Data.docker_account}}"
   dockerToken = "{{.Data.docker_token}}"


### PR DESCRIPTION
This change comes with a related change to vault to add a value.  This has been added to dev as:

"workflow_options_encryption_key": "nottheactualvalue"

but devops needs to to generate the encryption key for staging/alpha/prod and add these to vault before this version is promoted to those environments ( @abaumann @mmonnar )