### PR TITLE
REDO: Handle ActorInitializationException in supervisors Closes #1079 (#1084)

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -137,6 +137,8 @@ class WorkflowManagerActor(config: Config)
     /*
      Responses from services
      */
+      // TODO Restart: to be verified after restart is implemented but these WorkflowSucceededResponse/WorkflowFailedResponse seem useless
+      // Watching the transition should be enough for the WMA to do what it needs to
     case Event(WorkflowSucceededResponse(workflowId), data) =>
       log.info(s"$tag Workflow $workflowId succeeded!")
       stay()

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -137,7 +137,7 @@ class WorkflowManagerActor(config: Config)
     /*
      Responses from services
      */
-      // TODO Restart: to be verified after restart is implemented but these WorkflowSucceededResponse/WorkflowFailedResponse seem useless
+      // TODO PBE Restart: to be verified after restart is implemented but these WorkflowSucceededResponse/WorkflowFailedResponse seem useless
       // Watching the transition should be enough for the WMA to do what it needs to
     case Event(WorkflowSucceededResponse(workflowId), data) =>
       log.info(s"$tag Workflow $workflowId succeeded!")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
@@ -91,9 +91,6 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef, val wor
             val message = s"Workflow input processing failed."
             val errors = error
           })
-          error.zipWithIndex.foreach { case (err: String, idx: Int) =>
-            serviceRegistryActor ! PutMetadataAction(MetadataEvent(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Failures}[$idx]"), MetadataValue(err)))
-          }
           goto(MaterializationFailedState)
       }
     case Event(MaterializeWorkflowDescriptorAbortCommand, _) =>

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -2,7 +2,8 @@ package cromwell.engine.workflow.lifecycle.execution
 
 import java.time.OffsetDateTime
 
-import akka.actor.{ActorRef, FSM, LoggingFSM, Props}
+import akka.actor.SupervisorStrategy.{Escalate, Stop}
+import akka.actor._
 import com.typesafe.config.ConfigFactory
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
@@ -22,6 +23,7 @@ import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, Eng
 import cromwell.services.MetadataServiceActor._
 import cromwell.services._
 import lenthall.exception.ThrowableAggregation
+import wdl4s.Scope
 import wdl4s._
 import wdl4s.types.WdlArrayType
 import wdl4s.util.TryUtil
@@ -230,6 +232,14 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
 
   import WorkflowExecutionActor._
   import lenthall.config.ScalaConfig._
+
+  override def supervisorStrategy = AllForOneStrategy() {
+    case ex: ActorInitializationException =>
+      context.parent ! WorkflowExecutionFailedResponse(stateData.executionStore, stateData.outputStore, List(ex))
+      context.stop(self)
+      Stop
+    case t => super.supervisorStrategy.decider.applyOrElse(t, (_: Any) => Escalate)
+  }
 
   val tag = s"WorkflowExecutionActor [UUID(${workflowId.shortString})]"
   private lazy val DefaultMaxRetriesFallbackValue = 10

--- a/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -21,6 +21,8 @@ import scala.language.postfixOps
 
 object SimpleWorkflowActorSpec {
 
+  val failurePatternMatcher = """failures\[\d*\].message""".r
+
   object MetadataWatchActor {
     def props(matcher: Option[FailureMatcher], promise: Promise[Unit]): Props = Props(MetadataWatchActor(matcher, promise))
   }
@@ -43,7 +45,7 @@ object SimpleWorkflowActorSpec {
 
   case class FailureMatcher(value: String) {
     def matches(events: Traversable[MetadataEvent]): Boolean = {
-      events.exists(e => e.key.key == "failures[0]" && e.value.exists { v => v.value.contains(value) })
+      events.exists(e => failurePatternMatcher.findFirstIn(e.key.key).isDefined && e.value.exists { v => v.value.contains(value) })
     }
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -7,7 +7,6 @@ import better.files._
 import cromwell.backend.impl.jes.io._
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor, BackendWorkflowFinalizationActor}
 import cromwell.core.{ExecutionStore, OutputStore, PathCopier}
-import cromwell.core.retry.Retry
 import wdl4s.Call
 
 import scala.concurrent.Future
@@ -40,9 +39,7 @@ class JesFinalizationActor (override val workflowDescriptor: BackendWorkflowDesc
 
   private def deleteAuthenticationFile(): Future[Unit] = {
     if (jesConfiguration.needAuthFileUpload) {
-      val delete = () => Future(workflowPaths.gcsAuthFilePath.delete(false))
-
-      Retry.withRetry(delete, isFatal = isFatalJesException, isTransient = isTransientJesException)(context.system) map { _ => () }
+      Future(workflowPaths.gcsAuthFilePath.delete(false)) map { _ => () }
     } else {
       Future.successful(())
     }


### PR DESCRIPTION
With apologies to @Horneth, I merged too soon! This unfortunately caused  `sbt "test-only cromwellSimpleWorkflowActorSpec"` to hang indefinitely.

* Lazy-fiy workflowPaths to prevent actor from throwing during instantiation

* Handle ActorInitFailure with supervision

* with default'

* cleanup Workflow finalization

* clean imports

* PR commnet