### PR TITLE
Add actor based retry functionality. Closes #754

### DIFF
--- a/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
@@ -3,8 +3,9 @@ package cromwell.backend.async
 import akka.actor.{Actor, ActorLogging}
 import cromwell.backend.async.AsyncBackendJobExecutionActor._
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionFailedResponse, BackendJobExecutionResponse, BackendJobExecutionSucceededResponse}
-import cromwell.backend.{BackendJobDescriptor, Backoff}
+import cromwell.backend.BackendJobDescriptor
 import cromwell.core.CromwellFatalException
+import cromwell.core.retry.Backoff
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/core/src/main/scala/cromwell/core/retry/Backoff.scala
+++ b/core/src/main/scala/cromwell/core/retry/Backoff.scala
@@ -1,4 +1,4 @@
-package cromwell.backend
+package cromwell.core.retry
 
 import com.google.api.client.util.ExponentialBackOff
 

--- a/core/src/main/scala/cromwell/core/retry/Retry.scala
+++ b/core/src/main/scala/cromwell/core/retry/Retry.scala
@@ -1,0 +1,53 @@
+package cromwell.core.retry
+
+import akka.actor.ActorSystem
+import cromwell.core.CromwellFatalException
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.concurrent.{ExecutionContext, Future}
+import akka.pattern.after
+
+object Retry {
+  /**
+    * Retries a Future on a designated backoff strategy until either a designated number of retries or a fatal error
+    * is reached.
+    *
+    * @param f A Future thunk which will be executed once per cycle
+    * @param maxRetries An optional number of times to retry the thunk. If this is None, there is no limit.
+    * @param backoff An exponential backoff strategy to use for each retry strategy.
+    * @param isTransient An optional function of Throwable => Boolean. If provided and it returns true, this throwable
+    *                    does not count towards the maxRetries limit.
+    * @param isFatal An optional function of Throwable => Boolean. If provided and it returns true, withRetry will halt
+    * @param actorSystem An ActorSystem, used for its scheduler and dispatcher.
+    * @tparam A The return type of the thunk
+    * @return The final completed Future
+    */
+  def withRetry[A](f: => Future[A],
+                   maxRetries: Option[Int] = Option(10),
+                   backoff: SimpleExponentialBackoff = SimpleExponentialBackoff(5 seconds, 10 seconds, 1.1D),
+                   isTransient: Option[Throwable => Boolean] = None,
+                   isFatal: Option[Throwable => Boolean] = None)
+                   (implicit actorSystem: ActorSystem): Future[A] = {
+    // In the future we might want EC passed in separately but at the moment it caused more issues than it solved to do so
+    implicit val ec: ExecutionContext = actorSystem.dispatcher
+    val delay = backoff.backoffMillis.millis
+
+    if (maxRetries.forall(_ > 0)) {
+      f recoverWith {
+        case throwable if isFatal.evaluate(throwable) => Future.failed(new CromwellFatalException(throwable))
+        case throwable if !isFatal.evaluate(throwable) =>
+          val retriesLeft = if (isTransient.evaluate(throwable)) maxRetries else maxRetries map { _ - 1 }
+          after(delay, actorSystem.scheduler)(withRetry(f, backoff = backoff, maxRetries = retriesLeft))
+      }
+    } else f recoverWith {
+      case e: Exception => Future.failed(new CromwellFatalException(e))
+    }
+  }
+
+  implicit class EnhancedOptionThrowableToBoolean(val f: Option[Throwable => Boolean]) extends AnyVal {
+    /** If f is defined, run the function using the passed throwable otherwise return false */
+    def evaluate(throwable: Throwable) = f.fold(false) { _(throwable) }
+  }
+}
+

--- a/core/src/test/scala/cromwell/core/retry/BackoffSpec.scala
+++ b/core/src/test/scala/cromwell/core/retry/BackoffSpec.scala
@@ -1,7 +1,6 @@
-package cromwell.util
+package cromwell.core.retry
 
 import com.google.api.client.util.ExponentialBackOff.Builder
-import cromwell.backend.{InitialGapBackoff, SimpleExponentialBackoff}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._

--- a/core/src/test/scala/cromwell/core/retry/RetrySpec.scala
+++ b/core/src/test/scala/cromwell/core/retry/RetrySpec.scala
@@ -1,0 +1,92 @@
+package cromwell.core.retry
+
+import akka.actor.ActorSystem
+import cromwell.core.CromwellFatalException
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FlatSpec, Matchers}
+import Retry._
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class RetrySpec extends FlatSpec with Matchers with ScalaFutures {
+  implicit val actorSystem = ActorSystem("retry-spec")
+
+  class TransientException extends Exception
+  class MockWork(n: Int, transients: Int = 0) {
+    implicit val ec = actorSystem.dispatcher
+
+    var counter = n
+
+    def doIt(): Future[Int] = {
+      if (counter == 0)
+        Future.successful(9)
+      else {
+        counter -= 1
+        val ex = if (counter <= transients) new TransientException else new IllegalArgumentException("Failed")
+        Future.failed(ex)
+      }
+    }
+  }
+
+  implicit val defaultPatience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(100, Millis))
+
+  private def runRetry(retries: Int,
+                       work: MockWork,
+                       isTransient: Option[Throwable => Boolean] = None,
+                       isFatal: Option[Throwable => Boolean] = None): Future[Int] = {
+    implicit val ec = actorSystem.dispatcher
+
+    val backoff = SimpleExponentialBackoff(1.millis, 2.millis, 1)
+
+    withRetry(
+      f = work.doIt(),
+      maxRetries = Option(retries),
+      isTransient = isTransient,
+      isFatal = isFatal
+    )
+  }
+
+  "Retry" should "retry a function until it works" in {
+    val work = new MockWork(2)
+
+    whenReady(runRetry(3, work)) { x =>
+      x shouldBe 9
+      work.counter shouldBe 0
+    }
+  }
+
+  it should "fail if it hits the max retry count" in {
+    whenReady(runRetry(1, new MockWork(3)).failed) { x =>
+      x shouldBe an [CromwellFatalException]
+    }
+  }
+
+  it should "fail if it hits a fatal exception" in {
+    val work = new MockWork(3)
+
+    whenReady(runRetry(3, work, isFatal = Option((t: Throwable) => t.isInstanceOf[IllegalArgumentException])).failed) { x =>
+      x shouldBe an [CromwellFatalException]
+      work.counter shouldBe 2
+    }
+
+    val work2 = new MockWork(4, 2)
+    val retry = runRetry(4,
+      work2,
+      isFatal = Option((t: Throwable) => t.isInstanceOf[IllegalArgumentException]),
+      isTransient = Option((t: Throwable) => t.isInstanceOf[TransientException]))
+
+    whenReady(retry.failed) { x =>
+      x shouldBe an [CromwellFatalException]
+      work2.counter shouldBe 3
+    }
+  }
+
+  it should "not count transient errors against the max limit" in {
+    val work = new MockWork(3, 1)
+    whenReady(runRetry(3, work, isTransient = Option((t: Throwable) => t.isInstanceOf[TransientException]))) { x =>
+      x shouldBe 9
+      work.counter shouldBe 0
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
@@ -7,7 +7,7 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.FileAppender
-import cromwell.backend.SimpleExponentialBackoff
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{OldWorkflowContext, WorkflowId, WorkflowOptions}
 import cromwell.engine.backend.io._
 import cromwell.engine.{WorkflowFailureMode, WorkflowSourceFiles}

--- a/engine/src/main/scala/cromwell/engine/backend/jes/OldStyleJesBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/jes/OldStyleJesBackend.scala
@@ -12,7 +12,8 @@ import com.google.api.services.genomics.model.{LocalCopy, PipelineParameter}
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.impl.jes.io.{JesAttachedDisk, JesWorkingDisk}
 import cromwell.backend.wdl.{OldCallEngineFunctions, OldWorkflowEngineFunctions}
-import cromwell.backend.{ExecutionEventEntry, ExecutionHash, JobKey, PreemptedException, SimpleExponentialBackoff}
+import cromwell.backend.{ExecutionEventEntry, ExecutionHash, JobKey, PreemptedException}
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{CallOutput, CallOutputs, WorkflowOptions, _}
 import cromwell.engine._
 import cromwell.engine.backend.EnhancedWorkflowOptions._

--- a/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -51,7 +51,7 @@ trait DataAccess extends AutoCloseable {
   this: SqlDatabase =>
 
   private def withRetry[A](f: => Future[A])(implicit actorSystem: ActorSystem): Future[A] = {
-    Retry.withRetry(f, maxRetries = Option(10), backoff = RetryBackoff, isTransient = Option(isTransient))
+    Retry.withRetry(f, maxRetries = Option(10), backoff = RetryBackoff, isTransient = isTransient)
   }
 
   /**

--- a/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -4,9 +4,9 @@ import java.sql.Timestamp
 import java.util.Date
 
 import akka.actor.ActorSystem
-import akka.pattern.after
 import cromwell.backend.{ExecutionEventEntry, ExecutionHash, JobKey}
 import cromwell.core.{CallOutput, CallOutputs, WorkflowId}
+import cromwell.core.retry.{Retry, SimpleExponentialBackoff}
 import cromwell.database.SqlConverters._
 import cromwell.database.SqlDatabase
 import cromwell.database.obj._
@@ -15,7 +15,7 @@ import cromwell.engine.ExecutionIndex._
 import cromwell.engine.ExecutionStatus._
 import cromwell.engine._
 import cromwell.engine.backend.{OldStyleBackend, OldStyleBackendCallJobDescriptor, _}
-import cromwell.engine.db.DataAccess.WorkflowExecutionAndAux
+import cromwell.engine.db.DataAccess.{WorkflowExecutionAndAux, RetryBackoff}
 import cromwell.engine.db.EngineConverters._
 import cromwell.engine.finalcall.OldStyleFinalCall
 import cromwell.engine.workflow.OldStyleWorkflowManagerActor.WorkflowNotFoundException
@@ -29,6 +29,7 @@ import wdl4s.values.WdlValue
 import wdl4s.{CallInputs, _}
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.concurrent.{ExecutionContext, Future}
 
 @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
@@ -42,21 +43,7 @@ object DataAccess {
   case class WorkflowExecutionAndAux(execution: WorkflowExecution, aux: WorkflowExecutionAux)
 
   val FailureEventMaxMessageLength = 1024
-
-  // TODO: Nothing DataAccess specific in this retry method. Refactor to lenthall or similar and add a tests.
-  private def withRetry[A](f: => Future[A], delay: FiniteDuration, retries: Int)
-                          (shouldRetry: (Throwable) => Boolean)
-                          (implicit actorSystem: ActorSystem): Future[A] = {
-    // TODO: May want to pass a separate ec, or is the actor system's dispatcher ok?
-    implicit val ec = actorSystem.dispatcher
-    f recoverWith {
-      case throwable if shouldRetry(throwable) && retries > 0 =>
-        log.warn(
-          s"Transient exception detected: ${throwable.getMessage}.  Retrying in $delay ($retries retries remaining)"
-        )
-        after(delay, actorSystem.scheduler)(withRetry(f, delay, retries-1)(shouldRetry))
-    }
-  }
+  val RetryBackoff = SimpleExponentialBackoff(50 millis, 1 seconds, 1D)
 }
 
 @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")
@@ -64,7 +51,7 @@ trait DataAccess extends AutoCloseable {
   this: SqlDatabase =>
 
   private def withRetry[A](f: => Future[A])(implicit actorSystem: ActorSystem): Future[A] = {
-    DataAccess.withRetry(f, 200.millis, 10)(isTransient)
+    Retry.withRetry(f, maxRetries = Option(10), backoff = RetryBackoff, isTransient = Option(isTransient))
   }
 
   /**

--- a/engine/src/main/scala/cromwell/util/TryUtil.scala
+++ b/engine/src/main/scala/cromwell/util/TryUtil.scala
@@ -2,7 +2,7 @@ package cromwell.util
 
 import java.io.{PrintWriter, StringWriter}
 
-import cromwell.backend.Backoff
+import cromwell.core.retry.Backoff
 import cromwell.core.{CromwellAggregatedException, CromwellFatalException}
 import cromwell.logging.WorkflowLogger
 

--- a/engine/src/test/scala/cromwell/util/TryUtilSpec.scala
+++ b/engine/src/test/scala/cromwell/util/TryUtilSpec.scala
@@ -1,7 +1,7 @@
 package cromwell.util
 
-import cromwell.backend.SimpleExponentialBackoff
 import cromwell.core.CromwellFatalException
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.logging.WorkflowLogger
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
     "com.typesafe" % "config" % "1.3.0",
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "org.apache.commons" % "commons-lang3" % "3.4"
-  ) ++ testDependencies
+  ) ++ testDependencies ++ googleApiClientDependencies
 
   val backendDependencies = List(
     "joda-time" % "joda-time" % "2.8.2",

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -15,7 +15,8 @@ import cromwell.backend.async.{AbortedExecutionHandle, AsyncBackendJobExecutionA
 import cromwell.backend.impl.jes.Run.{RunStatus, TerminalRunStatus}
 import cromwell.backend.impl.jes.authentication.JesDockerCredentials
 import cromwell.backend.impl.jes.io._
-import cromwell.backend.{AttemptedLookupResult, BackendConfigurationDescriptor, BackendJobDescriptor, BackendWorkflowDescriptor, ExecutionHash, PreemptedException, SimpleExponentialBackoff}
+import cromwell.backend.{AttemptedLookupResult, BackendConfigurationDescriptor, BackendJobDescriptor, BackendWorkflowDescriptor, ExecutionHash, PreemptedException}
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{CallOutput, CromwellAggregatedException, _}
 import wdl4s.AstTools._
 import wdl4s.WdlExpression.ScopedLookupFunction


### PR DESCRIPTION
Strictly speaking does not technically close the original issue although at the moment the gcs auth file upload retrying doesn't seem to exist in develop (@mcovarr can you verify this?).

- Replaced the `withRetry` in `DataAccess` with the new functionality
- Did not remove nor replace the uses of `TryUtil.withRetry` as they're both OldeStyle and it didn't seem worth the hassle. If reviewers would rather they be switched over I can do that.