### PR TITLE
Run Finalize Actor even if workflow execution fails Closes #912

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowFinalizationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowFinalizationActor.scala
@@ -13,7 +13,6 @@ object BackendWorkflowFinalizationActor {
   sealed trait BackendWorkflowFinalizationActorCommand extends BackendWorkflowLifecycleActorCommand
 
   case object Finalize extends BackendWorkflowFinalizationActorCommand
-  case object Abort extends BackendWorkflowFinalizationActorCommand
 
   // Responses
   sealed trait WorkflowBackendFinalizationActorResponse extends BackendWorkflowLifecycleActorResponse
@@ -30,15 +29,7 @@ trait BackendWorkflowFinalizationActor extends BackendWorkflowLifecycleActor wit
 
   def receive: Receive = LoggingReceive {
     case Finalize => performActionThenRespond(afterAll, onFailure = FinalizationFailed)
-    case Abort => abortFinalization
   }
-
-  /**
-    * Trigger an abort of all finalizations.
-    *
-    * Abort all finalizations.
-    */
-  def abortFinalization: Unit
 
   /**
     * Happens after everything else runs

--- a/engine/src/main/scala/cromwell/engine/backend/BackendConfiguration.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/BackendConfiguration.scala
@@ -38,7 +38,7 @@ object BackendConfiguration {
   }
 
   def backendConfigurationDescriptor(backendName: String): Try[BackendConfigurationDescriptor] = {
-    AllBackendEntries.collect({case entry if entry.name == backendName => entry.asBackendConfigurationDescriptor}).headOption match {
+    AllBackendEntries.collect({case entry if entry.name.equalsIgnoreCase(backendName) => entry.asBackendConfigurationDescriptor}).headOption match {
       case Some(descriptor) => Success(descriptor)
       case None => Failure(new Exception(s"invalid backend: $backendName"))
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowInitializationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowInitializationActor.scala
@@ -1,19 +1,17 @@
 package cromwell.engine.workflow.lifecycle
 
-import akka.actor.{FSM, ActorRef, Props}
+import akka.actor.{FSM, Props}
 import cromwell.backend.BackendLifecycleActor.BackendActorAbortedResponse
 import cromwell.backend.BackendWorkflowInitializationActor
-import cromwell.backend.BackendConfigurationDescriptor
 import cromwell.backend.BackendWorkflowInitializationActor._
 import cromwell.core.WorkflowId
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
 import cromwell.engine.workflow.lifecycle.WorkflowInitializationActor._
 import cromwell.engine.workflow.lifecycle.WorkflowLifecycleActor._
-import wdl4s.Call
 
 import scala.language.postfixOps
-import scala.util.{Success, Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 object WorkflowInitializationActor {
 
@@ -46,7 +44,7 @@ object WorkflowInitializationActor {
   def props(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor): Props = Props(new WorkflowInitializationActor(workflowId, workflowDescriptor))
 }
 
-case class WorkflowInitializationActor(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor) extends WorkflowLifecycleActor[WorkflowInitializationActorState] {
+case class WorkflowInitializationActor(workflowId: WorkflowId, workflowDescriptor: EngineWorkflowDescriptor) extends AbortableWorkflowLifecycleActor[WorkflowInitializationActorState] {
 
   startWith(InitializationPendingState, WorkflowLifecycleActorData.empty)
   val tag = self.path.name

--- a/engine/src/test/scala/cromwell/BadDockerName.scala
+++ b/engine/src/test/scala/cromwell/BadDockerName.scala
@@ -12,7 +12,7 @@ class BadDockerName extends CromwellTestkitSpec {
     "fail properly" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.HelloWorld,
-        eventFilter = EventFilter.info(pattern = s"transition from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"transition from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         runtime = """
                     |runtime {
                     |  docker: "/fauxbuntu:nosuchversion"

--- a/engine/src/test/scala/cromwell/BadTaskOutputWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/BadTaskOutputWorkflowSpec.scala
@@ -12,7 +12,7 @@ class BadTaskOutputWorkflowSpec extends CromwellTestkitSpec {
     "fail and result in a failed workflow" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.BadTaskOutputWdl,
-        EventFilter.info(pattern = s"transition from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        EventFilter.info(pattern = s"transition from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         expectedOutputs = Map(),
         terminalState = WorkflowFailed
       )
@@ -21,7 +21,7 @@ class BadTaskOutputWorkflowSpec extends CromwellTestkitSpec {
     "fail properly in a unknown Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.BadTaskOutputWdl,
-        eventFilter = EventFilter.info(pattern = s"transition from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"transition from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         runtime = """
                     |runtime {
                     |  docker: "ubuntu:latest"

--- a/engine/src/test/scala/cromwell/ContinueOnReturnCodeWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/ContinueOnReturnCodeWorkflowSpec.scala
@@ -4,12 +4,12 @@ import akka.testkit.EventFilter
 import cromwell.core.WorkflowFailed
 import cromwell.util.SampleWdl
 
-class ContinueOnReturnCodeSpec extends CromwellTestkitSpec {
+class ContinueOnReturnCodeWorkflowSpec extends CromwellTestkitSpec {
   "A workflow with tasks that produce non-zero return codes" should {
     "have correct contents in stdout/stderr files for a call that implicitly continues on return code" in {
       runWdlAndAssertWorkflowStdoutStderr(
         sampleWdl = SampleWdl.ContinueOnReturnCode,
-        eventFilter = EventFilter.info(pattern = "transition from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "transition from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         stdout = Map("w.A" -> Seq("321\n")),
         stderr = Map("w.A" -> Seq("")),
         terminalState = WorkflowFailed
@@ -20,7 +20,7 @@ class ContinueOnReturnCodeSpec extends CromwellTestkitSpec {
       runWdlAndAssertWorkflowStdoutStderr(
         sampleWdl = SampleWdl.ContinueOnReturnCode,
         runtime = "runtime {continueOnReturnCode: false}",
-        eventFilter = EventFilter.info(pattern = "transition from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "transition from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         stdout = Map("w.A" -> Seq("321\n")),
         stderr = Map("w.A" -> Seq("")),
         terminalState = WorkflowFailed

--- a/engine/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/local/LocalBackendSpec.scala
@@ -42,7 +42,7 @@ class LocalBackendSpec extends CromwellTestkitSpec {
     "not allow stderr if failOnStderr is set" in {
       runWdl(
         sampleWdl = StderrWdl,
-        eventFilter = EventFilter.info(pattern = "transitioning from ExecutingWorkflowState to WorkflowFailedState", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "transitioning from FinalizingWorkflowState to WorkflowFailedState", occurrences = 1),
         runtime = "runtime {failOnStderr: true}",
         terminalState = WorkflowFailed)
     }


### PR DESCRIPTION
- Removes the ability to abort Finalization Actor

- Ensures that the finalization actor runs if the Workflow reaches the `Initialize` state, regardless of what happens next (failure, success, abort), or when it happens (initialization, execution).
