### PR TITLE
Added an execution token dispenser to limit # of concurrent calls

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
@@ -24,8 +24,9 @@ object BackendJobExecutionActor {
   sealed trait BackendJobExecutionResponse extends BackendJobExecutionActorResponse { def jobKey: BackendJobDescriptorKey }
   case class SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs, jobDetritusFiles: Option[Map[String, String]], executionEvents: Seq[ExecutionEvent]) extends BackendJobExecutionResponse
   case class AbortedResponse(jobKey: BackendJobDescriptorKey) extends BackendJobExecutionResponse
-  case class FailedNonRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobExecutionResponse
-  case class FailedRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobExecutionResponse
+  sealed trait BackendJobFailedResponse extends BackendJobExecutionResponse {  def throwable: Throwable; def returnCode: Option[Int] }
+  case class FailedNonRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobFailedResponse
+  case class FailedRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobFailedResponse
 }
 
 /**

--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.Config
 import cromwell.backend.callcaching.FileHashingActor
 import cromwell.backend.callcaching.FileHashingActor.FileHashingFunction
 import cromwell.backend.io.WorkflowPaths
+import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.core.{ExecutionStore, OutputStore}
 import wdl4s.Call
 import wdl4s.expression.WdlStandardLibraryFunctions
@@ -52,4 +53,6 @@ trait BackendLifecycleActorFactory {
   lazy val fileHashingActorCount: Int = 50
 
   def fileHashingActorProps: Props = FileHashingActor.props(fileHashingFunction)
+
+  def jobExecutionTokenType: JobExecutionTokenType = JobExecutionTokenType("Default", None)
 }

--- a/backend/src/main/scala/cromwell/backend/callcaching/CacheHitDuplicating.scala
+++ b/backend/src/main/scala/cromwell/backend/callcaching/CacheHitDuplicating.scala
@@ -48,7 +48,7 @@ trait CacheHitDuplicating {
 
   private def lookupSourceCallRootPath(sourceJobDetritusFiles: Map[String, String]): Path = {
     sourceJobDetritusFiles.get(JobPaths.CallRootPathKey).map(getPath).getOrElse(throw new RuntimeException(
-      s"The call detritus files for source cache hit aren't found for call ${jobDescriptor.call.fullyQualifiedName}")
+      s"${JobPaths.CallRootPathKey} wasn't found for call ${jobDescriptor.call.fullyQualifiedName}")
     )
   }
 

--- a/core/src/main/scala/cromwell/core/JobExecutionToken.scala
+++ b/core/src/main/scala/cromwell/core/JobExecutionToken.scala
@@ -1,0 +1,11 @@
+package cromwell.core
+
+import java.util.UUID
+
+import cromwell.core.JobExecutionToken.JobExecutionTokenType
+
+case class JobExecutionToken(jobExecutionTokenType: JobExecutionTokenType, id: UUID)
+
+object JobExecutionToken {
+  case class JobExecutionTokenType(backend: String, maxPoolSize: Option[Int])
+}

--- a/engine/src/main/scala/cromwell/engine/backend/BackendConfiguration.scala
+++ b/engine/src/main/scala/cromwell/engine/backend/BackendConfiguration.scala
@@ -1,6 +1,5 @@
 package cromwell.engine.backend
 
-import akka.actor.ActorSystem
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendLifecycleActorFactory}
 import lenthall.config.ScalaConfig._
@@ -11,8 +10,8 @@ import scala.util.{Failure, Success, Try}
 case class BackendConfigurationEntry(name: String, lifecycleActorFactoryClass: String, config: Config) {
   def asBackendLifecycleActorFactory: BackendLifecycleActorFactory = {
     Class.forName(lifecycleActorFactoryClass)
-         .getConstructor(classOf[BackendConfigurationDescriptor])
-         .newInstance(asBackendConfigurationDescriptor)
+         .getConstructor(classOf[String], classOf[BackendConfigurationDescriptor])
+         .newInstance(name, asBackendConfigurationDescriptor)
          .asInstanceOf[BackendLifecycleActorFactory]
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -140,9 +140,10 @@ object WorkflowActor {
             serviceRegistryActor: ActorRef,
             workflowLogCopyRouter: ActorRef,
             jobStoreActor: ActorRef,
-            callCacheReadActor: ActorRef): Props = {
+            callCacheReadActor: ActorRef,
+            jobTokenDispenserActor: ActorRef): Props = {
     Props(new WorkflowActor(workflowId, startMode, wdlSource, conf, serviceRegistryActor, workflowLogCopyRouter,
-      jobStoreActor, callCacheReadActor)).withDispatcher(EngineDispatcher)
+      jobStoreActor, callCacheReadActor, jobTokenDispenserActor)).withDispatcher(EngineDispatcher)
   }
 }
 
@@ -156,7 +157,8 @@ class WorkflowActor(val workflowId: WorkflowId,
                     serviceRegistryActor: ActorRef,
                     workflowLogCopyRouter: ActorRef,
                     jobStoreActor: ActorRef,
-                    callCacheReadActor: ActorRef)
+                    callCacheReadActor: ActorRef,
+                    jobTokenDispenserActor: ActorRef)
   extends LoggingFSM[WorkflowActorState, WorkflowActorData] with WorkflowLogging with PathFactory {
 
   implicit val ec = context.dispatcher
@@ -204,6 +206,7 @@ class WorkflowActor(val workflowId: WorkflowId,
         serviceRegistryActor,
         jobStoreActor,
         callCacheReadActor,
+        jobTokenDispenserActor,
         initializationData,
         restarting = restarting), name = s"WorkflowExecutionActor-$workflowId")
 

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -43,9 +43,10 @@ object WorkflowManagerActor {
             serviceRegistryActor: ActorRef,
             workflowLogCopyRouter: ActorRef,
             jobStoreActor: ActorRef,
-            callCacheReadActor: ActorRef): Props = {
+            callCacheReadActor: ActorRef,
+            jobTokenDispenserActor: ActorRef): Props = {
     Props(new WorkflowManagerActor(
-      workflowStore, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor)
+      workflowStore, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor, jobTokenDispenserActor)
     ).withDispatcher(EngineDispatcher)
   }
 
@@ -82,15 +83,17 @@ class WorkflowManagerActor(config: Config,
                            val serviceRegistryActor: ActorRef,
                            val workflowLogCopyRouter: ActorRef,
                            val jobStoreActor: ActorRef,
-                           val callCacheReadActor: ActorRef)
+                           val callCacheReadActor: ActorRef,
+                           val jobTokenDispenserActor: ActorRef)
   extends LoggingFSM[WorkflowManagerState, WorkflowManagerData] {
 
   def this(workflowStore: ActorRef,
            serviceRegistryActor: ActorRef,
            workflowLogCopyRouter: ActorRef,
            jobStoreActor: ActorRef,
-           callCacheReadActor: ActorRef) = this(
-    ConfigFactory.load, workflowStore, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor)
+           callCacheReadActor: ActorRef,
+           jobTokenDispenserActor: ActorRef) = this(
+    ConfigFactory.load, workflowStore, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor, jobTokenDispenserActor)
 
   private val maxWorkflowsRunning = config.getConfig("system").getIntOr("max-concurrent-workflows", default=DefaultMaxWorkflowsToRun)
   private val maxWorkflowsToLaunch = config.getConfig("system").getIntOr("max-workflow-launch-count", default=DefaultMaxWorkflowsToLaunch)
@@ -259,7 +262,7 @@ class WorkflowManagerActor(config: Config,
     }
 
     val wfProps = WorkflowActor.props(workflowId, startMode, workflow.sources, config, serviceRegistryActor,
-      workflowLogCopyRouter, jobStoreActor, callCacheReadActor)
+      workflowLogCopyRouter, jobStoreActor, callCacheReadActor, jobTokenDispenserActor)
     val wfActor = context.actorOf(wfProps, name = s"WorkflowActor-$workflowId")
 
     wfActor ! SubscribeTransitionCallBack(self)
@@ -272,4 +275,3 @@ class WorkflowManagerActor(config: Config,
     context.system.scheduler.scheduleOnce(newWorkflowPollRate, self, RetrieveNewWorkflows)(context.dispatcher)
   }
 }
-

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -138,10 +138,11 @@ object WorkflowExecutionActor {
             serviceRegistryActor: ActorRef,
             jobStoreActor: ActorRef,
             callCacheReadActor: ActorRef,
+            jobTokenDispenserActor: ActorRef,
             initializationData: AllBackendInitializationData,
             restarting: Boolean): Props = {
     Props(WorkflowExecutionActor(workflowId, workflowDescriptor, serviceRegistryActor, jobStoreActor,
-      callCacheReadActor, initializationData, restarting)).withDispatcher(EngineDispatcher)
+      callCacheReadActor, jobTokenDispenserActor, initializationData, restarting)).withDispatcher(EngineDispatcher)
   }
 
   private implicit class EnhancedExecutionStore(val executionStore: ExecutionStore) extends AnyVal {
@@ -227,7 +228,6 @@ object WorkflowExecutionActor {
       } toMap
     }
   }
-
 }
 
 final case class WorkflowExecutionActor(workflowId: WorkflowId,
@@ -235,6 +235,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
                                         serviceRegistryActor: ActorRef,
                                         jobStoreActor: ActorRef,
                                         callCacheReadActor: ActorRef,
+                                        jobTokenDispenserActor: ActorRef,
                                         initializationData: AllBackendInitializationData,
                                         restarting: Boolean)
   extends LoggingFSM[WorkflowExecutionActorState, WorkflowExecutionActorData] with WorkflowLogging {
@@ -585,7 +586,7 @@ final case class WorkflowExecutionActor(workflowId: WorkflowId,
             val ejeaName = s"${workflowDescriptor.id}-EngineJobExecutionActor-${jobKey.tag}"
             val ejeaProps = EngineJobExecutionActor.props(
               self, jobKey, data, factory, initializationData.get(backendName), restarting, serviceRegistryActor,
-              jobStoreActor, callCacheReadActor, backendName, workflowDescriptor.callCachingMode)
+              jobStoreActor, callCacheReadActor, jobTokenDispenserActor, backendName, workflowDescriptor.callCachingMode)
             val ejeaRef = context.actorOf(ejeaProps, ejeaName)
             pushNewJobMetadata(jobKey, backendName)
             ejeaRef ! EngineJobExecutionActor.Execute

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -1,0 +1,133 @@
+package cromwell.engine.workflow.tokens
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import cromwell.core.JobExecutionToken
+import JobExecutionToken._
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor._
+import cromwell.engine.workflow.tokens.TokenPool.TokenPoolPop
+
+import scala.collection.immutable.Queue
+import scala.language.postfixOps
+
+class JobExecutionTokenDispenserActor extends Actor with ActorLogging {
+
+  /**
+    * Lazily created token pool. We only create a pool for a token type when we need it
+    */
+  var tokenPools: Map[JobExecutionTokenType, TokenPool] = Map.empty
+  var tokenAssignments: Map[ActorRef, JobExecutionToken] = Map.empty
+
+  override def receive: Actor.Receive = {
+    case JobExecutionTokenRequest(tokenType) => sendTokenRequestResult(sender, tokenType)
+    case JobExecutionTokenReturn(token) => unassign(sender, token)
+    case Terminated(terminee) => onTerminate(terminee)
+  }
+
+  private def sendTokenRequestResult(sndr: ActorRef, tokenType: JobExecutionTokenType): Unit = {
+    if (tokenAssignments.contains(sndr)) {
+      sndr ! JobExecutionTokenDispensed(tokenAssignments(sndr))
+    } else {
+      context.watch(sndr)
+      val updatedTokenPool = getTokenPool(tokenType).pop() match {
+        case TokenPoolPop(newTokenPool, Some(token)) =>
+          assignAndSendToken(sndr, token)
+          newTokenPool
+        case TokenPoolPop(sizedTokenPoolAndQueue: SizedTokenPoolAndActorQueue, None) =>
+          val (poolWithActorEnqueued, positionInQueue) = sizedTokenPoolAndQueue.enqueue(sndr)
+          sndr ! JobExecutionTokenDenied(positionInQueue)
+          poolWithActorEnqueued
+        case TokenPoolPop(someOtherTokenPool, None) =>
+          //If this has happened, somebody's been playing around in this class and not covered this case:
+          throw new RuntimeException(s"Unexpected token pool type didn't return a token: ${someOtherTokenPool.getClass.getSimpleName}")
+      }
+
+      tokenPools += tokenType -> updatedTokenPool
+    }
+  }
+
+  private def getTokenPool(tokenType: JobExecutionTokenType): TokenPool = tokenPools.getOrElse(tokenType, createNewPool(tokenType))
+
+  private def createNewPool(tokenType: JobExecutionTokenType): TokenPool = {
+    val newPool = TokenPool(tokenType) match {
+      case s: SizedTokenPool => SizedTokenPoolAndActorQueue(s, Queue.empty)
+      case anythingElse => anythingElse
+    }
+    tokenPools += tokenType -> newPool
+    newPool
+  }
+
+  private def assignAndSendToken(actor: ActorRef, token: JobExecutionToken) = {
+    tokenAssignments += actor -> token
+    actor ! JobExecutionTokenDispensed(token)
+  }
+
+  private def unassign(actor: ActorRef, token: JobExecutionToken) = {
+    if (tokenAssignments.contains(actor) && tokenAssignments(actor) == token) {
+      tokenAssignments -= actor
+
+      val pool = getTokenPool(token.jobExecutionTokenType) match {
+        case SizedTokenPoolAndActorQueue(innerPool, queue) if queue.nonEmpty =>
+          val (nextInLine, newQueue) = queue.dequeue
+          assignAndSendToken(nextInLine, token)
+          SizedTokenPoolAndActorQueue(innerPool, newQueue)
+        case other =>
+          other.push(token)
+      }
+
+      tokenPools += token.jobExecutionTokenType -> pool
+      context.unwatch(actor)
+    } else {
+      log.error("Job execution token returned from incorrect actor: {}", token)
+    }
+  }
+
+  private def onTerminate(terminee: ActorRef) = {
+    tokenAssignments.get(terminee) match {
+      case Some(token) =>
+        log.error("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
+        self.tell(msg = JobExecutionTokenReturn(token), sender = terminee)
+      case None =>
+        log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
+        tokenPools = tokenPools map {
+          case (tokenType, SizedTokenPoolAndActorQueue(pool, queue)) => tokenType -> SizedTokenPoolAndActorQueue(pool, queue.filterNot(_ == terminee))
+          case (tokenType, other) => tokenType -> other
+        }
+    }
+    context.unwatch(terminee)
+  }
+}
+
+object JobExecutionTokenDispenserActor {
+
+  def props = Props(new JobExecutionTokenDispenserActor)
+
+  case class JobExecutionTokenRequest(jobExecutionTokenType: JobExecutionTokenType)
+  case class JobExecutionTokenReturn(jobExecutionToken: JobExecutionToken)
+
+  sealed trait JobExecutionTokenRequestResult
+  case class JobExecutionTokenDispensed(jobExecutionToken: JobExecutionToken) extends JobExecutionTokenRequestResult
+  case class JobExecutionTokenDenied(positionInQueue: Integer) extends JobExecutionTokenRequestResult
+
+  case class SizedTokenPoolAndActorQueue(sizedPool: SizedTokenPool, queue: Queue[ActorRef]) extends TokenPool {
+    override def currentLoans = sizedPool.currentLoans
+    override def push(jobExecutionToken: JobExecutionToken) = SizedTokenPoolAndActorQueue(sizedPool.push(jobExecutionToken), queue)
+    override def pop() = {
+      val underlyingPop = sizedPool.pop()
+      TokenPoolPop(SizedTokenPoolAndActorQueue(underlyingPop.newTokenPool.asInstanceOf[SizedTokenPool], queue), underlyingPop.poppedItem)
+    }
+
+    /**
+      * Enqueues an actor (or just finds its current position)
+      *
+      * @return The actor's position in the queue
+      */
+    def enqueue(actor: ActorRef): (SizedTokenPoolAndActorQueue, Int) = {
+      queue.indexOf(actor) match {
+        case -1 =>
+          val newQueue = queue :+ actor
+          (SizedTokenPoolAndActorQueue(sizedPool, newQueue), newQueue.size - 1) // Convert from 1-indexed to 0-indexed
+        case index => (this, index)
+      }
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenPool.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenPool.scala
@@ -1,0 +1,50 @@
+package cromwell.engine.workflow.tokens
+
+import java.util.UUID
+
+import cromwell.core.JobExecutionToken
+import JobExecutionToken.JobExecutionTokenType
+import cromwell.engine.workflow.tokens.TokenPool.TokenPoolPop
+
+import scala.language.postfixOps
+
+trait TokenPool {
+  def currentLoans: Set[JobExecutionToken]
+  def pop(): TokenPoolPop
+  def push(jobExecutionToken: JobExecutionToken): TokenPool
+}
+
+object TokenPool {
+
+  case class TokenPoolPop(newTokenPool: TokenPool, poppedItem: Option[JobExecutionToken])
+
+  def apply(tokenType: JobExecutionTokenType): TokenPool = {
+    tokenType.maxPoolSize map { ps =>
+      val pool = (1 to ps toList) map { _ => JobExecutionToken(tokenType, UUID.randomUUID()) }
+      SizedTokenPool(pool, Set.empty)
+    } getOrElse {
+      InfiniteTokenPool(tokenType, Set.empty)
+    }
+  }
+}
+
+final case class SizedTokenPool(pool: List[JobExecutionToken], override val currentLoans: Set[JobExecutionToken]) extends TokenPool {
+
+  override def pop(): TokenPoolPop = pool match {
+    case head :: tail => TokenPoolPop(SizedTokenPool(tail, currentLoans + head), Option(head))
+    case Nil => TokenPoolPop(SizedTokenPool(List.empty, currentLoans), None)
+  }
+
+
+  override def push(token: JobExecutionToken): SizedTokenPool = {
+    if (currentLoans.contains(token)) { SizedTokenPool(pool :+ token, currentLoans - token) } else this
+  }
+}
+
+final case class InfiniteTokenPool(tokenType: JobExecutionTokenType, override val currentLoans: Set[JobExecutionToken]) extends TokenPool {
+  override def pop() = {
+    val newToken = JobExecutionToken(tokenType, UUID.randomUUID())
+    TokenPoolPop(InfiniteTokenPool(tokenType, currentLoans + newToken), Option(newToken))
+  }
+  override def push(token: JobExecutionToken): InfiniteTokenPool = if (currentLoans.contains(token)) { InfiniteTokenPool(tokenType, currentLoans - token) } else this
+}

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -8,6 +8,7 @@ import com.typesafe.config.ConfigFactory
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.engine.workflow.lifecycle.CopyWorkflowLogsActor
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCache, CallCacheReadActor}
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowStore, WorkflowStoreActor}
 import cromwell.jobstore.{JobStore, JobStoreActor, SqlJobStore}
 import cromwell.services.{ServiceRegistryActor, SingletonServicesStore}
@@ -48,9 +49,11 @@ import lenthall.config.ScalaConfig.EnhancedScalaConfig
     .props(CallCacheReadActor.props(callCache)),
     "CallCacheReadActor")
 
+  lazy val jobExecutionTokenDispenserActor = context.actorOf(JobExecutionTokenDispenserActor.props)
+
   lazy val workflowManagerActor = context.actorOf(
     WorkflowManagerActor.props(
-      workflowStoreActor, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor),
+      workflowStoreActor, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor, jobExecutionTokenDispenserActor),
     "WorkflowManagerActor")
 
   override def receive = {

--- a/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -10,6 +10,7 @@ import cromwell.SimpleWorkflowActorSpec._
 import cromwell.core.{WorkflowId, WorkflowSourceFiles}
 import cromwell.engine.workflow.WorkflowActor
 import cromwell.engine.workflow.WorkflowActor._
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.HelloWorld.Addressee
 import org.scalatest.BeforeAndAfter
@@ -42,7 +43,8 @@ class SimpleWorkflowActorSpec extends CromwellTestkitSpec with BeforeAndAfter {
         serviceRegistryActor = watchActor,
         workflowLogCopyRouter = system.actorOf(Props.empty, s"workflow-copy-log-router-$workflowId-${UUID.randomUUID()}"),
         jobStoreActor = system.actorOf(AlwaysHappyJobStoreActor.props),
-        callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)),
+        callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props),
+      jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props)),
       supervisor = supervisor.ref,
       name = s"workflow-actor-$workflowId"
     )

--- a/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
@@ -22,7 +22,7 @@ case class DefaultBackendJobExecutionActor(override val jobDescriptor: BackendJo
   override def abort(): Unit = ()
 }
 
-class DefaultBackendLifecycleActorFactory(configurationDescriptor: BackendConfigurationDescriptor)
+class DefaultBackendLifecycleActorFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor)
   extends BackendLifecycleActorFactory {
   override def workflowInitializationActorProps(workflowDescriptor: BackendWorkflowDescriptor,
                                                 calls: Seq[Call],

--- a/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
@@ -5,7 +5,7 @@ import cromwell.backend._
 import wdl4s.Call
 import wdl4s.expression.{NoFunctions, WdlStandardLibraryFunctions}
 
-class RetryableBackendLifecycleActorFactory(configurationDescriptor: BackendConfigurationDescriptor)
+class RetryableBackendLifecycleActorFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor)
   extends BackendLifecycleActorFactory {
   override def workflowInitializationActorProps(workflowDescriptor: BackendWorkflowDescriptor,
                                                 calls: Seq[Call],

--- a/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -12,6 +12,7 @@ import cromwell.CromwellTestkitSpec._
 import cromwell.core.WorkflowSourceFiles
 import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
@@ -55,6 +56,7 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec {
   private val workflowStore = system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor))
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
   private val callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)
+  private val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props)
 
 
   def workflowManagerActor(): ActorRef = {
@@ -63,7 +65,8 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestkitSpec {
       dummyServiceRegistryActor,
       dummyLogCopyRouter,
       jobStore,
-      callCacheReadActor)), "WorkflowManagerActor")
+      callCacheReadActor,
+      jobTokenDispenserActor)), "WorkflowManagerActor")
   }
   
   def createRunnerActor(sampleWdl: SampleWdl = ThreeStep, managerActor: => ActorRef = workflowManagerActor(),

--- a/engine/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
@@ -52,7 +52,8 @@ class WorkflowActorSpec extends CromwellTestkitSpec with WorkflowDescriptorBuild
         serviceRegistryActor = mockServiceRegistryActor,
         workflowLogCopyRouter = TestProbe().ref,
         jobStoreActor = system.actorOf(AlwaysHappyJobStoreActor.props),
-        callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)
+        callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props),
+        jobTokenDispenserActor = TestProbe().ref
       ),
       supervisor = supervisorProbe.ref)
     actor.setState(stateName = state, stateData = WorkflowActorData(Option(currentLifecycleActor.ref), Option(descriptor),
@@ -155,7 +156,8 @@ class MockWorkflowActor(val finalizationProbe: TestProbe,
                         serviceRegistryActor: ActorRef,
                         workflowLogCopyRouter: ActorRef,
                         jobStoreActor: ActorRef,
-                        callCacheReadActor: ActorRef) extends WorkflowActor(workflowId, startMode, workflowSources, conf, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor) {
+                        callCacheReadActor: ActorRef,
+                        jobTokenDispenserActor: ActorRef) extends WorkflowActor(workflowId, startMode, workflowSources, conf, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, callCacheReadActor, jobTokenDispenserActor) {
 
   override def makeFinalizationActor(workflowDescriptor: EngineWorkflowDescriptor, executionStore: ExecutionStore, outputStore: OutputStore) = finalizationProbe.ref
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaPendingSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaPendingSpec.scala
@@ -1,8 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
-import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{CheckingJobStore, EngineJobExecutionActorState, Execute, Pending, PreparingJob}
-import cromwell.engine.workflow.lifecycle.execution.JobPreparationActor
-import cromwell.jobstore.JobStoreActor.QueryJobCompletion
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.JobExecutionTokenRequest
 import org.scalatest.concurrent.Eventually
 
 class EjeaPendingSpec extends EngineJobExecutionActorSpec with CanValidateJobStoreKey with Eventually {
@@ -11,29 +10,16 @@ class EjeaPendingSpec extends EngineJobExecutionActorSpec with CanValidateJobSto
 
   "An EJEA in the Pending state" should {
 
-    CallCachingModes foreach { mode =>
-      s"check against the Job Store if restarting is true ($mode)" in {
-        ejea = helper.buildEJEA(restarting = true)
+    List(false, true) foreach { restarting =>
+      s"wait for the Execute signal then request an execution token (with restarting=$restarting)" in {
+        ejea = helper.buildEJEA(restarting = restarting)
         ejea ! Execute
 
-        helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Awaiting job store lookup") {
-          case QueryJobCompletion(jobKey, taskOutputs) =>
-            validateJobStoreKey(jobKey)
-            taskOutputs should be(helper.task.outputs)
-        }
-        helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
-        helper.jobHashingInitializations shouldBe NothingYet
-        ejea.stateName should be(CheckingJobStore)
-      }
+        helper.jobTokenDispenserProbe.expectMsgClass(max = awaitTimeout, classOf[JobExecutionTokenRequest])
 
-
-      s"bypass the Job Store and start preparing the job for running or call caching ($mode)" in {
-        ejea = helper.buildEJEA(restarting = false)
-        ejea ! Execute
-
-        helper.jobPreparationProbe.expectMsg(max = awaitTimeout, hint = "Awaiting job preparation", JobPreparationActor.Start)
-        helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
-        ejea.stateName should be(PreparingJob)
+        helper.jobPreparationProbe.msgAvailable should be(false)
+        helper.jobStoreProbe.msgAvailable should be(false)
+        ejea.stateName should be(RequestingExecutionToken)
       }
     }
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRequestingExecutionTokenSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRequestingExecutionTokenSpec.scala
@@ -1,0 +1,54 @@
+package cromwell.engine.workflow.lifecycle.execution.ejea
+
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.JobPreparationActor
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDenied, JobExecutionTokenDispensed}
+import cromwell.jobstore.JobStoreActor.QueryJobCompletion
+import org.scalatest.concurrent.Eventually
+
+class EjeaRequestingExecutionTokenSpec extends EngineJobExecutionActorSpec with CanValidateJobStoreKey with Eventually {
+
+  override implicit val stateUnderTest: EngineJobExecutionActorState = RequestingExecutionToken
+
+  "An EJEA in the RequestingExecutionToken state" should {
+
+    List(true, false) foreach { restarting =>
+      s"do nothing when denied a token (with restarting=$restarting)" in {
+        ejea = helper.buildEJEA(restarting = restarting)
+        ejea ! JobExecutionTokenDenied(1) // 1 is arbitrary. Doesn't matter what position in the queue we are.
+
+        helper.jobTokenDispenserProbe.expectNoMsg(max = awaitAlmostNothing)
+        helper.jobPreparationProbe.msgAvailable should be(false)
+        helper.jobStoreProbe.msgAvailable should be(false)
+
+        ejea.stateName should be(RequestingExecutionToken)
+      }
+    }
+
+    CallCachingModes foreach { mode =>
+      s"check against the Job Store if restarting is true ($mode)" in {
+        ejea = helper.buildEJEA(restarting = true)
+        ejea ! JobExecutionTokenDispensed(helper.executionToken)
+
+        helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Awaiting job store lookup") {
+          case QueryJobCompletion(jobKey, taskOutputs) =>
+            validateJobStoreKey(jobKey)
+            taskOutputs should be(helper.task.outputs)
+        }
+        helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
+        helper.jobHashingInitializations shouldBe NothingYet
+        ejea.stateName should be(CheckingJobStore)
+      }
+
+
+      s"bypass the Job Store and start preparing the job for running or call caching ($mode)" in {
+        ejea = helper.buildEJEA(restarting = false)
+        ejea ! JobExecutionTokenDispensed(helper.executionToken)
+
+        helper.jobPreparationProbe.expectMsg(max = awaitTimeout, hint = "Awaiting job preparation", JobPreparationActor.Start)
+        helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
+        ejea.stateName should be(PreparingJob)
+      }
+    }
+  }
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -1,0 +1,311 @@
+package cromwell.engine.workflow.tokens
+
+import java.util.UUID
+
+import akka.actor.{ ActorRef, ActorSystem, Kill, PoisonPill}
+import org.scalatest._
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import cromwell.core.JobExecutionToken.JobExecutionTokenType
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDenied, JobExecutionTokenDispensed, JobExecutionTokenRequest, JobExecutionTokenReturn}
+import JobExecutionTokenDispenserActorSpec._
+import cromwell.core.JobExecutionToken
+import cromwell.engine.workflow.tokens.TokenGrabbingActor.StoppingSupervisor
+import org.scalatest.concurrent.Eventually
+
+import scala.concurrent.duration._
+
+class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec")) with ImplicitSender with FlatSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll with Eventually {
+
+  val MaxWaitTime = 100.milliseconds
+  implicit val pc: PatienceConfig = PatienceConfig(MaxWaitTime)
+
+  behavior of "JobExecutionTokenDispenserActor"
+
+  it should "dispense an infinite token correctly" in {
+    actorRefUnderTest ! JobExecutionTokenRequest(TestInfiniteTokenType)
+    expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+      case JobExecutionTokenDispensed(token) =>
+        token.jobExecutionTokenType should be(TestInfiniteTokenType)
+    }
+  }
+
+  it should "accept return of an infinite token correctly" in {
+    actorRefUnderTest ! JobExecutionTokenRequest(TestInfiniteTokenType)
+    expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+      case JobExecutionTokenDispensed(token) =>
+        actorRefUnderTest ! JobExecutionTokenReturn(token)
+    }
+  }
+
+  it should "dispense indefinitely for an infinite token type" in {
+    var currentSet: Set[JobExecutionToken] = Set.empty
+    100 indexedTimes { i =>
+      val sender = TestProbe()
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(TestInfiniteTokenType), sender = sender.ref)
+      sender.expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+        case JobExecutionTokenDispensed(token) =>
+          token.jobExecutionTokenType should be(TestInfiniteTokenType)
+          currentSet.contains(token) should be(false)
+          currentSet += token
+      }
+    }
+  }
+
+  it should "dispense a limited token correctly" in {
+
+    actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
+    expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+      case JobExecutionTokenDispensed(token) => token.jobExecutionTokenType should be(LimitedTo5Tokens)
+    }
+  }
+
+  it should "accept return of a limited token type correctly" in {
+    actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
+    expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+      case JobExecutionTokenDispensed(token) => actorRefUnderTest ! JobExecutionTokenReturn(token)
+    }
+  }
+
+  it should "limit the dispensing of a limited token type" in {
+
+    var currentTokens: Map[TestProbe, JobExecutionToken] = Map.empty
+    val dummyActors = (0 until 100 map { i => i -> TestProbe("dummy_" + i) }).toMap
+
+    // Dispense the first 5:
+    5 indexedTimes { i =>
+      val sndr = dummyActors(i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      sndr.expectMsgPF(max = MaxWaitTime, hint = "token dispensed message") {
+        case JobExecutionTokenDispensed(token) =>
+          token.jobExecutionTokenType should be(LimitedTo5Tokens)
+          currentTokens.values.toList.contains(token) should be(false) // Check we didn't already get this token
+          currentTokens += sndr -> token
+      }
+    }
+
+    // Queue the next 95:
+    95 indexedTimes { i =>
+      val sndr = dummyActors(5 + i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      sndr.expectMsgPF(max = MaxWaitTime, hint = "token denied message") {
+        case JobExecutionTokenDenied(positionInQueue) =>
+          positionInQueue should be(i)
+      }
+    }
+
+    // It should allow queued actors to check their position in the queue:
+    95 indexedTimes { i =>
+      val sndr = dummyActors(5 + i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      sndr.expectMsgPF(max = MaxWaitTime, hint = "token denied message") {
+        case JobExecutionTokenDenied(positionInQueue) =>
+          positionInQueue should be(i)
+      }
+    }
+
+    // It should release tokens as soon as they're available (while there's still a queue...):
+    95 indexedTimes { i =>
+      val returner = dummyActors(i)
+      val nextInLine = dummyActors(i + 5)
+      val tokenBeingReturned = currentTokens(returner)
+      actorRefUnderTest.tell(msg = JobExecutionTokenReturn(tokenBeingReturned), sender = returner.ref)
+      currentTokens -= returner
+      nextInLine.expectMsgPF(max = MaxWaitTime, hint = s"token dispensed message to the next in line actor (#${i + 5})") {
+        case JobExecutionTokenDispensed(token) =>
+          token should be(tokenBeingReturned) // It just gets immediately passed out again!
+          currentTokens += nextInLine -> token
+      }
+    }
+
+    // Double-check the queue state: when we request a token now, we should still be denied:
+    actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
+    expectMsgClass(classOf[JobExecutionTokenDenied])
+
+    //And finally, silently release the remaining tokens:
+    5 indexedTimes { i =>
+      val returner = dummyActors(i + 95)
+      val tokenBeingReturned = currentTokens(returner)
+      actorRefUnderTest.tell(msg = JobExecutionTokenReturn(tokenBeingReturned), sender = returner.ref)
+      currentTokens -= returner
+    }
+
+    // And we should have gotten our own token by now:
+    expectMsgClass(classOf[JobExecutionTokenDispensed])
+
+    // Check we didn't get anything else in the meanwhile:
+    msgAvailable should be(false)
+    dummyActors.values foreach { testProbe => testProbe.msgAvailable should be(false) }
+  }
+
+  it should "resend the same token to an actor which already has one" in {
+    actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
+    val firstResponse = expectMsgClass(classOf[JobExecutionTokenDispensed])
+
+    5 indexedTimes { i =>
+      actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
+      expectMsg(MaxWaitTime, s"same token again (attempt ${i + 1})", firstResponse) // Always the same
+    }
+  }
+
+
+  // Incidentally, also covers: it should "not be fooled if the wrong actor returns a token"
+  it should "not be fooled by a doubly-returned token" in {
+    var currentTokens: Map[TestProbe, JobExecutionToken] = Map.empty
+    val dummyActors = (0 until 7 map { i => i -> TestProbe("dummy_" + i) }).toMap
+
+    // Set up by taking all 5 tokens out, and then adding 2 to the queue:
+    5 indexedTimes { i =>
+      val sndr = dummyActors(i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      currentTokens += dummyActors(i) -> sndr.expectMsgClass(classOf[JobExecutionTokenDispensed]).jobExecutionToken
+    }
+    2 indexedTimes { i =>
+      val sndr = dummyActors(5 + i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      sndr.expectMsgClass(classOf[JobExecutionTokenDenied])
+    }
+
+    // The first time we return a token, the next in line should be given it:
+    val returningActor = dummyActors(0)
+    val nextInLine1 = dummyActors(5)
+    val nextInLine2 = dummyActors(6)
+    val tokenBeingReturned = currentTokens(returningActor)
+    currentTokens -= returningActor
+    actorRefUnderTest.tell(msg = JobExecutionTokenReturn(tokenBeingReturned), sender = returningActor.ref)
+    val tokenPassedOn = nextInLine1.expectMsgClass(classOf[JobExecutionTokenDispensed]).jobExecutionToken
+    tokenPassedOn should be(tokenBeingReturned)
+    currentTokens += nextInLine1 -> tokenPassedOn
+
+    // But the next time, nothing should happen because the wrong actor is returning the token:
+    actorRefUnderTest.tell(msg = JobExecutionTokenReturn(tokenBeingReturned), sender = returningActor.ref)
+    nextInLine2.expectNoMsg(MaxWaitTime)
+  }
+
+  it should "not be fooled if an actor returns a token which doesn't exist" in {
+    var currentTokens: Map[TestProbe, JobExecutionToken] = Map.empty
+    val dummyActors = (0 until 6 map { i => i -> TestProbe("dummy_" + i) }).toMap
+
+    // Set up by taking all 5 tokens out, and then adding 2 to the queue:
+    5 indexedTimes { i =>
+      val sndr = dummyActors(i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      currentTokens += dummyActors(i) -> sndr.expectMsgClass(classOf[JobExecutionTokenDispensed]).jobExecutionToken
+    }
+    1 indexedTimes { i =>
+      val sndr = dummyActors(5 + i)
+      actorRefUnderTest.tell(msg = JobExecutionTokenRequest(LimitedTo5Tokens), sender = sndr.ref)
+      sndr.expectMsgClass(classOf[JobExecutionTokenDenied])
+    }
+
+    actorRefUnderTest.tell(msg = JobExecutionTokenReturn(JobExecutionToken(LimitedTo5Tokens, UUID.randomUUID())), sender = dummyActors(0).ref)
+    dummyActors(5).expectNoMsg(MaxWaitTime)
+  }
+
+  val actorDeathMethods: List[(String, ActorRef => Unit)] = List(
+    ("external_stop", (a: ActorRef) => system.stop(a)),
+    ("internal_stop", (a: ActorRef) => a ! TokenGrabbingActor.InternalStop),
+    ("poison_pill", (a: ActorRef) => a ! PoisonPill),
+    ("kill_message", (a: ActorRef) => a ! Kill),
+    ("throw_exception", (a: ActorRef) => a ! TokenGrabbingActor.ThrowException)
+  )
+
+  actorDeathMethods foreach { case (name, stopMethod) =>
+    it should s"recover tokens lost to actors which are $name before they hand back their token" in {
+      var currentTokens: Map[TestActorRef[TokenGrabbingActor], JobExecutionToken] = Map.empty
+      var tokenGrabbingActors: Map[Int, TestActorRef[TokenGrabbingActor]] = Map.empty
+      val grabberSupervisor = TestActorRef(new StoppingSupervisor())
+
+      // Set up by taking all 5 tokens out, and then adding 2 to the queue:
+      5 indexedTimes { i =>
+        val newGrabbingActor = TestActorRef[TokenGrabbingActor](TokenGrabbingActor.props(actorRefUnderTest, LimitedTo5Tokens), grabberSupervisor, s"grabber_${name}_" + i)
+        tokenGrabbingActors += i -> newGrabbingActor
+        eventually {
+          newGrabbingActor.underlyingActor.token.isDefined should be(true)
+        }
+        currentTokens += newGrabbingActor -> newGrabbingActor.underlyingActor.token.get
+      }
+
+      val unassignedActorIndex = 5
+      val newGrabbingActor = TestActorRef(new TokenGrabbingActor(actorRefUnderTest, LimitedTo5Tokens), s"grabber_${name}_" + unassignedActorIndex)
+      tokenGrabbingActors += unassignedActorIndex -> newGrabbingActor
+      eventually {
+        newGrabbingActor.underlyingActor.rejections should be(1)
+      }
+
+      val actorToStop = tokenGrabbingActors(0)
+      val actorToStopsToken = currentTokens(actorToStop)
+      val nextInLine = tokenGrabbingActors(unassignedActorIndex)
+
+      val deathwatch = TestProbe()
+      deathwatch watch actorToStop
+      stopMethod(actorToStop)
+      deathwatch.expectTerminated(actorToStop)
+      eventually { nextInLine.underlyingActor.token should be(Some(actorToStopsToken)) }
+    }
+  }
+
+  it should "skip over dead actors when assigning tokens to the actor queue" in {
+    var currentTokens: Map[TestActorRef[TokenGrabbingActor], JobExecutionToken] = Map.empty
+    var tokenGrabbingActors: Map[Int, TestActorRef[TokenGrabbingActor]] = Map.empty
+    val grabberSupervisor = TestActorRef(new StoppingSupervisor())
+
+    // Set up by taking all 5 tokens out, and then adding 2 to the queue:
+    5 indexedTimes { i =>
+      val newGrabbingActor = TestActorRef[TokenGrabbingActor](TokenGrabbingActor.props(actorRefUnderTest, LimitedTo5Tokens), grabberSupervisor, s"skip_test_" + i)
+      tokenGrabbingActors += i -> newGrabbingActor
+      eventually {
+        newGrabbingActor.underlyingActor.token.isDefined should be(true)
+      }
+      currentTokens += newGrabbingActor -> newGrabbingActor.underlyingActor.token.get
+    }
+    2 indexedTimes { i =>
+      val index = i + 5
+      val newGrabbingActor = TestActorRef[TokenGrabbingActor](TokenGrabbingActor.props(actorRefUnderTest, LimitedTo5Tokens), grabberSupervisor, s"skip_test_" + index)
+      tokenGrabbingActors += index -> newGrabbingActor
+      eventually {
+        newGrabbingActor.underlyingActor.rejections should be(1)
+      }
+    }
+
+    val returningActor = tokenGrabbingActors(0)
+    val returnedToken = currentTokens(returningActor)
+    val nextInLine1 = tokenGrabbingActors(5)
+    val nextInLine2 = tokenGrabbingActors(6)
+
+    // First, kill off the actor which would otherwise be first in line:
+    val deathwatch = TestProbe()
+    deathwatch watch nextInLine1
+    nextInLine1 ! PoisonPill
+    deathwatch.expectTerminated(nextInLine1)
+
+    // Now, stop one of the workers unexpectedly and check that the released token goes to the right place:
+    actorRefUnderTest.tell(msg = JobExecutionTokenReturn(returnedToken), sender = returningActor)
+    eventually { nextInLine2.underlyingActor.token should be(Some(returnedToken)) } // Some is OK. This is the **expected** value!
+  }
+
+  var actorRefUnderTest: TestActorRef[JobExecutionTokenDispenserActor] = _
+
+  before {
+    actorRefUnderTest = TestActorRef(new JobExecutionTokenDispenserActor())
+
+  }
+  after {
+    actorRefUnderTest = null
+  }
+
+  override def afterAll = {
+    TestKit.shutdownActorSystem(system)
+  }
+}
+
+object JobExecutionTokenDispenserActorSpec {
+
+  implicit class intWithTimes(n: Int) {
+    def times(f: => Unit) = 1 to n foreach { _ => f }
+    def indexedTimes(f: Int => Unit) = 0 until n foreach { i => f(i) }
+  }
+
+  val TestInfiniteTokenType = JobExecutionTokenType("infinite", maxPoolSize = None)
+  def limitedTokenType(limit: Int) = JobExecutionTokenType(s"$limit-limit", maxPoolSize = Option(limit))
+  val LimitedTo5Tokens = limitedTokenType(5)
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/TokenGrabbingActor.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/TokenGrabbingActor.scala
@@ -1,0 +1,38 @@
+package cromwell.engine.workflow.tokens
+
+import akka.actor.{Actor, ActorRef, Props, SupervisorStrategy}
+import cromwell.core.JobExecutionToken
+import cromwell.core.JobExecutionToken.JobExecutionTokenType
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDenied, JobExecutionTokenDispensed, JobExecutionTokenRequest}
+import cromwell.engine.workflow.tokens.TokenGrabbingActor.{InternalStop, ThrowException}
+
+/**
+  * Grabs a token and doesn't let it go!
+  */
+class TokenGrabbingActor(tokenDispenser: ActorRef, tokenType: JobExecutionTokenType) extends Actor {
+
+  var token: Option[JobExecutionToken] = None
+  var rejections = 0
+
+  def receive = {
+    case JobExecutionTokenDispensed(dispensedToken) => token = Option(dispensedToken)
+    case JobExecutionTokenDenied(positionInQueue) => rejections += 1
+    case ThrowException => throw new RuntimeException("Test exception (don't be scared by the stack trace, it's deliberate!)")
+    case InternalStop => context.stop(self)
+  }
+
+  tokenDispenser ! JobExecutionTokenRequest(tokenType)
+}
+
+object TokenGrabbingActor {
+
+  def props(tokenDispenserActor: ActorRef, tokenType: JobExecutionTokenType) = Props(new TokenGrabbingActor(tokenDispenserActor, tokenType))
+
+  case object ThrowException
+  case object InternalStop
+
+  class StoppingSupervisor extends Actor {
+    override val supervisorStrategy = SupervisorStrategy.stoppingStrategy
+    override def receive = Actor.emptyBehavior
+  }
+}

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorBackendFactory.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorBackendFactory.scala
@@ -13,7 +13,7 @@ import wdl4s.expression.WdlStandardLibraryFunctions
 
 import scala.util.{Failure, Success, Try}
 
-case class HtCondorBackendFactory(configurationDescriptor: BackendConfigurationDescriptor)
+case class HtCondorBackendFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor)
   extends BackendLifecycleActorFactory with StrictLogging {
 
   override def workflowInitializationActorProps(workflowDescriptor: BackendWorkflowDescriptor,

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
@@ -15,7 +15,7 @@ import wdl4s.expression.WdlStandardLibraryFunctions
 
 import scala.language.postfixOps
 
-case class JesBackendLifecycleActorFactory(configurationDescriptor: BackendConfigurationDescriptor)
+case class JesBackendLifecycleActorFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor)
   extends BackendLifecycleActorFactory {
   import JesBackendLifecycleActorFactory._
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendLifecycleActorFactory.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendLifecycleActorFactory.scala
@@ -4,6 +4,7 @@ import cromwell.backend.callcaching.FileHashingActor.FileHashingFunction
 import cromwell.backend.impl.sfs.config.ConfigConstants._
 import cromwell.backend.sfs._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, RuntimeAttributeDefinition}
+import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import lenthall.config.ScalaConfig._
 import org.slf4j.LoggerFactory
 
@@ -12,7 +13,7 @@ import org.slf4j.LoggerFactory
   *
   * @param configurationDescriptor The config information.
   */
-class ConfigBackendLifecycleActorFactory(val configurationDescriptor: BackendConfigurationDescriptor)
+class ConfigBackendLifecycleActorFactory(name: String, val configurationDescriptor: BackendConfigurationDescriptor)
   extends SharedFileSystemBackendLifecycleActorFactory {
 
   lazy val logger = LoggerFactory.getLogger(getClass)
@@ -44,4 +45,9 @@ class ConfigBackendLifecycleActorFactory(val configurationDescriptor: BackendCon
   }
 
   override lazy val fileHashingActorCount: Int = 5
+
+  override val jobExecutionTokenType: JobExecutionTokenType = {
+    val concurrentJobLimit = configurationDescriptor.backendConfig.getIntOption("concurrent-job-limit")
+    JobExecutionTokenType(name, concurrentJobLimit)
+  }
 }

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -8,7 +8,7 @@ import cromwell.core.CallContext
 import wdl4s.Call
 import wdl4s.expression.WdlStandardLibraryFunctions
 
-case class SparkBackendFactory(configurationDescriptor: BackendConfigurationDescriptor, actorSystem: ActorSystem) extends BackendLifecycleActorFactory {
+case class SparkBackendFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor, actorSystem: ActorSystem) extends BackendLifecycleActorFactory {
   override def workflowInitializationActorProps(workflowDescriptor: BackendWorkflowDescriptor, calls: Seq[Call], serviceRegistryActor: ActorRef): Option[Props] = {
     Option(SparkInitializationActor.props(workflowDescriptor, calls, configurationDescriptor, serviceRegistryActor))
   }


### PR DESCRIPTION
Suggested reading order:

- JobExecutionTokenDispenserActorSpec (to see how the TokenDispenserActor is intended to operate)
- EJEA (to see how the token dispenser gets invoked)
- Everything else (a lot of the more annoying wiring can probably be refactored once I add per-backend god-actors in my other ticket)