### PR TITLE
Clone pipeline resources and strip out mount point for runtime Closes #1501

### DIFF
--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
@@ -57,7 +57,7 @@ object Run {
     // disks cannot have mount points at runtime, so set them null
     val runtimePipelineResources = {
       val resources = pipelineInfoBuilder.build(commandLine, runtimeAttributes).resources
-      val disksWithoutMountPoint = resources.getDisks.asScala map { d => d.setMountPoint(null) }
+      val disksWithoutMountPoint = resources.getDisks.asScala map { _.setMountPoint(null) }
       resources.setDisks(disksWithoutMountPoint.asJava)
     }
 


### PR DESCRIPTION
In order to allow the Private IP flag, it needs to be set both at pipeline creation time and run time. Run time resources override create time resources. However mount point must be set at create time but cannot be re-set at runtime... 

```
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "disks must not have mount points at run time",
    "reason" : "badRequest"
  } ],
  "message" : "disks must not have mount points at run time",
  "status" : "INVALID_ARGUMENT"
}
```

This sets mount points to null for run time only. The rest is strictly identical to create time.