### PR TITLE
Work In Progress: Job Store Writing closes #1121

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -10,6 +10,7 @@ import cromwell.engine._
 import cromwell.engine.workflow.WorkflowActor._
 import cromwell.engine.workflow.WorkflowManagerActor._
 import cromwell.engine.workflow.lifecycle.CopyWorkflowLogsActor
+import cromwell.jobstore.JobStoreWriterService.RegisterWorkflowCompleted
 import cromwell.services.MetadataServiceActor._
 import cromwell.services.ServiceRegistryClient
 import cromwell.webservice.CromwellApiHandler._
@@ -162,9 +163,11 @@ class WorkflowManagerActor(config: Config, val workflowStore: ActorRef)
       // Watching the transition should be enough for the WMA to do what it needs to
     case Event(WorkflowSucceededResponse(workflowId), data) =>
       log.info(s"$tag Workflow $workflowId succeeded!")
+      serviceRegistryActor ! RegisterWorkflowCompleted(workflowId)
       stay()
     case Event(WorkflowFailedResponse(workflowId, inState, reasons), data) =>
       log.error(s"$tag Workflow $workflowId failed (during $inState): ${reasons.mkString("\n")}")
+      serviceRegistryActor ! RegisterWorkflowCompleted(workflowId)
       stay()
     /*
      Watched transitions

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -6,7 +6,7 @@ import cromwell.backend.{BackendInitializationData, BackendJobDescriptor, Backen
 import cromwell.core.logging.WorkflowLogging
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.JobPreparationActor.{BackendJobPreparationFailed, BackendJobPreparationSucceeded}
-import cromwell.jobstore._
+import cromwell.jobstore.{Pending => _, _}
 
 object EngineJobExecutionActor {
   /** States */
@@ -53,11 +53,11 @@ class EngineJobExecutionActor(executionData: WorkflowExecutionActorData,
     case Event(JobComplete(jobKey, jobResult), _) =>
       jobResult match {
         case JobResultSuccess(returnCode, jobOutputs) =>
-          context.parent ! new SucceededResponse(jobKey, returnCode, jobOutputs)
+          context.parent ! SucceededResponse(jobKey, returnCode, jobOutputs)
           context stop self
           stay()
         case JobResultFailure(returnCode, reason) =>
-          context.parent ! new FailedNonRetryableResponse(jobKey, reason, returnCode)
+          context.parent ! FailedNonRetryableResponse(jobKey, reason, returnCode)
           context stop self
           stay()
       }

--- a/engine/src/main/scala/cromwell/jobstore/FilesystemJobStoreDatabase.scala
+++ b/engine/src/main/scala/cromwell/jobstore/FilesystemJobStoreDatabase.scala
@@ -1,0 +1,66 @@
+package cromwell.jobstore
+
+import java.io.File
+import java.nio.file.{Files, Path, Paths}
+
+import cromwell.core.ExecutionIndex._
+import cromwell.core.{JobOutputs, WorkflowId}
+import spray.json._
+import wdl4s.WdlExpression
+import wdl4s.types.WdlArrayType
+import wdl4s.values._
+import cromwell.webservice.WdlValueJsonFormatter._
+import org.apache.commons.io.FileUtils
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+
+case object FilesystemJobStoreDatabase extends JobStoreDatabase {
+
+  val separator = File.separator
+  val fsroot = Paths.get("JobStore").toAbsolutePath
+
+  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId])(implicit ec: ExecutionContext): Future[Unit] = {
+    for {
+      _ <- writeJobResultsSerially(jobCompletions)
+      _ <- writeWorkflowResultsSerially(workflowCompletions)
+    } yield ()
+  }
+
+  private def writeJobResultsSerially(jobCompletions: Map[JobStoreKey, JobResult])(implicit ec: ExecutionContext): Future[Unit] = {
+
+    def folderFunction(current: Future[Unit], nextPair: (JobStoreKey, JobResult)): Future[Unit] = {
+      val (jobStoreKey, jobResult) = nextPair
+      current map { _ => writeJobResult(jobStoreKey, jobResult) }
+    }
+    jobCompletions.foldLeft(Future.successful(()))(folderFunction)
+  }
+
+  private def writeJobResult(jobStoreKey: JobStoreKey, jobResult: JobResult)(implicit ec: ExecutionContext): Future[Unit] = {
+    Future {
+      import JobResultJsonFormatter._
+      val fileDir = Paths.get(s"${fsroot.toString}$separator${jobStoreKey.workflowId}").toAbsolutePath
+      if (Files.notExists(fileDir)) Files.createDirectories(fileDir)
+      val filePath = Paths.get(s"$fileDir$separator${jobStoreKey.callFqn}_index${jobStoreKey.index.fromIndex}_attempt${jobStoreKey.attempt}")
+
+      FileUtils.writeStringToFile(filePath.toFile, jobResult.toJson.toString)
+    }
+  }
+
+  private def writeWorkflowResultsSerially(workflowCompletions: List[WorkflowId])(implicit ec: ExecutionContext): Future[Unit] = {
+
+    def folderFunction(current: Future[Unit], nextId: WorkflowId): Future[Unit] = current map { _ => clearWorkflowResults(nextId) }
+
+    workflowCompletions.foldLeft(Future.successful(()))(folderFunction)
+  }
+
+  private def clearWorkflowResults(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[Unit] = {
+    Future {
+      val path = Paths.get(s"${fsroot.toString}$separator$workflowId").toAbsolutePath
+      if (Files.exists(path)) {
+        //Files.delete(path)
+      }
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/jobstore/FilesystemJobStoreDatabase.scala
+++ b/engine/src/main/scala/cromwell/jobstore/FilesystemJobStoreDatabase.scala
@@ -59,7 +59,11 @@ case object FilesystemJobStoreDatabase extends JobStoreDatabase {
     Future {
       val path = Paths.get(s"${fsroot.toString}$separator$workflowId").toAbsolutePath
       if (Files.exists(path)) {
-        //Files.delete(path)
+        path.toFile.listFiles foreach { x =>
+          System.out.println(s"Nuking $path from orbit!")
+          Files.delete(x.toPath) }
+        System.out.println(s"Nuking $path from orbit!")
+        Files.delete(path)
       }
     }
   }

--- a/engine/src/main/scala/cromwell/jobstore/JobResult.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobResult.scala
@@ -1,8 +1,0 @@
-package cromwell.jobstore
-
-import cromwell.core._
-
-sealed trait JobResult
-
-case class JobResultSuccess(returnCode: Option[Int], jobOutputs: JobOutputs) extends JobResult
-case class JobResultFailure(returnCode: Option[Int], reason: Throwable) extends JobResult

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreDatabase.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreDatabase.scala
@@ -1,0 +1,9 @@
+package cromwell.jobstore
+
+import cromwell.core.WorkflowId
+
+import scala.concurrent.Future
+
+trait JobStoreDatabase {
+  def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit]
+}

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreDatabase.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreDatabase.scala
@@ -2,8 +2,8 @@ package cromwell.jobstore
 
 import cromwell.core.WorkflowId
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait JobStoreDatabase {
-  def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit]
+  def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId])(implicit ec: ExecutionContext): Future[Unit]
 }

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriter.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriter.scala
@@ -1,0 +1,22 @@
+package cromwell.jobstore
+
+import akka.actor.LoggingFSM
+import cromwell.core.{JobKey, WorkflowId}
+
+class JobStoreWriter extends LoggingFSM[JobStoreWriterState, JobStoreWriterData] {
+
+}
+
+object JobStoreWriter {
+
+}
+
+case class JobStoreWriterData(jobCompletionsList: Map[JobKey, JobResult], workflowCompletionsList: List[WorkflowId])
+
+sealed trait JobStoreWriterState
+case object NothinDoin extends JobStoreWriterState
+case object WritingToDatabase extends JobStoreWriterState
+
+sealed trait JobStoreWriterCommand
+case class RegisterJobCompleted(jobKey: JobKey, jobResult: JobResult)
+case class RegisterWorkflowCompleted(workflowId: WorkflowId)

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriter.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriter.scala
@@ -1,22 +1,98 @@
 package cromwell.jobstore
 
-import akka.actor.LoggingFSM
-import cromwell.core.{JobKey, WorkflowId}
+import akka.actor.{ActorRef, LoggingFSM, Props}
+import cromwell.core.WorkflowId
 
-class JobStoreWriter extends LoggingFSM[JobStoreWriterState, JobStoreWriterData] {
+import scala.util.{Failure, Success}
 
+/**
+  * Singleton actor to coordinate writing job statuses to the database.
+  *
+  * State: Represents an actor either doing nothing, or currently writing to the database
+  * Data: If currently writing, the actor stores pending updates in the data. When one write completes, any further writes are written
+  */
+case class JobStoreWriter(jsd: JobStoreDatabase) extends LoggingFSM[JobStoreWriterState, JobStoreWriterData] {
+
+  implicit val ec = context.dispatcher
+
+  startWith(Pending, JobStoreWriterData.empty)
+
+  when(Pending) {
+    case Event(command: RegisterCompletionMessage, stateData) =>
+      val newData = writeNextOperationToDatabase(stateData.withNewOperation(sender, command))
+      goto(WritingToDatabase) using newData
+  }
+
+  when(WritingToDatabase) {
+    case Event(command: RegisterCompletionMessage, stateData) =>
+      stay using stateData.withNewOperation(sender, command)
+    case Event(WriteComplete, stateData) =>
+      val newData = writeNextOperationToDatabase(stateData)
+      goto(if (newData.isEmpty) Pending else WritingToDatabase) using newData
+  }
+
+  whenUnhandled {
+    case Event(someMessage, stateData) =>
+      log.error(s"JobStoreWriter: Unexpected message received in state $stateName: $someMessage")
+      stay()
+  }
+
+  onTransition {
+    case (oldState, newState) =>
+      log.debug(s"Transitioning from $oldState to $newState")
+  }
+
+  def writeNextOperationToDatabase(data: JobStoreWriterData): JobStoreWriterData = {
+
+    val newData = data.rolledOver
+
+    val workflowCompletions = newData.currentOperation collect {
+      case (_, RegisterWorkflowCompleted(wfid)) =>  wfid
+    }
+
+    val jobCompletions = newData.currentOperation collect {
+      case (_, RegisterJobCompleted(jobStoreKey, jobResult)) if !workflowCompletions.contains(jobStoreKey.workflowId) => (jobStoreKey, jobResult)
+    }
+
+    if (!(workflowCompletions.isEmpty && jobCompletions.isEmpty)) {
+      jsd.writeToDatabase(jobCompletions.toMap, workflowCompletions) onComplete {
+        case Success(_) =>
+          newData.currentOperation foreach { case (actor, message) => actor ! JobStoreWriteSuccess(message) }
+          self ! WriteComplete
+        case Failure(reason) =>
+          newData.currentOperation foreach { case (actor, message) => actor ! JobStoreWriteFailure(message, reason) }
+          self ! WriteComplete
+      }
+    }
+
+    newData
+  }
 }
 
 object JobStoreWriter {
-
+  def props(jobStoreDatabase: JobStoreDatabase): Props = Props(new JobStoreWriter(jobStoreDatabase))
 }
 
-case class JobStoreWriterData(jobCompletionsList: Map[JobKey, JobResult], workflowCompletionsList: List[WorkflowId])
+object JobStoreWriterData {
+  def empty = JobStoreWriterData(List.empty, List.empty)
+}
+
+case class JobStoreWriterData(currentOperation: List[(ActorRef, RegisterCompletionMessage)], nextOperation: List[(ActorRef, RegisterCompletionMessage)]){
+  def isEmpty = nextOperation.isEmpty && currentOperation.isEmpty
+  def withNewOperation(sender: ActorRef, command: RegisterCompletionMessage) = this.copy(nextOperation = this.nextOperation :+ (sender, command))
+  def rolledOver = JobStoreWriterData(this.nextOperation, List.empty)
+}
 
 sealed trait JobStoreWriterState
-case object NothinDoin extends JobStoreWriterState
+case object Pending extends JobStoreWriterState
 case object WritingToDatabase extends JobStoreWriterState
 
-sealed trait JobStoreWriterCommand
-case class RegisterJobCompleted(jobKey: JobKey, jobResult: JobResult)
-case class RegisterWorkflowCompleted(workflowId: WorkflowId)
+sealed trait JobStoreWriterMessage
+sealed trait RegisterCompletionMessage extends JobStoreWriterMessage
+case class RegisterJobCompleted(jobKey: JobStoreKey, jobResult: JobResult) extends RegisterCompletionMessage
+case class RegisterWorkflowCompleted(workflowId: WorkflowId) extends RegisterCompletionMessage
+case object WriteComplete extends JobStoreWriterMessage
+
+sealed trait JobStoreWriterResponse
+case class JobStoreWriteSuccess(writeCommand: RegisterCompletionMessage) extends JobStoreWriterResponse
+case class JobStoreWriteFailure(writeCommand: RegisterCompletionMessage, reason: Throwable) extends JobStoreWriterResponse

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -59,7 +59,7 @@ case class JobStoreWriterActor(jsd: JobStoreDatabase) extends LoggingFSM[JobStor
         case Success(_) =>
           newData.currentOperation foreach { case (actor, message) =>
             val msg = JobStoreWriteSuccess(message)
-            log.info("*** Sending $msg")
+            log.info(s"*** Sending $msg")
             actor ! msg }
           self ! WriteComplete
         case Failure(reason) =>

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
@@ -6,7 +6,7 @@ import cromwell.core.WorkflowId
 import cromwell.jobstore.JobStoreWriterService.JobStoreWriterServiceCommand
 import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Joins the service registry API to the JobStoreWriterActor.
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 case class JobStoreWriterService(serviceConfig: Config, globalConfig: Config) extends Actor {
 
   // TODO: Replace with a real database, probably from config.
-  val database = new ConsoleOutputJobStoreDatabase()
+  val database = FilesystemJobStoreDatabase
   var JSWActor = context.actorOf(JobStoreWriterActor.props(database))
 
   override def receive: Receive = {
@@ -32,13 +32,4 @@ object JobStoreWriterService {
   sealed trait JobStoreWriterServiceResponse
   case class JobStoreWriteSuccess(originalCommand: JobStoreWriterServiceCommand) extends JobStoreWriterServiceResponse
   case class JobStoreWriteFailure(originalCommand: JobStoreWriterServiceCommand, reason: Throwable) extends JobStoreWriterServiceResponse
-}
-
-class ConsoleOutputJobStoreDatabase extends JobStoreDatabase {
-
-  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit] = {
-    System.out.println(s"Jobs completed: ${jobCompletions.mkString}")
-    System.out.println(s"Workflows completed: ${workflowCompletions.mkString}")
-    Future.successful(())
-  }
 }

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
@@ -1,0 +1,44 @@
+package cromwell.jobstore
+
+import akka.actor.{Actor, ActorRef}
+import com.typesafe.config.Config
+import cromwell.core.WorkflowId
+import cromwell.jobstore.JobStoreWriterService.JobStoreWriterServiceCommand
+import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
+
+import scala.concurrent.Future
+
+/**
+  * Joins the service registry API to the JobStoreWriterActor.
+  *
+  * This level of indirection is a tiny bit awkward but allows the database to be injected.
+  */
+case class JobStoreWriterService(serviceConfig: Config, globalConfig: Config) extends Actor {
+
+  // TODO: Replace with a real database, probably from config.
+  val database = new ConsoleOutputJobStoreDatabase()
+  var JSWActor = context.actorOf(JobStoreWriterActor.props(database))
+
+  override def receive: Receive = {
+    case command: JobStoreWriterServiceCommand => JSWActor.tell(command, sender)
+  }
+}
+
+object JobStoreWriterService {
+  sealed trait JobStoreWriterServiceCommand extends ServiceRegistryMessage { override def serviceName = "JobStoreWriter" }
+  case class RegisterJobCompleted(jobKey: JobStoreKey, jobResult: JobResult) extends JobStoreWriterServiceCommand
+  case class RegisterWorkflowCompleted(workflowId: WorkflowId) extends JobStoreWriterServiceCommand
+
+  sealed trait JobStoreWriterServiceResponse
+  case class JobStoreWriteSuccess(originalCommand: JobStoreWriterServiceCommand) extends JobStoreWriterServiceResponse
+  case class JobStoreWriteFailure(originalCommand: JobStoreWriterServiceCommand, reason: Throwable) extends JobStoreWriterServiceResponse
+}
+
+class ConsoleOutputJobStoreDatabase extends JobStoreDatabase {
+
+  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit] = {
+    System.out.println(s"Jobs completed: ${jobCompletions.mkString}")
+    System.out.println(s"Workflows completed: ${workflowCompletions.mkString}")
+    Future.successful(())
+  }
+}

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterService.scala
@@ -6,7 +6,6 @@ import cromwell.core.WorkflowId
 import cromwell.jobstore.JobStoreWriterService.JobStoreWriterServiceCommand
 import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
 
-import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Joins the service registry API to the JobStoreWriterActor.

--- a/engine/src/main/scala/cromwell/jobstore/package.scala
+++ b/engine/src/main/scala/cromwell/jobstore/package.scala
@@ -19,7 +19,7 @@ package object jobstore {
   object JobResultJsonFormatter extends DefaultJsonProtocol {
     implicit object ThrowableFormat extends RootJsonFormat[Throwable] {
       def write(value: Throwable) = value.getMessage.toJson
-      def read(value: JsValue): Throwable = new Exception(value.toString())
+      def read(value: JsValue): Throwable = new Exception(value.convertTo[String])
     }
 
     implicit object JobOutputFormat extends RootJsonFormat[JobOutput] {

--- a/engine/src/main/scala/cromwell/jobstore/package.scala
+++ b/engine/src/main/scala/cromwell/jobstore/package.scala
@@ -6,7 +6,7 @@ import cromwell.core.{JobKey, JobOutputs, WorkflowId}
   * Created by chrisl on 7/5/16.
   */
 package object jobstore {
-  case class JobStoreKey(workflowId: WorkflowId, callFqn: String, index: Option[Int])
+  case class JobStoreKey(workflowId: WorkflowId, callFqn: String, index: Option[Int], attempt: Int)
 
   sealed trait JobResult
   case class JobResultSuccess(returnCode: Option[Int], jobOutputs: JobOutputs) extends JobResult

--- a/engine/src/main/scala/cromwell/jobstore/package.scala
+++ b/engine/src/main/scala/cromwell/jobstore/package.scala
@@ -1,0 +1,15 @@
+package cromwell
+
+import cromwell.core.{JobKey, JobOutputs, WorkflowId}
+
+/**
+  * Created by chrisl on 7/5/16.
+  */
+package object jobstore {
+  case class JobStoreKey(workflowId: WorkflowId, callFqn: String, index: Option[Int])
+
+  sealed trait JobResult
+  case class JobResultSuccess(returnCode: Option[Int], jobOutputs: JobOutputs) extends JobResult
+  case class JobResultFailure(returnCode: Option[Int], reason: Throwable) extends JobResult
+
+}

--- a/engine/src/main/scala/cromwell/jobstore/package.scala
+++ b/engine/src/main/scala/cromwell/jobstore/package.scala
@@ -1,10 +1,14 @@
 package cromwell
 
-import cromwell.core.{JobKey, JobOutputs, WorkflowId}
+import cromwell.core.{JobKey, JobOutput, JobOutputs, WorkflowId}
+import spray.json._
+import wdl4s.WdlExpression
+import wdl4s.types.WdlArrayType
+import wdl4s.values._
+import cromwell.webservice.WdlFileJsonFormatter._
+import cromwell.webservice.WdlValueJsonFormatter.WdlValueJsonFormat
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
 
-/**
-  * Created by chrisl on 7/5/16.
-  */
 package object jobstore {
   case class JobStoreKey(workflowId: WorkflowId, callFqn: String, index: Option[Int], attempt: Int)
 
@@ -12,4 +16,35 @@ package object jobstore {
   case class JobResultSuccess(returnCode: Option[Int], jobOutputs: JobOutputs) extends JobResult
   case class JobResultFailure(returnCode: Option[Int], reason: Throwable) extends JobResult
 
+  object JobResultJsonFormatter extends DefaultJsonProtocol {
+    implicit object ThrowableFormat extends RootJsonFormat[Throwable] {
+      def write(value: Throwable) = value.getMessage.toJson
+      def read(value: JsValue): Throwable = new Exception(value.toString())
+    }
+
+    implicit object JobOutputFormat extends RootJsonFormat[JobOutput] {
+      def write(value: JobOutput) = value.wdlValue.toJson
+      def read(value: JsValue): JobOutput = JobOutput(WdlValueJsonFormat.read(value), None)
+    }
+
+    implicit val JobResultSuccessFormat = jsonFormat2(JobResultSuccess)
+    implicit val JobResultFailureFormat = jsonFormat2(JobResultFailure)
+
+    implicit object JobResultFormat extends RootJsonFormat[JobResult] {
+      def write(value: JobResult) = JsObject(
+        value.getClass.getSimpleName -> (value match {
+          case x: JobResultSuccess => x.toJson
+          case x: JobResultFailure => x.toJson
+        })
+      )
+      def read(value: JsValue): JobResult = {
+        val fields = value.asJsObject.fields
+        if (fields.contains("JobResultSuccess")) {
+          fields("JobResultSuccess").convertTo[JobResultSuccess]
+        } else {
+          fields("JobResultFailure").convertTo[JobResultFailure]
+        }
+      }
+    }
+  }
 }

--- a/engine/src/main/scala/cromwell/webservice/WdlValueJsonFormatter.scala
+++ b/engine/src/main/scala/cromwell/webservice/WdlValueJsonFormatter.scala
@@ -18,7 +18,11 @@ object WdlValueJsonFormatter extends DefaultJsonProtocol {
       case m: WdlMap => new JsObject(m.value map {case(k,v) => k.valueString -> write(v)})
       case e: WdlExpression => JsString(e.toWdlString)
     }
-    // NOTE: This is NOT a completely safe way to read values from JSON. Should only be used for testing.
+
+    // NOTE: This assumes a map's keys are strings. Since we're coming from JSON this is fine.
+    // This won't support a map with complex keys (e.g. WdlMapType(WdlMapType(WdlIntegerType, WdlIntegerType), WdlStringType)
+    // That would require a more inventive JSON which splits out the key and value as full fields in their own right...
+    // In addition, we make a lot of assumptions about what type of WdlValue to create. Oh well... it should all fall out in the coercion (fingercrossed)!
     def read(value: JsValue): WdlValue = value match {
       case JsObject(fields) =>
         val wdlFields: Map[WdlValue, WdlValue] = fields map {case (k, v) => WdlString(k) -> read(v)}

--- a/engine/src/test/scala/cromwell/jobstore/JobResultSpec.scala
+++ b/engine/src/test/scala/cromwell/jobstore/JobResultSpec.scala
@@ -1,0 +1,55 @@
+package cromwell.jobstore
+
+import cromwell.core.JobOutput
+import cromwell.jobstore.JobResultJsonFormatter._
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.values.WdlString
+import spray.json._
+import wdl4s.WdlExpression
+import wdl4s.types.{WdlArrayType, WdlIntegerType, WdlMapType, WdlStringType}
+import wdl4s.values._
+
+class JobResultSpec extends FlatSpec with Matchers {
+
+  behavior of "JobResultJsonWriter"
+
+  it should "write and read JSON for Job successes" in {
+
+    val success = JobResultSuccess(Some(0), Map("abc" -> JobOutput(WdlString("hello"), None)))
+    val asJson = success.toJson
+
+    val jsonString = asJson.toString()
+    jsonString shouldBe "{\"returnCode\":0,\"jobOutputs\":{\"abc\":\"hello\"}}"
+
+    val fromJsonString = jsonString.parseJson
+    val fromJson = fromJsonString.convertTo[JobResultSuccess]
+
+    fromJson shouldBe success
+  }
+
+  it should "write and read more complicated WdlValues" in {
+    val success = JobResultSuccess(Some(0), Map("abc" -> JobOutput(WdlMap(WdlMapType(WdlStringType, WdlIntegerType), Map(WdlString("hello") -> WdlInteger(4), WdlString("goodbye") -> WdlInteger(6))), None)))
+    val asJson = success.toJson
+
+    val jsonString = asJson.toString()
+    val fromJsonString = jsonString.parseJson
+    val fromJson = fromJsonString.convertTo[JobResultSuccess]
+
+    fromJson shouldBe success
+  }
+
+  it should "write and read JSON for job failures" in {
+
+    val failure = JobResultFailure(Some(0), new Exception("abc"))
+    val asJson = failure.toJson
+
+    val jsonString = asJson.toString()
+    jsonString shouldBe "{\"returnCode\":0,\"reason\":\"abc\"}"
+
+    val fromJsonString = jsonString.parseJson
+    val fromJson = fromJsonString.convertTo[JobResultFailure]
+
+    fromJson.returnCode shouldBe failure.returnCode
+    fromJson.reason.getMessage shouldBe failure.reason.getMessage
+  }
+}

--- a/engine/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
+++ b/engine/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.Matchers
 
 import scala.concurrent.duration._
 import language.postfixOps
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class JobStoreWriterSpec extends CromwellTestkitSpec with Matchers {
 
@@ -68,7 +68,8 @@ class JobStoreWriterSpec extends CromwellTestkitSpec with Matchers {
 
 class WriteCountingJobStoreDatabase(var totalWritesCalled: Int, var jobCompletionsRecorded: Int, var workflowCompletionsRecorded: Int) extends JobStoreDatabase {
 
-  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit] = {
+  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId])
+                              (implicit ec: ExecutionContext): Future[Unit] = {
     totalWritesCalled += 1
     jobCompletionsRecorded += jobCompletions.size
     workflowCompletionsRecorded += workflowCompletions.size

--- a/engine/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
+++ b/engine/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
@@ -1,0 +1,78 @@
+package cromwell.jobstore
+
+import cromwell.CromwellTestkitSpec
+import cromwell.core.WorkflowId
+import org.scalatest.Matchers
+import scala.concurrent.duration._
+import language.postfixOps
+
+import scala.concurrent.Future
+
+class JobStoreWriterSpec extends CromwellTestkitSpec with Matchers {
+
+  "JobStoreWriter" should {
+    "be able to collapse writes together if they arrive while a database access is ongoing" in {
+      val database = WriteCountingJobStoreDatabase.makeNew
+      val jsw = system.actorOf(JobStoreWriter.props(database))
+      val wfid = WorkflowId.randomId()
+      def jobKey(number: Int): JobStoreKey = JobStoreKey(wfid, s"call.fqn_$number", None)
+      val jobResult: JobResult = JobResultSuccess(Some(0), Map.empty)
+
+      jsw ! RegisterJobCompleted(jobKey(0), jobResult)
+      jsw ! RegisterJobCompleted(jobKey(1), jobResult)
+      jsw ! RegisterJobCompleted(jobKey(2), jobResult)
+      val received = receiveN(3, 10 seconds)
+      received foreach {
+        case JobStoreWriteSuccess(RegisterJobCompleted(JobStoreKey(jsk_wfid, jsk_callfqn, None), result)) =>
+          jsk_wfid shouldBe wfid
+          jsk_callfqn should startWith("call.fqn")
+          result shouldBe jobResult
+        case message => fail(s"Unexpected response message: $message")
+      }
+
+      database.totalWritesCalled shouldBe 2
+      database.jobCompletionsRecorded shouldBe 3
+      database.workflowCompletionsRecorded shouldBe 0
+    }
+
+    "be able to skip job-completion writes if the workflow completes, but still respond appropriately" in {
+      val database = WriteCountingJobStoreDatabase.makeNew
+      val jsw = system.actorOf(JobStoreWriter.props(database))
+      val wfid = WorkflowId.randomId()
+      def jobKey(number: Int): JobStoreKey = JobStoreKey(wfid, s"call.fqn_$number", None)
+      val jobResult: JobResult = JobResultSuccess(Some(0), Map.empty)
+
+      jsw ! RegisterJobCompleted(jobKey(0), jobResult)
+      jsw ! RegisterJobCompleted(jobKey(1), jobResult)
+      jsw ! RegisterWorkflowCompleted(wfid)
+      val received = receiveN(3, 10 seconds)
+      received foreach {
+        case JobStoreWriteSuccess(RegisterJobCompleted(JobStoreKey(jsk_wfid, jsk_callfqn, None), result)) =>
+          jsk_wfid shouldBe wfid
+          jsk_callfqn should startWith("call.fqn_")
+          result shouldBe jobResult
+        case JobStoreWriteSuccess(RegisterWorkflowCompleted(rwc_wfid)) =>
+          rwc_wfid shouldBe wfid
+        case message => fail(s"Unexpected response message: $message")
+      }
+
+      database.totalWritesCalled shouldBe 2
+      database.jobCompletionsRecorded shouldBe 1
+      database.workflowCompletionsRecorded shouldBe 1
+    }
+  }
+}
+
+class WriteCountingJobStoreDatabase(var totalWritesCalled: Int, var jobCompletionsRecorded: Int, var workflowCompletionsRecorded: Int) extends JobStoreDatabase {
+
+  override def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId]): Future[Unit] = {
+    totalWritesCalled += 1
+    jobCompletionsRecorded += jobCompletions.size
+    workflowCompletionsRecorded += workflowCompletions.size
+    Future.successful(())
+  }
+}
+
+object WriteCountingJobStoreDatabase {
+  def makeNew = new WriteCountingJobStoreDatabase(0, 0, 0)
+}

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -19,7 +19,9 @@ object ServiceRegistryActor {
   def serviceNameToPropsMap(globalConfig: Config): Map[String, Props] = {
     val serviceNamesToConfigStanzas = globalConfig.getObject("services").entrySet.asScala.map(x => x.getKey -> x.getValue).toMap
     serviceNamesToConfigStanzas map {
-      case (serviceName, config: ConfigObject) => serviceName -> serviceProps(serviceName, globalConfig, config.toConfig)
+      case (serviceName, config: ConfigObject) =>
+        System.out.println(s"Make me a service! $serviceName")
+        serviceName -> serviceProps(serviceName, globalConfig, config.toConfig)
       case (serviceName, _) => throw new Exception(s"Invalid configuration for service $serviceName")
     }
   }


### PR DESCRIPTION
Was meaning to push this before heading out for the week: 

A work-in-progress Job Store writer which skirts the problem of databases by not actually ever using one. Instead, every Job has a known filesystem location and we just write to and (not yet) read back from disk.

Currently has all of the hooks and wiring needed to write jobs the JobStore and clear them out on workflow completion. All that should be left is to update the JobStoreReader to read back the JSON from an appropriate file (but the tests are there for the JSON implicits and they seems good).

NB I went down the JSON route because I anticipate an eventual DB schema more like the metadata, to avoid having to store multiple MBs or GBs in a single cell.