### PR TITLE
Move WdlStandardLibraryImpl to backend package. Closes #506

### DIFF
--- a/engine/src/main/scala/cromwell/engine/WorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/WorkflowDescriptor.scala
@@ -10,7 +10,7 @@ import ch.qos.logback.core.FileAppender
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.engine.backend.io._
 import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes
-import cromwell.engine.backend.{Backend, BackendType, CromwellBackend}
+import cromwell.engine.backend._
 import cromwell.engine.workflow.WorkflowOptions
 import cromwell.logging.WorkflowLogger
 import cromwell.util.{SimpleExponentialBackoff, TryUtil}

--- a/engine/src/main/scala/cromwell/engine/backend/BackendCall.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/BackendCall.scala
@@ -1,7 +1,7 @@
 package cromwell.engine.backend
 
 import cromwell.engine.backend.runtimeattributes.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet, CromwellRuntimeAttributes}
-import cromwell.engine.{CallEngineFunctions, CallOutputs, ExecutionEventEntry, ExecutionHash}
+import cromwell.engine.{CallOutputs, ExecutionEventEntry, ExecutionHash}
 import wdl4s._
 import wdl4s.values._
 

--- a/engine/src/main/scala/cromwell/engine/backend/EngineFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/EngineFunctions.scala
@@ -1,4 +1,4 @@
-package cromwell.engine
+package cromwell.engine.backend
 
 import java.nio.file.FileSystem
 

--- a/engine/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/JobDescriptor.scala
@@ -1,6 +1,6 @@
 package cromwell.engine.backend
 
-import cromwell.engine.{CallEngineFunctions, WorkflowDescriptor}
+import cromwell.engine.WorkflowDescriptor
 import cromwell.engine.workflow.{BackendCallKey, CallKey, FinalCallKey}
 import cromwell.webservice.WorkflowMetadataResponse
 import wdl4s._

--- a/engine/src/main/scala/cromwell/engine/backend/WdlStandardLibraryImpl.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/WdlStandardLibraryImpl.scala
@@ -1,7 +1,8 @@
-package cromwell.engine
+package cromwell.engine.backend
 
 import java.nio.file.FileSystem
 
+import cromwell.engine.backend
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.parser.MemoryUnit
 import wdl4s.types._

--- a/engine/src/main/scala/cromwell/engine/backend/jes/JesEngineFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/jes/JesEngineFunctions.scala
@@ -1,12 +1,13 @@
 package cromwell.engine.backend.jes
 
 import java.nio.file.FileSystem
-import better.files._
-import cromwell.engine._
-import cromwell.engine.backend.io._
-import wdl4s.values._
-import scala.language.postfixOps
 
+import better.files._
+import cromwell.engine.backend.io._
+import cromwell.engine.backend.{CallContext, CallEngineFunctions, WorkflowContext, WorkflowEngineFunctions}
+import wdl4s.values._
+
+import scala.language.postfixOps
 import scala.util.Try
 class JesWorkflowEngineFunctions(fileSystems: List[FileSystem], context: WorkflowContext) extends WorkflowEngineFunctions(fileSystems, context) {
   override def globPath(glob: String): String = context.root.toAbsolutePath(fileSystems).resolve(JesBackend.globDirectory(glob)).toString

--- a/engine/src/main/scala/cromwell/engine/backend/local/LocalEngineFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/local/LocalEngineFunctions.scala
@@ -2,7 +2,8 @@ package cromwell.engine.backend.local
 
 import java.nio.file.FileSystem
 
-import cromwell.engine.{CallContext, CallEngineFunctions, WorkflowContext, WorkflowEngineFunctions, _}
+import cromwell.engine._
+import cromwell.engine.backend.{CallContext, CallEngineFunctions, WorkflowContext, WorkflowEngineFunctions}
 import wdl4s.values.WdlValue
 
 import scala.language.postfixOps

--- a/engine/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/local/SharedFileSystem.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import cromwell.engine.backend.{AttemptedLookupResult, CallLogs, LocalFileSystemBackendCall, _}
 import cromwell.engine.io.gcs.GcsPath
 import cromwell.engine.workflow.WorkflowOptions
-import cromwell.engine.{WorkflowContext, WorkflowDescriptor, WorkflowEngineFunctions, _}
+import cromwell.engine._
 import cromwell.util.TryUtil
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -42,7 +42,7 @@ object SharedFileSystem {
   }).+:(localizeFromGcs _)
 
   private def localizeFromGcs(originalPath: String, executionPath: Path, descriptor: WorkflowDescriptor): Try[Unit] = Try {
-    import backend.io._
+    import cromwell.engine.backend.io._
     assert(originalPath.isGcsUrl)
     originalPath.toAbsolutePath(descriptor.fileSystems).copyTo(executionPath)
   }
@@ -89,7 +89,7 @@ object SharedFileSystem {
 
 trait SharedFileSystem { self: Backend =>
   import SharedFileSystem._
-  import backend.io._
+  import cromwell.engine.backend.io._
 
   def useCachedCall(cachedBackendCall: LocalFileSystemBackendCall, backendCall: LocalFileSystemBackendCall)(implicit ec: ExecutionContext): Future[ExecutionHandle] = Future {
     val fileSystems = backendCall.workflowDescriptor.fileSystems
@@ -196,7 +196,7 @@ trait SharedFileSystem { self: Backend =>
    *    This is yuck-tastic and I consider this a FIXME, but not for this refactor
    */
   def adjustSharedInputPaths(backendCall: BackendCall): CallInputs = {
-    import backend.io._
+    import cromwell.engine.backend.io._
 
     val strategies = if (backendCall.runtimeAttributes.docker.isDefined) DockerLocalizers else Localizers
 

--- a/engine/src/main/scala/cromwell/engine/backend/package.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/package.scala
@@ -4,6 +4,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.immutable.Seq
 
 package object backend {
+  class WorkflowContext(val root: String)
+  class CallContext(override val root: String, val stdout: String, val stderr: String) extends WorkflowContext(root)
+
   // Ordered by shards, and then ordered by attempts
   type AttemptedCallLogs = Seq[Seq[CallLogs]]
   // Grouped by FQNS

--- a/engine/src/main/scala/cromwell/engine/backend/sge/SgeCallEngineFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/sge/SgeCallEngineFunctions.scala
@@ -2,7 +2,7 @@ package cromwell.engine.backend.sge
 
 import java.nio.file.FileSystem
 
-import cromwell.engine.CallContext
+import cromwell.engine.backend.CallContext
 import cromwell.engine.backend.local.LocalCallEngineFunctions
 
 class SgeCallEngineFunctions(fileSystems: List[FileSystem], callContext: CallContext) extends LocalCallEngineFunctions(fileSystems, callContext)

--- a/engine/src/main/scala/cromwell/engine/package.scala
+++ b/engine/src/main/scala/cromwell/engine/package.scala
@@ -12,9 +12,6 @@ import scalaz.ValidationNel
 
 package object engine {
 
-  class WorkflowContext(val root: String)
-  class CallContext(override val root: String, val stdout: String, val stderr: String) extends WorkflowContext(root)
-
   /**
    * Represents the collection of source files that a user submits to run a workflow
    */

--- a/engine/src/test/scala/engine/backend/CromwellRuntimeAttributeSpec.scala
+++ b/engine/src/test/scala/engine/backend/CromwellRuntimeAttributeSpec.scala
@@ -8,7 +8,7 @@ import cromwell.engine.backend.jes.{JesAttachedDisk, JesBackend, JesEmptyMounted
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.backend.runtimeattributes.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet, CromwellRuntimeAttributes, _}
 import cromwell.engine.workflow.BackendCallKey
-import cromwell.engine.{WorkflowContext, WorkflowDescriptor, WorkflowId}
+import cromwell.engine.{WorkflowDescriptor, WorkflowId}
 import cromwell.util.SampleWdl
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table

--- a/engine/src/test/scala/engine/backend/jes/JesBackendSpec.scala
+++ b/engine/src/test/scala/engine/backend/jes/JesBackendSpec.scala
@@ -7,12 +7,12 @@ import java.util.UUID
 import com.google.api.client.testing.http.{HttpTesting, MockHttpTransport, MockLowLevelHttpRequest, MockLowLevelHttpResponse}
 import cromwell.CromwellTestkitSpec
 import cromwell.engine._
+import cromwell.engine.backend._
 import cromwell.engine.backend.io.filesystem.gcs.{GcsFileSystem, NioGcsPath}
 import cromwell.engine.backend.jes.JesBackend.{JesFileInput, JesFileOutput}
 import cromwell.engine.backend.jes.Run.Failed
 import cromwell.engine.backend.jes.authentication._
 import cromwell.engine.backend.runtimeattributes.{CromwellRuntimeAttributes, DiskType}
-import cromwell.engine.backend.{AbortedExecutionHandle, BackendCallJobDescriptor, FailedExecutionHandle, RetryableExecutionHandle}
 import cromwell.engine.io.gcs._
 import cromwell.engine.workflow.{BackendCallKey, WorkflowOptions}
 import cromwell.util.{EncryptionSpec, SampleWdl}


### PR DESCRIPTION
And also `EngineFunctions`, `CallContext` and `WorkflowContext`