### PR TITLE
Make Call backoff polling backend specific

### DIFF
--- a/src/main/scala/cromwell/engine/WorkflowDescriptor.scala
+++ b/src/main/scala/cromwell/engine/WorkflowDescriptor.scala
@@ -9,7 +9,7 @@ import ch.qos.logback.core.FileAppender
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.engine.backend.jes.JesBackend
 import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
-import cromwell.engine.backend.{BackendType, Backend, CromwellBackend}
+import cromwell.engine.backend.{Backend, BackendType, CromwellBackend}
 import cromwell.engine.db.DataAccess._
 import cromwell.engine.io.gcs.{GcsFileSystem, GoogleCloudStorage}
 import cromwell.engine.io.shared.SharedFileSystemIoInterface

--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.backend
 
 import akka.actor.ActorSystem
+import com.google.api.client.util.ExponentialBackOff
 import com.typesafe.config.Config
 import cromwell.engine._
 import cromwell.engine.backend.jes.JesBackend
@@ -157,4 +158,6 @@ trait Backend {
   )
 
   lazy val dockerHashClient = new SprayDockerRegistryApiClient()(actorSystem)
+
+  def pollBackoff: ExponentialBackOff
 }

--- a/src/main/scala/cromwell/engine/backend/BackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/BackendCall.scala
@@ -3,17 +3,12 @@ package cromwell.engine.backend
 import akka.event.LoggingAdapter
 import cromwell.engine.Hashing._
 import cromwell.engine.backend.runtimeattributes.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet, CromwellRuntimeAttributes}
-import cromwell.engine.workflow.CallKey
+import cromwell.engine.workflow.BackendCallKey
 import cromwell.engine.{CallOutputs, ExecutionEventEntry, ExecutionHash, WorkflowDescriptor}
 import cromwell.logging.WorkflowLogger
 import wdl4s._
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.values.WdlValue
-import cromwell.engine.workflow.BackendCallKey
-import cromwell.engine.{ExecutionEventEntry, ExecutionHash, WorkflowDescriptor}
-import cromwell.engine.CallOutputs
-import cromwell.logging.WorkflowLogger
-import cromwell.engine.Hashing._
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -3,9 +3,9 @@ package cromwell.engine.backend.jes
 import java.nio.file.Paths
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.client.util.ExponentialBackOff.Builder
 import com.typesafe.scalalogging.LazyLogging
-import wdl4s._
-import wdl4s.values.WdlFile
+import cromwell.engine.Hashing._
 import cromwell.engine.backend.jes.JesBackend._
 import cromwell.engine.backend.jes.Run.TerminalRunStatus
 import cromwell.engine.backend.jes.authentication.ProductionJesAuthentication
@@ -13,11 +13,13 @@ import cromwell.engine.backend.{BackendCall, CallLogs, JobKey, _}
 import cromwell.engine.io.gcs.GcsPath
 import cromwell.engine.workflow.BackendCallKey
 import cromwell.engine.{AbortRegistrationFunction, CallContext, WorkflowDescriptor, _}
+import wdl4s._
+import wdl4s.values.WdlFile
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
-import Hashing._
 
 object JesBackendCall {
   def jesLogBasename(key: BackendCallKey) = {

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
@@ -1,11 +1,14 @@
 package cromwell.engine.backend.local
 
 import better.files._
-import wdl4s.CallInputs
+import com.google.api.client.util.ExponentialBackOff
+import com.google.api.client.util.ExponentialBackOff.Builder
 import cromwell.engine.backend.{BackendCall, LocalFileSystemBackendCall, _}
 import cromwell.engine.workflow.BackendCallKey
 import cromwell.engine.{AbortRegistrationFunction, CallContext, WorkflowDescriptor}
+import wdl4s.CallInputs
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class LocalBackendCall(backend: LocalBackend,

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
@@ -1,11 +1,13 @@
 package cromwell.engine.backend.sge
 
-import wdl4s.CallInputs
+import com.google.api.client.util.ExponentialBackOff.Builder
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.backend.{BackendCall, LocalFileSystemBackendCall, _}
 import cromwell.engine.workflow.BackendCallKey
 import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
+import wdl4s.CallInputs
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 case class SgeBackendCall(backend: SgeBackend,

--- a/src/main/scala/cromwell/engine/callexecution/BackendCallExecutionActor.scala
+++ b/src/main/scala/cromwell/engine/callexecution/BackendCallExecutionActor.scala
@@ -1,10 +1,11 @@
 package cromwell.engine.callexecution
 
+import com.google.api.client.util.ExponentialBackOff
 import cromwell.engine.backend._
+import cromwell.engine.callexecution.CallExecutionActor._
 import cromwell.logging.WorkflowLogger
 
 import scala.language.postfixOps
-import CallExecutionActor._
 
 /**
   * Actor to manage the execution of a single backend call.
@@ -24,4 +25,6 @@ class BackendCallExecutionActor(backendCall: BackendCall) extends CallExecutionA
     case Resume(jobKey) => backendCall.resume(jobKey)
     case UseCachedCall(cachedBackendCall) => backendCall.useCachedCall(cachedBackendCall)
   }
+
+  override val backoff: ExponentialBackOff = backendCall.backend.pollBackoff
 }

--- a/src/main/scala/cromwell/engine/callexecution/FinalCallExecutionActor.scala
+++ b/src/main/scala/cromwell/engine/callexecution/FinalCallExecutionActor.scala
@@ -1,11 +1,14 @@
 package cromwell.engine.callexecution
 
+import com.google.api.client.util.ExponentialBackOff
+import com.google.api.client.util.ExponentialBackOff.Builder
 import cromwell.engine.backend.ExecutionHandle
 import cromwell.engine.callexecution.CallExecutionActor._
 import cromwell.engine.finalcall.FinalCall
 import cromwell.logging.WorkflowLogger
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 case class FinalCallExecutionActor(override val call: FinalCall) extends CallExecutionActor {
 
@@ -21,4 +24,12 @@ case class FinalCallExecutionActor(override val call: FinalCall) extends CallExe
     case UseCachedCall(cachedBackendCall) => Future.failed(new UnsupportedOperationException("Cannot use cached results for a FinalCall"))
     case _ => call.execute
   }
+
+  /** There is no polling for Final Calls (yet) as they are executed in Cromwell. */
+  override val backoff: ExponentialBackOff = new Builder()
+    .setInitialIntervalMillis(10.seconds.toMillis.toInt)
+    .setMaxElapsedTimeMillis(Int.MaxValue)
+    .setMaxIntervalMillis(10.minutes.toMillis.toInt)
+    .setMultiplier(1.1D)
+    .build()
 }

--- a/src/main/scala/cromwell/util/TryUtil.scala
+++ b/src/main/scala/cromwell/util/TryUtil.scala
@@ -5,7 +5,6 @@ import java.io.{PrintWriter, StringWriter}
 import cromwell.engine.CromwellFatalException
 import cromwell.logging.WorkflowLogger
 
-import scala.annotation.tailrec
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
@@ -55,7 +54,7 @@ object TryUtil {
     *
     * Use `retryLimit` value of None indicates to retry indefinitely.
     */
-  @tailrec
+  @annotation.tailrec
   def retryBlock[T](fn: Option[T] => T,
                     backoff: Backoff,
                     isSuccess: T => Boolean = defaultSuccessFunction _,

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -3,6 +3,7 @@ package cromwell.engine.db.slick
 import java.sql.SQLException
 import java.util.UUID
 
+import com.google.api.client.util.ExponentialBackOff
 import cromwell.CromwellSpec.IntegrationTest
 import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
 import cromwell.engine.Hashing._
@@ -88,7 +89,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
 
     override def backendType: BackendType = throw new NotImplementedError
     override def workflowContext(workflowOptions: WorkflowOptions, workflowId: WorkflowId, name: String): WorkflowContext = throw new NotImplementedError
-
+    override def pollBackoff: ExponentialBackOff = throw new NotImplementedError
   }
 
   // Tests against main database used for command line

--- a/src/test/scala/cromwell/util/TryUtilSpec.scala
+++ b/src/test/scala/cromwell/util/TryUtilSpec.scala
@@ -1,12 +1,14 @@
 package cromwell.util
 
-import cromwell.engine.CromwellFatalException
+import java.util.UUID
+
+import cromwell.engine.{CromwellFatalException, WorkflowId, WorkflowSourceFiles, WorkflowDescriptor}
 import cromwell.logging.WorkflowLogger
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.concurrent.duration._
 import scala.util.Success
 
 class TryUtilSpec extends FlatSpec with Matchers with MockitoSugar {


### PR DESCRIPTION
Decreases the polling frequency on JES jobs. It made sense to have different backends with different backoff timings (local can probably start with a higher frequency) so moved the backoff strategie to the BackendCall.