### PR TITLE
Don't compute task hash when Call Caching is turned of via Workflow Options Closes #837

### DIFF
--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleBackend.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleBackend.scala
@@ -207,7 +207,7 @@ trait OldStyleBackend {
       else
         Future.successful(Option(dockerImage))
 
-    if (descriptor.workflowDescriptor.configCallCaching)
+    if (descriptor.workflowDescriptor.writeToCache)
       descriptor.callRuntimeAttributes.docker map hashDockerImage getOrElse Future.successful(None) map hashGivenDockerHash(descriptor)
     else
       Future.successful(ExecutionHash("", None))

--- a/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/OldStyleWorkflowDescriptor.scala
@@ -228,7 +228,7 @@ case class OldStyleWorkflowDescriptor(id: WorkflowId,
   override def toString = s"WorkflowDescriptor(${id.id.toString})"
 
   def hash(wdlValue: WdlValue): Option[SymbolHash] = {
-    if (configCallCaching) Option(wdlValue.computeHash(fileHasher)) else None
+    if (writeToCache) Option(wdlValue.computeHash(fileHasher)) else None
   }
 }
 @deprecated(message = "This class will not be part of the PBE universe", since = "May 2nd 2016")


### PR DESCRIPTION
- [ ] Test it