### PR TITLE
Making the Validate API endpoint use the new ValidateActor. Closes #489

### DIFF
--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -15,7 +15,7 @@ object CromwellServer extends WorkflowManagerSystem {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   val conf = ConfigFactory.load()
-  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf), "cromwell-service")
+  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, validateActor, conf), "cromwell-service")
   val webserviceConf = conf.getConfig("webservice")
 
   def run(): Future[Any] = {

--- a/engine/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
+++ b/engine/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
@@ -1,9 +1,9 @@
 package cromwell.server
 
-import akka.actor.ActorSystem
+import akka.actor.{Props, ActorSystem}
 import com.typesafe.config.ConfigFactory
 import cromwell.engine.backend.{Backend, CromwellBackend}
-import cromwell.engine.workflow.WorkflowManagerActor
+import cromwell.engine.workflow.{ValidateActor, WorkflowManagerActor}
 
 trait WorkflowManagerSystem {
   protected def systemName = "cromwell-system"
@@ -21,4 +21,5 @@ trait WorkflowManagerSystem {
   lazy val backend: Backend = CromwellBackend.initBackend(backendType, actorSystem)
   // For now there's only one WorkflowManagerActor so no need to dynamically name it
   lazy val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props(backend), "WorkflowManagerActor")
+  lazy val validateActor = actorSystem.actorOf(Props[ValidateActor], "ValidationActor")
 }

--- a/engine/src/test/scala/webservice/CromwellApiServiceIntegrationSpec.scala
+++ b/engine/src/test/scala/webservice/CromwellApiServiceIntegrationSpec.scala
@@ -3,7 +3,7 @@ package cromwell.webservice
 import akka.testkit.TestActorRef
 import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
 import cromwell.engine.backend.local.LocalBackend
-import cromwell.engine.workflow.WorkflowManagerActor
+import cromwell.engine.workflow.{ValidateActor, WorkflowManagerActor}
 import cromwell.util.SampleWdl.HelloWorld
 import org.scalatest.{FlatSpec, Matchers}
 import spray.http.{FormData, StatusCodes}
@@ -15,6 +15,7 @@ class CromwellApiServiceIntegrationSpec extends FlatSpec with CromwellApiService
   val testWorkflowManagerSystem = new TestWorkflowManagerSystem
   override def actorRefFactory = testWorkflowManagerSystem.actorSystem
   override val workflowManager = TestActorRef(new WorkflowManagerActor(new LocalBackend(actorRefFactory)))
+  override val validateActor = TestActorRef(new ValidateActor())
   val version = "v1"
 
   override protected def afterAll() = {

--- a/engine/src/test/scala/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/webservice/CromwellApiServiceSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import akka.actor.{Actor, Props}
 import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
 import cromwell.engine.backend.{CallLogs, WorkflowQueryResult}
+import cromwell.engine.workflow.ValidateActor
 import cromwell.engine.workflow.WorkflowManagerActor.{CallCaching, CallOutputs, CallStdoutStderr, WorkflowAbort, WorkflowOutputs, WorkflowQuery, WorkflowStatus, WorkflowStdoutStderr, _}
 import cromwell.engine.{CallOutput, _}
 import cromwell.util.SampleWdl.HelloWorld
@@ -229,6 +230,7 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   val testWorkflowManagerSystem = new TestWorkflowManagerSystem
   override def actorRefFactory = testWorkflowManagerSystem.actorSystem
   override val workflowManager = actorRefFactory.actorOf(Props(new MockWorkflowManagerActor()))
+  override val validateActor = actorRefFactory.actorOf(Props(new ValidateActor()))
   val version = "v1"
 
   s"CromwellApiService $version" should "return 404 for get of unknown workflow" in {


### PR DESCRIPTION
CromwellApiHandler now uses a ValidateActor to validate a WF received via the API endpoint