### PR TITLE
PB & JES   Closes #657

### DIFF
--- a/backend/src/main/scala/cromwell/backend/Backoff.scala
+++ b/backend/src/main/scala/cromwell/backend/Backoff.scala
@@ -1,10 +1,9 @@
-package cromwell.util
+package cromwell.backend
 
 import com.google.api.client.util.ExponentialBackOff
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 sealed trait Backoff {
   /** Next interval in millis */
   def backoffMillis: Long
@@ -12,7 +11,6 @@ sealed trait Backoff {
   def next: Backoff
 }
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object InitialGapBackoff {
   def apply(initialGap: FiniteDuration, initialInterval: FiniteDuration, maxInterval: FiniteDuration, multiplier: Double) = {
     new InitialGapBackoff(initialGap, new ExponentialBackOff.Builder()
@@ -24,7 +22,6 @@ object InitialGapBackoff {
   }
 }
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class InitialGapBackoff(initialGapMillis: FiniteDuration, googleBackoff: ExponentialBackOff) extends Backoff {
   assert(initialGapMillis.compareTo(Duration.Zero) != 0, "Initial gap cannot be null, use SimpleBackoff instead.")
 
@@ -33,7 +30,6 @@ case class InitialGapBackoff(initialGapMillis: FiniteDuration, googleBackoff: Ex
   override def next = new SimpleExponentialBackoff(googleBackoff)
 }
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object SimpleExponentialBackoff {
   def apply(initialInterval: FiniteDuration, maxInterval: FiniteDuration, multiplier: Double) = {
     new SimpleExponentialBackoff(new ExponentialBackOff.Builder()
@@ -45,7 +41,6 @@ object SimpleExponentialBackoff {
   }
 }
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class SimpleExponentialBackoff(googleBackoff: ExponentialBackOff) extends Backoff {
   override def backoffMillis = googleBackoff.nextBackOffMillis()
   /** google ExponentialBackOff is mutable so we can keep returning the same instance */

--- a/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
@@ -1,0 +1,95 @@
+package cromwell.backend.async
+
+import akka.actor.{Actor, ActorLogging}
+import cromwell.backend.async.AsyncBackendJobExecutionActor._
+import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionFailedResponse, BackendJobExecutionResponse, BackendJobExecutionSucceededResponse}
+import cromwell.backend.{BackendJobDescriptor, Backoff}
+import cromwell.core.CromwellFatalException
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
+
+
+object AsyncBackendJobExecutionActor {
+
+  sealed trait AsyncBackendJobExecutionActorMessage
+  final case class IssuePollRequest(executionHandle: ExecutionHandle) extends AsyncBackendJobExecutionActorMessage
+  final case class PollResponseReceived(executionHandle: ExecutionHandle) extends AsyncBackendJobExecutionActorMessage
+  final case class Finish(executionHandle: ExecutionHandle) extends AsyncBackendJobExecutionActorMessage
+
+  sealed trait ExecutionMode extends AsyncBackendJobExecutionActorMessage
+  case object Execute extends ExecutionMode
+  final case class Resume(executionInfos: Map[String, Option[String]]) extends ExecutionMode
+  final case class UseCachedCall(cachedBackendCall: BackendJobDescriptor) extends ExecutionMode
+}
+
+
+trait AsyncBackendJobExecutionActor { this: Actor with ActorLogging =>
+
+  /**
+    * Schedule work according to the schedule of the `backoff`.
+    */
+  protected def scheduleWork(work: => Unit): Unit = {
+    val interval = backoff.backoffMillis.millis
+    context.system.scheduler.scheduleOnce(interval) {
+      work
+    }
+  }
+
+  def backoff: Backoff
+
+  /**
+    * If the `work` `Future` completes successfully, perform the `onSuccess` work, otherwise schedule
+    * the execution of the `onFailure` work using an exponential backoff.
+    */
+  def withRetry(work: Future[ExecutionHandle], onSuccess: ExecutionHandle => Unit, onFailure: => Unit): Unit = {
+    work onComplete {
+      case Success(s) => onSuccess(s)
+      case Failure(e: CromwellFatalException) =>
+        log.error(e.getMessage, e)
+        completionPromise.success(BackendJobExecutionFailedResponse(jobDescriptor.key, e))
+        context.stop(self)
+      case Failure(e: Exception) =>
+        log.error(e.getMessage, e)
+        scheduleWork(onFailure)
+      case Failure(throwable) =>
+        // This is a catch-all for a JVM-ending kind of exception, which is why we throw the exception
+        log.error(throwable.getMessage, throwable)
+        throw throwable
+    }
+  }
+
+  def receive: Receive = {
+    case mode: ExecutionMode =>
+      withRetry(executeOrRecover(mode),
+        onSuccess = self ! IssuePollRequest(_),
+        onFailure = self ! mode
+      )
+
+    case IssuePollRequest(handle) =>
+      withRetry(poll(handle),
+        onSuccess = self ! PollResponseReceived(_),
+        onFailure = self ! IssuePollRequest(handle)
+      )
+    case PollResponseReceived(handle) if handle.isDone => self ! Finish(handle)
+    case PollResponseReceived(handle) => scheduleWork(self ! IssuePollRequest(handle))
+    case Finish(SuccessfulExecutionHandle(outputs, returnCode, hash, resultsClonedFrom)) =>
+      completionPromise.success(BackendJobExecutionSucceededResponse(jobDescriptor.key, outputs))
+      context.stop(self)
+    case badMessage => log.error(s"Unexpected message $badMessage.")
+  }
+
+  /**
+    * Update the ExecutionHandle
+    */
+  def poll(previous: ExecutionHandle)(implicit ec: ExecutionContext): Future[ExecutionHandle]
+
+  def executeOrRecover(mode: ExecutionMode)(implicit ec: ExecutionContext): Future[ExecutionHandle]
+
+  def completionPromise: Promise[BackendJobExecutionResponse]
+
+  def jobDescriptor: BackendJobDescriptor
+
+  protected implicit def ec: ExecutionContext
+}

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
@@ -1,0 +1,37 @@
+package cromwell.backend.async
+
+import cromwell.backend.{BackendJobDescriptor, ExecutionHash}
+import cromwell.core.CallOutputs
+
+/**
+ * Trait to encapsulate whether an execution is complete and if so provide a result.  Useful in conjunction
+ * with the `poll` API to feed results of previous job status queries forward.
+ */
+trait ExecutionHandle {
+  def isDone: Boolean
+  def result: ExecutionResult
+}
+
+final case class CompletedExecutionHandle(override val result: ExecutionResult) extends ExecutionHandle {
+  override val isDone = true
+}
+
+final case class SuccessfulExecutionHandle(outputs: CallOutputs, returnCode: Int, hash: ExecutionHash, resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionHandle {
+  override val isDone = true
+  override val result = SuccessfulExecution(outputs, returnCode, hash, resultsClonedFrom)
+}
+
+final case class FailedExecutionHandle(throwable: Throwable, returnCode: Option[Int] = None) extends ExecutionHandle {
+  override val isDone = true
+  override val result = new NonRetryableExecution(throwable, returnCode)
+}
+
+final case class RetryableExecutionHandle(throwable: Throwable, returnCode: Option[Int] = None) extends ExecutionHandle {
+  override val isDone = true
+  override val result = new RetryableExecution(throwable, returnCode)
+}
+
+case object AbortedExecutionHandle extends ExecutionHandle {
+  override def isDone: Boolean = true
+  override def result: ExecutionResult = AbortedExecution
+}

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
@@ -1,0 +1,30 @@
+package cromwell.backend.async
+
+import cromwell.backend.{BackendJobDescriptor, ExecutionHash}
+import cromwell.core.CallOutputs
+
+/**
+ * ADT representing the result of an execution of a BackendCall.
+ */
+sealed trait ExecutionResult
+
+/**
+ * A successful execution with resolved outputs.
+ */
+final case class SuccessfulExecution(outputs: CallOutputs, returnCode: Int, hash: ExecutionHash, resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionResult
+
+/**
+ * A user-requested abort of the command.
+ */
+case object AbortedExecution extends ExecutionResult
+
+sealed trait FailedExecution extends ExecutionResult {
+  def e: Throwable
+  def returnCode: Option[Int]
+}
+
+/**
+  * Failed execution, possibly having a return code.
+  */
+final case class NonRetryableExecution(e: Throwable, returnCode: Option[Int] = None) extends FailedExecution
+final case class RetryableExecution(e: Throwable, returnCode: Option[Int] = None) extends FailedExecution

--- a/backend/src/main/scala/cromwell/backend/async/package.scala
+++ b/backend/src/main/scala/cromwell/backend/async/package.scala
@@ -1,0 +1,18 @@
+package cromwell.backend
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+package object async {
+  implicit class EnhancedFutureFuture[A](val ffa: Future[Future[A]])(implicit ec: ExecutionContext) {
+    def flatten: Future[A] = ffa flatMap identity
+  }
+
+  implicit class EnhancedExecutionHandle(val handle: ExecutionHandle) extends AnyVal {
+    def future = Future.successful(handle)
+  }
+
+  implicit class EnhancedExecutionResult(val result: ExecutionResult) extends AnyVal {
+    def future = Future.successful(result)
+  }
+}

--- a/core/src/main/scala/cromwell/core/ConfigUtil.scala
+++ b/core/src/main/scala/cromwell/core/ConfigUtil.scala
@@ -1,4 +1,4 @@
-package cromwell.util
+package cromwell.core
 
 import java.net.URL
 
@@ -7,11 +7,9 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConversions._
 import scala.reflect.{ClassTag, classTag}
-import scala.util.Try
 import scalaz.Scalaz._
 import scalaz._
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object ConfigUtil {
 
   val validationLogger = LoggerFactory.getLogger("ConfigurationValidation")
@@ -51,7 +49,6 @@ object ConfigUtil {
 
   }
 
-  @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
   implicit class EnhancedValidation[I <: AnyRef](val value: I) extends AnyVal {
     /**
      * Validates this value by applying validationFunction to it and returning a Validation:

--- a/core/src/main/scala/cromwell/core/DockerCredentials.scala
+++ b/core/src/main/scala/cromwell/core/DockerCredentials.scala
@@ -1,24 +1,20 @@
-package cromwell.util
+package cromwell.core
 
 import com.typesafe.config.Config
-import cromwell.util.ConfigUtil._
+import cromwell.core.ConfigUtil._
 
 /**
  * Encapsulate docker credential information.
  */
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class DockerCredentials(account: String, token: String)
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class DockerHubConfiguration(namespace: String, v1Registry: String, v2Registry: String)
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class DockerConfiguration(dockerCredentials: Option[DockerCredentials], dockerHubConf: DockerHubConfiguration)
 
 /**
  * Singleton encapsulating a DockerConf instance.
  */
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object DockerConfiguration {
   import lenthall.config.ScalaConfig._
 

--- a/core/src/main/scala/cromwell/core/package.scala
+++ b/core/src/main/scala/cromwell/core/package.scala
@@ -1,5 +1,6 @@
 package cromwell
 
+import lenthall.exception.ThrowableAggregation
 import wdl4s.values.{SymbolHash, WdlValue}
 
 import scalaz._
@@ -14,4 +15,7 @@ package object core {
   case class CallOutput(wdlValue: WdlValue, hash: Option[SymbolHash])
   type CallOutputs = Map[LocallyQualifiedName, CallOutput]
   type EvaluatedRuntimeAttributes = Map[String, WdlValue]
+
+  class CromwellFatalException(exception: Throwable) extends Exception(exception)
+  case class CromwellAggregatedException(throwables: Seq[Throwable], exceptionContext: String = "") extends ThrowableAggregation
 }

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleBackend.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.util.ExponentialBackOff
 import com.typesafe.config.Config
-import cromwell.backend.JobKey
+import cromwell.backend.{ExecutionHash, JobKey}
 import cromwell.backend.validation.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet}
 import cromwell.core.{WorkflowContext, WorkflowId, WorkflowOptions}
 import cromwell.engine.WorkflowSourceFiles

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleCallMetadata.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleCallMetadata.scala
@@ -1,7 +1,8 @@
 package cromwell.engine.backend
 
+import cromwell.backend.ExecutionEventEntry
 import cromwell.engine.workflow.CallCacheData
-import cromwell.engine.{ExecutionEventEntry, FailureEventEntry}
+import cromwell.engine.FailureEventEntry
 import org.joda.time.DateTime
 import wdl4s.values.{WdlFile, WdlValue}
 

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleExecutionHandle.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleExecutionHandle.scala
@@ -1,7 +1,7 @@
 package cromwell.engine.backend
 
+import cromwell.backend.{ExecutionEventEntry, ExecutionHash}
 import cromwell.core.CallOutputs
-import cromwell.engine.ExecutionEventEntry
 
 /**
  * Trait to encapsulate whether an execution is complete and if so provide a result.  Useful in conjunction

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleExecutionResult.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleExecutionResult.scala
@@ -1,7 +1,7 @@
 package cromwell.engine.backend
 
+import cromwell.backend.{ExecutionEventEntry, ExecutionHash}
 import cromwell.core.CallOutputs
-import cromwell.engine.ExecutionEventEntry
 
 /**
  * ADT representing the result of an execution of a BackendCall.

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleJobDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleJobDescriptor.scala
@@ -1,6 +1,6 @@
 package cromwell.engine.backend
 
-import cromwell.backend.JobKey
+import cromwell.backend.{ExecutionHash, JobKey}
 import cromwell.CallEngineFunctions
 import cromwell.engine.AbortRegistrationFunction
 import cromwell.engine.backend.runtimeattributes.CromwellRuntimeAttributes

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
@@ -7,11 +7,12 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.FileAppender
+import cromwell.backend.SimpleExponentialBackoff
 import cromwell.core.{WorkflowContext, WorkflowId, WorkflowOptions}
 import cromwell.engine.{WorkflowFailureMode, WorkflowSourceFiles}
 import cromwell.engine.backend.io._
 import cromwell.logging.WorkflowLogger
-import cromwell.util.{SimpleExponentialBackoff, TryUtil}
+import cromwell.util.TryUtil
 import cromwell.webservice.WorkflowMetadataResponse
 import org.slf4j.helpers.NOPLogger
 import org.slf4j.{Logger, LoggerFactory}
@@ -44,7 +45,6 @@ case class OldStyleWorkflowDescriptor(id: WorkflowId,
                                       fileSystems: List[FileSystem]) {
   import OldStyleWorkflowDescriptor._
 
-  val shortId = id.toString.split("-")(0)
   val name = namespace.workflow.unqualifiedName
   val actualInputs: WorkflowCoercedInputs = coercedInputs ++ declarations
   private val relativeWorkflowRootPath = s"$name/$id"

--- a/engine/src/main/scala/cromwell/engine/backend/jes/Run.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/jes/Run.scala
@@ -1,14 +1,15 @@
 package cromwell.engine.backend.jes
 
 import com.google.api.client.util.ArrayMap
-import com.google.api.services.genomics.model.{CancelOperationRequest, LoggingOptions, RunPipelineArgs, RunPipelineRequest, ServiceAccount, _}
+import com.google.api.services.genomics.model._
 import com.typesafe.config.ConfigFactory
 import cromwell.engine.backend.OldStyleBackendCallJobDescriptor
 import cromwell.engine.backend.jes.OldStyleJesBackend._
+import cromwell.backend.ExecutionEventEntry
+import cromwell.engine.AbortFunction
 import cromwell.engine.backend.jes.Run.{Failed, Running, Success, _}
 import cromwell.engine.db.DataAccess._
 import cromwell.engine.workflow.BackendCallKey
-import cromwell.engine.{AbortFunction, ExecutionEventEntry}
 import cromwell.logging.WorkflowLogger
 import cromwell.util.google.GenomicsScopes
 import org.joda.time.DateTime

--- a/engine/src/main/scala/cromwell/engine/backend/local/SharedFileSystemBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/local/SharedFileSystemBackend.scala
@@ -4,10 +4,11 @@ import java.nio.file._
 
 import better.files._
 import cromwell.WorkflowEngineFunctions
+import cromwell.backend.ExecutionEventEntry
 import cromwell.core.{CallOutput, CallOutputs, WorkflowOptions, _}
+import cromwell.engine.backend
 import cromwell.engine.backend._
 import cromwell.engine.io.gcs.GcsPath
-import cromwell.engine.{ExecutionEventEntry, backend}
 import cromwell.util.TryUtil
 import org.apache.commons.lang3.exception.ExceptionUtils
 import wdl4s.types.{WdlArrayType, WdlFileType, WdlMapType}

--- a/engine/src/main/scala/cromwell/engine/backend/package.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/package.scala
@@ -1,14 +1,9 @@
 package cromwell.engine
 
-import wdl4s.{Call, Scope}
-
-import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.immutable.Seq
+import scala.concurrent.{ExecutionContext, Future}
 
 package object backend {
-  @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
-  final case class ExecutionHash(overallHash: String, dockerHash: Option[String])
-
   // Ordered by shards, and then ordered by attempts
   type AttemptedCallLogs = Seq[Seq[CallLogs]]
   // Grouped by FQNS

--- a/engine/src/main/scala/cromwell/engine/backend/sge/OldStyleSgeBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/sge/OldStyleSgeBackend.scala
@@ -154,7 +154,7 @@ case class OldStyleSgeBackend(backendConfigEntry: BackendConfigurationEntry, act
     */
   private def launchQsub(jobDescriptor: OldStyleBackendCallJobDescriptor): (Int, Option[Int]) = {
     val logger = jobLogger(jobDescriptor)
-    val sgeJobName = s"cromwell_${jobDescriptor.workflowDescriptor.shortId}_${jobDescriptor.call.unqualifiedName}"
+    val sgeJobName = s"cromwell_${jobDescriptor.workflowDescriptor.id.shortString}_${jobDescriptor.call.unqualifiedName}"
     val argv = Seq("qsub", "-terse", "-N", sgeJobName, "-V", "-b", "n", "-wd", jobDescriptor.callRootPath.toAbsolutePath, "-o", jobDescriptor.stdout.getFileName, "-e", jobDescriptor.stderr.getFileName, jobDescriptor.script.toAbsolutePath).map(_.toString)
     val backendCommandString = argv.map(s => "\""+s+"\"").mkString(" ")
     logger.info(s"backend command: $backendCommandString")

--- a/engine/src/main/scala/cromwell/engine/callexecution/OldStyleCallExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/callexecution/OldStyleCallExecutionActor.scala
@@ -3,19 +3,21 @@ package cromwell.engine.callexecution
 import akka.actor.{Actor, Props}
 import akka.event.{Logging, LoggingReceive}
 import com.google.api.client.util.ExponentialBackOff
+import cromwell.core.CromwellFatalException
+import cromwell.engine.CromwellActor
 import cromwell.engine.backend._
 import cromwell.engine.callactor.OldStyleCallActor
 import cromwell.engine.callexecution.OldStyleCallExecutionActor.{ExecutionMode, Finish, IssuePollRequest, PollResponseReceived}
 import cromwell.engine.finalcall.OldStyleFinalCall
-import cromwell.engine.{CromwellActor, CromwellFatalException}
 import cromwell.logging.WorkflowLogger
 import cromwell.webservice.WorkflowMetadataResponse
 import wdl4s.Scope
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success}
+
 @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object OldStyleCallExecutionActor {
   sealed trait CallExecutionActorMessage

--- a/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -5,7 +5,7 @@ import java.util.Date
 
 import akka.actor.ActorSystem
 import akka.pattern.after
-import cromwell.backend.JobKey
+import cromwell.backend.{ExecutionEventEntry, ExecutionHash, JobKey}
 import cromwell.core.{CallOutput, CallOutputs, WorkflowId}
 import cromwell.database.SqlConverters._
 import cromwell.database.SqlDatabase

--- a/engine/src/main/scala/cromwell/engine/db/package.scala
+++ b/engine/src/main/scala/cromwell/engine/db/package.scala
@@ -1,8 +1,9 @@
 package cromwell.engine
 
+import cromwell.backend.ExecutionHash
 import cromwell.engine.ExecutionIndex.ExecutionIndex
 import cromwell.engine.ExecutionStatus.ExecutionStatus
-import cromwell.engine.backend.{OldStyleBackendCallJobDescriptor, ExecutionHash}
+import cromwell.engine.backend.OldStyleBackendCallJobDescriptor
 import wdl4s.Scatter
 
 package object db {

--- a/engine/src/main/scala/cromwell/engine/package.scala
+++ b/engine/src/main/scala/cromwell/engine/package.scala
@@ -25,7 +25,6 @@ package object engine {
   final case class AbortFunction(function: () => Unit)
   final case class AbortRegistrationFunction(register: AbortFunction => Unit)
 
-  final case class ExecutionEventEntry(description: String, startTime: DateTime, endTime: DateTime)
   final case class QualifiedFailureEventEntry(workflowId: String, execution: Option[ExecutionDatabaseKey], failure: String, timestamp: DateTime) {
     def dequalify = FailureEventEntry(failure, timestamp)
   }
@@ -37,9 +36,6 @@ package object engine {
   type FullyQualifiedName = String
 
   type HostInputs = Map[String, WdlValue]
-
-  class CromwellFatalException(exception: Throwable) extends Exception(exception)
-  class PreemptedException(msg: String) extends Exception(msg)
 
   implicit class EnhancedFullyQualifiedName(val fqn: FullyQualifiedName) extends AnyVal {
     def scopeAndVariableName: (String, String) = {

--- a/engine/src/main/scala/cromwell/engine/workflow/CallMetadataBuilder.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/CallMetadataBuilder.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.workflow
 
+import cromwell.backend.ExecutionEventEntry
 import cromwell.database.obj.Execution
 import cromwell.engine.ExecutionIndex._
 import cromwell.engine._

--- a/engine/src/main/scala/cromwell/engine/workflow/OldStyleWorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/OldStyleWorkflowActor.scala
@@ -5,6 +5,7 @@ import java.sql.SQLException
 import akka.actor._
 import akka.event.Logging
 import akka.pattern.pipe
+import cromwell.backend.{ExecutionEventEntry, ExecutionHash}
 import cromwell.core.{CallOutput, CallOutputs}
 import cromwell.database.obj.{Execution, ExecutionInfo}
 import cromwell.engine.ExecutionIndex._
@@ -1235,7 +1236,7 @@ case class OldStyleWorkflowActor(workflow: OldStyleWorkflowDescriptor)
       workflow.namespace.resolve(cachedExecution.callFqn) match {
         case Some(c: Call) =>
           val jobDescriptor = OldStyleBackendCallJobDescriptor(workflow, BackendCallKey(c, cachedExecution.index.toIndex, cachedExecution.attempt), callInputs)
-          log.info(s"Call Caching: Cache hit. Using UUID(${jobDescriptor.workflowDescriptor.shortId}):${jobDescriptor.key.tag} as results for UUID(${descriptor.workflowDescriptor.shortId}):${descriptor.key.tag}")
+          log.info(s"Call Caching: Cache hit. Using UUID(${jobDescriptor.workflowDescriptor.id.shortString}):${jobDescriptor.key.tag} as results for UUID(${descriptor.workflowDescriptor.id.shortString}):${descriptor.key.tag}")
           self ! UseCachedCall(callKey, OldStyleCallActor.UseCachedCall(jobDescriptor, descriptor,
             backend.stdoutStderr(descriptor)))
         case _ =>

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -4,14 +4,14 @@ import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
 import com.typesafe.config.Config
 import cromwell.core.WorkflowId
+import cromwell.engine.workflow.WorkflowActor._
+import cromwell.engine.workflow.lifecycle.MaterializeWorkflowDescriptorActor.{MaterializeWorkflowDescriptorCommand, MaterializeWorkflowDescriptorFailureResponse, MaterializeWorkflowDescriptorSuccessResponse}
+import cromwell.engine.workflow.lifecycle.WorkflowExecutionActor.{RestartExecutingWorkflowCommand, StartExecutingWorkflowCommand, WorkflowExecutionFailedResponse, WorkflowExecutionSucceededResponse}
+import cromwell.engine.workflow.lifecycle.WorkflowFinalizationActor.{StartFinalizationCommand, WorkflowFinalizationFailedResponse, WorkflowFinalizationSucceededResponse}
+import cromwell.engine.workflow.lifecycle.WorkflowInitializationActor.{StartInitializationCommand, WorkflowInitializationFailedResponse, WorkflowInitializationSucceededResponse}
+import cromwell.engine.workflow.lifecycle._
 import cromwell.engine.{EngineWorkflowDescriptor, WorkflowSourceFiles}
 
-import cromwell.engine.workflow.lifecycle.MaterializeWorkflowDescriptorActor.{MaterializeWorkflowDescriptorFailureResponse, MaterializeWorkflowDescriptorSuccessResponse, MaterializeWorkflowDescriptorCommand}
-import cromwell.engine.workflow.lifecycle.WorkflowExecutionActor.{WorkflowExecutionSucceededResponse, WorkflowExecutionFailedResponse, RestartExecutingWorkflowCommand, StartExecutingWorkflowCommand}
-import cromwell.engine.workflow.lifecycle.WorkflowFinalizationActor.{WorkflowFinalizationSucceededResponse, WorkflowFinalizationFailedResponse, StartFinalizationCommand}
-import cromwell.engine.workflow.lifecycle.WorkflowInitializationActor.{WorkflowInitializationFailedResponse, WorkflowInitializationSucceededResponse, StartInitializationCommand}
-import cromwell.engine.workflow.lifecycle._
-import cromwell.engine.workflow.WorkflowActor._
 import scala.language.postfixOps
 
 object WorkflowActor {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowExecutionActor.scala
@@ -6,10 +6,10 @@ import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionFailedRespo
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobDescriptorKey, BackendLifecycleActorFactory, JobKey}
 import cromwell.core.{WorkflowId, _}
 import cromwell.engine.ExecutionIndex._
-import cromwell.engine.ExecutionStatus._
+import cromwell.engine.ExecutionStatus.{ExecutionStatus, NotStarted}
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
 import cromwell.engine.workflow.JobInputEvaluator
-import cromwell.engine.workflow.lifecycle.WorkflowExecutionActor._
+import cromwell.engine.workflow.lifecycle.WorkflowExecutionActor.{WorkflowExecutionActorData, WorkflowExecutionActorState}
 import cromwell.engine.{EngineWorkflowDescriptor, ExecutionStatus}
 import cromwell.webservice.WdlValueJsonFormatter
 import lenthall.exception.ThrowableAggregation
@@ -207,9 +207,6 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId, workflowDescript
       log.warning(s"Job ${jobKey.tag} failed with a retryable failure: ${reason.getMessage}")
       handleRetryableFailure(jobKey)
     case Event(JobInitializationFailed(jobKey, reason), stateData) =>
-      log.warning(s"Job ${jobKey.tag} failed: $reason")
-      goto(WorkflowExecutionFailedState)
-    case Event(JobInitializationFailed(jobKey, reason), stateData) =>
       log.warning(s"Job ${jobKey.tag} failed to initialize: $reason")
       goto(WorkflowExecutionFailedState)
     case Event(AbortExecutingWorkflowCommand, stateData) => ??? // TODO: Implement!
@@ -289,7 +286,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId, workflowDescript
 
   private def isRunnable(entry: ExecutionStoreEntry, executionStore: ExecutionStore) = {
     entry match {
-      case (key, ExecutionStatus.NotStarted) => arePrerequisitesDone(key, executionStore)
+      case (key, NotStarted) => arePrerequisitesDone(key, executionStore)
       case _ => false
     }
   }

--- a/engine/src/main/scala/cromwell/logging/WorkflowLogger.scala
+++ b/engine/src/main/scala/cromwell/logging/WorkflowLogger.scala
@@ -35,7 +35,7 @@ case class WorkflowLogger(caller: String,
 
   lazy val tag: String = {
     val subtag = callTag.map(c => s":$c").getOrElse("")
-    s"$caller [UUID(${descriptor.shortId})$subtag]"
+    s"$caller [UUID(${descriptor.id.shortString})$subtag]"
   }
 
   private def format(msg: String): String = s"$tag: $msg"

--- a/engine/src/main/scala/cromwell/util/TryUtil.scala
+++ b/engine/src/main/scala/cromwell/util/TryUtil.scala
@@ -2,21 +2,13 @@ package cromwell.util
 
 import java.io.{PrintWriter, StringWriter}
 
-import cromwell.engine.CromwellFatalException
+import cromwell.backend.Backoff
+import cromwell.core.{CromwellAggregatedException, CromwellFatalException}
 import cromwell.logging.WorkflowLogger
-import lenthall.exception.ThrowableAggregation
-import org.slf4j.LoggerFactory
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
-object CromwellAggregatedException {
-  val logger = LoggerFactory.getLogger("AggregatedException")
-}
-
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
-case class CromwellAggregatedException(throwables: Seq[Throwable], exceptionContext: String = "") extends ThrowableAggregation
 
 @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 object TryUtil {

--- a/engine/src/main/scala/cromwell/util/docker/DockerIdentifierParser.scala
+++ b/engine/src/main/scala/cromwell/util/docker/DockerIdentifierParser.scala
@@ -2,7 +2,7 @@ package cromwell.util.docker
 
 import com.google.api.client.auth.oauth2.Credential
 import com.typesafe.config.Config
-import cromwell.util.DockerConfiguration
+import cromwell.core.DockerConfiguration
 
 import scala.annotation.tailrec
 

--- a/engine/src/main/scala/cromwell/util/docker/DockerRegistryIdentifierParser.scala
+++ b/engine/src/main/scala/cromwell/util/docker/DockerRegistryIdentifierParser.scala
@@ -1,7 +1,7 @@
 package cromwell.util.docker
 
 import com.google.api.client.auth.oauth2.Credential
-import cromwell.util.DockerConfiguration
+import cromwell.core.DockerConfiguration
 
 /**
   * Parses a String into a DockerIdentifier for a particular registry.

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiHandler.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiHandler.scala
@@ -6,8 +6,8 @@ import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import cromwell.core.WorkflowId
 import cromwell.engine._
-import cromwell.engine.backend.{OldStyleBackend, CallLogs}
-import cromwell.engine.workflow.{WorkflowManagerActor, OldStyleWorkflowManagerActor}
+import cromwell.engine.backend.{CallLogs, OldStyleBackend}
+import cromwell.engine.workflow.{OldStyleWorkflowManagerActor, WorkflowManagerActor}
 import cromwell.engine.workflow.OldStyleWorkflowManagerActor.{CallNotFoundException, WorkflowNotFoundException}
 import cromwell.webservice.PerRequest.RequestComplete
 import cromwell.{core, engine}

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -1,5 +1,6 @@
 package cromwell.webservice
 
+import cromwell.backend.ExecutionEventEntry
 import cromwell.engine._
 import cromwell.engine.backend.{CallLogs, OldStyleCallMetadata, WorkflowQueryResult}
 import cromwell.engine.db.ExecutionDatabaseKey

--- a/engine/src/test/scala/cromwell/RetryableCallsSpec.scala
+++ b/engine/src/test/scala/cromwell/RetryableCallsSpec.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import akka.testkit.{EventFilter, TestActorRef}
+import cromwell.backend.PreemptedException
 import cromwell.engine._
 import cromwell.engine.backend._
 import cromwell.engine.backend.local.OldStyleLocalBackend

--- a/engine/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/BackendCallSpec.scala
@@ -2,9 +2,10 @@ package cromwell.engine.backend
 
 import cromwell.CallCachingWorkflowSpec._
 import cromwell.CromwellTestkitSpec
+import cromwell.core.CromwellAggregatedException
 import cromwell.engine.backend.local.OldStyleLocalBackend
 import cromwell.engine.workflow.BackendCallKey
-import cromwell.util.{CromwellAggregatedException, SampleWdl}
+import cromwell.util.SampleWdl
 import org.scalatest.concurrent.ScalaFutures
 import wdl4s.values.WdlFile
 

--- a/engine/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/jes/JesBackendSpec.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import com.google.api.client.testing.http.{HttpTesting, MockHttpTransport, MockLowLevelHttpRequest, MockLowLevelHttpResponse}
 import cromwell.CromwellTestkitSpec
+import cromwell.backend.PreemptedException
 import cromwell.backend.impl.jes.io.{DiskType, JesWorkingDisk}
 import cromwell.core.{CallContext, WorkflowContext, WorkflowId, WorkflowOptions}
 import cromwell.engine._
@@ -59,6 +60,7 @@ class JesBackendSpec extends FlatSpec with Matchers with Mockito with BeforeAndA
     val logger: Logger = LoggerFactory.getLogger("JesBackendSpecLogger")
     val wd = mock[OldStyleWorkflowDescriptor]
     wd.workflowLogger returns logger
+    wd.id returns WorkflowId.randomId()
     val task = mock[Task]
     task.outputs returns Seq.empty
     val call = mock[Call]

--- a/engine/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/db/slick/SlickDataAccessSpec.scala
@@ -8,7 +8,7 @@ import com.google.api.client.util.ExponentialBackOff
 import com.typesafe.config.ConfigFactory
 import cromwell.CromwellSpec.DbmsTest
 import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
-import cromwell.backend.JobKey
+import cromwell.backend.{ExecutionEventEntry, JobKey}
 import cromwell.core._
 import cromwell.database.SqlConverters._
 import cromwell.database.obj.Execution

--- a/engine/src/test/scala/cromwell/util/BackoffSpec.scala
+++ b/engine/src/test/scala/cromwell/util/BackoffSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.util
 
 import com.google.api.client.util.ExponentialBackOff.Builder
+import cromwell.backend.{InitialGapBackoff, SimpleExponentialBackoff}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._

--- a/engine/src/test/scala/cromwell/util/TryUtilSpec.scala
+++ b/engine/src/test/scala/cromwell/util/TryUtilSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.util
 
-import cromwell.engine.CromwellFatalException
+import cromwell.backend.SimpleExponentialBackoff
+import cromwell.core.CromwellFatalException
 import cromwell.logging.WorkflowLogger
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}

--- a/engine/src/test/scala/cromwell/util/docker/DockerHashableSpec.scala
+++ b/engine/src/test/scala/cromwell/util/docker/DockerHashableSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.util.docker
 
-import cromwell.util.CromwellAggregatedException
+import cromwell.core.CromwellAggregatedException
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{FlatSpec, Matchers}

--- a/engine/src/test/scala/cromwell/util/docker/SprayDockerRegistryApiClientSpec.scala
+++ b/engine/src/test/scala/cromwell/util/docker/SprayDockerRegistryApiClientSpec.scala
@@ -3,9 +3,9 @@ package cromwell.util.docker
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import cromwell.CromwellSpec.{DockerTest, IntegrationTest}
+import cromwell.core.DockerConfiguration
 import cromwell.engine.backend.BackendConfiguration
 import cromwell.filesystems.gcs.GoogleCredentialFactorySpec
-import cromwell.util.DockerConfiguration
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,20 +28,26 @@ object Dependencies {
     "io.spray" %% "spray-json" % DowngradedSprayV
   )
 
-  val googleDependencies = List(
-    "com.fasterxml.jackson.core" % "jackson-core" % "2.4.5", // Used by swagger, but only in tests
+  val googleApiClientDependencies = List(
+    // Used by swagger, but only in tests.  This overrides an older 2.1.3 version of jackson-core brought in by
+    // these Google dependencies, but which isn't properly evicted by IntelliJ's sbt integration.
+    "com.fasterxml.jackson.core" % "jackson-core" % "2.4.5",
+    // The exclusions prevent guava 13 from colliding at assembly time with guava 18 brought in elsewhere.
+    "com.google.api-client" % "google-api-client-java6" % googleClientApiV exclude("com.google.guava", "guava-jdk5"),
+    "com.google.api-client" % "google-api-client-jackson2" % googleClientApiV exclude("com.google.guava", "guava-jdk5")
+  )
+
+  val googleCloudDependencies = List(
     "com.google.gcloud" % "gcloud-java" % "0.0.9",
-    "com.google.api-client" % "google-api-client-java6" % googleClientApiV,
-    "com.google.api-client" % "google-api-client-jackson2" % googleClientApiV,
     "com.google.oauth-client" % "google-oauth-client" % googleClientApiV,
     "com.google.cloud.bigdataoss" % "gcsio" % "1.4.4",
     "com.google.apis" % "google-api-services-genomics" % ("v1alpha2-rev14-" + googleClientApiV)
-  )
+  ) ++ googleApiClientDependencies
 
   val gcsFileSystemDependencies = List(
     "org.broadinstitute" %% "lenthall" % lenthallV,
     "org.scalaz" % "scalaz-core_2.11" % "7.1.3"
-  ) ++ testDependencies ++ googleDependencies
+  ) ++ testDependencies ++ googleCloudDependencies
 
   val databaseDependencies = List(
     "org.broadinstitute" %% "lenthall" % lenthallV,
@@ -58,14 +64,16 @@ object Dependencies {
 
   val coreDependencies = List(
     wdl4sDependency,
+    "org.broadinstitute" %% "lenthall" % lenthallV,
     "com.typesafe" % "config" % "1.3.0",
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "org.apache.commons" % "commons-lang3" % "3.4"
   ) ++ testDependencies
 
   val backendDependencies = List(
-    "org.broadinstitute" %% "lenthall" % lenthallV
-  ) ++ coreDependencies
+    "joda-time" % "joda-time" % "2.8.2",
+    "org.joda" % "joda-convert" % "1.8.1"
+  ) ++ coreDependencies ++ googleApiClientDependencies
 
   val localBackendDependencies = List(
     "org.broadinstitute" %% "lenthall" % lenthallV
@@ -73,7 +81,6 @@ object Dependencies {
 
   val engineDependencies = List(
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-    "org.joda" % "joda-convert" % "1.8.1",
     "org.webjars" % "swagger-ui" % "2.1.1",
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,
@@ -84,5 +91,5 @@ object Dependencies {
     "org.codehaus.janino" % "janino" % "2.7.8",
     "org.scalaz" % "scalaz-core_2.11" % "7.1.3",
     "com.github.pathikrit" %% "better-files" % betterFilesV
-  ) ++ coreDependencies ++ sprayDependencies
+  ) ++ coreDependencies ++ sprayDependencies ++ googleCloudDependencies ++ databaseDependencies ++ backendDependencies ++ gcsFileSystemDependencies
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/EnhancedWorkflowOptions.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/EnhancedWorkflowOptions.scala
@@ -1,0 +1,16 @@
+package cromwell.backend.impl.jes
+
+import cromwell.core.WorkflowOptions
+import cromwell.filesystems.gcs.GoogleAuthMode
+import cromwell.filesystems.gcs.GoogleAuthMode.GoogleAuthOptions
+
+import scala.util.Try
+
+object EnhancedWorkflowOptions {
+
+  implicit class GoogleAuthWorkflowOptions(val workflowOptions: WorkflowOptions) extends AnyVal {
+    def toGoogleAuthOptions: GoogleAuthMode.GoogleAuthOptions = new GoogleAuthOptions {
+      override def get(key: String): Try[String] = workflowOptions.get(key)
+    }
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
@@ -1,0 +1,25 @@
+package cromwell.backend.impl.jes
+
+import java.net.URL
+
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.http.HttpTransport
+import com.google.api.client.json.JsonFactory
+import com.google.api.services.genomics.Genomics
+import cromwell.filesystems.gcs.GoogleConfiguration
+
+
+object GenomicsFactory {
+
+  def apply(credential: Credential, endpointUrl: URL): Genomics = {
+    val gc = GoogleConfiguration.Instance
+    GoogleGenomics.from(gc.applicationName, endpointUrl, credential, credential.getJsonFactory, credential.getTransport)
+  }
+
+  // Wrapper object around Google's Genomics class providing a convenience 'from' "method"
+  object GoogleGenomics {
+    def from(applicationName: String, endpointUrl: URL, credential: Credential, jsonFactory: JsonFactory, httpTransport: HttpTransport): Genomics = {
+      new Genomics.Builder(httpTransport, jsonFactory, credential).setApplicationName(applicationName).setRootUrl(endpointUrl.toString).build
+    }
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -1,0 +1,579 @@
+package cromwell.backend.impl.jes
+
+
+import java.net.SocketTimeoutException
+import java.nio.file.{Path, Paths}
+import java.util.UUID
+
+import akka.actor.{Actor, ActorLogging, Props}
+import better.files._
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.genomics.Genomics
+import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
+import cromwell.backend.async.AsyncBackendJobExecutionActor.ExecutionMode
+import cromwell.backend.async.{AbortedExecutionHandle, AsyncBackendJobExecutionActor, ExecutionHandle, FailedExecutionHandle, RetryableExecutionHandle, SuccessfulExecutionHandle}
+import cromwell.backend.impl.jes.Run.{RunStatus, TerminalRunStatus}
+import cromwell.backend.impl.jes.authentication.JesDockerCredentials
+import cromwell.backend.impl.jes.io._
+import cromwell.backend.{AttemptedLookupResult, BackendConfigurationDescriptor, BackendJobDescriptor, BackendWorkflowDescriptor, ExecutionHash, PreemptedException, SimpleExponentialBackoff}
+import cromwell.core.{CallOutput, CromwellAggregatedException, _}
+import wdl4s.AstTools._
+import wdl4s.WdlExpression.ScopedLookupFunction
+import wdl4s._
+import wdl4s.command.ParameterCommandPart
+import wdl4s.expression.NoFunctions
+import wdl4s.util.TryUtil
+import wdl4s.values._
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+object JesAsyncBackendJobExecutionActor {
+
+  def props(jobDescriptor: BackendJobDescriptor, configurationDescriptor: BackendConfigurationDescriptor, completionPromise: Promise[BackendJobExecutionResponse]): Props = {
+    Props(new JesAsyncBackendJobExecutionActor(jobDescriptor, configurationDescriptor, completionPromise))
+  }
+
+  private val ExecParamName = "exec"
+  private val MonitoringParamName = "monitoring"
+
+  private val MonitoringScriptOptionKey = "monitoring_script"
+  private val JesMonitoringScript = "monitoring.sh"
+  private val JesMonitoringLogFile = "monitoring.log"
+  private val JesExecScript = "exec.sh"
+  private val AuthFilePathOptionKey = "auth_bucket"
+  private val ExtraConfigParamName = "__extra_config_gcs_path"
+  private val GoogleProjectOptionKey = "google_project"
+
+  private def splitFqn(fullyQualifiedName: FullyQualifiedName): (String, String) = {
+    val lastIndex = fullyQualifiedName.lastIndexOf(".")
+    (fullyQualifiedName.substring(0, lastIndex), fullyQualifiedName.substring(lastIndex + 1))
+  }
+
+  /**
+    * Takes a path in GCS and comes up with a local path which is unique for the given GCS path
+    *
+    * @param gcsPath The input path
+    * @return A path which is unique per input path
+    */
+  private def localFilePathFromCloudStoragePath(gcsPath: GcsPath): Path = {
+    Paths.get(gcsPath.bucket).resolve(gcsPath.objectName)
+  }
+
+  /**
+    * Takes a single WdlValue and maps google cloud storage (GCS) paths into an appropriate local file path.
+    * If the input is not a WdlFile, or the WdlFile is not a GCS path, the mapping is a noop.
+    *
+    * @param wdlValue the value of the input
+    * @return a new FQN to WdlValue pair, with WdlFile paths modified if appropriate.
+    */
+  private def gcsPathToLocal(wdlValue: WdlValue): WdlValue = {
+    wdlValue match {
+      case wdlFile: WdlFile =>
+        GcsPath.parse(wdlFile.value) match {
+          case Success(gcsPath) => WdlFile(localFilePathFromCloudStoragePath(gcsPath).toString, wdlFile.isGlob)
+          case Failure(e) => wdlValue
+        }
+      case wdlArray: WdlArray => wdlArray map gcsPathToLocal
+      case wdlMap: WdlMap => wdlMap map { case (k, v) => gcsPathToLocal(k) -> gcsPathToLocal(v) }
+      case _ => wdlValue
+    }
+  }
+}
+
+
+class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
+                                       val configurationDescriptor: BackendConfigurationDescriptor,
+                                       override val completionPromise: Promise[BackendJobExecutionResponse])
+  extends Actor with ActorLogging with AsyncBackendJobExecutionActor {
+
+  import JesAsyncBackendJobExecutionActor._
+
+  /**
+    * Exponential Backoff Builder to be used when polling for call status.
+    */
+  override lazy val backoff = SimpleExponentialBackoff(initialInterval = 30 seconds, maxInterval = 60 seconds, multiplier = 1.1)
+
+  private lazy val monitoringScript: Option[JesInput] = {
+    jobDescriptor.descriptor.workflowOptions.get(MonitoringScriptOptionKey) map { path =>
+      JesFileInput(s"$MonitoringParamName-in", GcsPath(path).toString, Paths.get(JesMonitoringScript), workingDisk)
+    } toOption
+  }
+  private lazy val workflowDescriptor = jobDescriptor.descriptor
+  private lazy val gcsFileSystem = buildGcsFileSystem(backendConfig, jobDescriptor.descriptor)
+  private lazy val backendConfig = configurationDescriptor.backendConfig
+  private lazy val jesCallPaths = JesCallPaths(jobDescriptor.key, gcsFileSystem, jobDescriptor.descriptor, configurationDescriptor.backendConfig)
+  private def workflowPath: Path = jesCallPaths.workflowRootPath
+  private def callRootPath: Path = jesCallPaths.callRootPath
+  private def returnCodeFilename = jesCallPaths.returnCodeFilename
+  private def returnCodeGcsPath = jesCallPaths.returnCodePath
+  private def jesStdoutFile = jesCallPaths.stdoutPath
+  private def jesStderrFile = jesCallPaths.stderrPath
+  private def jesLogFilename = jesCallPaths.jesLogFilename
+  private lazy val call = jobDescriptor.key.call
+  private lazy val runtimeAttributes = {
+    val evaluateAttrs = call.task.runtimeAttributes.attrs mapValues evaluate
+    // Fail the call if runtime attributes can't be evaluated
+    val evaluatedAttributes = TryUtil.sequenceMap(evaluateAttrs, "Runtime attributes evaluation").get
+    JesRuntimeAttributes(evaluatedAttributes)
+  }
+  private lazy val workingDisk: JesAttachedDisk = runtimeAttributes.disks.find(_.name == JesWorkingDisk.Name).get
+  private lazy val gcsExecPath: Path = callRootPath.resolve(JesExecScript)
+  private lazy val cmdInput = JesFileInput(ExecParamName, gcsExecPath.toString, Paths.get(JesExecScript), workingDisk)
+  private lazy val jesCommandLine = s"/bin/bash ${cmdInput.containerPath.toAbsolutePath.toString}"
+  private lazy val defaultMonitoringOutputPath = callRootPath.resolve(JesMonitoringLogFile)
+  private lazy val rcJesOutput = JesFileOutput(returnCodeFilename, returnCodeGcsPath.toString, Paths.get(returnCodeFilename), workingDisk)
+
+  private lazy val standardParameters = Seq(rcJesOutput)
+  // PBE this shouldn't need to be defined here, could be at the actor factory level.
+  private lazy val jesAttributes = JesAttributes(backendConfig)
+  private lazy val returnCodeContents = Try(returnCodeGcsPath.toAbsolutePath.contentAsString)
+  private lazy val dockerConfiguration: Option[JesDockerCredentials] = DockerConfiguration.build(backendConfig).dockerCredentials map JesDockerCredentials.apply
+  private lazy val maxPreemption = runtimeAttributes.preemptible
+  private lazy val preemptible: Boolean = jobDescriptor.key.attempt <= maxPreemption
+  private lazy val tag = self.path.name
+
+  private def globOutputPath(glob: String) = callRootPath.resolve(s"glob-${glob.md5Sum}/")
+
+  private def gcsAuthFilePath: Path =  {
+    // If we are going to upload an auth file we need a valid GCS path passed via workflow options.
+    val bucket = workflowDescriptor.workflowOptions.get(AuthFilePathOptionKey) getOrElse workflowPath.toString
+    bucket.toPath(gcsFileSystem).resolve(s"${workflowDescriptor.id}_auth.json")
+  }
+
+  private def authGcsCredentialsPath(gcsPath: String): JesInput = JesLiteralInput(ExtraConfigParamName, gcsPath)
+
+  private def gcsAuthParameter: Option[JesInput] = {
+    if (jesAttributes.gcsFilesystemAuth.requiresAuthFile || dockerConfiguration.isDefined)
+      Option(authGcsCredentialsPath(gcsAuthFilePath.toString))
+    else None
+  }
+
+  private val callEngineFunctions = {
+    val callContext = new CallContext(
+      callRootPath.toString,
+      jesStdoutFile.toString,
+      jesStderrFile.toString
+    )
+
+    new JesCallEngineFunctions(gcsFileSystem, callContext)
+  }
+
+  private val lookup: ScopedLookupFunction = {
+    val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
+    val unqualifiedWorkflowInputs = workflowDescriptor.inputs map {
+      case (fqn, v) => splitFqn(fqn)._2 -> v
+    }
+    val knownInputs = unqualifiedWorkflowInputs ++ jobDescriptor.inputs
+    WdlExpression.standardLookupFunction(knownInputs, declarations, callEngineFunctions)
+  }
+
+  private def evaluate(wdlExpression: WdlExpression) = wdlExpression.evaluate(lookup, callEngineFunctions)
+
+  /**
+    * Takes two arrays of remote and local WDL File paths and generates the necessary JesInputs.
+    */
+  private def jesInputsFromWdlFiles(jesNamePrefix: String,
+                                    remotePathArray: Seq[WdlFile],
+                                    localPathArray: Seq[WdlFile],
+                                    jobDescriptor: BackendJobDescriptor): Iterable[JesInput] = {
+    (remotePathArray zip localPathArray zipWithIndex) flatMap {
+      case ((remotePath, localPath), index) =>
+        Seq(JesFileInput(s"$jesNamePrefix-$index", remotePath.valueString, Paths.get(localPath.valueString), workingDisk))
+    }
+  }
+
+  /**
+    * Turns WdlFiles into relative paths.  These paths are relative to the working disk
+    *
+    * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
+    * relativeLocalizationPath("gs://some/bucket/foo.txt") -> "some/bucket/foo.txt"
+    */
+  private def relativeLocalizationPath(file: WdlFile): WdlFile = {
+    GcsPath.parse(file.value) match {
+      case Success(gcsPath) => WdlFile(gcsPath.bucket + "/" + gcsPath.objectName, file.isGlob)
+      case Failure(e) => file
+    }
+  }
+
+  private def generateJesInputs(jobDescriptor: BackendJobDescriptor): Iterable[JesInput] = {
+    /**
+      * Commands in WDL tasks can also generate input files.  For example: ./my_exec --file=${write_lines(arr)}
+      *
+      * write_lines(arr) would produce a string-ified version of the array stored as a GCS path.  The next block of code
+      * will go through each ${...} expression within the task's command section and find all write_*() ASTs and
+      * evaluate them so the files are written to GCS and the they can be included as inputs to Google's Pipeline object
+      */
+    val commandExpressions = jobDescriptor.key.scope.task.commandTemplate.collect({
+      case x: ParameterCommandPart => x.expression
+    })
+
+    val writeFunctionAsts = commandExpressions.map(_.ast).flatMap(x => AstTools.findAsts(x, "FunctionCall")).collect({
+      case y if y.getAttribute("name").sourceString.startsWith("write_") => y
+    })
+
+    val evaluatedExpressionMap = writeFunctionAsts map { ast =>
+      val expression = WdlExpression(ast)
+      val value = expression.evaluate(lookup, callEngineFunctions)
+      expression.toWdlString.md5SumShort -> value
+    } toMap
+
+    val writeFunctionFiles = evaluatedExpressionMap collect { case (k, v: Success[_]) => k -> v.get } collect { case (k, v: WdlFile) => k -> Seq(v)}
+
+    /** Collect all WdlFiles from inputs to the call */
+    val callInputFiles: Map[FullyQualifiedName, Seq[WdlFile]] = jobDescriptor.inputs mapValues { _.collectAsSeq { case w: WdlFile => w } }
+
+    (callInputFiles ++ writeFunctionFiles) flatMap {
+      case (name, files) => jesInputsFromWdlFiles(name, files, files.map(relativeLocalizationPath), jobDescriptor)
+    }
+  }
+
+  /**
+    * Given a path (relative or absolute), returns a (Path, JesAttachedDisk) tuple where the Path is
+    * relative to the AttachedDisk's mount point
+    *
+    * @throws Exception if the `path` does not live in one of the supplied `disks`
+    */
+  private def relativePathAndAttachedDisk(path: String, disks: Seq[JesAttachedDisk]): (Path, JesAttachedDisk) = {
+    val absolutePath = Paths.get(path) match {
+      case p if !p.isAbsolute => Paths.get(JesWorkingDisk.MountPoint).resolve(p)
+      case p => p
+    }
+
+    disks.find(d => absolutePath.startsWith(d.mountPoint)) match {
+      case Some(disk) => (disk.mountPoint.relativize(absolutePath), disk)
+      case None =>
+        throw new Exception(s"Absolute path $path doesn't appear to be under any mount points: ${disks.map(_.toString).mkString(", ")}")
+    }
+  }
+
+  /**
+    * If the desired reference name is too long, we don't want to break JES or risk collisions by arbitrary truncation. So,
+    * just use a hash. We only do this when needed to give better traceability in the normal case.
+    */
+  private def makeSafeJesReferenceName(referenceName: String) = {
+    if (referenceName.length <= 127) referenceName else referenceName.md5Sum
+  }
+
+  private def generateJesOutputs(jobDescriptor: BackendJobDescriptor): Seq[JesFileOutput] = {
+    val wdlFileOutputs = jobDescriptor.key.scope.task.outputs flatMap { taskOutput =>
+      taskOutput.requiredExpression.evaluateFiles(lookup, NoFunctions, taskOutput.wdlType) match {
+        case Success(wdlFiles) => wdlFiles map relativeLocalizationPath
+        case Failure(ex) =>
+          log.warning(s"Could not evaluate $taskOutput: ${ex.getMessage}", ex)
+          Seq.empty[WdlFile]
+      }
+    }
+
+    // Create the mappings. GLOB mappings require special treatment (i.e. stick everything matching the glob in a folder)
+    wdlFileOutputs.distinct map { wdlFile =>
+      val destination = wdlFile match {
+        case WdlSingleFile(filePath) => callRootPath.resolve(filePath).toString
+        case WdlGlobFile(filePath) => globOutputPath(filePath).toString
+      }
+      val (relpath, disk) = relativePathAndAttachedDisk(wdlFile.value, runtimeAttributes.disks)
+      JesFileOutput(makeSafeJesReferenceName(wdlFile.value), destination, relpath, disk)
+    }
+  }
+
+  private def instantiateCommand: Try[String] = {
+    val backendInputs = jobDescriptor.inputs mapValues gcsPathToLocal
+    jobDescriptor.call.instantiateCommandLine(backendInputs, callEngineFunctions, gcsPathToLocal)
+  }
+
+  private def uploadCommandScript(command: String, withMonitoring: Boolean): Try[Unit] = {
+    val monitoring = if (withMonitoring) {
+      s"""|touch $JesMonitoringLogFile
+          |chmod u+x $JesMonitoringScript
+          |./$JesMonitoringScript > $JesMonitoringLogFile &""".stripMargin
+    } else ""
+
+    val tmpDir = Paths.get(JesWorkingDisk.MountPoint).resolve("tmp")
+    val rcPath = Paths.get(JesWorkingDisk.MountPoint).resolve(returnCodeFilename)
+
+    val fileContent =
+      s"""
+         |#!/bin/bash
+         |export _JAVA_OPTIONS=-Djava.io.tmpdir=$tmpDir
+         |export TMPDIR=$tmpDir
+         |cd ${JesWorkingDisk.MountPoint}
+         |$monitoring
+         |$command
+         |echo $$? > $rcPath
+       """.stripMargin.trim
+
+    Try(gcsExecPath.write(fileContent))
+  }
+
+  private def googleProject(descriptor: BackendWorkflowDescriptor): String = {
+    descriptor.workflowOptions.getOrElse(GoogleProjectOptionKey, jesAttributes.project)
+  }
+
+  private def genomicsInterface(options: WorkflowOptions, jesAttributes: JesAttributes): Genomics = {
+    GenomicsFactory(jesAttributes.genomicsAuth.credential(options.toGoogleAuthOptions), jesAttributes.endpointUrl)
+  }
+
+  private def createJesRun(jesParameters: Seq[JesParameter], runIdForResumption: Option[String] = None): Try[Run] = Try {
+    Pipeline(
+      jobDescriptor = jobDescriptor,
+      runtimeAttributes = runtimeAttributes,
+      callRootPath = callRootPath.toString,
+      commandLine = jesCommandLine,
+      logFileName = jesLogFilename,
+      jesParameters,
+      googleProject(jobDescriptor.descriptor),
+      genomicsInterface(jobDescriptor.descriptor.workflowOptions, jesAttributes),
+      runIdForResumption
+    ).run
+  }
+
+  private def runWithJes(command: String,
+                         jesInputs: Seq[JesInput],
+                         jesOutputs: Seq[JesFileOutput],
+                         // runIdForResumption: Option[String],
+                         withMonitoring: Boolean): Future[ExecutionHandle] = Future {
+
+    val jesParameters = standardParameters ++ gcsAuthParameter ++ jesInputs ++ jesOutputs
+
+    val jesJobSetup = for {
+      _ <- uploadCommandScript(command, withMonitoring)
+      run <- createJesRun(jesParameters)
+    } yield run
+
+    jesJobSetup match {
+      case Failure(ex) =>
+        log.warning(s"Failed to create a JES run", ex)
+        throw ex  // Probably a transient issue, throwing retries it
+      case Success(run) => JesPendingExecutionHandle(jobDescriptor, jesOutputs, run, previousStatus = None)
+    }
+  }
+
+  override def executeOrRecover(mode: ExecutionMode)(implicit ec: ExecutionContext): Future[ExecutionHandle] = {
+    // PBE Currently assumes only execute
+    val monitoringOutput = monitoringScript map { _ =>
+      JesFileOutput(s"$MonitoringParamName-out", defaultMonitoringOutputPath.toString, Paths.get(JesMonitoringLogFile), workingDisk)
+    }
+
+    val jesInputs: Seq[JesInput] = generateJesInputs(jobDescriptor).toSeq ++ monitoringScript :+ cmdInput
+    val jesOutputs: Seq[JesFileOutput] = generateJesOutputs(jobDescriptor) ++ monitoringOutput
+
+    instantiateCommand match {
+      case Success(command) =>
+        runWithJes(command, jesInputs, jesOutputs, /* runIdForResumption, */ monitoringScript.isDefined)
+      case Failure(ex: SocketTimeoutException) => Future.successful(FailedExecutionHandle(ex))
+      case Failure(ex) => Future.successful(FailedExecutionHandle(ex))
+    }
+  }
+
+  /**
+    * Update the ExecutionHandle
+    */
+  override def poll(previous: ExecutionHandle)(implicit ec: ExecutionContext): Future[ExecutionHandle] = Future {
+    previous match {
+      case handle: JesPendingExecutionHandle =>
+        val wfId = handle.jobDescriptor.descriptor.id.shortString
+        val tag = handle.jobDescriptor.key.tag
+        val runId = handle.run.runId
+        log.debug(s"[UUID($wfId)$tag] Polling JES Job $runId")
+        val status = Try(handle.run.checkStatus(jobDescriptor, handle.previousStatus))
+        status match {
+          case Success(s: TerminalRunStatus) => executionResult(s, handle)
+          case Success(s) => handle.copy(previousStatus = Option(s)).future // Copy the current handle with updated previous status.
+          case Failure(e: GoogleJsonResponseException) if e.getStatusCode == 404 =>
+            log.error(s"JES Job ID ${handle.run.runId} has not been found, failing call")
+            FailedExecutionHandle(e).future
+          case Failure(e: Exception) =>
+            // Log exceptions and return the original handle to try again.
+            log.warning("Caught exception, retrying: " + e.getMessage, e)
+            handle.future
+          case Failure(e: Error) => Future.failed(e) // JVM-ending calamity.
+          case Failure(throwable) =>
+            // Someone has subclassed Throwable directly?
+            FailedExecutionHandle(throwable).future
+        }
+      case f: FailedExecutionHandle => f.future
+      case s: SuccessfulExecutionHandle => s.future
+      case badHandle => Future.failed(new IllegalArgumentException(s"Unexpected execution handle: $badHandle"))
+    }
+  } flatten
+
+  /**
+    * Turns a GCS path representing a workflow input into the GCS path where the file would be mirrored to in this workflow:
+    * task x {
+    *  File x
+    *  ...
+    *  Output {
+    *    File mirror = x
+    *  }
+    * }
+    *
+    * This function is more useful in working out the common prefix when the filename is modified somehow
+    * in the workflow (e.g. "-new.txt" is appended)
+    */
+  private def gcsInputToGcsOutput(inputValue: WdlValue): WdlValue = {
+    // Convert to the local path where the file is localized to in the VM:
+    val vmLocalizationPath = gcsPathToLocal(inputValue)
+
+    vmLocalizationPath match {
+      // If it's a file, work out where the file would be delocalized to, otherwise no-op:
+      case x : WdlFile =>
+        val delocalizationPath = callRootPath.resolve(vmLocalizationPath.valueString).toString
+        WdlFile(delocalizationPath)
+      case a: WdlArray => WdlArray(a.wdlType, a.value map { f => gcsInputToGcsOutput(f) })
+      case m: WdlMap => WdlMap(m.wdlType, m.value map { case (k, v) => gcsInputToGcsOutput(k) -> gcsInputToGcsOutput(v) })
+      case other => other
+    }
+  }
+
+  private def customLookupFunction(alreadyGeneratedOutputs: Map[String, WdlValue]): String => WdlValue = toBeLookedUp => {
+    val originalLookup: ScopedLookupFunction = x => alreadyGeneratedOutputs.getOrElse(x, lookup(x))
+    gcsInputToGcsOutput(originalLookup(toBeLookedUp))
+  }
+
+  private def wdlValueToGcsPath(jesOutputs: Seq[JesFileOutput])(value: WdlValue): WdlValue = {
+    def toGcsPath(wdlFile: WdlFile) = jesOutputs collectFirst { case o if o.name == makeSafeJesReferenceName(wdlFile.valueString) => WdlFile(o.gcs) } getOrElse value
+    value match {
+      case wdlArray: WdlArray => wdlArray map wdlValueToGcsPath(jesOutputs)
+      case wdlMap: WdlMap => wdlMap map {
+        case (k, v) => wdlValueToGcsPath(jesOutputs)(k) -> wdlValueToGcsPath(jesOutputs)(v)
+      }
+      case file: WdlFile => toGcsPath(file)
+      case other => other
+    }
+  }
+
+  private def outputLookup(taskOutput: TaskOutput, currentList: Seq[AttemptedLookupResult]) = for {
+  /**
+    * This will evaluate the task output expression and coerces it to the task output's type.
+    * If the result is a WdlFile, then attempt to find the JesOutput with the same path and
+    * return a WdlFile that represents the GCS path and not the local path.  For example,
+    *
+    * <pre>
+    * output {
+    *   File x = "out" + ".txt"
+    * }
+    * </pre>
+    *
+    * "out" + ".txt" is evaluated to WdlString("out.txt") and then coerced into a WdlFile("out.txt")
+    * Then, via wdlFileToGcsPath(), we attempt to find the JesOutput with .name == "out.txt".
+    * If it is found, then WdlFile("gs://some_bucket/out.txt") will be returned.
+    */
+    wdlValue <- taskOutput.requiredExpression.evaluate(customLookupFunction(currentList.toLookupMap), callEngineFunctions)
+    coercedValue <- taskOutput.wdlType.coerceRawValue(wdlValue)
+    value = wdlValueToGcsPath(generateJesOutputs(jobDescriptor))(coercedValue)
+  } yield value
+
+
+  private def outputFoldingFunction: (Seq[AttemptedLookupResult], TaskOutput) => Seq[AttemptedLookupResult] = {
+    (currentList: Seq[AttemptedLookupResult], taskOutput: TaskOutput) => {
+      currentList ++ Seq(AttemptedLookupResult(taskOutput.name, outputLookup(taskOutput, currentList)))
+    }
+  }
+
+  private def postProcess: Try[CallOutputs] = {
+    val outputs = call.task.outputs
+    val outputMappings = outputs.foldLeft(Seq.empty[AttemptedLookupResult])(outputFoldingFunction).map(_.toPair).toMap
+    TryUtil.sequenceMap(outputMappings) map { outputMap =>
+      outputMap mapValues { v =>
+        // PBE fix hashing
+        CallOutput(v, hash = None)
+      }
+    }
+  }
+
+  private def handleSuccess(outputMappings: Try[CallOutputs],
+                            returnCode: Int,
+                            hash: ExecutionHash,
+                            executionHandle: ExecutionHandle): ExecutionHandle = {
+    outputMappings match {
+      case Success(outputs) => SuccessfulExecutionHandle(outputs, returnCode, hash)
+      case Failure(ex: CromwellAggregatedException) if ex.throwables collectFirst { case s: SocketTimeoutException => s } isDefined =>
+        // Return the execution handle in this case to retry the operation
+        executionHandle
+      case Failure(ex) => FailedExecutionHandle(ex)
+    }
+  }
+
+  private def extractErrorCodeFromErrorMessage(errorMessage: String): Int = {
+    errorMessage.substring(0, errorMessage.indexOf(':')).toInt
+  }
+
+  private def preempted(errorCode: Int, errorMessage: Option[String]): Boolean = {
+    def isPreemptionCode(code: Int) = code == 13 || code == 14
+
+    try {
+      errorCode == 10 && errorMessage.isDefined && isPreemptionCode(extractErrorCodeFromErrorMessage(errorMessage.get)) && preemptible
+    } catch {
+      case _: NumberFormatException | _: StringIndexOutOfBoundsException =>
+        log.warning(s"Unable to parse JES error code from error message: ${errorMessage.get}, assuming this was not a preempted VM.")
+        false
+    }
+  }
+
+  private def handleFailure(errorCode: Int, errorMessage: Option[String]) = {
+    import lenthall.numeric.IntegerUtil._
+
+    val taskName = s"${workflowDescriptor.id}:${call.unqualifiedName}"
+    val attempt = jobDescriptor.key.attempt
+
+    if (errorMessage.exists(_.contains("Operation canceled at")))  {
+      AbortedExecutionHandle.future
+    } else if (preempted(errorCode, errorMessage)) {
+      val preemptedMsg = s"Task $taskName was preempted for the ${attempt.toOrdinal} time."
+
+      if (attempt < maxPreemption) {
+        val e = new PreemptedException(
+          s"""$preemptedMsg The call will be restarted with another preemptible VM (max preemptible attempts number is $maxPreemption).
+             |Error code $errorCode. Message: $errorMessage""".stripMargin
+        )
+        RetryableExecutionHandle(e, None).future
+      } else {
+        val e = new PreemptedException(
+          s"""$preemptedMsg The maximum number of preemptible attempts ($maxPreemption) has been reached. The call will be restarted with a non-preemptible VM.
+             |Error code $errorCode. Message: $errorMessage)""".stripMargin)
+        RetryableExecutionHandle(e, None).future
+      }
+    } else {
+      val e = new Throwable(s"Task ${workflowDescriptor.id}:${jobDescriptor.call.unqualifiedName} failed: error code $errorCode. Message: ${errorMessage.getOrElse("null")}")
+      FailedExecutionHandle(e, None).future
+    }
+  }
+
+  // PBE ideally hashes should be determinitic
+  private def completelyRandomExecutionHash: Future[ExecutionHash] = Future.successful(ExecutionHash(UUID.randomUUID().toString, dockerHash = None))
+
+  private def executionResult(status: RunStatus, handle: JesPendingExecutionHandle)(implicit ec: ExecutionContext): Future[ExecutionHandle] = Future {
+    try {
+      lazy val stderrLength: Long = jesStderrFile.size
+      lazy val returnCode = returnCodeContents map { _.trim.toInt }
+      lazy val continueOnReturnCode = runtimeAttributes.continueOnReturnCode
+
+      status match {
+        case Run.Success if runtimeAttributes.failOnStderr && stderrLength.intValue > 0 =>
+          // returnCode will be None if it couldn't be downloaded/parsed, which will yield a null in the DB
+          FailedExecutionHandle(new Throwable(s"execution failed: stderr has length $stderrLength"), returnCode.toOption).future
+        case Run.Success if returnCodeContents.isFailure =>
+          val exception = returnCode.failed.get
+          log.warning(s"$tag could not download return code file, retrying: " + exception.getMessage, exception)
+          // Return handle to try again.
+          handle.future
+        case Run.Success if returnCode.isFailure =>
+          FailedExecutionHandle(new Throwable(s"execution failed: could not parse return code as integer: " + returnCodeContents.get)).future
+        case Run.Success if !continueOnReturnCode.continueFor(returnCode.get) =>
+          FailedExecutionHandle(new Throwable(s"execution failed: disallowed command return code: " + returnCode.get), returnCode.toOption).future
+        case Run.Success =>
+          completelyRandomExecutionHash map { h => handleSuccess(postProcess, returnCode.get, h, handle) }
+        case Run.Failed(errorCode, errorMessage) => handleFailure(errorCode, errorMessage)
+      }
+    } catch {
+      case e: Exception =>
+        log.warning("Caught exception trying to download result, retrying: " + e.getMessage, e)
+        // Return the original handle to try again.
+        handle.future
+    }
+  } flatten
+
+  protected implicit def ec: ExecutionContext = context.dispatcher
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
@@ -1,0 +1,76 @@
+package cromwell.backend.impl.jes
+
+import java.net.URL
+
+import com.typesafe.config.Config
+import cromwell.backend.impl.jes.EnhancedWorkflowOptions._
+import cromwell.core.{ErrorOr, WorkflowOptions}
+import cromwell.filesystems.gcs.{GoogleAuthMode, GoogleConfiguration}
+import lenthall.config.ScalaConfig._
+import lenthall.config.ValidatedConfig._
+import wdl4s.ThrowableWithErrors
+
+import scala.language.postfixOps
+import scalaz.Scalaz._
+import scalaz.Validation.FlatMap._
+import scalaz._
+
+case class JesAttributes(project: String,
+                         genomicsAuth: GoogleAuthMode,
+                         gcsFilesystemAuth: GoogleAuthMode,
+                         executionBucket: String,
+                         endpointUrl: URL,
+                         maxPollingInterval: Int) {
+
+  def assertWorkflowOptions(options: WorkflowOptions): Unit = {
+    // These methods throw on bad options
+    genomicsAuth.assertWorkflowOptions(options.toGoogleAuthOptions)
+    gcsFilesystemAuth.assertWorkflowOptions(options.toGoogleAuthOptions)
+  }
+}
+
+object JesAttributes {
+
+  private val jesKeys = Set(
+    "project",
+    "root",
+    "maximum-polling-interval",
+    "dockerhub",
+    "genomics",
+    "filesystems",
+    "genomics.auth",
+    "genomics.endpoint-url",
+    "filesystems.gcs.auth"
+  )
+
+  private val context = "Jes"
+
+  def apply(backendConfig: Config): JesAttributes = {
+
+    backendConfig.warnNotRecognized(jesKeys, context)
+
+    val project: ErrorOr[String] = backendConfig.validateString("project")
+    val executionBucket: ErrorOr[String] = backendConfig.validateString("root")
+    val endpointUrl: ErrorOr[URL] = backendConfig.validateURL("genomics.endpoint-url")
+    val maxPollingInterval: Int = backendConfig.getIntOption("maximum-polling-interval").getOrElse(600)
+    val genomicsAuthName: ErrorOr[String] = backendConfig.validateString("genomics.auth")
+    val gcsFilesystemAuthName: ErrorOr[String] = backendConfig.validateString("filesystems.gcs.auth")
+
+    val gconf = GoogleConfiguration.Instance
+
+    (project |@| executionBucket |@| endpointUrl |@| genomicsAuthName |@| gcsFilesystemAuthName) {
+      (_, _, _, _, _)
+    } flatMap { case (p, b, u, genomicsName, gcsName) =>
+      (gconf.auth(genomicsName) |@| gconf.auth(gcsName)) { case (genomicsAuth, gcsAuth) =>
+        JesAttributes(p, genomicsAuth, gcsAuth, b, u, maxPollingInterval)
+      }
+    } match {
+      case Success(r) => r
+      case Failure(f) =>
+        throw new IllegalArgumentException() with ThrowableWithErrors {
+          override val message = "Jes Configuration is not valid: Errors"
+          override val errors = f
+        }
+    }
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
@@ -1,0 +1,33 @@
+package cromwell.backend.impl.jes
+
+import akka.actor.Props
+import com.typesafe.config.Config
+import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobDescriptorKey, BackendLifecycleActorFactory, BackendWorkflowDescriptor}
+import wdl4s.Call
+import wdl4s.expression.WdlStandardLibraryFunctions
+
+case class JesBackendLifecycleActorFactory(config: Config) extends BackendLifecycleActorFactory {
+
+  override def workflowInitializationActorProps(workflowDescriptor: BackendWorkflowDescriptor,
+                                                calls: Seq[Call],
+                                                configurationDescriptor: BackendConfigurationDescriptor): Option[Props] = {
+    Option(JesInitializationActor.props(workflowDescriptor, calls, configurationDescriptor))
+  }
+
+  override def jobExecutionActorProps(jobDescriptor: BackendJobDescriptor,
+                                      configurationDescriptor: BackendConfigurationDescriptor): Props = {
+    JesJobExecutionActor.props(jobDescriptor, configurationDescriptor)
+  }
+
+  override def workflowFinalizationActorProps(): Option[Props] = None
+
+  override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
+                                           jobKey: BackendJobDescriptorKey,
+                                           configurationDescriptor: BackendConfigurationDescriptor): WdlStandardLibraryFunctions = {
+
+    val fileSystem = buildGcsFileSystem(configurationDescriptor.backendConfig, workflowDescriptor)
+    val jesCallPaths = JesCallPaths(jobKey, fileSystem, workflowDescriptor, configurationDescriptor.backendConfig)
+    new JesCallEngineFunctions(fileSystem, jesCallPaths.buildCallContext)
+  }
+}
+

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesEngineFunctions.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesEngineFunctions.scala
@@ -1,0 +1,34 @@
+package cromwell.backend.impl.jes
+
+import java.nio.file.{FileSystem, Path}
+
+import better.files._
+import cromwell.core.PathFactory._
+import cromwell.core.{CallContext, WorkflowContext}
+import cromwell.filesystems.gcs.GcsFileSystem
+import cromwell.{CallEngineFunctions, WorkflowEngineFunctions}
+import wdl4s.values._
+
+import scala.language.postfixOps
+import scala.util.Try
+
+class JesWorkflowEngineFunctions(fileSystems: List[FileSystem], context: WorkflowContext) extends WorkflowEngineFunctions(context) {
+
+  private def globDirectory(glob: String): String = s"glob-${glob.md5Sum}/"
+
+  override def globPath(glob: String): String = context.root.toAbsolutePath(fileSystems).resolve(globDirectory(glob)).toString
+
+  override def glob(path: String, pattern: String): Seq[String] = {
+    path.toAbsolutePath(fileSystems).asDirectory.glob("**/*") map { _.path.fullPath } filterNot { _.toString == path } toSeq
+  }
+
+  override def toPath(str: String): Path = {
+    val path = buildPath(str, fileSystems)
+    if (!path.isAbsolute) context.root.toAbsolutePath(fileSystems).resolve(path) else path
+  }
+}
+
+class JesCallEngineFunctions(fileSystem: GcsFileSystem, context: CallContext) extends JesWorkflowEngineFunctions(List(fileSystem), context) with CallEngineFunctions {
+  override def stdout(params: Seq[Try[WdlValue]]) = stdout(context)
+  override def stderr(params: Seq[Try[WdlValue]]) = stderr(context)
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobExecutionActor.scala
@@ -1,11 +1,36 @@
 package cromwell.backend.impl.jes
 
+import akka.actor.{ActorRef, Props}
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
 import cromwell.backend._
+import cromwell.backend.async.AsyncBackendJobExecutionActor.Execute
+import org.slf4j.LoggerFactory
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
+import scala.language.postfixOps
 
-class JesJobExecutionActor extends BackendJobExecutionActor {
+
+object JesJobExecutionActor {
+  val logger = LoggerFactory.getLogger("JesBackend")
+
+  def props(jobDescriptor: BackendJobDescriptor, configurationDescriptor: BackendConfigurationDescriptor): Props =
+    Props(new JesJobExecutionActor(jobDescriptor, configurationDescriptor))
+
+}
+
+case class JesJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
+                                override val configurationDescriptor: BackendConfigurationDescriptor)
+  extends BackendJobExecutionActor {
+
+  // PBE keep a reference to be able to hand to a successor executor if the failure is recoverable, or to complete as a
+  // failure if the failure is not recoverable.
+  private lazy val completionPromise = Promise[BackendJobExecutionResponse]()
+
+  // PBE keep a reference for abort purposes.  Maybe we don't need this if we can look up actors by name.
+  private var executor: Option[ActorRef] = None
+
+  // PBE there should be some consideration of supervision here.
+
   /**
     * Restart or resume a previously-started job.
     */
@@ -14,11 +39,12 @@ class JesJobExecutionActor extends BackendJobExecutionActor {
   /**
     * Execute a new job.
     */
-  override def execute: Future[BackendJobExecutionResponse] = ???
-
-  override protected def configurationDescriptor: BackendConfigurationDescriptor = ???
-
-  override protected def jobDescriptor: BackendJobDescriptor = ???
+  override def execute: Future[BackendJobExecutionResponse] = {
+    val executorRef = context.actorOf(JesAsyncBackendJobExecutionActor.props(jobDescriptor, configurationDescriptor, completionPromise))
+    executor = Option(executorRef)
+    executorRef ! Execute
+    completionPromise.future
+  }
 
   /**
     * Abort a running job.

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesParameters.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesParameters.scala
@@ -1,0 +1,38 @@
+package cromwell.backend.impl.jes
+
+import java.nio.file.Path
+
+import com.google.api.services.genomics.model.{LocalCopy, PipelineParameter}
+import cromwell.backend.impl.jes.io.JesAttachedDisk
+
+sealed trait JesParameter {
+  def name: String
+  def toGooglePipelineParameter: PipelineParameter
+  def toGoogleRunParameter: String
+}
+
+sealed trait JesInput extends JesParameter
+
+final case class JesFileInput(name: String, gcs: String, local: Path, mount: JesAttachedDisk) extends JesInput {
+  def toGooglePipelineParameter = {
+    new PipelineParameter().setName(name).setLocalCopy(
+      new LocalCopy().setDisk(mount.name).setPath(local.toString)
+    )
+  }
+  val toGoogleRunParameter: String = gcs
+  def containerPath: Path = mount.mountPoint.resolve(local)
+}
+
+final case class JesLiteralInput(name: String, value: String) extends JesInput {
+  def toGooglePipelineParameter = new PipelineParameter().setName(name)
+  val toGoogleRunParameter: String = value
+}
+
+final case class JesFileOutput(name: String, gcs: String, local: Path, mount: JesAttachedDisk) extends JesParameter {
+  def toGooglePipelineParameter = {
+    new PipelineParameter().setName(name).setLocalCopy(
+      new LocalCopy().setDisk(mount.name).setPath(local.toString)
+    )
+  }
+  val toGoogleRunParameter: String = gcs
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeInfo.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeInfo.scala
@@ -1,0 +1,53 @@
+package cromwell.backend.impl.jes
+
+import com.google.api.services.genomics.model.{DockerExecutor, PipelineResources}
+import wdl4s.parser.MemoryUnit
+
+import scala.collection.JavaConverters._
+
+sealed trait JesRuntimeInfo {
+  def resources: PipelineResources
+  def docker: DockerExecutor
+}
+
+trait JesRuntimeInfoBuilder {
+  def buildDockerExecutor(commandLine: String, dockerImage: String): DockerExecutor = {
+    val docker = new DockerExecutor()
+    docker.setImageName(dockerImage).setCmd(commandLine)
+  }
+
+  def buildResources(runtimeAttributes: JesRuntimeAttributes): PipelineResources = {
+    new PipelineResources()
+      .setMinimumRamGb(runtimeAttributes.memory.to(MemoryUnit.GB).amount)
+      .setMinimumCpuCores(runtimeAttributes.cpu)
+      .setZones(runtimeAttributes.zones.asJava)
+      .setDisks(runtimeAttributes.disks.map(_.toGoogleDisk).asJava)
+      .setBootDiskSizeGb(runtimeAttributes.bootDiskSize)
+  }
+}
+
+object NonPreemptibleJesRuntimeInfo extends JesRuntimeInfoBuilder {
+  def apply(commandLine: String, runtimeAttributes: JesRuntimeAttributes): JesRuntimeInfo = {
+    /*
+     It should be impossible for docker to be None here. Enforcing that w/ ADTs seemed more trouble than
+      it was worth. If you're ever debugging a NoSuchElementException which leads you here, that means
+      the more trouble than worth calculation was incorrect and we should have separate RuntimeAttributes for
+      docker and no docker cases
+    */
+    val dockerImage = runtimeAttributes.dockerImage.get
+    val resources = buildResources(runtimeAttributes).setPreemptible(false)
+    new NonPreemptibleJesRuntimeInfo(resources, buildDockerExecutor(commandLine, dockerImage))
+  }
+}
+
+object PreemptibleJesRuntimeInfo extends JesRuntimeInfoBuilder {
+  def apply(commandLine: String, runtimeAttributes: JesRuntimeAttributes): JesRuntimeInfo = {
+    // See comment above
+    val dockerImage = runtimeAttributes.dockerImage.get
+    val resources = buildResources(runtimeAttributes).setPreemptible(true)
+    new PreemptibleJesRuntimeInfo(resources, buildDockerExecutor(commandLine, dockerImage))
+  }
+}
+
+case class NonPreemptibleJesRuntimeInfo(resources: PipelineResources, docker: DockerExecutor) extends JesRuntimeInfo
+case class PreemptibleJesRuntimeInfo(resources: PipelineResources, docker: DockerExecutor) extends JesRuntimeInfo

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Pipeline.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Pipeline.scala
@@ -1,0 +1,80 @@
+package cromwell.backend.impl.jes
+
+import com.google.api.services.genomics.model.{Disk, PipelineParameter}
+import com.google.api.services.genomics.{Genomics, model}
+import cromwell.backend.BackendJobDescriptor
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+
+object Pipeline {
+  def apply(jobDescriptor: BackendJobDescriptor,
+            runtimeAttributes: JesRuntimeAttributes,
+            callRootPath: String,
+            commandLine: String,
+            logFileName: String,
+            jesParameters: Seq[JesParameter],
+            projectId: String,
+            genomicsInterface: Genomics,
+            runIdForResumption: Option[String]): Pipeline = {
+
+    lazy val workflow = jobDescriptor.descriptor
+
+    val logger = LoggerFactory.getLogger(Pipeline.getClass)
+
+    logger.debug(s"Command line is: $commandLine")
+    val runtimeInfo = /* if (jesJobDescriptor.preemptible) PreemptibleJesRuntimeInfo(commandLine, runtimeAttributes) else */ NonPreemptibleJesRuntimeInfo(commandLine, runtimeAttributes)
+
+    val p = new model.Pipeline
+    p.setProjectId(projectId)
+    p.setDocker(runtimeInfo.docker)
+    p.setResources(runtimeInfo.resources)
+    p.setName(workflow.workflowNamespace.workflow.unqualifiedName)
+    p.setInputParameters(jesParameters.collect({ case i: JesInput => i.toGooglePipelineParameter }).toVector.asJava)
+    p.setOutputParameters(jesParameters.collect({ case i: JesFileOutput => i.toGooglePipelineParameter }).toVector.asJava)
+
+    def createPipeline = genomicsInterface.pipelines().create(p).execute().getPipelineId
+
+    def pipelineParameterString(p: PipelineParameter): String = {
+      val description = Option(p.getLocalCopy) match {
+        case Some(localCopy) => s"disk:${localCopy.getDisk} relpath:${localCopy.getPath}"
+        case None => s"(literal value)"
+      }
+      s"  ${p.getName} -> $description"
+    }
+    def diskString(d: Disk): String = {
+      s"  ${d.getName} -> ${d.getMountPoint} (${d.getSizeGb}GB ${d.getType})"
+    }
+    logger.info(s"Inputs:\n${p.getInputParameters.asScala.map(pipelineParameterString).mkString("\n")}")
+    logger.info(s"Outputs:\n${p.getOutputParameters.asScala.map(pipelineParameterString).mkString("\n")}")
+    logger.info(s"Mounts:\n${runtimeInfo.resources.getDisks.asScala.map(diskString).mkString("\n")}")
+
+    val pipelineId = if (runIdForResumption.isDefined) None else Option(createPipeline)
+
+    logger.info(s"Pipeline ID is ${pipelineId.getOrElse("(none)")}")
+    logger.info(s"Project ID: $projectId")
+    new Pipeline(
+      jobDescriptor = jobDescriptor,
+      command = commandLine,
+      logFileName = logFileName,
+      pipelineId = pipelineId,
+      projectId = projectId,
+      gcsPath = callRootPath,
+      jesParameters = jesParameters,
+      runtimeInfo = runtimeInfo,
+      genomicsService = genomicsInterface)
+  }
+}
+
+case class Pipeline private(jobDescriptor: BackendJobDescriptor,
+                            logFileName: String,
+                            command: String,
+                            pipelineId: Option[String],
+                            projectId: String,
+                            gcsPath: String,
+                            jesParameters: Seq[JesParameter],
+                            runtimeInfo: JesRuntimeInfo,
+                            genomicsService: Genomics,
+                            runIdForResumption: Option[String] = None) {
+  def run: Run = Run(this, logFileName)
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
@@ -1,0 +1,128 @@
+package cromwell.backend.impl.jes
+
+import com.google.api.services.genomics.model._
+import com.typesafe.config.ConfigFactory
+import cromwell.backend.BackendJobDescriptor
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+object Run  {
+  private val GenomicsScopes = List(
+    "https://www.googleapis.com/auth/genomics",
+    "https://www.googleapis.com/auth/compute"
+  ).asJava
+
+  private val JesServiceAccount = new ServiceAccount().setEmail("default").setScopes(GenomicsScopes)
+  private lazy val MaximumPollingInterval = Duration(ConfigFactory.load.getConfig("backend").getConfig("jes").getInt("maximumPollingInterval"), "seconds")
+  private val InitialPollingInterval = 5 seconds
+  private val PollingBackoffFactor = 1.1
+
+  def apply(pipeline: Pipeline, logFileName: String): Run = {
+    val logger = LoggerFactory.getLogger(Run.getClass)
+
+    if (pipeline.pipelineId.isDefined == pipeline.runIdForResumption.isDefined) {
+      val message =
+        s"""
+          |Exactly one of JES pipeline ID or run ID for resumption must be specified to create a Run.
+          |pipelineId = ${pipeline.pipelineId}, runIdForResumption = ${pipeline.runIdForResumption}.
+        """.stripMargin
+      throw new RuntimeException(message)
+    }
+
+    def runPipeline: String = {
+      val rpargs = new RunPipelineArgs().setProjectId(pipeline.projectId).setServiceAccount(JesServiceAccount)
+
+      rpargs.setInputs(pipeline.jesParameters.collect({ case i: JesInput => i.name -> i.toGoogleRunParameter }).toMap.asJava)
+      logger.info(s"Inputs:\n${stringifyMap(rpargs.getInputs.asScala.toMap)}")
+
+      rpargs.setOutputs(pipeline.jesParameters.collect({ case i: JesFileOutput => i.name -> i.toGoogleRunParameter }).toMap.asJava)
+      logger.info(s"Outputs:\n${stringifyMap(rpargs.getOutputs.asScala.toMap)}")
+
+      val rpr = new RunPipelineRequest().setPipelineId(pipeline.pipelineId.get).setPipelineArgs(rpargs)
+
+      val logging = new LoggingOptions()
+      logging.setGcsPath(s"${pipeline.gcsPath}/$logFileName")
+      rpargs.setLogging(logging)
+
+      val runId = pipeline.genomicsService.pipelines().run(rpr).execute().getName
+      logger.info(s"JES Run ID is $runId")
+      runId
+    }
+
+    // Only run the pipeline if the pipeline ID is defined.  The pipeline ID not being defined corresponds to a
+    // resumption of a previous run, and runIdForResumption will be defined.  The Run code takes care of polling
+    // in both the newly created and resumed scenarios.
+    val runId = if (pipeline.pipelineId.isDefined) runPipeline else pipeline.runIdForResumption.get
+    new Run(runId, pipeline /*, logger */)
+  }
+
+  private def stringifyMap(m: Map[String, String]): String = m map { case(k, v) => s"  $k -> $v"} mkString "\n"
+
+  implicit class RunOperationExtension(val operation: Operation) extends AnyVal {
+    def hasStarted = operation.getMetadata.asScala.get("startTime") isDefined
+  }
+
+  sealed trait RunStatus {
+    // Could be defined as false for Initializing and true otherwise, but this is more defensive.
+    def isRunningOrComplete = this match {
+      case Running | _: TerminalRunStatus => true
+      case _ => false
+    }
+  }
+  trait TerminalRunStatus extends RunStatus
+  case object Initializing extends RunStatus
+  case object Running extends RunStatus
+  case object Success extends TerminalRunStatus {
+    override def toString = "Success"
+  }
+  final case class Failed(errorCode: Int, errorMessage: Option[String]) extends TerminalRunStatus {
+    // Don't want to include errorMessage or code in the snappy status toString:
+    override def toString = "Failed"
+  }
+
+  // PBE deleted all the ExecutionEvent stuff
+}
+
+// PBE hacked out loggers
+case class Run(runId: String, pipeline: Pipeline /*, logger: WorkflowLogger */) {
+  import Run._
+
+  lazy val workflowId = pipeline.jobDescriptor.descriptor.id
+  lazy val call = pipeline.jobDescriptor.key.scope
+
+  def status(): RunStatus = {
+    val op = pipeline.genomicsService.operations().get(runId).execute
+    if (op.getDone) {
+      // If there's an error, generate a Failed status. Otherwise, we were successful!
+      // val eventList = getEventList(op)
+      Option(op.getError) map { x => Failed(x.getCode, Option(x.getMessage) /*, eventList */) } getOrElse Success
+    } else if (op.hasStarted) {
+      Running
+    } else {
+      Initializing
+    }
+  }
+
+  def checkStatus(jobDescriptor: BackendJobDescriptor, previousStatus: Option[RunStatus]): RunStatus = {
+    val currentStatus = status()
+
+    if (!(previousStatus contains currentStatus)) {
+      // If this is the first time checking the status, we log the transition as '-' to 'currentStatus'. Otherwise
+      // just use the state names.
+      val prevStateName = previousStatus map { _.toString } getOrElse "-"
+      println(s"Status change from $prevStateName to $currentStatus")
+
+      // PBE deleted db writes for run id and status
+      // PBE deleted abort function registration
+    }
+    currentStatus
+  }
+
+  def abort(): Unit = {
+    val cancellationRequest: CancelOperationRequest = new CancelOperationRequest()
+    pipeline.genomicsService.operations().cancel(runId, cancellationRequest).execute
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesVMAuthentication.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesVMAuthentication.scala
@@ -1,4 +1,4 @@
-package cromwell.engine.backend.jes.authentication
+package cromwell.backend.impl.jes.authentication
 
 import cromwell.core.DockerCredentials
 import cromwell.filesystems.gcs.ClientSecrets
@@ -8,7 +8,6 @@ import spray.json.{JsString, JsValue}
  * Interface for Authentication information that can be included in the json file uploaded to GCS
  * upon workflow creation and used in the VM.
  */
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 sealed trait JesAuthInformation {
   def context: String
   def map: Map[String, JsValue]
@@ -19,7 +18,6 @@ sealed trait JesAuthInformation {
 /**
  * Authentication information for data (de)localization as the user.
  */
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 case class GcsLocalizing(clientSecrets: ClientSecrets, token: String) extends JesAuthInformation {
   override val context = "boto"
   override val map = Map(
@@ -28,7 +26,7 @@ case class GcsLocalizing(clientSecrets: ClientSecrets, token: String) extends Je
     "refresh_token" -> JsString(token)
   )
 }
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
+
 object JesDockerCredentials {
   def apply(dockerCredentials: DockerCredentials): JesDockerCredentials = apply(dockerCredentials.account, dockerCredentials.token)
   def apply(account: String, token: String): JesDockerCredentials = new JesDockerCredentials(account, token)
@@ -37,7 +35,6 @@ object JesDockerCredentials {
 /**
  * Authentication information to pull docker images as the user.
  */
-@deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
 class JesDockerCredentials(account: String, token: String) extends DockerCredentials(account, token) with JesAuthInformation {
   override val context = "docker"
   override val map = Map(

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/io/GcsPath.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/io/GcsPath.scala
@@ -1,0 +1,43 @@
+package cromwell.backend.impl.jes.io
+
+import scala.language.implicitConversions
+import scala.util.{Failure, Success, Try}
+
+/** Represents a Google Cloud Storage path, like gs://bucket/path/to/object.txt
+  *
+  * @param bucket - should adhere to https://cloud.google.com/storage/docs/bucket-naming?hl=en#requirements
+  * @param objectName - the name of the thing
+  */
+case class GcsPath(bucket: String, objectName: String) {
+  override def toString = {
+    "gs://" + bucket + "/" + objectName
+  }
+}
+
+object GcsPath {
+
+  implicit def toGcsPath(str: String): GcsPath = GcsPath(str)
+
+  def apply(value: String): GcsPath = {
+    parse(value) match {
+      case Success(gcsPath) => gcsPath
+      case Failure(e) => throw e
+    }
+  }
+
+  def parse(value: String): Try[GcsPath] = {
+    val gsUriRegex = """gs://([^/]*)(.*)""".r
+    value match {
+      case gsUriRegex(bucket, objectName) => Success(GcsPath(bucket, objectName.stripPrefix("/")))
+      case _ => Failure(new IllegalArgumentException(s"Not a valid Google Cloud Storage URI: $value"))
+    }
+  }
+
+  def parseBucket(value: String): Try[String] = {
+    val gsUriRegex = """gs://([^/]*)""".r
+    value match {
+      case gsUriRegex(bucket) => Success(bucket)
+      case _ => Failure(new IllegalArgumentException(s"Not a valid Google Cloud Storage URI: $value"))
+    }
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/package.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/package.scala
@@ -1,0 +1,120 @@
+package cromwell.backend.impl
+
+import java.nio.file.{FileSystem, Path}
+
+import com.typesafe.config.Config
+import cromwell.backend.async.{ExecutionHandle, NonRetryableExecution}
+import cromwell.backend.impl.jes.Run.RunStatus
+import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.core.PathFactory._
+import cromwell.core.{CallContext, WorkflowOptions}
+import cromwell.filesystems.gcs.GoogleAuthMode.GoogleAuthOptions
+import cromwell.filesystems.gcs.{GcsFileSystem, GcsFileSystemProvider, GoogleAuthMode, GoogleConfiguration}
+
+import scala.util.Try
+
+
+package object jes {
+
+  implicit class PathString(val str: String) extends AnyVal {
+    def isGcsUrl: Boolean = str.startsWith("gs://")
+    def isUriWithProtocol: Boolean = "^[a-z]+://".r.findFirstIn(str).nonEmpty
+
+    def toPath(fss: List[FileSystem]): Path = buildPath(str, fss)
+    def toPath(fs: FileSystem): Path = str.toPath(List(fs))
+
+    def toAbsolutePath(fss: List[FileSystem]): Path = str.toPath(fss).toAbsolutePath
+    def toAbsolutePath(fs: FileSystem): Path = str.toAbsolutePath(List(fs))
+
+    def toDirectory(fss: List[FileSystem]): Path = buildPathAsDirectory(str, fss)
+    def toDirectory(fs: FileSystem): Path = str.toDirectory(List(fs))
+
+    // TODO this needs to go away because it's gcs specific. Replacing gcs FS with google implementatio (when available) will take care of it
+    private def buildPathAsDirectory(rawString: String, fileSystems: List[FileSystem]): Path = {
+      findFileSystem(rawString, fileSystems, {
+        case fs: GcsFileSystem => Try(fs.getPathAsDirectory(rawString))
+        case fs => Try(fs.getPath(rawString))
+      })
+    }
+  }
+
+  implicit class EnhancedPath(val path: Path) extends AnyVal {
+    def asDirectory = path.toString.toDirectory(path.getFileSystem)
+  }
+
+  /**
+    * Representing a running JES execution, instances of this class are never Done and it is never okay to
+    * ask them for results.
+    */
+  case class JesPendingExecutionHandle(jobDescriptor: BackendJobDescriptor,
+                                       jesOutputs: Seq[JesFileOutput],
+                                       run: Run,
+                                       previousStatus: Option[RunStatus]) extends ExecutionHandle {
+    override val isDone = false
+    override val result = NonRetryableExecution(new IllegalStateException("JesPendingExecutionHandle cannot yield a result"))
+  }
+
+  implicit class GoogleAuthWorkflowOptions(val workflowOptions: WorkflowOptions) extends AnyVal {
+    def toGoogleAuthOptions: GoogleAuthMode.GoogleAuthOptions = new GoogleAuthOptions {
+      override def get(key: String): Try[String] = workflowOptions.get(key)
+    }
+  }
+
+  def buildGcsFileSystem(backendConfig: Config, workflowDescriptor: BackendWorkflowDescriptor): GcsFileSystem = {
+      // PBE what follows lacks any semblance of error checking
+
+      // PBE check the config sanity in the actory factory, preferably in a fail-fast manner.
+      val genomicsAuth: GoogleAuthMode =
+        GoogleConfiguration.Instance.auth(backendConfig.getString("genomics.auth")) getOrElse { throw new RuntimeException("borked config") }
+
+      // PBE It might be nice to only build this filesystems once per workflow (maybe in the initialization actor) and
+      // somehow make that available to the workflow's job execution actors.
+      val authOptions = workflowDescriptor.workflowOptions.toGoogleAuthOptions
+      GcsFileSystemProvider(genomicsAuth.buildStorage(authOptions)).getFileSystem
+  }
+
+  object JesCallPaths {
+    def apply(jobKey: BackendJobDescriptorKey, gcsFileSystem: GcsFileSystem, workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config): JesCallPaths = {
+      val GcsRootOptionKey = "jes_gcs_root"
+      val CallPrefix = "call"
+      val ShardPrefix = "shard"
+      val AttemptPrefix = "attempt"
+
+      def jesLogBasename = {
+        val index = jobKey.index.map(s => s"-$s").getOrElse("")
+        s"${jobKey.scope.unqualifiedName}$index"
+      }
+
+      val rootPath: Path =
+        gcsFileSystem.getPath(workflowDescriptor.workflowOptions.getOrElse(GcsRootOptionKey, backendConfig.getString("root")))
+
+      val workflowRootPath: Path = rootPath.resolve(workflowDescriptor.workflowNamespace.workflow.unqualifiedName)
+            .resolve(workflowDescriptor.id.toString)
+
+      val callRootPath: Path = {
+        val callName = jobKey.call.fullyQualifiedName.split('.').last
+        val call = s"$CallPrefix-$callName"
+        val shard = jobKey.index map { s => s"$ShardPrefix-$s" } getOrElse ""
+        val retry = if (jobKey.attempt > 1) s"$AttemptPrefix-${jobKey.attempt}" else ""
+
+        List(call, shard, retry).foldLeft(workflowRootPath)((path, dir) => path.resolve(dir))
+      }
+
+      val returnCodeFilename: String = s"$jesLogBasename-rc.txt"
+      val stdoutFilename: String = s"$jesLogBasename-stdout.log"
+      val stderrFilename: String = s"$jesLogBasename-stderr.log"
+      val jesLogFilename: String = s"$jesLogBasename.log"
+      JesCallPaths(rootPath, workflowRootPath, callRootPath, stdoutFilename, stderrFilename, jesLogFilename, returnCodeFilename)
+    }
+  }
+
+  case class JesCallPaths private(rootPath: Path, workflowRootPath: Path, callRootPath: Path, stdoutFilename: String, stderrFilename: String, jesLogFilename: String, returnCodeFilename: String) {
+    lazy val returnCodePath: Path = callRootPath.resolve(returnCodeFilename)
+    lazy val stdoutPath: Path = callRootPath.resolve(stdoutFilename)
+    lazy val stderrPath: Path = callRootPath.resolve(stderrFilename)
+
+    def buildCallContext: CallContext = {
+      new CallContext(callRootPath.toString, stdoutFilename, stderrFilename)
+    }
+  }
+}


### PR DESCRIPTION
Some light reading for @Horneth and @kshakir.

This is largely Frankensteining of "Olde Style" code.  Known missing or broken, I need to confirm that appropriate tickets exist for the restoration of the following:

- [x] #753 Abort
- [x] #751 Recover
- [x] #749 Preemptibility
- [x] #785 Persistence of any data (note this would not be a ticket to create a KV / metadata service, but to integrate this backend with such a service)
- [x] #809 Hashing (prereq for #750)
- [x] #750 Caching
- [x] #806 implement Firecloud style auth upload / deletion (the code is not present here)
- [x] #808 Retries were removed from command script upload and JES run creation

Lessons learned:

- [x] #811 #812 Actor Factories should be responsible for sanity-checking configs .
- [x] #813 Initialization actors should have the ability to create workflow-level resources that can be shared by the other actors collaborating in the workflow execution.  e.g. GCS Filesystems need only be created once per workflow, not for every call.
- [x] It's not clear how workflow logging (or logging in general) should work.

