### PR TITLE
Enable all tests in SlickDataAccessSpec

### DIFF
--- a/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/db/DataAccess.scala
@@ -103,7 +103,8 @@ trait DataAccess extends AutoCloseable {
    * Creates a row in each of the backend-info specific tables for each call in `calls` corresponding to the backend
    * `backend`.  Or perhaps defer this?
    */
-  def createWorkflow(workflowDescriptor: OldStyleWorkflowDescriptor,
+  def createWorkflow(workflowDescriptor: EngineWorkflowDescriptor,
+                     sources: WorkflowSourceFiles,
                      workflowInputs: Traversable[SymbolStoreEntry],
                      calls: Traversable[Scope],
                      backend: OldStyleBackend)(implicit ec: ExecutionContext): Future[Unit] = {
@@ -116,9 +117,9 @@ trait DataAccess extends AutoCloseable {
     val workflowExecutionAux = (workflowExecutionId: Int) => {
       new WorkflowExecutionAux(
         workflowExecutionId,
-        workflowDescriptor.sourceFiles.wdlSource.toClob,
-        workflowDescriptor.sourceFiles.inputsJson.toClob,
-        workflowDescriptor.sourceFiles.workflowOptionsJson.toClob
+        sources.wdlSource.toClob,
+        sources.inputsJson.toClob,
+        sources.workflowOptionsJson.toClob
       )
     }
     val workflowSymbols = (workflowExecutionId: Int) => {

--- a/engine/src/main/scala/cromwell/engine/workflow/OldStyleWorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/OldStyleWorkflowActor.scala
@@ -303,8 +303,10 @@ case class OldStyleWorkflowActor(workflow: OldStyleWorkflowDescriptor)
     val symbolStoreEntries = buildSymbolStoreEntries(workflow, workflow.actualInputs)
     symbolCache = symbolStoreEntries.groupBy(entry => SymbolCacheKey(entry.scope, entry.isInput))
     val finalCalls = OldStyleFinalCall.createFinalCalls(workflow)
-    globalDataAccess.createWorkflow(
-      workflow, symbolStoreEntries, workflow.namespace.workflow.children ++ finalCalls, backend)
+//    globalDataAccess.createWorkflow(
+//      workflow, symbolStoreEntries, workflow.namespace.workflow.children ++ finalCalls, backend)
+    // PBE Olde Junke
+    ???
   }
 
   // This is passed as an implicit parameter to methods of classes in the companion object.

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -86,7 +86,8 @@ class WorkflowManagerActor(config: Config)
 
   override def preStart() {
     addShutdownHook()
-    restartIncompleteWorkflows()
+    // PBE turn this off it tries to do a bunch of Olde stuffe that is badley brokeene
+    // restartIncompleteWorkflows()
   }
 
   private def addShutdownHook(): Unit = {

--- a/engine/src/test/scala/cromwell/RestartWorkflowSpec.scala
+++ b/engine/src/test/scala/cromwell/RestartWorkflowSpec.scala
@@ -33,12 +33,12 @@ class RestartWorkflowSpec extends CromwellTestkitSpec with WorkflowDescriptorBui
   "RestartWorkflowSpec" should {
     "restart a call in Running state" ignore {
       val id = WorkflowId.randomId()
-      val descriptor = materializeWorkflowDescriptorFromSources(id, sources)
+      val descriptor = createMaterializedEngineWorkflowDescriptor(id, sources)
       val a = ExecutionDatabaseKey("w.a", Option(-1), 1)
       val b = ExecutionDatabaseKey("w.b", Option(-1), 1)
 
       (for {
-        _ <- dataAccess.createWorkflow(descriptor, Nil, descriptor.namespace.workflow.calls, localBackend)
+        _ <- dataAccess.createWorkflow(descriptor, sources, Nil, descriptor.namespace.workflow.calls, localBackend)
         _ <- dataAccess.updateWorkflowState(descriptor.id, WorkflowRunning)
         _ <- dataAccess.updateStatus(descriptor.id, Seq(a), ExecutionStatus.Running)
         _ <- dataAccess.updateStatus(descriptor.id, Seq(b), ExecutionStatus.NotStarted)

--- a/engine/src/test/scala/cromwell/engine/backend/WorkflowDescriptorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/WorkflowDescriptorSpec.scala
@@ -53,7 +53,7 @@ trait WorkflowDescriptorBuilder {
     implicit val timeout = akka.util.Timeout(awaitTimeout)
     implicit val ec = actorSystem.dispatcher
 
-    val actor = actorSystem.actorOf(MaterializeWorkflowDescriptorActor.props(), "MaterializeWorkflowDescriptorActor")
+    val actor = actorSystem.actorOf(MaterializeWorkflowDescriptorActor.props(), "MaterializeWorkflowDescriptorActor-" + id.id)
     val workflowDescriptorFuture = actor.ask(
       MaterializeWorkflowDescriptorCommand(id, workflowSources, ConfigFactory.load)
     ).mapTo[WorkflowDescriptorMaterializationResult]

--- a/engine/src/test/scala/cromwell/services/CromwellServicesSpec.scala
+++ b/engine/src/test/scala/cromwell/services/CromwellServicesSpec.scala
@@ -7,7 +7,7 @@ import cromwell.CromwellTestkitSpec
 import cromwell.CromwellTestkitSpec.TestWorkflowManagerSystem
 import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.{WorkflowId, WorkflowOptions}
-import cromwell.engine.WorkflowSourceFiles
+import cromwell.engine.{EngineWorkflowDescriptor, WorkflowSourceFiles}
 import cromwell.engine.backend.local.OldStyleLocalBackend
 import cromwell.engine.backend.{OldStyleWorkflowDescriptor, WorkflowDescriptorBuilder}
 import cromwell.engine.db.DataAccess
@@ -33,7 +33,7 @@ trait CromwellServicesSpec extends FlatSpec with Matchers with BeforeAndAfterAll
     super.afterAll()
   }
 
-  protected def getBackendJobDescriptorKey(descriptor: OldStyleWorkflowDescriptor, callName: String): BackendJobDescriptor = {
+  protected def getBackendJobDescriptorKey(descriptor: EngineWorkflowDescriptor, callName: String): BackendJobDescriptor = {
     val call = descriptor.namespace.workflow.calls.find(_.unqualifiedName == callName).get
     val backendWorkflowDescriptor = BackendWorkflowDescriptor(
       descriptor.id,
@@ -45,12 +45,12 @@ trait CromwellServicesSpec extends FlatSpec with Matchers with BeforeAndAfterAll
     BackendJobDescriptor(backendWorkflowDescriptor, key, Map.empty)
   }
 
-  protected def makeWorkflowDescriptor(sources: WorkflowSourceFiles): OldStyleWorkflowDescriptor = {
+  protected def makeWorkflowDescriptor(sources: WorkflowSourceFiles): EngineWorkflowDescriptor = {
     val workflowId = WorkflowId.randomId()
-    materializeWorkflowDescriptorFromSources(id = workflowId, workflowSources = sources)
+    createMaterializedEngineWorkflowDescriptor(id = workflowId, workflowSources = sources)
   }
 
-  protected def makeKeyValueActor(cromwellConfig: Config, workflowDescriptor: OldStyleWorkflowDescriptor): ActorRef = {
+  protected def makeKeyValueActor(cromwellConfig: Config): ActorRef = {
     actorSystem.actorOf(
       KeyValueServiceActor.props(ConfigFactory.parseString(""), cromwellConfig)
     )

--- a/engine/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
+++ b/engine/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
@@ -33,7 +33,7 @@ class ServiceRegistryActorSpec extends FlatSpec with Matchers with ScalaFutures 
     val kvGet = KvGet(ScopedKey(callKey, "k"))
 
     val future = for {
-      _ <- dataAccess.createWorkflow(descriptor, Nil, descriptor.namespace.workflow.calls, localBackend)
+      _ <- dataAccess.createWorkflow(descriptor, sources, Nil, descriptor.namespace.workflow.calls, localBackend)
       get0 <- ask(serviceRegistryActor, kvGet).mapTo[KvKeyLookupFailed]
       _ = get0.action shouldEqual kvGet
       put0 <- ask(serviceRegistryActor, kvPut).mapTo[KvResponse]


### PR DESCRIPTION
This enables tests on a lot of Slick code that's not actually used yet in the New Worlde (nothing writes to the core engine tables since only Recover needs that and Recover hasn't been implemented).  So these changes are valuable iff the New Worlde ultimately uses an engine Slick API that looks a lot like that in the Olde Worlde.  My guess is that will end up being true, but at this point that's only a guess.  Some things here will certainly be nixed (ExecutionEvents) or are likely to be heavily modified (anything caching-related).