### PR TITLE
JobStore read-side skeleton

### DIFF
--- a/engine/src/main/scala/cromwell/jobstore/JobResult.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobResult.scala
@@ -1,0 +1,8 @@
+package cromwell.jobstore
+
+import cromwell.core._
+
+sealed trait JobResult
+
+case class JobResultSuccess(returnCode: Option[Int], jobOutputs: JobOutputs) extends JobResult
+case class JobResultFailure(returnCode: Option[Int], reason: Throwable) extends JobResult

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreReader.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreReader.scala
@@ -1,0 +1,28 @@
+package cromwell.jobstore
+
+import akka.actor.{Actor, ActorLogging}
+import akka.event.LoggingReceive
+import cromwell.core.JobKey
+
+class JobStoreReader extends Actor with ActorLogging {
+  override def receive = LoggingReceive {
+    case QueryJobCompletion(jobKey) => sender ! JobNotComplete(jobKey)
+    case unknownMessage => log.error(s"Unexpected message to JobStoreReader: $unknownMessage")
+  }
+}
+
+/**
+  * Message to query the JobStoreReader, asks whether the specified job has already been completed.
+  */
+case class QueryJobCompletion(jobKey: JobKey)
+
+/**
+  * Message which indicates that a job has already completed, and contains the results of the job
+  */
+case class JobComplete(jobKey: JobKey, jobResult: JobResult)
+
+/**
+  * Indicates that the job has not been completed yet. Makes no statement about whether the job is
+  * running versus unstarted or (maybe?) doesn't even exist!
+  */
+case class JobNotComplete(jobKey: JobKey)


### PR DESCRIPTION
This is obviously a long way from being feature-complete, but is hopefully enough of a skeleton/statement of intent for JobStore readers to develop against in the meanwhile...