### PR TITLE
Hotfix -- configuring restarts

### DIFF
--- a/engine/src/main/resources/application.conf
+++ b/engine/src/main/resources/application.conf
@@ -30,6 +30,11 @@ spray.can {
   }
 }
 
+system {
+  //If 'true' then when Cromwell starts up, it tries to restart incomplete workflows
+  workflow-restart = true
+}
+
 workflow-options {
   // These workflow options will be encrypted when stored in the database
   encrypted-fields: []

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.workflow
 
+import akka.Main
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor._
 import akka.event.Logging
@@ -16,6 +17,7 @@ import cromwell.util.PromiseActor
 import cromwell.webservice.CromwellApiHandler._
 import cromwell.webservice._
 import cromwell.{core, engine}
+import cromwell.server._
 import lenthall.config.ScalaConfig.EnhancedScalaConfig
 import wdl4s._
 
@@ -102,9 +104,12 @@ class WorkflowManagerActor(config: Config)
 
   private val donePromise = Promise[Unit]()
 
+  val isRestartable = config.getBoolean("system.workflow-restart")
+  val isServerMode = CromwellServer.isServerMode
+
   override def preStart() {
     addShutdownHook()
-    restartIncompleteWorkflows()
+    if (isServerMode && isRestartable) { restartIncompleteWorkflows() }
   }
 
   private def addShutdownHook(): Unit = {

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -19,6 +19,7 @@ object CromwellServer extends WorkflowManagerSystem {
   val materializeWorkflowDescriptorActor = actorSystem.actorOf(MaterializeWorkflowDescriptorActor.props(), "MaterializeWorkflowDescriptorActor-CromwellServer")
   val service = actorSystem.actorOf(CromwellApiServiceActor.props(workflowManagerActor, materializeWorkflowDescriptorActor, conf), "cromwell-service")
   val webserviceConf = conf.getConfig("webservice")
+  val isServerMode = true
 
   def run(): Future[Any] = {
     val interface = webserviceConf.getString("interface")

--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -1,4 +1,4 @@
-package cromwell.main
+package cromwell
 
 import java.io.{File => JFile}
 import java.nio.file.{Files, Path, Paths}

--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -1,4 +1,4 @@
-package cromwell
+package cromwell.main
 
 import java.io.{File => JFile}
 import java.nio.file.{Files, Path, Paths}


### PR DESCRIPTION
When the workflow-restart config option is set to false, incomplete workflows will not be restarted, and instead all incomplete workflows are aborted. 

Note: Still need to update ReadMe

Questions: The sys.addShutdownHook takes about a minute to start startup (there's a minute long wait between the logs) which seems too long?