### PR TITLE
Patches to `SprayDockerRegistryApiClient` and spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,7 @@
 * The default per-upload bytes size for GCS is now the minumum 256K
 instead of 64M. There is also an undocumented config key
 `google.upload-buffer-bytes` that allows adjusting this internal value.
+
+* Updated Docker Hub hash retriever to parse json with [custom media
+types](https://github.com/docker/distribution/blob/05b0ab0/docs/spec/manifest-v2-1.md).
+

--- a/engine/src/main/scala/cromwell/util/docker/SprayDockerRegistryApiClient.scala
+++ b/engine/src/main/scala/cromwell/util/docker/SprayDockerRegistryApiClient.scala
@@ -6,7 +6,6 @@ import spray.client.pipelining._
 import spray.http.HttpHeaders.{Authorization, `WWW-Authenticate`}
 import spray.http._
 import spray.httpx.UnsuccessfulResponseException
-import spray.httpx.unmarshalling._
 
 import scala.concurrent.Future
 

--- a/engine/src/test/scala/cromwell/util/docker/DockerIdentifierParserSpec.scala
+++ b/engine/src/test/scala/cromwell/util/docker/DockerIdentifierParserSpec.scala
@@ -1,28 +1,21 @@
 package cromwell.util.docker
 
-import com.google.api.client.auth.oauth2.Credential
 import cromwell.CromwellSpec.IntegrationTest
-import cromwell.core.WorkflowOptions
-import cromwell.engine.backend.{BackendConfiguration, EnhancedWorkflowOptions}
-import cromwell.filesystems.gcs.{GoogleConfiguration, GoogleCredentialFactorySpec}
+import cromwell.engine.backend.BackendConfiguration
+import cromwell.filesystems.gcs.GoogleCredentialFactorySpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.language.postfixOps
-import EnhancedWorkflowOptions._
 
 class DockerIdentifierParserSpec extends FlatSpec with Matchers {
   behavior of "DockerIdentifierParser"
 
   private def defaultParser: DockerIdentifierParser = {
     val backendEntry = BackendConfiguration.DefaultBackendEntry
-    val options = WorkflowOptions.fromMap(Map.empty).get
-    val credential: Option[Credential] = GoogleConfiguration.Instance.auth("default").toOption map { _.credential(options.toGoogleAuthOptions) }
-    DockerIdentifierParser(backendEntry.config, credential)
+    DockerIdentifierParser(backendEntry.config, Option(GoogleCredentialFactorySpec.applicationDefaultCredential))
   }
 
-  it should "parse docker tagged identifiers" in {
+  it should "parse docker tagged identifiers" taggedAs IntegrationTest in {
     val parser = defaultParser
 
     val identifiers = Table(
@@ -49,8 +42,6 @@ class DockerIdentifierParserSpec extends FlatSpec with Matchers {
   }
 
   it should "parse gcr.io tagged identifiers" taggedAs IntegrationTest in {
-    GoogleCredentialFactorySpec.assumeAccountConfigExists()
-
     val parser = defaultParser
 
     val identifiers = Table(


### PR DESCRIPTION
Added Docker specification content types to the manifest unmarshaller.
Updated spec for testing GCR w/o authentication, as cromwell's Google Credentials utility now automatically detects the application default credentials on a system.