### PR TITLE
Restoring ShadowExecution functionality from Chris's branch. Closes #730

### DIFF
--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -1,8 +1,6 @@
 package cromwell.server
 
 import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
-import cromwell.engine.workflow.MaterializeWorkflowDescriptorActor
 import cromwell.webservice.CromwellApiServiceActor
 import lenthall.spray.SprayCanHttpService._
 
@@ -15,7 +13,6 @@ object CromwellServer extends WorkflowManagerSystem {
   implicit val timeout = Timeout(5.seconds)
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val conf = ConfigFactory.load()
   val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, conf), "cromwell-service")
   val webserviceConf = conf.getConfig("webservice")
 


### PR DESCRIPTION
Changes from `cjl_dummyWireThrough` were overwritten by Miguel's BackendConfig branch probably during a rebase. Bringing that functionality back here. This will enable to submit a Workflow using the Cromwell Server and execute it via the new execution route if the `shadowExecutionEnabled` config property is set to true. 

`SingleWorkflowRunnerActor` (and hence a submission via command line route) hasn't  been modified, since it requires a whole other set of commands / responses to track / emit output for a particular WF, possibly in all of the Shadow series actors.