### PR TITLE
fix timing diagram for calls that were preempted

### DIFF
--- a/src/main/resources/workflowTimings/workflowTimings.html
+++ b/src/main/resources/workflowTimings/workflowTimings.html
@@ -51,9 +51,16 @@
                 for (var callIndex in callList)
                 {
                     var index = callList[callIndex]["shardIndex"];
+                    var attempt = callList[callIndex]["attempt"];
+                    var callStatus = callList[callIndex].executionStatus;
+
+                    // add the index of the shard if there is one
+                    var thisCallName = (index == -1 ? callName : callName + "." + index);
+
+                    // add the retry number, unless this was a successfuly first attempt (for brevity)
+                    thisCallName = ( callStatus == "Done" && attempt == 1 ? thisCallName : thisCallName + ".retry-" + attempt)
 
                     // Remove the workflow name
-                    var thisCallName = (index == -1 ? callName : callName + "." + index);
                     thisCallName = thisCallName.replace(new RegExp("^" + workflowName + "\\."), "");
 
                     var executionEvents = callList[callIndex].executionEvents;
@@ -61,7 +68,7 @@
                     var firstEventStart = null;
                     var finalEventEnd = null;
 
-                    if(callList[callIndex].executionStatus == "Done" || callList[callIndex].executionStatus == "Failed") {
+                    if(callStatus == "Done" || callStatus == "Failed" || callStatus == "Preempted") {
                         executionCallsCount++;
                         for (var executionEventIndex in executionEvents) {
                             var executionEvent = callList[callIndex].executionEvents[executionEventIndex];


### PR DESCRIPTION
To verify this fix, I did the following:

1. rename the attached file (VIR_912.preempt.tieout.json) to 'metadata' and put it in a directory (e.g. /tmp/foo) along with the /src/main/resources/workflowTimings/workflowTimings.html from cromwell.

2. From that directory run:

    python -m SimpleHTTPServer 8080
to start up a simple http server on port 8080 serving out of the local directory

3. Hit http://localhost:8080/workflowTimings.html in your browser.

This works because the html makes a AJAX call to ./metadata to get the metadata for the chart. You can't do this on a local filesystem because of cross-site garbage but this simple server does the trick.
You can see the calls that have retries are labeled as such. For example AggregatedBamMarkDuplicates or the HaplotypeCaller (see attached screenshot)

<img width="534" alt="examplefix" src="https://cloud.githubusercontent.com/assets/1423491/13155522/2701b2fc-d64c-11e5-97a3-7b6f3be7bd10.png">