### PR TITLE
Some globbing Closes #1321 Closes #1308 Closes #1245

### DIFF
--- a/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
@@ -47,8 +47,13 @@ class JobPaths(workflowDescriptor: BackendWorkflowDescriptor,
   val callRoot = callPathBuilder(workflowRoot)
   val callDockerRoot = callPathBuilder(dockerWorkflowRoot)
 
-  val stdout = callRoot.resolve("stdout")
-  val stderr = callRoot.resolve("stderr")
-  val script = callRoot.resolve("script")
-  val returnCode = callRoot.resolve("rc")
+  val callExecutionRoot = callRoot.resolve("execution")
+  val callExecutionDockerRoot = callDockerRoot.resolve("execution")
+
+  val callInputsRoot = callRoot.resolve("inputs")
+
+  val stdout = callExecutionRoot.resolve("stdout")
+  val stderr = callExecutionRoot.resolve("stderr")
+  val script = callExecutionRoot.resolve("script")
+  val returnCode = callExecutionRoot.resolve("rc")
 }

--- a/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
@@ -38,36 +38,40 @@ class JobPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val id = wd.id
     jobPaths.callRoot.toString shouldBe
       File(s"local-cromwell-executions/hello/$id/call-hello").pathAsString
+    jobPaths.callExecutionRoot.toString shouldBe
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution").pathAsString
     jobPaths.returnCode.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/rc").pathAsString
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution/rc").pathAsString
     jobPaths.script.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/script").pathAsString
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution/script").pathAsString
     jobPaths.stderr.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/stderr").pathAsString
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution/stderr").pathAsString
     jobPaths.stdout.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/stdout").pathAsString
-    jobPaths.callRoot.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello").pathAsString
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution/stdout").pathAsString
+    jobPaths.callExecutionRoot.toString shouldBe
+      File(s"local-cromwell-executions/hello/$id/call-hello/execution").pathAsString
     jobPaths.callDockerRoot.toString shouldBe
       File(s"/root/hello/$id/call-hello").pathAsString
-    jobPaths.toDockerPath(Paths.get(s"local-cromwell-executions/hello/$id/call-hello/stdout")).toString shouldBe
-      File(s"/root/hello/$id/call-hello/stdout").pathAsString
+    jobPaths.callExecutionDockerRoot.toString shouldBe
+      File(s"/root/hello/$id/call-hello/execution").pathAsString
+    jobPaths.toDockerPath(Paths.get(s"local-cromwell-executions/hello/$id/call-hello/execution/stdout")).toString shouldBe
+      File(s"/root/hello/$id/call-hello/execution/stdout").pathAsString
     jobPaths.toDockerPath(Paths.get("/root/dock/path")).toString shouldBe
       File("/root/dock/path").pathAsString
 
     val jobKeySharded = BackendJobDescriptorKey(call, Option(0), 1)
     val jobPathsSharded = new JobPaths(wd, backendConfig, jobKeySharded)
-    jobPathsSharded.callRoot.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/shard-0").pathAsString
+    jobPathsSharded.callExecutionRoot.toString shouldBe
+      File(s"local-cromwell-executions/hello/$id/call-hello/shard-0/execution").pathAsString
 
     val jobKeyAttempt = BackendJobDescriptorKey(call, None, 2)
     val jobPathsAttempt = new JobPaths(wd, backendConfig, jobKeyAttempt)
-    jobPathsAttempt.callRoot.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/attempt-2").pathAsString
+    jobPathsAttempt.callExecutionRoot.toString shouldBe
+      File(s"local-cromwell-executions/hello/$id/call-hello/attempt-2/execution").pathAsString
 
     val jobKeyShardedAttempt = BackendJobDescriptorKey(call, Option(0), 2)
     val jobPathsShardedAttempt = new JobPaths(wd, backendConfig, jobKeyShardedAttempt)
-    jobPathsShardedAttempt.callRoot.toString shouldBe
-      File(s"local-cromwell-executions/hello/$id/call-hello/shard-0/attempt-2").pathAsString
+    jobPathsShardedAttempt.callExecutionRoot.toString shouldBe
+      File(s"local-cromwell-executions/hello/$id/call-hello/shard-0/attempt-2/execution").pathAsString
   }
 }

--- a/engine/src/test/scala/cromwell/CopyWorkflowOutputsSpec.scala
+++ b/engine/src/test/scala/cromwell/CopyWorkflowOutputsSpec.scala
@@ -36,10 +36,10 @@ class CopyWorkflowOutputsSpec extends CromwellTestkitSpec {
       )
 
       forAll(outputs) { (call, file) =>
-        val path = tmpDir.resolve(Paths.get("wfoutputs", workflowId.id.toString, call, file))
+        val path = tmpDir.resolve(Paths.get("wfoutputs", workflowId.id.toString, call, "execution", file))
         path.toFile should exist
       }
-      val path = tmpDir.resolve(Paths.get("wfoutputs", workflowId.id.toString, "call-C", "out"))
+      val path = tmpDir.resolve(Paths.get("wfoutputs", workflowId.id.toString, "call-C", "execution", "out"))
       path.toFile shouldNot exist
     }
 
@@ -54,7 +54,7 @@ class CopyWorkflowOutputsSpec extends CromwellTestkitSpec {
       val outputTuples = for {
         shard <- shards
         output <- outputNames
-      } yield ("call-A", s"shard-$shard/$output")
+      } yield ("call-A", s"shard-$shard/execution/$output")
 
       val outputs = Table(("call", "file"), outputTuples: _*)
 

--- a/engine/src/test/scala/cromwell/engine/EngineFunctionsSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/EngineFunctionsSpec.scala
@@ -82,6 +82,5 @@ class EngineFunctionsSpec extends FlatSpec with Matchers {
     val failure = failedSub.failed.get
     failure.isInstanceOf[IllegalArgumentException] shouldBe true
     failure.getMessage shouldBe "Invalid number of parameters for engine function sub: 4. sub takes exactly 3 parameters."
-
   }
 }

--- a/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -17,7 +17,7 @@ class WorkflowManagerActorSpec extends CromwellTestkitSpec with WorkflowDescript
       val outputName = "whereami.whereami.pwd"
       val salutation = outputs.get(outputName).get
       val actualOutput = salutation.valueString.trim
-      actualOutput should endWith("/call-whereami")
+      actualOutput should endWith("/call-whereami/execution")
     }
   }
 }

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorBackendFactory.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorBackendFactory.scala
@@ -33,7 +33,7 @@ case class HtCondorBackendFactory(configurationDescriptor: BackendConfigurationD
                                            initializationData: Option[BackendInitializationData]): WdlStandardLibraryFunctions = {
     val jobPaths = new JobPaths(workflowDescriptor, configurationDescriptor.backendConfig, jobKey)
     val callContext = CallContext(
-      jobPaths.callRoot,
+      jobPaths.callExecutionRoot,
       jobPaths.stdout.toAbsolutePath.toString,
       jobPaths.stderr.toAbsolutePath.toString
     )

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
@@ -51,7 +51,7 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
   private val jobPaths = new JobPaths(workflowDescriptor, configurationDescriptor.backendConfig, jobDescriptor.key)
 
   // Files
-  private val executionDir = jobPaths.callRoot
+  private val executionDir = jobPaths.callExecutionRoot
   private val returnCodePath = jobPaths.returnCode
   private val stdoutPath = jobPaths.stdout
   private val stderrPath = jobPaths.stderr
@@ -232,7 +232,7 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
       executionDir.toString.toFile.createIfNotExists(asDirectory = true, createParents = true)
 
       log.debug("{} Resolving job command", tag)
-      val command = localizeInputs(jobPaths.callRoot, runtimeAttributes.dockerImage.isDefined, fileSystems, jobDescriptor.inputs) flatMap {
+      val command = localizeInputs(jobPaths.callInputsRoot, runtimeAttributes.dockerImage.isDefined, fileSystems, jobDescriptor.inputs) flatMap {
         localizedInputs => resolveJobCommand(localizedInputs)
       }
 
@@ -241,7 +241,7 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
       File(scriptPath).addPermission(PosixFilePermission.OWNER_EXECUTE) // Add executable permissions to the script.
       //TODO: Need to append other runtime attributes from Wdl to Condor submit file
       val attributes: Map[String, Any] = Map(HtCondorRuntimeKeys.Executable -> scriptPath.toAbsolutePath,
-          HtCondorRuntimeKeys.InitialWorkingDir -> jobPaths.callRoot.toAbsolutePath,
+          HtCondorRuntimeKeys.InitialWorkingDir -> jobPaths.callExecutionRoot.toAbsolutePath,
           HtCondorRuntimeKeys.Output -> stdoutPath.toAbsolutePath,
           HtCondorRuntimeKeys.Error -> stderrPath.toAbsolutePath,
           HtCondorRuntimeKeys.Log -> htCondorLog.toAbsolutePath,

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -342,6 +342,8 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
   }
 
   "return a successful task status when it tries to run a docker command containing file data from a WDL file array" in {
+    import wdl4s.values._
+
     val runtime =
       """
         |runtime {
@@ -386,8 +388,8 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
     val bashScript = Source.fromFile(jobPaths.script.toFile).getLines.mkString
 
     assert(bashScript.contains("docker run -w /workingDir -v"))
-    assert(bashScript.contains(tempDir1.toAbsolutePath.toString))
-    assert(bashScript.contains(tempDir2.toAbsolutePath.toString))
+    assert(bashScript.contains(tempDir1.toAbsolutePath.toString.md5Sum))
+    assert(bashScript.contains(tempDir2.toAbsolutePath.toString.md5Sum))
     assert(bashScript.contains("/call-hello/execution:/outputDir --rm ubuntu/latest echo"))
 
     cleanUpJob(jobPaths)

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -305,7 +305,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
 
       assert(bashScript.contains("docker run -w /workingDir -v"))
       assert(bashScript.contains(":ro"))
-      assert(bashScript.contains("/call-hello:/outputDir --rm ubuntu/latest echo"))
+      assert(bashScript.contains("/call-hello/execution:/outputDir --rm ubuntu/latest echo"))
 
       cleanUpJob(jobPaths)
     }
@@ -388,7 +388,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
     assert(bashScript.contains("docker run -w /workingDir -v"))
     assert(bashScript.contains(tempDir1.toAbsolutePath.toString))
     assert(bashScript.contains(tempDir2.toAbsolutePath.toString))
-    assert(bashScript.contains("/call-hello:/outputDir --rm ubuntu/latest echo"))
+    assert(bashScript.contains("/call-hello/execution:/outputDir --rm ubuntu/latest echo"))
 
     cleanUpJob(jobPaths)
   }
@@ -408,7 +408,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
     val backendConfigurationDescriptor = BackendConfigurationDescriptor(backendConfig, ConfigFactory.load)
     val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty), emptyWorkflowOptions, Set.empty)
     val jobPaths = new JobPaths(backendWorkflowDescriptor, backendConfig, jobDesc.key)
-    val executionDir = File(jobPaths.callRoot)
+    val executionDir = File(jobPaths.callExecutionRoot)
     val stdout = File(executionDir.pathAsString, "stdout")
     stdout.createIfNotExists(asDirectory = false, createParents = true)
     val submitFileStderr = executionDir./("submitfile.stderr")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -130,14 +130,16 @@ trait SharedFileSystem extends PathFactory {
       */
     def toCallPath(path: String): PathsPair = {
       val src = buildPath(path, filesystems)
-      // Strip out potential prefix protocol
-      val localInputPath = stripProtocolScheme(src)
-      val dest = if (File(inputsRoot).isParentOf(localInputPath)) localInputPath
+      val inputsRootFile = File(inputsRoot)
+      val dest = if (inputsRootFile.isParentOf(File(src))) src
       else {
-        // Concatenate call directory with absolute input path
-        Paths.get(inputsRoot.toString, localInputPath.toString)
-      }
+        val pathHash = src.getParent match {
+          case null => src.toString.md5Sum
+          case parent => parent.toString.md5Sum
+        }
 
+        inputsRoot.resolve(pathHash).resolve(src.getFileName)
+      }
       (src, dest)
     }
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -94,10 +94,10 @@ trait SharedFileSystem extends PathFactory {
 
   def outputMapper(job: JobPaths)(wdlValue: WdlValue): Try[WdlValue] = {
     wdlValue match {
-      case fileNotFound: WdlFile if !hostAbsoluteFilePath(job.callRoot, fileNotFound.valueString).exists =>
+      case fileNotFound: WdlFile if !hostAbsoluteFilePath(job.callExecutionRoot, fileNotFound.valueString).exists =>
         Failure(new RuntimeException("Could not process output, file not found: " +
-          s"${hostAbsoluteFilePath(job.callRoot, fileNotFound.valueString).pathAsString}"))
-      case file: WdlFile => Try(WdlFile(hostAbsoluteFilePath(job.callRoot, file.valueString).pathAsString))
+          s"${hostAbsoluteFilePath(job.callExecutionRoot, fileNotFound.valueString).pathAsString}"))
+      case file: WdlFile => Try(WdlFile(hostAbsoluteFilePath(job.callExecutionRoot, file.valueString).pathAsString))
       case array: WdlArray =>
         val mappedArray = array.value map outputMapper(job)
         TryUtil.sequence(mappedArray) map { WdlArray(array.wdlType, _) }
@@ -112,8 +112,7 @@ trait SharedFileSystem extends PathFactory {
    *    end up with this implementation and thus use it to satisfy their contract with Backend.
    *    This is yuck-tastic and I consider this a FIXME, but not for this refactor
    */
-  def localizeInputs(callRoot: Path, docker: Boolean, filesystems: List[FileSystem], inputs: CallInputs): Try[CallInputs] = {
-
+  def localizeInputs(inputsRoot: Path, docker: Boolean, filesystems: List[FileSystem], inputs: CallInputs): Try[CallInputs] = {
     val strategies = if (docker) DockerLocalizers else Localizers
 
     // Use URI to identify protocol scheme and strip it out
@@ -133,10 +132,10 @@ trait SharedFileSystem extends PathFactory {
       val src = buildPath(path, filesystems)
       // Strip out potential prefix protocol
       val localInputPath = stripProtocolScheme(src)
-      val dest = if (File(callRoot).isParentOf(localInputPath)) localInputPath
+      val dest = if (File(inputsRoot).isParentOf(localInputPath)) localInputPath
       else {
         // Concatenate call directory with absolute input path
-        Paths.get(callRoot.toString, localInputPath.toString)
+        Paths.get(inputsRoot.toString, localInputPath.toString)
       }
 
       (src, dest)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -182,7 +182,7 @@ trait SharedFileSystemAsyncJobExecutionActor
 
   def instantiatedScript: String = {
     val pathTransformFunction: WdlValue => WdlValue = if (isDockerRun) toDockerPath else identity
-    val tryCommand = sharedFileSystem.localizeInputs(jobPaths.callRoot,
+    val tryCommand = sharedFileSystem.localizeInputs(jobPaths.callInputsRoot,
       isDockerRun, fileSystems, jobDescriptor.inputs) flatMap { localizedInputs =>
       call.task.instantiateCommand(localizedInputs, callEngineFunction, pathTransformFunction)
     }
@@ -232,7 +232,7 @@ trait SharedFileSystemAsyncJobExecutionActor
     metadataEvent(CallMetadataKeys.Stdout, jobPaths.stdout),
     metadataEvent(CallMetadataKeys.Stderr, jobPaths.stderr),
     metadataEvent("cache:allowResultReuse", true),
-    metadataEvent(CallMetadataKeys.CallRoot, jobPaths.callRoot)
+    metadataEvent(CallMetadataKeys.CallRoot, jobPaths.callExecutionRoot)
   )
 
   /**
@@ -247,8 +247,8 @@ trait SharedFileSystemAsyncJobExecutionActor
   def executeScript(): ExecutionHandle = {
     val script = instantiatedScript
     jobLogger.info(s"`$script`")
-    File(jobPaths.callRoot).createDirectories()
-    val cwd = if (isDockerRun) jobPaths.callDockerRoot else jobPaths.callRoot
+    File(jobPaths.callExecutionRoot).createDirectories()
+    val cwd = if (isDockerRun) jobPaths.callExecutionDockerRoot else jobPaths.callExecutionRoot
     writeScript(script, cwd)
     jobLogger.info(s"command: $processArgs")
     val runner = makeProcessRunner()

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
@@ -23,7 +23,7 @@ object SharedFileSystemExpressionFunctions {
             fileSystems: List[FileSystem]): SharedFileSystemExpressionFunctions = {
     val jobPaths = new JobPaths(workflowDescriptor, configurationDescriptor.backendConfig, jobKey)
     val callContext = CallContext(
-      jobPaths.callRoot,
+      jobPaths.callExecutionRoot,
       jobPaths.stdout.toString,
       jobPaths.stderr.toString
     )
@@ -32,7 +32,7 @@ object SharedFileSystemExpressionFunctions {
 
   def apply(jobPaths: JobPaths, fileSystems: List[FileSystem]): SharedFileSystemExpressionFunctions = {
     val callContext = CallContext(
-      jobPaths.callRoot,
+      jobPaths.callExecutionRoot,
       jobPaths.stdout.toString,
       jobPaths.stderr.toString
     )
@@ -45,7 +45,7 @@ object SharedFileSystemExpressionFunctions {
             initializationData: Option[BackendInitializationData]) = {
     val jobPaths = new JobPaths(workflowDescriptor, configurationDescriptor.backendConfig, jobKey)
     val callContext = CallContext(
-      jobPaths.callRoot,
+      jobPaths.callExecutionRoot,
       jobPaths.stdout.toString,
       jobPaths.stderr.toString
     )

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
@@ -62,7 +62,8 @@ class SharedFileSystemExpressionFunctions(override val fileSystems: List[FileSys
 
   override def globPath(glob: String) = context.root.toString
   override def glob(path: String, pattern: String): Seq[String] = {
-    File(toPath(path)).glob(s"**/$pattern") map { _.pathAsString } toSeq
+    val globPattern = toPath(globPath(pattern)).resolve(pattern).normalize.toString
+    File(toPath(path)).glob(globPattern) map { _.pathAsString } toSeq
   }
 
   override val writeDirectory = context.root

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -79,11 +79,11 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val symConf = templateConf("soft-link")
     val copyConf = templateConf("copy")
 
-    val jsonInputFile = createCannedFile("localize", "content from json inputs").pathAsString
-    val callInputFile = createCannedFile("localize", "content from call inputs").pathAsString
+    val jsonInputFile = createCannedFile("localize", "content from json inputs")
+    val callInputFile = createCannedFile("localize", "content from call inputs")
     val inputs = Map(
-      "inputFileFromCallInputs" -> WdlFile(callInputFile),
-      "inputFileFromJson" -> WdlFile(jsonInputFile)
+      "inputFileFromCallInputs" -> WdlFile(callInputFile.pathAsString),
+      "inputFileFromJson" -> WdlFile(jsonInputFile.pathAsString)
     )
 
     val expectedOutputs: JobOutputs = Map(
@@ -113,8 +113,10 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
 
       whenReady(backend.execute) { executionResponse =>
         assertResponse(executionResponse, expectedResponse)
-        val localizedJsonInputFile = Paths.get(jobPaths.callInputsRoot.toString, jsonInputFile)
-        val localizedCallInputFile = Paths.get(jobPaths.callInputsRoot.toString, callInputFile)
+        val hashJsonInputFile = jsonInputFile.parent.toString.md5Sum
+        val localizedJsonInputFile = Paths.get(jobPaths.callInputsRoot.toString, hashJsonInputFile, jsonInputFile.name)
+        val hashCallInputFile = callInputFile.parent.toString.md5Sum
+        val localizedCallInputFile = Paths.get(jobPaths.callInputsRoot.toString, hashCallInputFile, callInputFile.name)
 
         Files.isSymbolicLink(localizedJsonInputFile) shouldBe isSymlink
         val realJsonInputFile =

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -113,8 +113,8 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
 
       whenReady(backend.execute) { executionResponse =>
         assertResponse(executionResponse, expectedResponse)
-        val localizedJsonInputFile = Paths.get(jobPaths.callRoot.toString, jsonInputFile)
-        val localizedCallInputFile = Paths.get(jobPaths.callRoot.toString, callInputFile)
+        val localizedJsonInputFile = Paths.get(jobPaths.callInputsRoot.toString, jsonInputFile)
+        val localizedCallInputFile = Paths.get(jobPaths.callInputsRoot.toString, callInputFile)
 
         Files.isSymbolicLink(localizedJsonInputFile) shouldBe isSymlink
         val realJsonInputFile =
@@ -158,7 +158,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val backend = backendRef.underlyingActor
 
     val jobPaths = new JobPaths(workflowDescriptor, ConfigFactory.empty, jobDescriptor.key)
-    File(jobPaths.callRoot).createDirectories()
+    File(jobPaths.callExecutionRoot).createDirectories()
     File(jobPaths.stdout).write("Hello stubby ! ")
     File(jobPaths.stderr).touch()
 
@@ -199,7 +199,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
         failedResponse.returnCode should be(empty)
         failedResponse.throwable should be(a[RuntimeException])
         failedResponse.throwable.getMessage should startWith("Unable to determine that 0 is alive, and")
-        failedResponse.throwable.getMessage should endWith("call-hello/rc does not exist.")
+        failedResponse.throwable.getMessage should endWith("call-hello/execution/rc does not exist.")
       }
     }
   }
@@ -246,8 +246,8 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val jobDescriptor: BackendJobDescriptor = jobDescriptorFromSingleCallWorkflow(workflowDescriptor, inputs, WorkflowOptions.empty, runtimeAttributeDefinitions)
     val backend = createBackend(jobDescriptor, emptyBackendConfig)
     val jobPaths = new JobPaths(workflowDescriptor, emptyBackendConfig.backendConfig, jobDescriptor.key)
-    val expectedA = WdlFile(jobPaths.callRoot.resolve("a").toAbsolutePath.toString)
-    val expectedB = WdlFile(jobPaths.callRoot.resolve("dir").toAbsolutePath.resolve("b").toString)
+    val expectedA = WdlFile(jobPaths.callExecutionRoot.resolve("a").toAbsolutePath.toString)
+    val expectedB = WdlFile(jobPaths.callExecutionRoot.resolve("dir").toAbsolutePath.resolve("b").toString)
     val expectedOutputs = Map(
       "o1" -> JobOutput(expectedA),
       "o2" -> JobOutput(WdlArray(WdlArrayType(WdlFileType), Seq(expectedA, expectedB))),

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -25,9 +25,10 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
                        fileAlreadyExists: Boolean = false,
                        symlink: Boolean = false,
                        linkNb: Int = 1) = {
+    import wdl4s.values._
     val callDir = File.newTemporaryDirectory("SharedFileSystem")
     val orig = if (fileInCallDir) callDir.createChild("inputFile") else File.newTemporaryFile("inputFile")
-    val dest = if (fileInCallDir) orig else callDir./(orig.pathAsString.drop(1))
+    val dest = if (fileInCallDir) orig else callDir./(orig.parent.toString.md5Sum)./(orig.name)
     orig.touch()
     if (fileAlreadyExists) {
       dest.parent.createDirectories()

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -22,7 +22,7 @@ case class SparkBackendFactory(configurationDescriptor: BackendConfigurationDesc
                                            initializationData: Option[BackendInitializationData]): WdlStandardLibraryFunctions = {
     val jobPaths = new JobPaths(workflowDescriptor, configurationDescriptor.backendConfig, jobKey)
     val callContext = new CallContext(
-      jobPaths.callRoot,
+      jobPaths.callExecutionRoot,
       jobPaths.stdout.toAbsolutePath.toString,
       jobPaths.stderr.toAbsolutePath.toString
     )

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
@@ -246,7 +246,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubUntailed = new UntailedWriter(jobPaths.stdout) with MockPathWriter
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       File(jobPaths.stderr) < "failed"
-      File(jobPaths.callRoot.resolve("cluster.json")) < sampleSubmissionResponse
+      File(jobPaths.callExecutionRoot.resolve("cluster.json")) < sampleSubmissionResponse
 
       val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
         override lazy val clusterExtProcess = sparkClusterProcess
@@ -442,7 +442,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
     val backendConfigurationDescriptor = if (isCluster) BackendConfigurationDescriptor(backendClusterConfig, ConfigFactory.load) else BackendConfigurationDescriptor(backendClientConfig, ConfigFactory.load)
     val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty), WorkflowOptions.empty, Set.empty)
     val jobPaths = if (isCluster) new JobPaths(backendWorkflowDescriptor, backendClusterConfig, jobDesc.key) else new JobPaths(backendWorkflowDescriptor, backendClientConfig, jobDesc.key)
-    val executionDir = jobPaths.callRoot
+    val executionDir = jobPaths.callExecutionRoot
     val stdout = File(executionDir.toString, "stdout")
     stdout.createIfNotExists(asDirectory = false, createParents = true)
     val stderr = File(executionDir.toString, "stderr")


### PR DESCRIPTION

* Commit 1: Creates 2 subdirectories in the call directory.

```
cromwell-executions/globbinginput/
└── 970c776f-3b9d-4c0e-a2ff-dbd76395b4ba
    ├── call-globtask
    │   ├── execution
    │   │   ├── outputfile1.txt
    │   │   ├── outputfile2.txt
    │   │   ├── rc
    │   │   ├── script
    │   │   ├── script.background
    │   │   ├── script.submit
    │   │   ├── stderr
    │   │   ├── stderr.background
    │   │   ├── stdout
    │   │   └── stdout.background
    │   └── inputs
    │       └── 90e8d77e2a99e99efa82c33e27365d71
    │           └── somefile.txt
```

This prevents globbing from matching input files as they're not in the same branch.

* Commit 2: Instead of recreating the whole directory structure underneath the call directory, hash the path and create a single directory named with this hash. 

    * This reduces the depth of the call directory, and is hopefully a bit less confusing (people tend to be confused when they see the full path of their input file appended to the call directory)

    * The hash is only computed from the fullpath of the input's parent directory (not including the filename). This ensures that multiple files from the same directory will still end up in the same directory once localized).

The hashing part is not necessary to fix this bug at all, and I remember the choice was made not to use hashes because it's unreadable and makes it hard to know where the inputs came from but I feel like recreating the full path underneath the call directory is even worse...

* Commit 3: Change the globbing pattern so it does NOT traverse recursively the hierarchy looking for matches by default. If that's the desired behaviour it should be reflected in the glob pattern in the wdl (with `**`). This is necessary to allow for this kind of usage https://github.com/broadinstitute/cromwell/issues/1245
