### PR TITLE
Set the JES polling backoff to be the same as 0.19

### DIFF
--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -81,7 +81,7 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
 
   import JesAsyncBackendJobExecutionActor._
 
-  override lazy val pollBackoff = SimpleExponentialBackoff(initialInterval = 30 seconds, maxInterval = 60 seconds, multiplier = 1.1)
+  override lazy val pollBackoff = SimpleExponentialBackoff(initialInterval = 30 seconds, maxInterval = 10 minutes, multiplier = 1.1)
 
   override lazy val executeOrRecoverBackoff = SimpleExponentialBackoff(initialInterval = 3 seconds, maxInterval = 20 seconds, multiplier = 1.1)
 


### PR DESCRIPTION
We had previously capped the backoff at 10m and now at 60s. This doesn't resolve the QPS storm but does seem (he says unscientifically) to make it a little better. At the very least this wasn't helping.