### PR TITLE
Cromwell initialization Calls Order. Closes #1215.

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
@@ -18,6 +18,7 @@ import wdl4s._
 import wdl4s.expression.NoFunctions
 import wdl4s.values.{WdlString, WdlValue}
 
+import scala.collection.immutable.ListMap
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 import scalaz.Scalaz._
@@ -179,7 +180,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef, val wor
 
   private def validateBackendAssignments(calls: Seq[Call], workflowOptions: WorkflowOptions, defaultBackendName: Option[String]): ErrorOr[Map[Call, String]] = {
     val callToBackendMap = Try {
-      calls map { call =>
+      ListMap(calls map { call =>
         val backendPriorities = Seq(
           workflowOptions.get(RuntimeBackendKey).toOption,
           assignBackendUsingRuntimeAttrs(call),
@@ -191,7 +192,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef, val wor
           case Some(backendName) => throw new Exception(s"Backend for call ${call.fullyQualifiedName} ('$backendName') not registered in configuration file")
           case None => throw new Exception(s"No backend could be found for call ${call.fullyQualifiedName}")
         }
-      } toMap
+      }:_*)
     }
 
     callToBackendMap match {


### PR DESCRIPTION
This change ensure during initialization of the Backedn the sequence of calls to are in an order as specified in the WDL file. As we are doing `groupBy()` that is changing the order but some of the backend require calls to be in an order.

Formal reviewer @geoffjentry @francares 