### PR TITLE
Updates to liquibase handling.

### DIFF
--- a/database/src/test/scala/cromwell/database/slick/SlickDatabaseSpec.scala
+++ b/database/src/test/scala/cromwell/database/slick/SlickDatabaseSpec.scala
@@ -1,13 +1,18 @@
 package cromwell.database.slick
 
+import java.io.{ByteArrayOutputStream, PrintStream}
+
 import better.files._
 import com.typesafe.config.ConfigFactory
 import cromwell.database.liquibase.DiffResultFilter
+import liquibase.diff.output.DiffOutputControl
+import liquibase.diff.output.changelog.DiffToChangeLog
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContext
+import scala.xml.{Elem, TopScope, XML}
 
 class SlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures {
 
@@ -23,16 +28,43 @@ class SlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures {
       slickDatabase <- databaseForSchemaManager("slick").autoClosed
     } {
       val diffResult = LiquibaseSchemaManager.compare(
-        slickDatabase.dataAccess.driver, slickDatabase.database,
-        liquibaseDatabase.dataAccess.driver, liquibaseDatabase.database)
+        liquibaseDatabase.dataAccess.driver, liquibaseDatabase.database,
+        slickDatabase.dataAccess.driver, slickDatabase.database)
+
+      // TODO PBE get rid of this after the migration of #789 has run.
+      val oldeTables = Seq(
+        "EXECUTION_EVENT",
+        "FAILURE_EVENT"
+      )
 
       import DiffResultFilter._
       val diffFilters = StandardTypeFilters :+ UniqueIndexFilter
-      val filteredDiffResult = diffResult.filterOldeObjects.filterLiquibaseObjects.filterChangedObjects(diffFilters)
+      val filteredDiffResult = diffResult
+        .filterLiquibaseObjects
+        .filterTableObjects(oldeTables)
+        .filterChangedObjects(diffFilters)
 
-      filteredDiffResult.getChangedObjects should be(empty)
-      filteredDiffResult.getMissingObjects should be(empty)
-      filteredDiffResult.getUnexpectedObjects should be(empty)
+      val totalChanged =
+        filteredDiffResult.getChangedObjects.size +
+        filteredDiffResult.getMissingObjects.size +
+        filteredDiffResult.getUnexpectedObjects.size
+
+      if (totalChanged > 0) {
+        val outputStream = new ByteArrayOutputStream
+        val printStream = new PrintStream(outputStream, true)
+        val diffOutputControl = new DiffOutputControl(false, false, false, Array.empty)
+        val diffToChangeLog = new DiffToChangeLog(filteredDiffResult, diffOutputControl)
+        diffToChangeLog.print(printStream)
+        val changeSetsScoped = XML.loadString(outputStream.toString) \ "changeSet" \ "_"
+        val changeSets = changeSetsScoped map {
+          case elem: Elem => elem.copy(scope = TopScope) // strip the namespace
+          case other => other
+        }
+        fail(changeSets.mkString(
+          "The following changes are in liquibase but not in slick:\n  ",
+          "\n  ",
+          "\nEither add the changes to slick or remove them from liquibase."))
+      }
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
     "com.typesafe.slick" %% "slick-hikaricp" % slickV,
     "org.hsqldb" % "hsqldb" % "2.3.2",
     "mysql" % "mysql-connector-java" % "5.1.36",
-    "org.liquibase" % "liquibase-core" % "3.4.2",
+    "org.liquibase" % "liquibase-core" % "3.5.1",
     // This is to stop liquibase from being so noisy by default
     // See: http://stackoverflow.com/questions/20880783/how-to-get-liquibase-to-log-using-slf4j
     "com.mattbertolini" % "liquibase-slf4j" % "2.0.0",


### PR DESCRIPTION
Bumped `liquibase-core` version to latest `3.5.1` that fixes among other things a `ConcurrentModificationException` (see liquibase pull 539).
Moved cromwell specific liquibase diff filtering out of (hopefully someday) common `DiffResultFilter`.
Now filtering new "order" differences.
Prettier printing of liquibase/slick differences in `SlickDatabaseSpec`.