### PR TITLE
Adding UGER Support -q {long|short} and -P {projectId}

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,10 +498,25 @@ echo $? > rc
 The job is launched using the following command:
 
 ```
-qsub -N <job_name> -V -b n -wd <call_dir> -o stdout -e stderr <call_dir>/script.sh
+qsub -q <queue_name> -P <project_name> -N <job_name> -V -b n -wd <call_dir> -o stdout -e stderr <call_dir>/script.sh
 ```
 
 `<job_name>` is the string: `cromwell_<workflow_uuid_short>_<call_name>` (e.g. `cromwell_5103f8db_my_task`).
+
+`<queue_name>` is an optional parameter; (e.g., `long`).
+
+`<project_name>` is an optional parameter; (e.g., `MyProjectName`). These optional parameters can be configured in the Cromwell configuration file as follows: 
+
+```hocon
+backend {
+ 
+  sge {
+    queue: "long"
+    project: "MyProjectName"
+  }
+}
+```
+
 
 the `<call_dir>` contains the following special files added by the SGE backend:
 


### PR DESCRIPTION
Hi, 

I was wondering if I could submit a patch to Cromwell to support Broad's internal queue UGER, 

Currently, the GridEngine job submission backend (qsub) for Cromwell doesn't take a queue argument (-q) nor a project id (-P); both of these arguments are necessary for my group to be able to submit jobs to UGER queue successfully. 

I realize that I'm submitting this patch under 0.19_hotfix and not dev branch; and also not sure how the Cromwell team wants to organize the application.conf file to accommodate UGER arguments. 

So putting this forth initial pull request to get feedback/instructions to add this patch, 

Thanks,
Paul 

