### PR TITLE
Moved instantiateCommand into JobDescriptor closes #493

### DIFF
--- a/engine/src/main/scala/cromwell/engine/backend/Backend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/Backend.scala
@@ -7,6 +7,7 @@ import com.google.api.client.util.ExponentialBackOff
 import com.typesafe.config.Config
 import cromwell.engine.backend.jes.JesBackend
 import cromwell.engine.backend.local.LocalBackend
+import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
 import cromwell.engine.backend.sge.SgeBackend
 import cromwell.engine.db.DataAccess.ExecutionKeyToJobKey
 import cromwell.engine.io.IoInterface
@@ -81,6 +82,7 @@ trait Backend {
    * Return a possibly altered copy of inputs reflecting any localization of input file paths that might have
    * been performed for this `Backend` implementation.
    */
+  def adjustInputPaths(backendCallJobDescriptor: BackendCallJobDescriptor): CallInputs
   def adjustInputPaths(backendCall: BackendCall): CallInputs
 
   // FIXME: This is never called...
@@ -157,4 +159,8 @@ trait Backend {
   }
 
   def callEngineFunctions(descriptor: BackendCallJobDescriptor): CallEngineFunctions
+
+  def instantiateCommand(descriptor: BackendCallJobDescriptor): Try[String]
+
+  def runtimeAttributes(descriptor: BackendCallJobDescriptor): CromwellRuntimeAttributes = ???
 }

--- a/engine/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
@@ -1,10 +1,13 @@
 package cromwell.engine.backend
 
+import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
 import cromwell.engine.{CallEngineFunctions, WorkflowDescriptor}
 import cromwell.engine.workflow.{BackendCallKey, CallKey, FinalCallKey}
 import cromwell.webservice.WorkflowMetadataResponse
 import wdl4s._
 import wdl4s.values.WdlValue
+
+import scala.util.Try
 
 
 /** Aspires to be an equivalent of `TaskDescriptor` in the pluggable backends world, describing a job in a way
@@ -32,6 +35,15 @@ final case class BackendCallJobDescriptor(workflowDescriptor: WorkflowDescriptor
   def callRootPathWithBaseRoot(baseRoot: String) = backend.callRootPathWithBaseRoot(this, baseRoot)
 
   def callEngineFunctions: CallEngineFunctions = backend.callEngineFunctions(this)
+
+  def callRuntimeAttributes: CromwellRuntimeAttributes = backend.runtimeAttributes(this)
+
+  /**
+    * Attempt to evaluate all the ${...} tags in a command and return a String representation
+    * of the command.  This could fail for a variety of reasons related to expression evaluation
+    * which is why it returns a Try[String]
+    */
+  def instantiateCommand: Try[String] = backend.instantiateCommand(this)
 }
 
 final case class FinalCallJobDescriptor(workflowDescriptor: WorkflowDescriptor,

--- a/engine/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/jes/JesBackend.scala
@@ -237,6 +237,7 @@ case class JesBackend(actorSystem: ActorSystem)
   // FIXME: Add proper validation of jesConf and have it happen up front to provide fail-fast behavior (will do as a separate PR)
 
   override def adjustInputPaths(backendCall: BackendCall): CallInputs = backendCall.locallyQualifiedInputs mapValues gcsPathToLocal
+  override def adjustInputPaths(jobDescriptor: BackendCallJobDescriptor): CallInputs = jobDescriptor.locallyQualifiedInputs mapValues gcsPathToLocal
 
   override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = outputs mapValues {
     case CallOutput(value, hash) => CallOutput(gcsPathToLocal(value), hash)
@@ -884,5 +885,10 @@ case class JesBackend(actorSystem: ActorSystem)
 
     val callContext = new CallContext(callGcsPath.toString, jesStdoutGcsPath, jesStderrGcsPath)
     new JesCallEngineFunctions(workflowDescriptor.ioManager, callContext)
+  }
+
+  override def instantiateCommand(descriptor: BackendCallJobDescriptor): Try[String] = {
+    val backendInputs = adjustInputPaths(descriptor)
+    descriptor.key.scope.instantiateCommandLine(backendInputs, descriptor.callEngineFunctions, JesBackend.gcsPathToLocal)
   }
 }

--- a/engine/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/local/LocalBackend.scala
@@ -14,6 +14,7 @@ import cromwell.engine.db.DataAccess._
 import cromwell.engine.db.{CallStatus, ExecutionDatabaseKey}
 import cromwell.util.FileUtil._
 import org.slf4j.LoggerFactory
+import wdl4s.values.WdlValue
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -79,6 +80,7 @@ case class LocalBackend(actorSystem: ActorSystem) extends Backend with SharedFil
   type BackendCall = LocalBackendCall
 
   override def adjustInputPaths(backendCall: BackendCall) = adjustSharedInputPaths(backendCall)
+  override def adjustInputPaths(jobDescriptor: BackendCallJobDescriptor) = adjustSharedInputPaths(jobDescriptor)
 
   /**
     * Exponential Backoff Builder to be used when polling for call status.
@@ -221,5 +223,14 @@ case class LocalBackend(actorSystem: ActorSystem) extends Backend with SharedFil
 
   override def callEngineFunctions(descriptor: BackendCallJobDescriptor): CallEngineFunctions = {
     new LocalCallEngineFunctions(descriptor.workflowDescriptor.ioManager, buildCallContext(descriptor))
+  }
+
+  def instantiateCommand(jobDescriptor: BackendCallJobDescriptor): Try[String] = {
+    val backendInputs = adjustInputPaths(jobDescriptor)
+    val pathTransformFunction: WdlValue => WdlValue = jobDescriptor.callRuntimeAttributes.docker match {
+      case Some(_) => toDockerPath
+      case None => (v: WdlValue) => v
+    }
+    jobDescriptor.key.scope.instantiateCommandLine(backendInputs, jobDescriptor.callEngineFunctions, pathTransformFunction)
   }
 }

--- a/engine/src/test/scala/engine/db/slick/SlickDataAccessSpec.scala
+++ b/engine/src/test/scala/engine/db/slick/SlickDataAccessSpec.scala
@@ -34,6 +34,7 @@ import wdl4s.types.{WdlArrayType, WdlStringType}
 import wdl4s.values.{WdlArray, WdlString}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 object SlickDataAccessSpec {
   val AllowFalse = Seq(webservice.QueryParameter("allow", "false"))
@@ -71,6 +72,7 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
     override val actorSystem = workflowManagerSystem.actorSystem
 
     override def adjustInputPaths(backendCall: BackendCall) = throw new NotImplementedError
+    override def adjustInputPaths(backendCallJobDescriptor: BackendCallJobDescriptor) = throw new NotImplementedError()
 
     override def adjustOutputPaths(call: Call, outputs: CallOutputs): CallOutputs = throw new NotImplementedError
     override def stdoutStderr(backendCall: BackendCall): CallLogs = throw new NotImplementedError
@@ -85,7 +87,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
     override def rootPath(workflowOptions: WorkflowOptions): String = throw new NotImplementedError
     override def pollBackoff: ExponentialBackOff = throw new NotImplementedError
     override def executionInfoKeys: List[String] = List.empty
-    override def callEngineFunctions(descriptor: BackendCallJobDescriptor): CallEngineFunctions = throw new NotImplementedError()
+    override def callEngineFunctions(descriptor: BackendCallJobDescriptor): CallEngineFunctions = throw new NotImplementedError
+    override def instantiateCommand(descriptor: BackendCallJobDescriptor): Try[String] = throw new NotImplementedError
   }
 
   "SlickDataAccess" should "not deadlock" in {


### PR DESCRIPTION
NB: This is my first "Move X out of Y" ticket and I wasn't 100% sure where to stop. 

So, I've augmented the `JobDescriptor` with everything new it needs, but left the remnant in BackendCall for now (which seems to be how the other tickets did things for now).

I've also set up for `runtimeAttributes` in `JobDescriptor` since I needed a placeholder but I haven't actually implemented it (that's now #535).

- [ ] Needs some more work to get runtimeAttributes in backend