### PR TITLE
Abort wiring in shadow world. Closes #671

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
@@ -34,12 +34,11 @@ trait BackendJobExecutionActor extends BackendJobLifecycleActor with ActorLoggin
   def receive: Receive = LoggingReceive {
     case ExecuteJobCommand => performActionThenRespond(execute, onFailure = executionFailed)
     case RecoverJobCommand => performActionThenRespond(recover, onFailure = executionFailed)
-    case AbortJob          => performActionThenRespond(abortJob, onFailure = abortFailed)
+    case AbortJobCommand => abortJob
   }
 
   // We need this for receive because we can't do `onFailure = ExecutionFailure` directly - because BackendJobDescriptor =/= BackendJobDescriptorKey
   private def executionFailed = (t: Throwable) => BackendJobExecutionFailedResponse(jobDescriptor.key, t)
-  private def abortFailed = (t: Throwable) => BackendJobExecutionAbortFailedResponse(jobDescriptor.key, t)
 
   /**
     * Execute a new job.
@@ -54,5 +53,5 @@ trait BackendJobExecutionActor extends BackendJobLifecycleActor with ActorLoggin
   /**
     * Abort a running job.
     */
-  def abortJob: Future[JobAbortResponse]
+  def abortJob: Unit
 }

--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActor.scala
@@ -15,21 +15,14 @@ object BackendLifecycleActor {
    * Commands
    */
   trait BackendWorkflowLifecycleActorCommand extends BackendWorkflowLifecycleActorMessage
-  case object AbortWorkflow extends BackendWorkflowLifecycleActorCommand
-  final case class AbortJob(jobKey: BackendJobDescriptorKey) extends BackendWorkflowLifecycleActorCommand
+  case object AbortWorkflowCommand extends BackendWorkflowLifecycleActorCommand
+  case object AbortJobCommand extends BackendWorkflowLifecycleActorCommand
 
   /*
    * Responses
    */
   trait BackendWorkflowLifecycleActorResponse extends BackendWorkflowLifecycleActorMessage
-
-  sealed trait JobAbortResponse extends BackendWorkflowLifecycleActorResponse
-  sealed trait WorkflowAbortResponse extends BackendWorkflowLifecycleActorResponse
-
-  case object BackendWorkflowAbortSucceededResponse extends WorkflowAbortResponse
-  final case class BackendWorkflowAbortFailedResponse(throwable: Throwable) extends WorkflowAbortResponse
-  final case class BackendJobExecutionAbortSucceededResponse(jobKey: BackendJobDescriptorKey) extends JobAbortResponse
-  final case class BackendJobExecutionAbortFailedResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable) extends JobAbortResponse
+  case object BackendActorAbortedResponse extends BackendWorkflowLifecycleActorResponse
 }
 
 trait BackendLifecycleActor extends Actor {

--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowFinalizationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowFinalizationActor.scala
@@ -30,13 +30,15 @@ trait BackendWorkflowFinalizationActor extends BackendWorkflowLifecycleActor wit
 
   def receive: Receive = LoggingReceive {
     case Finalize => performActionThenRespond(afterAll, onFailure = FinalizationFailed)
-    case AbortWorkflow => performActionThenRespond(abortFinalization, onFailure = BackendWorkflowAbortFailedResponse)
+    case AbortWorkflowCommand => abortFinalization
   }
 
   /**
+    * Trigger an abort of all finalizations.
+    *
     * Abort all finalizations.
     */
-  def abortFinalization: Future[WorkflowAbortResponse]
+  def abortFinalization: Unit
 
   /**
     * Happens after everything else runs

--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -21,7 +21,7 @@ object BackendWorkflowInitializationActor {
   sealed trait BackendWorkflowInitializationActorCommand extends BackendWorkflowLifecycleActorCommand
   case object Initialize extends BackendWorkflowInitializationActorCommand
 
-  final case class Abort(jobKey: BackendJobDescriptorKey) extends BackendWorkflowInitializationActorCommand
+  case object Abort extends BackendWorkflowInitializationActorCommand
 
   // Responses
   sealed trait BackendWorkflowInitializationActorResponse extends BackendWorkflowLifecycleActorResponse
@@ -40,7 +40,7 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
 
   def receive: Receive = LoggingReceive {
     case Initialize => performActionThenRespond(initSequence(), onFailure = InitializationFailed)
-    case AbortWorkflow => performActionThenRespond(abortInitialization(), onFailure = BackendWorkflowAbortFailedResponse)
+    case AbortWorkflowCommand => abortInitialization()
   }
 
   /**
@@ -54,7 +54,7 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
   /**
     * Abort all initializations.
     */
-  def abortInitialization(): Future[WorkflowAbortResponse]
+  def abortInitialization(): Unit
 
   /**
     * A call which happens before anything else runs

--- a/engine/src/main/scala/cromwell/engine/backend/dummy/DummyBackendJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/dummy/DummyBackendJobExecutionActor.scala
@@ -2,7 +2,6 @@ package cromwell.engine.backend.dummy
 
 import akka.actor.Props
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionSucceededResponse, BackendJobExecutionResponse}
-import cromwell.backend.BackendLifecycleActor.{BackendJobExecutionAbortSucceededResponse, JobAbortResponse}
 import cromwell.backend._
 import cromwell.core.CallOutput
 import wdl4s.types._
@@ -46,6 +45,5 @@ case class DummyBackendJobExecutionActor(override val jobDescriptor: BackendJobD
   /**
     * Abort a running job.
     */
-  override def abortJob: Future[JobAbortResponse] = Future.successful(BackendJobExecutionAbortSucceededResponse(jobDescriptor.key))
-
+  override def abortJob: Unit = ()
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowInitializationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowInitializationActor.scala
@@ -1,6 +1,8 @@
 package cromwell.engine.workflow.lifecycle
 
 import akka.actor.{FSM, ActorRef, Props}
+import cromwell.backend.BackendLifecycleActor.BackendActorAbortedResponse
+import cromwell.backend.BackendWorkflowInitializationActor
 import cromwell.backend.BackendWorkflowInitializationActor._
 import cromwell.core.WorkflowId
 import cromwell.engine.EngineWorkflowDescriptor
@@ -19,49 +21,41 @@ object WorkflowInitializationActor {
   sealed trait WorkflowInitializationActorTerminalState extends WorkflowInitializationActorState with WorkflowLifecycleActorTerminalState
 
   case object InitializationPendingState extends WorkflowInitializationActorState
-  case object InitializingWorkflowState extends WorkflowInitializationActorState
+  case object InitializationInProgressState extends WorkflowInitializationActorState
+  case object InitializationAbortingState extends WorkflowInitializationActorState
   case object InitializationSucceededState extends WorkflowInitializationActorTerminalState
   case object InitializationFailedState extends WorkflowInitializationActorTerminalState
   case object InitializationsAbortedState extends WorkflowInitializationActorTerminalState
-
-  /**
-    * State data:
-    *
-    * @param backendActors The mapping from ActorRef to the backend which that actor is initializing.
-    * @param successes The list of successful initializations
-    * @param failures The map from ActorRef to the reason why that initialization failed.
-    */
-  final case class WorkflowInitializationActorData(backendActors: Map[ActorRef, String],
-                                                   successes: Seq[ActorRef],
-                                                   failures: Map[ActorRef, Throwable]) extends WorkflowLifecycleActorData
 
   /**
     * Commands
     */
   sealed trait WorkflowInitializationActorCommand
   case object StartInitializationCommand extends WorkflowInitializationActorCommand
-  case object AbortInitializationCommand extends WorkflowInitializationActorCommand
 
   /**
     * Responses
     */
   case object WorkflowInitializationSucceededResponse extends WorkflowLifecycleSuccessResponse
-  case object WorkflowInitializationAbortedResponse extends WorkflowLifecycleAbortedResponse
+  case object WorkflowInitializationAbortedResponse extends EngineLifecycleActorAbortedResponse
   final case class WorkflowInitializationFailedResponse(reasons: Seq[Throwable]) extends WorkflowLifecycleFailureResponse
 
   def props(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor): Props = Props(new WorkflowInitializationActor(workflowId, workflowDescriptor))
 }
 
-case class WorkflowInitializationActor(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor) extends WorkflowLifecycleActor[WorkflowInitializationActorState, WorkflowInitializationActorData] {
+case class WorkflowInitializationActor(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor) extends WorkflowLifecycleActor[WorkflowInitializationActorState] {
 
-  startWith(InitializationPendingState, WorkflowInitializationActorData(Map.empty, List.empty, Map.empty))
+  startWith(InitializationPendingState, WorkflowLifecycleActorData.empty)
   val tag = self.path.name
 
+  override val abortingState = InitializationAbortingState
   override val successState = InitializationSucceededState
   override val failureState = InitializationFailedState
+  override val abortedState = InitializationsAbortedState
 
   override val successResponse = WorkflowInitializationSucceededResponse
   override def failureResponse(reasons: Seq[Throwable]) = WorkflowInitializationFailedResponse(reasons)
+  override val abortedResponse = WorkflowInitializationAbortedResponse
 
   when(InitializationPendingState) {
     case Event(StartInitializationCommand, _) =>
@@ -71,25 +65,25 @@ case class WorkflowInitializationActor(workflowId: WorkflowId, workflowDescripto
         goto(InitializationSucceededState)
       } else {
         backendInitializationActors.keys foreach { _ ! Initialize }
-        goto(InitializingWorkflowState) using WorkflowInitializationActorData(backendInitializationActors, List.empty, Map.empty)
+        goto(InitializationInProgressState) using stateData.withBackendActors(backendInitializationActors)
       }
-    case Event(AbortInitializationCommand, _) =>
+    case Event(EngineLifecycleActorAbortCommand, _) =>
       context.parent ! WorkflowInitializationAbortedResponse
       goto(InitializationsAbortedState)
   }
 
-  when(InitializingWorkflowState) {
-    case Event(InitializationSuccess, stateData) =>
-      val newData = stateData.copy(
-        backendActors = stateData.backendActors - sender,
-        successes = stateData.successes ++ List(sender))
-      checkForDoneAndTransition(newData)
-    case Event(InitializationFailed(reason), stateData) =>
-      val newData = stateData.copy(
-        backendActors = stateData.backendActors - sender,
-        failures = stateData.failures ++ Map(sender -> reason))
-      checkForDoneAndTransition(newData)
-    case Event(AbortInitializationCommand, _) => ??? // TODO: Handle this
+  when(InitializationInProgressState) {
+    case Event(InitializationSuccess, stateData) => checkForDoneAndTransition(stateData.withSuccess(sender))
+    case Event(InitializationFailed(reason), stateData) => checkForDoneAndTransition(stateData.withFailure(sender, reason))
+    case Event(EngineLifecycleActorAbortCommand, stateData) =>
+      stateData.backendActors.keys foreach { _ ! BackendWorkflowInitializationActor.Abort }
+      goto(InitializationAbortingState)
+  }
+
+  when(InitializationAbortingState) {
+    case Event(InitializationSuccess, stateData) => checkForDoneAndTransition(stateData.withSuccess(sender))
+    case Event(InitializationFailed(reason), stateData) => checkForDoneAndTransition(stateData.withFailure(sender, reason))
+    case Event(BackendActorAbortedResponse, stateData) => checkForDoneAndTransition(stateData.withAborted(sender))
   }
 
   when(InitializationSucceededState) { FSM.NullFunction }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/package.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/package.scala
@@ -1,0 +1,8 @@
+package cromwell.engine.workflow
+
+package object lifecycle {
+  case object EngineLifecycleActorAbortCommand
+
+  trait EngineLifecycleStateCompleteResponse
+  trait EngineLifecycleActorAbortedResponse extends EngineLifecycleStateCompleteResponse
+}

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
@@ -1,7 +1,6 @@
 package cromwell.backend.impl.htcondor
 
 import akka.actor.Props
-import cromwell.backend.BackendLifecycleActor.WorkflowAbortResponse
 import cromwell.backend.impl.htcondor.HtCondorInitializationActor._
 import cromwell.backend.validation.ContinueOnReturnCodeSet
 import cromwell.backend.validation.RuntimeAttributesKeys._
@@ -26,7 +25,7 @@ class HtCondorInitializationActor(override val workflowDescriptor: BackendWorkfl
   /**
     * Abort all initializations.
     */
-  override def abortInitialization(): Future[WorkflowAbortResponse] = ???
+  override def abortInitialization(): Unit = ???
 
   /**
     * A call which happens before anything else runs

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
@@ -1,9 +1,7 @@
 package cromwell.backend.impl.htcondor
 
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
-import cromwell.backend.BackendLifecycleActor.JobAbortResponse
 import cromwell.backend._
-import wdl4s.Call
 
 import scala.concurrent.Future
 
@@ -25,5 +23,5 @@ class HtCondorJobExecutionActor extends BackendJobExecutionActor {
   /**
     * Abort a running job.
     */
-  override def abortJob: Future[JobAbortResponse] = ???
+  override def abortJob: Unit = ???
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -1,7 +1,6 @@
 package cromwell.backend.impl.jes
 
 import akka.actor.Props
-import cromwell.backend.BackendLifecycleActor.WorkflowAbortResponse
 import cromwell.backend.impl.jes.JesInitializationActor._
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor, BackendWorkflowInitializationActor}
@@ -23,7 +22,7 @@ class JesInitializationActor(override val workflowDescriptor: BackendWorkflowDes
   /**
     * Abort all initializations.
     */
-  override def abortInitialization(): Future[WorkflowAbortResponse] = ???
+  override def abortInitialization(): Unit = ???
 
   //TODO: Workflow options may need to be validated for JES.
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobExecutionActor.scala
@@ -1,9 +1,7 @@
 package cromwell.backend.impl.jes
 
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
-import cromwell.backend.BackendLifecycleActor.JobAbortResponse
 import cromwell.backend._
-import wdl4s.Call
 
 import scala.concurrent.Future
 
@@ -25,5 +23,5 @@ class JesJobExecutionActor extends BackendJobExecutionActor {
   /**
     * Abort a running job.
     */
-  override def abortJob: Future[JobAbortResponse] = ???
+  override def abortJob: Unit = ???
 }

--- a/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalInitializationActor.scala
+++ b/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalInitializationActor.scala
@@ -2,7 +2,6 @@ package cromwell.backend.impl.local
 
 import akka.actor.Props
 import better.files._
-import cromwell.backend.BackendLifecycleActor.WorkflowAbortResponse
 import cromwell.backend.impl.local.LocalInitializationActor._
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor, BackendWorkflowInitializationActor}
@@ -27,7 +26,7 @@ class LocalInitializationActor(override val workflowDescriptor: BackendWorkflowD
   /**
     * Abort all initializations.
     */
-  override def abortInitialization(): Future[WorkflowAbortResponse] = ???
+  override def abortInitialization(): Unit = ???
 
   /**
     * A call which happens before anything else runs

--- a/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalJobExecutionActor.scala
+++ b/supportedBackends/local/src/main/scala/cromwell/backend/impl/local/LocalJobExecutionActor.scala
@@ -3,7 +3,6 @@ package cromwell.backend.impl.local
 import java.nio.file.{FileSystems, Path, Paths}
 
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionAbortedResponse, BackendJobExecutionFailedResponse, BackendJobExecutionResponse, BackendJobExecutionSucceededResponse}
-import cromwell.backend.BackendLifecycleActor.{BackendJobExecutionAbortFailedResponse, BackendJobExecutionAbortSucceededResponse, JobAbortResponse}
 import cromwell.backend._
 import cromwell.core.CallContext
 import org.slf4j.LoggerFactory
@@ -135,13 +134,10 @@ class LocalJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
     case Failure(ex) => Future.successful(BackendJobExecutionFailedResponse(jobDescriptor.key, ex))
   }
 
-  override def abortJob: Future[JobAbortResponse] = {
-    process map { p =>
+  override def abortJob: Unit = {
+    process foreach { p =>
       p.destroy()
       process = None
-      Future.successful(BackendJobExecutionAbortSucceededResponse(jobDescriptor.key))
-    } getOrElse {
-      Future.successful(BackendJobExecutionAbortFailedResponse(jobDescriptor.key, new RuntimeException(s"Tried to abort ${jobDescriptor.key} before executing it.")))
     }
   }
 

--- a/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
+++ b/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeInitializationActor.scala
@@ -1,7 +1,6 @@
 package cromwell.backend.impl.sge
 
 import akka.actor.Props
-import cromwell.backend.BackendLifecycleActor.WorkflowAbortResponse
 import cromwell.backend.impl.sge.SgeInitializationActor._
 import cromwell.backend.validation.ContinueOnReturnCodeSet
 import cromwell.backend.validation.RuntimeAttributesKeys._
@@ -26,7 +25,7 @@ class SgeInitializationActor(override val workflowDescriptor: BackendWorkflowDes
   /**
     * Abort all initializations.
     */
-  override def abortInitialization(): Future[WorkflowAbortResponse] = ???
+  override def abortInitialization(): Unit = ???
 
   /**
     * A call which happens before anything else runs

--- a/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeJobExecutionActor.scala
+++ b/supportedBackends/sge/src/main/scala/cromwell/backend/impl/sge/SgeJobExecutionActor.scala
@@ -1,9 +1,7 @@
 package cromwell.backend.impl.sge
 
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
-import cromwell.backend.BackendLifecycleActor.JobAbortResponse
 import cromwell.backend._
-import wdl4s.Call
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,5 +25,5 @@ class SgeJobExecutionActor extends BackendJobExecutionActor {
   /**
     * Abort a running job.
     */
-  override def abortJob: Future[JobAbortResponse] = ???
+  override def abortJob: Unit = ???
 }


### PR DESCRIPTION
The idea being, sending an abort message does not get an `AbortSuccess` or `AbortFailed` response directly.

Instead, the actor being aborted will cause its operation to fail and the parent should expect an "Aborted" response instead of a Success or Failure (although a Success or Failure may still be returned anyway).

In this way, it's acceptable for a backend implementor to simply do nothing when `abort` is received. The parent will just continue waiting for a result of some sort.