### PR TITLE
Wholly unsatisfying monad transformer PR.  Does not close #1212

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/JobStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/JobStoreSlickDatabase.scala
@@ -1,5 +1,6 @@
 package cromwell.database.slick
 
+import cats.data.OptionT
 import cats.instances.future._
 import cats.syntax.functor._
 import cromwell.database.sql.JobStoreSqlDatabase
@@ -28,8 +29,7 @@ trait JobStoreSlickDatabase extends JobStoreSqlDatabase {
   }
 
   override def queryJobStores(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int,
-                              jobScatterAttempt: Int)(implicit ec: ExecutionContext):
-  Future[Option[JobStoreJoin]] = {
+                              jobScatterAttempt: Int)(implicit ec: ExecutionContext): OptionT[Future, JobStoreJoin] = {
 
     val action = for {
       jobStoreEntryOption <- dataAccess.
@@ -41,7 +41,7 @@ trait JobStoreSlickDatabase extends JobStoreSqlDatabase {
       }
     } yield jobStoreEntryOption.map(JobStoreJoin(_, jobStoreSimpletonEntries))
 
-    runTransaction(action)
+    OptionT(runTransaction(action))
   }
 
   override def removeJobStores(workflowExecutionUuids: Seq[String])

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -2,7 +2,7 @@ package cromwell.database.slick
 
 import java.sql.Timestamp
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, OptionT}
 import cromwell.database.sql.MetadataSqlDatabase
 import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
 
@@ -134,11 +134,11 @@ trait MetadataSlickDatabase extends MetadataSqlDatabase {
   }
 
   override def getWorkflowStatus(workflowExecutionUuid: String)
-                                (implicit ec: ExecutionContext): Future[Option[String]] = {
+                                (implicit ec: ExecutionContext): OptionT[Future, String] = {
     val action = dataAccess.workflowStatusesForWorkflowExecutionUuid(workflowExecutionUuid).result.headOption
     // The workflow might not exist, so `headOption`.  But even if the workflow does exist, the status might be None.
     // So flatten the Option[Option[String]] to Option[String].
-    runTransaction(action).map(_.flatten)
+    OptionT(runTransaction(action).map(_.flatten))
   }
 
   override def queryWorkflowSummaries(workflowStatuses: Set[String], workflowNames: Set[String],

--- a/database/sql/src/main/scala/cromwell/database/sql/JobStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/JobStoreSqlDatabase.scala
@@ -1,5 +1,6 @@
 package cromwell.database.sql
 
+import cats.data.OptionT
 import cromwell.database.sql.joins.JobStoreJoin
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,7 +11,7 @@ trait JobStoreSqlDatabase {
   def addJobStores(jobStoreJoins: Seq[JobStoreJoin])(implicit ec: ExecutionContext): Future[Unit]
 
   def queryJobStores(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int, jobScatterAttempt: Int)
-                    (implicit ec: ExecutionContext): Future[Option[JobStoreJoin]]
+                    (implicit ec: ExecutionContext): OptionT[Future, JobStoreJoin]
 
   def removeJobStores(workflowExecutionUuids: Seq[String])(implicit ec: ExecutionContext): Future[Seq[Int]]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -2,7 +2,7 @@ package cromwell.database.sql
 
 import java.sql.Timestamp
 
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList, OptionT}
 import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -69,7 +69,7 @@ trait MetadataSqlDatabase {
                                       => WorkflowMetadataSummaryEntry)
                                    (implicit ec: ExecutionContext): Future[Long]
 
-  def getWorkflowStatus(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Option[String]]
+  def getWorkflowStatus(workflowExecutionUuid: String)(implicit ec: ExecutionContext): OptionT[Future, String]
 
   def queryWorkflowSummaries(workflowStatuses: Set[String], workflowNames: Set[String],
                              workflowExecutionUuids: Set[String], startTimestampOption: Option[Timestamp],

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime
 
 import cats.Semigroup
 import cats.data.NonEmptyList
+import cats.instances.future._
 import cats.syntax.semigroup._
 import cromwell.core.{WorkflowId, WorkflowMetadataKeys, WorkflowState}
 import cromwell.database.sql.SqlConverters._
@@ -13,6 +14,7 @@ import cromwell.services.metadata.MetadataService.{QueryMetadata, WorkflowQueryR
 import cromwell.services.metadata._
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 
 object MetadataDatabaseAccess {
 
@@ -153,7 +155,7 @@ trait MetadataDatabaseAccess {
 
   def getWorkflowStatus(id: WorkflowId)
                        (implicit ec: ExecutionContext): Future[Option[WorkflowState]] = {
-    databaseInterface.getWorkflowStatus(id.toString) map { _ map WorkflowState.fromString }
+    databaseInterface.getWorkflowStatus(id.toString) map WorkflowState.fromString value
   }
 
   def workflowExistsWithId(possibleWorkflowId: String)(implicit ec: ExecutionContext): Future[Boolean] = {


### PR DESCRIPTION
tl;dr I tried replacing existing `Future[Option[A]]`s with monad transformers as requested by #1212, but unfortunately found them not to be a good fit for our use cases.  I wouldn't recommend merging this PR in its current state.

Problems:

1) Monad transformer examples seem to break down into a "happy path" or at least "substantive path" (in the case of `Option`).  A value is either mapped/flatMapped out of the fused monadic context on the happy path, or processing short circuits on the unhappy path and eventually results in a one-size-fits-all error.  But this doesn't really fit the patterns of our APIs.  Most of the `Future[Option[A]]`s on database APIs break down into 3 distinct states in engine or API code, while for initialization actors a failed `Future` is the only error case; if the inner `Option` is `None` that's perfectly fine but is handled in deeper business logic.

2) There are a couple of spots included in this PR where I could apply monad transformers.  But IMHO the net effect of these changes is to "Waldo" these two APIs to be inconsistent with the others for reasons that are not obvious or particularly compelling.  Also by the point above, this will restrict the way in which callers can use these APIs going forward.

