### PR TITLE
fixed type, and made more sensible default for JES filesystems auth

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -258,7 +258,7 @@ backend {
     //      }
     //    },
     //    JES {
-    //      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleFactory"
+    //      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleActorFactory"
     //      config {
     //        // Google project
     //        project = "my-cromwell-workflows"
@@ -287,7 +287,7 @@ backend {
     //        filesystems {
     //          gcs {
     //            // A reference to a potentially different auth for manipulating files via engine functions.
-    //            auth = "user-via-refresh"
+    //            auth = "application-default"
     //          }
     //        }
     //      }


### PR DESCRIPTION
The first is just a bug, the second is that the "default" in the commented out code is a complex scenario (refresh-token based JES usage) and ADC would be more common