### PR TITLE
Updated patterns on a collection of tests.

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -342,7 +342,8 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
   @tailrec
   private def startRunnableScopes(data: WorkflowExecutionActorData): WorkflowExecutionActorData = {
     val runnableScopes = data.executionStore.runnableScopes.toList
-    val runnableCalls = runnableScopes.view collect { case k if k.scope.isInstanceOf[Call] => k } sortBy { _.index.getOrElse(-1) } map { _.tag }
+    val runnableCalls = runnableScopes.view collect { case k if k.scope.isInstanceOf[Call] => k } sortBy { k =>
+      (k.scope.fullyQualifiedName, k.index.getOrElse(-1)) } map { _.tag }
     if (runnableCalls.nonEmpty) log.info(s"Starting calls: " + runnableCalls.mkString(", "))
 
     // Each process returns a Try[WorkflowExecutionDiff], which, upon success, contains potential changes to be made to the execution store.

--- a/engine/src/test/scala/cromwell/MultiLineCommandWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/MultiLineCommandWorkflowSpec.scala
@@ -9,17 +9,17 @@ import scala.language.postfixOps
 
 class MultiLineCommandWorkflowSpec extends CromwellTestkitSpec {
   "A workflow that calls a task with a multi-line command" should {
-    "honor the newlines in the command" ignore {
+    "honor the newlines in the command" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.MultiLineCommandWorkflowWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: wf.blah", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: wf.blah", occurrences = 1),
         expectedOutputs = Map("wf.blah.ab" -> WdlString("ab"))
       )
     }
-    "honor the newlines in the command in a Docker environment" taggedAs DockerTest ignore {
+    "honor the newlines in the command in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.MultiLineCommandWorkflowWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: wf.blah", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: wf.blah", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"

--- a/engine/src/test/scala/cromwell/MultipleFilesWithSameNameWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/MultipleFilesWithSameNameWorkflowSpec.scala
@@ -8,10 +8,10 @@ import scala.language.postfixOps
 
 class MultipleFilesWithSameNameWorkflowSpec extends CromwellTestkitSpec {
   "A workflow with two file inputs that have the same name" should {
-    "not clobber one file with the contents of another" ignore {
+    "not clobber one file with the contents of another" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.FileClobber,
-        EventFilter.info(pattern = s"starting calls: two.x, two.y", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: two.x:NA:1, two.y:NA:1", occurrences = 1),
         expectedOutputs = Map(
           "two.x.out" -> WdlString("first file.txt"),
           "two.y.out" -> WdlString("second file.txt")

--- a/engine/src/test/scala/cromwell/OptionalParamWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/OptionalParamWorkflowSpec.scala
@@ -2,11 +2,10 @@ package cromwell
 
 import akka.testkit._
 import cromwell.CromwellSpec.DockerTest
+import cromwell.util.SampleWdl
 import wdl4s.WdlNamespace
 import wdl4s.expression.NoFunctions
 import wdl4s.values.{WdlFile, WdlString}
-import cromwell.engine.backend.BackendType
-import cromwell.util.SampleWdl
 
 import scala.language.postfixOps
 
@@ -18,17 +17,19 @@ class OptionalParamWorkflowSpec extends CromwellTestkitSpec {
   )
 
   "A workflow with optional parameters" should {
-    "accept optional parameters" ignore {
+    "accept optional parameters" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.OptionalParamWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: optional.hello, optional.hello2, optional.hello_person", occurrences = 1),
+        eventFilter = EventFilter.info(pattern =
+          "Starting calls: optional.hello:NA:1, optional.hello2:NA:1, optional.hello_person:NA:1", occurrences = 1),
         expectedOutputs = outputs
       )
     }
-    "accept optional parameters in a Docker environment" taggedAs DockerTest ignore {
+    "accept optional parameters in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.OptionalParamWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: optional.hello, optional.hello2, optional.hello_person", occurrences = 1),
+        eventFilter = EventFilter.info(pattern =
+          "Starting calls: optional.hello:NA:1, optional.hello2:NA:1, optional.hello_person:NA:1", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"
@@ -40,7 +41,7 @@ class OptionalParamWorkflowSpec extends CromwellTestkitSpec {
   }
 
   "A workflow with an optional parameter that has a prefix inside the tag" should {
-    "not include that prefix if no value is specified" ignore {
+    "not include that prefix if no value is specified" in {
       val wf = """
          |task find {
          |  String? pattern

--- a/engine/src/test/scala/cromwell/PostfixQuantifierWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/PostfixQuantifierWorkflowSpec.scala
@@ -8,41 +8,41 @@ import scala.language.postfixOps
 
 class PostfixQuantifierWorkflowSpec extends CromwellTestkitSpec {
   "A task which contains a parameter with a zero-or-more postfix quantifier" should {
-    "accept an array of size 3" ignore {
+    "accept an array of size 3" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ZeroOrMorePostfixQuantifierWorkflowWithArrayInput,
-        EventFilter.info(pattern = s"starting calls: postfix.hello", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: postfix.hello", occurrences = 1),
         expectedOutputs = Map("postfix.hello.greeting" -> WdlString("hello alice,bob,charles"))
       )
     }
-    "accept an array of size 1" ignore {
+    "accept an array of size 1" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ZeroOrMorePostfixQuantifierWorkflowWithOneElementArrayInput,
-        EventFilter.info(pattern = s"starting calls: postfix.hello", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: postfix.hello", occurrences = 1),
         expectedOutputs = Map("postfix.hello.greeting" -> WdlString("hello alice"))
       )
     }
-    "accept an array of size 0" ignore {
+    "accept an array of size 0" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ZeroOrMorePostfixQuantifierWorkflowWithZeroElementArrayInput,
-        EventFilter.info(pattern = s"starting calls: postfix.hello", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: postfix.hello", occurrences = 1),
         expectedOutputs = Map("postfix.hello.greeting" -> WdlString("hello"))
       )
     }
   }
 
   "A task which contains a parameter with a one-or-more postfix quantifier" should {
-    "accept an array for the value" ignore {
+    "accept an array for the value" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.OneOrMorePostfixQuantifierWorkflowWithArrayInput,
-        EventFilter.info(pattern = s"starting calls: postfix.hello", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: postfix.hello", occurrences = 1),
         expectedOutputs = Map("postfix.hello.greeting" -> WdlString("hello alice,bob,charles"))
       )
     }
-    "accept a scalar for the value" ignore {
+    "accept a scalar for the value" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.OneOrMorePostfixQuantifierWorkflowWithScalarInput,
-        EventFilter.info(pattern = s"starting calls: postfix.hello", occurrences = 1),
+        EventFilter.info(pattern = "Starting calls: postfix.hello", occurrences = 1),
         expectedOutputs = Map("postfix.hello.greeting" -> WdlString("hello alice"))
       )
     }

--- a/engine/src/test/scala/cromwell/ReadLinesFunctionSpec.scala
+++ b/engine/src/test/scala/cromwell/ReadLinesFunctionSpec.scala
@@ -19,20 +19,22 @@ class ReadLinesFunctionSpec extends CromwellTestkitSpec {
   ))
 
   "A workflow with a read_lines() call in it" should {
-    "convert an output file to an Array[String]" ignore {
+    "convert an output file to an Array[String]" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ReadLinesFunctionWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: read_lines.cat_to_file, read_lines.cat_to_stdout", occurrences = 1),
+        eventFilter = EventFilter.info(pattern =
+          "Starting calls: read_lines.cat_to_file:NA:1, read_lines.cat_to_stdout:NA:1", occurrences = 1),
         expectedOutputs = Map(
           "read_lines.cat_to_file.lines" -> outputArray,
           "read_lines.cat_to_stdout.lines" -> outputArray
         )
       )
     }
-    "convert an output file to an Array[String] in a Docker environment" taggedAs DockerTest ignore {
+    "convert an output file to an Array[String] in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ReadLinesFunctionWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: read_lines.cat_to_file, read_lines.cat_to_stdout", occurrences = 1),
+        eventFilter = EventFilter.info(pattern =
+          "Starting calls: read_lines.cat_to_file:NA:1, read_lines.cat_to_stdout:NA:1", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"

--- a/engine/src/test/scala/cromwell/ReferencingPreviousInputsAndOutputs.scala
+++ b/engine/src/test/scala/cromwell/ReferencingPreviousInputsAndOutputs.scala
@@ -8,10 +8,10 @@ import scala.language.postfixOps
 
 class ReferencingPreviousInputsAndOutputs extends CromwellTestkitSpec {
   "A task with outputs which reference other outputs" should {
-    "run without let or hindrance" ignore {
+    "run without let or hindrance" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ReferencingPreviousInputsAndOutputs,
-        eventFilter = EventFilter.info(pattern = s"starting calls: wf.golden_pie", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"Starting calls: wf.golden_pie", occurrences = 1),
         expectedOutputs = Map(
           "wf.golden_pie.Au" -> WdlFloat(1.6180339887),
           "wf.golden_pie.doubleAu" -> WdlFloat(1.6180339887 * 2),

--- a/engine/src/test/scala/cromwell/StringInterpolationWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/StringInterpolationWorkflowSpec.scala
@@ -8,10 +8,10 @@ import scala.language.postfixOps
 
 class StringInterpolationWorkflowSpec extends CromwellTestkitSpec {
   "A workflow with a task that uses string interpolation" should {
-    "interpolate strings correctly and run" ignore {
+    "interpolate strings correctly and run" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.StringInterpolation,
-        EventFilter.info(pattern = s"starting calls: echo_wf.echo", occurrences = 1),
+        EventFilter.info(pattern = s"Starting calls: echo_wf.echo", occurrences = 1),
         expectedOutputs = Map(
           "echo_wf.echo.outfile" -> WdlFile("foobar.txt"),
           "echo_wf.echo.two" -> WdlInteger(2)

--- a/engine/src/test/scala/cromwell/WriteLinesSpec.scala
+++ b/engine/src/test/scala/cromwell/WriteLinesSpec.scala
@@ -2,11 +2,9 @@ package cromwell
 
 import akka.testkit._
 import cromwell.CromwellSpec.DockerTest
-import wdl4s.types.{WdlArrayType, WdlStringType, WdlFileType}
-import wdl4s.{WorkflowInput, NamespaceWithWorkflow}
-import wdl4s.values.{WdlArray, WdlInteger, WdlString}
-import cromwell.engine.backend.BackendType
 import cromwell.util.SampleWdl
+import wdl4s.types.{WdlArrayType, WdlStringType}
+import wdl4s.values.{WdlArray, WdlString}
 
 import scala.language.postfixOps
 
@@ -16,17 +14,18 @@ class WriteLinesSpec extends CromwellTestkitSpec {
   )
 
   "A task that calls write_lines() in the command section" should {
-    "run properly" ignore {
+    "run properly" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteLinesWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
         expectedOutputs = outputs
       )
     }
-    "run properly in a Docker environment" taggedAs DockerTest ignore {
+
+    "run properly in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteLinesWorkflow,
-        eventFilter = EventFilter.info(pattern = s"starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"

--- a/engine/src/test/scala/cromwell/WriteTsvSpec.scala
+++ b/engine/src/test/scala/cromwell/WriteTsvSpec.scala
@@ -21,14 +21,14 @@ class WriteTsvSpec extends CromwellTestkitSpec {
     "run properly" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteTsvWorkflow,
-        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: write_lines.a2f", occurrences = 1),
         expectedOutputs = outputs
       )
     }
     "run properly in a Docker environment" taggedAs DockerTest in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WriteTsvWorkflow,
-        eventFilter = EventFilter.info(pattern = s"Starting calls: write_lines.a2f", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: write_lines.a2f", occurrences = 1),
         runtime =
           """runtime {
             |  docker: "ubuntu:latest"


### PR DESCRIPTION
`starting` is now `Starting`.
`call_name` is now `call_name:NA:1`.
`runnableCalls` restored to sort the calls by fully qualified name.