### PR TITLE
Jes cache hit copying closes #1369

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
@@ -15,11 +15,11 @@ object BackendCacheHitCopyingActor {
 
 trait BackendCacheHitCopyingActor extends Actor with ActorLogging with BackendJobLifecycleActor {
 
-  def copyCachedOutputs(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String, String], returnCode: Option[Int]): Future[BackendJobExecutionResponse]
+  def copyCachedOutputs(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String, String], returnCode: Option[Int]): BackendJobExecutionResponse
 
   def receive: Receive = LoggingReceive {
     case CopyOutputsCommand(simpletons, jobDetritus, returnCode) =>
-      performActionThenRespond(copyCachedOutputs(simpletons, jobDetritus, returnCode), onFailure = cachingFailed, andThen = context stop self)
+      performActionThenRespond(Future(copyCachedOutputs(simpletons, jobDetritus, returnCode)), onFailure = cachingFailed, andThen = context stop self)
     case AbortJobCommand =>
       abort()
       context.parent ! AbortedResponse(jobDescriptor.key)

--- a/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
@@ -10,12 +10,12 @@ import cromwell.core.simpleton.WdlValueSimpleton
 import scala.concurrent.Future
 
 object BackendCacheHitCopyingActor {
-  final case class CopyOutputsCommand(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int])
+  final case class CopyOutputsCommand(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String, String], returnCode: Option[Int])
 }
 
 trait BackendCacheHitCopyingActor extends Actor with ActorLogging with BackendJobLifecycleActor {
 
-  def copyCachedOutputs(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int]): Future[BackendJobExecutionResponse]
+  def copyCachedOutputs(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String, String], returnCode: Option[Int]): Future[BackendJobExecutionResponse]
 
   def receive: Receive = LoggingReceive {
     case CopyOutputsCommand(simpletons, jobDetritus, returnCode) =>

--- a/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
@@ -5,21 +5,21 @@ import akka.event.LoggingReceive
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
 import cromwell.backend.BackendJobExecutionActor.{AbortedResponse, BackendJobExecutionResponse, FailedNonRetryableResponse}
 import cromwell.backend.BackendLifecycleActor._
-import cromwell.core.JobOutputs
+import cromwell.core.simpleton.WdlValueSimpleton
 
 import scala.concurrent.Future
 
 object BackendCacheHitCopyingActor {
-  final case class CopyOutputsCommand(outputs: JobOutputs)
+  final case class CopyOutputsCommand(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int])
 }
 
 trait BackendCacheHitCopyingActor extends Actor with ActorLogging with BackendJobLifecycleActor {
 
-  def copyCachedOutputs(cachedOutputs: JobOutputs): Future[BackendJobExecutionResponse]
+  def copyCachedOutputs(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int]): Future[BackendJobExecutionResponse]
 
   def receive: Receive = LoggingReceive {
-    case CopyOutputsCommand(cachedOutputs) =>
-      performActionThenRespond(copyCachedOutputs(cachedOutputs), onFailure = cachingFailed, andThen = context stop self)
+    case CopyOutputsCommand(simpletons, jobDetritus, returnCode) =>
+      performActionThenRespond(copyCachedOutputs(simpletons, jobDetritus, returnCode), onFailure = cachingFailed, andThen = context stop self)
     case AbortJobCommand =>
       abort()
       context.parent ! AbortedResponse(jobDescriptor.key)

--- a/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
@@ -22,10 +22,10 @@ object BackendJobExecutionActor {
   sealed trait BackendJobExecutionActorResponse extends BackendWorkflowLifecycleActorResponse
 
   sealed trait BackendJobExecutionResponse extends BackendJobExecutionActorResponse { def jobKey: BackendJobDescriptorKey }
-  case class SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs) extends BackendJobExecutionResponse
+  case class SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs, jobDetritusFiles: Option[Map[String, String]] = None) extends BackendJobExecutionResponse
+  case class AbortedResponse(jobKey: BackendJobDescriptorKey) extends BackendJobExecutionResponse
   case class FailedNonRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobExecutionResponse
   case class FailedRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobExecutionResponse
-  case class AbortedResponse(jobKey: BackendJobDescriptorKey) extends BackendJobExecutionResponse
 }
 
 /**

--- a/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
@@ -72,8 +72,8 @@ trait AsyncBackendJobExecutionActor { this: Actor with ActorLogging =>
     case PollResponseReceived(handle) if handle.isDone => self ! Finish(handle)
     case PollResponseReceived(handle) =>
       context.system.scheduler.scheduleOnce(pollBackOff.backoffMillis.millis, self, IssuePollRequest(handle))
-    case Finish(SuccessfulExecutionHandle(outputs, returnCode, resultsClonedFrom)) =>
-      completionPromise.success(SucceededResponse(jobDescriptor.key, Some(returnCode), outputs))
+    case Finish(SuccessfulExecutionHandle(outputs, returnCode, jobDetritusFiles, resultsClonedFrom)) =>
+      completionPromise.success(SucceededResponse(jobDescriptor.key, Some(returnCode), outputs, Option(jobDetritusFiles)))
       context.stop(self)
     case Finish(FailedNonRetryableExecutionHandle(throwable, returnCode)) =>
       completionPromise.success(FailedNonRetryableResponse(jobDescriptor.key, throwable, returnCode))

--- a/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/async/AsyncBackendJobExecutionActor.scala
@@ -6,8 +6,7 @@ import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, S
 import cromwell.backend.async.AsyncBackendJobExecutionActor._
 import cromwell.core.CromwellFatalException
 import cromwell.core.retry.{Retry, SimpleExponentialBackoff}
-import cromwell.services.metadata.MetadataService
-import MetadataService.MetadataServiceResponse
+import cromwell.services.metadata.MetadataService.MetadataServiceResponse
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
@@ -12,9 +12,9 @@ trait ExecutionHandle {
   def result: ExecutionResult
 }
 
-final case class SuccessfulExecutionHandle(outputs: JobOutputs, returnCode: Int, resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionHandle {
+final case class SuccessfulExecutionHandle(outputs: JobOutputs, returnCode: Int, callOutputFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionHandle {
   override val isDone = true
-  override val result = SuccessfulExecution(outputs, returnCode, resultsClonedFrom)
+  override val result = SuccessfulExecution(outputs, returnCode, callOutputFiles, resultsClonedFrom)
 }
 
 final case class FailedNonRetryableExecutionHandle(throwable: Throwable, returnCode: Option[Int] = None) extends ExecutionHandle {

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
@@ -12,9 +12,9 @@ trait ExecutionHandle {
   def result: ExecutionResult
 }
 
-final case class SuccessfulExecutionHandle(outputs: JobOutputs, returnCode: Int, callOutputFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionHandle {
+final case class SuccessfulExecutionHandle(outputs: JobOutputs, returnCode: Int, jobDetritusFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionHandle {
   override val isDone = true
-  override val result = SuccessfulExecution(outputs, returnCode, callOutputFiles, resultsClonedFrom)
+  override val result = SuccessfulExecution(outputs, returnCode, jobDetritusFiles, resultsClonedFrom)
 }
 
 final case class FailedNonRetryableExecutionHandle(throwable: Throwable, returnCode: Option[Int] = None) extends ExecutionHandle {

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
@@ -11,7 +11,7 @@ sealed trait ExecutionResult
 /**
  * A successful execution with resolved outputs.
  */
-final case class SuccessfulExecution(outputs: JobOutputs, returnCode: Int, resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionResult
+final case class SuccessfulExecution(outputs: JobOutputs, returnCode: Int, jobOutputFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionResult
 
 /**
  * A user-requested abort of the command.

--- a/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionResult.scala
@@ -11,7 +11,7 @@ sealed trait ExecutionResult
 /**
  * A successful execution with resolved outputs.
  */
-final case class SuccessfulExecution(outputs: JobOutputs, returnCode: Int, jobOutputFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionResult
+final case class SuccessfulExecution(outputs: JobOutputs, returnCode: Int, jobDetritusFiles: Map[String, String], resultsClonedFrom: Option[BackendJobDescriptor] = None) extends ExecutionResult
 
 /**
  * A user-requested abort of the command.

--- a/backend/src/test/scala/cromwell/backend/BackendSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/BackendSpec.scala
@@ -69,7 +69,7 @@ trait BackendSpec extends ScalaFutures with Matchers {
 
   def assertResponse(executionResponse: BackendJobExecutionResponse, expectedResponse: BackendJobExecutionResponse) = {
     (executionResponse, expectedResponse) match {
-      case (SucceededResponse(_, _, responseOutputs), SucceededResponse(_, _, expectedOutputs)) =>
+      case (SucceededResponse(_, _, responseOutputs, _), SucceededResponse(_, _, expectedOutputs, _)) =>
         responseOutputs.size shouldBe expectedOutputs.size
         responseOutputs foreach {
           case (fqn, out) =>

--- a/core/src/main/scala/cromwell/core/PathCopier.scala
+++ b/core/src/main/scala/cromwell/core/PathCopier.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import better.files._
 
 object PathCopier {
-  def copy(sourceContextPath: Path, sourceFilePath: Path, destinationDirPath: Path): Unit = {
+  def  copy(sourceContextPath: Path, sourceFilePath: Path, destinationDirPath: Path): Unit = {
     val relativeFileString: String = sourceContextPath.toAbsolutePath.relativize(sourceFilePath.toAbsolutePath).toString
     val destinationFilePath: Path = destinationDirPath.resolve(relativeFileString)
     copy(sourceFilePath, destinationFilePath)

--- a/core/src/main/scala/cromwell/core/PathCopier.scala
+++ b/core/src/main/scala/cromwell/core/PathCopier.scala
@@ -5,14 +5,14 @@ import java.nio.file.Path
 import better.files._
 
 object PathCopier {
-  def  copy(sourceContextPath: Path, sourceFilePath: Path, destinationDirPath: Path): Unit = {
+  def copy(sourceContextPath: Path, sourceFilePath: Path, destinationDirPath: Path, overwrite: Boolean): Unit = {
     val relativeFileString: String = sourceContextPath.toAbsolutePath.relativize(sourceFilePath.toAbsolutePath).toString
     val destinationFilePath: Path = destinationDirPath.resolve(relativeFileString)
-    copy(sourceFilePath, destinationFilePath)
+    copy(sourceFilePath, destinationFilePath, overwrite)
   }
 
-  def copy(sourceFilePath: Path, destinationFilePath: Path): Unit = {
+  def copy(sourceFilePath: Path, destinationFilePath: Path, overwrite: Boolean = false): Unit = {
     Option(File(destinationFilePath).parent).foreach(_.createDirectories())
-    File(sourceFilePath).copyTo(destinationFilePath)
+    File(sourceFilePath).copyTo(destinationFilePath, overwrite)
   }
 }

--- a/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
@@ -13,6 +13,8 @@ sealed trait CallCachingMode {
 }
 
 case object CallCachingOff extends CallCachingMode {
+  override val readFromCache = false
+  override val writeToCache = false
   override val withoutRead = this
   override val withoutWrite = this
 }

--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -46,6 +46,7 @@
     <include file="changesets/summary_status_table.xml" relativeToChangelogFile="true"/>
     <include file="changesets/standardize_column_names.xml" relativeToChangelogFile="true" />
     <include file="changesets/metadata_migration.xml" relativeToChangelogFile="true" />
+    <include file="changesets/call_caching_job_detritus.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>
 <!--
 

--- a/database/migration/src/main/resources/changesets/call_caching_job_detritus.xml
+++ b/database/migration/src/main/resources/changesets/call_caching_job_detritus.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="rmunshi" id="call_caching_job_detritus">
+        <comment>
+            One row per job detritus file per job (i.e, one row for the stdout, stderr, etc)
+            The standard output key contains the filename, such as hello-stdout, and the standard
+            output value contains the file path, such as gs://cromwell-root/hello/call-hello/hello-stdout.log.
+        </comment>
+        <createTable tableName="CALL_CACHING_JOB_DETRITUS">
+            <column autoIncrement="true" name="CALL_CACHING_JOB_DETRITUS_ID" type="INT">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_JOB_DETRITUS_ID"/>
+            </column>
+            <column name="JOB_DETRITUS_KEY" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_DETRITUS_VALUE" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="RESULT_METAINFO_ID" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <!-- Don't want to store the same standard output key twice for each job/RESULT_METAINFO_ID) -->
+    <changeSet author="rmunshi" id="call_caching_job_detritus_key_uniqueness">
+        <addUniqueConstraint constraintName="UK_CALL_CACHING_JOB_DETRITUS_KEY"
+                             tableName="CALL_CACHING_JOB_DETRITUS" columnNames="JOB_DETRITUS_KEY, RESULT_METAINFO_ID" />
+    </changeSet>
+
+    <!-- Make RESULT_METAINFO_ID a FK into CALL_CACHING_RESULT_METAINFO -->
+    <changeSet author="rmunshi" id="call_caching_job_detritus_foreign_key">
+        <addForeignKeyConstraint constraintName="CCJD_RESULT_METAINFO_ID_FK"
+                                 baseTableName="CALL_CACHING_JOB_DETRITUS"
+                                 baseColumnNames="RESULT_METAINFO_ID"
+                                 referencedTableName="CALL_CACHING_RESULT_METAINFO"
+                                 referencedColumnNames="CALL_CACHING_RESULT_METAINFO_ID"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/call_caching_job_detritus.xml
+++ b/database/migration/src/main/resources/changesets/call_caching_job_detritus.xml
@@ -5,9 +5,11 @@
 
     <changeSet author="rmunshi" id="call_caching_job_detritus">
         <comment>
-            One row per job detritus file per job (i.e, one row for the stdout, stderr, etc)
-            The standard output key contains the filename, such as hello-stdout, and the standard
-            output value contains the file path, such as gs://cromwell-root/hello/call-hello/hello-stdout.log.
+            One row per job detritus file (i.e, one row for the stdout, stderr, etc)
+            The job detritus key contains the filename, such as hello-stdout, and the job detritus
+            value contains the file path, such as gs://cromwell-root/hello/call-hello/hello-stdout.log.
+            Additionally there is a backend-specific key used to save the root directory path of the
+            given job.
         </comment>
         <createTable tableName="CALL_CACHING_JOB_DETRITUS">
             <column autoIncrement="true" name="CALL_CACHING_JOB_DETRITUS_ID" type="INT">

--- a/database/sql/src/main/scala/cromwell/database/slick/BackendKVStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/BackendKVStoreSlickDatabase.scala
@@ -10,7 +10,6 @@ trait BackendKVStoreSlickDatabase extends BackendKVStoreSqlDatabase {
 
   import dataAccess.driver.api._
 
-
   override def addBackendStoreKeyValuePair(workflowUuid: String, callFqn: String, callIndex: Int, callAttempt: Int, storeKey: String, storeValue: String)(implicit ec: ExecutionContext): Future[Unit] = {
 
     val entry = BackendKVStoreEntry(workflowUuid,
@@ -43,4 +42,3 @@ trait BackendKVStoreSlickDatabase extends BackendKVStoreSqlDatabase {
     runTransaction(action)
   }
 }
-

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -40,8 +40,8 @@ trait CallCachingSlickDatabase extends CallCachingStore {
 
   override def fetchCachedResult(callCachingResultMetaInfoId: Int)(implicit ec: ExecutionContext):
                                   Future[(Option[CallCachingResultMetaInfoEntry],
-                                  Seq[CallCachingResultSimpletonEntry],
-                                  Seq[CallCachingJobDetritusEntry])] = {
+                                         Seq[CallCachingResultSimpletonEntry],
+                                         Seq[CallCachingJobDetritusEntry])] = {
     val action = for {
       metaInfo <- dataAccess.metaInfoById(callCachingResultMetaInfoId).result.headOption
       resultSimpletons <- dataAccess.resultSimpletonsForMetaInfoId(callCachingResultMetaInfoId).result

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -1,9 +1,10 @@
 package cromwell.database.slick
 
 import cromwell.database.sql._
-import cromwell.database.sql.tables.{CallCachingHashEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
+import cromwell.database.sql.tables.{CallCachingHashEntry, CallCachingJobDetritusEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scalaz.NonEmptyList
 
 trait CallCachingSlickDatabase extends CallCachingStore {
   this: SlickDatabase =>
@@ -12,33 +13,40 @@ trait CallCachingSlickDatabase extends CallCachingStore {
 
   override def addToCache(callCachingResultMetaInfo: CallCachingResultMetaInfoEntry,
                           hashesToInsert: Int => Iterable[CallCachingHashEntry],
-                          resultToInsert: Int => Iterable[CallCachingResultSimpletonEntry])
+                          resultToInsert: Int => Iterable[CallCachingResultSimpletonEntry],
+                          jobDetritusToInsert: Int => Iterable[CallCachingJobDetritusEntry])
                          (implicit ec: ExecutionContext): Future[Unit] = {
     val action = for {
-      callCachingResultMetaInfoId <- dataAccess.callCachingResultMetaInfoAutoInc += callCachingResultMetaInfo
-      _ <- dataAccess.callCachingHashAutoInc ++= hashesToInsert(callCachingResultMetaInfoId)
+      callCachingResultMetaInfoId <- dataAccess.callCachingResultMetaInfoIdsAutoInc += callCachingResultMetaInfo
+      _ <- dataAccess.callCachingHashEntryIdsAutoInc ++= hashesToInsert(callCachingResultMetaInfoId)
       _ <- dataAccess.callCachingResultSimpletonAutoInc ++= resultToInsert(callCachingResultMetaInfoId)
+      _ <- dataAccess.callCachingJobDetritusIdAutoInc ++= jobDetritusToInsert(callCachingResultMetaInfoId)
     } yield ()
     runTransaction(action)
   }
 
-  override def metaInfoIdsMatchingHashes(hashKeyValuePairs: Seq[(String, String)])
+  override def metaInfoIdsMatchingHashes(hashKeyHashValues: Seq[(String, String)])
                                         (implicit ec: ExecutionContext): Future[Seq[Seq[Int]]] = {
+    val nel: NonEmptyList[(String, String)] = NonEmptyList(hashKeyHashValues.head, hashKeyHashValues.tail: _*)
+    metaInfoIdsMatchingHashes(nel).map(Seq.apply(_))
+  }
 
-    val actions = hashKeyValuePairs map {
-      case (hashKey, hashValue) => dataAccess.resultMetaInfoIdsForHashMatch(hashKey, hashValue).result
-    }
-    val action = DBIO.sequence(actions)
+  def metaInfoIdsMatchingHashes(hashKeyHashValues: NonEmptyList[(String, String)])
+                               (implicit ec: ExecutionContext): Future[Seq[Int]] = {
+    val action = dataAccess.callCachingResultMetaInfoIdByHashKeyHashValues(hashKeyHashValues).result
 
     runTransaction(action)
   }
 
   override def fetchCachedResult(callCachingResultMetaInfoId: Int)(implicit ec: ExecutionContext):
-  Future[(Option[CallCachingResultMetaInfoEntry], Seq[CallCachingResultSimpletonEntry])] = {
+                                  Future[(Option[CallCachingResultMetaInfoEntry],
+                                  Seq[CallCachingResultSimpletonEntry],
+                                  Seq[CallCachingJobDetritusEntry])] = {
     val action = for {
       metaInfo <- dataAccess.metaInfoById(callCachingResultMetaInfoId).result.headOption
       resultSimpletons <- dataAccess.resultSimpletonsForMetaInfoId(callCachingResultMetaInfoId).result
-    } yield (metaInfo, resultSimpletons)
+      jobDetritus <- dataAccess.jobDetritusForMetaInfoId(callCachingResultMetaInfoId).result
+    } yield (metaInfo, resultSimpletons, jobDetritus)
 
     runTransaction(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashComponent.scala
@@ -8,29 +8,27 @@ trait CallCachingHashComponent {
 
   import driver.api._
 
-  class CallCachingHashEntries(tag: Tag) extends Table[CallCachingHashEntry](tag, "CALL_CACHING_HASH") {
+  class CallCachingHashes(tag: Tag) extends Table[CallCachingHashEntry](tag, "CALL_CACHING_HASH") {
     def callCachingHashId = column[Int]("CALL_CACHING_HASH_ID", O.PrimaryKey, O.AutoInc)
+
     def hashKey = column[String]("HASH_KEY")
+
     def hashValue = column[String]("HASH_VALUE")
+
     def resultMetaInfoId = column[Int]("RESULT_METAINFO_ID")
 
     override def * = (hashKey, hashValue, resultMetaInfoId, callCachingHashId.?) <>
       (CallCachingHashEntry.tupled, CallCachingHashEntry.unapply)
 
-    def cchUniquenessConstraint = index("UK_CALL_CACHING_HASH", (hashKey, resultMetaInfoId), unique = true)
-    def resultMetaInfoIdForeignKey = foreignKey("CCH_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfo)(_.callCachingResultMetaInfoId)
+    def CallCachingHashesUniquenessConstraint =
+      index("UK_CALL_CACHING_HASH", (hashKey, resultMetaInfoId), unique = true)
+
+    def callCachingResultMetaInfo = foreignKey(
+      "CCH_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfos)(_.callCachingResultMetaInfoId)
   }
 
-  protected val callCachingHashes = TableQuery[CallCachingHashEntries]
+  protected val callCachingHashes = TableQuery[CallCachingHashes]
 
-  val callCachingHashAutoInc = callCachingHashes returning callCachingHashes.map(_.callCachingHashId)
-
-  /**
-    * Find all RESULT_METAINFO_IDs which match a given hashkey/hashvalue combination
-    */
-  val resultMetaInfoIdsForHashMatch = Compiled(
-    (hashKey: Rep[String], hashValue: Rep[String]) => for {
-      hashEntry <- callCachingHashes
-      if hashEntry.hashKey === hashKey && hashEntry.hashValue === hashValue
-    } yield hashEntry.resultMetaInfoId)
+  val callCachingHashEntryIdsAutoInc = callCachingHashes returning
+    callCachingHashes.map(_.callCachingHashId)
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashComponent.scala
@@ -8,7 +8,7 @@ trait CallCachingHashComponent {
 
   import driver.api._
 
-  class CallCachingHashes(tag: Tag) extends Table[CallCachingHashEntry](tag, "CALL_CACHING_HASH") {
+  class CallCachingHashEntries(tag: Tag) extends Table[CallCachingHashEntry](tag, "CALL_CACHING_HASH") {
     def callCachingHashId = column[Int]("CALL_CACHING_HASH_ID", O.PrimaryKey, O.AutoInc)
 
     def hashKey = column[String]("HASH_KEY")
@@ -27,7 +27,7 @@ trait CallCachingHashComponent {
       "CCH_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfos)(_.callCachingResultMetaInfoId)
   }
 
-  protected val callCachingHashes = TableQuery[CallCachingHashes]
+  protected val callCachingHashes = TableQuery[CallCachingHashEntries]
 
   val callCachingHashEntryIdsAutoInc = callCachingHashes returning
     callCachingHashes.map(_.callCachingHashId)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingJobDetritusComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingJobDetritusComponent.scala
@@ -1,0 +1,39 @@
+package cromwell.database.slick.tables
+
+import cromwell.database.sql.tables.CallCachingJobDetritusEntry
+
+trait CallCachingJobDetritusComponent {
+
+  this: DriverComponent with CallCachingResultMetaInfoComponent =>
+
+  import driver.api._
+
+  class CallCachingJobDetritus(tag: Tag) extends Table[CallCachingJobDetritusEntry](tag, "CALL_CACHING_JOB_DETRITUS") {
+    def callCachingJobDetritusId = column[Int]("CALL_CACHING_JOB_DETRITUS_ID", O.PrimaryKey, O.AutoInc)
+    def jobDetritusKey = column[String]("JOB_DETRITUS_KEY")
+    def jobDetritusValue = column[String]("JOB_DETRITUS_VALUE")
+    def resultMetaInfoId = column[Int]("RESULT_METAINFO_ID")
+
+    override def * = (jobDetritusKey, jobDetritusValue, resultMetaInfoId, callCachingJobDetritusId.?) <>
+      (CallCachingJobDetritusEntry.tupled, CallCachingJobDetritusEntry.unapply)
+
+    def callCachingJobDetritusUniquenessConstraint =
+      index("UK_CALL_CACHING_JOB_DETRITUS", (jobDetritusKey, resultMetaInfoId), unique = true)
+
+    def callCachingResultMetaInfo = foreignKey(
+      "CCJD_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfos)(_.callCachingResultMetaInfoId)
+  }
+
+  protected val callCachingJobDetritus = TableQuery[CallCachingJobDetritus]
+
+  val callCachingJobDetritusIdAutoInc =
+    callCachingJobDetritus returning callCachingJobDetritus.map(_.callCachingJobDetritusId)
+
+  /**
+    * Find all job detrita which match a given RESULT_METAINFO_ID
+    */
+  val jobDetritusForMetaInfoId = Compiled(
+    (resultMetaInfoId: Rep[Int]) => for {
+      jobDetritus <- callCachingJobDetritus if jobDetritus.resultMetaInfoId === resultMetaInfoId
+    } yield jobDetritus)
+}

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
@@ -14,7 +14,7 @@ trait CallCachingResultMetaInfoComponent {
   class CallCachingResultMetaInfoEntries(tag: Tag) extends Table[CallCachingResultMetaInfoEntry](tag, "CALL_CACHING_RESULT_METAINFO") {
     def callCachingResultMetaInfoId = column[Int]("CALL_CACHING_RESULT_METAINFO_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowUuid = column[String]("WORKFLOW_UUID")
+    def workflowUuid = column[String]("WORKFLOW_EXECUTION_UUID")
 
     def callFqn = column[String]("CALL_FQN")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultMetaInfoComponent.scala
@@ -3,18 +3,25 @@ package cromwell.database.slick.tables
 import cromwell.database.sql.tables.CallCachingResultMetaInfoEntry
 import slick.profile.RelationalProfile.ColumnOption.Default
 
+import scalaz._
+
 trait CallCachingResultMetaInfoComponent {
 
-  this: DriverComponent =>
+  this: DriverComponent with CallCachingHashComponent =>
 
   import driver.api._
 
   class CallCachingResultMetaInfoEntries(tag: Tag) extends Table[CallCachingResultMetaInfoEntry](tag, "CALL_CACHING_RESULT_METAINFO") {
     def callCachingResultMetaInfoId = column[Int]("CALL_CACHING_RESULT_METAINFO_ID", O.PrimaryKey, O.AutoInc)
-    def workflowUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+
+    def workflowUuid = column[String]("WORKFLOW_UUID")
+
     def callFqn = column[String]("CALL_FQN")
+
     def returnCode = column[Option[Int]]("RETURN_CODE")
+
     def scatterIndex = column[Int]("JOB_SCATTER_INDEX")
+
     def allowResultReuse = column[Boolean]("ALLOW_RESULT_REUSE", Default(true))
 
     override def * = (workflowUuid, callFqn, scatterIndex, returnCode, allowResultReuse, callCachingResultMetaInfoId.?) <>
@@ -23,17 +30,62 @@ trait CallCachingResultMetaInfoComponent {
     def ccmUniquenessConstraint = index("UK_CALL_CACHING_RESULT_METAINFO", (workflowUuid, callFqn, scatterIndex), unique = true)
   }
 
-  protected val callCachingResultMetaInfo = TableQuery[CallCachingResultMetaInfoEntries]
+  protected val callCachingResultMetaInfos = TableQuery[CallCachingResultMetaInfoEntries]
 
-  val callCachingResultMetaInfoAutoInc = callCachingResultMetaInfo returning callCachingResultMetaInfo.
-    map(_.callCachingResultMetaInfoId)
+  val callCachingResultMetaInfoIdsAutoInc =
+    callCachingResultMetaInfos returning callCachingResultMetaInfos.map(_.callCachingResultMetaInfoId)
 
   /**
     * Useful for finding the call caching result meta info for a given ID
     */
   val metaInfoById = Compiled(
     (metaInfoId: Rep[Int]) => for {
-      metaInfo <- callCachingResultMetaInfo
+      metaInfo <- callCachingResultMetaInfos
       if metaInfo.callCachingResultMetaInfoId === metaInfoId
     } yield metaInfo)
+
+  /**
+    * Returns true if there exists a row in callCachingHashes that matches the parameters.
+    *
+    * @param callCachingResultMetaInfoId The foreign key.
+    * @param hashKeyHashValue            The hash key and hash value as a tuple.
+    * @return True or false if the row exists.
+    */
+  private def existsCallCachingResultMetaInfoIdHashKeyHashValue(callCachingResultMetaInfoId: Rep[Int])
+                                                               (hashKeyHashValue: (String, String)): Rep[Boolean] = {
+    callCachingHashes.filter(callCachingHashEntry =>
+      callCachingHashEntry.resultMetaInfoId === callCachingResultMetaInfoId &&
+        callCachingHashEntry.hashKey === hashKeyHashValue._1 &&
+        callCachingHashEntry.hashValue === hashKeyHashValue._2
+    ).exists
+  }
+
+  /**
+    * Returns true if there exists rows for all the hashKeyHashValues.
+    *
+    * @param callCachingResultMetaInfoId The foreign key.
+    * @param hashKeyHashValues           The hash keys and hash values as tuples.
+    * @return True or false if all the rows exist.
+    */
+  private def existsAllCallCachingResultMetaInfoIdHashKeyHashValues(callCachingResultMetaInfoId: Rep[Int],
+                                                                    hashKeyHashValues: NonEmptyList[(String, String)]):
+  Rep[Boolean] = {
+    hashKeyHashValues.
+      map(existsCallCachingResultMetaInfoIdHashKeyHashValue(callCachingResultMetaInfoId)).
+      list.toList.reduce(_ && _)
+  }
+
+  /**
+    * Returns the callCachingResultMetaInfoId where all the hash keys and hash values exist.
+    *
+    * @param hashKeyHashValues The hash keys and hash values as tuples.
+    * @return The callCachingResultMetaInfoIds with all of the hash keys and hash values.
+    */
+  def callCachingResultMetaInfoIdByHashKeyHashValues(hashKeyHashValues: NonEmptyList[(String, String)]) = {
+    for {
+      callCachingResultMetaInfo <- callCachingResultMetaInfos
+      if existsAllCallCachingResultMetaInfoIdHashKeyHashValues(
+        callCachingResultMetaInfo.callCachingResultMetaInfoId, hashKeyHashValues)
+    } yield callCachingResultMetaInfo.callCachingResultMetaInfoId
+  }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultSimpletonComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingResultSimpletonComponent.scala
@@ -8,7 +8,7 @@ trait CallCachingResultSimpletonComponent {
 
   import driver.api._
 
-  class CallCachingResultSimpletonEntries(tag: Tag) extends Table[CallCachingResultSimpletonEntry](tag, "CALL_CACHING_RESULT_SIMPLETON") {
+  class CallCachingResultSimpletons(tag: Tag) extends Table[CallCachingResultSimpletonEntry](tag, "CALL_CACHING_RESULT_SIMPLETON") {
     def callCachingResultSimpletonId = column[Int]("CALL_CACHING_RESULT_SIMPLETON_ID", O.PrimaryKey, O.AutoInc)
     def simpletonKey = column[String]("SIMPLETON_KEY")
     def simpletonValue = column[String]("SIMPLETON_VALUE")
@@ -18,11 +18,14 @@ trait CallCachingResultSimpletonComponent {
     override def * = (simpletonKey, simpletonValue, wdlType, resultMetaInfoId, callCachingResultSimpletonId.?) <>
       (CallCachingResultSimpletonEntry.tupled, CallCachingResultSimpletonEntry.unapply)
 
-    def ccrsUniquenessConstraint = index("UK_CALL_CACHING_RESULT_SIMPLETON", (simpletonKey, resultMetaInfoId), unique = true)
-    def resultMetaInfoForeignKey = foreignKey("CCRS_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfo)(_.callCachingResultMetaInfoId)
+    def callCachingResultSimpletonUniquenessConstraint =
+      index("UK_CALL_CACHING_RESULT_SIMPLETON", (simpletonKey, resultMetaInfoId), unique = true)
+
+    def callCachingResultMetaInfo = foreignKey(
+      "CCRS_RESULT_METAINFO_ID_FK", resultMetaInfoId, callCachingResultMetaInfos)(_.callCachingResultMetaInfoId)
   }
 
-  protected val callCachingResultSimpletons = TableQuery[CallCachingResultSimpletonEntries]
+  protected val callCachingResultSimpletons = TableQuery[CallCachingResultSimpletons]
 
   val callCachingResultSimpletonAutoInc = callCachingResultSimpletons returning callCachingResultSimpletons.map(_.callCachingResultSimpletonId)
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/DataAccessComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/DataAccessComponent.scala
@@ -13,7 +13,8 @@ class DataAccessComponent(val driver: JdbcProfile)
     with CallCachingResultMetaInfoComponent
     with CallCachingHashComponent
     with CallCachingResultSimpletonComponent
-    with SummaryStatusComponent {
+    with SummaryStatusComponent
+    with CallCachingJobDetritusComponent {
 
   import driver.api._
 
@@ -24,8 +25,9 @@ class DataAccessComponent(val driver: JdbcProfile)
       jobStore.schema ++
       jobStoreResultSimpletons.schema ++
       backendKVStore.schema ++
-      callCachingResultMetaInfo.schema ++
+      callCachingResultMetaInfos.schema ++
       callCachingHashes.schema ++
       callCachingResultSimpletons.schema ++
-      summaryStatuses.schema
+      summaryStatuses.schema ++
+      callCachingJobDetritus.schema
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingStore.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingStore.scala
@@ -15,6 +15,7 @@ trait CallCachingStore {
                                (implicit ec: ExecutionContext): Future[Seq[Seq[Int]]]
 
   def fetchCachedResult(callCachingResultMetaInfoId: Int)(implicit ec: ExecutionContext):
-                         Future[(Option[CallCachingResultMetaInfoEntry],
-                         Seq[CallCachingResultSimpletonEntry], Seq[CallCachingJobDetritusEntry])]
+                        Future[(Option[CallCachingResultMetaInfoEntry],
+                        Seq[CallCachingResultSimpletonEntry],
+                        Seq[CallCachingJobDetritusEntry])]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingStore.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingStore.scala
@@ -1,18 +1,20 @@
 package cromwell.database.sql
 
-import cromwell.database.sql.tables.{CallCachingHashEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
+import cromwell.database.sql.tables.{CallCachingJobDetritusEntry, CallCachingHashEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait CallCachingStore {
   def addToCache(callCachingResultMetaInfo: CallCachingResultMetaInfoEntry,
                  hashesToInsert: Int => Iterable[CallCachingHashEntry],
-                 resultToInsert: Int => Iterable[CallCachingResultSimpletonEntry])
+                 resultToInsert: Int => Iterable[CallCachingResultSimpletonEntry],
+                 jobDetritusToInsert: Int => Iterable[CallCachingJobDetritusEntry])
                 (implicit ec: ExecutionContext): Future[Unit]
 
   def metaInfoIdsMatchingHashes(hashKeyValuePairs: Seq[(String, String)])
                                (implicit ec: ExecutionContext): Future[Seq[Seq[Int]]]
 
   def fetchCachedResult(callCachingResultMetaInfoId: Int)(implicit ec: ExecutionContext):
-  Future[(Option[CallCachingResultMetaInfoEntry], Seq[CallCachingResultSimpletonEntry])]
+                         Future[(Option[CallCachingResultMetaInfoEntry],
+                         Seq[CallCachingResultSimpletonEntry], Seq[CallCachingJobDetritusEntry])]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingJobDetritusEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingJobDetritusEntry.scala
@@ -1,0 +1,9 @@
+package cromwell.database.sql.tables
+
+final case class CallCachingJobDetritusEntry
+(
+  jobDetritusKey: String,
+  jobDetritusValue: String,
+  resultMetaInfoId: Int,
+  callCachingJobDetritusId: Option[Int] = None
+)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/CopyWorkflowOutputsActor.scala
@@ -35,7 +35,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, val workflowDescriptor: E
 
     outputFilePaths foreach {
       case (workflowRootPath, srcPath) =>
-        PathCopier.copy(workflowRootPath, srcPath, workflowOutputsPath)
+        PathCopier.copy(workflowRootPath, srcPath, workflowOutputsPath, false)
     }
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -438,15 +438,17 @@ object EngineJobExecutionActor {
   private def factoryFileHashingRouter(backendName: String,
                                        backendLifecycleActorFactory: BackendLifecycleActorFactory,
                                        actorRefFactory: ActorRefFactory): ActorRef = {
-    val (originalOrUpdated, result) = getOrElseUpdated(
-      factoryFileHashingRouters, backendLifecycleActorFactory, {
-        val numberOfInstances = backendLifecycleActorFactory.fileHashingActorCount
-        val props = backendLifecycleActorFactory.fileHashingActorProps
-        actorRefFactory.actorOf(RoundRobinPool(numberOfInstances).props(props), s"FileHashingActor-$backendName")
-      }
-    )
-    factoryFileHashingRouters = originalOrUpdated
-    result
+    synchronized {
+      val (originalOrUpdated, result) = getOrElseUpdated(
+        factoryFileHashingRouters, backendLifecycleActorFactory, {
+          val numberOfInstances = backendLifecycleActorFactory.fileHashingActorCount
+          val props = backendLifecycleActorFactory.fileHashingActorProps
+          actorRefFactory.actorOf(RoundRobinPool(numberOfInstances).props(props), s"FileHashingActor-$backendName")
+        }
+      )
+      factoryFileHashingRouters = originalOrUpdated
+      result
+    }
   }
 
   /**

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -21,7 +21,7 @@ import cromwell.jobstore.{Pending => _, _}
 import cromwell.services.SingletonServicesStore
 import wdl4s.TaskOutput
 
-import scala.util.{Success, Try}
+import scala.util.{Success, Try, Failure}
 
 class EngineJobExecutionActor(replyTo: ActorRef,
                               jobDescriptorKey: BackendJobDescriptorKey,
@@ -311,7 +311,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   private def saveJobCompletionToJobStore(updatedData: ResponseData) = {
     updatedData.response match {
-      case SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs) => saveSuccessfulJobResults(jobKey, returnCode, jobOutputs)
+      case SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs, _) => saveSuccessfulJobResults(jobKey, returnCode, jobOutputs)
       case AbortedResponse(jobKey: BackendJobDescriptorKey) =>
         log.debug("{}: Won't save aborted job response to JobStore", jobTag)
         forwardAndStop(updatedData.response)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -261,8 +261,9 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     context.actorOf(props, s"ejha_for_$jobDescriptor")
   }
 
+  def makeFetchCachedResultsActor(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput]): Unit = context.actorOf(FetchCachedResultsActor.props(cacheHit, self, new CallCache(SingletonServicesStore.databaseInterface)))
   def fetchCachedResults(data: ResponsePendingData, taskOutputs: Seq[TaskOutput], cacheHit: CacheHit) = {
-    context.actorOf(FetchCachedResultsActor.props(cacheHit, self, new CallCache(SingletonServicesStore.databaseInterface)))
+    makeFetchCachedResultsActor(cacheHit, taskOutputs)
     goto(FetchingCachedOutputsFromDatabase)
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -326,7 +326,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
       pushFailedJobMetadata(jobKey, None, throwable, retryableFailure = false)
       context.parent ! WorkflowExecutionFailedResponse(stateData.executionStore, stateData.outputStore, List(throwable))
       goto(WorkflowExecutionFailedState) using stateData.mergeExecutionDiff(WorkflowExecutionDiff(Map(jobKey -> ExecutionStatus.Failed)))
-    case Event(SucceededResponse(jobKey, returnCode, callOutputs), stateData) =>
+    case Event(SucceededResponse(jobKey, returnCode, callOutputs, _), stateData) =>
       pushSuccessfulJobMetadata(jobKey, returnCode, callOutputs)
       handleJobSuccessful(jobKey, callOutputs, stateData)
     case Event(FailedNonRetryableResponse(jobKey, reason, returnCode), stateData) =>
@@ -366,7 +366,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
     case Event(FailedRetryableResponse(jobKey, reason, returnCode), stateData) =>
       pushFailedJobMetadata(jobKey, returnCode, reason, retryableFailure = true)
       stay
-    case Event(SucceededResponse(jobKey, returnCode, callOutputs), stateData) =>
+    case Event(SucceededResponse(jobKey, returnCode, callOutputs, _), stateData) =>
       pushSuccessfulJobMetadata(jobKey, returnCode, callOutputs)
       stay
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -5,19 +5,21 @@ import cromwell.core.ExecutionIndex.IndexEnhancedIndex
 import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.core.{JobOutputs, WorkflowId}
 import cromwell.database.sql._
-import cromwell.database.sql.tables.{CallCachingHashEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
+import cromwell.database.sql.tables.{CallCachingJobDetritusEntry, CallCachingHashEntry, CallCachingResultMetaInfoEntry, CallCachingResultSimpletonEntry}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 
-case class MetaInfoId(id: Int)
+final case class MetaInfoId(id: Int)
 
-case class HashKeyAndValue(hashKey: String, hashValue: String)
+final case class HashKeyAndValue(hashKey: String, hashValue: String)
 
-case class ResultSimpleton(simpletonKey: String, simpletonValue: String, wdlType: String)
+final case class ResultSimpleton(simpletonKey: String, simpletonValue: String, wdlType: String)
 
-case class CachedResult(returnCode: Option[Int], resultSimpletons: Seq[CallCachingResultSimpletonEntry])
+final case class CacheHitJobFile(fileKey: String, fileValue: String)
+
+final case class CachedResult(returnCode: Option[Int], resultSimpletons: Seq[CallCachingResultSimpletonEntry], jobDetritus: Seq[CallCachingJobDetritusEntry])
 
 /**
   * Given a database-layer CallCacheStore, this accessor can access the database with engine-friendly data types.
@@ -33,12 +35,13 @@ class CallCache(database: CallCachingStore) {
       callCachingResultMetaInfoEntryId = None)
     val hashes = callCacheHashes.hashes map { hash => HashKeyAndValue(hash.hashKey.key, hash.hashValue.value) }
     val result = toResultSimpletons(response.jobOutputs)
+    val jobDetritus = response.jobDetritusFiles.get map  { case (fileName, filePath) => CacheHitJobFile(fileName, filePath) }
 
-    addToCache(metaInfo, hashes, result)
+    addToCache(metaInfo, hashes, result, jobDetritus)
   }
 
   private def addToCache(metaInfo: CallCachingResultMetaInfoEntry, hashes: Iterable[HashKeyAndValue],
-                         result: Iterable[ResultSimpleton])(implicit ec: ExecutionContext): Future[Unit] = {
+                         result: Iterable[ResultSimpleton], jobDetritus: Iterable[CacheHitJobFile])(implicit ec: ExecutionContext): Future[Unit] = {
 
     def hashesToInsert(callCachingResultMetaInfoEntryId: Int): Iterable[CallCachingHashEntry] = {
       hashes map {
@@ -54,7 +57,13 @@ class CallCache(database: CallCachingStore) {
       }
     }
 
-    database.addToCache(metaInfo, hashesToInsert, resultToInsert)
+    def jobDetritusToInsert(callCachingResultMetaInfoEntryId: Int): Iterable[CallCachingJobDetritusEntry] = {
+      jobDetritus map {
+        case CacheHitJobFile(fileName, filePath) => CallCachingJobDetritusEntry(fileName, filePath, callCachingResultMetaInfoEntryId)
+      }
+    }
+
+    database.addToCache(metaInfo, hashesToInsert, resultToInsert, jobDetritusToInsert)
   }
 
   private def toResultSimpletons(jobOutputs: JobOutputs): Seq[ResultSimpleton] = {
@@ -84,10 +93,11 @@ class CallCache(database: CallCachingStore) {
   }
 
   private def cachedResultOption(callCachingResultMetaInfoEntryOption: Option[CallCachingResultMetaInfoEntry],
-                                 callCachingResultSimpletonEntries: Seq[CallCachingResultSimpletonEntry]):
+                                 callCachingResultSimpletonEntries: Seq[CallCachingResultSimpletonEntry],
+                                 callCachingJobDetritusEntries: Seq[CallCachingJobDetritusEntry]):
   Option[CachedResult] = {
     callCachingResultMetaInfoEntryOption map { callCachingResultMetaInfoEntry =>
-      CachedResult(callCachingResultMetaInfoEntry.returnCode, callCachingResultSimpletonEntries)
+      CachedResult(callCachingResultMetaInfoEntry.returnCode, callCachingResultSimpletonEntries, callCachingJobDetritusEntries)
     }
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -21,6 +21,10 @@ final case class CacheHitJobFile(fileKey: String, fileValue: String)
 
 final case class CachedResult(returnCode: Option[Int], resultSimpletons: Seq[CallCachingResultSimpletonEntry], jobDetritus: Seq[CallCachingJobDetritusEntry])
 
+final case class CachingPackage(metaInfoEntry: Option[CallCachingResultMetaInfoEntry],
+                                simpletonEntries: Seq[CallCachingResultSimpletonEntry],
+                                detritusEntries: Seq[CallCachingJobDetritusEntry])
+
 /**
   * Given a database-layer CallCacheStore, this accessor can access the database with engine-friendly data types.
   */

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -2,6 +2,7 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{Actor, ActorLogging, Props}
 import cromwell.backend.BackendJobExecutionActor
+import cromwell.backend.BackendJobExecutionActor.SucceededResponse
 import cromwell.core.WorkflowId
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 
@@ -29,7 +30,7 @@ case class CallCacheWriteActor(callCache: CallCache, workflowId: WorkflowId, cal
 }
 
 object CallCacheWriteActor {
-  def props(callCache: CallCache, workflowId: WorkflowId, callCacheHashes: CallCacheHashes, succeededResponse: BackendJobExecutionActor.SucceededResponse): Props =
+  def props(callCache: CallCache, workflowId: WorkflowId, callCacheHashes: CallCacheHashes, succeededResponse: SucceededResponse): Props =
     Props(CallCacheWriteActor(callCache, workflowId, callCacheHashes, succeededResponse))
 }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -150,7 +150,7 @@ case class EngineJobHashingActor(receiver: ActorRef,
 
     if (filtered.nonEmpty) {
       val hashes = CallCacheHashes(filtered)
-      val subsets = hashes.hashes.sliding(100,100)
+      val subsets = hashes.hashes.grouped(100)
       subsets foreach { subset =>
         callCacheReadActor ! CacheLookupRequest(CallCacheHashes(subset))
       }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -145,14 +145,15 @@ case class EngineJobHashingActor(receiver: ActorRef,
   /**
     * Needs to convert a hash result into the set of CachedResults which are consistent with it
     */
-  private var lookupIndex = 0
   private def findCacheResults(hashResults: Set[HashResult]) = {
     val filtered = hashResults.filter(_.hashKey.checkForHitOrMiss)
 
     if (filtered.nonEmpty) {
       val hashes = CallCacheHashes(filtered)
-      lookupIndex += 1
-      callCacheReadActor ! CacheLookupRequest(hashes)
+      val subsets = hashes.hashes.sliding(100,100)
+      subsets foreach { subset =>
+        callCacheReadActor ! CacheLookupRequest(CallCacheHashes(subset))
+      }
     } else ()
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -2,28 +2,26 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.Simpletons._
-import cromwell.core.JobOutputs
-import cromwell.core.simpleton.WdlValueBuilder
+import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CacheHit
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
-import cromwell.services.SingletonServicesStore
-import wdl4s.TaskOutput
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 object FetchCachedResultsActor {
-  def props(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput], replyTo: ActorRef, callCache: CallCache): Props =
-    Props(new FetchCachedResultsActor(cacheHit, taskOutputs, replyTo, callCache))
+  def props(cacheHit: CacheHit, replyTo: ActorRef, callCache: CallCache): Props =
+    Props(new FetchCachedResultsActor(cacheHit, replyTo, callCache))
 
-  sealed trait CachedOutputLookupResponse
-  case class CachedOutputLookupFailed(metaInfoId: MetaInfoId, failure: Throwable) extends CachedOutputLookupResponse
-  case class CachedOutputLookupSucceeded(jobOutputs: JobOutputs, cacheHit: CacheHit) extends CachedOutputLookupResponse
+  sealed trait CachedResultResponse
+  case class CachedOutputLookupFailed(metaInfoId: MetaInfoId, failure: Throwable) extends CachedResultResponse
+  case class CachedOutputLookupSucceeded(simpletons: Seq[WdlValueSimpleton], callOutputFiles: Map[String,String], returnCode: Option[Int], cacheHit: CacheHit) extends CachedResultResponse
 }
 
 
-class FetchCachedResultsActor(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput], replyTo: ActorRef, callCache: CallCache)
+class FetchCachedResultsActor(cacheHit: CacheHit, replyTo: ActorRef, callCache: CallCache)
   extends Actor with ActorLogging {
+
   {
     implicit val ec: ExecutionContext = context.dispatcher
     val cacheResultId = cacheHit.cacheResultId
@@ -31,8 +29,8 @@ class FetchCachedResultsActor(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput], 
     callCache.fetchCachedResult(cacheResultId) onComplete {
       case Success(Some(result)) =>
         val simpletons = result.resultSimpletons map toSimpleton
-        val jobOutputs = WdlValueBuilder.toJobOutputs(taskOutputs, simpletons)
-        replyTo ! CachedOutputLookupSucceeded(jobOutputs, cacheHit)
+        val jobDetritusFiles = result.jobDetritus map { jobDetritusEntry => jobDetritusEntry.jobDetritusKey -> jobDetritusEntry.jobDetritusValue }
+        replyTo ! CachedOutputLookupSucceeded(simpletons, jobDetritusFiles.toMap, result.returnCode, cacheHit)
       case Success(None) =>
         val reason = new RuntimeException(s"Cache hit vanished between discovery and retrieval: $cacheResultId")
         replyTo ! CachedOutputLookupFailed(cacheResultId, reason)

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/BackendKeyValueDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/BackendKeyValueDatabaseAccess.scala
@@ -20,7 +20,6 @@ trait BackendKeyValueDatabaseAccess { this: ServicesStore =>
                                 jobKey: KvJobKey,
                                 backendStoreKey: String,
                                 backendStoreValue: String)(implicit ec: ExecutionContext, actorSystem: ActorSystem): Future[Unit] = {
-
     withRetry (() =>
       databaseInterface.addBackendStoreKeyValuePair(workflowId.toString, jobKey.callFqn, jobKey.callIndex.fromIndex, jobKey.callAttempt, backendStoreKey, backendStoreValue)
     )

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -572,10 +572,9 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
   }
 
   private def gatherJobDetritusFiles: Map[String,String] = {
-      val jobDetritusFiles = List(jesCallPaths.stderrPath, jesCallPaths.returnCodePath, jesCallPaths.stdoutPath, gcsExecPath)
-      val mapOfFiles = jobDetritusFiles map { path => path.getFileName.toString -> path.toString } toMap
-      val result = mapOfFiles ++ Map(jesCallPaths.callRootPathKey -> callRootPath.toString)
-      result
+      Map("stdout" -> jesCallPaths.stdoutPath.toString, "stderr" -> jesCallPaths.stderrPath.toString,
+        "returnCode" -> jesCallPaths.returnCodePath.toString, "jesLog" -> jesCallPaths.jesLogPath.toString,
+        "gcsExec" -> gcsExecPath.toString, jesCallPaths.CallRootPathKey -> callRootPath.toString)
   }
 
   private def handleSuccess(outputMappings: Try[JobOutputs], returnCode: Int, jobDetritusFiles: Map[String, String], executionHandle: ExecutionHandle): ExecutionHandle = {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -564,6 +564,13 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
   }
 
   private def postProcess: Try[JobOutputs] = {
+    //RUCHI: Move KvPut elsewhere, temporary position for testing.
+    val forStorage = Option(List(jesCallPaths.stderrPath, jesCallPaths.returnCodePath, jesCallPaths.stdoutPath, gcsExecPath).mkString)
+    println(s"the value being stored is: $forStorage")
+    serviceRegistryActor ! KvPut(KvPair(ScopedKey(jobDescriptor.workflowDescriptor.id,
+      KvJobKey(jobDescriptor.key.call.fullyQualifiedName, jobDescriptor.key.index, jobDescriptor.key.attempt),
+      callOutputFiles), forStorage))
+
     val outputs = call.task.outputs
     val outputMappings = outputs.foldLeft(Seq.empty[AttemptedLookupResult])(outputFoldingFunction).map(_.toPair).toMap
     TryUtil.sequenceMap(outputMappings) map { outputMap =>
@@ -571,9 +578,16 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
     }
   }
 
-  private def handleSuccess(outputMappings: Try[JobOutputs], returnCode: Int, executionHandle: ExecutionHandle): ExecutionHandle = {
+  private def gatherJobDetritusFiles: Map[String,String] = {
+      val callOutputFiles = List(jesCallPaths.stderrPath, jesCallPaths.returnCodePath, jesCallPaths.stdoutPath, gcsExecPath)
+      val mapOfFiles = callOutputFiles map { path => path.getFileName.toString -> path.toString } toMap
+      val result = mapOfFiles ++ Map(jesCallPaths.callRootPathKey -> callRootPath.toString)
+      result
+  }
+
+  private def handleSuccess(outputMappings: Try[JobOutputs], returnCode: Int, jobOutputFiles: Map[String, String], executionHandle: ExecutionHandle): ExecutionHandle = {
     outputMappings match {
-      case Success(outputs) => SuccessfulExecutionHandle(outputs, returnCode)
+      case Success(outputs) => SuccessfulExecutionHandle(outputs, returnCode, jobOutputFiles)
       case Failure(ex: CromwellAggregatedException) if ex.throwables collectFirst { case s: SocketTimeoutException => s } isDefined =>
         // Return the execution handle in this case to retry the operation
         executionHandle
@@ -652,7 +666,7 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
         case _: RunStatus.Success if !continueOnReturnCode.continueFor(returnCode.get) =>
           val badReturnCodeMessage = s"Call ${call.fullyQualifiedName}: return code was ${returnCode.getOrElse("(none)")}"
           FailedNonRetryableExecutionHandle(new RuntimeException(badReturnCodeMessage), returnCode.toOption).future
-        case _: RunStatus.Success => handleSuccess(postProcess, returnCode.get, handle).future
+        case _: RunStatus.Success => handleSuccess(postProcess, returnCode.get, gatherJobDetritusFiles, handle).future
         case RunStatus.Failed(errorCode, errorMessage, _, _, _, _) => handleFailure(errorCode, errorMessage)
       }
     } catch {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -166,7 +166,7 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
     else None
   }
 
-  private val callContext = CallContext(
+  private lazy val callContext = CallContext(
     callRootPath,
     jesStdoutFile.toString,
     jesStderrFile.toString

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
@@ -3,13 +3,15 @@ package cromwell.backend.impl.jes
 import java.nio.file.Path
 
 import akka.actor.{ActorRef, Props}
+import better.files.File
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, FailedNonRetryableResponse, SucceededResponse}
 import cromwell.backend.{BackendCacheHitCopyingActor, BackendJobDescriptor, BackendJobDescriptorKey}
+import cromwell.core.logging.JobLogging
 import cromwell.core.simpleton.{WdlValueBuilder, WdlValueSimpleton}
 import cromwell.core.{JobOutputs, PathCopier}
+import cromwell.services.metadata.CallMetadataKeys._
 import cromwell.services.metadata.MetadataService.PutMetadataAction
 import cromwell.services.metadata._
-import org.slf4j.LoggerFactory
 import wdl4s.values.WdlFile
 
 import scala.concurrent.Future
@@ -17,9 +19,11 @@ import scala.concurrent.Future
 case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescriptor,
                                    jesConfiguration: JesConfiguration,
                                    initializationData: JesBackendInitializationData,
-                                   serviceRegistryActor: ActorRef) extends BackendCacheHitCopyingActor {
+                                   serviceRegistryActor: ActorRef) extends BackendCacheHitCopyingActor with JobLogging {
 
   override val configurationDescriptor = jesConfiguration.configurationDescriptor
+  private lazy val runtimeAttributes = JesRuntimeAttributes(jobDescriptor.runtimeAttributes, jobLogger)
+  private lazy val tag = s"${this.getClass.getSimpleName} [UUID(${workflowId.shortString}):${jobDescriptor.key.tag}]"
   private lazy val jesAttributes = jesConfiguration.jesAttributes
   private lazy val metadataJobKey = {
     val jobDescriptorKey: BackendJobDescriptorKey = jobDescriptor.key
@@ -29,62 +33,86 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
   override def copyCachedOutputs(seqOfSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String],
                                  returnCode: Option[Int]): Future[BackendJobExecutionResponse] = {
 
-      val gcsFileSystem = initializationData.workflowPaths.gcsFileSystemWithUserAuth
-      val jesCallPaths = initializationData.workflowPaths.toJesCallPaths(jobDescriptor.key)
-      val destinationCallRootPath: Path = jesCallPaths.callRootPath
-      val getSourceCallRootPath = jobDetritusFiles.get(jesCallPaths.callRootPathKey) match {
-        case Some(srcPath) => gcsFileSystem.getPath(srcPath)
-        case None => val error = new RuntimeException(s"The call detritus files for source cache hit aren't found for call ${jobDescriptor.call.fullyQualifiedName}")
-      }
+    val gcsFileSystem = initializationData.workflowPaths.gcsFileSystemWithUserAuth
+    val jesCallPaths = initializationData.workflowPaths.toJesCallPaths(jobDescriptor.key)
+    val destinationCallRootPath: Path = jesCallPaths.callRootPath
+    val getSourceCallRootPath = jobDetritusFiles.get(jesCallPaths.CallRootPathKey) match {
+      case Some(srcPath) => gcsFileSystem.getPath(srcPath)
+      case None => new RuntimeException(s"The call detritus files for source cache hit aren't found for call ${jobDescriptor.call.fullyQualifiedName}")
+    }
 
-    def cacheIfPossible = {
+    def cacheIfPossible: Future[BackendJobExecutionResponse] = {
       getSourceCallRootPath match {
         case Some(path: Path) =>
-          copyFiles(path)
+          copyAndRenameFiles(path)
           updateMetadata
           Future(SucceededResponse(jobDescriptor.key, returnCode, createJobOutputs))
-        case error: RuntimeException => Future(FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1)))
+        case error: Throwable => Future(FailedNonRetryableResponse(jobDescriptor.key, error, None))
       }
     }
 
-      def copyFiles(sourceCallRootPath: Path) = {
-        seqOfSimpletons ++ jobDetritusFiles foreach {
-          case WdlValueSimpleton(key, wdlFile: WdlFile) =>
-            copyCachedCallOutputFiles(wdlFile.value, sourceCallRootPath)
-          case (fileName: String, filePath: String) if fileName != jesCallPaths.callRootPathKey =>
-            copyCachedCallOutputFiles(filePath, sourceCallRootPath)
-          case _ =>
-            val error = new RuntimeException(s"Unable to copy cached job outputs for ${jobDescriptor.call.fullyQualifiedName}")
-            FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1))
-        }
+    def copyAndRenameFiles(sourceCallRootPath: Path) = {
+      seqOfSimpletons ++ jobDetritusFiles foreach {
+        case WdlValueSimpleton(key, wdlFile: WdlFile) =>
+          copyFile(wdlFile.value, sourceCallRootPath)
+        case (fileName: String, filePath: String) if fileName != jesCallPaths.CallRootPathKey =>
+          copyFile(filePath, sourceCallRootPath)
+          fileName match {
+            case "stdout" => File(gcsFileSystem.getPath(filePath)).copyTo(jesCallPaths.stdoutPath)
+            case "stderr" => File(gcsFileSystem.getPath(filePath)).copyTo(jesCallPaths.stderrPath)
+            case "returnCode" => File(gcsFileSystem.getPath(filePath)).copyTo(jesCallPaths.returnCodePath)
+            case "jesLog" => File(gcsFileSystem.getPath(filePath)).copyTo(jesCallPaths.jesLogPath)
+          }
+
+        case _ =>
+          val error = new RuntimeException(s"Unable to copy cached job outputs for ${jobDescriptor.call.fullyQualifiedName}")
+          FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1))
+      }
+      jobLogger.info(s"{} successfully finished copying all cached job outputs.", tag)
+    }
+
+    def copyFile(sourceString: String, srcContextPath: Path): Unit = {
+      val sourcePath = gcsFileSystem.getPath(sourceString)
+      PathCopier.copy(srcContextPath, sourcePath, destinationCallRootPath, overwrite = true)
+    }
+
+
+    def tellMetadata(key: String, value: Any): Unit = {
+      val event = metadataEvent(key, value)
+      val putMetadataAction = PutMetadataAction(event)
+      serviceRegistryActor ! putMetadataAction
+    }
+
+    def metadataEvent(key: String, value: Any) = {
+      val metadataValue = MetadataValue(value)
+      MetadataEvent(metadataKey(key), metadataValue)
+    }
+
+    def metadataKey(key: String) = MetadataKey(workflowId, Option(metadataJobKey), key)
+
+    def updateMetadata = {
+      val projectEvents = List(
+        metadataEvent(JesMetadataKeys.GoogleProject, jesAttributes.project),
+        metadataEvent(JesMetadataKeys.ExecutionBucket, jesAttributes.executionBucket),
+        metadataEvent(JesMetadataKeys.EndpointUrl, jesAttributes.endpointUrl))
+
+      val runtimeAttributesEvent = runtimeAttributes.asMap map {
+        case (key, value) => MetadataEvent(metadataKey(s"runtimeAttributes:$key"), MetadataValue(value))
       }
 
-      def copyCachedCallOutputFiles(sourceString: String, srcContextPath: Path): Unit = {
-        val sourcePath = gcsFileSystem.getPath(sourceString)
-        PathCopier.copy(srcContextPath, sourcePath, destinationCallRootPath)
-      }
+      val detritusEvents = List(
+          metadataEvent(CallMetadataKeys.CallRoot, destinationCallRootPath),
+          metadataEvent(Stdout, jesCallPaths.stdoutPath),
+          metadataEvent(Stderr, jesCallPaths.stderrPath),
+          metadataEvent(ReturnCode, jesCallPaths.returnCodePath),
+          metadataEvent(BackendLogsPrefix + ":log", jesCallPaths.jesLogPath),
+          metadataEvent("cache:allowResultReuse", true)
+      )
 
+      val events = runtimeAttributesEvent ++ projectEvents ++ detritusEvents
 
-      def tellMetadata(key: String, value: Any): Unit = {
-        val event = metadataEvent(key, value)
-        val putMetadataAction = PutMetadataAction(event)
-        serviceRegistryActor ! putMetadataAction
-      }
-
-      def metadataEvent(key: String, value: Any) = {
-        val metadataValue = MetadataValue(value)
-        MetadataEvent(metadataKey(key), metadataValue)
-      }
-
-      def metadataKey(key: String) = MetadataKey(workflowId, Option(metadataJobKey), key)
-
-      def updateMetadata = {
-        tellMetadata(CallMetadataKeys.CallRoot, destinationCallRootPath)
-        tellMetadata(JesMetadataKeys.GoogleProject, jesAttributes.project)
-        tellMetadata(JesMetadataKeys.ExecutionBucket, jesAttributes.executionBucket)
-        tellMetadata(JesMetadataKeys.EndpointUrl, jesAttributes.endpointUrl)
-      }
-
+      serviceRegistryActor ! PutMetadataAction(events)
+    }
 
     def createJobOutputs: JobOutputs = WdlValueBuilder.toJobOutputs(jobDescriptor.call.task.outputs, seqOfSimpletons)
 
@@ -93,7 +121,6 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
 }
 
 object JesCacheHitCopyingActor {
-  val logger = LoggerFactory.getLogger("JesBackend")
 
   def props(jobDescriptor: BackendJobDescriptor,
             jesConfiguration: JesConfiguration,

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
@@ -45,6 +45,7 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
           Future(SucceededResponse(jobDescriptor.key, returnCode, createJobOutputs))
         case error: RuntimeException => Future(FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1)))
       }
+    }
 
       def copyFiles(sourceCallRootPath: Path) = {
         seqOfSimpletons ++ jobDetritusFiles foreach {
@@ -62,6 +63,7 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
         val sourcePath = gcsFileSystem.getPath(sourceString)
         PathCopier.copy(srcContextPath, sourcePath, destinationCallRootPath)
       }
+
 
       def tellMetadata(key: String, value: Any): Unit = {
         val event = metadataEvent(key, value)
@@ -82,7 +84,7 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
         tellMetadata(JesMetadataKeys.ExecutionBucket, jesAttributes.executionBucket)
         tellMetadata(JesMetadataKeys.EndpointUrl, jesAttributes.endpointUrl)
       }
-    }
+
 
     def createJobOutputs: JobOutputs = WdlValueBuilder.toJobOutputs(jobDescriptor.call.task.outputs, seqOfSimpletons)
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
@@ -1,13 +1,93 @@
 package cromwell.backend.impl.jes
 
+import java.nio.file.Path
+
 import akka.actor.{ActorRef, Props}
-import cromwell.backend.{BackendCacheHitCopyingActor, BackendJobDescriptor}
-import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, SucceededResponse}
-import cromwell.backend.impl.jes.JesImplicits.PathString
+import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, FailedNonRetryableResponse, SucceededResponse}
+import cromwell.backend.{BackendCacheHitCopyingActor, BackendJobDescriptor, BackendJobDescriptorKey}
+import cromwell.core.simpleton.{WdlValueBuilder, WdlValueSimpleton}
 import cromwell.core.{JobOutputs, PathCopier}
+import cromwell.services.metadata.MetadataService.PutMetadataAction
+import cromwell.services.metadata._
 import org.slf4j.LoggerFactory
+import wdl4s.values.WdlFile
 
 import scala.concurrent.Future
+
+case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescriptor,
+                                   jesConfiguration: JesConfiguration,
+                                   initializationData: JesBackendInitializationData,
+                                   serviceRegistryActor: ActorRef) extends BackendCacheHitCopyingActor {
+
+  override val configurationDescriptor = jesConfiguration.configurationDescriptor
+  private lazy val jesAttributes = jesConfiguration.jesAttributes
+  private lazy val metadataJobKey = {
+    val jobDescriptorKey: BackendJobDescriptorKey = jobDescriptor.key
+    MetadataJobKey(jobDescriptorKey.call.fullyQualifiedName, jobDescriptorKey.index, jobDescriptorKey.attempt)
+  }
+
+  override def copyCachedOutputs(seqOfSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String],
+                                 returnCode: Option[Int]): Future[BackendJobExecutionResponse] = {
+
+    def tryCaching = {
+      val gcsFileSystem = initializationData.workflowPaths.gcsFileSystemWithUserAuth
+      val jesCallPaths = initializationData.workflowPaths.toJesCallPaths(jobDescriptor.key)
+      val destinationCallRootPath: Path = jesCallPaths.callRootPath
+      val getSourceCallRootPath = jobDetritusFiles.get(jesCallPaths.callRootPathKey) match {
+        case Some(srcPath) => gcsFileSystem.getPath(srcPath)
+        case None => val error = new RuntimeException(s"The call detritus files for source cache hit aren't found for call ${jobDescriptor.call.fullyQualifiedName}")
+      }
+      getSourceCallRootPath match {
+        case Some(path: Path) =>
+          copyFiles(path)
+          updateMetadata
+          Future(SucceededResponse(jobDescriptor.key, returnCode, createJobOutputs))
+        case error: RuntimeException => Future(FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1)))
+      }
+
+      def copyFiles(sourceCallRootPath: Path) = {
+        seqOfSimpletons ++ jobDetritusFiles foreach {
+          case WdlValueSimpleton(key, wdlFile: WdlFile) =>
+            copyCachedCallOutputFiles(wdlFile.value, sourceCallRootPath)
+          case (fileName: String, filePath: String) if fileName != "callRootPath" =>
+            copyCachedCallOutputFiles(filePath, sourceCallRootPath)
+          case _ =>
+            val error = new RuntimeException(s"Unable to copy cached job outputs for ${jobDescriptor.call.fullyQualifiedName}")
+            FailedNonRetryableResponse(jobDescriptor.key, error, Option(-1))
+        }
+      }
+
+      def copyCachedCallOutputFiles(sourceString: String, srcContextPath: Path): Unit = {
+        val sourcePath = gcsFileSystem.getPath(sourceString)
+        PathCopier.copy(srcContextPath, sourcePath, destinationCallRootPath)
+      }
+
+      def tellMetadata(key: String, value: Any): Unit = {
+        val event = metadataEvent(key, value)
+        val putMetadataAction = PutMetadataAction(event)
+        serviceRegistryActor ! putMetadataAction
+      }
+
+      def metadataEvent(key: String, value: Any) = {
+        val metadataValue = MetadataValue(value)
+        MetadataEvent(metadataKey(key), metadataValue)
+      }
+
+      def metadataKey(key: String) = MetadataKey(workflowId, Option(metadataJobKey), key)
+
+      def updateMetadata = {
+        tellMetadata(CallMetadataKeys.CallRoot, destinationCallRootPath)
+        tellMetadata(JesMetadataKeys.GoogleProject, jesAttributes.project)
+        tellMetadata(JesMetadataKeys.ExecutionBucket, jesAttributes.executionBucket)
+        tellMetadata(JesMetadataKeys.EndpointUrl, jesAttributes.endpointUrl)
+      }
+    }
+
+    def createJobOutputs: JobOutputs = WdlValueBuilder.toJobOutputs(jobDescriptor.call.task.outputs, seqOfSimpletons)
+
+    tryCaching
+  }
+}
 
 object JesCacheHitCopyingActor {
   val logger = LoggerFactory.getLogger("JesBackend")
@@ -17,55 +97,5 @@ object JesCacheHitCopyingActor {
             initializationData: JesBackendInitializationData,
             serviceRegistryActor: ActorRef): Props = {
     Props(new JesCacheHitCopyingActor(jobDescriptor, jesConfiguration, initializationData, serviceRegistryActor))
-  }
-}
-
-case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescriptor,
-                                   jesConfiguration: JesConfiguration,
-                                   initializationData: JesBackendInitializationData,
-                                   serviceRegistryActor: ActorRef) extends BackendCacheHitCopyingActor {
-
-  override val configurationDescriptor = jesConfiguration.configurationDescriptor
-
-  override def copyCachedOutputs(cachedJobOutputs: JobOutputs): Future[BackendJobExecutionResponse] = {
-    val workflowPaths = initializationData.workflowPaths
-    val jesWorkflowPaths = workflowPaths.toJesCallPaths(jobDescriptor.key)
-    val callRootPath = jesWorkflowPaths.callRootPath
-    val callRootParent = callRootPath.getParent
-    val callRootRoot = callRootPath.getRoot
-
-    //renaming requires some tech talk
-    def renameCallSpecificFiles: List[String] = {
-      val jesFileNames = List(
-        jesWorkflowPaths.returnCodeFilename,
-        jesWorkflowPaths.stderrFilename,
-        jesWorkflowPaths.stdoutFilename,
-        jesWorkflowPaths.jesLogFilename
-      )
-      jesFileNames
-    }
-
-    val gcsFileSystem = workflowPaths.gcsFileSystemWithUserAuth
-
-    def copyFilesInGcs() = {
-      val stringFilePaths = cachedJobOutputs map { case (lqn, jobOutput) => lqn -> jobOutput.wdlValue.valueString }
-
-      stringFilePaths foreach {
-        case (lqn, filePath) => if (filePath.isGcsUrl)
-          copyCachedCallOutputFiles(filePath)
-      }
-    }
-
-    //nested array output copying? or more complicated file structures
-    def copyCachedCallOutputFiles(sourcePath: String): Unit = {
-      val sourceCallDirectory = gcsFileSystem.getPath(sourcePath)
-      // suspicious that this is unused
-      val buildCallDestinationDirectory = gcsFileSystem.getPathAsDirectory(callRootPath.getParent.toString)
-
-      PathCopier.copy(callRootPath, sourceCallDirectory.getParent, callRootParent)
-    }
-
-    copyFilesInGcs()
-    Future(SucceededResponse(jobDescriptor.key, Option(0), cachedJobOutputs))
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
@@ -18,6 +18,7 @@ class JesCallPaths(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendW
   val CallPrefix = "call"
   val ShardPrefix = "shard"
   val AttemptPrefix = "attempt"
+  val callRootPathKey = "callRootPath"
 
   val jesLogBasename = {
     val index = jobKey.index.map(s => s"-$s").getOrElse("")

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
@@ -38,10 +38,12 @@ class JesCallPaths(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendW
   val stdoutFilename: String = s"$jesLogBasename-stdout.log"
   val stderrFilename: String = s"$jesLogBasename-stderr.log"
   val jesLogFilename: String = s"$jesLogBasename.log"
+  val gcsExecFilename: String = s"exec.sh"
 
   lazy val returnCodePath: Path = callRootPath.resolve(returnCodeFilename)
   lazy val stdoutPath: Path = callRootPath.resolve(stdoutFilename)
   lazy val stderrPath: Path = callRootPath.resolve(stderrFilename)
   lazy val jesLogPath: Path = callRootPath.resolve(jesLogFilename)
+  lazy val gcsExecPath: Path = callRootPath.resolve(gcsExecFilename)
   lazy val callContext = new CallContext(callRootPath, stdoutFilename, stderrFilename)
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
@@ -18,7 +18,7 @@ class JesCallPaths(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendW
   val CallPrefix = "call"
   val ShardPrefix = "shard"
   val AttemptPrefix = "attempt"
-  val callRootPathKey = "callRootPath"
+  val CallRootPathKey = "callRootPath"
 
   val jesLogBasename = {
     val index = jobKey.index.map(s => s"-$s").getOrElse("")

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -77,7 +77,7 @@ class JesFinalizationActor (override val workflowDescriptor: BackendWorkflowDesc
 
   private def copyLogs(callLogsDirPath: Path, logPaths: Seq[Path]): Unit = {
     workflowPaths match {
-      case Some(paths) => logPaths.foreach(PathCopier.copy(paths.rootPath, _, callLogsDirPath))
+      case Some(paths) => logPaths.foreach(PathCopier.copy(paths.rootPath, _, callLogsDirPath, false))
       case None =>
     }
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -25,10 +25,6 @@ class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor, jesConfigu
 
   val finalCallLogsPath = workflowDescriptor.getWorkflowOption(FinalCallLogsDir) map { gcsFileSystemWithUserAuth.getPath(_) }
 
-  private val storage = jesConfiguration.jesAttributes.genomicsAuth.buildStorage(workflowDescriptor.workflowOptions.toGoogleAuthOptions, jesConfiguration.googleConfig)
-  val fileSystemProvider = GcsFileSystemProvider(storage)(gcsFileSystemWithUserAuth.gcsFileSystemProvider.executionContext)
-  val fileSystemWithGenomicsAuth = GcsFileSystem(fileSystemProvider)
-
   val gcsAuthFilePath: Path = {
 
     val storage = jesConfiguration.jesAttributes.genomicsAuth.buildStorage(workflowDescriptor.workflowOptions.toGoogleAuthOptions, jesConfiguration.googleConfig)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -30,6 +30,10 @@ class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor, jesConfigu
   val fileSystemWithGenomicsAuth = GcsFileSystem(fileSystemProvider)
 
   val gcsAuthFilePath: Path = {
+
+    val storage = jesConfiguration.jesAttributes.genomicsAuth.buildStorage(workflowDescriptor.workflowOptions.toGoogleAuthOptions, jesConfiguration.googleConfig)
+    val fileSystemProvider = GcsFileSystemProvider(storage)(gcsFileSystemWithUserAuth.gcsFileSystemProvider.executionContext)
+    val fileSystemWithGenomicsAuth = GcsFileSystem(fileSystemProvider)
     /*
      * This is an "exception". The filesystem used here is built from genomicsAuth
      * unlike everywhere else where the filesystem used is built from gcsFileSystemAuth

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashing.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashing.scala
@@ -9,8 +9,8 @@ import scala.util.{Failure, Try}
 private[jes] object JesBackendFileHashing {
   def getCrc32c(singleFileHashRequest: SingleFileHashRequest, log: LoggingAdapter): Try[String] = {
     def usingJesInitData(jesInitData: JesBackendInitializationData) = for {
-      path <- Try(jesInitData.workflowPaths.fileSystemWithGenomicsAuth.getPath(singleFileHashRequest.file.valueString))
-      crc32c <- Try(jesInitData.workflowPaths.fileSystemProvider.crc32cHash(path))
+      path <- Try(jesInitData.workflowPaths.gcsFileSystemWithUserAuth.getPath(singleFileHashRequest.file.valueString))
+      crc32c <- Try(jesInitData.workflowPaths.gcsFileSystemWithUserAuth.gcsFileSystemProvider.crc32cHash(path))
     } yield crc32c
 
     singleFileHashRequest.initializationData match {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -362,7 +362,7 @@ trait SharedFileSystemAsyncJobExecutionActor
     def processSuccess(returnCode: Int) = {
       val successfulFuture = for {
         outputs <- Future.fromTry(processOutputs())
-      } yield SuccessfulExecutionHandle(outputs, returnCode, Map.empty) //Ruchi: Need to fix this for SFS caching
+      } yield SuccessfulExecutionHandle(outputs, returnCode, Map.empty) //FIXME: Need to pass in real detritus files
 
       successfulFuture recover {
         case failed: Throwable =>

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -362,7 +362,7 @@ trait SharedFileSystemAsyncJobExecutionActor
     def processSuccess(returnCode: Int) = {
       val successfulFuture = for {
         outputs <- Future.fromTry(processOutputs())
-      } yield SuccessfulExecutionHandle(outputs, returnCode, None)
+      } yield SuccessfulExecutionHandle(outputs, returnCode, Map.empty) //Ruchi: Need to fix this for SFS caching
 
       successfulFuture recover {
         case failed: Throwable =>


### PR DESCRIPTION
1. Looking specifically for feedback on what places JesCacheHitCopyingActor would require more error handling.
2. Within the JesCacheHitCopyingActor, are there any messages not being sent to the metadata service that should be sent ?
3. Currently, not re-saving the JobOutputs that JesCacheHitCopyingActor is copying, since we shouldn't require multiple copies of the same outputs
