### PR TITLE
configure restarting workflow closes #755

### DIFF
--- a/engine/src/main/resources/application.conf
+++ b/engine/src/main/resources/application.conf
@@ -192,67 +192,6 @@ backend {
       //          }
       //        }
       //      }
-//    },
-//    SGE {
-//      actor-factory = "cromwell.backend.impl.sge.SgeBackendLifecycleActorFactory"
-//      config {
-//        // Root directory where Cromwell writes job results.  This directory must be
-//        // visible and writeable by the Cromwell process as well as the jobs that Cromwell
-//        // launches.
-//        root: "cromwell-executions"
-//
-//        // Cromwell makes a link to your input files within <root>/<workflow UUID>/workflow-inputs
-//        // The following are strategies used to make those links.  They are ordered.  If one fails
-//        // The next one is tried:
-//        //
-//        // hard-link: attempt to create a hard-link to the file
-//        // copy: copy the file
-//        // soft-link: create a symbolic link to the file
-//        //
-//        // NOTE: soft-link will be skipped for Docker jobs
-//        filesystems = {
-//          local {
-//            localization: [
-//              "hard-link", "soft-link", "copy"
-//            ]
-//          }
-//        }
-//      }
-//    },
-//    JES {
-//      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleFactory"
-//      config {
-//        // Google project
-//        project = "my-cromwell-workflows"
-//
-//        // Base bucket for workflow executions
-//        root = "gs://my-cromwell-workflows-bucket"
-//
-//        // Polling for completion backs-off gradually for slower-running jobs.
-//        // This is the maximum polling interval (in seconds):
-//        maximum-polling-interval = 600
-//
-//        // Optional Dockerhub Credentials. Can be used to access private docker images.
-//        dockerhub {
-//          // account = ""
-//          // token = ""
-//        }
-//
-//        genomics {
-//          // A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
-//          // Pipelines and manipulate auth JSONs.
-//          auth = "application-default"
-//          // Endpoint for APIs, no reason to change this unless directed by Google.
-//          endpoint-url = "https://genomics.googleapis.com/"
-//        }
-//
-//        filesystems {
-//          gcs {
-//            // A reference to a potentially different auth for manipulating files via engine functions.
-//            auth = "user-via-refresh"
-//          }
-//        }
-//      }
     }
   }
 }
@@ -286,6 +225,8 @@ database {
     }
   }
 }
+
+
 
 
 

--- a/engine/src/main/resources/application.conf
+++ b/engine/src/main/resources/application.conf
@@ -131,6 +131,67 @@ backend {
           }
         }
       }
+      //    },
+      //    SGE {
+      //      actor-factory = "cromwell.backend.impl.sge.SgeBackendLifecycleActorFactory"
+      //      config {
+      //        // Root directory where Cromwell writes job results.  This directory must be
+      //        // visible and writeable by the Cromwell process as well as the jobs that Cromwell
+      //        // launches.
+      //        root: "cromwell-executions"
+      //
+      //        // Cromwell makes a link to your input files within <root>/<workflow UUID>/workflow-inputs
+      //        // The following are strategies used to make those links.  They are ordered.  If one fails
+      //        // The next one is tried:
+      //        //
+      //        // hard-link: attempt to create a hard-link to the file
+      //        // copy: copy the file
+      //        // soft-link: create a symbolic link to the file
+      //        //
+      //        // NOTE: soft-link will be skipped for Docker jobs
+      //        filesystems = {
+      //          local {
+      //            localization: [
+      //              "hard-link", "soft-link", "copy"
+      //            ]
+      //          }
+      //        }
+      //      }
+      //    },
+      //    JES {
+      //      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleFactory"
+      //      config {
+      //        // Google project
+      //        project = "my-cromwell-workflows"
+      //
+      //        // Base bucket for workflow executions
+      //        root = "gs://my-cromwell-workflows-bucket"
+      //
+      //        // Polling for completion backs-off gradually for slower-running jobs.
+      //        // This is the maximum polling interval (in seconds):
+      //        maximum-polling-interval = 600
+      //
+      //        // Optional Dockerhub Credentials. Can be used to access private docker images.
+      //        dockerhub {
+      //          // account = ""
+      //          // token = ""
+      //        }
+      //
+      //        genomics {
+      //          // A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
+      //          // Pipelines and manipulate auth JSONs.
+      //          auth = "application-default"
+      //          // Endpoint for APIs, no reason to change this unless directed by Google.
+      //          endpoint-url = "https://genomics.googleapis.com/"
+      //        }
+      //
+      //        filesystems {
+      //          gcs {
+      //            // A reference to a potentially different auth for manipulating files via engine functions.
+      //            auth = "user-via-refresh"
+      //          }
+      //        }
+      //      }
 //    },
 //    SGE {
 //      actor-factory = "cromwell.backend.impl.sge.SgeBackendLifecycleActorFactory"

--- a/engine/src/main/resources/application.conf
+++ b/engine/src/main/resources/application.conf
@@ -35,6 +35,9 @@ system {
 
   // Max number of retries per job that the engine will attempt in case of a retryable failure received from the backend
   max-retries = 10
+
+  //If 'true' then when Cromwell starts up, it tries to restart incomplete workflows
+  workflow-restart = true
 }
 
 workflow-options {

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -78,9 +78,11 @@ class WorkflowManagerActor(config: Config)
 
   private val donePromise = Promise[Unit]()
 
+  private val conf = ConfigFactory.load
+
   override def preStart() {
     addShutdownHook()
-    restartIncompleteWorkflows()
+    if (conf.getBoolean("system.workflow-restart")) { restartIncompleteWorkflows() }
   }
 
   private def addShutdownHook(): Unit = {

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -78,11 +78,9 @@ class WorkflowManagerActor(config: Config)
 
   private val donePromise = Promise[Unit]()
 
-  private val conf = ConfigFactory.load
-
   override def preStart() {
     addShutdownHook()
-    if (conf.getBoolean("system.workflow-restart")) { restartIncompleteWorkflows() }
+    if (config.getBoolean("system.workflow-restart")) { restartIncompleteWorkflows() }
   }
 
   private def addShutdownHook(): Unit = {

--- a/engine/src/test/scala/cromwell/services/MetadataServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/services/MetadataServiceSpec.scala
@@ -1,0 +1,59 @@
+package cromwell.services
+
+import akka.actor.PoisonPill
+import akka.pattern.ask
+import com.typesafe.config.ConfigFactory
+import cromwell.core.WorkflowId
+import cromwell.services.MetadataServiceActor._
+
+class MetadataServiceSpec extends CromwellServicesSpec {
+
+  val config = ConfigFactory.load("{}")
+  val actor = actorSystem.actorOf(MetadataServiceActor.props(config, config))
+
+  val workflowId = WorkflowId.randomId()
+
+  behavior of "MetadataServiceActor"
+
+  /*
+  Simple store / retrieve
+   */
+
+  val key1 = MetadataKey(workflowId, None, "key1")
+  val key2 = MetadataKey(workflowId, None, "key2")
+
+  val event1_1 = MetadataEvent(key1, MetadataValue("value1"))
+  val event1_2 = MetadataEvent(key1, MetadataValue("value2"))
+  val event2_1 = MetadataEvent(key2, MetadataValue("value1"))
+
+  it should "Store values for different keys" in {
+    val putAction1 = PutMetadataAction(event1_1)
+    val putAction2 = PutMetadataAction(event1_2)
+    val putAction3 = PutMetadataAction(event2_1)
+    (for {
+      response1 <- (actor ? putAction1).mapTo[MetadataServiceResponse]
+      response2 <- (actor ? putAction2).mapTo[MetadataServiceResponse]
+      response3 <- (actor ? putAction3).mapTo[MetadataServiceResponse]
+      _ = response1 shouldBe MetadataPutAcknowledgement(putAction1)
+      _ = response2 shouldBe MetadataPutAcknowledgement(putAction2)
+      _ = response3 shouldBe MetadataPutAcknowledgement(putAction3)
+    } yield ()).futureValue
+  }
+
+  it should "Retrieve the correct values for different keys" in {
+    val query1 = MetadataQuery.forKey(key1)
+    val query2 = MetadataQuery.forKey(key2)
+
+    (for {
+      response1 <- (actor ? GetMetadataQueryAction(query1)).mapTo[MetadataServiceResponse]
+      _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
+
+      response2 <- (actor ? GetMetadataQueryAction(query2)).mapTo[MetadataServiceResponse]
+      _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
+    } yield ()).futureValue
+  }
+
+  override def afterAll = {
+    actor ! PoisonPill
+  }
+}


### PR DESCRIPTION
Made a small change to the preStart method of WFMA, it only tries to re-start incomplete workflows when the config "workflow-restart" is set to true. I don't know if I loved how I named that field, and I'm open to suggestions. 

Since we don't have restarts configured right now, I didn't have a chance to test this change. I didn't update the Readme yet either, since this is not a change users can use yet, I'm realizing now we do need some way to keep track of all the documentation changes we'll need to make.