### PR TITLE
fix a regression introduced by switching to the new JES API

### DIFF
--- a/src/main/scala/cromwell/engine/backend/jes/Pipeline.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/Pipeline.scala
@@ -45,7 +45,11 @@ object Pipeline {
     def createPipeline = jesConnection.genomics.pipelines().create(p).execute().getPipelineId
 
     def pipelineParameterString(p: PipelineParameter): String = {
-      s"  ${p.getName} -> disk:${p.getLocalCopy.getDisk} relpath:${p.getLocalCopy.getPath}"
+      val description = Option(p.getLocalCopy) match {
+        case Some(localCopy) => s"disk:${localCopy.getDisk} relpath:${localCopy.getPath}"
+        case None => s"(literal value)"
+      }
+      s"  ${p.getName} -> $description"
     }
     def diskString(d: Disk): String = {
       s"  ${d.getName} -> ${d.getMountPoint} (${d.getSizeGb}GB ${d.getType})"


### PR DESCRIPTION
- [x] Run full Tyburn tests to make sure remaining failing workflows now pass

This appears to NOT affect the GotC workflow, but it does affect 3 of the Tyburn WDLs