### PR TITLE
Refactored DataAccess retries.

### DIFF
--- a/engine/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -1072,6 +1072,8 @@ class SlickDataAccessSpec extends FlatSpec with Matchers with ScalaFutures with 
       } yield ()).failed.futureValue should be(a[NoSuchElementException])
     }
 
+    // TODO: Still need a test that consistently reproduces the deadlock exception when we do NOT retry.
+    // TODO: We also don't have a unit test for our withRetry.
     it should "not deadlock with upserts" taggedAs DbmsTest in {
       assume(canConnect || testRequired)
 


### PR DESCRIPTION
Extracted the retries out of SlickDataAccess.
Having trouble producing a true positive deadlock test that this code fixes, so left that out and moving on for now.