### PR TITLE
Cromwell-backend as a sub-project of Cromwell

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,11 +3,11 @@ import sbtrelease.ReleasePlugin._
 
 name := "cromwell"
 
-version := "0.19"
-
 organization := "org.broadinstitute"
 
 scalaVersion := "2.11.7"
+
+version := "0.19"
 
 val lenthallV = "0.16"
 
@@ -82,8 +82,6 @@ libraryDependencies ++= Seq(
 )
 
 releaseSettings
-
-shellPrompt := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value)}
 
 assemblyJarName in assembly := "cromwell-" + version.value + ".jar"
 
@@ -165,10 +163,12 @@ lazy val CromwellIntegrationTest = config("integration") extend Test
 
 lazy val CromwellNoIntegrationTest = config("nointegration") extend Test
 
+lazy val CromwellBackend = Project(id = "CromwellBackend", base = file("cromwell-backend"))
+
 // NOTE: The following block may cause problems with IntelliJ IDEA
 // by creating multiple test configurations.
 // May need to comment out when importing the project.
-lazy val root = sbt.project.in(file("."))
+lazy val root = Project(id = "Cromwell", base = file(".")).aggregate(CromwellBackend).dependsOn(CromwellBackend)
   .configs(AllTests).settings(inConfig(AllTests)(Defaults.testTasks): _*)
   .configs(NoTests).settings(inConfig(NoTests)(Defaults.testTasks): _*)
   .configs(DockerTest).settings(inConfig(DockerTest)(Defaults.testTasks): _*)

--- a/cromwell-backend/CHANGELOG.MD
+++ b/cromwell-backend/CHANGELOG.MD
@@ -1,0 +1,5 @@
+# Cromwell-Backend Change Log
+
+1.0:
+=====
+

--- a/cromwell-backend/README.md
+++ b/cromwell-backend/README.md
@@ -1,0 +1,1 @@
+Generic Cromwell backend code.

--- a/cromwell-backend/build.sbt
+++ b/cromwell-backend/build.sbt
@@ -1,0 +1,27 @@
+name := "Cromwell Backend"
+
+scalaVersion := "2.11.7"
+
+organization := "org.broadinstitute"
+
+version := "0.1"
+
+// Shorten the git commit hash
+git.gitHeadCommit := git.gitHeadCommit.value map { _.take(7) }
+
+// Travis will deploy tagged releases, add -SNAPSHOT for all local builds
+git.gitUncommittedChanges := true
+
+versionWithGit
+
+assemblyJarName in assembly := "cromwell-backend-" + version.value + ".jar"
+
+scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+
+// The reason why -Xmax-classfile-name is set is because this will fail
+// to build on Docker otherwise.  The reason why it's 200 is because it
+// fails if the value is too close to 256 (even 254 fails).  For more info:
+//
+// https://github.com/sbt/sbt-assembly/issues/69
+// https://github.com/scala/pickling/issues/10
+scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xmax-classfile-name", "200")

--- a/cromwell-backend/project/plugins.sbt
+++ b/cromwell-backend/project/plugins.sbt
@@ -1,0 +1,17 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-M4")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.9")
+
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+
+logLevel := Level.Warn

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 


### PR DESCRIPTION
1. Added Cromwell-backend library as sub-project of Cromwell.
2. Added base interfaces from Cromwell-backend.
3. Tried to use SBT Git plugin for versioning but I couldn't get it work with sbt multi-projects.

@geoffjentry and @scottfrazer could you please review this PR?