### PR TITLE
Lowering per upload memory for GCS to the minimum 256K.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Cromwell Change Log
 
 ## 0.20
+
+* The default per-upload bytes size for GCS is now the minumum 256K
+instead of 64M. There is also an undocumented config key
+`google.upload-buffer-bytes` that allows adjusting this internal value.

--- a/engine/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/engine/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -27,7 +27,7 @@ object ServiceRegistryActor {
   }
 
   private def serviceProps(serviceName: String, globalConfig: Config, serviceStanza: Config): Props = {
-    val serviceConfigStanza = serviceStanza.getConfigOption("config").getOrElse(ConfigFactory.parseString(""))
+    val serviceConfigStanza = serviceStanza.getConfigOr("config", ConfigFactory.parseString(""))
     val className = serviceStanza.getStringOr(
       "class",
       throw new Exception(s"Invalid configuration for service $serviceName: missing 'class' definition")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  lazy val lenthallV = "0.18-34ff8bd-SNAPSHOT"
+  lazy val lenthallV = "0.18-e690fc2-SNAPSHOT"
   lazy val wdl4sV = "0.4"
   lazy val sprayV = "1.3.2"
   lazy val DowngradedSprayV = "1.3.1"


### PR DESCRIPTION
Added an undocumented config option to tweak this value if we need to adjust it for further testing.