### PR TITLE
Updates to re-enable `WriteTsvSpec`.

### DIFF
--- a/engine/src/main/scala/cromwell/engine/WdlFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/WdlFunctions.scala
@@ -36,5 +36,5 @@ class WdlFunctions(workflowOptions: WorkflowOptions) extends WdlStandardLibraryF
   override def stderr(params: Seq[Try[WdlValue]]): Try[WdlFile] = fail("stderr")
   override def glob(path: String, pattern: String): Seq[String] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
   override def writeTempFile(path: String, prefix: String, suffix: String, content: String): String = throw new NotImplementedError(s"Cromwell doesn't support write_* functions at the workflow level")
-  override def write_tsv(params: Seq[Try[WdlValue]]): Try[WdlFile] = fail("stderr")
+  override def write_tsv(params: Seq[Try[WdlValue]]): Try[WdlFile] = fail("write_tsv")
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/JobPreparationActor.scala
@@ -35,7 +35,8 @@ case class JobPreparationActor(executionData: WorkflowExecutionActorData,
   override val workflowDescriptor: EngineWorkflowDescriptor = executionData.workflowDescriptor
   override val executionStore: ExecutionStore = executionData.executionStore
   override val outputStore: OutputStore = executionData.outputStore
-  override val expressionLanguageFunctions = executionData.expressionLanguageFunctions
+  override val expressionLanguageFunctions = factory.expressionLanguageFunctions(
+    workflowDescriptor.backendDescriptor, jobKey, configDescriptor)
 
   override def receive = {
     case Start =>

--- a/engine/src/test/scala/cromwell/WriteTsvSpec.scala
+++ b/engine/src/test/scala/cromwell/WriteTsvSpec.scala
@@ -2,11 +2,9 @@ package cromwell
 
 import akka.testkit._
 import cromwell.CromwellSpec.DockerTest
-import wdl4s.types.{WdlArrayType, WdlStringType, WdlFileType}
-import wdl4s.{WorkflowInput, NamespaceWithWorkflow}
-import wdl4s.values.{WdlArray, WdlInteger, WdlString}
-import cromwell.engine.backend.BackendType
 import cromwell.util.SampleWdl
+import wdl4s.types.{WdlArrayType, WdlStringType}
+import wdl4s.values.{WdlArray, WdlString}
 
 import scala.language.postfixOps
 
@@ -20,17 +18,17 @@ class WriteTsvSpec extends CromwellTestkitSpec {
   )
 
   "A task that calls write_tsv() called in the command section or declaration" should {
-    "run properly" ignore {
+    "run properly" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteTsvWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
         expectedOutputs = outputs
       )
     }
-    "run properly in a Docker environment" taggedAs DockerTest ignore {
+    "run properly in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteTsvWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"


### PR DESCRIPTION
`JobPreparationActor` using factory `expressionLanguageFunctions` instead of the unimplemented ones in executionData.