### PR TITLE
Wire in call cache reading. Closes #1232

### DIFF
--- a/backend/src/test/scala/cromwell/backend/caching/CachingConfigSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/caching/CachingConfigSpec.scala
@@ -29,7 +29,7 @@ class CachingConfigSpec extends FlatSpec with Matchers {
       readOption <- options
     } yield (ConfigFactory.parseMap(config.asJava), makeOptions(writeOption, readOption))).toSet
 
-    // writeCache is ON when config is ON and write-to-cache is None or true
+    // writeCache is ON when config is ON and write_to_cache is None or true
     val writeCacheOnCombinations = (for {
       config <- configs if config == configWithCallCachingOn
       writeOption <- options if writeOption.isEmpty || writeOption.get

--- a/database/src/main/resources/changelog.xml
+++ b/database/src/main/resources/changelog.xml
@@ -40,6 +40,7 @@
     <include file="changesets/backend_KV_Store.xml" relativeToChangelogFile="true" />
     <include file="changesets/job_store.xml" relativeToChangelogFile="true" />
     <include file="changesets/callcaching.xml" relativeToChangelogFile="true" />
+    <include file="changesets/call_caching_allow_result_reuse_fix.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>
 <!--
 

--- a/database/src/main/resources/changesets/call_caching_allow_result_reuse_fix.xml
+++ b/database/src/main/resources/changesets/call_caching_allow_result_reuse_fix.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <property name="boolean.type" value="BOOLEAN" dbms="!mysql"/>
+    <property name="boolean.type" value="TINYINT" dbms="mysql"/>
+
+    <changeSet id="call_caching_fix_boolean" author="mcovarr">
+        <modifyDataType columnName="ALLOW_RESULT_REUSE"
+                        newDataType="${boolean.type}"
+                        tableName="CALL_CACHING_RESULT_METAINFO"/>
+    </changeSet>
+
+    <changeSet id="call_caching_reuse_default" author="mcovarr">
+        <addDefaultValue columnName="ALLOW_RESULT_REUSE"
+                         defaultValueBoolean="true"
+                         tableName="CALL_CACHING_RESULT_METAINFO"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -23,9 +23,9 @@ trait CallCachingSlickDatabase extends CallCachingStore {
     runTransaction(action)
   }
 
-  override def metaInfoIdsMatchingHashes(hashKeyValuePairs: Seq[HashKeyAndValue])(implicit ec: ExecutionContext): Future[Set[MetaInfoId]] = {
+  override def metaInfoIdsMatchingHashes(hashKeyValuePairs: Set[HashKeyAndValue])(implicit ec: ExecutionContext): Future[Set[MetaInfoId]] = {
 
-    val actions = hashKeyValuePairs map { case HashKeyAndValue(hashKey, hashValue) => dataAccess.resultMetaInfoIdsForHashMatch(hashKey, hashValue).result }
+    val actions = hashKeyValuePairs.toList map { case HashKeyAndValue(hashKey, hashValue) => dataAccess.resultMetaInfoIdsForHashMatch(hashKey, hashValue).result }
     val action = DBIO.sequence(actions)
 
     def setIntersection(current: Set[Int], next: Seq[Int]) = current.intersect(next.toSet)

--- a/database/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
+++ b/database/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
@@ -1,6 +1,7 @@
 package cromwell.database.slick.tables
 
 import cromwell.database.sql.tables.CallCachingResultMetaInfoEntry
+import slick.profile.RelationalProfile.ColumnOption.Default
 
 trait CallCachingResultMetaInfoComponent {
 
@@ -14,7 +15,7 @@ trait CallCachingResultMetaInfoComponent {
     def callFqn = column[String]("CALL_FQN")
     def returnCode = column[Option[Int]]("RETURN_CODE")
     def scatterIndex = column[Int]("JOB_SCATTER_INDEX")
-    def allowResultReuse = column[Boolean]("ALLOW_RESULT_REUSE")
+    def allowResultReuse = column[Boolean]("ALLOW_RESULT_REUSE", Default(true))
 
     override def * = (workflowUuid, callFqn, scatterIndex, returnCode, allowResultReuse, callCachingResultMetaInfoId.?) <>
       (CallCachingResultMetaInfoEntry.tupled, CallCachingResultMetaInfoEntry.unapply)

--- a/database/src/main/scala/cromwell/database/sql/CallCachingStore.scala
+++ b/database/src/main/scala/cromwell/database/sql/CallCachingStore.scala
@@ -6,7 +6,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait CallCachingStore {
   def addToCache(metaInfo: CallCachingResultMetaInfoEntry, hashes: Iterable[HashKeyAndValue], result: Iterable[ResultSimpleton])(implicit ec: ExecutionContext): Future[Unit]
-  def metaInfoIdsMatchingHashes(hashKeyValuePairs: Seq[HashKeyAndValue])(implicit ec: ExecutionContext): Future[Set[MetaInfoId]]
+  def metaInfoIdsMatchingHashes(hashKeyValuePairs: Set[HashKeyAndValue])(implicit ec: ExecutionContext): Future[Set[MetaInfoId]]
   def fetchCachedResult(metaInfoId: MetaInfoId)(implicit ec: ExecutionContext): Future[Option[CachedResult]]
 }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -7,6 +7,7 @@ import cromwell.core.logging.WorkflowLogging
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core._
 import cromwell.database.CromwellDatabase
+import cromwell.database.sql.MetaInfoId
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.JobPreparationActor.{BackendJobPreparationFailed, BackendJobPreparationSucceeded}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, CallCacheHashes}
@@ -152,10 +153,10 @@ class EngineJobExecutionActor(jobKey: BackendJobDescriptorKey,
     context.actorOf(EngineJobHashingActor.props(jobDescriptor, fileHasherActor, activity))
   }
 
-  def lookupCachedResult(jobDescriptor: BackendJobDescriptor, cacheResultId: Int) = {
+  def lookupCachedResult(jobDescriptor: BackendJobDescriptor, cacheResultId: MetaInfoId) = {
     // TODO: Start up a backend job copying actor (if possible, otherwise just runJob). That should send back the BackendJobExecutionResponse
-    self ! FailedNonRetryableResponse(jobKey, new Exception("Call cache writing incomplete! Turn it off!!"), None)
-    // While the cache result is looked up, we wait for the resoonse just like we were waiting for a Job to complete:
+    self ! FailedNonRetryableResponse(jobKey, new Exception("Call cache result copying not implemented!"), None)
+    // While the cache result is looked up, we wait for the response just like we were waiting for a Job to complete:
     goto(RunningJob) using EJEAPartialCompletionData(None, None)
   }
 
@@ -173,7 +174,7 @@ class EngineJobExecutionActor(jobKey: BackendJobDescriptorKey,
 
   private def saveCacheResults(completionData: EJEASuccessfulCompletionDataWithHashes) = {
     val callCache = new CallCache(CromwellDatabase.databaseInterface)
-    context.actorOf(CallCacheWriteActor.props(callCache, workflowId, completionData.hashes, completionData.jobResult))
+    context.actorOf(CallCacheWriteActor.props(callCache, workflowId, completionData.hashes, completionData.jobResult), s"CallCacheWriteActor-$workflowId")
     goto(UpdatingCallCache) using completionData
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -1,0 +1,31 @@
+package cromwell.engine.workflow.lifecycle.execution.callcaching
+
+import akka.actor.{Actor, ActorLogging, Props}
+import cromwell.database.CromwellDatabase
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+object CallCacheReadActor {
+  def props(callCacheHashes: CallCacheHashes): Props = {
+    Props(new CallCacheReadActor(callCacheHashes))
+  }
+}
+
+class CallCacheReadActor(callCacheHashes: CallCacheHashes) extends Actor with ActorLogging {
+  {
+    implicit val ec: ExecutionContext = context.dispatcher
+
+    val replyTo = context.parent
+    val cache = new CallCache(CromwellDatabase.databaseInterface)
+    cache.fetchMetaInfoIdsMatchingHashes(callCacheHashes) onComplete {
+      case Success(s) => replyTo ! CacheResultMatchesForHashes(callCacheHashes.hashes, s)
+      case Failure(t) => replyTo ! CacheResultLookupFailure(t)
+    }
+  }
+
+  override def receive: Receive = {
+    case any => log.error("Unexpected message to CallCacheReadActor: " + any)
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FileHasherActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FileHasherActor.scala
@@ -40,7 +40,7 @@ object FileHasherActor {
   case class JobFileHashRequests(jobKey: JobKey, files: Iterable[SingleFileHashRequest]) extends FileHasherCommand
   case class HashesNoLongerRequired(jobKey: JobKey)
 
-  case class FileHasherResponse(hashResult: HashResult) extends HashResultMessage { override def hashes = List(hashResult) }
+  case class FileHasherResponse(hashResult: HashResult) extends HashResultMessage { override def hashes = Set(hashResult) }
 }
 
 
@@ -48,11 +48,10 @@ object FileHasherActor {
 @deprecated("This is really stupid", "always")
 class ReallyStupidFileHasher extends Actor with ActorLogging {
   override def receive: Receive = {
-    case JobFileHashRequests(jobKey, fileHashRequests) => {
+    case JobFileHashRequests(jobKey, fileHashRequests) =>
       fileHashRequests foreach { hashRequest =>
         sender ! HashResult(hashRequest.hashKey, HashValue(hashRequest.file.toAbsolutePath.toString))
       }
-    }
   }
 }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/package.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/package.scala
@@ -1,5 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution
 
+import cromwell.database.sql.MetaInfoId
+
 package object callcaching {
 
   // TODO: Find somewhere better for all these?
@@ -7,7 +9,8 @@ package object callcaching {
   case class HashValue(value: String)
   case class HashResult(hashKey: HashKey, hashValue: HashValue)
 
-  private[callcaching] case class CacheResultMatchesForHashes(hashResults: Iterable[HashResult], cacheResultIds: Set[Int])
+  private[callcaching] case class CacheResultMatchesForHashes(hashResults: Set[HashResult], cacheResultIds: Set[MetaInfoId])
+  private[callcaching] case class CacheResultLookupFailure(reason: Throwable)
 
   sealed trait CallCachingMode { def activity: Option[CallCachingActivity]; def readFromCache = false; def writeToCache = false; def lookupDockerHashes: Boolean = false }
   object CallCachingMode {


### PR DESCRIPTION
- Creates a `CallCacheReadActor` to find cache hits in the database.
- Fixes a bug on cache hit checking that was referencing obsolete state data and missing legitimate cache hits.
- Makes data types that are logically sets actually `Set`s.
- Fix data type of `ALLOW_RESULT_REUSE` to match the 0.19 equivalent.
- Fix `CallCachingResultMetaInfoComponent` file naming to match the updated class name.