### PR TITLE
Added Docker support to HtCondor backend. Closes #884

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,26 @@ cache {
 * forceRewrite: it allows to invalidate the cache entry and store result again.
 * db section: configuration related to MongoDB provider. It may not exists for other implementations. 
 
+### Docker
+This backend supports the following optional runtime attributes / workflow options for working with Docker:
+* docker: Docker image to use such as "Ubuntu".
+* dockerWorkingDir: defines the working directory in the container. 
+* dockerOutputDir: defiles the output directory in the container when there is the need to define a volume for outputs within the container. By default if this attribute is not set, dockerOutputDir will be the job working directory. 
+
+Inputs: 
+HtCondor backend analyzes all inputs and do a distinct of the folders in order to mount input folders into the container.
+
+Outputs: 
+It will use dockerOutputDir runtime attribute / workflow option to resolve the folder in which the execution results will placed. If there is no dockerOutputDir defined it will use the current working directory.
+
+### CPU, Memory and Disk
+This backend supports CPU, memory and disk size configuration through the use of the following runtime attributes / workflow options:
+* cpu: defines the amount of CPU to use. Default value: 1. Type: Integer. Ex: 4.
+* memory: defines the amount of memory to use. Default value: "512 MB". Type: String. Ex: "4 GB" or "4096 MB"
+* disk: defines the amount of disk to use. Default value: "1024 MB". Type: String. Ex: "1 GB" or "1024 MB"
+
+It they are not set, HtCondor backend will use default values.
+
 ## Google JES Backend
 
 Google JES (Job Execution Service) is a Docker-as-a-service from Google.

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
@@ -1,30 +1,46 @@
 package cromwell.backend.impl.htcondor
 
+import cromwell.backend.MemorySize
 import cromwell.backend.validation.ContinueOnReturnCode
 import cromwell.backend.validation.RuntimeAttributesDefault._
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.validation.RuntimeAttributesValidation._
-import cromwell.core.WorkflowOptions
+import cromwell.core._
 import lenthall.exception.MessageAggregation
-import wdl4s.types.{WdlStringType, WdlBooleanType, WdlType}
-import wdl4s.values.{WdlBoolean, WdlInteger, WdlValue}
+import wdl4s.types.{WdlIntegerType, WdlStringType, WdlBooleanType, WdlType}
+import wdl4s.values.{WdlString, WdlBoolean, WdlInteger, WdlValue}
 
 import scalaz.Scalaz._
 import scalaz._
 
 object HtCondorRuntimeAttributes {
-  val FailOnStderrDefaultValue = false
-  val ContinueOnRcDefaultValue = 0
+  private val FailOnStderrDefaultValue = false
+  private val ContinueOnRcDefaultValue = 0
+  private val CpuDefaultValue = 1
+  private val MemoryDefaultValue = "0.512 GB"
+  private val DisksDefaultValue = "1.024 GB"
+
+  private val DockerWorkingDirKey = "dockerWorkingDir"
+  private val DockerOutputDirKey = "dockerOutputDir"
+  private val DiskKey = "disk"
 
   val staticDefaults = Map(
     FailOnStderrKey -> WdlBoolean(FailOnStderrDefaultValue),
-    ContinueOnReturnCodeKey -> WdlInteger(ContinueOnRcDefaultValue)
+    ContinueOnReturnCodeKey -> WdlInteger(ContinueOnRcDefaultValue),
+    CpuKey -> WdlInteger(CpuDefaultValue),
+    MemoryKey -> WdlString(MemoryDefaultValue),
+    DiskKey -> WdlString(DisksDefaultValue)
   )
 
   val coercionMap: Map[String, Set[WdlType]] = Map (
     FailOnStderrKey -> Set[WdlType](WdlBooleanType),
     ContinueOnReturnCodeKey -> ContinueOnReturnCode.validWdlTypes,
-    DockerKey -> Set(WdlStringType)
+    DockerKey -> Set(WdlStringType),
+    DockerWorkingDirKey -> Set(WdlStringType),
+    DockerOutputDirKey -> Set(WdlStringType),
+    CpuKey -> Set(WdlIntegerType),
+    MemoryKey -> Set(WdlStringType),
+    DiskKey -> Set(WdlStringType)
   )
 
   def apply(attrs: Map[String, WdlValue], options: WorkflowOptions): HtCondorRuntimeAttributes = {
@@ -33,10 +49,16 @@ object HtCondorRuntimeAttributes {
     val withDefaultValues = withDefaults(attrs, List(defaultFromOptions, staticDefaults))
 
     val docker = validateDocker(withDefaultValues.get(DockerKey), None.successNel)
+    val dockerWorkingDir = validateDockerWorkingDir(withDefaultValues.get(DockerWorkingDirKey), None.successNel)
+    val dockerOutputDir = validateDockerOutputDir(withDefaultValues.get(DockerOutputDirKey), None.successNel)
     val failOnStderr = validateFailOnStderr(withDefaultValues.get(FailOnStderrKey), noValueFoundFor(FailOnStderrKey))
     val continueOnReturnCode = validateContinueOnReturnCode(withDefaultValues.get(ContinueOnReturnCodeKey), noValueFoundFor(ContinueOnReturnCodeKey))
-    (continueOnReturnCode |@| docker |@| failOnStderr) {
-      new HtCondorRuntimeAttributes(_, _, _)
+    val cpu = validateCpu(withDefaultValues.get(CpuKey), noValueFoundFor(CpuKey))
+    val memory = validateMemory(withDefaultValues.get(MemoryKey), noValueFoundFor(MemoryKey))
+    val disk = validateDisk(withDefaultValues.get(DiskKey), noValueFoundFor(DiskKey))
+
+    (continueOnReturnCode |@| docker |@| dockerWorkingDir |@| dockerOutputDir |@| failOnStderr |@| cpu |@| memory |@| disk) {
+      new HtCondorRuntimeAttributes(_, _, _, _, _, _, _, _)
     } match {
       case Success(x) => x
       case Failure(nel) => throw new RuntimeException with MessageAggregation {
@@ -45,6 +67,40 @@ object HtCondorRuntimeAttributes {
       }
     }
   }
+
+  private def validateDockerWorkingDir(dockerWorkingDir: Option[WdlValue], onMissingKey: => ErrorOr[Option[String]]): ErrorOr[Option[String]] = {
+    dockerWorkingDir match {
+      case Some(WdlString(s)) => Some(s).successNel
+      case None => onMissingKey
+      case _ => s"Expecting $DockerWorkingDirKey runtime attribute to be a String".failureNel
+    }
+  }
+
+  private def validateDockerOutputDir(dockerOutputDir: Option[WdlValue], onMissingKey: => ErrorOr[Option[String]]): ErrorOr[Option[String]] = {
+    dockerOutputDir match {
+      case Some(WdlString(s)) => Some(s).successNel
+      case None => onMissingKey
+      case _ => s"Expecting $DockerOutputDirKey runtime attribute to be a String".failureNel
+    }
+  }
+
+  private def validateDisk(value: Option[WdlValue], onMissingKey: => ErrorOr[MemorySize]): ErrorOr[MemorySize] = {
+    val diskWrongFormatMsg = s"Expecting $DiskKey runtime attribute to be an Integer or String with format '8 GB'. Exception: %s"
+
+    value match {
+      case Some(i: WdlInteger) => parseMemoryInteger(i)
+      case Some(s: WdlString) => parseMemoryString(s)
+      case Some(_) => String.format(diskWrongFormatMsg, "Not supported WDL type value").failureNel
+      case None => onMissingKey
+    }
+  }
 }
 
-case class HtCondorRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode, dockerImage: Option[String], failOnStderr: Boolean)
+case class HtCondorRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode,
+                                     dockerImage: Option[String],
+                                     dockerWorkingDir: Option[String],
+                                     dockerOutputDir: Option[String],
+                                     failOnStderr: Boolean,
+                                     cpu: Int,
+                                     memory: MemorySize,
+                                     disk: MemorySize)

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
@@ -51,7 +51,21 @@ object HtCondorCommands {
 
 class HtCondorCommands extends StrictLogging {
 
-  def generateSubmitFile(path: Path, attributes: Map[String, String]): String = {
+  /**
+    * Writes the script file containing the user's command from the WDL as well
+    * as some extra shell code for monitoring jobs
+    */
+  def writeScript(instantiatedCommand: String, filePath: Path, containerRoot: Path): Unit = {
+    logger.debug(s"Writing bash script for execution. Command: $instantiatedCommand.")
+    filePath.write(
+      s"""#!/bin/sh
+          |cd $containerRoot
+          |$instantiatedCommand
+          |echo $$? > rc
+          |""".stripMargin)
+  }
+
+  def generateSubmitFile(path: Path, attributes: Map[String, Any]): String = {
     def htCondorSubmitCommand(filePath: Path) = {
       s"${HtCondorCommands.Submit} ${filePath.toString}"
     }
@@ -134,7 +148,9 @@ object HtCondorRuntimeKeys {
   val Queue = "queue"
   val Rank = "rank"
   val Requirements = "requirements"
-  val RequestMemory = "request_memory"
   val Cpu = "request_cpus"
+  val Memory = "request_memory"
   val Disk = "request_disk"
+  val LogXml = "log_xml"
+  val LeaveInQueue = "leave_in_queue"
 }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributesSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributesSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.backend.impl.htcondor
 
-import cromwell.backend.BackendWorkflowDescriptor
+import cromwell.backend.{MemorySize, BackendWorkflowDescriptor}
 import cromwell.backend.validation.ContinueOnReturnCodeSet
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.core.{WorkflowId, WorkflowOptions}
@@ -34,7 +34,10 @@ class HtCondorRuntimeAttributesSpec extends WordSpecLike with Matchers {
     """.stripMargin
 
   val emptyWorkflowOptions = WorkflowOptions(JsObject(Map.empty[String, JsValue]))
-  val staticDefaults = new HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), None, false)
+
+  val memorySize = MemorySize.parse("0.512 GB").get
+  val diskSize = MemorySize.parse("1.024 GB").get
+  val staticDefaults = new HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), None, None, None, false, 1, memorySize, diskSize)
 
   def workflowOptionsWithDefaultRA(defaults: Map[String, JsValue]) = {
     WorkflowOptions(JsObject(Map(
@@ -42,7 +45,7 @@ class HtCondorRuntimeAttributesSpec extends WordSpecLike with Matchers {
     )))
   }
 
-  "LocalRuntimeAttributes" should {
+  "HtCondorRuntimeAttributes" should {
     "return an instance of itself when there are no runtime attributes defined." in {
       val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
       assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, emptyWorkflowOptions, staticDefaults)
@@ -69,6 +72,52 @@ class HtCondorRuntimeAttributesSpec extends WordSpecLike with Matchers {
     "throw an exception when tries to validate an invalid Docker entry" in {
       val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: 1 }""").head
       assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting docker runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid docker working directory entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(dockerWorkingDir = Option("/workingDir"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerWorkingDir: "/workingDir" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, emptyWorkflowOptions, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid docker working directory entry based on input" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(dockerWorkingDir = Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerWorkingDir: "\${addressee}" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, emptyWorkflowOptions, expectedRuntimeAttributes)
+    }
+
+    "use workflow options as default if docker working directory key is missing" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val workflowOptions = workflowOptionsWithDefaultRA(Map("dockerWorkingDir" -> JsString("/workingDir")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, staticDefaults.copy(dockerWorkingDir = Some("/workingDir")))
+    }
+
+    "throw an exception when tries to validate an invalid docker working directory entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerWorkingDir: 1 }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting dockerWorkingDir runtime attribute to be a String")
+    }
+
+    "return an instance of itself when tries to validate a valid docker output directory entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(dockerOutputDir = Option("/outputDir"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerOutputDir: "/outputDir" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, emptyWorkflowOptions, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid docker output directory entry based on input" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(dockerOutputDir = Option("you"))
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerOutputDir: "\${addressee}" }""").head
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, emptyWorkflowOptions, expectedRuntimeAttributes)
+    }
+
+    "use workflow options as default if docker output directory key is missing" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val workflowOptions = workflowOptionsWithDefaultRA(Map("dockerOutputDir" -> JsString("/outputDir")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, staticDefaults.copy(dockerOutputDir = Some("/outputDir")))
+    }
+
+    "throw an exception when tries to validate an invalid docker output directory entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { dockerOutputDir: 1 }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting dockerOutputDir runtime attribute to be a String")
     }
 
     "return an instance of itself when tries to validate a valid failOnStderr entry" in {
@@ -105,6 +154,86 @@ class HtCondorRuntimeAttributesSpec extends WordSpecLike with Matchers {
       val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
       val workflowOptions = workflowOptionsWithDefaultRA(Map(ContinueOnReturnCodeKey -> JsArray(Vector(JsNumber(1), JsNumber(2)))))
       assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, staticDefaults.copy(continueOnReturnCode = ContinueOnReturnCodeSet(Set(1, 2))))
+    }
+
+    "return an instance of itself when tries to validate a valid cpu entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(cpu = 2)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { cpu: 2 }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map(CpuKey -> JsString("6")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid cpu entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { cpu: "value" }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting cpu runtime attribute to be an Integer")
+    }
+
+    "use workflow options as default if cpu key is missing" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val expectedRuntimeAttributes = staticDefaults.copy(cpu = 6)
+      val workflowOptions = workflowOptionsWithDefaultRA(Map(CpuKey -> JsString("6")))
+      val workflowOptions2 = workflowOptionsWithDefaultRA(Map(CpuKey -> JsNumber("6")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, expectedRuntimeAttributes)
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions2, expectedRuntimeAttributes)
+    }
+
+    "use default cpu value when there is no cpu key entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(cpu = 1)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map())
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid memory entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(memory = MemorySize.parse("1 GB").get)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { memory: "1 GB" }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map(MemoryKey -> JsString("blahaha")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid memory entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" memory: "value" }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting memory runtime attribute to be an Integer or String with format '8 GB'")
+    }
+
+    "use workflow options as default if memory key is missing" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val expectedRuntimeAttributes = staticDefaults.copy(memory = MemorySize.parse("65 GB").get)
+      val workflowOptions = workflowOptionsWithDefaultRA(Map(MemoryKey -> JsString("65 GB")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, expectedRuntimeAttributes)
+    }
+
+    "use default memory value when there is no memory key entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(memory = MemorySize.parse("0.512 GB").get)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map())
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
+    }
+
+    "return an instance of itself when tries to validate a valid disk entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(disk = MemorySize.parse("1 GB").get)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { disk: "1 GB" }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map("disk" -> JsString("blahaha")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
+    }
+
+    "throw an exception when tries to validate an invalid disk entry" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { docker: "ubuntu:latest" disk: "value" }""").head
+      assertHtCondorRuntimeAttributesFailedCreation(runtimeAttributes, "Expecting memory runtime attribute to be an Integer or String with format '8 GB'")
+    }
+
+    "use workflow options as default if disk key is missing" in {
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val expectedRuntimeAttributes = staticDefaults.copy(disk = MemorySize.parse("65 GB").get)
+      val workflowOptions = workflowOptionsWithDefaultRA(Map("disk" -> JsString("65 GB")))
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, workflowOptions, expectedRuntimeAttributes)
+    }
+
+    "use default disk value when there is no disk key entry" in {
+      val expectedRuntimeAttributes = staticDefaults.copy(disk = MemorySize.parse("1.024 GB").get)
+      val runtimeAttributes = createRuntimeAttributes(HelloWorld, """runtime { }""").head
+      val shouldBeIgnored = workflowOptionsWithDefaultRA(Map())
+      assertHtCondorRuntimeAttributesSuccessfulCreation(runtimeAttributes, shouldBeIgnored, expectedRuntimeAttributes)
     }
   }
 

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
@@ -7,7 +7,7 @@ import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.util.JSON
 import com.mongodb.{DBObject, WriteResult}
 import com.typesafe.config.{Config, ConfigFactory}
-import cromwell.backend.BackendJobDescriptorKey
+import cromwell.backend.{MemorySize, BackendJobDescriptorKey}
 import cromwell.backend.BackendJobExecutionActor.SucceededResponse
 import cromwell.backend.impl.htcondor.HtCondorRuntimeAttributes
 import cromwell.backend.impl.htcondor.caching.CacheActor._
@@ -31,7 +31,9 @@ class MongoCacheActorSpec extends TestKit(ActorSystem("MongoCacheProviderActorSp
 
   val config: Config = ConfigFactory.load()
   val mongoDbCollectionMock = mock[MongoCollection]
-  val runtimeConfig = HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), Some("tool-name"), true)
+  val memorySize = MemorySize.parse("0.512 GB").get
+  val diskSize = MemorySize.parse("1.024 GB").get
+  val runtimeConfig = HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), Some("tool-name"), Some("/workingDir"), Some("/outputDir"), true, 1, memorySize, diskSize)
   val jobHash = "88dde49db10f1551299fb9937f313c10"
   val taskStatus = "done"
   val succeededResponseMock = SucceededResponse(BackendJobDescriptorKey(Call(None, "TestJob", null, null, null, None), None, 0), None, Map("test" -> JobOutput(WdlString("Test"))))


### PR DESCRIPTION
- Added docker support to HtCondor backend without the idea of using HtCondor universe.
- Added Cpu, Memory, Disk, DockerWorkingDir and DockerOutputDir runtime attributes.

Formal reviewers: @gauravs90 and @geoffjentry.