### PR TITLE
resolve workflow state for the metadata endpoint

### DIFF
--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -4,7 +4,8 @@ import scalaz.Semigroup
 
 sealed trait WorkflowState {
   def isTerminal: Boolean
-  def append(that: WorkflowState): WorkflowState
+  protected def ordinal: Int
+  def append(that: WorkflowState): WorkflowState = if (this.ordinal > that.ordinal) this else that
 }
 
 object WorkflowState {
@@ -16,40 +17,42 @@ object WorkflowState {
   implicit val WorkflowStateSemigroup = new Semigroup[WorkflowState] {
     override def append(f1: WorkflowState, f2: => WorkflowState): WorkflowState = f1.append(f2)
   }
+
+  implicit val WorkflowStateOrdering = Ordering.by { self: WorkflowState => self.ordinal }
 }
 
 case object WorkflowSubmitted extends WorkflowState {
   override val toString: String = "Submitted"
   override val isTerminal = false
-  override def append(that: WorkflowState): WorkflowState = that
+  override val ordinal = 0
 }
 
 case object WorkflowRunning extends WorkflowState {
   override val toString: String = "Running"
   override val isTerminal = false
-  override def append(that: WorkflowState): WorkflowState = if (that == WorkflowSubmitted) this else that
+  override val ordinal = 1
 }
 
 case object WorkflowAborting extends WorkflowState {
   override val toString: String = "Aborting"
   override val isTerminal = false
-  override def append(that: WorkflowState): WorkflowState = if (that.isTerminal) that else this
-}
-
-case object WorkflowFailed extends WorkflowState {
-  override val toString: String = "Failed"
-  override val isTerminal = true
-  override def append(that: WorkflowState): WorkflowState = this
-}
-
-case object WorkflowSucceeded extends WorkflowState {
-  override val toString: String = "Succeeded"
-  override val isTerminal = true
-  override def append(that: WorkflowState): WorkflowState = if (that == WorkflowFailed) that else this
+  override val ordinal = 2
 }
 
 case object WorkflowAborted extends WorkflowState {
   override val toString: String = "Aborted"
   override val isTerminal = true
-  override def append(that: WorkflowState): WorkflowState = if (that.isTerminal) that else this
+  override val ordinal = 3
+}
+
+case object WorkflowSucceeded extends WorkflowState {
+  override val toString: String = "Succeeded"
+  override val isTerminal = true
+  override val ordinal = 4
+}
+
+case object WorkflowFailed extends WorkflowState {
+  override val toString: String = "Failed"
+  override val isTerminal = true
+  override val ordinal = 5
 }

--- a/engine/src/main/scala/cromwell/webservice/MetadataBuilderActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/MetadataBuilderActor.scala
@@ -195,10 +195,21 @@ object MetadataBuilderActor {
     MetadataForIndex(index.getOrElse(-1), metadata)
   }
 
+  private def reduceWorkflowEvents(workflowEvents: Seq[MetadataEvent]): Seq[MetadataEvent] = {
+    // This handles state specially so a sensible final value is returned irrespective of the order in which raw state
+    // events were recorded in the journal.
+    val (workflowStatusEvents, workflowNonStatusEvents) = workflowEvents partition(_.key.key == WorkflowMetadataKeys.Status)
+
+    val ordering = implicitly[Ordering[WorkflowState]]
+    // This orders by value in WorkflowState CRDT resolution, not necessarily the chronologically most recent state.
+    val sortedStateEvents = workflowStatusEvents sortWith { case (a, b) => ordering.gt(a.value.toWorkflowState, b.value.toWorkflowState) }
+    workflowNonStatusEvents ++ sortedStateEvents.headOption.toList
+  }
+
   private def parseWorkflowEventsToIndexedJsonValue(events: Seq[MetadataEvent]): IndexedJsonValue = {
     // Partition if sequence of events in a pair of (Workflow level events, Call level events)
     val (workflowLevel, callLevel) = events partition { _.key.jobKey.isEmpty }
-    val foldedWorkflowValues = eventsToIndexedJson(workflowLevel)
+    val foldedWorkflowValues = eventsToIndexedJson(reduceWorkflowEvents(workflowLevel))
 
     val callsGroupedByFQN = callLevel groupBy { _.key.jobKey.get.callFqn }
     val callsGroupedByFQNAndIndex = callsGroupedByFQN mapValues { _ groupBy { _.key.jobKey.get.index } }
@@ -225,6 +236,9 @@ object MetadataBuilderActor {
     JsObject(events.groupBy(_.key.workflowId.toString) mapValues parseWorkflowEvents)
   }
 
+  implicit class EnhancedMetadataValue(val value: MetadataValue) extends AnyVal {
+    def toWorkflowState: WorkflowState = WorkflowState.fromString(value.value)
+  }
 }
 
 class MetadataBuilderActor(serviceRegistryActor: ActorRef) extends LoggingFSM[MetadataBuilderActorState, Unit]


### PR DESCRIPTION
The metadata endpoint was previously not applying any business logic to workflow states so it simply returned the last state written to the journal.  This adds specific resolution logic similar to that used for workflow summary.