### PR TITLE
Workflows now fail slow

### DIFF
--- a/src/test/scala/cromwell/BadDockerName.scala
+++ b/src/test/scala/cromwell/BadDockerName.scala
@@ -1,0 +1,26 @@
+package cromwell
+
+import akka.testkit._
+import cromwell.CromwellSpec.{IntegrationTest, DockerTest}
+import cromwell.engine.WorkflowFailed
+import cromwell.util.SampleWdl
+
+import scala.language.postfixOps
+
+class BadDockerName extends CromwellTestkitSpec {
+  "A task which has a bad docker image name" should {
+    "fail properly" taggedAs DockerTest in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.HelloWorld,
+        eventFilter = EventFilter.info(pattern = s"transitioning from Running to Failed.", occurrences = 1),
+        runtime = """
+                    |runtime {
+                    |  docker: "/fauxbuntu:nosuchversion"
+                    |}
+                  """.stripMargin,
+        expectedOutputs = Map(),
+        terminalState = WorkflowFailed
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/BadTaskOutputWorkflowSpec.scala
+++ b/src/test/scala/cromwell/BadTaskOutputWorkflowSpec.scala
@@ -12,7 +12,7 @@ class BadTaskOutputWorkflowSpec extends CromwellTestkitSpec {
     "fail and result in a failed workflow" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.BadTaskOutputWdl,
-        EventFilter.info(pattern = s"starting calls: badExample.bad", occurrences = 1),
+        EventFilter.info(pattern = s"transitioning from Running to Failed.", occurrences = 1),
         expectedOutputs = Map(),
         terminalState = WorkflowFailed
       )
@@ -20,11 +20,11 @@ class BadTaskOutputWorkflowSpec extends CromwellTestkitSpec {
 
     "fail properly in a unknown Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
-        sampleWdl = SampleWdl.HelloWorld,
+        sampleWdl = SampleWdl.BadTaskOutputWdl,
         eventFilter = EventFilter.info(pattern = s"transitioning from Running to Failed.", occurrences = 1),
         runtime = """
                     |runtime {
-                    |  docker: "/fauxbuntu:nosuchversion"
+                    |  docker: "ubuntu:latest"
                     |}
                   """.stripMargin,
         expectedOutputs = Map(),

--- a/src/test/scala/cromwell/WorkflowFailSlowSpec.scala
+++ b/src/test/scala/cromwell/WorkflowFailSlowSpec.scala
@@ -1,0 +1,19 @@
+package cromwell
+
+import akka.testkit._
+import cromwell.engine.WorkflowFailed
+import cromwell.util.SampleWdl
+
+class WorkflowFailSlowSpec extends CromwellTestkitSpec {
+  "A workflow containing a failing task" should {
+    "complete other tasks but ultimately fail" in {
+      runWdlAndAssertOutputs(
+        sampleWdl = SampleWdl.WorkflowFailSlow,
+        eventFilter = EventFilter.info(pattern = s"persisting status of E to Done.", occurrences = 1),
+        runtime = "",
+        expectedOutputs = Map(),
+        terminalState = WorkflowFailed
+      )
+    }
+  }
+}

--- a/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/src/test/scala/cromwell/util/SampleWdl.scala
@@ -2252,4 +2252,68 @@ object SampleWdl {
       "w.x.a" -> 5
     )
   }
+
+  object WorkflowFailSlow extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """
+task shouldCompleteFast {
+        |    Int a
+        |    command {
+        |        echo "The number was: ${a}"
+        |    }
+        |    output {
+        |        Int echo = a
+        |    }
+        |}
+        |
+        |task shouldCompleteSlow {
+        |    Int a
+        |    command {
+        |        echo "The number was: ${a}"
+        |        sleep 0.2
+        |    }
+        |    output {
+        |        Int echo = a
+        |    }
+        |}
+        |
+        |task failMeSlowly {
+        |    Int a
+        |    command {
+        |        echo "The number was: ${a}"
+        |        sleep 0.2
+        |        ./NOOOOOO
+        |    }
+        |    output {
+        |        Int echo = a
+        |    }
+        |}
+        |
+        |task shouldNeverRun {
+        |    Int a
+        |    Int b
+        |    command {
+        |        echo "You can't fight in here - this is the war room ${a + b}"
+        |    }
+        |    output {
+        |        Int echo = a
+        |    }
+        |}
+        |
+        |workflow wf {
+        |    call shouldCompleteFast as A { input: a = 5 }
+        |    call shouldCompleteFast as B { input: a = 5 }
+        |
+        |    call failMeSlowly as ohNOOOOOOOO { input: a = A.echo }
+        |    call shouldCompleteSlow as C { input: a = B.echo }
+        |
+        |    call shouldNeverRun as D { input: a = ohNOOOOOOOO.echo, b = C.echo }
+        |    call shouldCompleteSlow as E { input: a = C.echo }
+        |}
+      """.stripMargin
+
+    val rawInputs = Map(
+      "w.x.a" -> 5
+    )
+  }
 }


### PR DESCRIPTION
Not *quite* as neat as I hoped, hopefully this change makes sense to people. 

In an ideal world, the state data would include executionStore, since it's just state by another name and would make things so much easier to work out.