### PR TITLE
Made metadata great again

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -190,7 +190,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
       pushSuccessfulJobMetadata(jobKey, returnCode, callOutputs)
       handleJobSuccessful(jobKey, callOutputs, stateData)
     case Event(FailedNonRetryableResponse(jobKey, reason, returnCode), stateData) =>
-      log.warning(s"Job ${jobKey.tag} failed! Reason: ${reason.getMessage}", reason) // TODO: This log is a candidate for removal. It's now recorded in metadata
+      log.warning(s"Job ${jobKey.tag} failed! Reason: ${reason.getMessage}") // TODO: PBE This log is a candidate for removal. It's now recorded in metadata
       pushFailedJobMetadata(jobKey, returnCode, reason, retryableFailure = false)
       context.parent ! WorkflowExecutionFailedResponse(List(reason))
       val mergedStateData = mergeExecutionDiff(stateData, WorkflowExecutionDiff(Map(jobKey -> ExecutionStatus.Failed)))
@@ -200,7 +200,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
       pushFailedJobMetadata(jobKey, None, reason, retryableFailure = true)
       handleRetryableFailure(jobKey, reason, returnCode)
     case Event(JobInitializationFailed(jobKey, reason), stateData) =>
-      log.warning(s"Jobs failed to initialize: $reason") // TODO: This log is a candidate for removal. It's now recorded in metadata
+      log.warning(s"Jobs failed to initialize: $reason") // TODO: PBE This log is a candidate for removal. It's now recorded in metadata
       pushFailedJobMetadata(jobKey, None, reason, retryableFailure = false)
       goto(WorkflowExecutionFailedState)
     case Event(ScatterCollectionSucceededResponse(jobKey, callOutputs), stateData) =>

--- a/engine/src/main/scala/cromwell/services/EngineMetadataServiceActor.scala
+++ b/engine/src/main/scala/cromwell/services/EngineMetadataServiceActor.scala
@@ -83,7 +83,7 @@ case class EngineMetadataServiceActor(serviceConfig: Config, globalConfig: Confi
           log.error(t, "Sending {} failure message {}", sndr, msg)
           sndr ! msg
       }
-    case GetAllMetadataAction(workflowId) => queryAndRespond(MetadataQuery(workflowId, None, None))
+    case GetSingleWorkflowMetadataAction(workflowId) => queryAndRespond(MetadataQuery(workflowId, None, None))
     case GetMetadataQueryAction(query@MetadataQuery(_, _, _)) => queryAndRespond(query)
     case GetStatus(workflowId) => queryStatusAndRespond(workflowId)
     case WorkflowQuery(uri, parameters) => queryWorkflowsAndRespond(uri, parameters)

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -531,7 +531,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
   }
 
   def getWorkflowOutputsFromMetadata(id: WorkflowId): Map[FullyQualifiedName, WdlValue] = {
-    getWorkflowMetadata(id).fields.head._2.asInstanceOf[JsObject].getFields(WorkflowMetadataKeys.Outputs).toList match {
+    getWorkflowMetadata(id).getFields(WorkflowMetadataKeys.Outputs).toList match {
       case head::_ => head.asInstanceOf[JsObject].fields.map( x => (x._1, jsValueToWdlValue(x._2)))
       case _ => Map.empty
     }

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -61,40 +61,40 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
     )
     val workflowAEvents = workflowACalls map { makeEvent(workflowA, _) }
 
+    // We'll use a Query instead of a SingleWorkflowMetadataGet, so we expect the WorkflowID this time:
     val expectedRes =
       s"""{
-        |  "$workflowA": {
-        |    "calls": {
-        |      "callB": [{
-        |        "attempt": 1,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": -1
-        |      }, {
-        |        "attempt": 1,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": 0
-        |      }, {
-        |        "attempt": 1,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": 1
-        |      }, {
-        |        "attempt": 2,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": 1
-        |      }, {
-        |        "attempt": 3,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": 1
-        |      }],
-        |      "callA": [{
-        |        "attempt": 1,
-        |        "NOT_CHECKED": "NOT_CHECKED",
-        |        "shardIndex": -1
-        |      }]
-        |    },
-        |    "NOT_CHECKED": "NOT_CHECKED"
-        |  }
-        |}""".stripMargin
+        |  "calls": {
+        |    "callB": [{
+        |      "attempt": 1,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": -1
+        |    }, {
+        |      "attempt": 1,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": 0
+        |    }, {
+        |      "attempt": 1,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": 1
+        |    }, {
+        |      "attempt": 2,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": 1
+        |    }, {
+        |      "attempt": 3,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": 1
+        |    }],
+        |    "callA": [{
+        |      "attempt": 1,
+        |      "NOT_CHECKED": "NOT_CHECKED",
+        |      "shardIndex": -1
+        |    }]
+        |  },
+        |  "NOT_CHECKED": "NOT_CHECKED",
+        |  "workflowId": "$workflowA"
+      |}""".stripMargin
 
     val mdQuery = MetadataQuery(workflowA, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
@@ -111,10 +111,10 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
     val workflow = WorkflowId.randomId()
 
     val events = eventList map { e => (e._1, MetadataValue(e._2), e._3) } map Function.tupled(makeEvent(workflow))
-    val expectedRes = s"""{"${workflow.id.toString}": { "calls": {}, $expectedJson } }"""
+    val expectedRes = s"""{ "calls": {}, $expectedJson, "workflowId":"$workflow" }"""
 
     val mdQuery = MetadataQuery(workflow, None, None)
-    val queryAction = GetAllMetadataAction(workflow)
+    val queryAction = GetSingleWorkflowMetadataAction(workflow)
     assertMetadataResponse(queryAction, mdQuery, events, expectedRes)
   }
 
@@ -281,7 +281,6 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
 
     val expectedResponse =
       s"""{
-          |"$workflowId": {
           | "calls": {},
           | "a": 2,
           | "b": 2,
@@ -290,9 +289,9 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
           | "e": 2.9,
           | "f": true,
           | "g": false,
-          | "h": "false"
+          | "h": "false",
+          | "workflowId":"$workflowId"
           | }
-          |}
       """.stripMargin
 
     val mdQuery = MetadataQuery(workflowId, None, None)
@@ -310,10 +309,9 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
 
     val expectedResponse =
       s"""{
-          |"$workflowId": {
           | "calls": {},
-          | "i": "UnknownClass(50)"
-          | }
+          | "i": "UnknownClass(50)",
+          | "workflowId":"$workflowId"
           |}
       """.stripMargin
 
@@ -331,10 +329,9 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
 
     val expectedResponse =
       s"""{
-          |"$workflowId": {
           | "calls": {},
-          | "i": "notAnInt"
-          | }
+          | "i": "notAnInt",
+          | "workflowId":"$workflowId"
           |}
       """.stripMargin
 

--- a/services/src/main/scala/cromwell/services/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/MetadataServiceActor.scala
@@ -29,7 +29,7 @@ object MetadataServiceActor {
     def serviceName = MetadataServiceName
   }
   case class PutMetadataAction(event: MetadataEvent) extends MetadataServiceAction
-  case class GetAllMetadataAction(workflowId: WorkflowId) extends MetadataServiceAction
+  case class GetSingleWorkflowMetadataAction(workflowId: WorkflowId) extends MetadataServiceAction
   case class GetMetadataQueryAction(key: MetadataQuery) extends MetadataServiceAction
   case class GetStatus(workflowId: WorkflowId) extends MetadataServiceAction
   case class WorkflowQuery(uri: Uri, parameters: Seq[(String, String)]) extends MetadataServiceAction


### PR DESCRIPTION
This removes the awkward `"workflowId": { }` wrapping around single workflow metadata responses.