### PR TITLE
Missing runtime attribute bug fix

### DIFF
--- a/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -1166,7 +1166,7 @@ case class WorkflowActor(workflow: WorkflowDescriptor, backend: Backend)
     Try(backendCall.runtimeAttributes) map { _ => startCall } recover {
       case f =>
         logger.error(f.getMessage)
-        self ! CheckForWorkflowComplete
+        self ! CallFailedToInitialize(callKey)
     }
   }
 


### PR DESCRIPTION
Stops the WorkflowActor from waiting forever if a call fails to initialise with invalid Runtime Attributes.