### PR TITLE
Fix JobStore handling of File outputs.  Closes #1349.

### DIFF
--- a/database/src/main/scala/cromwell/database/sql/tables/CallCachingResultSimpletonEntry.scala
+++ b/database/src/main/scala/cromwell/database/sql/tables/CallCachingResultSimpletonEntry.scala
@@ -7,4 +7,4 @@ case class CallCachingResultSimpletonEntry
   wdlType: String,
   resultMetaInfoId: Int,
   callCachingResultSimpletonId: Option[Int]
-)
+) extends DatabaseSimpleton

--- a/database/src/main/scala/cromwell/database/sql/tables/DatabaseSimpleton.scala
+++ b/database/src/main/scala/cromwell/database/sql/tables/DatabaseSimpleton.scala
@@ -1,0 +1,7 @@
+package cromwell.database.sql.tables
+
+trait DatabaseSimpleton {
+  def simpletonKey: String
+  def simpletonValue: String
+  def wdlType: String
+}

--- a/database/src/main/scala/cromwell/database/sql/tables/JobStoreResultSimpletonEntry.scala
+++ b/database/src/main/scala/cromwell/database/sql/tables/JobStoreResultSimpletonEntry.scala
@@ -7,5 +7,5 @@ case class JobStoreResultSimpletonEntry
   wdlType: String,
   jobStoreId: Int,
   jobStoreSimpletonEntryId: Option[Int] = None
-)
+) extends DatabaseSimpleton
 

--- a/engine/src/main/scala/cromwell/Simpletons.scala
+++ b/engine/src/main/scala/cromwell/Simpletons.scala
@@ -1,0 +1,25 @@
+package cromwell
+
+import cromwell.core.simpleton.WdlValueSimpleton
+import cromwell.database.sql.tables.DatabaseSimpleton
+import wdl4s.types.{WdlBooleanType, WdlFloatType, WdlIntegerType, WdlStringType}
+import wdl4s.values.{WdlPrimitive, WdlSingleFile, WdlValue}
+
+import scala.util.Try
+
+object Simpletons {
+  /** Converts `DatabaseSimpleton`s to `WdlValueSimpleton`s, explicitly instantiating objects of "File" type
+    * to `WdlSingleFile` instances.
+    */
+  def toSimpleton(entry: DatabaseSimpleton): WdlValueSimpleton = {
+    val wdlValue: String => Try[WdlValue] = entry.wdlType match {
+      case "String" => WdlStringType.coerceRawValue
+      case "Int" => WdlIntegerType.coerceRawValue
+      case "Float" => WdlFloatType.coerceRawValue
+      case "Boolean" => WdlBooleanType.coerceRawValue
+      case "File" => s => Try(WdlSingleFile(s))
+      case _ => throw new RuntimeException(s"$entry: unrecognized WDL type: ${entry.wdlType}")
+    }
+    WdlValueSimpleton(entry.simpletonKey, wdlValue(entry.simpletonValue).get.asInstanceOf[WdlPrimitive])
+  }
+}

--- a/engine/src/main/scala/cromwell/jobstore/SqlJobStore.scala
+++ b/engine/src/main/scala/cromwell/jobstore/SqlJobStore.scala
@@ -1,14 +1,13 @@
 package cromwell.jobstore
 
+import cromwell.Simpletons._
 import cromwell.core.ExecutionIndex._
 import cromwell.core.WorkflowId
+import cromwell.core.simpleton.WdlValueBuilder
 import cromwell.core.simpleton.WdlValueSimpleton._
-import cromwell.core.simpleton.{WdlValueBuilder, WdlValueSimpleton}
 import cromwell.database.sql.JobStoreSqlDatabase
 import cromwell.database.sql.tables.{JobStoreEntry, JobStoreResultSimpletonEntry}
 import wdl4s.TaskOutput
-import wdl4s.types._
-import wdl4s.values.WdlPrimitive
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -48,17 +47,6 @@ class SqlJobStore(sqlDatabase: JobStoreSqlDatabase) extends JobStore {
         val simpletons: Int => Iterable[JobStoreResultSimpletonEntry] = _ => List.empty
         (entry, simpletons)
     }
-  }
-
-  private def toSimpleton(entry: JobStoreResultSimpletonEntry): WdlValueSimpleton = {
-    val wdlType: WdlType = entry.wdlType match {
-      case "String" => WdlStringType
-      case "Int" => WdlIntegerType
-      case "Float" => WdlFloatType
-      case "Boolean" => WdlBooleanType
-      case _ => throw new RuntimeException(s"$entry: unrecognized WDL type: ${entry.wdlType}")
-    }
-    WdlValueSimpleton(entry.simpletonKey, wdlType.coerceRawValue(entry.simpletonValue).get.asInstanceOf[WdlPrimitive])
   }
 
   override def readJobResult(jobStoreKey: JobStoreKey, taskOutputs: Seq[TaskOutput])(implicit ec: ExecutionContext): Future[Option[JobResult]] = {


### PR DESCRIPTION
* Handle "File" output types for the JobStore
* Create a common `DatabaseSimpleton` trait for Job Store and call cache result code to share
* Centralize logic for conversion of `DatabaseSimpleton`s to `WdlValueSimpleton`s