### PR TITLE
Upgrade Akka to latest 2.3.x version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val wdl4sV = "0.5-ed015a6-SNAPSHOT"
   lazy val sprayV = "1.3.2"
   lazy val DowngradedSprayV = "1.3.1"
-  lazy val akkaV = "2.3.12"
+  lazy val akkaV = "2.3.15"
   lazy val slickV = "3.1.1"
   lazy val googleClientApiV = "1.20.0"
   lazy val betterFilesV = "2.13.0"


### PR DESCRIPTION
2.3.x is dead, long live 2.4.x. However I didn't want to progress to 2.4.x for a couple of reasons