### PR TITLE
Engine pushes to the MetadataService closes #668

### DIFF
--- a/engine/src/main/resources/application.conf
+++ b/engine/src/main/resources/application.conf
@@ -207,6 +207,9 @@ backend {
 services {
   KeyValue {
     class = "cromwell.services.KeyValueServiceActor"
+  },
+  MetadataService {
+    class = "cromwell.services.MetadataServiceActor"
   }
 }
 

--- a/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
@@ -1,0 +1,13 @@
+package cromwell.engine
+
+import cromwell.backend.BackendWorkflowDescriptor
+import wdl4s._
+
+final case class EngineWorkflowDescriptor(backendDescriptor: BackendWorkflowDescriptor,
+                                          declarations: WorkflowCoercedInputs,
+                                          backendAssignments: Map[Call, String],
+                                          failureMode: WorkflowFailureMode) {
+  def id = backendDescriptor.id
+  def namespace = backendDescriptor.workflowNamespace
+  def name = namespace.workflow.unqualifiedName
+}

--- a/engine/src/main/scala/cromwell/engine/package.scala
+++ b/engine/src/main/scala/cromwell/engine/package.scala
@@ -81,11 +81,4 @@ package object engine {
     }
   }
 
-  final case class EngineWorkflowDescriptor(backendDescriptor: BackendWorkflowDescriptor,
-                                            declarations: WorkflowCoercedInputs,
-                                            backendAssignments: Map[Call, String],
-                                            failureMode: WorkflowFailureMode) {
-    def id = backendDescriptor.id
-    def namespace = backendDescriptor.workflowNamespace
-  }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/package.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/package.scala
@@ -1,0 +1,17 @@
+package cromwell.engine
+
+package object workflow {
+
+  object WorkflowMetadataKeys {
+    val Name = "workflowName"
+    val Id = "id"
+    val SubmissionTime = "submission"
+    val Calls = "calls"
+    val Inputs = "inputs"
+    val Outputs = "outputs"
+    val Status = "status"
+    val StartTime = "start"
+    val EndTime = "end"
+  }
+
+}

--- a/engine/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/engine/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -40,7 +40,7 @@ case class ServiceRegistryActor(globalConfig: Config) extends Actor {
   import ServiceRegistryActor._
 
   val services: Map[String, ActorRef] = serviceNameToPropsMap(globalConfig) map {
-    case (name, props) => name -> context.actorOf(props, "ServiceRegistryActor")
+    case (name, props) => name -> context.actorOf(props, name)
   }
 
   def receive = {


### PR DESCRIPTION
Okay. So initially, I was passing the `ServiceRegistryActor` reference via props down the chain of actors, and each of the actors needed to follow a pattern of steps to insert into the metadata (e.g. create a `MetadataEvent` with a `MetadataPutAction` within which the `Metadata[Key, Value]` resided, send this message over to the the service registry, and handle failures, if any. It did not look good by any stretch IMO. All the metadata generating entities needed to be aware of the `MetadataService` (the erstwhile dataAcess)

**Edit:** Using the above design in-fact now.

~~Currently, what I've done below is create a single instance of the `ServiceRegistryActor` in the `WorkflowManagerActor`and then create a `WorkflowProfilerActor` (one per workflow) which is supposed to handle all the metadata information coming from the engine side for a particular workflow. The way it happens is based on the presumption that almost all the information that we needed was present in the `StateName` and `StateData` of our FSMs. Unfortunately, with Akka's `SubscribeTransitionalCallback` we can only monitor the FSM states, and not the data. So I've created a trait (which the Engine's FSMs can extend from) which provide the semantics of wrapping up the state and data of the FSM in a message, and publish it into Akka's event stream. The ProfilerActor is the listener of these events and handles them appropriately. With this, I was able to make the FSMs unaware of the MetadataServices, and simply publish it's state and data in the event stream while performing any transitions.~~

~~Let me know if you guys have any (other?) ideas / suggestions.~~

Contents added to metadata with this PR:

- [x] workflowName
- [ ]  calls (To come from the backends)
- [x] outputs 
- [x] id
- [x] inputs
- [x] submission
- [x] status
- [x] end
- [x] start