### PR TITLE
Return workflow outputs.  Closes #1257

### DIFF
--- a/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
@@ -232,7 +232,7 @@ class MetadataBuilderActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Me
       allDone
     case Event(WorkflowOutputsResponse(id, events), _) =>
       // Add in an empty output event if there aren't already any output events.
-      val hasOutputs = events collectFirst { case MetadataEvent(MetadataKey(_, _, key), _, _) if key == WorkflowMetadataKeys.Outputs => () } isDefined
+      val hasOutputs = events exists { _.key.key.startsWith(WorkflowMetadataKeys.Outputs + ":") }
       val updatedEvents = if (hasOutputs) events else MetadataEvent.empty(MetadataKey(id, None, WorkflowMetadataKeys.Outputs)) +: events
       context.parent ! RequestComplete(StatusCodes.OK, workflowMetadataResponse(id, updatedEvents, includeCallsIfEmpty = false))
       allDone


### PR DESCRIPTION
The outputs query was changed such that the key the `MetadataBuilderActor` was looking for in the `WorkflowOutputsResponse` handler was never returned.  `MetadataBuilderActor` quietly (some might say blithely) fell back to returning empty outputs.  

It's alarming that this total breakage was not caught by any tests.  But rather than add to the morass that is `CromwellTestKitSpec` I'm going to look at enhancing Centaur to be able to hit the outputs endpoint.