### PR TITLE
[HtCondor] Added configurable docker container default working and output directories.

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -228,13 +228,16 @@ backend {
     #
     #    #Placeholders:
     #    #1. Working directory.
-    #    #2. Inputs volumes.
-    #    #3. Output volume.
-    #    #4. Docker image.
-    #    #5. Job command.
+    #    #2. Working directory volume.
+    #    #3. Inputs volumes.
+    #    #4. Output volume.
+    #    #5. Docker image.
+    #    #6. Job command.
     #    docker {
     #      #Allow soft links in dockerized jobs
-    #      cmd = "docker run -w %s %s %s --rm %s %s"
+    #      cmd = "docker run -w %s %s %s %s --rm %s %s"
+    #      defaultWorkingDir = "/workingDir/"
+    #      defaultOutputDir = "/output/"
     #    }
     #
     #    cache {

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
@@ -319,12 +319,15 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
 
       log.debug("{} List of input volumes: {}", tag, dockerInputDataVol.mkString(","))
       val dockerCmd = configurationDescriptor.backendConfig.getString("docker.cmd")
+      val defaultWorkingDir = configurationDescriptor.backendConfig.getString("docker.defaultWorkingDir")
+      val defaultOutputDir = configurationDescriptor.backendConfig.getString("docker.defaultOutputDir")
       val dockerVolume = "-v %s:%s"
       val dockerVolumeInputs = s"$dockerVolume:ro"
       // `v.get` is safe below since we filtered the list earlier with only defined elements
       val inputVolumes = dockerInputDataVol.distinct.map(v => dockerVolumeInputs.format(v, v)).mkString(" ")
-      val outputVolume = dockerVolume.format(executionDir.toAbsolutePath.toString, runtimeAttributes.dockerOutputDir.getOrElse(executionDir.toAbsolutePath.toString))
-      val cmd = dockerCmd.format(runtimeAttributes.dockerWorkingDir.getOrElse(executionDir.toAbsolutePath.toString), inputVolumes, outputVolume, runtimeAttributes.dockerImage.get, jobCmd.get)
+      val outputVolume = dockerVolume.format(executionDir.toAbsolutePath.toString, runtimeAttributes.dockerOutputDir.getOrElse(defaultOutputDir))
+      val workingDir = dockerVolume.format(executionDir.toAbsolutePath.toString, runtimeAttributes.dockerWorkingDir.getOrElse(defaultWorkingDir))
+      val cmd = dockerCmd.format(runtimeAttributes.dockerWorkingDir.getOrElse(defaultWorkingDir), workingDir, inputVolumes, outputVolume, runtimeAttributes.dockerImage.get, jobCmd.get)
       log.debug("{} Docker command line to be used for task execution: {}.", tag, cmd)
       cmd
     }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -102,7 +102,9 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
         |  root = "local-cromwell-executions"
         |
         |  docker {
-        |    cmd = "docker run -w %s %s %s --rm %s %s"
+        |    cmd = "docker run -w %s %s %s %s --rm %s %s"
+        |    defaultWorkingDir = "/workingDir/"
+        |    defaultOutputDir = "/output/"
         |  }
         |
         |  filesystems {
@@ -280,8 +282,8 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
         """
           |runtime {
           | docker: "ubuntu/latest"
-          | dockerWorkingDir: "/workingDir"
-          | dockerOutputDir: "/outputDir"
+          | dockerWorkingDir: "/workingDir/"
+          | dockerOutputDir: "/outputDir/"
           |}
         """.stripMargin
       val jsonInputFile = createCannedFile("testFile", "some content").pathAsString
@@ -313,9 +315,10 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
 
       val bashScript = Source.fromFile(jobPaths.script.toFile).getLines.mkString
 
-      assert(bashScript.contains("docker run -w /workingDir -v"))
+      assert(bashScript.contains("docker run -w /workingDir/ -v"))
+      assert(bashScript.contains(":/workingDir/"))
       assert(bashScript.contains(":ro"))
-      assert(bashScript.contains("/call-hello/execution:/outputDir --rm ubuntu/latest echo"))
+      assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest echo"))
 
       cleanUpJob(jobPaths)
     }
@@ -356,8 +359,8 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
       """
         |runtime {
         | docker: "ubuntu/latest"
-        | dockerWorkingDir: "/workingDir"
-        | dockerOutputDir: "/outputDir"
+        | dockerWorkingDir: "/workingDir/"
+        | dockerOutputDir: "/outputDir/"
         |}
       """.stripMargin
 
@@ -396,10 +399,11 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
 
     val bashScript = Source.fromFile(jobPaths.script.toFile).getLines.mkString
 
-    assert(bashScript.contains("docker run -w /workingDir -v"))
+    assert(bashScript.contains("docker run -w /workingDir/ -v"))
+    assert(bashScript.contains(":/workingDir/"))
     assert(bashScript.contains(tempDir1.toAbsolutePath.toString))
     assert(bashScript.contains(tempDir2.toAbsolutePath.toString))
-    assert(bashScript.contains("/call-hello/execution:/outputDir --rm ubuntu/latest echo"))
+    assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest echo"))
 
     cleanUpJob(jobPaths)
   }


### PR DESCRIPTION
Goals of these changes:
1. Support configurable default docker container working dir for cases where dockerWorkingDir is not defined in runtime attributes.
2. Support configurable default docker container output dir for cases where dockerOutputDir is not defined in runtime attributes.
3. Be able to mount working directories for cases where a tool creates intermediate results (big files) in order to produce final output in the node FS and this is not capable to handle those file sizes.