### PR TITLE
Print PID to stdout.background, SGE

### DIFF
--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -231,7 +231,9 @@ trait SharedFileSystemAsyncJobExecutionActor
     * @return A process runner that will relatively quickly submit the script asynchronously.
     */
   def makeProcessRunner(): ProcessRunner = {
-    new ProcessRunner(processArgs.argv, jobPaths.stdout, jobPaths.stderr)
+    val stdout = pathPlusSuffix(jobPaths.stdout, "background")
+    val stderr = pathPlusSuffix(jobPaths.stderr, "background")
+    new ProcessRunner(processArgs.argv, stdout.path, stderr.path)
   }
 
   /**

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -231,8 +231,8 @@ trait SharedFileSystemAsyncJobExecutionActor
     * @return A process runner that will relatively quickly submit the script asynchronously.
     */
   def makeProcessRunner(): ProcessRunner = {
-    val stdout = pathPlusSuffix(jobPaths.stdout, "background")
-    val stderr = pathPlusSuffix(jobPaths.stderr, "background")
+    val stdout = pathPlusSuffix(jobPaths.stdout, "submit")
+    val stderr = pathPlusSuffix(jobPaths.stderr, "submit")
     new ProcessRunner(processArgs.argv, stdout.path, stderr.path)
   }
 


### PR DESCRIPTION
closes #1512

Bug fix -- Currently we have the SGE process ID printed to stdout, and instead this PR redirects it to a stdout.background file instead (mimicking the behavior of Local) 
