### PR TITLE
JES stdout/stderr

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalaVersion := "2.11.7"
 
 val lenthallV = "0.15"
 
-val wdl4sV = "0.2-d949ac2-SNAPSHOT"
+val wdl4sV = "0.2-6f2ba49-SNAPSHOT"
 
 val sprayV = "1.3.2"
 

--- a/src/main/scala/cromwell/engine/CallActor.scala
+++ b/src/main/scala/cromwell/engine/CallActor.scala
@@ -111,7 +111,7 @@ class CallActor(key: CallKey, locallyQualifiedInputs: CallInputs, backend: Backe
       // There's no special Retry/Ack handling required for CallStarted message, the WorkflowActor can always
       // handle those immediately.
       context.parent ! WorkflowActor.CallStarted(key)
-      val backendCall = backend.bindCall(workflowDescriptor, key, locallyQualifiedInputs, AbortRegistrationFunction(registerAbortFunction))
+      val backendCall = backend.bindCall(workflowDescriptor, key, locallyQualifiedInputs, Option(AbortRegistrationFunction(registerAbortFunction)))
       val executionActorName = s"CallExecutionActor-${workflowDescriptor.id}-${call.unqualifiedName}"
       context.actorOf(CallExecutionActor.props(backendCall), executionActorName) ! startMode.executionMessage
       goto(CallRunningAbortUnavailable)

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -2,24 +2,22 @@ package cromwell.engine.backend
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
-import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
-import wdl4s._
-import cromwell.engine.ExecutionIndex.ExecutionIndex
 import cromwell.engine._
 import cromwell.engine.backend.jes.JesBackend
 import cromwell.engine.backend.local.LocalBackend
+import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
 import cromwell.engine.backend.sge.SgeBackend
 import cromwell.engine.db.ExecutionDatabaseKey
 import cromwell.engine.io.IoInterface
 import cromwell.engine.workflow.{CallKey, WorkflowOptions}
-import cromwell.engine.{HostInputs, CallOutputs}
 import cromwell.logging.WorkflowLogger
 import cromwell.util.docker.SprayDockerRegistryApiClient
 import org.slf4j.LoggerFactory
+import wdl4s._
 import wdl4s.values.WdlValue
-import scala.language.postfixOps
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 import scala.util.{Success, Try}
 
 object Backend {
@@ -113,8 +111,8 @@ trait Backend {
    */
   def bindCall(workflowDescriptor: WorkflowDescriptor,
                key: CallKey,
-               locallyQualifiedInputs: CallInputs,
-               abortRegistrationFunction: AbortRegistrationFunction): BackendCall
+               locallyQualifiedInputs: CallInputs = Map.empty[String, WdlValue],
+               abortRegistrationFunction: Option[AbortRegistrationFunction] = None): BackendCall
 
   def workflowContext(workflowOptions: WorkflowOptions, workflowId: WorkflowId, name: String): WorkflowContext
 
@@ -126,9 +124,9 @@ trait Backend {
   def prepareForRestart(restartableWorkflow: WorkflowDescriptor)(implicit ec: ExecutionContext): Future[Unit]
 
   /**
-   * Return CallStandardOutput which contains the stdout/stderr of the particular call
+   * Return CallLogs which contains the stdout/stderr of the particular call
    */
-  def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): CallLogs
+  def stdoutStderr(backendCall: BackendCall): CallLogs
 
   def backendType: BackendType
 

--- a/src/main/scala/cromwell/engine/backend/BackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/BackendCall.scala
@@ -1,16 +1,14 @@
 package cromwell.engine.backend
 
 import akka.event.LoggingAdapter
-import cromwell.engine
-import cromwell.engine.backend.runtimeattributes.{ContinueOnReturnCodeSet, ContinueOnReturnCodeFlag, CromwellRuntimeAttributes}
+import cromwell.engine.Hashing._
+import cromwell.engine.backend.runtimeattributes.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet, CromwellRuntimeAttributes}
+import cromwell.engine.workflow.CallKey
+import cromwell.engine.{CallOutputs, ExecutionEventEntry, ExecutionHash, WorkflowDescriptor}
+import cromwell.logging.WorkflowLogger
 import wdl4s._
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.values.WdlValue
-import cromwell.engine.workflow.CallKey
-import cromwell.engine.{ExecutionEventEntry, ExecutionHash, WorkflowDescriptor}
-import cromwell.engine.CallOutputs
-import cromwell.logging.WorkflowLogger
-import cromwell.engine.Hashing._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -90,15 +88,15 @@ trait BackendCall {
   def backend: Backend
 
   /**
-   * Inputs to the call.  For example, if a call's task specifies a command like this:
-   *
-   * command {
-   *   File some_dir
-   *   ls ${some_dir}
-   * }
-   *
-   * Then locallyQualifiedInputs could be Map("some_dir" -> WdlFile("/some/path"))
-   */
+    * Inputs to the call.  For example, if a call's task specifies a command like this:
+    *
+    * File some_dir
+    * command {
+    *   ls ${some_dir}
+    * }
+    *
+    * Then locallyQualifiedInputs could be Map("some_dir" -> WdlFile("/some/path"))
+    */
   def locallyQualifiedInputs: CallInputs
 
   /**
@@ -130,6 +128,11 @@ trait BackendCall {
   }
 
   def useCachedCall(cachedBackendCall: BackendCall)(implicit ec: ExecutionContext): Future[ExecutionHandle] = ???
+
+  /**
+    * Return CallLogs which contains the stdout/stderr of the particular call
+    */
+  def stdoutStderr: CallLogs
 
   @throws[IllegalArgumentException]
   lazy val runtimeAttributes = CromwellRuntimeAttributes(call.task.runtimeAttributes, backend.backendType)

--- a/src/main/scala/cromwell/engine/backend/jes/JesConfiguration.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesConfiguration.scala
@@ -4,9 +4,6 @@ import cromwell.engine.backend.jes.authentication.JesDockerCredentials
 import cromwell.engine.io.gcs.GoogleConfiguration
 import cromwell.util.DockerConfiguration
 
-/**
- * Trait for JesConfiguration
- */
 trait JesConfiguration {
   def jesConf: JesAttributes
   def googleConf: GoogleConfiguration

--- a/src/main/scala/cromwell/engine/backend/jes/Run.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/Run.scala
@@ -52,7 +52,7 @@ object Run  {
       logger.info(s"Outputs:\n${stringifyMap(rpr.getOutputs.asScala.toMap)}")
 
       val logging = new Logging()
-      logging.setGcsPath(s"${pipeline.gcsPath}/${JesBackendCall.JesLog}")
+      logging.setGcsPath(s"${pipeline.gcsPath}/${JesBackendCall.jesLogFilename(pipeline.key)}")
       rpr.setLogging(logging)
 
       // Currently, some resources (specifically disk) need to be specified both at pipeline creation and pipeline run time
@@ -162,7 +162,7 @@ case class Run(runId: String, pipeline: Pipeline, logger: WorkflowLogger) {
       // If this has transitioned to a running or complete state from a state this is not running or complete,
       // register the abort function.
       if (currentStatus.isRunningOrComplete && (previousStatus.isEmpty || !previousStatus.get.isRunningOrComplete)) {
-        backendCall.callAbortRegistrationFunction.register(AbortFunction(() => abort()))
+        backendCall.callAbortRegistrationFunction.foreach(_.register(AbortFunction(() => abort())))
       }
     }
 

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
@@ -12,7 +12,7 @@ case class LocalBackendCall(backend: LocalBackend,
                             workflowDescriptor: WorkflowDescriptor,
                             key: CallKey,
                             locallyQualifiedInputs: CallInputs,
-                            callAbortRegistrationFunction: AbortRegistrationFunction) extends BackendCall with LocalFileSystemBackendCall {
+                            callAbortRegistrationFunction: Option[AbortRegistrationFunction]) extends BackendCall with LocalFileSystemBackendCall {
   val workflowRootPath = LocalBackend.hostExecutionPath(workflowDescriptor)
   val callRootPath = LocalBackend.hostCallPath(workflowDescriptor, call.unqualifiedName, key.index)
   val dockerContainerExecutionDir = LocalBackend.containerExecutionPath(workflowDescriptor)
@@ -35,4 +35,6 @@ case class LocalBackendCall(backend: LocalBackend,
 
   override def useCachedCall(avoidedTo: BackendCall)(implicit ec: ExecutionContext): Future[ExecutionHandle] =
     backend.useCachedCall(avoidedTo.asInstanceOf[LocalBackendCall], this)
+
+  override def stdoutStderr: CallLogs = backend.stdoutStderr(this)
 }

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
@@ -12,7 +12,7 @@ case class SgeBackendCall(backend: SgeBackend,
                           workflowDescriptor: WorkflowDescriptor,
                           key: CallKey,
                           locallyQualifiedInputs: CallInputs,
-                          callAbortRegistrationFunction: AbortRegistrationFunction) extends BackendCall with LocalFileSystemBackendCall {
+                          callAbortRegistrationFunction: Option[AbortRegistrationFunction]) extends BackendCall with LocalFileSystemBackendCall {
   val workflowRootPath = LocalBackend.hostExecutionPath(workflowDescriptor)
   val callRootPath = LocalBackend.hostCallPath(workflowDescriptor, call.unqualifiedName, key.index)
   val stdout = callRootPath.resolve("stdout")
@@ -28,4 +28,6 @@ case class SgeBackendCall(backend: SgeBackend,
 
   override def useCachedCall(avoidedTo: BackendCall)(implicit ec: ExecutionContext): Future[ExecutionHandle] =
     backend.useCachedCall(avoidedTo.asInstanceOf[SgeBackendCall], this)
+
+  override def stdoutStderr: CallLogs = backend.stdoutStderr(this)
 }

--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -1033,7 +1033,7 @@ case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend)
 
   private def sendStartMessage(callKey: CallKey, callInputs: Map[String, WdlValue]) = {
     def registerAbortFunction(abortFunction: AbortFunction): Unit = {}
-    val backendCall = backend.bindCall(workflow, callKey, callInputs, AbortRegistrationFunction(registerAbortFunction))
+    val backendCall = backend.bindCall(workflow, callKey, callInputs, Option(AbortRegistrationFunction(registerAbortFunction)))
     val log = backendCall.workflowLoggerWithCall("WorkflowActor", Option(akkaLogger))
 
     def loadCachedBackendCallAndMessage(descriptor: WorkflowDescriptor, cachedExecution: Execution) = {
@@ -1043,7 +1043,7 @@ case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend)
             descriptor,
             CallKey(c, cachedExecution.index.toIndex),
             callInputs,
-            AbortRegistrationFunction(registerAbortFunction)
+            Option(AbortRegistrationFunction(registerAbortFunction))
           )
           log.info(s"Call Caching: Cache hit. Using UUID(${cachedCall.workflowDescriptor.shortId}):${cachedCall.key.tag} as results for UUID(${backendCall.workflowDescriptor.shortId}):${backendCall.key.tag}")
           self ! UseCachedCall(callKey, CallActor.UseCachedCall(cachedCall, backendCall))

--- a/src/test/scala/cromwell/InvalidRuntimeAttributesSpec.scala
+++ b/src/test/scala/cromwell/InvalidRuntimeAttributesSpec.scala
@@ -3,10 +3,9 @@ package cromwell
 import java.net.URL
 
 import akka.testkit.{EventFilter, TestActorRef}
-import cromwell.engine.ExecutionIndex._
 import cromwell.engine._
 import cromwell.engine.backend.jes.{JesAttributes, JesBackend}
-import cromwell.engine.io.gcs.{GoogleConfiguration, Refresh, ServiceAccountMode, SimpleClientSecrets}
+import cromwell.engine.io.gcs.{GoogleConfiguration, ServiceAccountMode}
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.util.SampleWdl
 import org.scalatest.BeforeAndAfterAll
@@ -31,13 +30,12 @@ class InvalidRuntimeAttributesSpec extends CromwellTestkitSpec with BeforeAndAft
           executionBucket = anyString,
           endpointUrl = anyURL) {
         }
-        override def callGcsPath(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): String = "gs://fake/path"
         override def jesUserConnection(workflow: WorkflowDescriptor) = null
         override lazy val jesCromwellInterface = null
         override lazy val googleConf = GoogleConfiguration("appName", ServiceAccountMode("accountID", "pem"), None)
       }
 
-      val workflowSources = WorkflowSourceFiles(SampleWdl.HelloWorld.wdlSource(), SampleWdl.HelloWorld.wdlJson, "{}")
+      val workflowSources = WorkflowSourceFiles(SampleWdl.HelloWorld.wdlSource(), SampleWdl.HelloWorld.wdlJson, """ {"jes_gcs_root": "gs://fake/path"} """)
       val submitMessage = WorkflowManagerActor.SubmitWorkflow(workflowSources)
 
       runWdlWithWorkflowManagerActor(

--- a/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -78,7 +78,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec {
           val worldSymbolHash = worldWdlString.getHash(descriptor)
           val symbols = Map(key -> new SymbolStoreEntry(key, WdlStringType, Option(worldWdlString), worldSymbolHash))
           // FIXME? null AST
-          val task = new Task("taskName", Seq.empty[Declaration], Seq.empty[CommandPart], Seq.empty, null)
+          val task = Task.empty
           val call = new Call(None, key.scope, task, Set.empty[FullyQualifiedName], Map.empty, None)
           for {
             _ <- globalDataAccess.createWorkflow(descriptor, symbols.values, Seq(call), new LocalBackend(system))

--- a/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
@@ -18,7 +18,7 @@ class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures {
   val sources = SampleWdl.CallCachingHashingWdl.asWorkflowSources()
   val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), sources)
   val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "t").get
-  val backendCall = backend.bindCall(descriptor, CallKey(call, None), descriptor.actualInputs, AbortRegistrationFunction(_ => ()))
+  val backendCall = backend.bindCall(descriptor, CallKey(call, None), descriptor.actualInputs, abortRegistrationFunction = None)
 
   "BackendCall hash function" should {
     "not change very often - if it changes, make sure it is for a good reason" in {
@@ -32,7 +32,7 @@ class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures {
       val sources = SampleWdl.CallCachingHashingWdl.asWorkflowSources( s"""runtime { docker: "$nameAndDigest" } """)
       val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), sources)
       val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "t").get
-      val backendCall = backend.bindCall(descriptor, CallKey(call, None), descriptor.actualInputs, AbortRegistrationFunction(_ => ()))
+      val backendCall = backend.bindCall(descriptor, CallKey(call, None), descriptor.actualInputs, abortRegistrationFunction = None)
 
       val actual = backendCall.hash.futureValue.overallHash
       val expected = "ca6ee457780b78290785f112c3a3acb4"

--- a/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
@@ -39,7 +39,7 @@ class LocalBackendSpec extends CromwellTestkitSpec with Mockito {
   def testFailOnStderr(descriptor: WorkflowDescriptor, expectSuccess: Boolean): Unit = {
     val call = descriptor.namespace.workflow.calls.head
     val backend = new LocalBackend(system)
-    val backendCall = backend.bindCall(descriptor, CallKey(call, None), Map.empty[String, WdlValue], AbortRegistrationFunction(_ => ()))
+    val backendCall = backend.bindCall(descriptor, CallKey(call, None), Map.empty[String, WdlValue], abortRegistrationFunction = None)
     backendCall.execute map { _.result } map {
       case FailedExecution(e, _) => if (expectSuccess) fail("A call in a failOnStderr test which should have succeeded has failed ", e)
       case SuccessfulExecution(_, _, _, _, _) => if (!expectSuccess) fail("A call in a failOnStderr test which should have failed has succeeded")

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -75,14 +75,14 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
                                  ) = throw new NotImplementedError
 
     override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = throw new NotImplementedError
-    override def stdoutStderr(descriptor: WorkflowDescriptor, callName: String, index: ExecutionIndex): CallLogs = throw new NotImplementedError
+    override def stdoutStderr(backendCall: BackendCall): CallLogs = throw new NotImplementedError
     override def initializeForWorkflow(workflow: WorkflowDescriptor) = throw new NotImplementedError
     override def prepareForRestart(restartableWorkflow: WorkflowDescriptor)(implicit ec: ExecutionContext) = throw new NotImplementedError
 
     override def bindCall(workflowDescriptor: WorkflowDescriptor,
                           key: CallKey,
                           locallyQualifiedInputs: CallInputs,
-                          abortRegistrationFunction: AbortRegistrationFunction): BackendCall =
+                          abortRegistrationFunction: Option[AbortRegistrationFunction]): BackendCall =
       throw new NotImplementedError
 
     override def backendType: BackendType = throw new NotImplementedError
@@ -357,7 +357,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       assume(canConnect || testRequired)
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val callFqn = "fully.qualified.name"
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
@@ -485,7 +485,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
         val workflowId = WorkflowId(UUID.randomUUID())
         val workflowInfo = WorkflowDescriptor(workflowId, testSources)
 
-        val task = new Task("taskName", Nil, Nil, Nil, null)
+        val task = Task.empty
         val call =
           if (setCallParent) {
             val workflow = new Workflow("workflow.name", Nil, Nil)
@@ -543,7 +543,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val callFqn = "call.fully.qualified.scope"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
       val callKey = CallKey(call, None)
       (for {
@@ -575,7 +575,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = true)
       val entry = new SymbolStoreEntry(key, WdlStringType, Option(testWdlString), Option(testWdlStringHash))
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -607,7 +607,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val workflowDescriptor = WorkflowDescriptor(workflowId, testSources)
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = true)
       val entry = new SymbolStoreEntry(key, WdlArrayType(WdlStringType), Option(wdlArray), wdlArray.getHash(workflowDescriptor))
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -648,7 +648,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val symbolLqn = "symbol"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
       val workflowOutputList = Seq(ReportableSymbol("call.fully.qualified.scope.symbol", WdlArrayType(WdlStringType)))
 
@@ -678,7 +678,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val callFqn2 = "call.fully.qualified.scope$s2"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call1 = new Call(None, callFqn1, task, Set.empty[FullyQualifiedName], Map.empty, None)
       val shardIndex1 = Option(0)
       val pid1 = Option(123)
@@ -711,7 +711,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val symbolLqn = "symbol"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -760,7 +760,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val callFqn = "call.fully.qualified.scope"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       dataAccess.createWorkflow(workflowInfo, Nil, Seq(call),
@@ -772,7 +772,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val callFqn = "call.fully.qualified.scope"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       dataAccess.createWorkflow(workflowInfo, Nil, Seq(call),
@@ -788,7 +788,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
       val key = new SymbolStoreKey(callFqn, symbolFqn, None, input = true)
       val entry = new SymbolStoreEntry(key, WdlStringType, Option(testWdlString), Option(testWdlStringHash))
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -819,7 +819,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val symbolFqn = callFqn + "." + symbolLqn
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -835,7 +835,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       assume(canConnect || testRequired)
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
       val backendInfo = new LocalCallBackendInfo(Option(123))
 
@@ -858,7 +858,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val workflowId2 = WorkflowId(UUID.randomUUID())
       val workflowInfo1 = WorkflowDescriptor(workflowId1, testSources)
       val workflowInfo2 = WorkflowDescriptor(workflowId2, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
       val backendInfo1 = new LocalCallBackendInfo(Option(123))
       val backendInfo2 = new LocalCallBackendInfo(Option(321))
@@ -887,7 +887,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       assume(canConnect || testRequired)
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       (for {
@@ -902,7 +902,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       val callFqn = "call.fully.qualified.scope"
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, callFqn, task, Set.empty[FullyQualifiedName], Map.empty, None)
 
       // Assert a singular `Execution` in `executions`, and that the dates of the `Execution` are defined
@@ -936,7 +936,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       // We need an execution to create an event. We need a workflow to make an execution. Le Sigh...
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
       val shardedCall = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
       val shardIndex = Some(0)
@@ -980,7 +980,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       // We need an execution to create an event. We need a workflow to make an execution. Le Sigh...
       val workflowId = WorkflowId(UUID.randomUUID())
       val workflowInfo = WorkflowDescriptor(workflowId, testSources)
-      val task = new Task("taskName", Nil, Nil, Nil, null)
+      val task = Task.empty
       val call = new Call(None, "fully.qualified.name", task, Set.empty[FullyQualifiedName], Map.empty, None)
       val backendInfo = new LocalCallBackendInfo(Option(123))
 

--- a/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
+++ b/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
@@ -31,7 +31,7 @@ class WorkflowLoggerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     descriptor,
     CallKey(descriptor.namespace.workflow.calls.find(_.unqualifiedName == "x").head, None),
     Map.empty[String, WdlValue],
-    AbortRegistrationFunction(_ => ())
+    callAbortRegistrationFunction = None
   )
 
   "WorkflowLogger" should "create a valid tag" in {

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -1141,6 +1141,7 @@ object SampleWdl {
       |  command {
       |    echo -n -e "jeff\nchris\nmiguel\nthibault\nkhalid\nscott"
       |  }
+      |  RUNTIME
       |  output {
       |    Array[String] A_out = read_lines(stdout())
       |  }
@@ -1151,6 +1152,7 @@ object SampleWdl {
       |  command {
       |    python -c "print(len('${B_in}'))"
       |  }
+      |  RUNTIME
       |  output {
       |    Int B_out = read_int(stdout())
       |  }
@@ -1161,6 +1163,7 @@ object SampleWdl {
       |  command {
       |    python -c "print(${C_in}*100)"
       |  }
+      |  RUNTIME
       |  output {
       |    Int C_out = read_int(stdout())
       |  }
@@ -1171,6 +1174,7 @@ object SampleWdl {
       |  command {
       |    python -c "print(${sep = '+' D_in})"
       |  }
+      |  RUNTIME
       |  output {
       |    Int D_out = read_int(stdout())
       |  }
@@ -1180,6 +1184,7 @@ object SampleWdl {
       |  command {
       |    python -c "print(9)"
       |  }
+      |  RUNTIME
       |  output {
       |    Int E_out = read_int(stdout())
       |  }
@@ -1198,7 +1203,7 @@ object SampleWdl {
         |  }
         |  call D {input: D_in = B.B_out}
         |}
-      """.stripMargin
+      """.stripMargin.replaceAll("RUNTIME", runtime)
 
     override lazy val rawInputs = Map.empty[String, String]
   }
@@ -1219,7 +1224,7 @@ object SampleWdl {
         |  }
         |  call D {input: D_in = B.B_out}
         |}
-      """.stripMargin
+      """.stripMargin.replaceAll("RUNTIME", runtime)
 
     override lazy val rawInputs = Map.empty[String, String]
   }


### PR DESCRIPTION
See the corresponding wdl4s change: https://github.com/broadinstitute/wdl4s/pull/6
See the corresponding Tyburn change: https://github.com/broadinstitute/tyburn/pull/17

Instead of creating these files:

```
gs://path/to/call/jes.log
gs://path/to/call/jes-stdout.log
gs://path/to/call/jes-stderr.log
```

We will now create (`hello` is the name of the call)

```
gs://path/to/call/hello.log
gs://path/to/call/hello-stdout.log
gs://path/to/call/hello-stderr.log
```

We no longer manually redirect the stdout/stderr and let JES take care of it.

[Example output](https://console.developers.google.com/storage/browser/cromwell-dev/stdout_stderr_passing/0f3758c3-b186-41d3-86c1-d92e55b24332/?project=broad-dsde-dev&pli=1) of running the WDL in https://github.com/broadinstitute/tyburn/pull/17