### PR TITLE
Fixed .pullapprove.yml

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -7,7 +7,6 @@ reviewers:
     members:
         - cjllanwarne
         - Horneth
-        - scottfrazer
         - mcovarr
         - geoffjentry
         - kshakir


### PR DESCRIPTION
Some builds were failing to pullapprove because the config contains a lost collaborator :(