### PR TITLE
Adding query parameters for metadata endpoint. Closes #719 as hotfix

### DIFF
--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -373,6 +373,18 @@ paths:
           required: true
           type: string
           in: path
+        - name: outputs
+          description: Include output metadata
+          required: false
+          type: boolean
+          in: query
+          default: true
+        - name: timings
+          description: Include timing metadata
+          required: false
+          type: boolean
+          in: query
+          default: true
       tags:
         - Workflows
       responses:

--- a/engine/src/main/resources/workflowTimings/workflowTimings.html
+++ b/engine/src/main/resources/workflowTimings/workflowTimings.html
@@ -16,7 +16,7 @@
     }
 
     function drawChart() {
-        $.getJSON("./metadata", function( data ) {
+        $.getJSON("./metadata?outputs=false&timings=true", function( data ) {
 
             var container = document.getElementById('chart_div');
             var chart = new google.visualization.Timeline(container);

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataBuilder.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataBuilder.scala
@@ -4,21 +4,21 @@ import akka.actor.ActorSystem
 import cromwell.core.WorkflowId
 import cromwell.engine
 import cromwell.engine._
-import cromwell.engine.backend.CallMetadata
-import cromwell.engine.db.DataAccess.WorkflowExecutionAndAux
+import cromwell.engine.backend.{CallMetadata, WorkflowDescriptor}
 import cromwell.engine.db.slick._
-import cromwell.engine.db.{CallStatus, ExecutionDatabaseKey, ExecutionInfosByExecution}
+import cromwell.engine.db.{ExecutionDatabaseKey, ExecutionInfosByExecution}
 import cromwell.engine.finalcall.FinalCall._
-import cromwell.engine.workflow.WorkflowManagerActor._
+import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.webservice._
 import org.joda.time.DateTime
 import spray.json._
 import wdl4s._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.io.Source
+import scala.concurrent.Future
 
 object WorkflowMetadataBuilder {
+
+  private type DBMap[+V] = Map[ExecutionDatabaseKey, V]
 
   // TODO: This assertion could be added to the db layer: "In the future I'll fail if the workflow doesn't exist"
   def assertWorkflowExistence(id: WorkflowId, workflowState: Option[WorkflowState]): Future[Unit] = {
@@ -28,98 +28,134 @@ object WorkflowMetadataBuilder {
       case _ => Future.successful(Unit)
     }
   }
-
-  private def buildWorkflowMetadata(workflowExecution: WorkflowExecution,
-                                    workflowExecutionAux: WorkflowExecutionAux,
-                                    workflowOutputs: engine.WorkflowOutputs,
-                                    callMetadata: Map[FullyQualifiedName, Seq[CallMetadata]],
-                                    workflowFailures: Seq[FailureEventEntry]):
+  private def build(workflowDescriptor: WorkflowDescriptor,
+                    execution: WorkflowExecution,
+                    workflowOutputs: engine.WorkflowOutputs,
+                    callMetadata: Map[FullyQualifiedName, Seq[CallMetadata]],
+                    workflowFailures: Traversable[FailureEventEntry]):
   WorkflowMetadataResponse = {
 
-    val startDate = new DateTime(workflowExecution.startDt)
-    val endDate = workflowExecution.endDt map {
-      new DateTime(_)
-    }
-    // TODO: Refactor db to expose the clob <-> string implicits.
-    val workflowInputs = Source.fromInputStream(workflowExecutionAux.jsonInputs.getAsciiStream)
-      .mkString.parseJson.asInstanceOf[JsObject]
+    val startDate = new DateTime(execution.startDt)
+    val endDate = execution.endDt map { new DateTime(_) }
+    val workflowInputs = workflowDescriptor.sourceFiles.inputsJson.parseJson.asInstanceOf[JsObject]
     val failures = if (workflowFailures.isEmpty) None else Option(workflowFailures)
 
     WorkflowMetadataResponse(
-      id = workflowExecution.workflowExecutionUuid.toString,
-      workflowName = workflowExecution.name,
-      status = workflowExecution.status,
+      id = execution.workflowExecutionUuid.toString,
+      workflowName = execution.name,
+      status = execution.status,
       // We currently do not make a distinction between the submission and start dates of a workflow, but it's
       // possible at least theoretically that a workflow might not begin to execute immediately upon submission.
       submission = startDate,
       start = Option(startDate),
       end = endDate,
       inputs = workflowInputs,
-      outputs = Option(workflowOutputs) map {
-        _.mapToValues
-      },
+      outputs = Option(workflowOutputs) map { _.mapToValues },
       calls = callMetadata,
-      failures = failures)
+      failures = failures.map(_.toSeq))
   }
 
-  private def callFailuresMap(failureEvents: Seq[QualifiedFailureEventEntry]): Map[ExecutionDatabaseKey, Seq[FailureEventEntry]] = {
+  private def callFailuresMap(failureEvents: Seq[QualifiedFailureEventEntry]): DBMap[Seq[FailureEventEntry]] = {
     failureEvents filter { _.execution.isDefined } groupBy { _.execution } map {
       case (key, qualifiedEntries: Seq[QualifiedFailureEventEntry]) => key.get -> (qualifiedEntries map { _.dequalify })
     }
   }
 
-  private def buildWorkflowMetadata(id: WorkflowId,
-                                    workflowExecution: WorkflowExecution,
-                                    workflowOutputs: Traversable[SymbolStoreEntry],
-                                    workflowExecutionAux: WorkflowExecutionAux,
-                                    executionStatuses: Map[ExecutionDatabaseKey, CallStatus],
-                                    callInputs: Traversable[SymbolStoreEntry],
-                                    callOutputs: Traversable[SymbolStoreEntry],
-                                    infosByExecution: Traversable[ExecutionInfosByExecution],
-                                    runtimeAttributes: Map[ExecutionDatabaseKey, Map[String, String]],
-                                    executionEvents: Map[ExecutionDatabaseKey, Seq[ExecutionEventEntry]],
-                                    cacheData: Traversable[ExecutionWithCacheData],
-                                    failures: Seq[QualifiedFailureEventEntry]) (implicit ec: ExecutionContext, actorSystem: ActorSystem):
-  Future[WorkflowMetadataResponse] = {
-    val executionAndAux = WorkflowExecutionAndAux(workflowExecution, workflowExecutionAux)
-    workflowDescriptorFromExecutionAndAux(executionAndAux) map { workflowDescriptor =>
+  private def emptySeq[A] = Future.successful(Seq.empty[A])
+
+  private def retrieveTraversable[A](runQuery: Boolean,
+                                     queryResult: => Future[Traversable[A]],
+                                     defaultResult: => Future[Traversable[A]] = emptySeq): Future[Traversable[A]] = {
+    if (runQuery) queryResult else defaultResult
+  }
+
+  private def emptyMap[V] = Future.successful(Map.empty[ExecutionDatabaseKey, V])
+
+  private def retrieveMap[V](runQuery: Boolean,
+                             queryResult: => Future[DBMap[V]],
+                             defaultResult: => Future[DBMap[V]] = emptyMap): Future[DBMap[V]] = {
+    if (runQuery) queryResult else defaultResult
+  }
+}
+
+class WorkflowMetadataBuilder(id: WorkflowId, parameters: WorkflowMetadataQueryParameters)(implicit actorSystem: ActorSystem) {
+
+  private[this] implicit val ec = actorSystem.dispatcher
+
+  import WorkflowMetadataBuilder._
+  import cromwell.engine.db.DataAccess.globalDataAccess
+
+  private def futureAssertWorkflowExistsByState = for {
+    workflowState <- globalDataAccess.getWorkflowState(id)
+    // TODO: This assertion could be added to the db layer: "In the future I'll fail if the workflow doesn't exist"
+    _ <- assertWorkflowExistence(id, workflowState)
+  } yield ()
+
+  private def futureWorkflowExecutionAndAux = globalDataAccess.getWorkflowExecutionAndAux(id)
+
+  // If outputs requested, don't retrieve the execution infos, only executions
+  private def futureInfosByExecution = retrieveTraversable(parameters.outputs,
+    globalDataAccess.infosByExecution(id),
+    globalDataAccess.getExecutions(id) map { _ map { ExecutionInfosByExecution(_, Seq.empty) } })
+
+  // If outputs requested, get the workflow outputs
+  private def futureWorkflowOutputs = retrieveTraversable(parameters.outputs, globalDataAccess.getWorkflowOutputs(id))
+
+  // If timings requested, we need the call statuses and execution events
+  private def futureCallToStatusMap = retrieveMap(parameters.timings, globalDataAccess.getExecutionStatuses(id))
+
+  private def futureExecutionEvents = retrieveMap(parameters.timings, globalDataAccess.getAllExecutionEvents(id))
+
+  // Drop the below if timings _or_ outputs requested
+  private def futureCallInputs = retrieveTraversable(parameters.timings && parameters.outputs,
+    globalDataAccess.getAllInputs(id))
+
+  private def futureCallOutputs = retrieveTraversable(parameters.timings && parameters.outputs,
+    globalDataAccess.getAllOutputs(id))
+
+  private def futureCallCacheData = retrieveTraversable(parameters.timings && parameters.outputs,
+    globalDataAccess.callCacheDataByExecution(id))
+
+  private def futureRuntimeAttributes = retrieveMap(parameters.timings && parameters.outputs,
+    globalDataAccess.getAllRuntimeAttributes(id))
+
+  private def futureFailures = retrieveTraversable(parameters.timings && parameters.outputs,
+    globalDataAccess.getFailureEvents(id))
+
+  def build(): Future[WorkflowMetadataResponse] = {
+
+    for {
+      assertWorkflowExistsByState <- futureAssertWorkflowExistsByState
+      workflowExecutionAndAux <- futureWorkflowExecutionAndAux
+      infosByExecution <- futureInfosByExecution
+      workflowOutputs <- futureWorkflowOutputs
+      callToStatusMap <- futureCallToStatusMap
+      executionEvents <- futureExecutionEvents
+      callInputs <- futureCallInputs
+      callOutputs <- futureCallOutputs
+      callCacheData <- futureCallCacheData
+      runtimeAttributes <- futureRuntimeAttributes
+      failures <- futureFailures
+
+      // Database work complete, but we do need one more future to get the workflow descriptor
+      workflowDescriptor <- workflowDescriptorFromExecutionAndAux(workflowExecutionAndAux)
+    } yield {
+
+      val execution = workflowExecutionAndAux.execution
       val nonFinalEvents = executionEvents.filterKeys(!_.fqn.isFinalCall)
       val nonFinalInfosByExecution = infosByExecution.filterNot(_.execution.callFqn.isFinalCall)
 
       val wfFailures = failures collect {
         case QualifiedFailureEventEntry(_, None, message, timestamp) => FailureEventEntry(message, timestamp)
       }
-      val callFailures = callFailuresMap(failures)
+      val callFailures = callFailuresMap(failures.toSeq)
 
       val engineWorkflowOutputs = SymbolStoreEntry.toWorkflowOutputs(workflowOutputs)
       val callMetadata = CallMetadataBuilder.build(nonFinalInfosByExecution, callInputs, callOutputs, nonFinalEvents,
-        runtimeAttributes, cacheData, callFailures)
-      buildWorkflowMetadata(workflowExecution, workflowExecutionAux, engineWorkflowOutputs, callMetadata, wfFailures)
+        runtimeAttributes, callCacheData, callFailures)
+
+      WorkflowMetadataBuilder.build(workflowDescriptor, execution, engineWorkflowOutputs, callMetadata, wfFailures)
     }
-  }
 
-  def workflowMetadata(id: WorkflowId)(implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[WorkflowMetadataResponse] = {
-
-    // TODO: This entire block of chained database actions should be a single request to the db layer.
-    import cromwell.engine.db.DataAccess.globalDataAccess
-
-    for {
-      workflowState <- globalDataAccess.getWorkflowState(id)
-      // TODO: This assertion could be added to the db layer: "In the future I'll fail if the workflow doesn't exist"
-      _ <- assertWorkflowExistence(id, workflowState)
-      workflowExecution <- globalDataAccess.getWorkflowExecution(id)
-      workflowOutputs <- globalDataAccess.getWorkflowOutputs(id)
-      workflowExecutionAux <- globalDataAccess.getWorkflowExecutionAux(id)
-      callToStatusMap <- globalDataAccess.getExecutionStatuses(id)
-      callInputs <- globalDataAccess.getAllInputs(id)
-      callOutputs <- globalDataAccess.getAllOutputs(id)
-      infosByExecution <- globalDataAccess.infosByExecution(id)
-      callCacheData <- globalDataAccess.callCacheDataByExecution(id)
-      runtimeAttributes <- globalDataAccess.getAllRuntimeAttributes(id)
-      executionEvents <- globalDataAccess.getAllExecutionEvents(id)
-      failures <- globalDataAccess.getFailureEvents(id)
-      wfMetadata <- buildWorkflowMetadata(id, workflowExecution, workflowOutputs, workflowExecutionAux,
-        callToStatusMap, callInputs, callOutputs, infosByExecution, runtimeAttributes, executionEvents, callCacheData, failures)
-    } yield wfMetadata
   }
 }

--- a/engine/src/main/scala/cromwell/webservice/ApiDataModels.scala
+++ b/engine/src/main/scala/cromwell/webservice/ApiDataModels.scala
@@ -23,6 +23,8 @@ case class CallOutputResponse(id: String, callFqn: String, outputs: Map[FullyQua
 
 case class CallStdoutStderrResponse(id: String, logs: Map[FullyQualifiedName, Seq[CallLogs]])
 
+case class WorkflowMetadataQueryParameters(outputs: Boolean = true, timings: Boolean = true)
+
 case class WorkflowMetadataResponse(id: String,
                                     workflowName: String,
                                     status: String,

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -44,9 +44,6 @@ class CromwellApiServiceActor(val workflowManager: ActorRef, val workflowDescrip
 }
 
 trait CromwellApiService extends HttpService with PerRequestCreator {
-
-  import CromwellApiServiceActor._
-
   val workflowManager: ActorRef
   val workflowDescriptorMaterializer: ActorRef
 
@@ -171,10 +168,13 @@ trait CromwellApiService extends HttpService with PerRequestCreator {
   def metadataRoute =
     path("workflows" / Segment / Segment / "metadata") { (version, workflowId) =>
       traceName("workflowMetadata") {
-        Try(WorkflowId.fromString(workflowId)) match {
-          case Success(w) =>
-            requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager), CromwellApiHandler.ApiHandlerWorkflowMetadata(w))
-          case Failure(_) => invalidWorkflowId(workflowId)
+        parameters('outputs ? true, 'timings ? true).as(WorkflowMetadataQueryParameters) { parameters =>
+          Try(WorkflowId.fromString(workflowId)) match {
+            case Success(w) =>
+              requestContext => perRequest(requestContext, CromwellApiHandler.props(workflowManager),
+                CromwellApiHandler.ApiHandlerWorkflowMetadata(w, parameters))
+            case Failure(_) => invalidWorkflowId(workflowId)
+          }
         }
       }
     }


### PR DESCRIPTION
Workflow execution info retrieval now optionally retrieves events.
Only (lazily) retrieving the workflow metadata future once instead of per-call.