### PR TITLE
Evaluate runtime attributes outside the backend

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -38,8 +38,7 @@ trait BackendLifecycleActorFactory {
       new WorkflowPaths(workflowDescriptor, backendConfig).executionRoot
   }
 
-  def runtimeAttributeDefinitions(initializationDataOption: Option[BackendInitializationData]):
-  Set[RuntimeAttributeDefinition] = Set.empty
+  def runtimeAttributeDefinitions(initializationDataOption: Option[BackendInitializationData]): Set[RuntimeAttributeDefinition] = Set.empty
 
   lazy val fileHashingFunction: Option[FileHashingFunction] = None
   lazy val fileHashingWorkerCount: Int = 50

--- a/backend/src/main/scala/cromwell/backend/RuntimeAttributeDefinition.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeAttributeDefinition.scala
@@ -1,0 +1,54 @@
+package cromwell.backend
+
+import cromwell.core.WorkflowOptions
+import cromwell.util.JsonFormatting.WdlValueJsonFormatter
+import wdl4s.{WdlExpressionException, _}
+import wdl4s.expression.WdlStandardLibraryFunctions
+import wdl4s.util.TryUtil
+import wdl4s.values.WdlValue
+
+import scala.util.{Success, Try}
+
+/**
+  * @param name Attribute name (LHS of name: "value" in the runtime section).
+  * @param factoryDefault An optional default value for this attribute.
+  * @param usedInCallCaching Whether or not this attribute is used to determine a cache hit or miss. ALL attributes are hashed and stored.
+  */
+case class RuntimeAttributeDefinition(name: String, factoryDefault: Option[WdlValue], usedInCallCaching: Boolean)
+
+object RuntimeAttributeDefinition {
+
+  def evaluateRuntimeAttributes(unevaluated: RuntimeAttributes,
+                                wdlFunctions: WdlStandardLibraryFunctions,
+                                evaluatedInputs: Map[LocallyQualifiedName, WdlValue]): Try[Map[String, WdlValue]] = {
+    val tryInputs = evaluatedInputs map { case (x, y) => x -> Success(y) }
+    val mapBasedLookup = buildMapBasedLookup(tryInputs) _
+    val mapOfTries = unevaluated.attrs mapValues {
+      expr => expr.evaluate(mapBasedLookup, wdlFunctions)
+    }
+    TryUtil.sequenceMap(mapOfTries)
+  }
+
+  def buildMapBasedLookup(evaluatedDeclarations: Map[LocallyQualifiedName, Try[WdlValue]])(identifier: String): WdlValue = {
+    val successfulEvaluations = evaluatedDeclarations collect {
+      case (k, v) if v.isSuccess => k -> v.get
+    }
+    successfulEvaluations.getOrElse(identifier, throw new WdlExpressionException(s"Could not resolve variable $identifier as a task input"))
+  }
+
+  def addDefaultsToAttributes(runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition], workflowOptions: WorkflowOptions)
+                             (specifiedAttributes: Map[LocallyQualifiedName, WdlValue]): Map[LocallyQualifiedName, WdlValue] = {
+    import WdlValueJsonFormatter._
+    import spray.json._   // IGNORE INTELLIJ - this *is* required (unless it isn't any more, who will ever know...!)
+
+    def isUnspecifiedAttribute(name: String) = !specifiedAttributes.contains(name)
+
+    val missing = runtimeAttributeDefinitions filter { x => isUnspecifiedAttribute(x.name) }
+    val defaults = missing map { x => (x, workflowOptions.getDefaultRuntimeOption(x.name)) } collect {
+      case (runtimeAttributeDefinition, Success(jsValue)) => runtimeAttributeDefinition.name -> jsValue.convertTo[WdlValue]
+      case (RuntimeAttributeDefinition(name, Some(factoryDefault), _), _) => name -> factoryDefault
+    }
+
+    specifiedAttributes ++ defaults
+  }
+}

--- a/backend/src/main/scala/cromwell/backend/package.scala
+++ b/backend/src/main/scala/cromwell/backend/package.scala
@@ -3,7 +3,10 @@ package cromwell
 import com.typesafe.config.Config
 import cromwell.core.WorkflowOptions.WorkflowOption
 import cromwell.core.{JobKey, WorkflowId, WorkflowOptions}
+import cromwell.util.JsonFormatting.WdlValueJsonFormatter
 import wdl4s._
+import wdl4s.expression.WdlStandardLibraryFunctions
+import wdl4s.util.TryUtil
 import wdl4s.values.WdlValue
 
 import scala.language.postfixOps
@@ -60,6 +63,4 @@ package object backend {
   }
 
   case class PreemptedException(msg: String) extends Exception(msg)
-
-  case class RuntimeAttributeDefinition(name: String, required: Boolean, default: Option[WdlValue], usedInCallCaching: Boolean)
 }

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
@@ -181,14 +181,13 @@ object RuntimeAttributesValidation {
     */
   def toRuntimeAttributeDefinition(validation: RuntimeAttributesValidation[_]): RuntimeAttributeDefinition = {
     val name = validation.key
-    val unusedBoolean = false // ... at the time of this writing
     val default = validation.staticDefaultOption
     import cromwell.backend.validation.RuntimeAttributesKeys._
     val usedInCallCaching = name match {
       case DockerKey | ContinueOnReturnCodeKey | FailOnStderrKey => true
       case _ => false
     }
-    RuntimeAttributeDefinition(name, unusedBoolean, default, usedInCallCaching)
+    RuntimeAttributeDefinition(name, default, usedInCallCaching)
   }
 }
 

--- a/core/src/main/scala/cromwell/core/WorkflowOptions.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowOptions.scala
@@ -129,6 +129,8 @@ object WorkflowOptions {
     case Some(jsVal: JsValue) => Failure(new IllegalArgumentException(s"Unsupported value as JsValue: $jsVal"))
     case None => Failure(new OptionNotFoundException(s"Field not found: $key"))
   }
+
+  val empty = WorkflowOptions.fromMap(Map.empty).get
 }
 
 case class WorkflowOptions(jsObject: JsObject) {

--- a/core/src/main/scala/cromwell/util/JsonFormatting/WdlValueJsonFormatter.scala
+++ b/core/src/main/scala/cromwell/util/JsonFormatting/WdlValueJsonFormatter.scala
@@ -1,4 +1,4 @@
-package cromwell.webservice
+package cromwell.util.JsonFormatting
 
 import spray.json._
 import wdl4s.WdlExpression

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -589,7 +589,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
           case Some(factory) =>
             val ejeaName = s"${workflowDescriptor.id}-EngineJobExecutionActor-${jobKey.tag}"
             val ejeaProps = EngineJobExecutionActor.props(
-              jobKey, data, factory, initializationData.get(backendName), restarting, serviceRegistryActor,
+              self, jobKey, data, factory, initializationData.get(backendName), restarting, serviceRegistryActor,
               jobStoreActor, callCacheReadActor, backendName, workflowDescriptor.callCachingMode)
             val ejeaRef = context.actorOf(ejeaProps, ejeaName)
             pushNewJobMetadata(jobKey, backendName)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -5,7 +5,7 @@ import cromwell.core.ExecutionStatus._
 import cromwell.core.OutputStore.{OutputCallKey, OutputEntry}
 import cromwell.core._
 import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
-import cromwell.webservice.WdlValueJsonFormatter
+import cromwell.util.JsonFormatting.WdlValueJsonFormatter
 import wdl4s.Scope
 
 import scala.language.postfixOps

--- a/engine/src/main/scala/cromwell/jobstore/JobResultJsonFormatter.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobResultJsonFormatter.scala
@@ -1,7 +1,8 @@
 package cromwell.jobstore
 
 import cromwell.core.JobOutput
-import cromwell.webservice.WdlValueJsonFormatter.WdlValueJsonFormat
+import cromwell.util.JsonFormatting.WdlValueJsonFormatter
+import WdlValueJsonFormatter.WdlValueJsonFormat
 import spray.json.{DefaultJsonProtocol, JsValue, RootJsonFormat, _}
 
 object JobResultJsonFormatter extends DefaultJsonProtocol {

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -6,7 +6,8 @@ import cromwell.core.WorkflowSourceFiles
 import cromwell.engine._
 import cromwell.services.metadata.MetadataService
 import MetadataService.{WorkflowQueryResponse, WorkflowQueryResult}
-import cromwell.webservice.WdlValueJsonFormatter._
+import cromwell.util.JsonFormatting.WdlValueJsonFormatter
+import WdlValueJsonFormatter._
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
 
 object WorkflowJsonSupport extends DefaultJsonProtocol {

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -410,10 +410,12 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
     file
   }
 
+  val emptyWorkflowOptions = WorkflowOptions.fromMap(Map.empty).get
+
   private def prepareJob(source: String = helloWorldWdl, runtimeString: String = "", inputFiles: Option[Map[String, WdlValue]] = None): TestJobDescriptor = {
     val backendWorkflowDescriptor = buildWorkflowDescriptor(wdl = source, inputs = inputFiles.getOrElse(Map.empty), runtime = runtimeString)
     val backendConfigurationDescriptor = BackendConfigurationDescriptor(backendConfig, ConfigFactory.load)
-    val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty))
+    val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty), emptyWorkflowOptions, Set.empty)
     val jobPaths = new JobPaths(backendWorkflowDescriptor, backendConfig, jobDesc.key)
     val executionDir = jobPaths.callRoot
     val stdout = Paths.get(executionDir.path.toString, "stdout")

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -119,14 +119,8 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
   private def jesStderrFile = jesCallPaths.stderrPath
   private def jesLogFilename = jesCallPaths.jesLogFilename
   private lazy val call = jobDescriptor.key.call
-  private lazy val runtimeAttributes = {
-    val evaluatedAttributes = {
-      val evaluateAttrs = call.task.runtimeAttributes.attrs mapValues evaluate
-      // Fail the call if runtime attributes can't be evaluated
-      TryUtil.sequenceMap(evaluateAttrs, "Runtime attributes evaluation").get
-    }
-    JesRuntimeAttributes(evaluatedAttributes, jobDescriptor.workflowDescriptor.workflowOptions, jobLogger)
-  }
+  private lazy val runtimeAttributes = JesRuntimeAttributes(jobDescriptor.runtimeAttributes, jobLogger)
+
   override lazy val retryable = jobDescriptor.key.attempt <= runtimeAttributes.preemptible
   private lazy val workingDisk: JesAttachedDisk = runtimeAttributes.disks.find(_.name == JesWorkingDisk.Name).get
   private lazy val gcsExecPath: Path = callRootPath.resolve(JesExecScript)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -167,11 +167,8 @@ trait SharedFileSystemAsyncJobExecutionActor
     as[SharedFileSystemBackendInitializationData](backendInitializationDataOption)
 
   lazy val validatedRuntimeAttributes: ValidatedRuntimeAttributes = {
-    val evaluateAttrs = call.task.runtimeAttributes.attrs mapValues evaluate
-    // Fail the call if runtime attributes can't be evaluated
-    val evaluatedAttributes = TryUtil.sequenceMap(evaluateAttrs, "Runtime attributes evaluation").get
     val builder = initializationData.runtimeAttributesBuilder
-    builder.build(evaluatedAttributes, jobDescriptor.workflowDescriptor.workflowOptions, jobLogger)
+    builder.build(jobDescriptor.runtimeAttributes, jobLogger)
   }
 
   lazy val isDockerRun = RuntimeAttributesValidation.extractOption(

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
@@ -11,7 +11,7 @@ import better.files._
 
 import scala.concurrent.Future
 import cromwell.backend.io._
-import cromwell.core.{PathWriter, TailedWriter, TestKitSuite, UntailedWriter}
+import cromwell.core._
 import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito._
@@ -450,7 +450,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
   private def prepareJob(wdlSource: WdlSource = helloWorldWdl, runtimeString: String = passOnStderr, inputFiles: Option[Map[String, WdlValue]] = None, isCluster: Boolean = false): TestJobDescriptor = {
     val backendWorkflowDescriptor = buildWorkflowDescriptor(wdl = wdlSource, inputs = inputFiles.getOrElse(Map.empty), runtime = runtimeString)
     val backendConfigurationDescriptor = if (isCluster) BackendConfigurationDescriptor(backendClusterConfig, ConfigFactory.load) else BackendConfigurationDescriptor(backendClientConfig, ConfigFactory.load)
-    val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty))
+    val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty), WorkflowOptions.empty, Set.empty)
     val jobPaths = if (isCluster) new JobPaths(backendWorkflowDescriptor, backendClusterConfig, jobDesc.key) else new JobPaths(backendWorkflowDescriptor, backendClientConfig, jobDesc.key)
     val executionDir = jobPaths.callRoot
     val stdout = Paths.get(executionDir.path.toString, "stdout")


### PR DESCRIPTION
Known test failures:

- [x] cromwell.SimpleWorkflowActorSpec
- [x] cromwell.engine.workflow.SingleWorkflowRunnerActorWithBadMetadataSpec
- [x] cromwell.ArrayWorkflowSpec
- [x] cromwell.engine.workflow.SingleWorkflowRunnerActorWithMetadataSpec
- [x] cromwell.ArrayOfArrayCoercionSpec
- [x] cromwell.WdlFunctionsAtWorkflowLevelSpec
- [x] cromwell.MapWorkflowSpec
- [x] cromwell.WorkflowOutputsSpec
- [x] cromwell.engine.workflow.SingleWorkflowRunnerActorWithMetadataOnFailureSpec
- [x] cromwell.WorkflowFailSlowSpec
- [x] cromwell.FilePassingWorkflowSpec
- [x] cromwell.engine.workflow.SingleWorkflowRunnerActorNormalSpec
- [x] cromwell.engine.WorkflowManagerActorSpec
- [x] cromwell.MultipleFilesWithSameNameWorkflowSpec
- [x] cromwell.CopyWorkflowOutputsSpec
- [x] cromwell.PostfixQuantifierWorkflowSpec
- [x] cromwell.ScatterWorkflowSpec

Ready for review!