### PR TITLE
Added support for cacheEnabled and cacheForceRw through workflow options. Closes #1163.

### DIFF
--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActor.scala
@@ -2,15 +2,17 @@ package cromwell.backend.impl.htcondor
 
 import akka.actor.Props
 import cromwell.backend.impl.htcondor.HtCondorInitializationActor._
+import cromwell.backend.impl.htcondor.HtCondorRuntimeAttributes._
 import cromwell.backend.validation.RuntimeAttributesKeys._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor, BackendWorkflowInitializationActor}
-import wdl4s.types.{WdlBooleanType, WdlStringType}
+import wdl4s.types.{WdlBooleanType, WdlIntegerType, WdlStringType}
 import wdl4s.{Call, WdlExpression}
 
 import scala.concurrent.Future
 
 object HtCondorInitializationActor {
-  val SupportedKeys = Set(DockerKey, FailOnStderrKey, ContinueOnReturnCodeKey)
+  val SupportedKeys = Set(DockerKey, DockerWorkingDirKey, DockerOutputDirKey, FailOnStderrKey,
+    ContinueOnReturnCodeKey, CpuKey, MemoryKey, DiskKey)
 
   def props(workflowDescriptor: BackendWorkflowDescriptor, calls: Seq[Call], configurationDescriptor: BackendConfigurationDescriptor): Props =
     Props(new HtCondorInitializationActor(workflowDescriptor, calls, configurationDescriptor))
@@ -22,8 +24,13 @@ class HtCondorInitializationActor(override val workflowDescriptor: BackendWorkfl
 
   override protected def runtimeAttributeValidators: Map[String, (Option[WdlExpression]) => Boolean] = Map(
     DockerKey -> wdlTypePredicate(valueRequired = false, WdlStringType.isCoerceableFrom),
+    DockerWorkingDirKey -> wdlTypePredicate(valueRequired = false, WdlStringType.isCoerceableFrom),
+    DockerOutputDirKey -> wdlTypePredicate(valueRequired = false, WdlStringType.isCoerceableFrom),
     FailOnStderrKey -> wdlTypePredicate(valueRequired = false, WdlBooleanType.isCoerceableFrom),
-    ContinueOnReturnCodeKey -> continueOnReturnCodePredicate(valueRequired = false)
+    ContinueOnReturnCodeKey -> continueOnReturnCodePredicate(valueRequired = false),
+    CpuKey -> wdlTypePredicate(valueRequired = false, WdlIntegerType.isCoerceableFrom),
+    MemoryKey -> wdlTypePredicate(valueRequired = false, WdlStringType.isCoerceableFrom),
+    DiskKey -> wdlTypePredicate(valueRequired = false, WdlStringType.isCoerceableFrom)
   )
 
   /**

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorRuntimeAttributes.scala
@@ -20,9 +20,9 @@ object HtCondorRuntimeAttributes {
   private val MemoryDefaultValue = "0.512 GB"
   private val DisksDefaultValue = "1.024 GB"
 
-  private val DockerWorkingDirKey = "dockerWorkingDir"
-  private val DockerOutputDirKey = "dockerOutputDir"
-  private val DiskKey = "disk"
+  val DockerWorkingDirKey = "dockerWorkingDir"
+  val DockerOutputDirKey = "dockerOutputDir"
+  val DiskKey = "disk"
 
   val staticDefaults = Map(
     FailOnStderrKey -> WdlBoolean(FailOnStderrDefaultValue),

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/CacheActorFactory.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/CacheActorFactory.scala
@@ -4,6 +4,6 @@ import akka.actor.Props
 
 trait CacheActorFactory {
 
-  def getCacheActorProps(): Props
+  def getCacheActorProps(forceRewrite: Boolean): Props
 
 }

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorFactory.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorFactory.scala
@@ -13,9 +13,8 @@ class MongoCacheActorFactory(config: Config) extends CacheActorFactory {
   val dbInstance: MongoClient = MongoClient(dbHost, dbPort)
   val db = dbInstance(dbName)
   val collection: MongoCollection = db(dbCollectionName)
-  val forceRewrite = config.getBoolean("cache.forceRewrite")
 
-  override def getCacheActorProps(): Props = {
+  override def getCacheActorProps(forceRewrite: Boolean): Props = {
     Props(new MongoCacheActor(collection, forceRewrite))
   }
 

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorInitializationActorSpec.scala
@@ -41,8 +41,8 @@ class HtCondorInitializationActorSpec extends TestKitSuite("HtCondorInitializati
   "HtCondorInitializationActor" should {
     "log a warning message when there are unsupported runtime attributes" in {
       within(Timeout) {
-        EventFilter.warning(message = s"Key/s [memory] is/are not supported by HtCondorBackend. Unsupported attributes will not be part of jobs executions.", occurrences = 1) intercept {
-          val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { memory: 1 }""")
+        EventFilter.warning(message = s"Key/s [proc] is/are not supported by HtCondorBackend. Unsupported attributes will not be part of jobs executions.", occurrences = 1) intercept {
+          val workflowDescriptor = buildWorkflowDescriptor(HelloWorld, runtime = """runtime { proc: 1 }""")
           val backend = getHtCondorBackend(workflowDescriptor, workflowDescriptor.workflowNamespace.workflow.calls,
             emptyBackendConfig)
           backend ! Initialize


### PR DESCRIPTION
1. Added cacheEnabled and cacheForceRw support in workflow options.
2. Added missing keys during initialization to log a warning message if a key is not in that list.

Reviewers: @jainh and @geoffjentry.