### PR TITLE
[HtCondor] Create symlink after cache hit. Closes #1425.

### DIFF
--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalization.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalization.scala
@@ -1,0 +1,39 @@
+package cromwell.backend.impl.htcondor.caching.localization
+
+import java.nio.file.{Files, Path, Paths}
+
+import better.files.File
+import cromwell.core.{JobOutput, _}
+import wdl4s.types.{WdlArrayType, WdlFileType}
+import wdl4s.values.{WdlArray, WdlSingleFile, WdlValue}
+
+trait CachedResultLocalization {
+  private[localization] def localizePathViaSymbolicLink(originalPath: Path, executionPath: Path): Path = {
+    if (File(originalPath).isDirectory) throw new UnsupportedOperationException("Cannot localize directory with symbolic links.")
+    else {
+      File(executionPath).parent.createDirectories()
+      Files.createSymbolicLink(executionPath, originalPath.toAbsolutePath)
+    }
+  }
+
+  private[localization] def localizeCachedFile(executionPath: Path, output: WdlValue): WdlSingleFile = {
+    val origPath = Paths.get(output.valueString)
+    val newPath = executionPath.toAbsolutePath.resolve(origPath.getFileName)
+    val slPath = localizePathViaSymbolicLink(origPath, newPath)
+    WdlSingleFile(slPath.toString)
+  }
+
+  def localizeCachedOutputs(executionPath: Path, outputs: JobOutputs): JobOutputs = {
+    outputs map { case (lqn, jobOutput) =>
+      jobOutput.wdlValue.wdlType match {
+        case WdlFileType => (lqn -> JobOutput(localizeCachedFile(executionPath, jobOutput.wdlValue)))
+        case WdlArrayType(WdlFileType) =>
+          val newArray: Seq[WdlSingleFile] = jobOutput.wdlValue.asInstanceOf[WdlArray].value map {
+            localizeCachedFile(executionPath, _)
+          }
+          (lqn -> JobOutput(WdlArray(WdlArrayType(WdlFileType), newArray)))
+        case _ => (lqn, jobOutput)
+      }
+    }
+  }
+}

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
@@ -4,7 +4,7 @@ import better.files._
 
 import org.scalatest.{Matchers, WordSpecLike}
 
-class HtCondorCommandSpec extends WordSpecLike with Matchers{
+class HtCondorCommandSpec extends WordSpecLike with Matchers {
   val attributes = Map("executable" -> "test.sh", "input" -> "/temp/test", "error"->"stderr")
   val resultAttributes = List("executable=test.sh","input=/temp/test","error=stderr", "queue")
   val htCondorCommands = new HtCondorCommands

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalizationSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalizationSpec.scala
@@ -1,0 +1,64 @@
+package cromwell.backend.impl.htcondor.caching.localization
+
+import java.nio.file.Files
+
+import cromwell.core.{JobOutput, JobOutputs}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
+import wdl4s.types.{WdlArrayType, WdlFileType}
+import wdl4s.values.{WdlArray, WdlSingleFile, WdlString}
+
+class CachedResultLocalizationSpec extends WordSpecLike with Matchers with BeforeAndAfterAll {
+  private class CachedResultLocalizationMock extends CachedResultLocalization
+  private val defaultTmpDir = Files.createTempDirectory("cachedFiles").toAbsolutePath
+  private val defaultCachedFile = defaultTmpDir.resolve("input.txt")
+  private val newTmpDir = Files.createTempDirectory("newFiles").toAbsolutePath
+  private val newTmpFile = newTmpDir.resolve(defaultCachedFile.getFileName())
+  private val cachedResults = new CachedResultLocalizationMock()
+  private val defaultFileArray = Seq("arrInput1.txt", "arrInput2.txt", "arrInput3.txt").map(defaultTmpDir.resolve(_).toAbsolutePath)
+  private val newFileArray = Seq("arrInput1.txt", "arrInput2.txt", "arrInput3.txt").map(newTmpDir.resolve(_).toAbsolutePath)
+
+  override def afterAll() = {
+    Seq(defaultCachedFile, newTmpFile) ++ newFileArray ++ Seq(defaultTmpDir, newTmpDir) foreach { _.toFile.delete() }
+  }
+
+  "CachedResultLocalization" should {
+    "localize file path via symbolic link" in {
+      val slPath = cachedResults.localizePathViaSymbolicLink(defaultCachedFile, newTmpFile)
+      assert(Files.isSymbolicLink(slPath))
+      Files.delete(newTmpFile)
+    }
+
+    "not localize dir path via symbolic link" in {
+      assertThrows[UnsupportedOperationException](cachedResults.localizePathViaSymbolicLink(defaultTmpDir, newTmpFile))
+    }
+
+    "localize cached job outputs which are WDL files using symbolic link" in {
+      val outputs: JobOutputs = Map("File1" -> JobOutput(WdlSingleFile(defaultCachedFile.toAbsolutePath.toString)))
+      val newJobOutputs = cachedResults.localizeCachedOutputs(newTmpDir, outputs)
+      newJobOutputs foreach { case (lqn, jobOutput) =>
+        assert(jobOutput.wdlValue.valueString == newTmpFile.toString)
+      }
+    }
+
+    "localize cached job outputs which are WDL File Array using symbolic link" in {
+      val wdlArray = WdlArray(WdlArrayType(WdlFileType), defaultFileArray.map(file => WdlSingleFile(file.toString())))
+      val outputs = Map("File1" -> JobOutput(wdlArray))
+      val newJobOutputs = cachedResults.localizeCachedOutputs(newTmpDir, outputs)
+      newJobOutputs foreach { case (lqn, jobOutput) =>
+        val wdlArray = jobOutput.wdlValue.asInstanceOf[WdlArray].value
+        wdlArray foreach { entry =>
+          assert(!entry.valueString.contains(defaultTmpDir.toString))
+          assert(entry.valueString.contains(newTmpDir.toString))
+        }
+      }
+    }
+
+    "not localize cached job outputs which are not WDL files" in {
+      val outputs = Map("String1" -> JobOutput(WdlString(defaultCachedFile.toAbsolutePath.toString)))
+      val newJobOutputs = cachedResults.localizeCachedOutputs(newTmpDir, outputs)
+      newJobOutputs foreach { case (lqn, jobOutput) =>
+        assert(jobOutput.wdlValue.valueString == defaultCachedFile.toString)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Functionality added to localize WdlFile / WdlArray[WdlFile] cached results in HtCondor so in that way cached results are link to the new task.

i.e.:
1. w0/task1 execution produces w0/result1.
2. w0/result1 is stored in the cache.
3. w1/task1 (w1/task1 is the same as w0/task1) is executed again.
4. Cache result is hit.
5. File cached results are used to generate new symlinks to point to them in current task.
6. Result is generated using new paths based on symlinks and/or other cached results.

This change is based on new security/permissions requirements.