### PR TITLE
Change default version on status API.  Closes #937

### DIFF
--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -314,7 +314,7 @@ paths:
           required: true
           type: string
           in: path
-          default: v2
+          default: v1
         - name: id
           description: Workflow ID
           required: true


### PR DESCRIPTION
The API itself ignores version and always returns data in the classic format, so remove mention of "v2".