### PR TITLE
Added spray-routing-shapeless2 dependency to be able to work with Lens. Closes #1148

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
 
   val sprayDependencies = List(
     "io.spray" %% "spray-can" % sprayV,
-    "io.spray" %% "spray-routing" % sprayV,
+    "io.spray" %% "spray-routing-shapeless2" % sprayV,
     "io.spray" %% "spray-client" % sprayV,
     "io.spray" %% "spray-http" % sprayV,
     "io.spray" %% "spray-json" % DowngradedSprayV,


### PR DESCRIPTION
Minor change in order to get Spray and Lens working together.

Formal reviewers: @geoffjentry and @kshakir.