### PR TITLE
Enter the JobDescriptor.  Closes #496

### DIFF
--- a/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -104,9 +104,7 @@ trait Backend {
   /**
    * Essentially turns a Call object + CallInputs into a BackendCall
    */
-  def bindCall(workflowDescriptor: WorkflowDescriptor,
-               key: BackendCallKey,
-               locallyQualifiedInputs: CallInputs = Map.empty[String, WdlValue],
+  def bindCall(jobDescriptor: BackendCallJobDescriptor,
                abortRegistrationFunction: Option[AbortRegistrationFunction] = None): BackendCall
 
   def engineFunctions(ioInterface: IoInterface, workflowContext: WorkflowContext): WorkflowEngineFunctions

--- a/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
+++ b/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
@@ -1,0 +1,35 @@
+package cromwell.engine.backend
+
+import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
+import cromwell.engine.workflow.{FinalCallKey, CallKey, BackendCallKey}
+import wdl4s._
+import wdl4s.values.WdlValue
+
+
+/** Aspires to be an equivalent of `TaskDescriptor` in the pluggable backends world, describing a job in a way
+  * that is complete enough for it to be executed on any backend and free of references to engine types.
+  * Currently a ways to go in freedom from engine types.
+  *
+  * @tparam K CallKey subtype
+  */
+sealed trait JobDescriptor[K <: CallKey] {
+  def workflowDescriptor: WorkflowDescriptor
+  def key: K
+  def locallyQualifiedInputs: CallInputs
+}
+
+final case class BackendCallJobDescriptor(workflowDescriptor: WorkflowDescriptor,
+                                          key: BackendCallKey,
+                                          locallyQualifiedInputs: CallInputs = Map.empty) extends JobDescriptor[BackendCallKey] {
+
+  // PBE temporarily still required.  Once we have call-scoped Backend actors they will know themselves and the
+  // backend won't need to be in the WorkflowDescriptor and this method won't need to exist.
+  def backend = workflowDescriptor.backend
+}
+
+final case class FinalCallJobDescriptor(workflowDescriptor: WorkflowDescriptor,
+                                        key: FinalCallKey) extends JobDescriptor[FinalCallKey] {
+
+  override val locallyQualifiedInputs = Map.empty[String, WdlValue]
+}
+

--- a/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/jes/JesBackendCall.scala
@@ -32,9 +32,7 @@ object JesBackendCall {
 }
 
 class JesBackendCall(val backend: JesBackend,
-                     val workflowDescriptor: WorkflowDescriptor,
-                     val key: BackendCallKey,
-                     val locallyQualifiedInputs: CallInputs,
+                     val jobDescriptor: BackendCallJobDescriptor,
                      val callAbortRegistrationFunction: Option[AbortRegistrationFunction])
   extends BackendCall with ProductionJesAuthentication with LazyLogging {
 
@@ -60,7 +58,7 @@ class JesBackendCall(val backend: JesBackend,
 
   private lazy val callContext = new CallContext(callGcsPath.toString, jesStdoutGcsPath, jesStderrGcsPath)
 
-  lazy val engineFunctions = new JesCallEngineFunctions(workflowDescriptor.ioManager, callContext)
+  lazy val callEngineFunctions = new JesCallEngineFunctions(workflowDescriptor.ioManager, callContext)
 
   lazy val rcJesOutput = JesFileOutput(returnCodeFilename, returnCodeGcsPath, Paths.get(returnCodeFilename), workingDisk)
   lazy val cmdInput = JesFileInput(ExecParamName, gcsExecPath.toString, Paths.get(JesExecScript), workingDisk)
@@ -71,7 +69,7 @@ class JesBackendCall(val backend: JesBackend,
 
   def instantiateCommand: Try[String] = {
     val backendInputs = backend.adjustInputPaths(this)
-    call.instantiateCommandLine(backendInputs, engineFunctions, JesBackend.gcsPathToLocal)
+    call.instantiateCommandLine(backendInputs, callEngineFunctions, JesBackend.gcsPathToLocal)
   }
 
   /**

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -93,11 +93,9 @@ case class LocalBackend(actorSystem: ActorSystem) extends Backend with SharedFil
 
   override def pollBackoff = pollBackoffBuilder.build()
 
-  override def bindCall(workflowDescriptor: WorkflowDescriptor,
-                        key: BackendCallKey,
-                        locallyQualifiedInputs: CallInputs,
+  override def bindCall(jobDescriptor: BackendCallJobDescriptor,
                         abortRegistrationFunction: Option[AbortRegistrationFunction]): BackendCall = {
-    LocalBackendCall(this, workflowDescriptor, key, locallyQualifiedInputs, abortRegistrationFunction)
+    LocalBackendCall(this, jobDescriptor, abortRegistrationFunction)
   }
 
   def stdoutStderr(backendCall: BackendCall): CallLogs = sharedFileSystemStdoutStderr(backendCall)

--- a/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/local/LocalBackendCall.scala
@@ -11,9 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 case class LocalBackendCall(backend: LocalBackend,
-                            workflowDescriptor: WorkflowDescriptor,
-                            key: BackendCallKey,
-                            locallyQualifiedInputs: CallInputs,
+                            jobDescriptor: BackendCallJobDescriptor,
                             callAbortRegistrationFunction: Option[AbortRegistrationFunction]) extends BackendCall with LocalFileSystemBackendCall {
   val dockerContainerExecutionDir = workflowDescriptor.workflowRootPathWithBaseRoot(LocalBackend.ContainerRoot)
   lazy val containerCallRoot = runtimeAttributes.docker match {
@@ -25,7 +23,7 @@ case class LocalBackendCall(backend: LocalBackend,
   val stderr = callRootPath.resolve("stderr")
   val script = callRootPath.resolve("script")
   private val callContext = new CallContext(callRootPath.fullPath, stdout.fullPath, stderr.fullPath)
-  val engineFunctions = new LocalCallEngineFunctions(workflowDescriptor.ioManager, callContext)
+  val callEngineFunctions = new LocalCallEngineFunctions(workflowDescriptor.ioManager, callContext)
 
   callRootPath.toFile.mkdirs
 
@@ -35,7 +33,7 @@ case class LocalBackendCall(backend: LocalBackend,
       case Some(_) => backend.toDockerPath
       case None => (v: WdlValue) => v
     }
-    call.instantiateCommandLine(backendInputs, engineFunctions, pathTransformFunction)
+    call.instantiateCommandLine(backendInputs, callEngineFunctions, pathTransformFunction)
   }
 
   override def execute(implicit ec: ExecutionContext) = backend.execute(this)

--- a/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -141,7 +141,7 @@ trait SharedFileSystem {
   }
 
   private def outputLookup(taskOutput: TaskOutput, backendCall: LocalFileSystemBackendCall, currentList: Seq[AttemptedLookupResult]) = for {
-    expressionValue <- taskOutput.requiredExpression.evaluate(backendCall.lookupFunction(currentList.toLookupMap), backendCall.engineFunctions)
+    expressionValue <- taskOutput.requiredExpression.evaluate(backendCall.lookupFunction(currentList.toLookupMap), backendCall.callEngineFunctions)
     convertedValue <- outputAutoConversion(backendCall, taskOutput, expressionValue)
     pathAdjustedValue <- Success(absolutizeOutputWdlFile(convertedValue, backendCall.callRootPath))
   } yield pathAdjustedValue

--- a/src/main/scala/cromwell/engine/backend/runtimeattributes/CromwellRuntimeAttributes.scala
+++ b/src/main/scala/cromwell/engine/backend/runtimeattributes/CromwellRuntimeAttributes.scala
@@ -34,7 +34,7 @@ object CromwellRuntimeAttributes {
     val supportedKeys = backendCall.backend.backendType.supportedKeys map { _.key }
 
     val attributes = for {
-      attributesFromTask <- TryUtil.sequenceMap(wdlRuntimeAttributes.evaluate(backendCall.lookupFunction(backendCall.locallyQualifiedInputs), backendCall.engineFunctions))
+      attributesFromTask <- TryUtil.sequenceMap(wdlRuntimeAttributes.evaluate(backendCall.lookupFunction(backendCall.locallyQualifiedInputs), backendCall.callEngineFunctions))
       attributesWithDefaults <- Try(getAttributesWithDefaults(attributesFromTask, workflowOptions))
       _ <- validateKeys(attributesWithDefaults.keySet, backendCall.backend.backendType)
       supportedAttributes = attributesWithDefaults.filterKeys(k => supportedKeys.contains(k))

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackend.scala
@@ -48,11 +48,9 @@ case class SgeBackend(actorSystem: ActorSystem) extends Backend with SharedFileS
 
   override def pollBackoff = pollBackoffBuilder.build()
 
-  override def bindCall(workflowDescriptor: WorkflowDescriptor,
-                        key: BackendCallKey,
-                        locallyQualifiedInputs: CallInputs,
+  override def bindCall(jobDescriptor: BackendCallJobDescriptor,
                         abortRegistrationFunction: Option[AbortRegistrationFunction]): BackendCall = {
-    SgeBackendCall(this, workflowDescriptor, key, locallyQualifiedInputs, abortRegistrationFunction)
+    SgeBackendCall(this, jobDescriptor, abortRegistrationFunction)
   }
 
   def stdoutStderr(backendCall: BackendCall): CallLogs = sharedFileSystemStdoutStderr(backendCall)

--- a/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeBackendCall.scala
@@ -9,21 +9,19 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 case class SgeBackendCall(backend: SgeBackend,
-                          workflowDescriptor: WorkflowDescriptor,
-                          key: BackendCallKey,
-                          locallyQualifiedInputs: CallInputs,
+                          jobDescriptor: BackendCallJobDescriptor,
                           callAbortRegistrationFunction: Option[AbortRegistrationFunction]) extends BackendCall with LocalFileSystemBackendCall {
   val workflowRootPath = workflowDescriptor.workflowRootPath
   val stdout = callRootPath.resolve("stdout")
   val stderr = callRootPath.resolve("stderr")
   val script = callRootPath.resolve("script.sh")
   val returnCode = callRootPath.resolve("rc")
-  val engineFunctions: SgeEngineFunctions = new SgeEngineFunctions(callRootPath, stdout, stderr, workflowDescriptor.ioManager)
+  val callEngineFunctions: SgeCallEngineFunctions = new SgeCallEngineFunctions(callRootPath, stdout, stderr, workflowDescriptor.ioManager)
   callRootPath.toFile.mkdirs
 
   def instantiateCommand: Try[String] = {
     val backendInputs = backend.adjustInputPaths(this)
-    call.instantiateCommandLine(backendInputs, engineFunctions)
+    call.instantiateCommandLine(backendInputs, callEngineFunctions)
   }
 
   override def execute(implicit ec: ExecutionContext) = backend.execute(this)

--- a/src/main/scala/cromwell/engine/backend/sge/SgeCallEngineFunctions.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeCallEngineFunctions.scala
@@ -1,0 +1,9 @@
+package cromwell.engine.backend.sge
+
+import java.nio.file.Path
+
+import cromwell.engine.CallContext
+import cromwell.engine.backend.local.LocalCallEngineFunctions
+import cromwell.engine.io.IoInterface
+
+class SgeCallEngineFunctions(cwd: Path, stdout: Path, stderr: Path, interface: IoInterface) extends LocalCallEngineFunctions(interface, new CallContext(cwd.toString, stdout.toString, stderr.toString))

--- a/src/main/scala/cromwell/engine/backend/sge/SgeEngineFunctions.scala
+++ b/src/main/scala/cromwell/engine/backend/sge/SgeEngineFunctions.scala
@@ -1,9 +1,0 @@
-package cromwell.engine.backend.sge
-
-import java.nio.file.Path
-
-import cromwell.engine.CallContext
-import cromwell.engine.backend.local.LocalCallEngineFunctions
-import cromwell.engine.io.IoInterface
-
-class SgeEngineFunctions(cwd: Path, stdout: Path, stderr: Path, interface: IoInterface) extends LocalCallEngineFunctions(interface, new CallContext(cwd.toString, stdout.toString, stderr.toString))

--- a/src/main/scala/cromwell/engine/callactor/BackendCallActor.scala
+++ b/src/main/scala/cromwell/engine/callactor/BackendCallActor.scala
@@ -1,18 +1,14 @@
 package cromwell.engine.callactor
 
+import cromwell.engine.AbortRegistrationFunction
+import cromwell.engine.backend.BackendCallJobDescriptor
 import cromwell.engine.callexecution.CallExecutionActor
-import cromwell.engine.{AbortRegistrationFunction, WorkflowDescriptor}
-import cromwell.engine.backend.Backend
 import cromwell.engine.workflow.BackendCallKey
-import wdl4s._
 
-case class BackendCallActor(override val key: BackendCallKey,
-                            locallyQualifiedInputs: CallInputs,
-                            backend: Backend,
-                            override val workflowDescriptor: WorkflowDescriptor) extends CallActor {
+case class BackendCallActor(jobDescriptor: BackendCallJobDescriptor) extends CallActor[BackendCallJobDescriptor] {
 
   override lazy val callExecutionActor = {
-    val backendCall = backend.bindCall(workflowDescriptor, key, locallyQualifiedInputs, Option(AbortRegistrationFunction(registerAbortFunction)))
+    val backendCall = jobDescriptor.backend.bindCall(jobDescriptor, Option(AbortRegistrationFunction(registerAbortFunction)))
     val executionActorName = s"CallExecutionActor-${workflowDescriptor.id}-${call.unqualifiedName}"
     context.actorOf(CallExecutionActor.props(backendCall), executionActorName)
   }

--- a/src/main/scala/cromwell/engine/callactor/FinalCallActor.scala
+++ b/src/main/scala/cromwell/engine/callactor/FinalCallActor.scala
@@ -2,12 +2,10 @@ package cromwell.engine.callactor
 
 import akka.actor.ActorRef
 import cromwell.engine.WorkflowDescriptor
+import cromwell.engine.backend.{FinalCallJobDescriptor, BackendCallJobDescriptor}
 import cromwell.engine.callexecution.CallExecutionActor
 import cromwell.engine.workflow.FinalCallKey
 
-case class FinalCallActor(override val key: FinalCallKey) extends CallActor {
-  override protected lazy val callExecutionActor: ActorRef = context.actorOf(CallExecutionActor.props(key.scope))
-
-  // Marked as lazy so that it can be called in the superclass constructor:
-  override lazy val workflowDescriptor: WorkflowDescriptor = key.scope.workflow
+case class FinalCallActor(jobDescriptor: FinalCallJobDescriptor) extends CallActor[FinalCallJobDescriptor] {
+  override protected lazy val callExecutionActor: ActorRef = context.actorOf(CallExecutionActor.props(jobDescriptor.key.scope))
 }

--- a/src/main/scala/cromwell/engine/package.scala
+++ b/src/main/scala/cromwell/engine/package.scala
@@ -25,8 +25,8 @@ package object engine {
    */
   final case class WorkflowSourceFiles(wdlSource: WdlSource, inputsJson: WdlJson, workflowOptionsJson: WorkflowOptionsJson)
 
-  final case class AbortFunction(function: ()=>Unit)
-  final case class AbortRegistrationFunction(register: AbortFunction=>Unit)
+  final case class AbortFunction(function: () => Unit)
+  final case class AbortRegistrationFunction(register: AbortFunction => Unit)
 
   final case class ExecutionEventEntry(description: String, startTime: DateTime, endTime: DateTime)
   final case class QualifiedFailureEventEntry(workflowId: String, execution: Option[ExecutionDatabaseKey], failure: String, timestamp: DateTime) {

--- a/src/test/scala/cromwell/RetryableCallsSpec.scala
+++ b/src/test/scala/cromwell/RetryableCallsSpec.scala
@@ -5,11 +5,11 @@ import cromwell.engine.backend._
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.engine.workflow.WorkflowManagerActor._
-import cromwell.engine.{PreemptedException, WorkflowId, WorkflowSucceeded}
+import cromwell.engine.{PreemptedException, WorkflowSucceeded}
 import cromwell.util.SampleWdl
 import cromwell.webservice.CromwellApiHandler._
 import org.specs2.mock.Mockito
-import wdl4s.values.{WdlValue, WdlArray}
+import wdl4s.values.{WdlArray, WdlValue}
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
@@ -16,7 +16,8 @@ class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures {
   val sources = SampleWdl.CallCachingHashingWdl.asWorkflowSources()
   val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), sources)
   val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "t").get
-  val backendCall = backend.bindCall(descriptor, BackendCallKey(call, None, 1), descriptor.actualInputs, abortRegistrationFunction = None)
+  val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), descriptor.actualInputs)
+  val backendCall = backend.bindCall(jobDescriptor, abortRegistrationFunction = None)
 
   "BackendCall hash function" should {
     "not change very often - if it changes, make sure it is for a good reason" in {
@@ -30,7 +31,8 @@ class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures {
       val sources = SampleWdl.CallCachingHashingWdl.asWorkflowSources( s"""runtime { docker: "$nameAndDigest" } """)
       val descriptor = WorkflowDescriptor(WorkflowId(UUID.randomUUID()), sources)
       val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "t").get
-      val backendCall = backend.bindCall(descriptor, BackendCallKey(call, None, 1), descriptor.actualInputs, abortRegistrationFunction = None)
+      val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), descriptor.actualInputs)
+      val backendCall = backend.bindCall(jobDescriptor, abortRegistrationFunction = None)
 
       val actual = backendCall.hash.futureValue.overallHash
       val expected = "09eb4d544ecbd3740838c9798109a6d0"

--- a/src/test/scala/cromwell/engine/backend/CromwellRuntimeAttributeSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/CromwellRuntimeAttributeSpec.scala
@@ -37,7 +37,8 @@ class CromwellRuntimeAttributeSpec extends FlatSpec with Matchers with EitherVal
     val inputs = coercedInputs collect { case (k, v) if s"${call.fullyQualifiedName}\\.[a-zA-Z0-9_-]+".r.findFirstMatchIn(k).isDefined =>
       k.replace(s"${call.fullyQualifiedName}.", "") -> v
     }
-    backend.bindCall(descriptor, BackendCallKey(call, None, 1), inputs).runtimeAttributes
+    val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), inputs)
+    backend.bindCall(jobDescriptor).runtimeAttributes
   }
 
   it should "have reasonable defaults" in {

--- a/src/test/scala/cromwell/engine/backend/jes/JesBackendCallSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/JesBackendCallSpec.scala
@@ -3,6 +3,7 @@ package cromwell.engine.backend.jes
 import java.net.URL
 
 import cromwell.engine.WorkflowDescriptor
+import cromwell.engine.backend.BackendCallJobDescriptor
 import cromwell.engine.workflow.BackendCallKey
 import org.scalatest.{FlatSpec, Matchers}
 import org.slf4j.{Logger, LoggerFactory}
@@ -22,28 +23,30 @@ class JesBackendCallSpec extends FlatSpec with Matchers with Mockito {
     val backendCallKeyWithAttempt2 = mock[BackendCallKey]
     backendCallKeyWithAttempt2.attempt returns 2
 
+    val callDescriptor1 = BackendCallJobDescriptor(mock[WorkflowDescriptor], backendCallKeyWithAttempt1, mock[CallInputs])
+    val callDescriptor2 = BackendCallJobDescriptor(mock[WorkflowDescriptor], backendCallKeyWithAttempt2, mock[CallInputs])
 
-    val backendCallWithMax0AndKey1 = new JesBackendCall(mock[JesBackend], mock[WorkflowDescriptor], backendCallKeyWithAttempt1, mock[CallInputs], None) {
+    val backendCallWithMax0AndKey1 = new JesBackendCall(mock[JesBackend], callDescriptor1, None) {
       override lazy val maxPreemption = 0
     }
     backendCallWithMax0AndKey1.preemptible shouldBe false
 
-    val backendCallWithMax1AndKey1 = new JesBackendCall(mock[JesBackend], mock[WorkflowDescriptor], backendCallKeyWithAttempt1, mock[CallInputs], None) {
+    val backendCallWithMax1AndKey1 = new JesBackendCall(mock[JesBackend], callDescriptor1, None) {
       override lazy val maxPreemption = 1
     }
     backendCallWithMax1AndKey1.preemptible shouldBe true
 
-    val backendCallWithMax2AndKey1 = new JesBackendCall(mock[JesBackend], mock[WorkflowDescriptor], backendCallKeyWithAttempt1, mock[CallInputs], None) {
+    val backendCallWithMax2AndKey1 = new JesBackendCall(mock[JesBackend], callDescriptor1, None) {
       override lazy val maxPreemption = 2
     }
     backendCallWithMax2AndKey1.preemptible shouldBe true
 
-    val backendCallWithMax1AndKey2 = new JesBackendCall(mock[JesBackend], mock[WorkflowDescriptor], backendCallKeyWithAttempt2, mock[CallInputs], None) {
+    val backendCallWithMax1AndKey2 = new JesBackendCall(mock[JesBackend], callDescriptor2, None) {
       override lazy val maxPreemption = 1
     }
     backendCallWithMax1AndKey2.preemptible shouldBe false
 
-    val backendCallWithMax2AndKey2 = new JesBackendCall(mock[JesBackend], mock[WorkflowDescriptor], backendCallKeyWithAttempt2, mock[CallInputs], None) {
+    val backendCallWithMax2AndKey2 = new JesBackendCall(mock[JesBackend], callDescriptor2, None) {
       override lazy val maxPreemption = 2
     }
     backendCallWithMax2AndKey2.preemptible shouldBe true

--- a/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
@@ -11,7 +11,7 @@ import cromwell.engine.backend.jes.JesBackend.{JesFileInput, JesFileOutput}
 import cromwell.engine.backend.jes.Run.Failed
 import cromwell.engine.backend.jes.authentication._
 import cromwell.engine.backend.runtimeattributes.{CromwellRuntimeAttributes, DiskType}
-import cromwell.engine.backend.{AbortedExecutionHandle, FailedExecutionHandle, RetryableExecutionHandle}
+import cromwell.engine.backend.{AbortedExecutionHandle, BackendCallJobDescriptor, FailedExecutionHandle, RetryableExecutionHandle}
 import cromwell.engine.io.IoInterface
 import cromwell.engine.io.gcs._
 import cromwell.engine.workflow.{BackendCallKey, WorkflowOptions}
@@ -263,7 +263,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito with BeforeAndA
     backendCall.callGcsPath returns new NioGcsPath(Seq("call", "gcs", "path").toArray, absolute=true)(mock[GcsFileSystem])
     backendCall.lookupFunction(inputs) returns lookup
     backendCall.runtimeAttributes returns runtimeAttributes
-    backendCall.engineFunctions returns functions
+    backendCall.callEngineFunctions returns functions
     backendCall
   }
 
@@ -375,7 +375,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito with BeforeAndA
     )).copy(wfContext = new WorkflowContext("gs://path/to/gcs_root"))
 
     val call = wd.namespace.workflow.findCallByName("hello").get
-    val backendCall = jesBackend.bindCall(wd, BackendCallKey(call, None, 1))
+    val backendCall = jesBackend.bindCall(BackendCallJobDescriptor(wd, BackendCallKey(call, None, 1)))
     val stdoutstderr = backendCall.stdoutStderr
 
     stdoutstderr.stdout shouldBe WdlFile("gs://path/to/gcs_root/hello/e6236763-c518-41d0-9688-432549a8bf7c/call-hello/hello-stdout.log")
@@ -393,7 +393,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito with BeforeAndA
       workflowOptions = """ {"jes_gcs_root": "gs://path/to/gcs_root"} """
     )).copy(wfContext = new WorkflowContext("gs://path/to/gcs_root"))
     val call = wd.namespace.workflow.findCallByName("B").get
-    val backendCall = jesBackend.bindCall(wd, BackendCallKey(call, Some(2), 1))
+    val backendCall = jesBackend.bindCall(BackendCallJobDescriptor(wd, BackendCallKey(call, Some(2), 1)))
     val stdoutstderr = backendCall.stdoutStderr
 
     stdoutstderr.stdout shouldBe WdlFile("gs://path/to/gcs_root/w/e6236763-c518-41d0-9688-432549a8bf7c/call-B/shard-2/B-2-stdout.log")

--- a/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
+++ b/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
@@ -38,7 +38,8 @@ class LocalBackendSpec extends CromwellTestkitSpec with Mockito {
   def testFailOnStderr(descriptor: WorkflowDescriptor, expectSuccess: Boolean): Unit = {
     val call = descriptor.namespace.workflow.calls.head
     val backend = new LocalBackend(system)
-    val backendCall = backend.bindCall(descriptor, BackendCallKey(call, None, 1), Map.empty[String, WdlValue], abortRegistrationFunction = None)
+    val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), Map.empty[String, WdlValue])
+    val backendCall = backend.bindCall(jobDescriptor, abortRegistrationFunction = None)
     backendCall.execute map { _.result } map {
       case NonRetryableExecution(e, _, _) => if (expectSuccess) fail("A call in a failOnStderr test which should have succeeded has failed ", e)
       case RetryableExecution(e, _, _) => if (expectSuccess) fail("A call in a failOnStderr test which should have succeeded has failed ", e)

--- a/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -11,7 +11,7 @@ import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
 import cromwell.engine.Hashing._
 import cromwell.engine.backend.local.LocalBackend.InfoKeys
 import cromwell.engine.backend.local.{LocalBackend, LocalBackendCall}
-import cromwell.engine.backend.{Backend, BackendType, CallLogs}
+import cromwell.engine.backend._
 import cromwell.engine.db.slick.SlickDataAccessSpec.{AllowFalse, AllowTrue}
 import cromwell.engine.db.{DiffResultFilter, ExecutionDatabaseKey}
 import cromwell.engine.io.IoInterface
@@ -78,9 +78,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
     override def initializeForWorkflow(workflow: WorkflowDescriptor) = throw new NotImplementedError
     override def prepareForRestart(restartableWorkflow: WorkflowDescriptor)(implicit ec: ExecutionContext) = throw new NotImplementedError
 
-    override def bindCall(workflowDescriptor: WorkflowDescriptor,
-                          key: BackendCallKey,
-                          locallyQualifiedInputs: CallInputs,
+    override def bindCall(jobDescriptor: BackendCallJobDescriptor,
                           abortRegistrationFunction: Option[AbortRegistrationFunction]): BackendCall =
       throw new NotImplementedError
 

--- a/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
+++ b/src/test/scala/cromwell/logging/WorkflowLoggerSpec.scala
@@ -3,6 +3,7 @@ package cromwell.logging
 import java.util.UUID
 
 import cromwell.CromwellTestkitSpec
+import cromwell.engine.backend.BackendCallJobDescriptor
 import wdl4s.values.WdlValue
 import cromwell.engine.backend.local.{LocalBackend, LocalBackendCall}
 import cromwell.engine.workflow.BackendCallKey
@@ -26,13 +27,12 @@ class WorkflowLoggerSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     )
   )
   val backend = LocalBackend(testWorkflowManagerSystem.actorSystem)
-  val backendCall = LocalBackendCall(
-    backend,
+  val jobDescriptor = BackendCallJobDescriptor(
     descriptor,
     BackendCallKey(descriptor.namespace.workflow.calls.find(_.unqualifiedName == "x").head, None, 1),
-    Map.empty[String, WdlValue],
-    callAbortRegistrationFunction = None
-  )
+    Map.empty[String, WdlValue])
+
+  val backendCall = LocalBackendCall(backend, jobDescriptor, callAbortRegistrationFunction = None)
 
   "WorkflowLogger" should "create a valid tag" in {
     backend.workflowLogger(descriptor).tag shouldBe "LocalBackend [UUID(fc6cfad9)]"


### PR DESCRIPTION
This introduces a ~~`CallDescriptor`~~ `JobDescriptor` abstraction that I hope resembles what we'd want in the world of pluggable backends.  Although this is a backend class, it holds a reference to a `WorkflowDescriptor` which still has tons of references to engine things which we plan to refactor out, possibly into backend.  `CallDescriptor` currently interacts with `BackendCall`s because that's what Cromwell has right now.  :smile: 

There was one very special bit of weirdness about our backend handling exposed by `RetryableCallsSpec` where the backend passed to `WorkflowManagerActor` is not necessarily the same backend used to build `WorkflowDescriptor`s. :frowning:  That could use some extra scrutiny by reviewers.