### PR TITLE
Fmc 725 validation exp eval. Closes #725.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -62,71 +62,8 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
   def beforeAll(): Future[Unit]
 
   /**
-    * Validates runtime attributes for one specific call.
-    *
-    * @param runtimeAttributes Runtime Attributes with already evaluated values.
-    * @return If all entries from runtime attributes section are valid Success otherwise
-    *         Failure with the aggregation of errors.
-    */
-  def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[scalaz.Validation[NonEmptyList[String], Unit]]
-
-  /**
     * Validate that this WorkflowBackendActor can run all of the calls that it's been assigned
     */
-  protected def validate(): Future[Unit] = {
-    def eval(call: Call) = validateRuntimeAttributes(evaluateRuntimeAttributesWdlExpressions(call))
+  def validate(): Future[Unit]
 
-    val validationResult: Future[Seq[(Call, Validation[NonEmptyList[String], Unit])]] =
-      Future.sequence(calls map { call => eval(call) map { valRes => (call, valRes) } })
-
-    val failedValidations = validationResult.map(evaluateValidationResultPerCall)
-
-    //TODO: Add recover or not but refactor this as part of https://github.com/broadinstitute/cromwell/issues/725.
-    failedValidations map { failures =>
-      if (failures.nonEmpty) {
-        throw new AggregatedException("Runtime attribute validation failed", failures)
-      }
-    }
-  }
-
-  /**
-    * Creates WDL expression evaluator for the specific call.
-    *
-    * @param call Call which contains WDL expressions in it.
-    * @return A WDL ValueEvaluator.
-    */
-  protected def createLookup(call: Call): ScopedLookupFunction = {
-    val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
-    val knownInputs = workflowDescriptor.inputs
-    WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
-  }
-
-  /**
-    * Evaluates WDL expressions within call runtime attributes.
-    *
-    * @param call Call which contains WDL expressions in it.
-    * @return Evaluated runtime attributes.
-    */
-  private def evaluateRuntimeAttributesWdlExpressions(call: Call): EvaluatedRuntimeAttributes = {
-    val lookup = createLookup(call)
-    def evaluate(wdlExpression: WdlExpression) = wdlExpression.evaluate(lookup, NoFunctions)
-    val evaluateAttrs = call.task.runtimeAttributes.attrs mapValues evaluate
-    TryUtils.sequenceMap(evaluateAttrs, "Runtime attributes evaluation").get
-  }
-
-  /**
-    * Checks if there was any validation failure.
-    *
-    * @param evaluation Tuple with a call and related validation result.
-    * @return A list with all validation exceptions.
-    */
-  private def evaluateValidationResultPerCall(evaluation: Seq[(Call, ErrorOr[Unit])]): Seq[ValidationAggregatedException] = {
-    evaluation collect {
-      case (call, validation: Failure[NonEmptyList[String]]) =>
-        validation match {
-          case failureWithStringErr: Failure[NonEmptyList[String]] =>
-            ValidationAggregatedException(s"Runtime attribute validation failed for task '${call.taskFqn}'.", failureWithStringErr.e.list)
-        }
-    }
-  }
 }

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
@@ -14,8 +14,7 @@ import scala.concurrent.Future
 import scalaz.Scalaz._
 
 object HtCondorInitializationActor {
-  val FailOnStderrDefaultValue = true
-  val ContinueOnRcDefaultValue = 0
+  val SupportedKeys = Set(Docker, FailOnStderr, ContinueOnReturnCode)
 
   def props(workflowDescriptor: BackendWorkflowDescriptor, calls: Seq[Call], configurationDescriptor: BackendConfigurationDescriptor): Props =
     Props(new HtCondorInitializationActor(workflowDescriptor, calls, configurationDescriptor))
@@ -35,20 +34,18 @@ class HtCondorInitializationActor(override val workflowDescriptor: BackendWorkfl
   override def beforeAll(): Future[Unit] = Future.successful(())
 
   /**
-    * Validates runtime attributes for one specific call.
-    *
-    * @param runtimeAttributes Runtime Attributes with already evaluated values.
-    * @return If all entries from runtime attributes section are valid Success otherwise
-    *         Failure with the aggregation of errors.
+    * Validate that this WorkflowBackendActor can run all of the calls that it's been assigned
     */
-  override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
+  override def validate(): Future[Unit] = {
     Future {
-      val docker = validateDocker(runtimeAttributes.get(Docker), "Failed to get Docker mandatory key from runtime attributes".failureNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
-      val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
-      (docker |@| failOnStderr |@| continueOnReturnCode) {
-        (_, _, _)
+      calls foreach { call =>
+        val runtimeAttributes = call.task.runtimeAttributes.attrs
+        val notSupportedAttributes = runtimeAttributes filterKeys { !SupportedKeys.contains(_) }
+
+        if (notSupportedAttributes.nonEmpty) {
+          val notSupportedAttrString = notSupportedAttributes.keys mkString ", "
+          log.warning(s"Key/s [$notSupportedAttrString] is/are not supported by HtCondorBackend. Unsupported attributes will not be part of jobs executions.")
+        }
       }
     }
   }

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
@@ -1,25 +1,25 @@
-package cromwell.backend.impl.local
+package cromwell.backend.impl.htcondor
 
+import cromwell.backend.validation.{ContinueOnReturnCodeSet, ContinueOnReturnCode}
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.validation.RuntimeAttributesValidation._
-import cromwell.backend.validation.{ContinueOnReturnCode, ContinueOnReturnCodeSet}
 import lenthall.exception.MessageAggregation
 import wdl4s.values.WdlValue
 
-import scalaz.Scalaz._
 import scalaz._
+import Scalaz._
 
-object LocalRuntimeAttributes {
+object HtCondorRuntimeAttributes {
   val FailOnStderrDefaultValue = false
   val ContinueOnRcDefaultValue = 0
 
-  def apply(attrs: Map[String, WdlValue]): LocalRuntimeAttributes = {
+  def apply(attrs: Map[String, WdlValue]): HtCondorRuntimeAttributes = {
     val docker = validateDocker(attrs.get(Docker), None.successNel)
     val failOnStderr = validateFailOnStderr(attrs.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
     val continueOnReturnCode = validateContinueOnReturnCode(attrs.get(ContinueOnReturnCode),
       ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
     (continueOnReturnCode |@| docker |@| failOnStderr) {
-      new LocalRuntimeAttributes(_, _, _)
+      new HtCondorRuntimeAttributes(_, _, _)
     } match {
       case Success(x) => x
       case Failure(nel) => throw new RuntimeException with MessageAggregation {
@@ -30,4 +30,4 @@ object LocalRuntimeAttributes {
   }
 }
 
-case class LocalRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode, dockerImage: Option[String], failOnStderr: Boolean)
+case class HtCondorRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode, dockerImage: Option[String], failOnStderr: Boolean)

--- a/supportedBackends/htcondor/src/test/scala/HtCondorRuntimeAttributesSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/HtCondorRuntimeAttributesSpec.scala
@@ -1,0 +1,135 @@
+package cromwell.backend.impl.htcondor
+
+import cromwell.backend.BackendWorkflowDescriptor
+import cromwell.backend.validation.RuntimeAttributesKeys._
+import cromwell.backend.validation.{TryUtils, ContinueOnReturnCode, ContinueOnReturnCodeSet}
+import cromwell.core.{WorkflowId, WorkflowOptions}
+import org.scalatest.{Matchers, WordSpecLike}
+import spray.json.{JsValue, JsObject}
+import wdl4s.WdlExpression.ScopedLookupFunction
+import wdl4s.expression.NoFunctions
+import wdl4s.values.WdlValue
+import wdl4s.{Call, WdlExpression, WdlSource, NamespaceWithWorkflow}
+
+class HtCondorRuntimeAttributesSpec extends WordSpecLike with Matchers {
+
+  val HelloWorld =
+    """
+      |task hello {
+      |  String addressee = "you"
+      |  command {
+      |    echo "Hello ${addressee}!"
+      |  }
+      |  output {
+      |    String salutation = read_string(stdout())
+      |  }
+      |
+      |  RUNTIME
+      |}
+      |
+      |workflow hello {
+      |  call hello
+      |}
+    """.stripMargin
+
+  val defaultRuntimeAttributes = Map(
+    Docker -> None,
+    FailOnStderr -> false,
+    ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(0)))
+
+  "HtCondorRuntimeAttributes" should {
+    "return an instance of itself when there are no runtime attributes defined." in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, defaultRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("ubuntu:latest"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry based on input" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "\${addressee}" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid Docker entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: 1 }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting docker runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid failOnStderr entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (FailOnStderr -> true)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "true" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid failOnStderr entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "yes" }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+    }
+
+    "return an instance of itself when tries to validate a valid continueOnReturnCode entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(1)))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: 1 }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid continueOnReturnCode entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: "value" }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]")
+    }
+
+  }
+
+  private def buildWorkflowDescriptor(wdl: WdlSource,
+                                      inputs: Map[String, WdlValue] = Map.empty,
+                                      options: WorkflowOptions = WorkflowOptions(JsObject(Map.empty[String, JsValue])),
+                                      runtime: String = "") = {
+    new BackendWorkflowDescriptor(
+      WorkflowId.randomId(),
+      NamespaceWithWorkflow.load(wdl.replaceAll("RUNTIME", runtime)),
+      inputs,
+      options
+    )
+  }
+
+  private def createRuntimeAttributes(wdlSource: WdlSource, runtimeAttributes: String = "") = {
+    val workflowDescriptor = buildWorkflowDescriptor(wdlSource, runtime = runtimeAttributes)
+
+    def createLookup(call: Call): ScopedLookupFunction = {
+      val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
+      val knownInputs = workflowDescriptor.inputs
+      WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
+    }
+
+    workflowDescriptor.workflowNamespace.workflow.calls map {
+      call =>
+        val ra = call.task.runtimeAttributes.attrs mapValues { _.evaluate(createLookup(call), NoFunctions) }
+        TryUtils.sequenceMap(ra, "Runtime attributes evaluation").get
+    }
+  }
+
+  private def assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WdlValue], expectedRuntimeAttributes: Map[String, Any]): Unit = {
+    try {
+      val htCondorRuntimeAttributes = HtCondorRuntimeAttributes(runtimeAttributes)
+      assert(htCondorRuntimeAttributes.dockerImage == expectedRuntimeAttributes.get(Docker).get.asInstanceOf[Option[String]])
+      assert(htCondorRuntimeAttributes.failOnStderr == expectedRuntimeAttributes.get(FailOnStderr).get.asInstanceOf[Boolean])
+      assert(htCondorRuntimeAttributes.continueOnReturnCode == expectedRuntimeAttributes.get(ContinueOnReturnCode).get.asInstanceOf[ContinueOnReturnCode])
+    } catch {
+      case ex: RuntimeException => fail(s"Exception was not expected but received: ${ex.getMessage}")
+    }
+  }
+
+  private def assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WdlValue], exMsg: String): Unit = {
+    try {
+      HtCondorRuntimeAttributes(runtimeAttributes)
+      fail("A RuntimeException was expected.")
+    } catch {
+      case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
+    }
+  }
+}
+

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -3,34 +3,15 @@ package cromwell.backend.impl.jes
 import akka.actor.Props
 import cromwell.backend.BackendLifecycleActor.WorkflowAbortResponse
 import cromwell.backend.impl.jes.JesInitializationActor._
-import cromwell.backend.impl.jes.io.{JesAttachedDisk, JesWorkingDisk}
-import cromwell.backend.validation.ContinueOnReturnCodeSet
 import cromwell.backend.validation.RuntimeAttributesKeys._
-import cromwell.backend.validation.RuntimeAttributesValidation._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor, BackendWorkflowInitializationActor}
-import cromwell.core._
 import wdl4s.Call
-import wdl4s.types.{WdlIntegerType, WdlStringType}
-import wdl4s.values.{WdlArray, WdlInteger, WdlString, WdlValue}
 
 import scala.concurrent.Future
-import scalaz.Scalaz._
 
 object JesInitializationActor {
-  //TODO: check if these need to be configurable.
-  val CpuDefaultValue = 1
-  val ZonesKey = "zones"
-  val ZoneDefaultValue = Seq("us-central1-a")
-  val PreemptibleKey = "preemptible"
-  val PreemptibleDefaultValue = 0
-  val BootDiskSizeKey = "bootDiskSizeGb"
-  val BootDiskSizeDefaultValue = 10
-  val MemoryDefaultValue = "2 GB"
-  val DisksKey = "disks"
-  val DisksDefaultValue = s"${JesWorkingDisk.Name} 10 SSD"
-  val DefaultJesWorkingDisk = JesAttachedDisk.parse(DisksDefaultValue).get
-  val FailOnStderrDefaultValue = false
-  val ContinueOnRcDefaultValue = 0
+  val SupportedKeys = Set(Cpu, Memory, Docker, FailOnStderr, ContinueOnReturnCode, JesRuntimeAttributes.ZonesKey,
+    JesRuntimeAttributes.PreemptibleKey, JesRuntimeAttributes.BootDiskSizeKey, JesRuntimeAttributes.DisksKey)
 
   def props(workflowDescriptor: BackendWorkflowDescriptor, calls: Seq[Call], configurationDescriptor: BackendConfigurationDescriptor): Props =
     Props(new JesInitializationActor(workflowDescriptor, calls, configurationDescriptor))
@@ -52,83 +33,21 @@ class JesInitializationActor(override val workflowDescriptor: BackendWorkflowDes
   override def beforeAll(): Future[Unit] = Future.successful(())
 
   /**
-    * Validates runtime attributes for one specific call.
-    *
-    * @param runtimeAttributes Runtime Attributes with already evaluated values.
-    * @return If all entries from runtime attributes section are valid Success otherwise
-    *         Failure with the aggregation of errors.
+    * Validate that this WorkflowBackendActor can run all of the calls that it's been assigned
     */
-  override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
+  override def validate(): Future[Unit] = {
     Future {
-      val cpu = validateCpu(runtimeAttributes.get(Cpu), CpuDefaultValue.successNel)
-      val zones = validateZone(runtimeAttributes.get(ZonesKey))
-      val preemptible = validatePreemptible(runtimeAttributes.get(PreemptibleKey))
-      val bootDiskSize = validateBootDisk(runtimeAttributes.get(BootDiskSizeKey))
-      val memory = validateMemory(runtimeAttributes.get(Memory), parseMemoryString(WdlString(MemoryDefaultValue)))
-      val disks = validateLocalDisks(runtimeAttributes.get(DisksKey))
-      val docker = validateDocker(runtimeAttributes.get(Docker), "Failed to get Docker mandatory key from runtime attributes".failureNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
-      val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
-      (cpu |@| zones |@| preemptible |@| bootDiskSize |@| memory |@| disks |@| docker |@| failOnStderr |@| continueOnReturnCode) {
-        (_, _, _, _, _, _, _, _, _)
+      calls foreach { call =>
+        val runtimeAttributes = call.task.runtimeAttributes.attrs
+        val notSupportedAttributes = runtimeAttributes filterKeys { !SupportedKeys.contains(_) }
+
+        if (notSupportedAttributes.nonEmpty) {
+          val notSupportedAttrString = notSupportedAttributes.keys mkString ", "
+          log.warning(s"Key/s [$notSupportedAttrString] is/are not supported by JesBackend. Unsupported attributes will not be part of jobs executions.")
+        }
+
+        runtimeAttributes.get(Docker).orElse(throw new IllegalArgumentException(s"$Docker mandatory runtime attribute is missing."))
       }
-    }
-  }
-
-  private def validateZone(zoneValue: Option[WdlValue]): ErrorOr[Vector[String]] = {
-    zoneValue match {
-      case Some(WdlString(s)) => s.split("\\s+").toVector.successNel
-      case Some(WdlArray(wdlType, value)) if wdlType.memberType == WdlStringType =>
-        value.map(_.valueString).toVector.successNel
-      case Some(_) => s"Expecting $ZonesKey runtime attribute to be either a whitespace separated String or an Array[String]".failureNel
-      case None => ZoneDefaultValue.toVector.successNel
-    }
-  }
-
-  private def validatePreemptible(preemptible: Option[WdlValue]): ErrorOr[Int] = {
-    val preemptibleValidation = preemptible.map(validateInt).getOrElse(PreemptibleDefaultValue.successNel)
-    if (preemptibleValidation.isFailure) {
-      s"Expecting $PreemptibleKey runtime attribute to be an Integer".failureNel
-    }
-    else {
-      preemptibleValidation
-    }
-  }
-
-  private def validateBootDisk(diskSize: Option[WdlValue]): ErrorOr[Int] = diskSize match {
-    case Some(x) if WdlIntegerType.isCoerceableFrom(x.wdlType) =>
-      WdlIntegerType.coerceRawValue(x) match {
-        case scala.util.Success(x: WdlInteger) => x.value.intValue.successNel
-        case scala.util.Success(unhandled) => s"Coercion was expected to create an Integer but instead got $unhandled".failureNel
-        case scala.util.Failure(t) => s"Expecting $BootDiskSizeKey runtime attribute to be an Integer".failureNel
-      }
-    case None => BootDiskSizeDefaultValue.successNel
-  }
-
-  private def validateLocalDisks(value: Option[WdlValue]): ErrorOr[Seq[JesAttachedDisk]] = {
-    val nels = value match {
-      case Some(WdlString(s)) => s.split(",\\s*").toSeq.map(validateLocalDisk)
-      case Some(WdlArray(wdlType, seq)) if wdlType.memberType == WdlStringType =>
-        seq.map(_.valueString).map(validateLocalDisk)
-      case Some(_) =>
-        Seq(s"Expecting $DisksKey runtime attribute to be a comma separated String or Array[String]".failureNel[JesAttachedDisk])
-      case None => Seq(DefaultJesWorkingDisk).map(_.successNel)
-    }
-
-    val emptyDiskNel = Vector.empty[JesAttachedDisk].successNel[String]
-    val disksNel = nels.foldLeft(emptyDiskNel)((acc, v) => (acc |@| v) { (a, v) => a :+ v })
-
-    disksNel map {
-      case disks if disks.exists(_.name == JesWorkingDisk.Name) => disks
-      case disks => disks :+ DefaultJesWorkingDisk
-    }
-  }
-
-  private def validateLocalDisk(disk: String): ErrorOr[JesAttachedDisk] = {
-    JesAttachedDisk.parse(disk) match {
-      case scala.util.Success(localDisk) => localDisk.successNel
-      case scala.util.Failure(ex) => ex.getMessage.failureNel
     }
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeAttributes.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeAttributes.scala
@@ -1,0 +1,118 @@
+package cromwell.backend.impl.jes
+
+import cromwell.backend.impl.jes.io.{JesWorkingDisk, JesAttachedDisk}
+import cromwell.backend.validation.RuntimeAttributesKeys._
+import cromwell.backend.validation.RuntimeAttributesValidation._
+import cromwell.backend.validation._
+import cromwell.core._
+import lenthall.exception.MessageAggregation
+import wdl4s.types.{WdlStringType, WdlIntegerType}
+import wdl4s.values.{WdlInteger, WdlArray, WdlString, WdlValue}
+
+import scalaz._
+import Scalaz._
+
+case class JesRuntimeAttributes(cpu: Int,
+                                zones: Vector[String],
+                                preemptible: Int,
+                                bootDiskSize: Int,
+                                memory: MemorySize,
+                                disks: Seq[JesAttachedDisk],
+                                dockerImage: Option[String],
+                                failOnStderr: Boolean,
+                                continueOnReturnCode: ContinueOnReturnCode)
+
+object JesRuntimeAttributes {
+  val CpuDefaultValue = 1
+  val ZonesKey = "zones"
+  val ZoneDefaultValue = Seq("us-central1-a")
+  val PreemptibleKey = "preemptible"
+  val PreemptibleDefaultValue = 0
+  val BootDiskSizeKey = "bootDiskSizeGb"
+  val BootDiskSizeDefaultValue = 10
+  val MemoryDefaultValue = "2 GB"
+  val DisksKey = "disks"
+  val DisksDefaultValue = s"${JesWorkingDisk.Name} 10 SSD"
+  val DefaultJesWorkingDisk = JesAttachedDisk.parse(DisksDefaultValue).get
+  val FailOnStderrDefaultValue = false
+  val ContinueOnRcDefaultValue = 0
+
+  def apply(attrs: Map[String, WdlValue]): JesRuntimeAttributes = {
+    val cpu = validateCpu(attrs.get(Cpu), CpuDefaultValue.successNel)
+    val zones = validateZone(attrs.get(ZonesKey))
+    val preemptible = validatePreemptible(attrs.get(PreemptibleKey))
+    val bootDiskSize = validateBootDisk(attrs.get(BootDiskSizeKey))
+    val memory = validateMemory(attrs.get(Memory), parseMemoryString(WdlString(MemoryDefaultValue)))
+    val disks = validateLocalDisks(attrs.get(DisksKey))
+    val docker = validateDocker(attrs.get(Docker), "Failed to get Docker mandatory key from runtime attributes".failureNel)
+    val failOnStderr = validateFailOnStderr(attrs.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
+    val continueOnReturnCode = validateContinueOnReturnCode(attrs.get(ContinueOnReturnCode),
+      ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
+    (cpu |@| zones |@| preemptible |@| bootDiskSize |@| memory |@| disks |@| docker |@| failOnStderr |@| continueOnReturnCode) {
+      new JesRuntimeAttributes(_, _, _, _, _, _, _, _, _)
+    } match {
+      case Success(x) => x
+      case Failure(nel) => throw new RuntimeException with MessageAggregation {
+        override def exceptionContext: String = "Runtime attribute validation failed"
+        override def errorMessages: Traversable[String] = nel.list
+      }
+    }
+  }
+
+  private def validateZone(zoneValue: Option[WdlValue]): ErrorOr[Vector[String]] = {
+    zoneValue match {
+      case Some(WdlString(s)) => s.split("\\s+").toVector.successNel
+      case Some(WdlArray(wdlType, value)) if wdlType.memberType == WdlStringType =>
+        value.map(_.valueString).toVector.successNel
+      case Some(_) => s"Expecting $ZonesKey runtime attribute to be either a whitespace separated String or an Array[String]".failureNel
+      case None => ZoneDefaultValue.toVector.successNel
+    }
+  }
+
+  private def validatePreemptible(preemptible: Option[WdlValue]): ErrorOr[Int] = {
+    val preemptibleValidation = preemptible.map(validateInt).getOrElse(PreemptibleDefaultValue.successNel)
+    if (preemptibleValidation.isFailure) {
+      s"Expecting $PreemptibleKey runtime attribute to be an Integer".failureNel
+    }
+    else {
+      preemptibleValidation
+    }
+  }
+
+  private def validateBootDisk(diskSize: Option[WdlValue]): ErrorOr[Int] = diskSize match {
+    case Some(x) if WdlIntegerType.isCoerceableFrom(x.wdlType) =>
+      WdlIntegerType.coerceRawValue(x) match {
+        case scala.util.Success(x: WdlInteger) => x.value.intValue.successNel
+        case scala.util.Success(unhandled) => s"Coercion was expected to create an Integer but instead got $unhandled".failureNel
+        case scala.util.Failure(t) => s"Expecting $BootDiskSizeKey runtime attribute to be an Integer".failureNel
+      }
+    case None => BootDiskSizeDefaultValue.successNel
+  }
+
+  private def validateLocalDisks(value: Option[WdlValue]): ErrorOr[Seq[JesAttachedDisk]] = {
+    val nels = value match {
+      case Some(WdlString(s)) => s.split(",\\s*").toSeq.map(validateLocalDisk)
+      case Some(WdlArray(wdlType, seq)) if wdlType.memberType == WdlStringType =>
+        seq.map(_.valueString).map(validateLocalDisk)
+      case Some(_) =>
+        Seq(s"Expecting $DisksKey runtime attribute to be a comma separated String or Array[String]".failureNel[JesAttachedDisk])
+      case None => Seq(DefaultJesWorkingDisk).map(_.successNel)
+    }
+
+    val emptyDiskNel = Vector.empty[JesAttachedDisk].successNel[String]
+    val disksNel = nels.foldLeft(emptyDiskNel)((acc, v) => (acc |@| v) { (a, v) => a :+ v })
+
+    disksNel map {
+      case disks if disks.exists(_.name == JesWorkingDisk.Name) => disks
+      case disks => disks :+ DefaultJesWorkingDisk
+    }
+  }
+
+  private def validateLocalDisk(disk: String): ErrorOr[JesAttachedDisk] = {
+    JesAttachedDisk.parse(disk) match {
+      case scala.util.Success(localDisk) => localDisk.successNel
+      case scala.util.Failure(ex) => ex.getMessage.failureNel
+    }
+  }
+
+}

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -1,12 +1,11 @@
 package cromwell.backend.impl.jes
 
 import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestDuration, TestKit}
+import akka.testkit.{EventFilter, ImplicitSender, TestDuration, TestKit}
 import com.typesafe.config.ConfigFactory
 import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed, InitializationSuccess, Initialize}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor}
 import cromwell.core.{WorkflowId, WorkflowOptions}
-import lenthall.exception.AggregatedException
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
 import spray.json.{JsObject, JsValue}
 import wdl4s.values.WdlValue
@@ -14,8 +13,8 @@ import wdl4s.{Call, NamespaceWithWorkflow, WdlSource}
 
 import scala.concurrent.duration._
 
-class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationActorSpec"))
-  with WordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
+class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationActorSpec", ConfigFactory.parseString(
+  """akka.loggers = ["akka.testkit.TestEventListener"]"""))) with WordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
   val Timeout = 5.second.dilated
 
   val HelloWorld =
@@ -37,7 +36,7 @@ class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationA
       |}
     """.stripMargin
 
-  val defaultBackendConfig = new BackendConfigurationDescriptor("jes-config", ConfigFactory.load())
+  val defaultBackendConfig = new BackendConfigurationDescriptor("config", ConfigFactory.load())
 
   private def buildWorkflowDescriptor(wdl: WdlSource,
                                       inputs: Map[String, WdlValue] = Map.empty,
@@ -60,7 +59,22 @@ class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationA
   }
 
   "JesInitializationActor" should {
-    "return InitializationFailed when there are no runtime attributes defined." in {
+    "log a warning message when there are unsupported runtime attributes" in {
+      within(Timeout) {
+        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu/latest" test: true }""")
+        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
+        backend ! Initialize
+        EventFilter.warning(message = s"Key/s [test] is/are not supported by JesBackend. Unsupported attributes will not be part of jobs executions.", occurrences = 1) intercept {
+          //Log message was intercepted.
+        }
+        expectMsgPF() {
+          case InitializationSuccess => //Docker entry is present.
+          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
+        }
+      }
+    }
+
+    "return InitializationFailed when docker runtime attribute key is not present" in {
       within(Timeout) {
         val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { }""")
         val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
@@ -68,257 +82,9 @@ class JesInitializationActorSpec extends TestKit(ActorSystem("JesInitializationA
         expectMsgPF() {
           case InitializationFailed(failure) =>
             failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
+              case exception: IllegalArgumentException =>
+                if (!exception.getMessage.equals("docker mandatory runtime attribute is missing."))
                   fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Failed to get Docker mandatory key from runtime attributes"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Failed to get Docker mandatory key from runtime attributes'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid cpu entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" cpu: 1}""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid cpu entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" cpu: "value" }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting cpu runtime attribute to be an Integer"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting cpu runtime attribute to be an Integer'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid zones entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" zones: "us-central1-a" }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid zones entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" zones: 1 }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid array zones entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" zones: ["us-central1-a", "us-central1-b"] }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid array zones entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" zones: [2, 1] }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid preemptible entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" preemptible: 1}""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid preemptible entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" preemptible: "value" }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting preemptible runtime attribute to be an Integer"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting preemptible runtime attribute to be an Integer'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid bootDiskSizeGb entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" bootDiskSizeGb: 1}""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid bootDiskSizeGb entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" bootDiskSizeGb: "value" }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting bootDiskSizeGb runtime attribute to be an Integer"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting bootDiskSizeGb runtime attribute to be an Integer'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid disks entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" disks: "local-disk 10 SSD"}""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid disks entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" disks: 10 }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting disks runtime attribute to be a comma separated String or Array[String]"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting disks runtime attribute to be a comma separated String or Array[String]'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid array disks entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" disks: [10, 11] }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting disks runtime attribute to be a comma separated String or Array[String]"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting disks runtime attribute to be a comma separated String or Array[String]'.")
-            }
-        }
-      }
-    }
-
-    "return InitializationSuccess when tries to validate a valid memory entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" memory: 1}""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationSuccess => //Entry is valid as expected.
-          case InitializationFailed(failure) => fail(s"InitializationSuccess was expected but got $failure")
-        }
-      }
-    }
-
-    "return InitializationFailed when tries to validate an invalid memory entry" in {
-      within(Timeout) {
-        val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { docker: "ubuntu:latest" memory: "value" }""")
-        val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls, defaultBackendConfig)
-        backend ! Initialize
-        expectMsgPF() {
-          case InitializationFailed(failure) =>
-            failure match {
-              case exception: AggregatedException =>
-                if (!exception.exceptionContext.equals("Runtime attribute validation failed"))
-                  fail("Exception message does not contains 'Runtime attribute validation failed'.")
-                if (exception.throwables.size != 1)
-                  fail("Number of errors coming from AggregatedException is not equals to one.")
-                if (!exception.throwables.head.getMessage.contains("Expecting memory runtime attribute to be an Integer or String with format '8 GB'"))
-                  fail("Message from error nr 1 in validation exception does not contains 'Expecting memory runtime attribute to be an Integer or String with format '8 GB''.")
             }
         }
       }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesRuntimeAttributesSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesRuntimeAttributesSpec.scala
@@ -1,0 +1,232 @@
+package cromwell.backend.impl.jes
+
+import cromwell.backend.BackendWorkflowDescriptor
+import cromwell.backend.impl.jes.io.JesAttachedDisk
+import cromwell.backend.validation.RuntimeAttributesKeys._
+import cromwell.backend.validation.{ContinueOnReturnCode, ContinueOnReturnCodeSet, MemorySize, TryUtils}
+import cromwell.core.{WorkflowId, WorkflowOptions}
+import org.scalatest.{Matchers, WordSpecLike}
+import spray.json.{JsObject, JsValue}
+import wdl4s.WdlExpression.ScopedLookupFunction
+import wdl4s.expression.NoFunctions
+import wdl4s.parser.MemoryUnit
+import wdl4s.values.WdlValue
+import wdl4s.{Call, NamespaceWithWorkflow, WdlExpression, WdlSource}
+
+class JesRuntimeAttributesSpec extends WordSpecLike with Matchers {
+
+  val HelloWorld =
+    """
+      |task hello {
+      |  String addressee = "you"
+      |  command {
+      |    echo "Hello ${addressee}!"
+      |  }
+      |  output {
+      |    String salutation = read_string(stdout())
+      |  }
+      |
+      |  RUNTIME
+      |}
+      |
+      |workflow hello {
+      |  call hello
+      |}
+    """.stripMargin
+
+  val defaultRuntimeAttributes = Map(
+    Docker -> Some("ubuntu:latest"),
+    FailOnStderr -> false,
+    ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(0)),
+    Cpu -> 1,
+    Memory -> MemorySize(2.0, MemoryUnit.GB),
+    JesRuntimeAttributes.ZonesKey -> JesRuntimeAttributes.ZoneDefaultValue.toVector,
+    JesRuntimeAttributes.BootDiskSizeKey -> JesRuntimeAttributes.BootDiskSizeDefaultValue,
+    JesRuntimeAttributes.PreemptibleKey -> JesRuntimeAttributes.PreemptibleDefaultValue,
+    JesRuntimeAttributes.DisksKey -> Seq(JesRuntimeAttributes.DefaultJesWorkingDisk)
+  )
+
+  "JesRuntimeAttributes" should {
+
+    "throw an exception when there are no runtime attributes defined." in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Failed to get Docker mandatory key from runtime attributes")
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, defaultRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry based on input" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "\${addressee}" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid Docker entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: 1 }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting docker runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid failOnStderr entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (FailOnStderr -> true)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" failOnStderr: "true" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid failOnStderr entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" failOnStderr: "yes" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+    }
+
+    "return an instance of itself when tries to validate a valid continueOnReturnCode entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(1)))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" failOnStderr: "false" continueOnReturnCode: 1 }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid continueOnReturnCode entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" failOnStderr: "yes" continueOnReturnCode: "value" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]")
+    }
+
+    "return an instance of itself when tries to validate a valid cpu entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Cpu -> 2)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" cpu: 2 }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid cpu entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" cpu: "value" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting cpu runtime attribute to be an Integer")
+    }
+
+    "return an instance of itself when tries to validate a valid zones entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (JesRuntimeAttributes.ZonesKey -> Seq("us-central1-z").toVector)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" zones: "us-central1-z" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid zones entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" zones: 1 }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]")
+    }
+
+    "return InitializationSuccess when tries to validate a valid array zones entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (JesRuntimeAttributes.ZonesKey -> Seq("us-central1-y", "us-central1-z").toVector)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" zones: ["us-central1-y", "us-central1-z"] }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid array zones entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" zones: [2, 1] }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting zones runtime attribute to be either a whitespace separated String or an Array[String]")
+    }
+
+    "return an instance of itself when tries to validate a valid preemptible entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (JesRuntimeAttributes.PreemptibleKey -> 3)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" preemptible: 3 }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid preemptible entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" preemptible: "value" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting preemptible runtime attribute to be an Integer")
+    }
+
+    "return InitializationSuccess when tries to validate a valid bootDiskSizeGb entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (JesRuntimeAttributes.BootDiskSizeKey -> 4)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" bootDiskSizeGb: 4 }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid bootDiskSizeGb entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" bootDiskSizeGb: "value" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting bootDiskSizeGb runtime attribute to be an Integer")
+    }
+
+    "return an instance of itself when tries to validate a valid disks entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (JesRuntimeAttributes.DisksKey -> Seq(JesAttachedDisk.parse("local-disk 20 SSD").get))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" disks: "local-disk 20 SSD" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid disks entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" disks: 10 }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting disks runtime attribute to be a comma separated String or Array[String]")
+    }
+
+    "throw an exception when tries to validate an invalid array disks entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" disks: [10, 11] }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting disks runtime attribute to be a comma separated String or Array[String]")
+    }
+
+    "return an instance of itself when tries to validate a valid memory entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Memory -> MemorySize.parse("1 GB").get)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" memory: "1 GB" }""").head
+      assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid memory entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" memory: "value" }""").head
+      assertJesRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting memory runtime attribute to be an Integer or String with format '8 GB'")
+    }
+  }
+
+  private def buildWorkflowDescriptor(wdl: WdlSource,
+                                      inputs: Map[String, WdlValue] = Map.empty,
+                                      options: WorkflowOptions = WorkflowOptions(JsObject(Map.empty[String, JsValue])),
+                                      runtime: String = "") = {
+    new BackendWorkflowDescriptor(
+      WorkflowId.randomId(),
+      NamespaceWithWorkflow.load(wdl.replaceAll("RUNTIME", runtime)),
+      inputs,
+      options
+    )
+  }
+
+  private def createRuntimeAttributes(wdlSource: WdlSource, runtimeAttributes: String = "") = {
+    val workflowDescriptor = buildWorkflowDescriptor(wdlSource, runtime = runtimeAttributes)
+
+    def createLookup(call: Call): ScopedLookupFunction = {
+      val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
+      val knownInputs = workflowDescriptor.inputs
+      WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
+    }
+
+    workflowDescriptor.workflowNamespace.workflow.calls map {
+      call =>
+        val ra = call.task.runtimeAttributes.attrs mapValues {
+          _.evaluate(createLookup(call), NoFunctions)
+        }
+        TryUtils.sequenceMap(ra, "Runtime attributes evaluation").get
+    }
+  }
+
+  private def assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WdlValue], expectedRuntimeAttributes: Map[String, Any]): Unit = {
+    try {
+      val jesRuntimeAttributes = JesRuntimeAttributes(runtimeAttributes)
+      assert(jesRuntimeAttributes.dockerImage == expectedRuntimeAttributes.get(Docker).get.asInstanceOf[Option[String]])
+      assert(jesRuntimeAttributes.failOnStderr == expectedRuntimeAttributes.get(FailOnStderr).get.asInstanceOf[Boolean])
+      assert(jesRuntimeAttributes.continueOnReturnCode == expectedRuntimeAttributes.get(ContinueOnReturnCode).get.asInstanceOf[ContinueOnReturnCode])
+      assert(jesRuntimeAttributes.cpu == expectedRuntimeAttributes.get(Cpu).get.asInstanceOf[Int])
+      assert(jesRuntimeAttributes.memory == expectedRuntimeAttributes.get(Memory).get.asInstanceOf[MemorySize])
+      assert(jesRuntimeAttributes.zones == expectedRuntimeAttributes.get(JesRuntimeAttributes.ZonesKey).get.asInstanceOf[Vector[String]])
+      assert(jesRuntimeAttributes.bootDiskSize == expectedRuntimeAttributes.get(JesRuntimeAttributes.BootDiskSizeKey).get.asInstanceOf[Int])
+      assert(jesRuntimeAttributes.preemptible == expectedRuntimeAttributes.get(JesRuntimeAttributes.PreemptibleKey).get.asInstanceOf[Int])
+      assert(jesRuntimeAttributes.disks == expectedRuntimeAttributes.get(JesRuntimeAttributes.DisksKey).get.asInstanceOf[Seq[JesAttachedDisk]])
+    } catch {
+      case ex: RuntimeException => fail(s"Exception was not expected but received: ${ex.getMessage}")
+    }
+  }
+
+  private def assertJesRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WdlValue], exMsg: String): Unit = {
+    try {
+      JesRuntimeAttributes(runtimeAttributes)
+      fail("A RuntimeException was expected.")
+    } catch {
+      case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
+    }
+  }
+}

--- a/supportedBackends/local/src/test/scala/cromwell/backend/impl/local/LocalRuntimeAttributesSpec.scala
+++ b/supportedBackends/local/src/test/scala/cromwell/backend/impl/local/LocalRuntimeAttributesSpec.scala
@@ -1,0 +1,134 @@
+package cromwell.backend.impl.local
+
+import cromwell.backend.BackendWorkflowDescriptor
+import cromwell.backend.validation.RuntimeAttributesKeys._
+import cromwell.backend.validation.{ContinueOnReturnCode, ContinueOnReturnCodeSet}
+import cromwell.core.{WorkflowId, WorkflowOptions}
+import org.scalatest.{Matchers, WordSpecLike}
+import spray.json.{JsValue, JsObject}
+import wdl4s.WdlExpression.ScopedLookupFunction
+import wdl4s.expression.NoFunctions
+import wdl4s.values.WdlValue
+import wdl4s.{Call, WdlExpression, WdlSource, NamespaceWithWorkflow}
+
+class LocalRuntimeAttributesSpec extends WordSpecLike with Matchers {
+
+  val HelloWorld =
+    """
+      |task hello {
+      |  String addressee = "you"
+      |  command {
+      |    echo "Hello ${addressee}!"
+      |  }
+      |  output {
+      |    String salutation = read_string(stdout())
+      |  }
+      |
+      |  RUNTIME
+      |}
+      |
+      |workflow hello {
+      |  call hello
+      |}
+    """.stripMargin
+
+  val defaultRuntimeAttributes = Map(
+    Docker -> None,
+    FailOnStderr -> false,
+    ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(0)))
+
+  "LocalRuntimeAttributes" should {
+    "return an instance of itself when there are no runtime attributes defined." in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes, defaultRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("ubuntu:latest"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" }""").head
+      assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry based on input" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "\${addressee}" }""").head
+      assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid Docker entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: 1 }""").head
+      assertLocalRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting docker runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid failOnStderr entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (FailOnStderr -> true)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "true" }""").head
+      assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid failOnStderr entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "yes" }""").head
+      assertLocalRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+    }
+
+    "return an instance of itself when tries to validate a valid continueOnReturnCode entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(1)))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: 1 }""").head
+      assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid continueOnReturnCode entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: "value" }""").head
+      assertLocalRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]")
+    }
+
+  }
+
+  private def buildWorkflowDescriptor(wdl: WdlSource,
+                                      inputs: Map[String, WdlValue] = Map.empty,
+                                      options: WorkflowOptions = WorkflowOptions(JsObject(Map.empty[String, JsValue])),
+                                      runtime: String = "") = {
+    new BackendWorkflowDescriptor(
+      WorkflowId.randomId(),
+      NamespaceWithWorkflow.load(wdl.replaceAll("RUNTIME", runtime)),
+      inputs,
+      options
+    )
+  }
+
+  private def createRuntimeAttributes(wdlSource: WdlSource, runtimeAttributes: String = "") = {
+    val workflowDescriptor = buildWorkflowDescriptor(wdlSource, runtime = runtimeAttributes)
+
+    def createLookup(call: Call): ScopedLookupFunction = {
+      val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
+      val knownInputs = workflowDescriptor.inputs
+      WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
+    }
+
+    workflowDescriptor.workflowNamespace.workflow.calls map {
+      call =>
+        val ra = call.task.runtimeAttributes.attrs mapValues { _.evaluate(createLookup(call), NoFunctions) }
+        TryUtils.sequenceMap(ra, "Runtime attributes evaluation").get
+    }
+  }
+
+  private def assertLocalRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WdlValue], expectedRuntimeAttributes: Map[String, Any]): Unit = {
+    try {
+      val localRuntimeAttributes = LocalRuntimeAttributes(runtimeAttributes)
+      assert(localRuntimeAttributes.dockerImage == expectedRuntimeAttributes.get(Docker).get.asInstanceOf[Option[String]])
+      assert(localRuntimeAttributes.failOnStderr == expectedRuntimeAttributes.get(FailOnStderr).get.asInstanceOf[Boolean])
+      assert(localRuntimeAttributes.continueOnReturnCode == expectedRuntimeAttributes.get(ContinueOnReturnCode).get.asInstanceOf[ContinueOnReturnCode])
+    } catch {
+      case ex: RuntimeException => fail(s"Exception was not expected but received: ${ex.getMessage}")
+    }
+  }
+
+  private def assertLocalRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WdlValue], exMsg: String): Unit = {
+    try {
+      LocalRuntimeAttributes(runtimeAttributes)
+      fail("A RuntimeException was expected.")
+    } catch {
+      case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
+    }
+  }
+}

--- a/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
+++ b/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
@@ -14,8 +14,7 @@ import scala.concurrent.Future
 import scalaz.Scalaz._
 
 object SgeInitializationActor {
-  val FailOnStderrDefaultValue = false
-  val ContinueOnRcDefaultValue = 0
+  val SupportedKeys = Set(Docker, FailOnStderr, ContinueOnReturnCode)
 
   def props(workflowDescriptor: BackendWorkflowDescriptor, calls: Seq[Call], configurationDescriptor: BackendConfigurationDescriptor): Props =
     Props(new SgeInitializationActor(workflowDescriptor, calls, configurationDescriptor))
@@ -35,20 +34,18 @@ class SgeInitializationActor(override val workflowDescriptor: BackendWorkflowDes
   override def beforeAll(): Future[Unit] = Future.successful(())
 
   /**
-    * Validates runtime attributes for one specific call.
-    *
-    * @param runtimeAttributes Runtime Attributes with already evaluated values.
-    * @return If all entries from runtime attributes section are valid Success otherwise
-    *         Failure with the aggregation of errors.
+    * Validate that this WorkflowBackendActor can run all of the calls that it's been assigned
     */
-  override def validateRuntimeAttributes(runtimeAttributes: EvaluatedRuntimeAttributes): Future[ErrorOr[Unit]] = {
+  override def validate(): Future[Unit] = {
     Future {
-      val docker = validateDocker(runtimeAttributes.get(Docker), None.successNel)
-      val failOnStderr = validateFailOnStderr(runtimeAttributes.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
-      val continueOnReturnCode = validateContinueOnReturnCode(runtimeAttributes.get(ContinueOnReturnCode),
-        ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
-      (docker |@| failOnStderr |@| continueOnReturnCode) {
-        (_, _, _)
+      calls foreach { call =>
+        val runtimeAttributes = call.task.runtimeAttributes.attrs
+        val notSupportedAttributes = runtimeAttributes filterKeys { !SupportedKeys.contains(_) }
+
+        if (notSupportedAttributes.nonEmpty) {
+          val notSupportedAttrString = notSupportedAttributes.keys mkString ", "
+          log.warning(s"Key/s [$notSupportedAttrString] is/are not supported by SgeBackend. Unsupported attributes will not be part of jobs executions.")
+        }
       }
     }
   }

--- a/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeRuntimeAttributes.scala
+++ b/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeRuntimeAttributes.scala
@@ -1,25 +1,25 @@
-package cromwell.backend.impl.local
+package cromwell.backend.impl.sge
 
+import cromwell.backend.validation.{ContinueOnReturnCodeSet, ContinueOnReturnCode}
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.validation.RuntimeAttributesValidation._
-import cromwell.backend.validation.{ContinueOnReturnCode, ContinueOnReturnCodeSet}
 import lenthall.exception.MessageAggregation
 import wdl4s.values.WdlValue
 
-import scalaz.Scalaz._
 import scalaz._
+import Scalaz._
 
-object LocalRuntimeAttributes {
+object SgeRuntimeAttributes {
   val FailOnStderrDefaultValue = false
   val ContinueOnRcDefaultValue = 0
 
-  def apply(attrs: Map[String, WdlValue]): LocalRuntimeAttributes = {
+  def apply(attrs: Map[String, WdlValue]): SgeRuntimeAttributes = {
     val docker = validateDocker(attrs.get(Docker), None.successNel)
     val failOnStderr = validateFailOnStderr(attrs.get(FailOnStderr), FailOnStderrDefaultValue.successNel)
     val continueOnReturnCode = validateContinueOnReturnCode(attrs.get(ContinueOnReturnCode),
       ContinueOnReturnCodeSet(Set(ContinueOnRcDefaultValue)).successNel)
     (continueOnReturnCode |@| docker |@| failOnStderr) {
-      new LocalRuntimeAttributes(_, _, _)
+      new SgeRuntimeAttributes(_, _, _)
     } match {
       case Success(x) => x
       case Failure(nel) => throw new RuntimeException with MessageAggregation {
@@ -30,4 +30,4 @@ object LocalRuntimeAttributes {
   }
 }
 
-case class LocalRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode, dockerImage: Option[String], failOnStderr: Boolean)
+case class SgeRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode, dockerImage: Option[String], failOnStderr: Boolean)

--- a/supportedBackends/sge/src/test/scala/cromwell/backend/impl/sge/SgeRuntimeAttributesSpec.scala
+++ b/supportedBackends/sge/src/test/scala/cromwell/backend/impl/sge/SgeRuntimeAttributesSpec.scala
@@ -1,0 +1,134 @@
+package cromwell.backend.impl.sge
+
+import cromwell.backend.BackendWorkflowDescriptor
+import cromwell.backend.validation.RuntimeAttributesKeys._
+import cromwell.backend.validation.{TryUtils, ContinueOnReturnCode, ContinueOnReturnCodeSet}
+import cromwell.core.{WorkflowId, WorkflowOptions}
+import org.scalatest.{Matchers, WordSpecLike}
+import spray.json.{JsValue, JsObject}
+import wdl4s.WdlExpression.ScopedLookupFunction
+import wdl4s.expression.NoFunctions
+import wdl4s.values.WdlValue
+import wdl4s.{Call, WdlExpression, WdlSource, NamespaceWithWorkflow}
+
+class SgeRuntimeAttributesSpec extends WordSpecLike with Matchers {
+
+  val HelloWorld =
+    """
+      |task hello {
+      |  String addressee = "you"
+      |  command {
+      |    echo "Hello ${addressee}!"
+      |  }
+      |  output {
+      |    String salutation = read_string(stdout())
+      |  }
+      |
+      |  RUNTIME
+      |}
+      |
+      |workflow hello {
+      |  call hello
+      |}
+    """.stripMargin
+
+  val defaultRuntimeAttributes = Map(
+    Docker -> None,
+    FailOnStderr -> false,
+    ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(0)))
+
+  "SgeRuntimeAttributes" should {
+    "return an instance of itself when there are no runtime attributes defined." in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes, defaultRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("ubuntu:latest"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" }""").head
+      assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid Docker entry based on input" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (Docker -> Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "\${addressee}" }""").head
+      assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid Docker entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: 1 }""").head
+      assertSgeRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting docker runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid failOnStderr entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (FailOnStderr -> true)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "true" }""").head
+      assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid failOnStderr entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { failOnStderr: "yes" }""").head
+      assertSgeRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+    }
+
+    "return an instance of itself when tries to validate a valid continueOnReturnCode entry" in {
+      val expectedRuntimeAttributes = defaultRuntimeAttributes + (ContinueOnReturnCode -> ContinueOnReturnCodeSet(Set(1)))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: 1 }""").head
+      assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid continueOnReturnCode entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { continueOnReturnCode: "value" }""").head
+      assertSgeRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]")
+    }
+
+  }
+
+  private def buildWorkflowDescriptor(wdl: WdlSource,
+                                      inputs: Map[String, WdlValue] = Map.empty,
+                                      options: WorkflowOptions = WorkflowOptions(JsObject(Map.empty[String, JsValue])),
+                                      runtime: String = "") = {
+    new BackendWorkflowDescriptor(
+      WorkflowId.randomId(),
+      NamespaceWithWorkflow.load(wdl.replaceAll("RUNTIME", runtime)),
+      inputs,
+      options
+    )
+  }
+
+  private def createRuntimeAttributes(wdlSource: WdlSource, runtimeAttributes: String = "") = {
+    val workflowDescriptor = buildWorkflowDescriptor(wdlSource, runtime = runtimeAttributes)
+
+    def createLookup(call: Call): ScopedLookupFunction = {
+      val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
+      val knownInputs = workflowDescriptor.inputs
+      WdlExpression.standardLookupFunction(knownInputs, declarations, NoFunctions)
+    }
+
+    workflowDescriptor.workflowNamespace.workflow.calls map {
+      call =>
+        val ra = call.task.runtimeAttributes.attrs mapValues { _.evaluate(createLookup(call), NoFunctions) }
+        TryUtils.sequenceMap(ra, "Runtime attributes evaluation").get
+    }
+  }
+
+  private def assertSgeRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WdlValue], expectedRuntimeAttributes: Map[String, Any]): Unit = {
+    try {
+      val sgeRuntimeAttributes = SgeRuntimeAttributes(runtimeAttributes)
+      assert(sgeRuntimeAttributes.dockerImage == expectedRuntimeAttributes.get(Docker).get.asInstanceOf[Option[String]])
+      assert(sgeRuntimeAttributes.failOnStderr == expectedRuntimeAttributes.get(FailOnStderr).get.asInstanceOf[Boolean])
+      assert(sgeRuntimeAttributes.continueOnReturnCode == expectedRuntimeAttributes.get(ContinueOnReturnCode).get.asInstanceOf[ContinueOnReturnCode])
+    } catch {
+      case ex: RuntimeException => fail(s"Exception was not expected but received: ${ex.getMessage}")
+    }
+  }
+
+  private def assertSgeRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WdlValue], exMsg: String): Unit = {
+    try {
+      SgeRuntimeAttributes(runtimeAttributes)
+      fail("A RuntimeException was expected.")
+    } catch {
+      case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
+    }
+  }
+}


### PR DESCRIPTION
Main purpose of this PR is to validate the idea of "Runtime Attributes validation" at Backend **initialization** an **execution** level.

[x] LocalBackend
- Initialization => No runtime attribute keys validation. Just a warning for those attributes that are not supported.
- Execution => Validate values of supported runtime attributes.

[x] JesBackend
- Initialization => Validate Docker key is present and warn for those attributes that are not supported.
- Execution => Validate values of supported runtime attributes.

[x] HtCondorBackend
- Initialization => No runtime attribute keys validation. Just a warning for those attributes that are not supported.
- Execution => Validate values of supported runtime attributes.

[x] SgeBackend
- Initialization => No runtime attribute keys validation. Just a warning for those attributes that are not supported.
- Execution => Validate values of supported runtime attributes.

The idea is to have this public while I implement this functionality so we all are in the same page. 