### PR TITLE
Add configurable docker command and soft links for dockerized jobs. Closes #1433.

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -226,6 +226,17 @@ backend {
     #    # launches.
     #    root: "cromwell-executions"
     #
+    #    #Placeholders:
+    #    #1. Working directory.
+    #    #2. Inputs volumes.
+    #    #3. Output volume.
+    #    #4. Docker image.
+    #    #5. Job command.
+    #    docker {
+    #      #Allow soft links in dockerized jobs
+    #      cmd = "docker run -w %s %s %s --rm %s %s"
+    #    }
+    #
     #    cache {
     #      provider = "cromwell.backend.impl.htcondor.caching.provider.mongodb.MongoCacheActorFactory"
     #      enabled = false

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
@@ -318,7 +318,7 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
       }.flatten.toSeq
 
       log.debug("{} List of input volumes: {}", tag, dockerInputDataVol.mkString(","))
-      val dockerCmd = "docker run -w %s %s %s --rm %s %s"
+      val dockerCmd = configurationDescriptor.backendConfig.getString("docker.cmd")
       val dockerVolume = "-v %s:%s"
       val dockerVolumeInputs = s"$dockerVolume:ro"
       // `v.get` is safe below since we filtered the list earlier with only defined elements

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -100,6 +100,11 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
   private val backendConfig = ConfigFactory.parseString(
     s"""{
         |  root = "local-cromwell-executions"
+        |
+        |  docker {
+        |    cmd = "docker run -w %s %s %s --rm %s %s"
+        |  }
+        |
         |  filesystems {
         |    local {
         |      localization = [


### PR DESCRIPTION
Minor changes in order to support:
1. Configurable docker command in HtCondor.
2. Allow the use of soft-links in dockerized jobs.