### PR TITLE
Add call caching information to metadata endpoint.  Closes #559

### DIFF
--- a/engine/src/main/scala/cromwell/engine/backend/CallMetadata.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/CallMetadata.scala
@@ -1,8 +1,9 @@
 package cromwell.engine.backend
 
-import wdl4s.values.{WdlFile, WdlValue}
-import cromwell.engine.{FailureEventEntry, ExecutionEventEntry}
+import cromwell.engine.workflow.CallCacheData
+import cromwell.engine.{ExecutionEventEntry, FailureEventEntry}
 import org.joda.time.DateTime
+import wdl4s.values.{WdlFile, WdlValue}
 
 case class CallMetadata(inputs: Map[String, WdlValue],
                         executionStatus: String,
@@ -21,4 +22,5 @@ case class CallMetadata(inputs: Map[String, WdlValue],
                         attempt: Int,
                         runtimeAttributes: Map[String, String],
                         preemptible: Option[Boolean],
+                        cache: Option[CallCacheData],
                         failures: Option[Seq[FailureEventEntry]])

--- a/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -143,4 +143,6 @@ trait DataAccess extends AutoCloseable {
   def updateCallCaching(cachingParameters: CallCachingParameters)(implicit ec: ExecutionContext): Future[Int]
 
   def infosByExecution(id: WorkflowId)(implicit ec: ExecutionContext): Future[Traversable[ExecutionInfosByExecution]]
+
+  def callCacheDataByExecution(id: WorkflowId)(implicit ec: ExecutionContext): Future[Traversable[ExecutionWithCacheData]]
 }

--- a/engine/src/main/scala/cromwell/engine/db/slick/ExecutionInfoComponent.scala
+++ b/engine/src/main/scala/cromwell/engine/db/slick/ExecutionInfoComponent.scala
@@ -5,7 +5,6 @@ case class ExecutionInfo(executionId: Int,
                          value: Option[String] = None,
                          executionInfoId: Option[Int] = None)
 
-case class ExecutionAndExecutionInfo(execution: Execution, executionInfo: ExecutionInfo)
 case class ExecutionInfosByExecution(execution: Execution, executionInfos: Seq[ExecutionInfo])
 
 trait ExecutionInfoComponent {

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataBuilder.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataBuilder.scala
@@ -119,6 +119,7 @@ object WorkflowMetadataBuilder {
                                     infosByExecution: Traversable[ExecutionInfosByExecution],
                                     runtimeAttributes: Map[ExecutionDatabaseKey, Map[String, String]],
                                     executionEvents: Map[ExecutionDatabaseKey, Seq[ExecutionEventEntry]],
+                                    cacheData: Traversable[ExecutionWithCacheData],
                                     failures: Seq[QualifiedFailureEventEntry]):
   WorkflowMetadataResponse = {
     val nonFinalEvents = executionEvents.filterKeys(!_.fqn.isFinalCall)
@@ -133,7 +134,7 @@ object WorkflowMetadataBuilder {
     val engineWorkflowOutputs = SymbolStoreEntry.toWorkflowOutputs(workflowOutputs)
     val callStandardStreamsMap = workflowStdoutStderr(id, backend, workflowDescriptor, nonFinalStatuses)
     val callMetadata = CallMetadataBuilder.build(nonFinalInfosByExecution, callStandardStreamsMap, callInputs,
-      callOutputs, nonFinalEvents, runtimeAttributes, callFailures)
+      callOutputs, nonFinalEvents, runtimeAttributes, cacheData, callFailures)
     buildWorkflowMetadata(workflowExecution, workflowExecutionAux, engineWorkflowOutputs, callMetadata, wfFailures)
   }
 
@@ -154,6 +155,7 @@ object WorkflowMetadataBuilder {
       callInputs <- globalDataAccess.getAllInputs(id)
       callOutputs <- globalDataAccess.getAllOutputs(id)
       infosByExecution <- globalDataAccess.infosByExecution(id)
+      callCacheData <- globalDataAccess.callCacheDataByExecution(id)
       runtimeAttributes <- globalDataAccess.getAllRuntimeAttributes(id)
       executionEvents <- globalDataAccess.getAllExecutionEvents(id)
       failures <- globalDataAccess.getFailureEvents(id)
@@ -170,6 +172,7 @@ object WorkflowMetadataBuilder {
       infosByExecution,
       runtimeAttributes,
       executionEvents,
+      callCacheData,
       failures)
   }
 }

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -1,10 +1,11 @@
 package cromwell.webservice
 
-import WdlFileJsonFormatter._
-import WdlValueJsonFormatter._
-import cromwell.engine.db.ExecutionDatabaseKey
 import cromwell.engine._
-import cromwell.engine.backend.{WorkflowQueryResult, CallMetadata, CallLogs}
+import cromwell.engine.backend.{CallLogs, CallMetadata, WorkflowQueryResult}
+import cromwell.engine.db.ExecutionDatabaseKey
+import cromwell.engine.workflow.CallCacheData
+import cromwell.webservice.WdlFileJsonFormatter._
+import cromwell.webservice.WdlValueJsonFormatter._
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
@@ -37,7 +38,8 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val unqualifiedFailureEventEntry = jsonFormat2(FailureEventEntry)
   implicit val qualifiedFailureEventEntry = jsonFormat4(QualifiedFailureEventEntry)
   implicit val executionEventProtocol = jsonFormat3(ExecutionEventEntry)
-  implicit val callMetadataProtocol = jsonFormat18(CallMetadata)
+  implicit val callCacheHitProtocol = jsonFormat3(CallCacheData)
+  implicit val callMetadataProtocol = jsonFormat19(CallMetadata)
   implicit val workflowMetadataResponse = jsonFormat10(WorkflowMetadataResponse)
   implicit val workflowFailuresResponse = jsonFormat4(WorkflowFailuresResponse)
   implicit val workflowQueryResult = jsonFormat5(WorkflowQueryResult)

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -218,7 +218,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
     WorkflowDescriptor(WorkflowId(uuid), workflowSources, backend)
   }
 
-  private def buildWorkflowManagerActor(sampleWdl: SampleWdl, runtime: String, config: Config) = {
+  private def buildWorkflowManagerActor(config: Config) = {
     TestActorRef(new WorkflowManagerActor(config))
   }
 
@@ -242,7 +242,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
              runtime: String = "",
              terminalState: WorkflowState = WorkflowSucceeded,
              config: Config = WorkflowManagerActor.defaultConfig)(implicit ec: ExecutionContext): WorkflowOutputs = {
-    val wma = buildWorkflowManagerActor(sampleWdl, runtime, config)
+    val wma = buildWorkflowManagerActor(config)
     val sources = WorkflowSourceFiles(sampleWdl.wdlSource(runtime), sampleWdl.wdlJson, "{}")
     eventFilter.intercept {
       within(timeoutDuration) {
@@ -260,9 +260,10 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
                              workflowOptions: String = "{}",
                              allowOtherOutputs: Boolean = true,
                              terminalState: WorkflowState = WorkflowSucceeded,
-                             config: Config = WorkflowManagerActor.defaultConfig)
+                             config: Config = WorkflowManagerActor.defaultConfig,
+                             workflowManagerActor: Option[TestActorRef[WorkflowManagerActor]] = None)
                             (implicit ec: ExecutionContext): WorkflowId = {
-    val workflowManager = buildWorkflowManagerActor(sampleWdl, runtime, config)
+    val workflowManager = workflowManagerActor.getOrElse(buildWorkflowManagerActor(config))
     val sources = sampleWdl.asWorkflowSources(runtime, workflowOptions)
     eventFilter.intercept {
       within(timeoutDuration) {
@@ -352,7 +353,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
                                   stderr: Option[Seq[String]] = None,
                                   config: Config = WorkflowManagerActor.defaultConfig)
                                  (implicit ec: ExecutionContext) = {
-    val actor = buildWorkflowManagerActor(sampleWdl, runtime, config)
+    val actor = buildWorkflowManagerActor(config)
     val sources = WorkflowSourceFiles(sampleWdl.wdlSource(runtime), sampleWdl.wdlJson, "{}")
     runSingleCallWdlWithWorkflowManagerActor(actor, sources, eventFilter, fqn, index, stdout, stderr)
   }
@@ -365,7 +366,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
                                           terminalState: WorkflowState = WorkflowSucceeded,
                                           config: Config = WorkflowManagerActor.defaultConfig)
                                          (implicit ec: ExecutionContext) = {
-    val actor = buildWorkflowManagerActor(sampleWdl, runtime, config)
+    val actor = buildWorkflowManagerActor(config)
     val workflowSources = WorkflowSourceFiles(sampleWdl.wdlSource(runtime), sampleWdl.wdlJson, "{}")
     runWdlWithWorkflowManagerActor(actor, workflowSources, eventFilter, stdout, stderr, Map.empty, terminalState)
   }

--- a/engine/src/test/scala/cromwell/engine/WorkflowDescriptorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowDescriptorSpec.scala
@@ -5,16 +5,14 @@ import java.nio.file.{Files, Paths}
 import better.files._
 import com.typesafe.config.ConfigFactory
 import cromwell.CromwellTestkitSpec
-import cromwell.engine.backend.io._
 import cromwell.engine.backend.CallMetadata
+import cromwell.engine.backend.io._
 import cromwell.util.SampleWdl
 import cromwell.webservice.WorkflowMetadataResponse
 import org.joda.time.DateTime
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
-import org.scalatest.time.SpanSugar._
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 import spray.json.JsObject
@@ -157,24 +155,25 @@ class WorkflowDescriptorSpec extends FlatSpec with Matchers with ScalaFutures {
     val calls = Seq("call-A", "call-B").map({
       case call =>
         val metadata = CallMetadata(
-          Map.empty,
-          ExecutionStatus.Done.toString,
-          None,
-          None,
-          None,
-          None,
-          None,
-          None,
-          None,
-          0,
-          Option(workflowFile(descriptor, s"$call/stdout")),
-          Option(workflowFile(descriptor, s"$call/stderr")),
-          if (call == "call-A") Option(Map("backendLog" -> workflowFile(descriptor, s"$call/backendout"))) else None,
-          Seq.empty,
-          1,
-          Map.empty,
-          None,
-          None)
+          inputs=Map.empty,
+          executionStatus=ExecutionStatus.Done.toString,
+          backend=None,
+          backendStatus=None,
+          outputs=None,
+          start=None,
+          end=None,
+          jobId=None,
+          returnCode=None,
+          shardIndex=0,
+          stdout=Option(workflowFile(descriptor, s"$call/stdout")),
+          stderr=Option(workflowFile(descriptor, s"$call/stderr")),
+          backendLogs=if (call == "call-A") Option(Map("backendLog" -> workflowFile(descriptor, s"$call/backendout"))) else None,
+          executionEvents=Seq.empty,
+          attempt=1,
+          runtimeAttributes=Map.empty,
+          preemptible=None,
+          cache=None,
+          failures=None)
         call -> Seq(metadata)
     }).toMap
 

--- a/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -6,8 +6,8 @@ import akka.testkit.{EventFilter, TestActorRef, _}
 import cromwell.CromwellSpec.DockerTest
 import cromwell.CromwellTestkitSpec._
 import cromwell.engine.ExecutionStatus.{NotStarted, Running}
-import cromwell.engine.backend.{CallMetadata, Backend}
 import cromwell.engine.backend.local.LocalBackend
+import cromwell.engine.backend.{Backend, CallMetadata}
 import cromwell.engine.db.DataAccess._
 import cromwell.engine.db.ExecutionDatabaseKey
 import cromwell.engine.workflow.WorkflowManagerActor


### PR DESCRIPTION
see `calls['w.x']['cache']` and `calls['w.y']['cache']`:

```json
HTTP/1.1 200 OK
Content-Length: 2056
Content-Type: application/json; charset=UTF-8
Date: Wed, 23 Mar 2016 13:22:35 GMT
Server: spray-can/1.3.2

{
    "calls": {
        "w.x": [
            {
                "attempt": 1,
                "backend": "Local",
                "cache": {
                    "allowResultReuse": true
                },
                "end": "2016-03-23T09:22:30.000-04:00",
                "executionEvents": [],
                "executionStatus": "Done",
                "inputs": {
                    "s": "foo"
                },
                "outputs": {
                    "t": "foo"
                },
                "returnCode": 0,
                "runtimeAttributes": {
                    "continueOnReturnCode": "0",
                    "docker": "ubuntu:latest",
                    "failOnStderr": "false"
                },
                "shardIndex": -1,
                "start": "2016-03-23T09:22:28.000-04:00",
                "stderr": "/Users/sfrazer/projects/cromwell/cromwell-executions/w/d21f9706-0d85-4859-af96-cb58b6913085/call-x/stderr",
                "stdout": "/Users/sfrazer/projects/cromwell/cromwell-executions/w/d21f9706-0d85-4859-af96-cb58b6913085/call-x/stdout"
            }
        ],
        "w.y": [
            {
                "attempt": 1,
                "backend": "Local",
                "cache": {
                    "allowResultReuse": true,
                    "cacheHitCall": "w.x",
                    "cacheHitWorkflow": "d21f9706-0d85-4859-af96-cb58b6913085"
                },
                "end": "2016-03-23T09:22:30.000-04:00",
                "executionEvents": [],
                "executionStatus": "Done",
                "inputs": {
                    "s": "foo"
                },
                "outputs": {
                    "t": "foo"
                },
                "returnCode": 0,
                "runtimeAttributes": {
                    "continueOnReturnCode": "0",
                    "docker": "ubuntu:latest",
                    "failOnStderr": "false"
                },
                "shardIndex": -1,
                "start": "2016-03-23T09:22:30.000-04:00",
                "stderr": "/Users/sfrazer/projects/cromwell/cromwell-executions/w/d21f9706-0d85-4859-af96-cb58b6913085/call-y/stderr",
                "stdout": "/Users/sfrazer/projects/cromwell/cromwell-executions/w/d21f9706-0d85-4859-af96-cb58b6913085/call-y/stdout"
            }
        ]
    },
    "end": "2016-03-23T09:22:31.000-04:00",
    "id": "d21f9706-0d85-4859-af96-cb58b6913085",
    "inputs": {},
    "outputs": {
        "w.x.t": "foo",
        "w.y.t": "foo"
    },
    "start": "2016-03-23T09:22:28.000-04:00",
    "status": "Succeeded",
    "submission": "2016-03-23T09:22:28.000-04:00",
    "workflowName": "w"
}
```