### PR TITLE
Avoid unnecessary token refreshing

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -109,18 +109,18 @@ google {
       name = "application-default"
       scheme = "application_default"
     },
-    {
-      name = "user-via-refresh"
-      scheme = "refresh_token"
-      client-id = "secret_id"
-      client-secret = "secret_secret"
-    },
-    {
-      name = "service-account"
-      scheme = "service_account"
-      service-account-id = "my-service-account"
-      pem-file = "/path/to/file.pem"
-    }
+//    {
+//      name = "user-via-refresh"
+//      scheme = "refresh_token"
+//      client-id = "secret_id"
+//      client-secret = "secret_secret"
+//    },
+//    {
+//      name = "service-account"
+//      scheme = "service_account"
+//      service-account-id = "my-service-account"
+//      pem-file = "/path/to/file.pem"
+//    }
   ]
 }
 

--- a/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
@@ -7,22 +7,30 @@ import cromwell.core.WorkflowOptions
 import cromwell.engine.backend.EnhancedWorkflowOptions._
 import cromwell.filesystems.gcs.{GcsFileSystem, GcsFileSystemProvider, GoogleConfiguration}
 import lenthall.config.ScalaConfig._
+import lenthall.exception.MessageAggregation
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 object EngineFilesystems {
 
   private val config = ConfigFactory.load
+  private val googleConf: GoogleConfiguration = GoogleConfiguration(config)
+  private val googleAuthMode = config.getStringOption("engine.filesystems.gcs.auth") map { confMode =>
+    googleConf.auth(confMode) match {
+      case scalaz.Success(mode) => mode
+      case scalaz.Failure(errors) => throw new RuntimeException() with MessageAggregation {
+        override def exceptionContext: String = s"Failed to create authentication mode for $confMode"
+        override def errorMessages: Traversable[String] = errors.list.toList
+      }
+    }
+  }
 
   def filesystemsForWorkflow(workflowOptions: WorkflowOptions)(implicit ec: ExecutionContext): List[FileSystem] = {
     def gcsFileSystem: Option[GcsFileSystem] = {
-      for {
-        authModeString <- config.getStringOption("engine.filesystems.gcs.auth")
-        authMode <- GoogleConfiguration(config).auth(authModeString).toOption
-        fs <- Try(GcsFileSystem(GcsFileSystemProvider(
-          authMode.buildStorage(workflowOptions.toGoogleAuthOptions, config)))).toOption
-      } yield fs
+      googleAuthMode map { mode =>
+        val storage = mode.buildStorage(workflowOptions.toGoogleAuthOptions, googleConf.applicationName)
+        GcsFileSystem(GcsFileSystemProvider(storage))
+      }
     }
 
     List(gcsFileSystem, Option(FileSystems.getDefault)).flatten

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleAuthMode.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleAuthMode.scala
@@ -12,7 +12,6 @@ import com.google.api.client.json.JsonFactory
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.store.FileDataStoreFactory
 import com.google.api.services.storage.{Storage, StorageScopes}
-import com.typesafe.config.Config
 import cromwell.filesystems.gcs.GoogleAuthMode.{GcsScopes, GoogleAuthOptions}
 import org.slf4j.LoggerFactory
 
@@ -21,6 +20,8 @@ import scala.util.{Failure, Success, Try}
 
 object GoogleAuthMode {
 
+  lazy val jsonFactory = JacksonFactory.getDefaultInstance
+  lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val RefreshTokenOptionKey = "refresh_token"
 
   /**
@@ -46,6 +47,13 @@ object GoogleAuthMode {
     }
   }
 
+  def buildStorage(credential: Credential, applicationName: String) = {
+    new Storage.Builder(
+      httpTransport,
+      jsonFactory,
+      credential).setApplicationName(applicationName).build()
+  }
+
   trait GoogleAuthOptions {
     def get(key: String): Try[String]
   }
@@ -58,19 +66,13 @@ object GoogleAuthMode {
 
 
 sealed trait GoogleAuthMode {
-
-  def credential(options: GoogleAuthOptions): Credential = {
-    validateCredentials(buildCredentials(options))
-  }
+  def credential(options: GoogleAuthOptions): Credential
 
   def assertWorkflowOptions(options: GoogleAuthOptions): Unit = ()
 
   def name: String
 
   def requiresAuthFile: Boolean = false
-
-  protected lazy val jsonFactory = JacksonFactory.getDefaultInstance
-  protected lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
 
   protected lazy val log = LoggerFactory.getLogger(getClass.getSimpleName)
 
@@ -81,36 +83,35 @@ sealed trait GoogleAuthMode {
     }
   }
 
-  protected def buildCredentials(options: GoogleAuthOptions): Credential
-
-  def buildStorage(options: GoogleAuthOptions, config: Config): Storage = {
-    buildStorage(options, GoogleConfiguration(config))
-  }
-
-  def buildStorage(options: GoogleAuthOptions, googleConfig: GoogleConfiguration): Storage = {
-    new Storage.Builder(
-      httpTransport,
-      jsonFactory,
-      credential(options)).setApplicationName(googleConfig.applicationName).build()
+  def buildStorage(options: GoogleAuthOptions, applicationName: String): Storage = {
+    GoogleAuthMode.buildStorage(credential(options), applicationName)
   }
 }
 
 final case class ServiceAccountMode(override val name: String, accountId: String, pemPath: String, scopes: List[String] = GcsScopes) extends GoogleAuthMode {
-  override protected def buildCredentials(options: GoogleAuthOptions): Credential = {
+  import GoogleAuthMode._
+
+  private val credentials: Credential = {
     val pemFile = Paths.get(pemPath).toAbsolutePath
     if (!Files.exists(pemFile)) {
       throw new FileNotFoundException(s"PEM file $pemFile does not exist")
     }
-    new GoogleCredential.Builder().setTransport(httpTransport)
+    validateCredentials(
+      new GoogleCredential.Builder().setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
       .setServiceAccountId(accountId)
       .setServiceAccountScopes(scopes.asJava)
       .setServiceAccountPrivateKeyFromPemFile(pemFile.toFile)
       .build()
+    )
   }
+
+  override def credential(options: GoogleAuthOptions) = credentials
 }
 
 final case class UserMode(override val name: String, user: String, secretsFile: String, datastoreDir: String, scopes: List[String] = GcsScopes) extends GoogleAuthMode {
+  import GoogleAuthMode._
+
   private def filePathToSecrets(secrets: String, jsonFactory: JsonFactory) = {
     val secretsPath = Paths.get(secrets).toAbsolutePath
     if(!Files.isReadable(secretsPath)) {
@@ -121,7 +122,7 @@ final case class UserMode(override val name: String, user: String, secretsFile: 
     GoogleClientSecrets.load(jsonFactory, secretStream)
   }
 
-  override protected def buildCredentials(options: GoogleAuthOptions): Credential = {
+  private val credentials: Credential = {
     val clientSecrets = filePathToSecrets(secretsFile, jsonFactory)
     val dataStore = Paths.get(datastoreDir).toAbsolutePath
     val dataStoreFactory = new FileDataStoreFactory(dataStore.toFile)
@@ -129,21 +130,27 @@ final case class UserMode(override val name: String, user: String, secretsFile: 
       jsonFactory,
       clientSecrets,
       scopes.asJava).setDataStoreFactory(dataStoreFactory).build
-    new AuthorizationCodeInstalledApp(flow, new GooglePromptReceiver).authorize(user)
+    validateCredentials(new AuthorizationCodeInstalledApp(flow, new GooglePromptReceiver).authorize(user))
   }
+
+  override def credential(options: GoogleAuthOptions) = credentials
 }
 
 // It would be goofy to have multiple auths that are application_default, but Cromwell won't prevent it.
 final case class ApplicationDefaultMode(override val name: String, scopes: List[String] = GcsScopes) extends GoogleAuthMode {
-  override protected def buildCredentials(options: GoogleAuthOptions): Credential = {
+  import GoogleAuthMode._
+
+  private val credentials: Credential = {
     try {
-      GoogleCredential.getApplicationDefault().createScoped(scopes.asJava)
+      validateCredentials(GoogleCredential.getApplicationDefault().createScoped(scopes.asJava))
     } catch {
       case e: IOException =>
         log.warn("Failed to get application default credentials", e)
         throw e
     }
   }
+
+  override def credential(options: GoogleAuthOptions) = credentials
 }
 
 final case class RefreshTokenMode(name: String, clientId: String, clientSecret: String) extends GoogleAuthMode with ClientSecrets {
@@ -160,12 +167,14 @@ final case class RefreshTokenMode(name: String, clientId: String, clientSecret: 
     options.get(RefreshTokenOptionKey).getOrElse(throw new IllegalArgumentException(s"Missing parameters in workflow options: $RefreshTokenOptionKey"))
   }
 
-  override protected def buildCredentials(options: GoogleAuthOptions): Credential = {
-    new GoogleCredential.Builder().setTransport(httpTransport)
+  override def credential(options: GoogleAuthOptions): Credential = {
+    validateCredentials(
+      new GoogleCredential.Builder().setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
       .setClientSecrets(clientId, clientSecret)
       .build()
       .setRefreshToken(getToken(options))
+    )
   }
 }
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleAuthMode.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleAuthMode.scala
@@ -91,7 +91,7 @@ sealed trait GoogleAuthMode {
 final case class ServiceAccountMode(override val name: String, accountId: String, pemPath: String, scopes: List[String] = GcsScopes) extends GoogleAuthMode {
   import GoogleAuthMode._
 
-  private val credentials: Credential = {
+  private lazy val credentials: Credential = {
     val pemFile = Paths.get(pemPath).toAbsolutePath
     if (!Files.exists(pemFile)) {
       throw new FileNotFoundException(s"PEM file $pemFile does not exist")
@@ -122,7 +122,7 @@ final case class UserMode(override val name: String, user: String, secretsFile: 
     GoogleClientSecrets.load(jsonFactory, secretStream)
   }
 
-  private val credentials: Credential = {
+  private lazy val credentials: Credential = {
     val clientSecrets = filePathToSecrets(secretsFile, jsonFactory)
     val dataStore = Paths.get(datastoreDir).toAbsolutePath
     val dataStoreFactory = new FileDataStoreFactory(dataStore.toFile)
@@ -140,7 +140,7 @@ final case class UserMode(override val name: String, user: String, secretsFile: 
 final case class ApplicationDefaultMode(override val name: String, scopes: List[String] = GcsScopes) extends GoogleAuthMode {
   import GoogleAuthMode._
 
-  private val credentials: Credential = {
+  private lazy val credentials: Credential = {
     try {
       validateCredentials(GoogleCredential.getApplicationDefault().createScoped(scopes.asJava))
     } catch {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
@@ -11,8 +11,8 @@ import cromwell.filesystems.gcs.GoogleConfiguration
 
 object GenomicsFactory {
 
-  def apply(googleConfig: GoogleConfiguration, credential: Credential, endpointUrl: URL): Genomics = {
-    GoogleGenomics.from(googleConfig.applicationName, endpointUrl, credential, credential.getJsonFactory, credential.getTransport)
+  def apply(applicationName: String, credential: Credential, endpointUrl: URL): Genomics = {
+    GoogleGenomics.from(applicationName, endpointUrl, credential, credential.getJsonFactory, credential.getTransport)
   }
 
   // Wrapper object around Google's Genomics class providing a convenience 'from' "method"

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -55,7 +55,6 @@ object JesAsyncBackendJobExecutionActor {
 
   object WorkflowOptionKeys {
     val MonitoringScript = "monitoring_script"
-    val AuthFilePath = "auth_bucket"
     val GoogleProject = "google_project"
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -172,7 +172,7 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
     jesStderrFile.toString
   )
 
-  private[jes] lazy val callEngineFunctions = new JesExpressionFunctions(List(jesCallPaths.gcsFileSystemWithUserAuth), callContext)
+  private[jes] lazy val callEngineFunctions = new JesExpressionFunctions(List(jesCallPaths.gcsFileSystem), callContext)
 
   private val lookup: ScopedLookupFunction = {
     val declarations = workflowDescriptor.workflowNamespace.workflow.declarations ++ call.task.declarations
@@ -704,7 +704,7 @@ class JesAsyncBackendJobExecutionActor(override val jobDescriptor: BackendJobDes
     }
   }
 
-  private def getPath(str: String) = jesCallPaths.gcsFileSystemWithUserAuth.getPath(str)
+  private def getPath(str: String) = jesCallPaths.gcsFileSystem.getPath(str)
 
   protected implicit def ec: ExecutionContext = context.dispatcher
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
@@ -21,12 +21,8 @@ case class JesAttributes(project: String,
                          executionBucket: String,
                          endpointUrl: URL,
                          maxPollingInterval: Int) {
-
-  def assertWorkflowOptions(options: WorkflowOptions): Unit = {
-    // These methods throw on bad options
-    genomicsAuth.assertWorkflowOptions(options.toGoogleAuthOptions)
-    gcsFilesystemAuth.assertWorkflowOptions(options.toGoogleAuthOptions)
-  }
+  def genomicsCredential(options: WorkflowOptions) = genomicsAuth.credential(options.toGoogleAuthOptions)
+  def gcsCredential(options: WorkflowOptions) = gcsFilesystemAuth.credential(options.toGoogleAuthOptions)
 }
 
 object JesAttributes {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
@@ -64,7 +64,7 @@ case class JesBackendLifecycleActorFactory(configurationDescriptor: BackendConfi
                                            initializationData: Option[BackendInitializationData]): WdlStandardLibraryFunctions = {
 
     val jesCallPaths = initializationData.toJes.get.workflowPaths.toJesCallPaths(jobKey)
-    new JesExpressionFunctions(List(jesCallPaths.gcsFileSystemWithUserAuth), jesCallPaths.callContext)
+    new JesExpressionFunctions(List(jesCallPaths.gcsFileSystem), jesCallPaths.callContext)
   }
 
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
@@ -33,7 +33,7 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
   override def copyCachedOutputs(seqOfSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String],
                                  returnCode: Option[Int]): BackendJobExecutionResponse = {
 
-    val gcsFileSystem = initializationData.workflowPaths.gcsFileSystemWithUserAuth
+    val gcsFileSystem = initializationData.workflowPaths.gcsFileSystem
     val jesCallPaths = initializationData.workflowPaths.toJesCallPaths(jobDescriptor.key)
     val destinationCallRootPath: Path = jesCallPaths.callRootPath
     val getSourceCallRootPath: Try[Path] = Try {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCallPaths.scala
@@ -2,18 +2,24 @@ package cromwell.backend.impl.jes
 
 import java.nio.file.Path
 
+import cromwell.backend.impl.jes.authentication.JesCredentials
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.CallContext
-import cromwell.filesystems.gcs.GcsFileSystem
+
+import scala.concurrent.ExecutionContext
 
 object JesCallPaths {
-  def apply(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor, jesConfiguration: JesConfiguration, gcsFileSystem: GcsFileSystem): JesCallPaths = {
-    new JesCallPaths(jobKey, workflowDescriptor, jesConfiguration, gcsFileSystem)
+  def apply(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor,
+            jesConfiguration: JesConfiguration,
+            credentials: JesCredentials)(implicit ec: ExecutionContext): JesCallPaths = {
+    new JesCallPaths(jobKey, workflowDescriptor, jesConfiguration, credentials)
   }
 }
 
-class JesCallPaths(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor, jesConfiguration: JesConfiguration,
-                   gcsFileSystem: GcsFileSystem) extends JesWorkflowPaths(workflowDescriptor, jesConfiguration, gcsFileSystem) {
+class JesCallPaths(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor,
+                   jesConfiguration: JesConfiguration,
+                   credentials: JesCredentials)(implicit ec: ExecutionContext) extends
+  JesWorkflowPaths(workflowDescriptor, jesConfiguration, credentials)(ec) {
 
   val CallPrefix = "call"
   val ShardPrefix = "shard"

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -2,42 +2,51 @@ package cromwell.backend.impl.jes
 
 import java.nio.file.Path
 
-import cromwell.backend.impl.jes.JesImplicits.GoogleAuthWorkflowOptions
+import cromwell.backend.impl.jes.authentication.JesCredentials
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.WorkflowOptions.FinalCallLogsDir
-import cromwell.filesystems.gcs.{GcsFileSystem, GcsFileSystemProvider}
+import cromwell.filesystems.gcs.{GcsFileSystem, GcsFileSystemProvider, GoogleAuthMode}
+
+import scala.concurrent.ExecutionContext
 
 object JesWorkflowPaths {
   private val GcsRootOptionKey = "jes_gcs_root"
   private val AuthFilePathOptionKey = "auth_bucket"
 
-  def apply(workflowDescriptor: BackendWorkflowDescriptor, jesConfiguration: JesConfiguration, gcsFileSystem: GcsFileSystem) = {
-    new JesWorkflowPaths(workflowDescriptor, jesConfiguration, gcsFileSystem)
+  def apply(workflowDescriptor: BackendWorkflowDescriptor,
+            jesConfiguration: JesConfiguration,
+            credentials: JesCredentials)(implicit ec: ExecutionContext) = {
+    new JesWorkflowPaths(workflowDescriptor, jesConfiguration, credentials)
   }
 }
 
-class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor, jesConfiguration: JesConfiguration, val gcsFileSystemWithUserAuth: GcsFileSystem) {
+class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
+                       jesConfiguration: JesConfiguration,
+                       credentials: JesCredentials)(implicit ec: ExecutionContext) {
+
+  private val gcsStorage = GoogleAuthMode.buildStorage(credentials.gcsCredential, jesConfiguration.googleConfig.applicationName)
+  val gcsFileSystemProvider: GcsFileSystemProvider = GcsFileSystemProvider(gcsStorage)(ec)
+  val gcsFileSystem = GcsFileSystem(gcsFileSystemProvider)
+
   val rootPath: Path =
-    gcsFileSystemWithUserAuth.getPath(workflowDescriptor.workflowOptions.getOrElse(JesWorkflowPaths.GcsRootOptionKey, jesConfiguration.root))
+    gcsFileSystem.getPath(workflowDescriptor.workflowOptions.getOrElse(JesWorkflowPaths.GcsRootOptionKey, jesConfiguration.root))
 
   val workflowRootPath: Path = rootPath.resolve(workflowDescriptor.workflowNamespace.workflow.unqualifiedName)
     .resolve(workflowDescriptor.id.toString)
 
-  val finalCallLogsPath = workflowDescriptor.getWorkflowOption(FinalCallLogsDir) map { gcsFileSystemWithUserAuth.getPath(_) }
+  val finalCallLogsPath = workflowDescriptor.getWorkflowOption(FinalCallLogsDir) map { gcsFileSystem.getPath(_) }
 
   val gcsAuthFilePath: Path = {
-
-    val storage = jesConfiguration.jesAttributes.genomicsAuth.buildStorage(workflowDescriptor.workflowOptions.toGoogleAuthOptions, jesConfiguration.googleConfig)
-    val fileSystemProvider = GcsFileSystemProvider(storage)(gcsFileSystemWithUserAuth.gcsFileSystemProvider.executionContext)
-    val fileSystemWithGenomicsAuth = GcsFileSystem(fileSystemProvider)
     /*
      * This is an "exception". The filesystem used here is built from genomicsAuth
      * unlike everywhere else where the filesystem used is built from gcsFileSystemAuth
      */
+    val genomicsStorage = GoogleAuthMode.buildStorage(credentials.genomicsCredential, jesConfiguration.googleConfig.applicationName)
+    val fileSystemWithGenomicsAuth = GcsFileSystem(GcsFileSystemProvider(genomicsStorage)(ec))
     val bucket = workflowDescriptor.workflowOptions.get(JesWorkflowPaths.AuthFilePathOptionKey) getOrElse workflowRootPath.toString
 
     fileSystemWithGenomicsAuth.getPath(bucket).resolve(s"${workflowDescriptor.id}_auth.json")
   }
 
-  def toJesCallPaths(jobKey: BackendJobDescriptorKey) = JesCallPaths(jobKey, workflowDescriptor, jesConfiguration, gcsFileSystemWithUserAuth)
+  def toJesCallPaths(jobKey: BackendJobDescriptorKey) = JesCallPaths(jobKey, workflowDescriptor, jesConfiguration, credentials)(ec)
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesCredentials.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesCredentials.scala
@@ -1,0 +1,5 @@
+package cromwell.backend.impl.jes.authentication
+
+import com.google.api.client.auth.oauth2.Credential
+
+case class JesCredentials(genomicsCredential: Credential, gcsCredential: Credential)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashing.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashing.scala
@@ -9,8 +9,8 @@ import scala.util.{Failure, Try}
 private[jes] object JesBackendFileHashing {
   def getCrc32c(singleFileHashRequest: SingleFileHashRequest, log: LoggingAdapter): Try[String] = {
     def usingJesInitData(jesInitData: JesBackendInitializationData) = for {
-      path <- Try(jesInitData.workflowPaths.gcsFileSystemWithUserAuth.getPath(singleFileHashRequest.file.valueString))
-      crc32c <- Try(jesInitData.workflowPaths.gcsFileSystemWithUserAuth.gcsFileSystemProvider.crc32cHash(path))
+      path <- Try(jesInitData.workflowPaths.gcsFileSystem.getPath(singleFileHashRequest.file.valueString))
+      crc32c <- Try(jesInitData.workflowPaths.gcsFileSystemProvider.crc32cHash(path))
     } yield crc32c
 
     singleFileHashRequest.initializationData match {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -31,6 +31,7 @@ import wdl4s.{Call, LocallyQualifiedName, NamespaceWithWorkflow}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Success, Try}
+import cromwell.backend.impl.jes.MockObjects._
 
 class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackendJobExecutionActorSpec")
   with FlatSpecLike with Matchers with ImplicitSender with Mockito {
@@ -76,11 +77,13 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
         override def get(key: String): Try[String] = Try(throw new RuntimeException(s"key '$key' not found"))
       }
 
-      val storage = jesConfiguration.jesAttributes.gcsFilesystemAuth.buildStorage(authOptions, jesConfiguration.googleConfig)
+      val storage = jesConfiguration.jesAttributes.gcsFilesystemAuth.buildStorage(authOptions, "appName")
       GcsFileSystem(GcsFileSystemProvider(storage)(scala.concurrent.ExecutionContext.global))
     }
 
-    val workflowPaths = JesWorkflowPaths(jobDescriptor.workflowDescriptor, configuration, gcsFileSystem)
+    val workflowPaths = JesWorkflowPaths(jobDescriptor.workflowDescriptor,
+      configuration,
+      mockCredentials)(scala.concurrent.ExecutionContext.global)
     JesBackendInitializationData(workflowPaths, null)
   }
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
@@ -1,12 +1,11 @@
 package cromwell.backend.impl.jes
 
 import cromwell.backend.BackendSpec
-import cromwell.core.Tags._
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpec, Matchers}
 import org.specs2.mock.Mockito
-
-import cromwell.filesystems.gcs.MockGcsFileSystemBuilder._
+import scala.concurrent.ExecutionContext.Implicits.global
+import cromwell.backend.impl.jes.MockObjects._
 
 class JesCallPathsSpec extends FlatSpec with Matchers with Mockito {
 
@@ -20,7 +19,8 @@ class JesCallPathsSpec extends FlatSpec with Matchers with Mockito {
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration, mockGcsFileSystem)
+    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor,
+      jesConfiguration, mockCredentials)
     callPaths.returnCodeFilename should be("hello-rc.txt")
     callPaths.stderrFilename should be("hello-stderr.log")
     callPaths.stdoutFilename should be("hello-stdout.log")
@@ -32,7 +32,8 @@ class JesCallPathsSpec extends FlatSpec with Matchers with Mockito {
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration, mockGcsFileSystem)
+    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration,
+      mockCredentials)
     callPaths.returnCodePath.toString should
       be(s"gs://my-cromwell-workflows-bucket/hello/${workflowDescriptor.id}/call-hello/hello-rc.txt")
     callPaths.stdoutPath.toString should
@@ -48,7 +49,8 @@ class JesCallPathsSpec extends FlatSpec with Matchers with Mockito {
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration, mockGcsFileSystem)
+    val callPaths = JesCallPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration,
+      mockCredentials)
     callPaths.callContext.root.toString should
       be(s"gs://my-cromwell-workflows-bucket/hello/${workflowDescriptor.id}/call-hello")
     callPaths.callContext.stdout should be("hello-stdout.log")

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
@@ -29,18 +29,6 @@ object JesTestConfig {
        |    {
        |      name = "application-default"
        |      scheme = "application_default"
-       |    },
-       |    {
-       |      name = "user-via-refresh"
-       |      scheme = "refresh_token"
-       |      client-id = "secret_id"
-       |      client-secret = "secret_secret"
-       |    },
-       |    {
-       |      name = "service-account"
-       |      scheme = "service_account"
-       |      service-account-id = "my-service-account"
-       |      pem-file = "/path/to/file.pem"
        |    }
        |  ]
        |}

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
@@ -1,10 +1,10 @@
 package cromwell.backend.impl.jes
 
 import cromwell.backend.BackendSpec
-import cromwell.filesystems.gcs.MockGcsFileSystemBuilder._
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpec, Matchers}
 import org.specs2.mock.Mockito
+import cromwell.backend.impl.jes.MockObjects._
 
 class JesWorkflowPathsSpec extends FlatSpec with Matchers with Mockito {
   import BackendSpec._
@@ -16,7 +16,7 @@ class JesWorkflowPathsSpec extends FlatSpec with Matchers with Mockito {
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, jesConfiguration, mockGcsFileSystem)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, jesConfiguration, mockCredentials)(scala.concurrent.ExecutionContext.global)
     workflowPaths.rootPath.toString should be("gs://my-cromwell-workflows-bucket")
     workflowPaths.workflowRootPath.toString should
       be(s"gs://my-cromwell-workflows-bucket/hello/${workflowDescriptor.id}")

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/MockObjects.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/MockObjects.scala
@@ -1,0 +1,9 @@
+package cromwell.backend.impl.jes
+
+import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
+import cromwell.backend.impl.jes.authentication.JesCredentials
+
+object MockObjects {
+  val mockCredential = new MockGoogleCredential.Builder().build()
+  val mockCredentials = JesCredentials(mockCredential, mockCredential)
+}

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/GcsWorkflowFileSystemProvider.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/GcsWorkflowFileSystemProvider.scala
@@ -29,7 +29,7 @@ object GcsWorkflowFileSystemProvider extends WorkflowFileSystemProvider {
       override def get(key: String): Try[String] = workflowOptions.get(key)
     }
 
-    val storage = gcsAuthMode.buildStorage(authOptions, googleConfig)
+    val storage = gcsAuthMode.buildStorage(authOptions, googleConfig.applicationName)
     GcsFileSystem(GcsFileSystemProvider(storage)(params.fileSystemExecutionContext))
   }
 }


### PR DESCRIPTION
Only the refresh-token mode requires new credentials to be created/validated for every workflow, all other modes can be validated only from the configuration. This ensures we don't re-create unnecessary auth modes. 