### PR TITLE
Ensuring directories are created in the SFS localizers. Closes #646

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_script:
   - mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
   - mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY '';"
   - mysql -u root -e "GRANT ALL PRIVILEGES ON cromwell_test . * TO 'travis'@'localhost';"
-script: sbt -Dbackend.shared-filesystem.localization.0=copy clean coverage nointegration:test coverageReport && sbt coverageAggregate && sbt assembly
+script: sbt -Dbackend.providers.0.name="Local" -Dbackend.providers.0.class="cromwell.engine.backend.local.LocalBackend" -Dbackend.providers.0.config.root="cromwell-executions" -Dbackend.providers.0.config.filesystems.local.localization.0=copy clean coverage nointegration:test coverageReport && sbt coverageAggregate && sbt assembly
 after_success: sbt coveralls

--- a/engine/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
@@ -4,8 +4,9 @@ import cromwell.CallCachingWorkflowSpec._
 import cromwell.CromwellTestkitSpec
 import cromwell.engine.backend.local.LocalBackend
 import cromwell.engine.workflow.BackendCallKey
-import cromwell.util.SampleWdl
+import cromwell.util.{CromwellAggregatedException, SampleWdl}
 import org.scalatest.concurrent.ScalaFutures
+import wdl4s.values.WdlFile
 
 class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures with WorkflowDescriptorBuilder {
   override implicit val actorSystem = system
@@ -35,13 +36,26 @@ class BackendCallSpec extends CromwellTestkitSpec with ScalaFutures with Workflo
     "not change with a Docker image hash specified - if it changes, make sure it is for a good reason" in {
       val nameAndDigest = "ubuntu@sha256:a2c950138e95bf603d919d0f74bec16a81d5cc1e3c3d574e8d5ed59795824f47"
       val sources = SampleWdl.CallCachingHashingWdl.asWorkflowSources( s"""runtime { docker: "$nameAndDigest" } """)
-      val descriptor =materializeWorkflowDescriptorFromSources(workflowSources = sources, conf = callCachingConfig)
+      val descriptor = materializeWorkflowDescriptorFromSources(workflowSources = sources, conf = callCachingConfig)
       val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "t").get
       val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), descriptor.actualInputs)
 
       val actual = jobDescriptor.hash.futureValue.overallHash
       val expected = "e0fac3e3f6d3b611334fd2e0a504e99a"
       assert(actual == expected, s"Expected BackendCall hash to be $expected, but got $actual.  Did the hashing algorithm change?")
+    }
+  }
+
+  "BackendCall adjustSharedInputPaths" should {
+    "produce the correctly formatted exception message" in {
+      val sources = SampleWdl.CannedFilePassing.asWorkflowSources()
+      val descriptor = materializeWorkflowDescriptorFromSources(workflowSources = sources)
+      val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == "wc").get
+      val inputs = Map("in_file" -> WdlFile("/bad/path/to/file"))
+      val jobDescriptor = BackendCallJobDescriptor(descriptor, BackendCallKey(call, None, 1), inputs)
+      val exception = intercept[CromwellAggregatedException](backend.adjustSharedInputPaths(jobDescriptor))
+      exception.getMessage should startWith("Failures during localization\nCould not localize /bad/path/to/file -> ")
+      exception.getMessage should endWith("/call-wc/bad/path/to/file")
     }
   }
 }

--- a/engine/src/test/scala/cromwell/engine/backend/local/SharedFileSystemBackendSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/local/SharedFileSystemBackendSpec.scala
@@ -1,0 +1,312 @@
+package cromwell.engine.backend.local
+
+import java.nio.file.{FileSystems, Files, NoSuchFileException}
+
+import better.files._
+import cromwell.CromwellSpec.IntegrationTest
+import cromwell.engine.backend.WorkflowDescriptor
+import cromwell.filesystems.gcs.GoogleAuthMode.GoogleAuthOptions
+import cromwell.filesystems.gcs._
+import org.scalatest.{FlatSpec, Matchers}
+import org.specs2.mock.Mockito
+
+import scala.util.{Failure, Success}
+
+class SharedFileSystemBackendSpec extends FlatSpec with Matchers with Mockito {
+
+  behavior of "SharedFileSystemBackend"
+
+  it should "localize the same path as already localized" in {
+    val orig = File.newTemp("file").write("hello world")
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, orig.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(orig) should be(1)
+
+    orig.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path already localized" in {
+    val orig = File.newTemp("file").write("hello world")
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    dest.toJava shouldNot exist
+    orig.copyTo(dest)
+    dest.toJava should exist
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+
+    orig.delete(ignoreIOExceptions = true)
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "not localize a path not localized" in {
+    val orig = File.newTemp("file").write("hello world")
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, dest.path, workflowDescriptor)
+    result.isFailure should be(true)
+
+    val exception = intercept[NoSuchFileException](result.get)
+    exception.getMessage should endWith("does not exist")
+
+    orig.delete(ignoreIOExceptions = true)
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via copy" in {
+    val orig = File.newTemp("file").write("hello world")
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaCopy(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world")
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(false)
+    dest.contentAsString should be("hello world.")
+
+    orig.delete(ignoreIOExceptions = true)
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via hard link" in {
+    val orig = File.newTemp("file").write("hello world")
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaHardLink(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world.")
+    countLinks(orig) should be(2)
+    countLinks(dest) should be(2)
+    isSymLink(dest) should be(false)
+    dest.contentAsString should be("hello world.")
+
+    orig.delete(ignoreIOExceptions = true)
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via symbolic link" in {
+    val orig = File.newTemp("file").write("hello world")
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaSymbolicLink(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world.")
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(true)
+    dest.contentAsString should be("hello world.")
+
+    orig.delete(ignoreIOExceptions = true)
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize from gcs" taggedAs IntegrationTest in {
+    // via https://cloud.google.com/storage/docs/access-public-data
+    val origPath = "gs://uspto-pair/applications/05900002.zip"
+    val dest = File.newTemp("file").delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    val auth: GoogleAuthMode = new ApplicationDefaultMode("default")
+    val storage = auth.buildStorage(new GoogleAuthOptions {
+      override def get(key: String) = Failure(new UnsupportedOperationException("empty options"))
+    })
+    val fileSystem = GcsFileSystemProvider(storage).getFileSystem
+    workflowDescriptor.fileSystems returns List(fileSystem, FileSystems.getDefault)
+
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizeFromGcs(origPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(false)
+    dest.toJava should have length 1811
+
+    dest.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize the same path as already localized in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, orig.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(orig) should be(1)
+
+    origDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path already localized in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    dest.parent.createDirectories()
+    orig.copyTo(dest)
+    destDir.toJava should exist
+    dest.toJava should exist
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+
+    origDir.delete(ignoreIOExceptions = true)
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "not localize a path not localized in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    val workflowDescriptor = mock[WorkflowDescriptor]
+    val result = SharedFileSystemBackend.localizePathAlreadyLocalized(orig.fullPath, dest.path, workflowDescriptor)
+    result.isFailure should be(true)
+
+    val exception = intercept[NoSuchFileException](result.get)
+    exception.getMessage should endWith("does not exist")
+
+    origDir.delete(ignoreIOExceptions = true)
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via copy in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaCopy(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world")
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(false)
+    dest.contentAsString should be("hello world.")
+
+    origDir.delete(ignoreIOExceptions = true)
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via hard link in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaHardLink(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world.")
+    countLinks(orig) should be(2)
+    countLinks(dest) should be(2)
+    isSymLink(dest) should be(false)
+    dest.contentAsString should be("hello world.")
+
+    origDir.delete(ignoreIOExceptions = true)
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize a path via symbolic link in a directory" in {
+    val origDir = File.newTempDir("orig")
+    val orig = origDir.createChild("subdir/file").write("hello world")
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    val workflowDescriptor = mock[WorkflowDescriptor]
+
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizePathViaSymbolicLink(orig.fullPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    dest.append(".")
+
+    orig.contentAsString should be("hello world.")
+    countLinks(orig) should be(1)
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(true)
+    dest.contentAsString should be("hello world.")
+
+    origDir.delete(ignoreIOExceptions = true)
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  it should "localize from gcs to a directory" taggedAs IntegrationTest in {
+    // via https://cloud.google.com/storage/docs/access-public-data
+    val origPath = "gs://uspto-pair/applications/05900002.zip"
+    val destDir = File.newTempDir("dest")
+    val dest = destDir./("subdir/file")
+    destDir.delete(ignoreIOExceptions = false)
+    val auth: GoogleAuthMode = new ApplicationDefaultMode("default")
+    val storage = auth.buildStorage(new GoogleAuthOptions {
+      override def get(key: String) = Failure(new UnsupportedOperationException("empty options"))
+    })
+    val fileSystem = GcsFileSystemProvider(storage).getFileSystem
+    val workflowDescriptor = mock[WorkflowDescriptor]
+    workflowDescriptor.fileSystems returns List(fileSystem, FileSystems.getDefault)
+
+    destDir.toJava shouldNot exist
+    dest.toJava shouldNot exist
+    val result = SharedFileSystemBackend.localizeFromGcs(origPath, dest.path, workflowDescriptor)
+    result should be(Success(()))
+
+    countLinks(dest) should be(1)
+    isSymLink(dest) should be(false)
+    dest.toJava should have length 1811
+
+    destDir.delete(ignoreIOExceptions = true)
+  }
+
+  private[this] def countLinks(file: File): Int = Files.getAttribute(file.path, "unix:nlink").asInstanceOf[Int]
+
+  private[this] def isSymLink(file: File): Boolean = Files.isSymbolicLink(file.path)
+}


### PR DESCRIPTION
Updated the travis configuration to again use copy-only localization.
As the other localizers were previously broken, travis was _only_ able to run copy.