### PR TITLE
JES Recover Closes #751

### DIFF
--- a/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
@@ -21,9 +21,15 @@ object AsyncBackendJobExecutionActor {
   private final case class FailAndStop(reason: Throwable) extends AsyncBackendJobExecutionActorMessage
   private final case class Finish(executionHandle: ExecutionHandle) extends AsyncBackendJobExecutionActorMessage
 
-  sealed trait ExecutionMode extends AsyncBackendJobExecutionActorMessage
+  trait JobId
+
+  sealed trait ExecutionMode extends AsyncBackendJobExecutionActorMessage {
+    def jobId: Option[JobId] = None
+  }
   case object Execute extends ExecutionMode
-  final case class Resume(executionInfos: Map[String, Option[String]]) extends ExecutionMode
+  final case class Recover(recoveryId: JobId) extends ExecutionMode {
+    override def jobId = Option(recoveryId)
+  }
   final case class UseCachedCall(cachedBackendCall: BackendJobDescriptor) extends ExecutionMode
 }
 

--- a/database/src/main/scala/cromwell/database/CromwellDatabase.scala
+++ b/database/src/main/scala/cromwell/database/CromwellDatabase.scala
@@ -3,6 +3,7 @@ package cromwell.database
 import cromwell.database.slick.SlickDatabase
 import cromwell.database.sql.SqlDatabase
 
+
 object CromwellDatabase {
   val databaseInterface: SqlDatabase = new SlickDatabase()
 }

--- a/database/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -143,6 +143,7 @@ class SlickDatabase(databaseConfig: Config) extends SqlDatabase
     dataAccess.driver.capabilities.contains(JdbcProfile.capabilities.insertOrUpdate)
 
   protected[this] def assertUpdateCount(description: String, updates: Int, expected: Int): DBIO[Unit] = {
+
     if (updates == expected) {
       DBIO.successful(Unit)
     } else {

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseAccess.scala
@@ -1,34 +1,7 @@
 package cromwell.services.keyvalue.impl
 
-import akka.actor.ActorSystem
-import cromwell.core.ExecutionIndex._
-import cromwell.util.DatabaseUtil._
-import cromwell.core.{JobKey, WorkflowId}
 import cromwell.database.Database
-import wdl4s.Scope
-
-import scala.concurrent.{ExecutionContext, Future}
 
 trait KeyValueDatabaseAccess { this: Database =>
 
-  def getExecutionInfoByKey(workflowId: WorkflowId, call: Scope, attempt: Int, key: String)
-                           (implicit ec: ExecutionContext): Future[Option[Option[String]]] = {
-    databaseInterface.getExecutionInfoByKey(workflowId.toString, call.fullyQualifiedName, attempt, key)
-  }
-
-  /**
-    * TODO: the interface for retrying SQL commands that might fail because
-    * of transient reasons (e.g. upsertExecutionInfo and upsertRuntimeAttributes)
-    * could be made better.  Also it'd be nice if it were transparently
-    * turned on/off for all methods in dataAccess.
-    *
-    * https://github.com/broadinstitute/cromwell/issues/693
-    */
-  def upsertExecutionInfo(workflowId: WorkflowId,
-                          callKey: JobKey,
-                          keyValues: Map[String, Option[String]])(implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[Unit] = {
-    withRetry (() =>
-      databaseInterface.upsertExecutionInfo(workflowId.toString, callKey.scope.fullyQualifiedName, callKey.index.fromIndex, callKey.attempt, keyValues)
-    )
-  }
 }


### PR DESCRIPTION
Doesn't close #751 but stabs in its general direction.  There is no persistent DB here, I replaced the DB-based approach in `KeyValueServiceActor` with a simple `Map` since the DB-based approach always failed to write due to referential integrity constraints that aren't going to be fixed (no `EXECUTION` or `WORKFLOW_EXECUTION` data for FK constraints).  Ruchi and/or I will have a follow-on PR to put a DB table behind this.

Also fixed "abort" to message the KV service instead of metadata service, removed now-unused `EXECUTION_INFO`-related methods, other assorted cleanup.