### PR TITLE
Fixes to `SlickDataAccessSpec` plus some other patches.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,13 +63,5 @@ lazy val root = (project in file("."))
   .settings(rootSettings: _*)
   .dependsOn(core % "test->test;compile->compile")
   .dependsOn(engine % "test->test;compile->compile")
-  .dependsOn(backend)
-  .dependsOn(localBackend)
-  .dependsOn(sgeBackend)
-  .dependsOn(jesBackend)
-  .dependsOn(htCondorBackend)
-  .dependsOn(gcsfilesystem)
-  .aggregate(core, backend, engine, localBackend, sgeBackend, jesBackend, htCondorBackend, gcsfilesystem)
+  .aggregate(core, database, backend, engine, localBackend, sgeBackend, jesBackend, htCondorBackend, gcsfilesystem)
   .withTestSettings
-
-

--- a/engine/src/test/scala/cromwell/ArrayWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/ArrayWorkflowSpec.scala
@@ -32,7 +32,7 @@ class ArrayWorkflowSpec extends CromwellTestkitSpec {
   }
 
   "A static Array[File] declaration" should {
-    "be a valid declaration" ignore {
+    "be a valid declaration" in {
       val declaration = ns.workflow.declarations.find {_.name == "arr"}.getOrElse {
         fail("Expected declaration 'arr' to be found")
       }
@@ -44,7 +44,7 @@ class ArrayWorkflowSpec extends CromwellTestkitSpec {
       }
       value shouldEqual WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("f1"), WdlString("f2"), WdlString("f3")))
     }
-    "be usable as an input" ignore {
+    "be usable as an input" in {
       val catTask = ns.findTask("cat").getOrElse {
         fail("Expected to find task 'cat'")
       }
@@ -53,7 +53,7 @@ class ArrayWorkflowSpec extends CromwellTestkitSpec {
       }
       command shouldEqual "cat -s f1 f2 f3"
     }
-    "Coerce Array[String] to Array[File] when running the workflow" ignore {
+    "Coerce Array[String] to Array[File] when running the workflow" in {
       val outputs = Map(
         "wf.cat.lines" -> WdlArray(WdlArrayType(WdlStringType), Seq(
             WdlString("line1"),
@@ -68,7 +68,7 @@ class ArrayWorkflowSpec extends CromwellTestkitSpec {
       val sampleWdl = SampleWdl.ArrayLiteral(Paths.get("."))
       runWdlAndAssertOutputs(
         sampleWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: wf.cat", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: wf.cat", occurrences = 1),
         expectedOutputs = outputs
       )
       sampleWdl.cleanup()

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -285,13 +285,13 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
         case (_: WdlString, expectedFile: WdlFile) => fileEquality(a.valueString, expectedFile.valueString)
         case (array: WdlArray, expectedArray: WdlArray) =>
           (array.value.length == expectedArray.value.length) &&
-            array.value.zip(expectedArray.value).map(Function.tupled(areEqual)).fold(true)(_ && _)
+            array.value.zip(expectedArray.value).map(Function.tupled(areEqual)).forall(identity)
         case (map: WdlMap, expectedMap: WdlMap) =>
           val mapped = map.value.map {
             case (k, v) => expectedMap.value.get(k).isDefined && areEqual(v, expectedMap.value(k))
           }
 
-          (map.value.size == expectedMap.value.size) &&  mapped.fold(true)(_ && _)
+          (map.value.size == expectedMap.value.size) && mapped.forall(identity)
         case _ => a == b
       }
 
@@ -300,7 +300,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
   }
 
   def startingCallsFilter[T](callNames: String*)(block: => T): T =
-    waitForPattern(s"starting calls: ${callNames.mkString(", ")}$$") {
+    waitForPattern(s"Starting calls: ${callNames.mkString("", ":NA:1, ", ":NA:1")}$$") {
       block
     }
 

--- a/engine/src/test/scala/cromwell/ReadTsvWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/ReadTsvWorkflowSpec.scala
@@ -7,10 +7,12 @@ import wdl4s.values.{WdlFile, WdlString, WdlInteger, WdlArray}
 
 class ReadTsvWorkflowSpec extends CromwellTestkitSpec {
   "A workflow with array/map indexes in expressions" should {
-    "run locally" ignore {
+    "run locally" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.ReadTsvWdl,
-        eventFilter = EventFilter.info(pattern = s"starting calls: test.output_file_table, test.output_matrix, test.output_table", occurrences = 1),
+        eventFilter = EventFilter.info(
+          pattern = "Starting calls: test.output_file_table:NA:1, test.output_matrix:NA:1, test.output_table:NA:1",
+          occurrences = 1),
         expectedOutputs = Map(
           "test.output_matrix.matrix" -> WdlArray(
             WdlArrayType(WdlArrayType(WdlIntegerType)),

--- a/engine/src/test/scala/cromwell/WdlFunctionsAtWorkflowLevelSpec.scala
+++ b/engine/src/test/scala/cromwell/WdlFunctionsAtWorkflowLevelSpec.scala
@@ -16,10 +16,10 @@ class WdlFunctionsAtWorkflowLevelSpec extends CromwellTestkitSpec {
   ))
 
   "A workflow with a read_lines() and read_map() at the workflow level" should {
-    "execute those functions properly" ignore {
+    "execute those functions properly" in {
       runWdlAndAssertOutputs(
         sampleWdl = SampleWdl.WdlFunctionsAtWorkflowLevel,
-        eventFilter = EventFilter.info(pattern = s"starting calls: w.a", occurrences = 1),
+        eventFilter = EventFilter.info(pattern = "Starting calls: w.a", occurrences = 1),
         expectedOutputs = Map(
           "w.a.x" -> WdlString("one two three four five"),
           "w.a.y" -> outputMap


### PR DESCRIPTION
Fixes to `SlickDataAccessSpec` plus some other patches.
`SlickDataAccessSpec` should talk to the currently tested `SlickDatabase with DataAccess`, NOT the `service` layer, that in turn talks to the global singleton.
The `root` project was not aggregating `database`.
The `root` project with `Main` only actually depends on `engine` and `core` tests.
More tests fixed that were waiting for the wrong message.
Changed waiting for `start` to `Starting`.
Changed waiting for `call.name` to `call.name:NA:1`.
