### PR TITLE
Fmc 726 memory validation. Closes #726.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -98,7 +98,7 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
   protected def createLookup(call: Call): ScopedLookupFunction = {
     val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
     val knownInputs = workflowDescriptor.inputs
-   WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
+    WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
   }
 
   /**

--- a/backend/src/main/scala/cromwell/backend/WdlStandardLibraryImpl.scala
+++ b/backend/src/main/scala/cromwell/backend/WdlStandardLibraryImpl.scala
@@ -3,11 +3,12 @@ package cromwell.backend
 import java.nio.file.Path
 
 import better.files._
+import cromwell.backend.validation.MemorySize
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.parser.MemoryUnit
 import wdl4s.types._
 import wdl4s.values._
-import wdl4s.{MemorySize, TsvSerializable}
+import wdl4s.TsvSerializable
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}

--- a/backend/src/main/scala/cromwell/backend/validation/MemorySize.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/MemorySize.scala
@@ -1,4 +1,4 @@
-package cromwell.backend.impl.jes.model
+package cromwell.backend.validation
 
 import wdl4s.parser.MemoryUnit
 

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
@@ -4,4 +4,6 @@ object RuntimeAttributesKeys {
   val Docker = "docker"
   val FailOnStderr = "failOnStderr"
   val ContinueOnReturnCode = "continueOnReturnCode"
+  val Cpu = "cpu"
+  val Memory = "memory"
 }

--- a/backend/src/test/scala/cromwell/backend/validation/MemorySizeSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/validation/MemorySizeSpec.scala
@@ -1,4 +1,4 @@
-package cromwell.backend.impl.jes.model
+package cromwell.backend.validation
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table

--- a/backend/src/test/scala/cromwell/backend/validation/RuntimeAttributesValidationSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/validation/RuntimeAttributesValidationSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.validation
 
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import wdl4s.parser.MemoryUnit
 import wdl4s.types.{WdlIntegerType, WdlStringType, WdlArrayType}
 import wdl4s.values.{WdlArray, WdlBoolean, WdlInteger, WdlString}
 
@@ -12,7 +13,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a valid Docker entry" in {
       val dockerValue = Some(WdlString("someImage"))
       val result = RuntimeAttributesValidation.validateDocker(dockerValue,
-        () => "Failed to get Docker mandatory key from runtime attributes".failureNel)
+        "Failed to get Docker mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x.get == "someImage")
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -21,7 +22,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
 
     "return success (based on defined HoF) when tries to validate a docker entry but it does not contain a value" in {
       val dockerValue = None
-      val result = RuntimeAttributesValidation.validateDocker(dockerValue, () => None.successNel)
+      val result = RuntimeAttributesValidation.validateDocker(dockerValue, None.successNel)
       result match {
         case scalaz.Success(x) => assert(!x.isDefined)
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -31,7 +32,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return failure (based on defined HoF) when tries to validate a docker entry but it does not contain a value" in {
       val dockerValue = None
       val result = RuntimeAttributesValidation.validateDocker(dockerValue,
-        () => "Failed to get Docker mandatory key from runtime attributes".failureNel)
+        "Failed to get Docker mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => fail("A failure was expected.")
         case scalaz.Failure(e) => assert(e.head == "Failed to get Docker mandatory key from runtime attributes")
@@ -41,7 +42,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return failure when there is an invalid docker runtime attribute defined" in {
       val dockerValue = Some(WdlInteger(1))
       val result = RuntimeAttributesValidation.validateDocker(dockerValue,
-        () => "Failed to get Docker mandatory key from runtime attributes".failureNel)
+        "Failed to get Docker mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => fail("A failure was expected.")
         case scalaz.Failure(e) => assert(e.head == "Expecting docker runtime attribute to be a String")
@@ -51,7 +52,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a failOnStderr boolean entry" in {
       val failOnStderrValue = Some(WdlBoolean(true))
       val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue,
-        () => "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
+        "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x)
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -61,7 +62,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a failOnStderr 'true' string entry" in {
       val failOnStderrValue = Some(WdlString("true"))
       val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue,
-        () => "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
+        "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x)
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -71,7 +72,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a failOnStderr 'false' string entry" in {
       val failOnStderrValue = Some(WdlString("false"))
       val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue,
-        () => "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
+        "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(!x)
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -81,7 +82,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return failure when there is an invalid failOnStderr runtime attribute defined" in {
       val failOnStderrValue = Some(WdlInteger(1))
       val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue,
-        () => "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
+        "Failed to get failOnStderr mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => fail("A failure was expected.")
         case scalaz.Failure(e) => assert(e.head == "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
@@ -90,7 +91,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
 
     "return success (based on defined HoF) when tries to validate a failOnStderr entry but it does not contain a value" in {
       val failOnStderrValue = None
-      val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue, () => true.successNel)
+      val result = RuntimeAttributesValidation.validateFailOnStderr(failOnStderrValue, true.successNel)
       result match {
         case scalaz.Success(x) => assert(x)
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -100,7 +101,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a continueOnReturnCode boolean entry" in {
       val continueOnReturnCodeValue = Some(WdlBoolean(true))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeFlag(true))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -110,7 +111,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a continueOnReturnCode 'true' string entry" in {
       val continueOnReturnCodeValue = Some(WdlString("true"))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeFlag(true))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -120,7 +121,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a continueOnReturnCode 'false' string entry" in {
       val continueOnReturnCodeValue = Some(WdlString("false"))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeFlag(false))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -130,7 +131,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when tries to validate a continueOnReturnCode int entry" in {
       val continueOnReturnCodeValue = Some(WdlInteger(12))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeSet(Set(12)))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -140,7 +141,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return failure when there is an invalid continueOnReturnCode runtime attribute defined" in {
       val continueOnReturnCodeValue = Some(WdlString("yes"))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => fail("A failure was expected.")
         case scalaz.Failure(e) =>
@@ -151,7 +152,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return success when there is a valid integer array in continueOnReturnCode runtime attribute" in {
       val continueOnReturnCodeValue = Some(WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(1), WdlInteger(2))))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeSet(Set(1, 2)))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
@@ -161,7 +162,7 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
     "return failure when there is an invalid array in continueOnReturnCode runtime attribute" in {
       val continueOnReturnCodeValue = Some(WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("one"), WdlString("two"))))
       val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue,
-        () => "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
+        "Failed to get continueOnReturnCode mandatory key from runtime attributes".failureNel)
       result match {
         case scalaz.Success(x) => fail("A failure was expected.")
         case scalaz.Failure(e) => assert(e.head == "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]")
@@ -170,10 +171,112 @@ class RuntimeAttributesValidationSpec extends WordSpecLike with Matchers with Be
 
     "return success (based on defined HoF) when tries to validate a continueOnReturnCode entry but it does not contain a value" in {
       val continueOnReturnCodeValue = None
-      val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue, () => ContinueOnReturnCodeFlag(false).successNel)
+      val result = RuntimeAttributesValidation.validateContinueOnReturnCode(continueOnReturnCodeValue, ContinueOnReturnCodeFlag(false).successNel)
       result match {
         case scalaz.Success(x) => assert(x == ContinueOnReturnCodeFlag(false))
         case scalaz.Failure(e) => fail(e.toList.mkString(" "))
+      }
+    }
+
+    "return success when tries to validate a valid Integer memory entry" in {
+      val expectedGb = 1
+      val memoryValue = Some(WdlInteger(1000000000))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => assert(x.amount == expectedGb)
+        case scalaz.Failure(e) => fail(e.toList.mkString(" "))
+      }
+    }
+
+    "return failure when tries to validate an invalid Integer memory entry" in {
+      val memoryValue = Some(WdlInteger(-1))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Expecting memory runtime attribute value greater than 0 but got -1")
+      }
+    }
+
+    "return success when tries to validate a valid String memory entry" in {
+      val expectedGb = 2
+      val memoryValue = Some(WdlString("2 GB"))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => assert(x.amount == expectedGb)
+        case scalaz.Failure(e) => fail(e.toList.mkString(" "))
+      }
+    }
+
+    "return failure when tries to validate an invalid size in String memory entry" in {
+      val memoryValue = Some(WdlString("0 GB"))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Expecting memory runtime attribute value greater than 0 but got 0.0")
+      }
+    }
+
+    "return failure when tries to validate an invalid String memory entry" in {
+      val memoryValue = Some(WdlString("value"))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Expecting memory runtime attribute to be an Integer or String with format '8 GB'. Exception: value should be of the form 'X Unit' where X is a number, e.g. 8 GB")
+      }
+    }
+
+    "return failure when tries to validate an invalid memory entry" in {
+      val memoryValue = Some(WdlBoolean(true))
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Expecting memory runtime attribute to be an Integer or String with format '8 GB'. Exception: Not supported WDL type value")
+      }
+    }
+
+    "return failure when tries to validate a non-provided memory entry" in {
+      val memoryValue = None
+      val result = RuntimeAttributesValidation.validateMemory(memoryValue,
+        "Failed to get memory mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Failed to get memory mandatory key from runtime attributes")
+      }
+    }
+
+    "return success when tries to validate a valid cpu entry" in {
+      val cpuValue = Some(WdlInteger(1))
+      val result = RuntimeAttributesValidation.validateCpu(cpuValue,
+        "Failed to get cpu mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => assert(x == 1)
+        case scalaz.Failure(e) => fail(e.toList.mkString(" "))
+      }
+    }
+
+    "return failure when tries to validate an invalid cpu entry" in {
+      val cpuValue = Some(WdlInteger(-1))
+      val result = RuntimeAttributesValidation.validateCpu(cpuValue,
+        "Failed to get cpu mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Expecting cpu runtime attribute value greater than 0")
+      }
+    }
+
+    "return failure when tries to validate a non-provided cpu entry" in {
+      val cpuValue = None
+      val result = RuntimeAttributesValidation.validateMemory(cpuValue,
+        "Failed to get cpu mandatory key from runtime attributes".failureNel)
+      result match {
+        case scalaz.Success(x) => fail("A failure was expected.")
+        case scalaz.Failure(e) => assert(e.head == "Failed to get cpu mandatory key from runtime attributes")
       }
     }
   }

--- a/engine/src/test/scala/cromwell/engine/backend/CromwellRuntimeAttributeSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/CromwellRuntimeAttributeSpec.scala
@@ -148,14 +148,14 @@ class CromwellRuntimeAttributeSpec extends FlatSpec with Matchers with EitherVal
     val ex = intercept[IllegalArgumentException] {
       runtimeAttributes(SampleWdl.WorkflowWithMessedUpMemory, "messed_up_memory", jesBackend)
     }
-    ex.getMessage should include ("should be of the form 'X Unit'")
+    ex.getMessage should include ("Expecting memory runtime attribute to be an Integer or String with format '8 GB'")
   }
 
   it should "reject a task with an invalid 'memory' attribute (2)" in {
     val ex = intercept[IllegalArgumentException] {
       runtimeAttributes(SampleWdl.WorkflowWithMessedUpMemoryUnit, "messed_up_memory", jesBackend)
     }
-    ex.getMessage should include ("is an invalid memory unit")
+    ex.getMessage should include ("Expecting memory runtime attribute to be an Integer or String with format '8 GB'")
   }
 
   it should "reject a task with an invalid 'disks' parameter" in {

--- a/engine/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/engine/src/test/scala/cromwell/util/SampleWdl.scala
@@ -2130,6 +2130,7 @@ object SampleWdl {
         |      echo "YO"
         |  }
         |  runtime {
+        |    docker: "ubuntu:latest"
         |    memory: "HI TY"
         |  }
         |}
@@ -2150,6 +2151,7 @@ object SampleWdl {
         |      echo "YO"
         |  }
         |  runtime {
+        |    docker: "ubuntu:latest"
         |    memory: "5 TY"
         |  }
         |}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val lenthallV = "0.18-e690fc2-SNAPSHOT"
-  lazy val wdl4sV = "0.4"
+  lazy val wdl4sV = "0.5-574ae20-SNAPSHOT"
   lazy val sprayV = "1.3.2"
   lazy val DowngradedSprayV = "1.3.1"
   lazy val akkaV = "2.3.12"

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
@@ -43,10 +43,10 @@ class HtCondorInitializationActor(override val workflowDescriptor: BackendWorkfl
     */
   override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
     Future {
-      val docker = validateDocker(runtimeAttributes.get(Docker), () => "Failed to get Docker mandatory key from runtime attributes".failureNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), () => FailOnStderrDefaultValue.successNel)
+      val docker = validateDocker(runtimeAttributes.get(Docker), "Failed to get Docker mandatory key from runtime attributes".failureNel)
+      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
       val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        () => ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
+        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
       (docker |@| failOnStderr |@| continueOnReturnCode) {
         (_, _, _)
       }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -304,7 +304,7 @@ class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationA
       }
     }
 
-    "return InitializationFailed when tries to validate an invalid memory entry" ignore {
+    "return InitializationFailed when tries to validate an invalid memory entry" in {
       within(Timeout) {
         val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" memory: "value" }""")
         val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)

--- a/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalInitializationActor.scala
+++ b/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalInitializationActor.scala
@@ -49,10 +49,10 @@ class LocalInitializationActor(override val workflowDescriptor: BackendWorkflowD
     */
   override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
     Future {
-      val docker = validateDocker(runtimeAttributes.get(Docker), () => None.successNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), () => FailOnStderrDefaultValue.successNel)
+      val docker = validateDocker(runtimeAttributes.get(Docker), None.successNel)
+      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
       val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        () => ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
+        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
       (docker |@| failOnStderr |@| continueOnReturnCode) {
         (_, _, _)
       }

--- a/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalRuntimeAttributes.scala
+++ b/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalRuntimeAttributes.scala
@@ -15,10 +15,10 @@ object LocalRuntimeAttributes {
   def apply(attrs: Map[String, WdlValue]): LocalRuntimeAttributes = {
 
     // FIXME Duplicated from validation - need a way to share this
-    val docker = validateDocker(attrs.get(Docker), () => None.successNel)
-    val failOnStderr = validateFailOnStderr(attrs.get(FailOnStderr), () => FailOnStderrDefaultValue.successNel)
+    val docker = validateDocker(attrs.get(Docker), None.successNel)
+    val failOnStderr = validateFailOnStderr(attrs.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
     val continueOnReturnCode = validateContinueOnReturnCode(attrs.get(ContinueOnReturnCode),
-      () => ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
+      ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
     (continueOnReturnCode |@| docker |@| failOnStderr) {
       new LocalRuntimeAttributes(_, _, _)
     } match {

--- a/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
+++ b/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
@@ -43,10 +43,10 @@ class SgeInitializationActor(override val workflowDescriptor: BackendWorkflowDes
     */
   override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
     Future {
-      val docker = validateDocker(runtimeAttributes.get(Docker), () => None.successNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), () => FailOnStderrDefaultValue.successNel)
+      val docker = validateDocker(runtimeAttributes.get(Docker), None.successNel)
+      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
       val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        () => ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
+        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
       (docker |@| failOnStderr |@| continueOnReturnCode) {
         (_, _, _)
       }


### PR DESCRIPTION
- Moved memory validation from WDL4s to Backend validation.
- Removed unused validation functions from CromwellRuntimeAttributes.
- Added validation for negative values in memory and cpu.
- Moved CPU validation from JES backend to generic backend validation functions object.