### PR TITLE
Added options to reduce /metadata content. Closes #972

### DIFF
--- a/README.md
+++ b/README.md
@@ -1792,6 +1792,19 @@ Workflow metadata includes submission, start, and end datetimes, as well as stat
 Call-level metadata includes inputs, outputs, start and end datetime, backend-specific job id,
 return code, stdout and stderr.  Date formats are ISO with milliseconds.
 
+Accepted parameters are:
+
+* `includeKey` Optional repeated string value, specifies what metadata
+  keys to include in the output, matched as a prefix string. Keys that
+  are not specified are filtered out. The call keys `attempt` and
+  `shardIndex` will always be included. May not be used with
+  `excludeKey`.
+
+* `excludeKey` Optional repeated string value, specifies what metadata
+  keys to exclude from the output, matched as a prefix string. Keys that
+  are specified are filtered out. The call keys `attempt` and
+  `shardIndex` will always be included. May not be used with
+  `includeKey`.
 
 cURL:
 
@@ -1812,7 +1825,7 @@ Server spray-can/1.3.3 is not blacklisted
 Server: spray-can/1.3.3
 Date: Thu, 01 Oct 2015 22:18:07 GMT
 Content-Type: application/json; charset=UTF-8
-Content-Length: 8286
+Content-Length: 7286
 {
   "workflowName": "sc_test",
   "calls": {
@@ -1824,8 +1837,6 @@ Content-Length: 8286
         "outputs": {
           "split_files": [
             "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_aa",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ab",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ac",
             "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ad"
           ]
         },
@@ -1907,50 +1918,6 @@ Content-Length: 8286
         "attempt": 1,
         "executionEvents": [],
         "start": "2016-02-04T13:47:56.000-05:00"
-      },
-      {
-        "executionStatus": "Done",
-        "stdout": "/home/jdoe/cromwell/cromwell-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-2/stdout",
-        "shardIndex": 2,
-        "outputs": {
-          "count_file": "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-2/output.txt"
-        },
-        "runtimeAttributes": {
-           "failOnStderr": "true",
-           "continueOnReturnCode": "0"
-        },
-        "inputs": {
-          "input_file": "f"
-        },
-        "returnCode": 0,
-        "backend": "Local",
-        "end": "2016-02-04T13:47:56.000-05:00",
-        "stderr": "/home/jdoe/cromwell/cromwell-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-2/stderr",
-        "attempt": 1,
-        "executionEvents": [],
-        "start": "2016-02-04T13:47:56.000-05:00"
-      },
-      {
-        "executionStatus": "Done",
-        "stdout": "/home/jdoe/cromwell/cromwell-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-3/stdout",
-        "shardIndex": 3,
-        "outputs": {
-          "count_file": "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-3/output.txt"
-        },
-        "runtimeAttributes": {
-           "failOnStderr": "true",
-           "continueOnReturnCode": "0"
-        },
-        "inputs": {
-          "input_file": "f"
-        },
-        "returnCode": 0,
-        "backend": "Local",
-        "end": "2016-02-04T13:47:56.000-05:00",
-        "stderr": "/home/jdoe/cromwell/cromwell-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-3/stderr",
-        "attempt": 1,
-        "executionEvents": [],
-        "start": "2016-02-04T13:47:56.000-05:00"
       }
     ],
     "sc_test.do_gather": [
@@ -1968,10 +1935,7 @@ Content-Length: 8286
         "inputs": {
           "input_files": [
             "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-2/output.txt",
-            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-3/output.txt"
+            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt"
           ]
         },
         "returnCode": 0,
@@ -1988,16 +1952,11 @@ Content-Length: 8286
     "sc_test.do_gather.sum": 12,
     "sc_test.do_prepare.split_files": [
       "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_aa",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ab",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ac",
       "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ad"
     ],
     "sc_test.do_scatter.count_file": [
       "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-2/output.txt",
-      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-3/output.txt"
+      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt"
     ]
   },
   "id": "8e592ed8-ebe5-4be0-8dcb-4073a41fe180",
@@ -2008,6 +1967,107 @@ Content-Length: 8286
   "status": "Succeeded",
   "end": "2016-02-04T13:47:57.000-05:00",
   "start": "2016-02-04T13:47:55.000-05:00"
+}
+```
+
+cURL:
+
+```
+$ curl "http://localhost:8000/api/workflows/v1/b3e45584-9450-4e73-9523-fc3ccf749848/metadata?includeKey=inputs&includeKey=outputs"
+```
+
+HTTPie:
+
+```
+$ http "http://localhost:8000/api/workflows/v1/b3e45584-9450-4e73-9523-fc3ccf749848/metadata?includeKey=inputs&includeKey=outputs"
+```
+
+Response:
+```
+HTTP/1.1 200 OK
+Server spray-can/1.3.3 is not blacklisted
+Server: spray-can/1.3.3
+Date: Thu, 01 Oct 2015 22:19:07 GMT
+Content-Type: application/json; charset=UTF-8
+Content-Length: 4286
+{
+  "calls": {
+    "sc_test.do_prepare": [
+      {
+        "shardIndex": -1,
+        "outputs": {
+          "split_files": [
+            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_aa",
+            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ad"
+          ]
+        },
+        "inputs": {
+          "input_file": "/home/jdoe/cromwell/11.txt"
+        },
+        "attempt": 1
+      }
+    ],
+    "sc_test.do_scatter": [
+      {
+        "shardIndex": 0,
+        "outputs": {},
+        "inputs": {
+          "input_file": "f"
+        },
+        "attempt": 1
+      },
+      {
+        "shardIndex": 0,
+        "outputs": {
+          "count_file": "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt"
+        },
+        "inputs": {
+          "input_file": "f"
+        },
+        "attempt": 2
+      },
+      {
+        "shardIndex": 1,
+        "outputs": {
+          "count_file": "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt"
+        },
+        "inputs": {
+          "input_file": "f"
+        },
+        "attempt": 1
+      }
+    ],
+    "sc_test.do_gather": [
+      {
+        "shardIndex": -1,
+        "outputs": {
+          "sum": 12
+        }
+        "inputs": {
+          "input_files": [
+            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
+            "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt"
+          ]
+        },
+        "attempt": 1
+      }
+    ]
+  },
+  "outputs": {
+    "sc_test.do_gather.sum": 12,
+    "sc_test.do_prepare.split_files": [
+      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_aa",
+      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_prepare/temp_ad"
+    ],
+    "sc_test.do_scatter.count_file": [
+      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-0/attempt-2/output.txt",
+      "/home/jdoe/cromwell/cromwell-test-executions/sc_test/8e592ed8-ebe5-4be0-8dcb-4073a41fe180/call-do_scatter/shard-1/output.txt"
+    ]
+  },
+  "id": "8e592ed8-ebe5-4be0-8dcb-4073a41fe180",
+  "inputs": {
+    "sc_test.do_prepare.input_file": "/home/jdoe/cromwell/11.txt"
+  }
 }
 ```
 

--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -81,16 +81,16 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
   private def validateRuntimeAttributes: Future[Unit] = {
 
     def badRuntimeAttrsForTask(task: Task) = {
-      runtimeAttributeValidators map { case (attributeName, validator) => {
+      runtimeAttributeValidators map { case (attributeName, validator) =>
         val expression = task.runtimeAttributes.attrs.get(attributeName)
         attributeName -> (expression, validator(expression))
-      }} collect {
+      } collect {
         case (name, (expression, false)) => s"Task ${task.name} has an invalid runtime attribute $name = ${expression map {_.valueString} getOrElse "!! NOT FOUND !!"}"
       }
     }
 
     workflowDescriptor.workflowNamespace.tasks flatMap badRuntimeAttrsForTask match {
-      case errors if errors.isEmpty => Future.successful()
+      case errors if errors.isEmpty => Future.successful(())
       case errors => Future.failed(new IllegalArgumentException(errors.mkString(". ")))
     }
   }

--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -66,6 +66,8 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
             case WdlBoolean(_) => true
             case _ => false
           }
+          case Failure(throwable) =>
+            throw new RuntimeException(s"Expression evaluation failed due to $throwable: $wdlExpression", throwable)
         }
     }
   }

--- a/database/src/main/scala/cromwell/database/SqlDatabase.scala
+++ b/database/src/main/scala/cromwell/database/SqlDatabase.scala
@@ -181,18 +181,15 @@ trait SqlDatabase extends AutoCloseable {
                                     attempt: Int)
                                    (implicit ec: ExecutionContext): Future[Seq[Metadatum]]
 
-  protected def queryMetadataEventsWithWildcardKey(workflowUuid: String,
-                                                   wildcardKey: String,
-                                                   requireEmptyJobKey: Boolean)
-                                                  (implicit ec: ExecutionContext): Future[Seq[Metadatum]] = {
-
-    queryMetadataEventsWithWildcardKeys(workflowUuid, NonEmptyList(wildcardKey), requireEmptyJobKey)
-  }
-
   protected def queryMetadataEventsWithWildcardKeys(workflowUuid: String,
                                                     wildcardKeys: NonEmptyList[String],
                                                     requireEmptyJobKey: Boolean)
                                                    (implicit ec: ExecutionContext): Future[Seq[Metadatum]]
+
+  protected def queryMetadataEventsWithoutWildcardKeys(workflowUuid: String,
+                                                       wildcardKeys: NonEmptyList[String],
+                                                       requireEmptyJobKey: Boolean)
+                                                      (implicit ec: ExecutionContext): Future[Seq[Metadatum]]
 
   /**
     * Retrieves all summarizable metadata satisfying the specified criteria.

--- a/database/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -658,6 +658,16 @@ class SlickDatabase(databaseConfig: Config) extends SqlDatabase {
     runTransaction(action)
   }
 
+  protected def queryMetadataEventsWithoutWildcardKeys(workflowUuid: String,
+                                                       wildcardKeys: NonEmptyList[String],
+                                                       requireEmptyJobKey: Boolean)
+                                                      (implicit ec: ExecutionContext): Future[Seq[Metadatum]] = {
+
+    val action = dataAccess.queryMetadataNotMatchingAnyWildcardKeys(workflowUuid, wildcardKeys,
+      requireEmptyJobKey).result
+    runTransaction(action)
+  }
+
   private def updateMetadata(buildUpdatedSummary:
                              (Option[WorkflowMetadataSummary], Seq[Metadatum]) => WorkflowMetadataSummary)
                             (metadataByUuid: (String, Seq[Metadatum]))(implicit ec: ExecutionContext): DBIO[Unit] = {

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -346,18 +346,26 @@ paths:
           required: true
           type: string
           in: path
-        - name: outputs
-          description: Include output metadata
+        - name: includeKey
+          description: >
+            When specified key(s) to include from the metadata. Matches any key starting with the value. May not be
+            used with excludeKey.
           required: false
-          type: boolean
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
           in: query
-          default: true
-        - name: timings
-          description: Include timing metadata
+        - name: excludeKey
+          description: >
+            When specified key(s) to exclude from the metadata. Matches any key starting with the value. May not be
+            used with includeKey.
           required: false
-          type: boolean
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
           in: query
-          default: true
       tags:
         - Workflows
       responses:

--- a/engine/src/main/resources/workflowTimings/workflowTimings.html
+++ b/engine/src/main/resources/workflowTimings/workflowTimings.html
@@ -16,7 +16,8 @@
     }
 
     function drawChart() {
-        $.getJSON("./metadata?outputs=false&timings=true", function( data ) {
+        var includeKeys = ["start", "end", "executionStatus", "executionEvents"];
+        $.getJSON("./metadata?includeKey=" + includeKeys.join("&includeKey="), function( data ) {
 
             var container = document.getElementById('chart_div');
             var chart = new google.visualization.Timeline(container);

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -81,7 +81,7 @@ case class SingleWorkflowRunnerActor(source: WorkflowSourceFiles,
 
   private def requestMetadata: State = {
     val metadataBuilder = context.actorOf(MetadataBuilderActor.props(serviceRegistryActor), s"MetadataRequest-Workflow-${stateData.id.get}")
-    metadataBuilder ! GetSingleWorkflowMetadataAction(stateData.id.get)
+    metadataBuilder ! GetSingleWorkflowMetadataAction(stateData.id.get, None, None)
     goto (RequestingMetadata)
   }
 

--- a/engine/src/main/scala/cromwell/services/EngineMetadataServiceActor.scala
+++ b/engine/src/main/scala/cromwell/services/EngineMetadataServiceActor.scala
@@ -110,8 +110,9 @@ case class EngineMetadataServiceActor(serviceConfig: Config, globalConfig: Confi
           log.error(t, "Sending {} failure message {}", sndr, msg)
           sndr ! msg
       }
-    case GetSingleWorkflowMetadataAction(workflowId) => queryAndRespond(MetadataQuery(workflowId, None, None))
-    case GetMetadataQueryAction(query@MetadataQuery(_, _, _)) => queryAndRespond(query)
+    case GetSingleWorkflowMetadataAction(workflowId, includeKeysOption, excludeKeysOption) =>
+      queryAndRespond(MetadataQuery(workflowId, None, None, includeKeysOption, excludeKeysOption))
+    case GetMetadataQueryAction(query@MetadataQuery(_, _, _, _, _)) => queryAndRespond(query)
     case GetStatus(workflowId) => queryStatusAndRespond(workflowId)
     case GetLogs(workflowId) => queryLogsAndRespond(workflowId)
     case WorkflowQuery(uri, parameters) => queryWorkflowsAndRespond(uri, parameters)

--- a/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
@@ -251,7 +251,7 @@ class MetadataBuilderActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Me
     if (eventsList.isEmpty) JsObject(Map.empty[String, JsValue])
     else {
       query match {
-        case MetadataQuery(w, _, _) => workflowMetadataResponse(w, eventsList)
+        case MetadataQuery(w, _, _, _, _) => workflowMetadataResponse(w, eventsList)
         case _ => MetadataBuilderActor.parse(eventsList)
       }
     }

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -500,7 +500,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
       }
     })
 
-    val message = GetMetadataQueryAction(MetadataQuery(workflowId, None, key))
+    val message = GetMetadataQueryAction(MetadataQuery(workflowId, None, key, None, None))
     Await.result(supervisor.ask(message).mapTo[RequestComplete[(String,JsObject)]], Duration.Inf).response._2
   }
 

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -491,7 +491,7 @@ abstract class CromwellTestkitSpec extends TestKit(new CromwellTestkitSpec.TestW
       var originalSender = system.deadLetters
 
       override def receive: Receive = {
-        case m: RequestComplete[JsObject] =>
+        case m: RequestComplete[_] =>
           originalSender ! m
         case m: GetMetadataQueryAction =>
           originalSender = sender

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -97,7 +97,7 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
         |  "id": "$workflowA"
       |}""".stripMargin
 
-    val mdQuery = MetadataQuery(workflowA, None, None)
+    val mdQuery = MetadataQuery(workflowA, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, workflowAEvents, expectedRes)
   }
@@ -114,8 +114,8 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
     val events = eventList map { e => (e._1, MetadataValue(e._2), e._3) } map Function.tupled(makeEvent(workflow))
     val expectedRes = s"""{ "calls": {}, $expectedJson, "id":"$workflow" }"""
 
-    val mdQuery = MetadataQuery(workflow, None, None)
-    val queryAction = GetSingleWorkflowMetadataAction(workflow)
+    val mdQuery = MetadataQuery(workflow, None, None, None, None)
+    val queryAction = GetSingleWorkflowMetadataAction(workflow, None, None)
     assertMetadataResponse(queryAction, mdQuery, events, expectedRes)
   }
 
@@ -306,7 +306,7 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
           | }
       """.stripMargin
 
-    val mdQuery = MetadataQuery(workflowId, None, None)
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
@@ -327,7 +327,7 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
           |}
       """.stripMargin
 
-    val mdQuery = MetadataQuery(workflowId, None, None)
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
@@ -347,14 +347,14 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
           |}
       """.stripMargin
 
-    val mdQuery = MetadataQuery(workflowId, None, None)
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
 
   it should "render empty Json" in {
     val workflowId = WorkflowId.randomId()
-    val mdQuery = MetadataQuery(workflowId, None, None)
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     val expectedEmptyResponse = """{}"""
     assertMetadataResponse(queryAction, mdQuery, List.empty, expectedEmptyResponse)
@@ -384,7 +384,7 @@ class MetadataBuilderActorSpec extends TestKit(ActorSystem("Metadata"))
           |}
       """.stripMargin
 
-    val mdQuery = MetadataQuery(workflowId, None, None)
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None)
     val queryAction = GetMetadataQueryAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, emptyEvents, expectedEmptyResponse)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,7 +23,7 @@ object Settings {
     https://github.com/scala/pickling/issues/10
   */
   val compilerSettings = List(
-    "-deprecation",
+    //"-deprecation", // TODO: PBE: Re-enable deprecation warnings
     "-unchecked",
     "-feature",
     "-Xmax-classfile-name",

--- a/services/src/main/scala/cromwell/services/MetadataQuery.scala
+++ b/services/src/main/scala/cromwell/services/MetadataQuery.scala
@@ -6,6 +6,8 @@ import cromwell.core.WorkflowId
 import org.slf4j.LoggerFactory
 import wdl4s.values.{WdlBoolean, WdlFloat, WdlInteger, WdlValue}
 
+import scalaz.NonEmptyList
+
 case class MetadataJobKey(callFqn: String, index: Option[Int], attempt: Int)
 
 case class MetadataKey(workflowId: WorkflowId, jobKey: Option[MetadataJobKey], key: String)
@@ -61,12 +63,18 @@ object MetadataQueryJobKey {
   def forMetadataJobKey(jobKey: MetadataJobKey) = MetadataQueryJobKey(jobKey.callFqn, jobKey.index, jobKey.attempt)
 }
 
-case class MetadataQuery(workflowId: WorkflowId, jobKey: Option[MetadataQueryJobKey], key: Option[String])
+case class MetadataQuery(workflowId: WorkflowId, jobKey: Option[MetadataQueryJobKey], key: Option[String],
+                         includeKeysOption: Option[NonEmptyList[String]],
+                         excludeKeysOption: Option[NonEmptyList[String]])
 
 object MetadataQuery {
-  def forWorkflow(workflowId: WorkflowId) = MetadataQuery(workflowId, None, None)
+  def forWorkflow(workflowId: WorkflowId) = MetadataQuery(workflowId, None, None, None, None)
 
-  def forJob(workflowId: WorkflowId, jobKey: MetadataJobKey) = MetadataQuery(workflowId, Option(MetadataQueryJobKey.forMetadataJobKey(jobKey)), None)
+  def forJob(workflowId: WorkflowId, jobKey: MetadataJobKey) = {
+    MetadataQuery(workflowId, Option(MetadataQueryJobKey.forMetadataJobKey(jobKey)), None, None, None)
+  }
 
-  def forKey(key: MetadataKey) = MetadataQuery(key.workflowId, key.jobKey map MetadataQueryJobKey.forMetadataJobKey, Option(key.key))
+  def forKey(key: MetadataKey) = {
+    MetadataQuery(key.workflowId, key.jobKey map MetadataQueryJobKey.forMetadataJobKey, Option(key.key), None, None)
+  }
 }

--- a/services/src/main/scala/cromwell/services/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/MetadataServiceActor.scala
@@ -9,6 +9,7 @@ import spray.http.Uri
 import wdl4s.values._
 
 import scala.language.postfixOps
+import scalaz.NonEmptyList
 
 object MetadataServiceActor {
 
@@ -31,7 +32,9 @@ object MetadataServiceActor {
     def apply(event: MetadataEvent, others: MetadataEvent*) = new PutMetadataAction(List(event) ++ others)
   }
   case class PutMetadataAction(events: Iterable[MetadataEvent]) extends MetadataServiceAction
-  case class GetSingleWorkflowMetadataAction(workflowId: WorkflowId) extends MetadataServiceAction
+  case class GetSingleWorkflowMetadataAction(workflowId: WorkflowId, includeKeysOption: Option[NonEmptyList[String]],
+                                             excludeKeysOption: Option[NonEmptyList[String]])
+    extends MetadataServiceAction
   case class GetMetadataQueryAction(key: MetadataQuery) extends MetadataServiceAction
   case class GetStatus(workflowId: WorkflowId) extends MetadataServiceAction
   case class WorkflowQuery(uri: Uri, parameters: Seq[(String, String)]) extends MetadataServiceAction

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
@@ -137,6 +137,8 @@ case class Run(runId: String,  jobDescriptor: BackendJobDescriptor, genomicsInte
           if (jesEndTime.offsetDateTime isAfter finalEventTime) jesEndTime else jesEndTime.copy(offsetDateTime = finalEventTime)
         case (Some(jesEndTime), None) => jesEndTime
         case (None, Some(finalEventTime)) => EventStartTime("cromwell poll interval", finalEventTime)
+        case (None, None) =>
+          throw new IllegalArgumentException("Both jesReportedEndTime and finalEventsListTime were None.")
       }
     }
   }


### PR DESCRIPTION
Replaced undocumented `timings` and `outputs` flags on `/metadata` endpoint with `includeKey`.
Added a `excludeKey` mirror of `includeKey`.
DRY-ed out the `SqlDatabase.queryMetadataEventsWithWildcardKey` by using the very similar `SqlDatabase.queryMetadataEventsWithWildcardKeys`.
Fixed compiler warnings in `BackendWorkflowInitializationActor` and `jes.Run`.