### PR TITLE
Tweak Travis Centaur.wdl/inputs

### DIFF
--- a/src/bin/travis/resources/centaur.inputs
+++ b/src/bin/travis/resources/centaur.inputs
@@ -1,6 +1,7 @@
 {
   "centaur.centaur.cromwell_jar":"gs://cloud-cromwell-dev/travis-centaur/CROMWELL_JAR",
   "centaur.centaur.cromwell_branch":"BRANCH",
-  "centaur.centaur.conf":"gs://cloud-cromwell-dev/travis-centaur/jes.conf",
-  "centaur.centaur.pem":"gs://cloud-cromwell-dev/travis-centaur/cromwell-account.pem"
+  "centaur.centaur.conf":"gs://cloud-cromwell-dev/travis-centaur/refreshJes.conf",
+  "centaur.centaur.pem":"gs://cloud-cromwell-dev/travis-centaur/cromwell-account.pem",
+  "centaur.centaur.token": "gs://cloud-cromwell-dev/travis-centaur/token.txt"
 }

--- a/src/bin/travis/resources/centaur.inputs
+++ b/src/bin/travis/resources/centaur.inputs
@@ -1,7 +1,7 @@
 {
   "centaur.centaur.cromwell_jar":"gs://cloud-cromwell-dev/travis-centaur/CROMWELL_JAR",
   "centaur.centaur.cromwell_branch":"BRANCH",
-  "centaur.centaur.conf":"gs://cloud-cromwell-dev/travis-centaur/refreshJes.conf",
+  "centaur.centaur.conf":"gs://cloud-cromwell-dev/travis-centaur/multiBackend.conf",
   "centaur.centaur.pem":"gs://cloud-cromwell-dev/travis-centaur/cromwell-account.pem",
   "centaur.centaur.token": "gs://cloud-cromwell-dev/travis-centaur/token.txt"
 }

--- a/src/bin/travis/resources/centaur.wdl
+++ b/src/bin/travis/resources/centaur.wdl
@@ -1,3 +1,5 @@
+#TODO: replace rm_refreshToken_test and replace with develop
+
 task centaur {
     String cromwell_branch
     File conf

--- a/src/bin/travis/resources/centaur.wdl
+++ b/src/bin/travis/resources/centaur.wdl
@@ -1,5 +1,3 @@
-#TODO: replace rm_refreshToken_test with develop
-
 task centaur {
     String cromwell_branch
     File conf
@@ -13,7 +11,7 @@ task centaur {
         export SBT_OPTS=-Dsbt.ivy.home=/cromwell_root/tmp/.ivy2
         git clone https://github.com/broadinstitute/centaur.git
         cd centaur
-        git checkout rm_refreshToken_test
+        git checkout develop
         ./test_cromwell.sh -j${cromwell_jar} -c/cromwell_root/${conf} -r/cromwell_root -t ${secret}
     >>>
 

--- a/src/bin/travis/resources/centaur.wdl
+++ b/src/bin/travis/resources/centaur.wdl
@@ -3,14 +3,16 @@ task centaur {
     File conf
     File pem
     File cromwell_jar
+    File token
+    String secret = read_string(token)
 
     command<<<
         mkdir -p /cromwell_root/tmp/ivy2
         export SBT_OPTS=-Dsbt.ivy.home=/cromwell_root/tmp/.ivy2
         git clone https://github.com/broadinstitute/centaur.git
         cd centaur
-        git checkout develop
-        ./test_cromwell.sh -j${cromwell_jar} -c/cromwell_root/${conf} -r/cromwell_root
+        git checkout rm_refreshToken_test
+        ./test_cromwell.sh -j${cromwell_jar} -c/cromwell_root/${conf} -r/cromwell_root -t ${secret}
     >>>
 
     output {
@@ -25,7 +27,6 @@ task centaur {
         failOnStderr: false
     }
 }
-
 workflow centaur {
     call centaur
 }

--- a/src/bin/travis/resources/centaur.wdl
+++ b/src/bin/travis/resources/centaur.wdl
@@ -1,4 +1,4 @@
-#TODO: replace rm_refreshToken_test and replace with develop
+#TODO: replace rm_refreshToken_test with develop branch
 
 task centaur {
     String cromwell_branch

--- a/src/bin/travis/resources/centaur.wdl
+++ b/src/bin/travis/resources/centaur.wdl
@@ -1,4 +1,4 @@
-#TODO: replace rm_refreshToken_test with develop branch
+#TODO: replace rm_refreshToken_test with develop
 
 task centaur {
     String cromwell_branch


### PR DESCRIPTION
Making small changes to accommodate the Refresh_Token test in Centaur.

NOTE: There's a todo that requires changing the centaur.wdl command from "git checkout rm_refreshToken_test" --> "git checkout develop". Must merge the refresh_token test into Centaur first before the develop branch will pass.