### PR TITLE
Processing messages in the Shadow Hierarchy. Closes #692. Closes #648.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -30,7 +30,7 @@ object BackendWorkflowInitializationActor {
   */
 trait BackendWorkflowInitializationActor extends BackendLifecycleActor with ActorLogging {
 
-  def receive: Receive = LoggingReceive {
+  final def receive: Receive = LoggingReceive {
     case Initialize    => performActionThenRespond(initSequence, onFailure = InitializationFailed)
     case AbortWorkflow => performActionThenRespond(abortInitialization, onFailure = BackendWorkflowAbortFailedResponse)
   }

--- a/backend/src/main/scala/cromwell/backend/package.scala
+++ b/backend/src/main/scala/cromwell/backend/package.scala
@@ -27,7 +27,9 @@ package object backend {
     */
   case class BackendJobDescriptor(descriptor: BackendWorkflowDescriptor,
                                   key: BackendJobDescriptorKey,
-                                  symbolMap: Map[FullyQualifiedName, WdlValue])
+                                  symbolMap: Map[FullyQualifiedName, WdlValue]) {
+    val call = key.call
+  }
 
   /**
     * For passing to a BackendActor construction time

--- a/engine/src/main/scala/cromwell/engine/backend/dummy/DummyBackendJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/dummy/DummyBackendJobExecutionActor.scala
@@ -1,0 +1,46 @@
+package cromwell.engine.backend.dummy
+
+import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionSucceededResponse, BackendJobExecutionResponse}
+import cromwell.backend.BackendLifecycleActor.{BackendJobExecutionAbortSucceededResponse, JobAbortResponse}
+import cromwell.backend._
+import cromwell.core.CallOutput
+import wdl4s.types._
+import wdl4s.values._
+import wdl4s.{TaskOutput, Call}
+
+import scala.concurrent.Future
+
+case class DummyBackendJobExecutionActor(workflowDescriptor: BackendWorkflowDescriptor, configurationDescriptor: BackendConfigurationDescriptor, calls: Seq[Call]) extends BackendJobExecutionActor {
+  /**
+    * Execute a new job.
+    */
+  override def execute(jobDescriptor: BackendJobDescriptor): Future[BackendJobExecutionResponse] = {
+    val outputs = (jobDescriptor.call.task.outputs map taskOutputToJobOutput _).toMap
+    Future.successful(BackendJobExecutionSucceededResponse(jobDescriptor.key, outputs))
+  }
+
+  private def taskOutputToJobOutput(taskOutput: TaskOutput) =
+    taskOutput.name -> CallOutput(sampleValue(taskOutput.wdlType), None)
+
+  private def sampleValue(wdlType: WdlType): WdlValue = wdlType match {
+    case WdlIntegerType => WdlInteger(3)
+    case WdlFloatType => WdlFloat(55.55)
+    case WdlStringType => WdlString("The rain in Spain falls mainly in the plain")
+    case WdlBooleanType => WdlBoolean(true)
+    case WdlFileType => WdlFile("/root/of/all/evil")
+    case WdlArrayType(memberType) => WdlArray(WdlArrayType(memberType), List(sampleValue(memberType)))
+    case WdlObjectType => WdlObject(Map("a" -> WdlString("1"), "b" -> WdlString("2")))
+    case WdlMapType(keyType, valueType) => WdlMap(WdlMapType(keyType, valueType), Map(sampleValue(keyType) -> sampleValue(valueType)))
+  }
+
+  /**
+    * Restart or resume a previously-started job.
+    */
+  override def recover(jobDescriptor: BackendJobDescriptor) = execute(jobDescriptor)
+
+  /**
+    * Abort a running job.
+    */
+  override def abortJob(jobKey: BackendJobDescriptorKey): Future[JobAbortResponse] = Future.successful(BackendJobExecutionAbortSucceededResponse(jobKey))
+
+}

--- a/engine/src/main/scala/cromwell/engine/package.scala
+++ b/engine/src/main/scala/cromwell/engine/package.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import akka.actor.ActorSystem
+import cromwell.backend.BackendWorkflowDescriptor
 import cromwell.core.{CallOutput, WorkflowId}
 import cromwell.engine.ExecutionStatus._
 import cromwell.engine.backend.WorkflowDescriptor
@@ -98,5 +99,13 @@ package object engine {
     } andThen {
       case _ => actorSystem.stop(materializeWorkflowDescriptorActor)
     }
+  }
+
+  final case class EngineWorkflowDescriptor(backendDescriptor: BackendWorkflowDescriptor,
+                                            declarations: WorkflowCoercedInputs,
+                                            backendAssignments: Map[Call, String],
+                                            failureMode: WorkflowFailureMode) {
+    def id = backendDescriptor.id
+    def namespace = backendDescriptor.workflowNamespace
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/ShadowWorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/ShadowWorkflowManagerActor.scala
@@ -1,0 +1,235 @@
+package cromwell.engine.workflow
+
+import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
+import akka.actor._
+import akka.event.Logging
+import com.typesafe.config.{Config, ConfigFactory}
+import cromwell.core.WorkflowId
+import cromwell.engine._
+import cromwell.engine.backend._
+import cromwell.engine.db.DataAccess._
+import cromwell.engine.workflow.ShadowWorkflowActor._
+import cromwell.engine.workflow.ShadowWorkflowManagerActor.AbortWorkflowCommand
+import cromwell.engine.workflow.ShadowWorkflowManagerActor._
+import cromwell.webservice.CromwellApiHandler._
+import lenthall.config.ScalaConfig.EnhancedScalaConfig
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+import scala.language.postfixOps
+
+object ShadowWorkflowManagerActor {
+
+  case class WorkflowIdToActorRef(workflowId: WorkflowId, workflowActor: ActorRef)
+
+  sealed trait ShadowWorkflowManagerActorMessage
+  /**
+    * Commands
+    */
+  sealed trait ShadowWorkflowManagerActorCommand extends ShadowWorkflowManagerActorMessage
+
+  case class SubmitWorkflowCommand(source: WorkflowSourceFiles) extends ShadowWorkflowManagerActorCommand
+  case class AbortWorkflowCommand(id: WorkflowId) extends ShadowWorkflowManagerActorCommand
+  case object AbortAllWorkflowsCommand extends ShadowWorkflowManagerActorCommand
+  private[ShadowWorkflowManagerActor] final case class RestartWorkflowsCommand(workflows: Seq[WorkflowDescriptor]) extends ShadowWorkflowManagerActorCommand
+
+  /**
+    * Responses
+    */
+  sealed trait ShadowWorkflowManagerActorResponse extends ShadowWorkflowManagerActorMessage
+  // None yet?
+
+  def props(): Props = Props(new ShadowWorkflowManagerActor())
+
+  /**
+    * States
+    */
+  sealed trait ShadowWorkflowManagerState
+  case object Running extends ShadowWorkflowManagerState
+  case object Aborting extends ShadowWorkflowManagerState
+  case object Done extends ShadowWorkflowManagerState
+
+  /**
+    * Data
+    */
+  case class ShadowWorkflowManagerData(workflows: Map[WorkflowId, ActorRef]) {
+    def idFromActor(actor: ActorRef): Option[WorkflowId] =
+      workflows.collectFirst { case (id, a) if a == actor => id }
+    def withAddition(entry: WorkflowIdToActorRef): ShadowWorkflowManagerData =
+      this.copy(workflows = workflows + (entry.workflowId -> entry.workflowActor))
+    def without(id: WorkflowId): ShadowWorkflowManagerData =
+      this.copy(workflows = workflows - id)
+    def without(actor: ActorRef): ShadowWorkflowManagerData = {
+      // If the ID was found in the lookup return a modified copy of the state data, otherwise just return
+      // the same state data.
+      idFromActor(actor) map without getOrElse this
+    }
+  }
+
+  lazy val defaultConfig = ConfigFactory.load
+}
+
+class ShadowWorkflowManagerActor(config: Config)
+  extends LoggingFSM[ShadowWorkflowManagerState, ShadowWorkflowManagerData] with CromwellActor {
+
+  def this() = this(ShadowWorkflowManagerActor.defaultConfig)
+  implicit val actorSystem = context.system
+
+  private val RestartDelay: FiniteDuration = 200 milliseconds
+  private val logger = Logging(context.system, this)
+  private val tag = self.path.name
+
+  private val donePromise = Promise[Unit]()
+
+  override def preStart() {
+    addShutdownHook()
+    restartIncompleteWorkflows()
+  }
+
+  private def addShutdownHook(): Unit = {
+    // Only abort jobs on SIGINT if the config explicitly sets backend.abortJobsOnTerminate = true.
+    val abortJobsOnTerminate =
+      config.getConfig("backend").getBooleanOr("abortJobsOnTerminate", default = false)
+
+    if (abortJobsOnTerminate) {
+      sys.addShutdownHook {
+        logger.info(s"$tag: Received shutdown signal. Aborting all running workflows...")
+        self ! AbortAllWorkflowsCommand
+        Await.ready(donePromise.future, Duration.Inf)
+      }
+    }
+  }
+
+  startWith(Running, ShadowWorkflowManagerData(workflows = Map.empty))
+
+  when (Running) {
+    /*
+     Commands from clients
+     */
+    case Event(SubmitWorkflowCommand(source), stateData) =>
+      val updatedEntry = submitWorkflow(source, replyTo = Option(sender), id = None)
+      // Submit success brought in from the Cromwell API handler
+      sender ! WorkflowManagerSubmitSuccess(updatedEntry.workflowId)
+      stay() using stateData.withAddition(updatedEntry)
+    case Event(AbortWorkflowCommand(id), stateData) =>
+      val workflowActor = stateData.workflows.get(id)
+      workflowActor match {
+        case Some(actor) =>
+          // TODO: This case needs implementing
+          sender ! WorkflowManagerAbortFailure(id, new NotImplementedError(s"Couldn't abort $id because abort is missing"))
+          stay()
+        case None =>
+          sender ! WorkflowManagerAbortFailure(id, new NotImplementedError(s"Couldn't abort $id because no workflow with that ID is in progress"))
+          stay()
+      }
+    case Event(AbortAllWorkflowsCommand, data) if data.workflows.isEmpty =>
+      goto(Done)
+    case Event(AbortAllWorkflowsCommand, data) =>
+      data.workflows.values.foreach { _ ! WorkflowActor.AbortWorkflow }
+      goto(Aborting)
+    /*
+     Internal commands
+     */
+    case Event(RestartWorkflowsCommand(w :: ws), stateData) =>
+      val updatedEntry = restartWorkflow(w)
+      context.system.scheduler.scheduleOnce(RestartDelay) { self ! RestartWorkflowsCommand(ws) }
+      stay() using stateData.withAddition(updatedEntry)
+    case Event(RestartWorkflowsCommand(Nil), _) =>
+      // No more workflows need restarting.
+      stay()
+    /*
+     Responses from services
+     */
+    case Event(ShadowWorkflowSucceededResponse(workflowId, outputs), data) =>
+      log.info(s"Workflow $workflowId succeeded!")
+      stay()
+    case Event(ShadowWorkflowFailedResponse(workflowId, inState, reasons), data) =>
+      log.error(s"Workflow $workflowId failed (during $inState): ${reasons.mkString("\n")}")
+      stay()
+    /*
+     Watched transitions
+     */
+    case Event(Transition(workflowActor, _, toState: ShadowWorkflowActorTerminalState), data) =>
+      log.info(workflowActor.path.name + "has gone terminal")
+      stay using data.without(workflowActor)
+  }
+
+  when (Aborting) {
+    case Event(Transition(workflowActor, _, toState: WorkflowState), data) if toState.isTerminal =>
+      // Remove this terminal actor from the workflowStore and log a progress message.
+      val updatedData = data.without(workflowActor)
+      logger.info(s"$tag: Waiting for all workflows to abort (${updatedData.workflows.size} remaining).")
+      // If there are no more workflows to abort we're done, otherwise just stay in the current state.
+      (if (updatedData.workflows.isEmpty) goto(Done) else stay()) using updatedData
+  }
+
+  when (Done) { FSM.NullFunction }
+
+  whenUnhandled {
+    // Uninteresting transition and current state notifications.
+    case Event((Transition(_, _, _) | CurrentState(_, _)), _) => stay()
+    // Anything else certainly IS interesting:
+    case Event(unhandled, data) =>
+      log.warning(s"$tag: Unhandled message: $unhandled")
+      stay()
+  }
+
+  onTransition {
+    case _ -> Done =>
+      logger.info(s"$tag: All workflows aborted.")
+      donePromise.trySuccess(())
+    case fromState -> toState =>
+      logger.info(s"$tag transitioning from $fromState to $toState")
+  }
+
+
+  /** Submit the workflow and return an updated copy of the state data reflecting the addition of a
+    * Workflow ID -> WorkflowActorRef entry.
+    */
+  private def submitWorkflow(source: WorkflowSourceFiles, replyTo: Option[ActorRef], id: Option[WorkflowId]): WorkflowIdToActorRef = {
+    val workflowId: WorkflowId = id.getOrElse(WorkflowId.randomId())
+    logger.info(s"$tag submitWorkflow input id = $id, effective id = $workflowId")
+    val isRestart = id.isDefined
+
+    val startMode = if (isRestart) RestartExistingWorkflow else StartNewWorkflow
+    val wfActor = context.actorOf(ShadowWorkflowActor.props(workflowId, startMode, source, config), name = s"WorkflowActor-$workflowId")
+    replyTo.foreach { _ ! WorkflowManagerSubmitSuccess(id = workflowId) }
+    wfActor ! SubscribeTransitionCallBack(self)
+    wfActor ! StartWorkflowCommand
+    logger.info(s"Successfuly started ${wfActor.path} for Workflow $workflowId")
+    WorkflowIdToActorRef(workflowId, wfActor)
+  }
+
+  private def restartWorkflow(restartableWorkflow: WorkflowDescriptor): WorkflowIdToActorRef = {
+    logger.info("Invoking restartableWorkflow on " + restartableWorkflow.id.shortString)
+    submitWorkflow(restartableWorkflow.sourceFiles, replyTo = None, Option(restartableWorkflow.id))
+  }
+
+  private def restartIncompleteWorkflows(): Unit = {
+    def logRestarts(restartableWorkflows: Traversable[WorkflowDescriptor]): Unit = {
+      val num = restartableWorkflows.size
+      val displayNum = if (num == 0) "no" else num.toString
+      val plural = if (num == 1) "" else "s"
+
+      logger.info(s"$tag Found $displayNum workflow$plural to restart.")
+
+      if (num > 0) {
+        val ids = restartableWorkflows.map { _.id.toString }.toSeq.sorted
+        logger.info(s"$tag Restarting workflow ID$plural: " + ids.mkString(", "))
+      }
+    }
+
+    // TODO: This floating Future is awkward in an actor method. I would like to move all of this out into a WorkflowRestarterActor
+    val result = for {
+      restartableWorkflowExecutionAndAuxes <- globalDataAccess.getWorkflowExecutionAndAuxByState(Seq(WorkflowSubmitted, WorkflowRunning))
+      restartableWorkflows <- Future.sequence(restartableWorkflowExecutionAndAuxes map workflowDescriptorFromExecutionAndAux)
+      _ = logRestarts(restartableWorkflows)
+      _ = self ! RestartWorkflowsCommand(restartableWorkflows.toSeq)
+    } yield ()
+
+    result recover {
+      case e: Throwable => logger.error(e, e.getMessage)
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowFinalizationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowFinalizationActor.scala
@@ -1,33 +1,31 @@
 package cromwell.engine.workflow.lifecycle
 
-import akka.actor.{Props, ActorRef, LoggingFSM}
+import akka.actor.{Props, ActorRef}
 import cromwell.backend.BackendWorkflowFinalizationActor.{FinalizationFailed, FinalizationSuccess, Finalize}
+import cromwell.core.WorkflowId
+import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.workflow.lifecycle.WorkflowFinalizationActor._
+import cromwell.engine.workflow.lifecycle.WorkflowLifecycleActor._
 import wdl4s.Call
+
+import scala.language.postfixOps
 
 object WorkflowFinalizationActor {
 
   /**
     * States
     */
-  sealed trait WorkflowFinalizationActorState { def terminal = false }
-  sealed trait WorkflowFinalizationActorTerminalState extends WorkflowFinalizationActorState { override def terminal = true }
+  sealed trait WorkflowFinalizationActorState extends WorkflowLifecycleActorState
+  sealed trait WorkflowFinalizationActorTerminalState extends WorkflowFinalizationActorState
   case object ReadyToFinalize extends WorkflowFinalizationActorState
-  case object EngineFinalizing extends WorkflowFinalizationActorState
-  case object EngineFinalizationSucceededState extends WorkflowFinalizationActorTerminalState
-  case object EngineFinalizationFailedState extends WorkflowFinalizationActorTerminalState
-  case object EngineFinalizationAbortedState extends WorkflowFinalizationActorTerminalState
+  case object WorkflowFinalizing extends WorkflowFinalizationActorState
+  case object WorkflowFinalizationSucceededState extends WorkflowFinalizationActorTerminalState
+  case object WorkflowFinalizationFailedState extends WorkflowFinalizationActorTerminalState
+  case object WorkflowFinalizationAbortedState extends WorkflowFinalizationActorTerminalState
 
-  /**
-    * State data:
-    *
-    * @param finalizationActors The mapping from ActorRef to the name of the backend which that actor is finalizing.
-    * @param successes The list of successful initializations
-    * @param failures The map from ActorRef to the reason why that initialization failed.
-    */
-  final case class WorkflowFinalizationActorData(finalizationActors: Map[ActorRef, String],
-                                                       successes: Seq[ActorRef],
-                                                       failures: Map[ActorRef, Throwable])
+  final case class WorkflowFinalizationActorData(backendActors: Map[ActorRef, String],
+                                                 successes: Seq[ActorRef],
+                                                 failures: Map[ActorRef, Throwable]) extends WorkflowLifecycleActorData
 
   /**
     * Commands
@@ -39,80 +37,72 @@ object WorkflowFinalizationActor {
   /**
     * Responses
     */
-  sealed trait WorkflowFinalizationActorResponse
-  case object WorkflowFinalizationSucceededResponse extends WorkflowFinalizationActorResponse
-  case object WorkflowFinalizationAbortedResponse extends WorkflowFinalizationActorResponse
-  final case class WorkflowFinalizationFailedResponse(reasons: Seq[Throwable]) extends WorkflowFinalizationActorResponse
+  case object WorkflowFinalizationSucceededResponse extends WorkflowLifecycleSuccessResponse
+  case object WorkflowFinalizationAbortedResponse extends WorkflowLifecycleAbortedResponse
+  final case class WorkflowFinalizationFailedResponse(reasons: Seq[Throwable]) extends WorkflowLifecycleFailureResponse
 
-  def props(workflowTag: String, backendAssignments: Map[Call, String]): Props = Props(new WorkflowFinalizationActor(workflowTag, backendAssignments))
+  def props(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor): Props = Props(new WorkflowFinalizationActor(workflowId, workflowDescriptor))
 
 }
 
-case class WorkflowFinalizationActor(workflowTag: String, backendsToFinalize: Map[Call, String]) extends LoggingFSM[WorkflowFinalizationActorState, WorkflowFinalizationActorData] {
+case class WorkflowFinalizationActor(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor) extends WorkflowLifecycleActor[WorkflowFinalizationActorState, WorkflowFinalizationActorData] {
 
-  val tag = s"$workflowTag finalizer"
+  val tag = self.path.name
+  val backendAssignments = workflowDescriptor.backendAssignments
+
+  override val successState = WorkflowFinalizationSucceededState
+  override val failureState = WorkflowFinalizationFailedState
+  override val abortedState = WorkflowFinalizationAbortedState
+
+  override val successResponse = WorkflowFinalizationSucceededResponse
+  override def failureResponse(reasons: Seq[Throwable]) = WorkflowFinalizationFailedResponse(reasons)
+
   startWith(ReadyToFinalize, WorkflowFinalizationActorData(Map.empty, List.empty, Map.empty))
 
   when(ReadyToFinalize) {
     case Event(StartEngineFinalizationCommand, _) =>
       // Create each FinalizationActor with the list of calls which ere assigned to that backend.
-      val backendInitializationActors = backendWorkflowFinalizationActors
-      backendInitializationActors.keys foreach { _ ! Finalize }
-      goto(EngineFinalizing) using WorkflowFinalizationActorData(backendInitializationActors, List.empty, Map.empty)
+      val backendFinalizationActors = backendWorkflowActors(backendAssignments)
+      backendFinalizationActors.keys foreach { _ ! Finalize }
+      goto(WorkflowFinalizing) using WorkflowFinalizationActorData(backendFinalizationActors, List.empty, Map.empty)
     case Event(AbortEngineFinalizationCommand, _) =>
       context.parent ! WorkflowFinalizationAbortedResponse
-      goto(EngineFinalizationAbortedState)
+      goto(WorkflowFinalizationAbortedState)
   }
 
-  when(EngineFinalizing) {
+  when(WorkflowFinalizing) {
     case Event(FinalizationSuccess, stateData) =>
-      val newData = stateData.copy(successes = stateData.successes ++ List(sender))
+      val newData = stateData.copy(
+        backendActors = stateData.backendActors - sender,
+        successes = stateData.successes ++ List(sender))
       checkForDoneAndTransition(newData)
     case Event(FinalizationFailed(reason), stateData) =>
-      val newData = stateData.copy(failures = stateData.failures ++ Map(sender -> reason))
+      val newData = stateData.copy(
+        backendActors = stateData.backendActors - sender,
+        failures = stateData.failures ++ Map(sender -> reason))
       checkForDoneAndTransition(newData)
     case Event(AbortEngineFinalizationCommand, stateData) => ??? // TODO: Implement
   }
 
-  private def checkForDoneAndTransition(newData: WorkflowFinalizationActorData): State = {
-    if (checkForDone(newData)) {
-      if (newData.failures.isEmpty) {
-        context.parent ! WorkflowFinalizationSucceededResponse
-        goto(EngineFinalizationSucceededState) using newData
-      }
-      else {
-        context.parent ! WorkflowFinalizationFailedResponse(newData.failures.values.toSeq)
-        goto(EngineFinalizationFailedState)
-      }
-    }
-    else {
-      stay using newData
-    }
-  }
-
-  private def checkForDone(stateData: WorkflowFinalizationActorData) = {
-    // TODO: Check these are actually the same?
-    val allActorResponses = stateData.successes ++ stateData.failures.keys
-    allActorResponses.size == backendsToFinalize.size
-  }
-
   whenUnhandled {
     case unhandledMessage =>
-      log.warning(s"Backends finalizer for $workflowTag received an unhandled message: $unhandledMessage")
+      log.warning(s"$tag received an unhandled message: $unhandledMessage")
       stay
   }
 
   onTransition {
     case _ -> toState if toState.terminal =>
-      log.debug(s"$tag is done. Shutting down.")
+      log.debug(s"$tag state is now terminal. Shutting down.")
       context.stop(self)
     case fromState -> toState =>
-      log.debug(s"$tag is transitioning from $fromState to $toState.")
+      log.debug(s"$tag transitioning from $fromState to $toState.")
   }
 
   /**
-    * Based on the backendAssignments, creates a BackendWorkflowFinalizationActor per backend and maps the actor to the
-    * name of the backend which it is finalizing.
+    * Makes a BackendWorkflowFinalizationActor for a backend
     */
-  def backendWorkflowFinalizationActors:  Map[ActorRef, String] = ??? //TODO: Implement this!
+  override def backendActor(backendName: String, callAssignments: Seq[Call]): Option[ActorRef] = {
+    // TODO: Implement this!
+    None
+  }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
@@ -1,0 +1,107 @@
+package cromwell.engine.workflow.lifecycle
+
+import akka.actor.{FSM, ActorRef, LoggingFSM}
+import cromwell.engine.workflow.lifecycle.WorkflowLifecycleActor._
+import wdl4s.Call
+
+object WorkflowLifecycleActor {
+
+  trait WorkflowLifecycleActorState { def terminal = false }
+  trait WorkflowLifecycleActorTerminalState extends WorkflowLifecycleActorState { override val terminal = true }
+
+  trait WorkflowLifecycleSuccessResponse
+  trait WorkflowLifecycleFailureResponse
+  trait WorkflowLifecycleAbortedResponse
+
+  /**
+    * State data
+    */
+  trait WorkflowLifecycleActorData{
+    /**
+      * The mapping from ActorRef to the backend-specific actor for that backend
+      */
+    def backendActors: Map[ActorRef, String]
+
+    /**
+      * The list of successful backend-specific actors
+      */
+    def successes: Seq[ActorRef]
+
+    /**
+      * The list of failed backend-specific actors
+      */
+    def failures: Map[ActorRef, Throwable]
+  }
+}
+
+trait WorkflowLifecycleActor[S <: WorkflowLifecycleActorState, D <: WorkflowLifecycleActorData] extends LoggingFSM[S, D] {
+
+  val successState: S
+  val failureState: S
+  val abortedState: S
+
+  def successResponse: WorkflowLifecycleSuccessResponse
+  def failureResponse(reasons: Seq[Throwable]): WorkflowLifecycleFailureResponse
+
+  when(successState) { FSM.NullFunction }
+  when(failureState) { FSM.NullFunction }
+  when(abortedState) { FSM.NullFunction }
+
+  whenUnhandled {
+    case unhandledMessage =>
+      log.warning(s"received an unhandled message: $unhandledMessage")
+      stay
+  }
+
+  onTransition {
+    case _ -> state if state.terminal =>
+      log.debug("State is now terminal. Shutting down.")
+      context.stop(self)
+    case fromState -> toState =>
+      // Only log this at debug - these states are never seen or used outside of the CallActor itself.
+      log.debug(s"State is transitioning from $fromState to $toState.")
+  }
+
+  /**
+    * Turns a mapping from Call => backendName into a mapping from backendName => List[Call]
+    */
+  protected def callAssignments(backendAssignments: Map[Call, String]): Map[String, List[Call]] =
+    backendAssignments.groupBy(_._2).mapValues(_.keys.toList)
+
+  /**
+    * Based on backendAssignments, creates a BackendWorkflowInitializationActor per backend and maps the actor to the
+    * name of the backend which it is initializing.
+    */
+  protected def backendWorkflowActors(backendAssignments: Map[Call, String]):  Map[ActorRef, String] = {
+    val callAssignmentMap = callAssignments(backendAssignments)
+    val backendsToInitialize = backendAssignments.values.toSet
+    backendsToInitialize
+      .map { backend => (backendActor(backend, callAssignmentMap(backend)), backend) } // Create the initializationActors
+      .collect { case (Some(actorRef), backend) => actorRef -> backend } // Only track the backends which need initialization
+      .toMap
+  }
+
+  /**
+    * Makes an appropriate Backend actor for this backend. The call assignments are a list of calls which this
+    * backend will be or has been requested to perform.
+    */
+  protected def backendActor(backendName: String, callAssignments: Seq[Call]): Option[ActorRef]
+
+  protected def checkForDoneAndTransition(newData: D): State = {
+    if (checkForDone(newData)) {
+      if (newData.failures.isEmpty){
+        context.parent ! successResponse
+        goto(successState)
+      }
+      else {
+        context.parent ! failureResponse(newData.failures.values.toSeq)
+        goto(failureState) using newData
+      }
+    }
+    else {
+      stay using newData
+    }
+  }
+
+  private def checkForDone(stateData: WorkflowLifecycleActorData) = stateData.backendActors.isEmpty
+}

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -15,8 +15,7 @@ object CromwellServer extends WorkflowManagerSystem {
   implicit val timeout = Timeout(5.seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val conf = ConfigFactory.load()
-  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf), "cromwell-service")
+  val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf, shadowMode), "cromwell-service")
   val webserviceConf = conf.getConfig("webservice")
 
   def run(): Future[Any] = {

--- a/engine/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
+++ b/engine/src/main/scala/cromwell/server/WorkflowManagerSystem.scala
@@ -10,6 +10,8 @@ trait WorkflowManagerSystem {
   protected def systemName = "cromwell-system"
 
   protected def newActorSystem(): ActorSystem = ActorSystem(systemName)
+  val conf = ConfigFactory.load()
+  val shadowMode = conf.getBoolean("system.shadowExecutionEnabled")
 
   implicit final lazy val actorSystem = newActorSystem()
 
@@ -21,7 +23,7 @@ trait WorkflowManagerSystem {
 
   def defaultBackend: String = ConfigFactory.load.getConfig("backend").getString("defaultBackend")
 
-  CromwellBackend.initBackends(allowedBackends, defaultBackend, actorSystem)
+  if (!shadowMode) CromwellBackend.initBackends(allowedBackends, defaultBackend, actorSystem)
   // For now there's only one WorkflowManagerActor so no need to dynamically name it
-  lazy val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props(), "WorkflowManagerActor")
+  lazy val workflowManagerActor = actorSystem.actorOf(WorkflowManagerActor.props(shadowMode), "WorkflowManagerActor")
 }

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -23,12 +23,12 @@ trait SwaggerService extends SwaggerUiResourceHttpService {
 }
 
 object CromwellApiServiceActor {
-  def props(workflowManagerActorRef: ActorRef, config: Config): Props = {
-    Props(classOf[CromwellApiServiceActor], workflowManagerActorRef, config)
+  def props(workflowManagerActorRef: ActorRef, config: Config, shadowMode: Boolean): Props = {
+    Props(classOf[CromwellApiServiceActor], workflowManagerActorRef, config, shadowMode)
   }
 }
 
-class CromwellApiServiceActor(val workflowManager: ActorRef, config: Config)
+case class CromwellApiServiceActor(val workflowManager: ActorRef, config: Config, shadowMode: Boolean)
   extends Actor with CromwellApiService with SwaggerService {
   implicit def executionContext = actorRefFactory.dispatcher
   def actorRefFactory = context
@@ -42,7 +42,8 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
 
   import CromwellApiServiceActor._
 
-  val workflowManager: ActorRef
+  def shadowMode: Boolean
+  def workflowManager: ActorRef
 
   private def invalidWorkflowId(id: String) = respondWithMediaType(`application/json`) {
     complete(StatusCodes.BadRequest, APIResponse.fail(new Throwable(s"Invalid workflow ID: '$id'.")).toJson.prettyPrint)
@@ -56,7 +57,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       get {
         Try(WorkflowId.fromString(workflowId)) match {
           case Success(w) =>
-            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowStatus(w))
+            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowStatus(w))
           case Failure(ex) => invalidWorkflowId(workflowId)
         }
       }
@@ -67,7 +68,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       parameterSeq { parameters =>
         get {
           requestContext =>
-            perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowQuery(parameters))
+            perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowQuery(parameters))
         }
       }
     }
@@ -77,7 +78,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       post {
         Try(WorkflowId.fromString(workflowId)) match {
           case Success(w) =>
-            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowAbort(w))
+            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowAbort(w))
           case Failure(ex) => invalidWorkflowId(workflowId)
         }
       }
@@ -89,7 +90,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
         formFields("wdlSource", "workflowInputs".?, "workflowOptions".?) { (wdlSource, workflowInputs, workflowOptions) =>
           requestContext =>
             val workflowSourceFiles = WorkflowSourceFiles(wdlSource, workflowInputs.getOrElse("{}"), workflowOptions.getOrElse("{}"))
-            perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowSubmit(workflowSourceFiles))
+            perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowSubmit(workflowSourceFiles))
         }
       }
     }
@@ -99,7 +100,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       get {
         Try(WorkflowId.fromString(workflowId)) match {
           case Success(w) =>
-            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowOutputs(w))
+            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowOutputs(w))
           case Failure(ex) => invalidWorkflowId(workflowId)
         }
       }
@@ -110,7 +111,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       Try(WorkflowId.fromString(workflowId)) match {
         case Success(w) =>
           // This currently does not attempt to parse the call name for conformation to any pattern.
-          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerCallOutputs(w, callFqn))
+          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerCallOutputs(w, callFqn))
         case Failure(_) => invalidWorkflowId(workflowId)
       }
     }
@@ -120,7 +121,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
       Try(WorkflowId.fromString(workflowId)) match {
         case Success(w) =>
           // This currently does not attempt to parse the call name for conformation to any pattern.
-          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerCallStdoutStderr(w, callFqn))
+          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerCallStdoutStderr(w, callFqn))
         case Failure(_) => invalidWorkflowId(workflowId)
       }
     }
@@ -129,7 +130,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
     path("workflows" / Segment / Segment / "logs") { (version, workflowId) =>
       Try(WorkflowId.fromString(workflowId)) match {
         case Success(w) =>
-          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowStdoutStderr(w))
+          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowStdoutStderr(w))
         case Failure(_) => invalidWorkflowId(workflowId)
       }
     }
@@ -138,7 +139,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
     path("workflows" / Segment / Segment / "metadata") { (version, workflowId) =>
       Try(WorkflowId.fromString(workflowId)) match {
         case Success(w) =>
-          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowMetadata(w))
+          requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerWorkflowMetadata(w))
         case Failure(_) => invalidWorkflowId(workflowId)
       }
     }
@@ -159,7 +160,7 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
           Try(WorkflowId.fromString(workflowId)) match {
             case Success(w) =>
               requestContext =>
-                perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerCallCaching(w, queryParameters, callFqn))
+                perRequest(requestContext, CromwellApiHandler.props(workflowManager, shadowMode), CromwellApiHandler.ApiHandlerCallCaching(w, queryParameters, callFqn))
             case Failure(_) => invalidWorkflowId(workflowId)
           }
         }

--- a/engine/src/test/scala/cromwell/RetryableCallsSpec.scala
+++ b/engine/src/test/scala/cromwell/RetryableCallsSpec.scala
@@ -37,7 +37,7 @@ class RetryableCallsSpec extends CromwellTestkitSpec with Mockito with WorkflowD
 
     "succeed and return correct metadata" in {
       CromwellBackend.registerCustomBackend("customizedLocalBackend", customizedLocalBackend)
-      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test Workflow metadata with Retried Calls")
+      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test Workflow metadata with Retried Calls")
       val wd = materializeWorkflowDescriptorFromSources(workflowSources = SampleWdl.PrepareScatterGatherWdl().asWorkflowSources(workflowOptions = customizedLocalBackendOptions))
       val workflowId = waitForHandledMessagePattern(pattern = "transitioning from Running to Succeeded") {
         EventFilter.info(pattern = s"persisting status of do_scatter:0:2 to Starting", occurrences = 1).intercept {

--- a/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -36,7 +36,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "run the Hello World workflow" in {
 
-      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test the WorkflowManagerActor")
+      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test the WorkflowManagerActor")
 
       val workflowId = waitForHandledMessagePattern(pattern = "transitioning from Running to Succeeded") {
         messageAndWait[WorkflowManagerSubmitSuccess](SubmitWorkflow(HelloWorld.asWorkflowSources())).id
@@ -57,7 +57,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "Not try to restart any workflows when there are no workflows in restartable states" in {
       waitForPattern("Found no workflows to restart.") {
-        TestActorRef(WorkflowManagerActor.props(), self, "No workflows")
+        TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "No workflows")
       }
     }
 
@@ -93,7 +93,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
             // Both the previously in-flight call and the never-started call should get started.
             waitForPattern("starting calls: hello.hello", occurrences = 2) {
               waitForPattern("transitioning from Running to Succeeded", occurrences = 2) {
-                TestActorRef(WorkflowManagerActor.props(), self, "2 restartable workflows")
+                TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "2 restartable workflows")
               }
             }
           }
@@ -104,7 +104,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "Handle coercion failures gracefully" in {
       within(TestExecutionTimeout) {
-        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test WorkflowManagerActor coercion failures")
+        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test WorkflowManagerActor coercion failures")
         waitForErrorWithException("Workflow failed submission") {
           val e = messageAndWait[WorkflowManagerSubmitFailure](SubmitWorkflow(Incr.asWorkflowSources())).failure
           e.getMessage should include("Could not coerce value for 'incr.incr.val' into: WdlIntegerType")
@@ -113,14 +113,14 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
     }
 
     "error when running a workflowless WDL" in {
-      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test a workflowless submission")
+      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test a workflowless submission")
       val e = messageAndWait[WorkflowManagerSubmitFailure](SubmitWorkflow(HelloWorldWithoutWorkflow.asWorkflowSources())).failure
       e.getMessage should include("Namespace does not have a local workflow to run")
     }
 
     "error when asked for outputs of a nonexistent workflow" in {
       within(TestExecutionTimeout) {
-        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(),
+        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false),
           self, "Test WorkflowManagerActor output lookup failure")
         val id = WorkflowId(UUID.randomUUID())
 
@@ -131,7 +131,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "error when asked for call logs of a nonexistent workflow" in {
       within(TestExecutionTimeout) {
-        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(),
+        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false),
           self, "Test WorkflowManagerActor call log lookup failure")
         val id = WorkflowId.randomId()
         val e = messageAndWait[WorkflowManagerCallStdoutStderrFailure](CallStdoutStderr(id, "foo.bar")).failure
@@ -142,7 +142,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "error when asked for logs of a nonexistent workflow" in {
       within(TestExecutionTimeout) {
-        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(),
+        implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false),
           self, "Test WorkflowManagerActor log lookup failure")
         val id = WorkflowId.randomId()
         val e = messageAndWait[WorkflowManagerWorkflowStdoutStderrFailure](WorkflowStdoutStderr(id)).failure
@@ -161,7 +161,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
 
     "build metadata correctly" in {
 
-      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test Workflow metadata construction")
+      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test Workflow metadata construction")
 
       val workflowId = waitForHandledMessagePattern(pattern = "transitioning from Running to Succeeded") {
         messageAndWait[WorkflowManagerSubmitSuccess](SubmitWorkflow(new SampleWdl.ScatterWdl().asWorkflowSources())).id
@@ -209,7 +209,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
     "show (only supported) runtime attributes in metadata" taggedAs DockerTest in {
 
       val backendInstance = Backend.from(CromwellSpec.Config, system)
-      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(), self, "Test Workflow metadata construction")
+      implicit val workflowManagerActor = TestActorRef(WorkflowManagerActor.props(shadowMode = false), self, "Test Workflow metadata construction")
 
       val fullWfOptions =
         """

--- a/engine/src/test/scala/cromwell/engine/workflow/ShadowWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/ShadowWorkflowActorSpec.scala
@@ -1,0 +1,97 @@
+package cromwell.engine.workflow
+
+import akka.testkit.TestFSMRef
+import com.typesafe.config.ConfigFactory
+import cromwell.CromwellTestkitSpec
+import cromwell.core.WorkflowId
+import cromwell.engine.workflow.ShadowWorkflowActor._
+import cromwell.engine.workflow.lifecycle.ShadowMaterializeWorkflowDescriptorActor
+import cromwell.engine.workflow.lifecycle.ShadowMaterializeWorkflowDescriptorActor.{ShadowMaterializeWorkflowDescriptorCommand, ShadowMaterializeWorkflowDescriptorFailureResponse, ShadowMaterializeWorkflowDescriptorSuccessResponse, ShadowWorkflowDescriptorMaterializationResult}
+import cromwell.engine.{EngineWorkflowDescriptor, WorkflowSourceFiles}
+import cromwell.util.SampleWdl.{HelloWorld, ThreeStep}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.concurrent.Await
+
+class ShadowWorkflowActorSpec extends CromwellTestkitSpec {
+
+  // Blocking call to get the `EngineWorkflowDescriptor`
+  private def createMaterializedEngineWorkflowDescriptor(workflowSources: WorkflowSourceFiles): EngineWorkflowDescriptor = {
+    import akka.pattern.ask
+
+    import scala.concurrent.duration._
+
+    val actor = system.actorOf(ShadowMaterializeWorkflowDescriptorActor.props())
+    val workflowDescriptorFuture =
+      (actor ? ShadowMaterializeWorkflowDescriptorCommand(WorkflowId.randomId(), workflowSources, ConfigFactory.load))
+        .mapTo[ShadowWorkflowDescriptorMaterializationResult]
+
+    Await.result(workflowDescriptorFuture map {
+      case ShadowMaterializeWorkflowDescriptorSuccessResponse(workflowDescriptor) => workflowDescriptor
+      case ShadowMaterializeWorkflowDescriptorFailureResponse(reason) => throw reason
+    }, 3.seconds)
+  }
+
+  private def createWorkflowActor(workflowId: WorkflowId = WorkflowId.randomId(),
+                                  startMode: StartMode = StartNewWorkflow,
+                                  wdlSource: WorkflowSourceFiles) = {
+    TestFSMRef(new ShadowWorkflowActor(workflowId, startMode, wdlSource,ConfigFactory.load()))
+  }
+
+  "ShadowWorkflowActor" should {
+    "move from WorkflowUnstartedState to MaterializingWorkflowDescriptorState" in {
+      val wdlSources = WorkflowSourceFiles(HelloWorld.wdlSource("runtime { }"),
+        HelloWorld.rawInputs.toJson.toString(), "{ }")
+      val testActor = createWorkflowActor(wdlSource = wdlSources)
+      testActor.setState(stateName = WorkflowUnstartedState, stateData = EmptyShadowWorkflowActorData)
+      testActor ! StartWorkflowCommand
+      testActor.stateName should be (ShadowWorkflowActor.MaterializingWorkflowDescriptorState)
+      testActor.stop()
+    }
+
+    "transition to InitializingWorkflowState with correct call assignments given workflow options" in {
+      import scala.concurrent.duration._
+      val wfOptions =
+        """{
+          | "backend": "Jes"
+          |}
+        """.stripMargin
+      val runtimeAttributes =
+        """runtime {
+          | backend: "SGE"
+          |}""".stripMargin
+      // WorkflowOptions (Jes) should trump runtime attributes (SGE)
+      val wdlSources = ThreeStep.asWorkflowSources(runtime = runtimeAttributes, workflowOptions = wfOptions)
+      val descriptor = createMaterializedEngineWorkflowDescriptor(workflowSources = wdlSources)
+      val expectedStateData = ShadowWorkflowActorDataWithDescriptor(descriptor)
+      val testActor = createWorkflowActor(wdlSource = wdlSources)
+      testActor.setState(stateName = MaterializingWorkflowDescriptorState, stateData = EmptyShadowWorkflowActorData)
+      within(5.seconds) {
+        testActor ! ShadowMaterializeWorkflowDescriptorSuccessResponse(descriptor)
+        testActor.stateName should be(ShadowWorkflowActor.InitializingWorkflowState)
+        testActor.stateData should be(expectedStateData)
+      }
+      testActor.stop()
+    }
+
+    "transition to InitializingWorkflowState with correct call assignments given runtime-attributes" in {
+      import scala.concurrent.duration._
+      val runtimeAttributes =
+        """runtime {
+          | backend: "SGE"
+          |}""".stripMargin
+      val wdlSources = ThreeStep.asWorkflowSources(runtime = runtimeAttributes)
+      val descriptor = createMaterializedEngineWorkflowDescriptor(workflowSources = wdlSources)
+      val expectedStateData = ShadowWorkflowActorDataWithDescriptor(descriptor)
+      val testActor = createWorkflowActor(wdlSource = wdlSources)
+      testActor.setState(stateName = MaterializingWorkflowDescriptorState, stateData = EmptyShadowWorkflowActorData)
+      within(5.seconds) {
+        testActor ! ShadowMaterializeWorkflowDescriptorSuccessResponse(descriptor)
+        testActor.stateName should be(ShadowWorkflowActor.InitializingWorkflowState)
+        testActor.stateData should be(expectedStateData)
+      }
+      testActor.stop()
+    }
+  }
+}

--- a/engine/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/engine/src/test/scala/cromwell/util/SampleWdl.scala
@@ -248,7 +248,7 @@ object SampleWdl {
   }
 
   trait ThreeStepTemplate extends SampleWdl {
-    override def wdlSource(runtime: String = "") = sourceString()
+    override def wdlSource(runtime: String = "") = sourceString().replaceAll("RUNTIME", runtime)
     private val outputSectionPlaceholder = "OUTPUTSECTIONPLACEHOLDER"
     def sourceString(outputsSection: String = "") = {
       val withPlaceholders =
@@ -260,6 +260,7 @@ object SampleWdl {
         |  output {
         |    File procs = stdout()
         |  }
+        |  RUNTIME
         |}
         |
         |task cgrep {
@@ -272,6 +273,7 @@ object SampleWdl {
         |  output {
         |    Int count = read_int(stdout())
         |  }
+        |  RUNTIME
         |}
         |
         |task wc {
@@ -282,6 +284,7 @@ object SampleWdl {
         |  output {
         |    Int count = read_int(stdout())
         |  }
+        |  RUNTIME
         |}
         |
         |workflow three_step {
@@ -312,7 +315,7 @@ object SampleWdl {
         | cgrep.count
         | wc.count
         |}
-      """.stripMargin)
+      """.stripMargin).replaceAll("RUNTIME", runtime)
   }
 
   object ThreeStepWithInputsInTheOutputsSection extends ThreeStepTemplate {
@@ -321,7 +324,7 @@ object SampleWdl {
         |output {
         | cgrep.pattern
         |}
-      """.stripMargin)
+      """.stripMargin).replaceAll("RUNTIME", runtime)
   }
 
   object ThreeStepLargeJson extends ThreeStepTemplate {

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceIntegrationSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceIntegrationSpec.scala
@@ -12,6 +12,7 @@ import spray.testkit.ScalatestRouteTest
 
 class CromwellApiServiceIntegrationSpec extends FlatSpec with CromwellApiService with ScalatestRouteTest with Matchers {
   val testWorkflowManagerSystem = new TestWorkflowManagerSystem
+  override val shadowMode = false
   override def actorRefFactory = testWorkflowManagerSystem.actorSystem
   override val workflowManager = TestActorRef(new WorkflowManagerActor())
   val version = "v1"

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -228,6 +228,7 @@ object CromwellApiServiceSpec {
 class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with ScalatestRouteTest with Matchers {
   import spray.httpx.SprayJsonSupport._
 
+  override val shadowMode = false
   override def actorRefFactory = system
   override val workflowManager = actorRefFactory.actorOf(Props(new MockWorkflowManagerActor() with WorkflowDescriptorBuilder {
     override implicit  val actorSystem = context.system


### PR DESCRIPTION
To set expectations, this PR sets up shadow mode to actually process messages through the new set of lifecycle actors. It can be seen that submissions return an ID and make it through the `MaterializeWorkflowDescriptor` phase. However not the `Initialize` phase. This is all done in a shadow hierarchy which has not affected the normal operation yet...

We still need:
* The part which assigns backends to calls (currently blocked out to happen in `ShadowMaterializeWorkflowDescriptorActor`)
* The part which generates actors from backend name strings (blocked out at the bottom of both the `InitializeWorkflowActor` and `FinalizeWorkflowActor`)
* The entire `WorkflowExecutionActor`

If you try to run anything in shadow mode, it'll fail in the `InitializeWorkflow` phase with an exception saying that no backend assignments were found.