### PR TITLE
Modified CallCacheReadActor to enable routing/pooling and better testing

### DIFF
--- a/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
@@ -15,8 +15,7 @@ case object CallCachingOff extends CallCachingMode {
 }
 
 case class CallCachingActivity (readWriteMode: ReadWriteMode,
-                                dockerHashingType: DockerHashingType,
-                                fileHashingType: FileHashingType) extends CallCachingMode
+                                dockerHashingType: DockerHashingType = HashDockerName) extends CallCachingMode
 {
   override val readFromCache = readWriteMode.r
   override val writeToCache = readWriteMode.w
@@ -35,7 +34,3 @@ case object ReadAndWriteCache extends ReadWriteMode
 sealed trait DockerHashingType
 case object HashDockerName extends DockerHashingType
 case object HashDockerNameAndLookupDockerHash extends DockerHashingType
-
-sealed trait FileHashingType
-case object HashFilePath extends FileHashingType
-case object HashFileContents extends FileHashingType

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -139,8 +139,9 @@ object WorkflowActor {
             serviceRegistryActor: ActorRef,
             workflowLogCopyRouter: ActorRef,
             jobStoreActor: ActorRef,
+            callCacheReadActor: ActorRef,
             dockerHashLookupActor: ActorRef): Props = {
-    Props(new WorkflowActor(workflowId, startMode, wdlSource, conf, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, dockerHashLookupActor)).withDispatcher(EngineDispatcher)
+    Props(new WorkflowActor(workflowId, startMode, wdlSource, conf, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor, dockerHashLookupActor)).withDispatcher(EngineDispatcher)
   }
 }
 
@@ -154,6 +155,7 @@ class WorkflowActor(val workflowId: WorkflowId,
                     serviceRegistryActor: ActorRef,
                     workflowLogCopyRouter: ActorRef,
                     jobStoreActor: ActorRef,
+                    callCacheReadActor: ActorRef,
                     dockerHashLookupActor: ActorRef)
   extends LoggingFSM[WorkflowActorState, WorkflowActorData] with WorkflowLogging with PathFactory {
 
@@ -204,6 +206,7 @@ class WorkflowActor(val workflowId: WorkflowId,
         workflowDescriptor,
         serviceRegistryActor,
         jobStoreActor,
+        callCacheReadActor,
         dockerHashLookupActor,
         initializationData,
         restarting = restarting), name = s"WorkflowExecutionActor-$workflowId")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
@@ -293,20 +293,16 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef, val wor
     val enabled = conf.getBooleanOption("call-caching.enabled").getOrElse(false)
     if (enabled) {
       val lookupDockerHashes = conf.getBooleanOption("call-caching.lookup-docker-hash").getOrElse(false)
-      // TODO: This option isn't advertised in the README and probably won't last very long, so don't get used to it!
-      val hashFileContents = conf.getBooleanOption("call-caching.hash-file-contents").getOrElse(true)
-
       val dockerHashingType = if (lookupDockerHashes) HashDockerNameAndLookupDockerHash else HashDockerName
-      val fileHashingType = if (hashFileContents) HashFileContents else HashFilePath
 
       val readFromCache = readOptionalOption(ReadFromCache)
       val writeToCache = readOptionalOption(WriteToCache)
 
       (readFromCache |@| writeToCache) {
         case (false, false) => CallCachingOff
-        case (true, false) => CallCachingActivity(ReadCache, dockerHashingType, fileHashingType)
-        case (false, true) => CallCachingActivity(WriteCache, dockerHashingType, fileHashingType)
-        case (true, true) => CallCachingActivity(ReadAndWriteCache, dockerHashingType, fileHashingType)
+        case (true, false) => CallCachingActivity(ReadCache, dockerHashingType)
+        case (false, true) => CallCachingActivity(WriteCache, dockerHashingType)
+        case (true, true) => CallCachingActivity(ReadAndWriteCache, dockerHashingType)
       }
     }
     else {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -1,32 +1,71 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
-import akka.actor.{Actor, ActorLogging, Props}
-import cromwell.database.CromwellDatabase
-import cromwell.engine.workflow.lifecycle.execution.{CacheResultLookupFailure, CacheResultMatchesForHashes}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
+import akka.pattern.pipe
+import cromwell.core.callcaching.HashResult
+import cromwell.database.sql.MetaInfoId
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 
-object CallCacheReadActor {
-  def props(callCacheHashes: CallCacheHashes): Props = {
-    Props(new CallCacheReadActor(callCacheHashes))
+/**
+  * Queues up work sent to it because its receive is non-blocking.
+  *
+  * Would be nice if instead there was a pull- rather than push-based mailbox but I can't find one...
+  */
+class CallCacheReadActor(cache: CallCache) extends Actor with ActorLogging {
+
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  var requestQueue: List[RequestTuple] = List.empty
+  var currentRequester: Option[ActorRef] = None
+
+  override def receive: Receive = {
+    case CacheLookupRequest(callCacheHashes) =>
+      receiveNewRequest(callCacheHashes)
+    case r: CallCacheReadActorResponse =>
+      currentRequester foreach { _ ! r }
+      cycleRequestQueue()
+    case other =>
+      log.error("Unexpected message type to CallCacheReadActor: " + other.getClass.getSimpleName)
+  }
+
+  private def runRequest(callCacheHashes: CallCacheHashes) = {
+    val response = cache.fetchMetaInfoIdsMatchingHashes(callCacheHashes) map {
+      CacheResultMatchesForHashes(callCacheHashes.hashes, _)
+    } recover {
+      case t => CacheResultLookupFailure(t)
+    }
+
+    response.pipeTo(self)
+  }
+
+  private def cycleRequestQueue() = requestQueue match {
+    case RequestTuple(replyTo, request) :: tail =>
+      currentRequester = Option(replyTo)
+      requestQueue = tail
+      runRequest(request)
+    case Nil =>
+      currentRequester = None
+  }
+
+  private def receiveNewRequest(callCacheHashes: CallCacheHashes) = currentRequester match {
+    case Some(x) => requestQueue :+= RequestTuple(sender, callCacheHashes)
+    case None =>
+      currentRequester = Option(sender)
+      runRequest(callCacheHashes)
   }
 }
 
-class CallCacheReadActor(callCacheHashes: CallCacheHashes) extends Actor with ActorLogging {
-  {
-    implicit val ec: ExecutionContext = context.dispatcher
+object CallCacheReadActor {
+  def props(callCache: CallCache): Props = Props(new CallCacheReadActor(callCache))
 
-    val replyTo = context.parent
-    val cache = new CallCache(CromwellDatabase.databaseInterface)
-    cache.fetchMetaInfoIdsMatchingHashes(callCacheHashes) onComplete {
-      case Success(s) => replyTo ! CacheResultMatchesForHashes(callCacheHashes.hashes, s)
-      case Failure(t) => replyTo ! CacheResultLookupFailure(t)
-    }
-  }
+  private[CallCacheReadActor] case class RequestTuple(requester: ActorRef, hashes: CallCacheHashes)
 
-  override def receive: Receive = {
-    case any => log.error("Unexpected message to CallCacheReadActor: " + any)
-  }
+  case class CacheLookupRequest(callCacheHashes: CallCacheHashes)
+
+  sealed trait CallCacheReadActorResponse
+  case class CacheResultMatchesForHashes(hashResults: Set[HashResult], cacheResultIds: Set[MetaInfoId]) extends CallCacheReadActorResponse
+  case class CacheResultLookupFailure(reason: Throwable) extends CallCacheReadActorResponse
 }

--- a/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestkitSpec.scala
@@ -3,7 +3,6 @@ package cromwell
 import java.nio.file.Paths
 import java.util.UUID
 
-import akka.actor.Actor.Receive
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.testkit._
@@ -14,6 +13,8 @@ import cromwell.core._
 import cromwell.core.retry.{Retry, SimpleExponentialBackoff}
 import cromwell.engine.backend.BackendConfigurationEntry
 import cromwell.engine.workflow.WorkflowManagerActor.RetrieveNewWorkflows
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor.{CacheLookupRequest, CacheResultMatchesForHashes}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowSubmittedToStore
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
 import cromwell.jobstore.JobStoreActor.{JobStoreWriteSuccess, JobStoreWriterCommand}
@@ -551,4 +552,14 @@ class AlwaysHappyJobStoreActor extends Actor {
 
 object AlwaysHappyJobStoreActor {
   def props: Props = Props(new AlwaysHappyJobStoreActor)
+}
+
+class EmptyCallCacheReadActor extends Actor {
+  override def receive: Receive = {
+    case CacheLookupRequest(CallCacheHashes(hashes)) => sender ! CacheResultMatchesForHashes(hashes, Set.empty)
+  }
+}
+
+object EmptyCallCacheReadActor {
+  def props: Props = Props(new EmptyCallCacheReadActor)
 }

--- a/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -63,10 +63,11 @@ class SimpleWorkflowActorSpec extends CromwellTestkitSpec {
     val watchActor = system.actorOf(MetadataWatchActor.props(matcher, promise), s"service-registry-$workflowId-${UUID.randomUUID()}")
     val workflowActor = TestFSMRef(
       factory = new WorkflowActor(workflowId, StartNewWorkflow, workflowSources, ConfigFactory.load(),
-        watchActor,
-        system.actorOf(Props.empty, s"workflow-copy-log-router-$workflowId-${UUID.randomUUID()}"),
-        system.actorOf(AlwaysHappyJobStoreActor.props),
-        system.actorOf(Props(new DockerHashLookupWorkerActor))),
+        serviceRegistryActor = watchActor,
+        workflowLogCopyRouter = system.actorOf(Props.empty, s"workflow-copy-log-router-$workflowId-${UUID.randomUUID()}"),
+        jobStoreActor = system.actorOf(AlwaysHappyJobStoreActor.props),
+        callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props),
+        dockerHashLookupActor = system.actorOf(Props(new DockerHashLookupWorkerActor))),
       name = s"workflow-actor-$workflowId"
     )
     WorkflowActorAndMetadataPromise(workflowActor, promise)

--- a/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -16,7 +16,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.DockerHashLookup
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
-import cromwell.{AlwaysHappyJobStoreActor, CromwellTestkitSpec}
+import cromwell.{AlwaysHappyJobStoreActor, CromwellTestkitSpec, EmptyCallCacheReadActor}
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
 import spray.json._
 
@@ -55,7 +55,9 @@ object SingleWorkflowRunnerActorSpec {
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec {
   private val workflowStore = system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor))
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
+  private val callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)
   private val dockerHashLookupActor = system.actorOf(Props(new DockerHashLookupWorkerActor))
+
 
   def workflowManagerActor(): ActorRef = {
     system.actorOf(Props(new WorkflowManagerActor(ConfigFactory.load(),
@@ -63,6 +65,7 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec {
       dummyServiceRegistryActor,
       dummyLogCopyRouter,
       jobStore,
+      callCacheReadActor,
       dockerHashLookupActor)), "WorkflowManagerActor")
   }
   


### PR DESCRIPTION
Most of this is just wiring so start by looking at the changes in CallCacheReadActor. I've updated it and made it accessed via a global, routed actor in CromwellRoot. Tests will inject their own dummy version.

Mainly this makes testing easier as it's easier to inject the actor rather than relying on it being created to aim at an empty database.

Potential downside: actor hierarchy is a little bit more top heavy now :(