### PR TITLE
Call caching output copy failures handling. Closes #1510

### DIFF
--- a/core/src/main/scala/cromwell/core/PathCopier.scala
+++ b/core/src/main/scala/cromwell/core/PathCopier.scala
@@ -1,5 +1,6 @@
 package cromwell.core
 
+import java.io.IOException
 import java.nio.file.Path
 
 import better.files._
@@ -23,7 +24,12 @@ object PathCopier {
     */
   def copy(sourceFilePath: Path, destinationFilePath: Path): Unit = {
     Option(File(destinationFilePath).parent).foreach(_.createDirectories())
-    File(sourceFilePath).copyTo(destinationFilePath, overwrite = true)
-    ()
+    try {
+      File(sourceFilePath).copyTo(destinationFilePath, overwrite = true)
+      ()
+    } catch {
+      case ex: Exception =>
+        throw new IOException(s"Failed to copy ${sourceFilePath.toUri.toString} to ${destinationFilePath.toUri.toString}", ex)
+    }
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -51,7 +51,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
                                (implicit ec: ExecutionContext): Future[Unit] = {
     import cats.syntax.functor._
     import cats.instances.future._
-    val action = dataAccess.allowResultReuseForCallCachingEntry(callCachingEntryId).update(false)
+    val action = dataAccess.allowResultReuseForCallCachingEntryId(callCachingEntryId).update(false)
     runTransaction(action) void
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -46,4 +46,12 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
 
     runTransaction(action)
   }
+
+  override def invalidateCall(callCachingEntryId: Int)
+                               (implicit ec: ExecutionContext): Future[Unit] = {
+    import cats.syntax.functor._
+    import cats.instances.future._
+    val action = dataAccess.allowResultReuseForCallCachingEntry(callCachingEntryId).update(false)
+    runTransaction(action) void
+  }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -41,7 +41,7 @@ trait CallCachingEntryComponent {
     } yield callCachingEntry
   )
 
-  val allowResultReuseForCallCachingEntry = Compiled(
+  val allowResultReuseForCallCachingEntryId = Compiled(
     (callCachingEntryId: Rep[Int]) => for {
       callCachingEntry <- callCachingEntries
       if callCachingEntry.callCachingEntryId === callCachingEntryId

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -40,4 +40,11 @@ trait CallCachingEntryComponent {
       if callCachingEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingEntry
   )
+
+  val allowResultReuseForCallCachingEntry = Compiled(
+    (callCachingEntryId: Rep[Int]) => for {
+      callCachingEntry <- callCachingEntries
+      if callCachingEntry.callCachingEntryId === callCachingEntryId
+    } yield callCachingEntry.allowResultReuse
+  )
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -13,4 +13,7 @@ trait CallCachingSqlDatabase {
 
   def queryCallCaching(callCachingResultMetainfoId: Int)
                       (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
+
+  def invalidateCall(callCachingResultMetainfoId: Int)
+                    (implicit ec: ExecutionContext): Future[Unit]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -11,9 +11,9 @@ trait CallCachingSqlDatabase {
   def queryCallCachingEntryIds(hashKeyHashValues: NonEmptyList[(String, String)])
                               (implicit ec: ExecutionContext): Future[Seq[Int]]
 
-  def queryCallCaching(callCachingResultMetainfoId: Int)
+  def queryCallCaching(callCachingEntryId: Int)
                       (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
 
-  def invalidateCall(callCachingResultMetainfoId: Int)
+  def invalidateCall(callCachingEntryId: Int)
                     (implicit ec: ExecutionContext): Future[Unit]
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -4,6 +4,7 @@ import java.time.OffsetDateTime
 
 import akka.actor.{ActorRef, ActorRefFactory, LoggingFSM, Props}
 import akka.routing.RoundRobinPool
+import cats.data.NonEmptyList
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.{BackendInitializationData, BackendJobDescriptor, BackendJobDescriptorKey, BackendLifecycleActorFactory}
@@ -129,8 +130,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       writeToMetadata(Map(callCachingReadResultMetadataKey -> "Cache Miss"))
       log.debug("Cache miss for job {}", jobTag)
       runJob(data)
-    case Event(hit @ CacheHit(cacheResultId), data: ResponsePendingData) =>
-      fetchCachedResults(data, jobDescriptorKey.call.task.outputs, hit)
+    case Event(hit: CacheHit, data: ResponsePendingData) =>
+      fetchCachedResults(jobDescriptorKey.call.task.outputs, hit.cacheResultIds.head) using data.withCacheHit(hit).popCacheHitId._2
     case Event(HashError(t), data: ResponsePendingData) =>
       writeToMetadata(Map(callCachingReadResultMetadataKey -> s"Hashing Error: ${t.getMessage}"))
       disableCallCaching(t)
@@ -141,7 +142,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     case Event(CachedOutputLookupSucceeded(wdlValueSimpletons, jobDetritus, returnCode, cacheResultId, cacheHitDetails), data: ResponsePendingData) =>
       writeToMetadata(Map(callCachingReadResultMetadataKey -> s"Cache Hit: $cacheHitDetails"))
       log.debug("Cache hit for {}! Fetching cached result {}", jobTag, cacheResultId)
-      makeBackendCopyCacheHit(cacheResultId, wdlValueSimpletons, jobDetritus, returnCode, data)
+      makeBackendCopyCacheHit(wdlValueSimpletons, jobDetritus, returnCode, data)
     case Event(CachedOutputLookupFailed(metaInfoId, error), data: ResponsePendingData) =>
       log.warning("Can't make a copy of the cached job outputs for {} due to {}. Running job.", jobTag, error)
       runJob(data)
@@ -155,20 +156,22 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   when(BackendIsCopyingCachedOutputs) {
     // Backend copying response:
-    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, Some(Success(hashes)))) =>
+    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, Some(Success(hashes)), _)) =>
       saveCacheResults(hashes, data.withSuccessResponse(response))
-    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, None)) if effectiveCallCachingMode.writeToCache =>
+    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, None, _)) if effectiveCallCachingMode.writeToCache =>
       // Wait for the CallCacheHashes
       stay using data.withSuccessResponse(response)
     case Event(response: SucceededResponse, data: ResponsePendingData) => // bad hashes or cache write off
       saveJobCompletionToJobStore(data.withSuccessResponse(response))
-    case Event(response: BackendJobExecutionResponse, data: ResponsePendingData) =>
+    case Event(response: BackendJobExecutionResponse, data @ ResponsePendingData(_, _, _, Some(cacheHit))) =>
       // This matches all response types other than `SucceededResponse`.
       response match {
-        case f: BackendJobFailedResponse =>log.error("{}: Failed copying cache results, falling back to running job: {}", jobDescriptorKey, f.throwable)
-        case _ => //
+        case f: BackendJobFailedResponse =>
+          invalidateCacheHit(cacheHit.cacheResultIds.head)
+          log.error(f.throwable, "Failed copying cache results for job {}, invalidating cache entry.", jobDescriptorKey)
+          goto(InvalidatingCacheEntry)
+        case _ => runJob(data)
       }
-      runJob(data)
 
     // Hashes arrive:
     case Event(hashes: CallCacheHashes, data: SucceededResponseData) =>
@@ -186,6 +189,21 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       stay using data.copy(hashes = Option(Failure(t)))
   }
 
+  when(InvalidatingCacheEntry) {
+    case Event(CallCacheInvalidatedSuccess, data: ResponsePendingData) =>
+      data.popCacheHitId match {
+        case (Some(nextId), newData) =>
+          log.info("Trying to use another cache hit for job: {}", jobDescriptorKey)
+          fetchCachedResults(jobDescriptorKey.call.task.outputs, nextId) using newData
+        case (None, newData) =>
+          log.info("Could not find another cache hit, falling back to running job: {}", jobDescriptorKey)
+          runJob(newData)
+      }
+    case Event(CallCacheInvalidatedFailure(failure), data: ResponsePendingData) =>
+      log.error(failure, "Failed to invalidate cache entry for job: {}", jobDescriptorKey)
+      runJob(data)
+  }
+
   when(RunningJob) {
     case Event(hashes: CallCacheHashes, data: SucceededResponseData) =>
       saveCacheResults(hashes, data)
@@ -199,10 +217,10 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       disableCallCaching(t)
       stay using data.copy(hashes = Option(Failure(t)))
 
-    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, Some(Success(hashes)))) if effectiveCallCachingMode.writeToCache =>
+    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, Some(Success(hashes)), _)) if effectiveCallCachingMode.writeToCache =>
       eventList ++= response.executionEvents
       saveCacheResults(hashes, data.withSuccessResponse(response))
-    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, None)) if effectiveCallCachingMode.writeToCache =>
+    case Event(response: SucceededResponse, data @ ResponsePendingData(_, _, None, _)) if effectiveCallCachingMode.writeToCache =>
       log.debug(s"Got job result for {}, awaiting hashes", jobTag)
       stay using data.withSuccessResponse(response)
     case Event(response: BackendJobExecutionResponse, data: ResponsePendingData) =>
@@ -302,24 +320,24 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     ()
   }
 
-  def makeFetchCachedResultsActor(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput]): Unit = {
-    context.actorOf(FetchCachedResultsActor.props(cacheHit, self, new CallCache(SingletonServicesStore.databaseInterface)))
+  def makeFetchCachedResultsActor(metaInfoId: MetaInfoId, taskOutputs: Seq[TaskOutput]): Unit = {
+    context.actorOf(FetchCachedResultsActor.props(metaInfoId, self, new CallCache(SingletonServicesStore.databaseInterface)))
     ()
   }
 
-  private def fetchCachedResults(data: ResponsePendingData, taskOutputs: Seq[TaskOutput], cacheHit: CacheHit) = {
-    makeFetchCachedResultsActor(cacheHit, taskOutputs)
+  private def fetchCachedResults(taskOutputs: Seq[TaskOutput], metaInfoId: MetaInfoId) = {
+    makeFetchCachedResultsActor(metaInfoId, taskOutputs)
     goto(FetchingCachedOutputsFromDatabase)
   }
 
-  private def makeBackendCopyCacheHit(cacheHit: CacheHit, wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int], data: ResponsePendingData) = {
+  private def makeBackendCopyCacheHit(wdlValueSimpletons: Seq[WdlValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int], data: ResponsePendingData) = {
     factory.cacheHitCopyingActorProps match {
       case Some(propsMaker) =>
         val backendCacheHitCopyingActorProps = propsMaker(data.jobDescriptor, initializationData, serviceRegistryActor)
         val cacheHitCopyActor = context.actorOf(backendCacheHitCopyingActorProps, buildCacheHitCopyingActorName(data.jobDescriptor))
         cacheHitCopyActor ! CopyOutputsCommand(wdlValueSimpletons, jobDetritusFiles, returnCode)
         replyTo ! JobRunning(data.jobDescriptor, None)
-        goto(BackendIsCopyingCachedOutputs) using data
+        goto(BackendIsCopyingCachedOutputs)
       case None =>
         // This should be impossible with the FSM, but luckily, we CAN recover if some foolish future programmer makes this happen:
         val errorMessage = "Call caching copying should never have even been attempted with no copy actor props! (Programmer error!)"
@@ -348,6 +366,12 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   protected def createSaveCacheResultsActor(hashes: CallCacheHashes, success: SucceededResponse): Unit = {
     val callCache = new CallCache(SingletonServicesStore.databaseInterface)
     context.actorOf(CallCacheWriteActor.props(callCache, workflowId, hashes, success), s"CallCacheWriteActor-$tag")
+    ()
+  }
+
+  protected def invalidateCacheHit(cacheId: MetaInfoId): Unit = {
+    val callCache = new CallCache(SingletonServicesStore.databaseInterface)
+    context.actorOf(CallCacheInvalidateActor.props(callCache, cacheId), s"CallCacheInvalidateActor${cacheId.id}-$tag")
     ()
   }
 
@@ -439,6 +463,7 @@ object EngineJobExecutionActor {
   case object RunningJob extends EngineJobExecutionActorState
   case object UpdatingCallCache extends EngineJobExecutionActorState
   case object UpdatingJobStore extends EngineJobExecutionActorState
+  case object InvalidatingCacheEntry extends EngineJobExecutionActorState
 
   /** Commands */
   sealed trait EngineJobExecutionActorCommand
@@ -483,13 +508,20 @@ object EngineJobExecutionActor {
 
   private[execution] case class ResponsePendingData(jobDescriptor: BackendJobDescriptor,
                                                     bjeaProps: Props,
-                                                    hashes: Option[Try[CallCacheHashes]] = None) extends EJEAData {
+                                                    hashes: Option[Try[CallCacheHashes]] = None,
+                                                    cacheHit: Option[CacheHit] = None) extends EJEAData {
 
     def withSuccessResponse(success: SucceededResponse) = SucceededResponseData(success, hashes)
 
     def withResponse(response: BackendJobExecutionResponse) = response match {
       case success: SucceededResponse => SucceededResponseData(success, hashes)
       case failure => NotSucceededResponseData(failure, hashes)
+    }
+
+    def withCacheHit(cacheHit: CacheHit) = this.copy(cacheHit = Option(cacheHit))
+    def popCacheHitId: (Option[MetaInfoId], ResponsePendingData) = cacheHit match {
+      case Some(hit) => (Option(hit.cacheResultIds.head), this.copy(cacheHit = NonEmptyList.fromList(hit.cacheResultIds.tail) map CacheHit.apply))
+      case None => (None, this)
     }
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -77,4 +77,8 @@ class CallCache(database: CallCachingSqlDatabase) {
   def fetchCachedResult(metaInfoId: MetaInfoId)(implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {
     database.queryCallCaching(metaInfoId.id)
   }
+
+  def invalidate(metaInfoId: MetaInfoId)(implicit ec: ExecutionContext) = {
+    database.invalidateCall(metaInfoId.id)
+  }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -13,7 +13,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashing
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final case class MetaInfoId(id: Int)
+final case class CallCachingEntryId(id: Int)
 
 /**
   * Given a database-layer CallCacheStore, this accessor can access the database with engine-friendly data types.
@@ -34,7 +34,7 @@ class CallCache(database: CallCachingSqlDatabase) {
     addToCache(metaInfo, hashes, result, jobDetritus)
   }
 
-  private def addToCache(metaInfo: CallCachingEntry, hashes: Set[HashResult],
+  private def addToCache(callCachingEntry: CallCachingEntry, hashes: Set[HashResult],
                          result: Iterable[WdlValueSimpleton], jobDetritus: Map[String, String])
                         (implicit ec: ExecutionContext): Future[Unit] = {
 
@@ -56,29 +56,29 @@ class CallCache(database: CallCachingSqlDatabase) {
     }
 
     val callCachingJoin =
-      CallCachingJoin(metaInfo, hashesToInsert.toSeq, resultToInsert.toSeq, jobDetritusToInsert.toSeq)
+      CallCachingJoin(callCachingEntry, hashesToInsert.toSeq, resultToInsert.toSeq, jobDetritusToInsert.toSeq)
 
     database.addCallCaching(callCachingJoin)
   }
 
-  def fetchMetaInfoIdsMatchingHashes(callCacheHashes: CallCacheHashes)(implicit ec: ExecutionContext): Future[Set[MetaInfoId]] = {
-    metaInfoIdsMatchingHashes(NonEmptyList.fromListUnsafe(callCacheHashes.hashes.toList))
+  def callCachingEntryIdsMatchingHashes(callCacheHashes: CallCacheHashes)(implicit ec: ExecutionContext): Future[Set[CallCachingEntryId]] = {
+    callCachingEntryIdsMatchingHashes(NonEmptyList.fromListUnsafe(callCacheHashes.hashes.toList))
   }
 
-  private def metaInfoIdsMatchingHashes(hashKeyValuePairs: NonEmptyList[HashResult])
-                                       (implicit ec: ExecutionContext): Future[Set[MetaInfoId]] = {
+  private def callCachingEntryIdsMatchingHashes(hashKeyValuePairs: NonEmptyList[HashResult])
+                                       (implicit ec: ExecutionContext): Future[Set[CallCachingEntryId]] = {
     val result = database.queryCallCachingEntryIds(hashKeyValuePairs map {
       case HashResult(hashKey, hashValue) => (hashKey.key, hashValue.value)
     })
 
-    result.map(_.toSet.map(MetaInfoId))
+    result.map(_.toSet.map(CallCachingEntryId))
   }
 
-  def fetchCachedResult(metaInfoId: MetaInfoId)(implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {
-    database.queryCallCaching(metaInfoId.id)
+  def fetchCachedResult(callCachingEntryId: CallCachingEntryId)(implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {
+    database.queryCallCaching(callCachingEntryId.id)
   }
 
-  def invalidate(metaInfoId: MetaInfoId)(implicit ec: ExecutionContext) = {
-    database.invalidateCall(metaInfoId.id)
+  def invalidate(callCachingEntryId: CallCachingEntryId)(implicit ec: ExecutionContext) = {
+    database.invalidateCall(callCachingEntryId.id)
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
@@ -1,0 +1,35 @@
+package cromwell.engine.workflow.lifecycle.execution.callcaching
+
+import akka.actor.{Actor, ActorLogging, Props}
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+class CallCacheInvalidateActor(callCache: CallCache, cacheId: MetaInfoId) extends Actor with ActorLogging {
+
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  def receiver = context.parent
+
+  callCache.invalidate(cacheId) onComplete {
+    case Success(_) =>
+      receiver ! CallCacheInvalidatedSuccess
+      context.stop(self)
+    case Failure(t) =>
+      receiver ! CallCacheInvalidatedFailure(t)
+      context.stop(self)
+  }
+
+  override def receive: Receive = {
+    case any => log.error("Unexpected message to InvalidateCallCacheActor: " + any)
+  }
+}
+
+object CallCacheInvalidateActor {
+  def props(callCache: CallCache, cacheId: MetaInfoId) = {
+    Props(new CallCacheInvalidateActor(callCache: CallCache, cacheId: MetaInfoId))
+  }
+}
+
+case object CallCacheInvalidatedSuccess
+case class CallCacheInvalidatedFailure(t: Throwable)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
@@ -31,5 +31,6 @@ object CallCacheInvalidateActor {
   }
 }
 
-case object CallCacheInvalidatedSuccess
-case class CallCacheInvalidatedFailure(t: Throwable)
+sealed trait CallCacheInvalidatedResponse
+case object CallCacheInvalidatedSuccess extends CallCacheInvalidatedResponse
+case class CallCacheInvalidatedFailure(t: Throwable) extends CallCacheInvalidatedResponse

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
@@ -5,7 +5,7 @@ import akka.actor.{Actor, ActorLogging, Props}
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
-class CallCacheInvalidateActor(callCache: CallCache, cacheId: MetaInfoId) extends Actor with ActorLogging {
+class CallCacheInvalidateActor(callCache: CallCache, cacheId: CallCachingEntryId) extends Actor with ActorLogging {
 
   implicit val ec: ExecutionContext = context.dispatcher
 
@@ -26,8 +26,8 @@ class CallCacheInvalidateActor(callCache: CallCache, cacheId: MetaInfoId) extend
 }
 
 object CallCacheInvalidateActor {
-  def props(callCache: CallCache, cacheId: MetaInfoId) = {
-    Props(new CallCacheInvalidateActor(callCache: CallCache, cacheId: MetaInfoId))
+  def props(callCache: CallCache, cacheId: CallCachingEntryId) = {
+    Props(new CallCacheInvalidateActor(callCache: CallCache, cacheId: CallCachingEntryId))
   }
 }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -31,7 +31,7 @@ class CallCacheReadActor(cache: CallCache) extends Actor with ActorLogging {
   }
 
   private def runRequest(callCacheHashes: CallCacheHashes): Unit = {
-    val response = cache.fetchMetaInfoIdsMatchingHashes(callCacheHashes) map {
+    val response = cache.callCachingEntryIdsMatchingHashes(callCacheHashes) map {
       CacheResultMatchesForHashes(callCacheHashes.hashes, _)
     } recover {
       case t => CacheResultLookupFailure(t)
@@ -66,6 +66,6 @@ object CallCacheReadActor {
   case class CacheLookupRequest(callCacheHashes: CallCacheHashes)
 
   sealed trait CallCacheReadActorResponse
-  case class CacheResultMatchesForHashes(hashResults: Set[HashResult], cacheResultIds: Set[MetaInfoId]) extends CallCacheReadActorResponse
+  case class CacheResultMatchesForHashes(hashResults: Set[HashResult], cacheResultIds: Set[CallCachingEntryId]) extends CallCacheReadActorResponse
   case class CacheResultLookupFailure(reason: Throwable) extends CallCacheReadActorResponse
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -201,7 +201,7 @@ object EngineJobHashingActor {
   case object GeneratingAllHashes extends EJHAState
 
   sealed trait EJHAResponse
-  case class CacheHit(cacheResultIds: NonEmptyList[MetaInfoId]) extends EJHAResponse
+  case class CacheHit(cacheResultIds: NonEmptyList[CallCachingEntryId]) extends EJHAResponse
   case object CacheMiss extends EJHAResponse
   case class HashError(t: Throwable) extends EJHAResponse {
     override def toString = s"HashError(${t.getMessage})"
@@ -225,7 +225,7 @@ object EngineJobHashingActor {
   * @param hashesKnown The set of all hashes calculated so far (including initial hashes)
   * @param remainingHashesNeeded The set of hashes which are still needed for writing to the database
   */
-private[callcaching] case class EJHAData(possibleCacheResults: Option[Set[MetaInfoId]],
+private[callcaching] case class EJHAData(possibleCacheResults: Option[Set[CallCachingEntryId]],
                                          remainingCacheChecks: Set[HashKey],
                                          hashesKnown: Set[HashResult],
                                          remainingHashesNeeded: Set[HashKey]) {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{ActorLogging, ActorRef, LoggingFSM, Props}
+import cats.data.NonEmptyList
 import cromwell.backend.callcaching.FileHashingActor.SingleFileHashRequest
 import cromwell.backend.{BackendInitializationData, BackendJobDescriptor, RuntimeAttributeDefinition}
 import cromwell.core.callcaching._
@@ -123,7 +124,8 @@ case class EngineJobHashingActor(receiver: ActorRef,
   }
 
   private def respondWithHitOrMissThenTransition(newData: EJHAData) = {
-    val hitOrMissResponse: EJHAResponse = newData.cacheHit map CacheHit getOrElse CacheMiss
+    import cats.data.NonEmptyList
+    val hitOrMissResponse: EJHAResponse = newData.cacheHits map { _.toList } flatMap NonEmptyList.fromList map CacheHit.apply getOrElse CacheMiss
 
     receiver ! hitOrMissResponse
     if (!activity.writeToCache) {
@@ -199,7 +201,7 @@ object EngineJobHashingActor {
   case object GeneratingAllHashes extends EJHAState
 
   sealed trait EJHAResponse
-  case class CacheHit(cacheResultId: MetaInfoId) extends EJHAResponse
+  case class CacheHit(cacheResultIds: NonEmptyList[MetaInfoId]) extends EJHAResponse
   case object CacheMiss extends EJHAResponse
   case class HashError(t: Throwable) extends EJHAResponse {
     override def toString = s"HashError(${t.getMessage})"
@@ -249,7 +251,8 @@ private[callcaching] case class EJHAData(possibleCacheResults: Option[Set[MetaIn
   def allHashesKnown = remainingHashesNeeded.isEmpty
   def allCacheResultsIntersected = remainingCacheChecks.isEmpty
   def cacheHit = if (allCacheResultsIntersected) possibleCacheResults flatMap { _.headOption } else None
-  def isDefinitelyCacheHit = cacheHit.isDefined
+  def cacheHits = if (allCacheResultsIntersected) possibleCacheResults else None
+  def isDefinitelyCacheHit = cacheHits.isDefined
   def isDefinitelyCacheMiss = possibleCacheResults.exists(_.isEmpty)
   def isDefinitelyCacheHitOrMiss = isDefinitelyCacheHit || isDefinitelyCacheMiss
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -9,17 +9,17 @@ import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 object FetchCachedResultsActor {
-  def props(metaInfoId: MetaInfoId, replyTo: ActorRef, callCache: CallCache): Props =
-    Props(new FetchCachedResultsActor(metaInfoId, replyTo, callCache))
+  def props(callCachingEntryId: CallCachingEntryId, replyTo: ActorRef, callCache: CallCache): Props =
+    Props(new FetchCachedResultsActor(callCachingEntryId, replyTo, callCache))
 
   sealed trait CachedResultResponse
-  case class CachedOutputLookupFailed(metaInfoId: MetaInfoId, failure: Throwable) extends CachedResultResponse
+  case class CachedOutputLookupFailed(callCachingEntryId: CallCachingEntryId, failure: Throwable) extends CachedResultResponse
   case class CachedOutputLookupSucceeded(simpletons: Seq[WdlValueSimpleton], callOutputFiles: Map[String,String],
-                                         returnCode: Option[Int], cacheHit: MetaInfoId, cacheHitDetails: String) extends CachedResultResponse
+                                         returnCode: Option[Int], cacheHit: CallCachingEntryId, cacheHitDetails: String) extends CachedResultResponse
 }
 
 
-class FetchCachedResultsActor(cacheResultId: MetaInfoId, replyTo: ActorRef, callCache: CallCache)
+class FetchCachedResultsActor(cacheResultId: CallCachingEntryId, replyTo: ActorRef, callCache: CallCache)
   extends Actor with ActorLogging {
 
   {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -3,29 +3,27 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.Simpletons._
 import cromwell.core.simpleton.WdlValueSimpleton
-import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CacheHit
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 object FetchCachedResultsActor {
-  def props(cacheHit: CacheHit, replyTo: ActorRef, callCache: CallCache): Props =
-    Props(new FetchCachedResultsActor(cacheHit, replyTo, callCache))
+  def props(metaInfoId: MetaInfoId, replyTo: ActorRef, callCache: CallCache): Props =
+    Props(new FetchCachedResultsActor(metaInfoId, replyTo, callCache))
 
   sealed trait CachedResultResponse
   case class CachedOutputLookupFailed(metaInfoId: MetaInfoId, failure: Throwable) extends CachedResultResponse
   case class CachedOutputLookupSucceeded(simpletons: Seq[WdlValueSimpleton], callOutputFiles: Map[String,String],
-                                         returnCode: Option[Int], cacheHit: CacheHit, cacheHitDetails: String) extends CachedResultResponse
+                                         returnCode: Option[Int], cacheHit: MetaInfoId, cacheHitDetails: String) extends CachedResultResponse
 }
 
 
-class FetchCachedResultsActor(cacheHit: CacheHit, replyTo: ActorRef, callCache: CallCache)
+class FetchCachedResultsActor(cacheResultId: MetaInfoId, replyTo: ActorRef, callCache: CallCache)
   extends Actor with ActorLogging {
 
   {
     implicit val ec: ExecutionContext = context.dispatcher
-    val cacheResultId = cacheHit.cacheResultId
 
     callCache.fetchCachedResult(cacheResultId) onComplete {
       case Success(Some(result)) =>
@@ -39,7 +37,7 @@ class FetchCachedResultsActor(cacheHit: CacheHit, replyTo: ActorRef, callCache: 
 
         replyTo ! CachedOutputLookupSucceeded(simpletons, jobDetritusFiles.toMap,
                                               result.callCachingEntry.returnCode,
-                                              cacheHit, sourceCacheDetails)
+                                              cacheResultId, sourceCacheDetails)
       case Success(None) =>
         val reason = new RuntimeException(s"Cache hit vanished between discovery and retrieval: $cacheResultId")
         replyTo ! CachedOutputLookupFailed(cacheResultId, reason)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EJHADataSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EJHADataSpec.scala
@@ -59,14 +59,14 @@ class EJHADataSpec extends FlatSpec with Matchers {
 
     // To save you time I'll just tell you: the intersection of all these sets is Set(5)
     val cacheLookupResults: List[CacheResultMatchesForHashes] = List(
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey1)), Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey2)), Set(1, 2, 3, 4, 5, 6) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey3)), Set(1, 2, 3, 5, 7, 8, 9, 10) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey4)), Set(4, 5, 6, 7, 8, 9, 10) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey5)), Set(1, 2, 5, 6, 7, 10) map MetaInfoId))
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey1)), Set(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey2)), Set(1, 2, 3, 4, 5, 6) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey3)), Set(1, 2, 3, 5, 7, 8, 9, 10) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey4)), Set(4, 5, 6, 7, 8, 9, 10) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey5)), Set(1, 2, 5, 6, 7, 10) map CallCachingEntryId))
     val newData = cacheLookupResults.foldLeft(data)( (d, c) => d.intersectCacheResults(c) )
     newData.possibleCacheResults match{
-      case Some(set) => set should be(Set(MetaInfoId(5)))
+      case Some(set) => set should be(Set(CallCachingEntryId(5)))
       case None => fail("There should be a cache result set")
     }
     newData.allCacheResultsIntersected should be(true)
@@ -79,9 +79,9 @@ class EJHADataSpec extends FlatSpec with Matchers {
 
     // To save you time I'll just tell you: the intersection of all these sets is empty Set()
     val cacheLookupResults: List[CacheResultMatchesForHashes] = List(
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey1)), Set(1, 2, 3, 4, 5, 6) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey2)), Set(1, 2, 3, 7, 8, 9) map MetaInfoId),
-      CacheResultMatchesForHashes(Set(makeHashResult(hashKey3)), Set(5, 7, 8, 9, 10) map MetaInfoId))
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey1)), Set(1, 2, 3, 4, 5, 6) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey2)), Set(1, 2, 3, 7, 8, 9) map CallCachingEntryId),
+      CacheResultMatchesForHashes(Set(makeHashResult(hashKey3)), Set(5, 7, 8, 9, 10) map CallCachingEntryId))
     val newData = cacheLookupResults.foldLeft(data)( (d, c) => d.intersectCacheResults(c) )
     newData.possibleCacheResults match{
       case Some(set) => set should be(Set.empty)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
@@ -2,6 +2,7 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import cats.data.NonEmptyList
 import cromwell.CromwellTestkitSpec
 import cromwell.backend.callcaching.FileHashingActor.{FileHashResponse, SingleFileHashRequest}
 import cromwell.backend.{BackendInitializationData, BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor, RuntimeAttributeDefinition}
@@ -47,7 +48,7 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
 
         deathWatch watch ejha
 
-        if (activity.readFromCache) replyTo.expectMsg(CacheHit(MetaInfoId(1)))
+        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(MetaInfoId(1))))
         if (activity.writeToCache) replyTo.expectMsgPF(max = 5 seconds, hint = "awaiting cache hit message") {
           case CallCacheHashes(hashes) => hashes.size should be(4)
           case x => fail(s"Cache hit anticipated! Instead got a ${x.getClass.getSimpleName}")
@@ -86,7 +87,7 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
           }
         }
 
-        if (activity.readFromCache) replyTo.expectMsg(CacheHit(MetaInfoId(1)))
+        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(MetaInfoId(1))))
         if (activity.writeToCache) replyTo.expectMsgPF(max = 5 seconds, hint = "awaiting cache hit message") {
           case CallCacheHashes(hashes) => hashes.size should be(6)
           case x => fail(s"Cache hit anticipated! Instead got a ${x.getClass.getSimpleName}")

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
@@ -36,11 +36,11 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
       }
 
       s"Respect the CallCachingMode and report back $expectation for the ${activity.readWriteMode} activity" in {
-        val singleMetaInfoIdSet = Set(MetaInfoId(1))
+        val singleCallCachingEntryIdSet = Set(CallCachingEntryId(1))
         val replyTo = TestProbe()
         val deathWatch = TestProbe()
 
-        val cacheLookupResponses: Map[String, Set[MetaInfoId]] = if (activity.readFromCache) standardCacheLookupResponses(singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet) else Map.empty
+        val cacheLookupResponses: Map[String, Set[CallCachingEntryId]] = if (activity.readFromCache) standardCacheLookupResponses(singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet) else Map.empty
         val ejha = createEngineJobHashingActor(
           replyTo = replyTo.ref,
           activity = activity,
@@ -48,7 +48,7 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
 
         deathWatch watch ejha
 
-        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(MetaInfoId(1))))
+        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(CallCachingEntryId(1))))
         if (activity.writeToCache) replyTo.expectMsgPF(max = 5 seconds, hint = "awaiting cache hit message") {
           case CallCacheHashes(hashes) => hashes.size should be(4)
           case x => fail(s"Cache hit anticipated! Instead got a ${x.getClass.getSimpleName}")
@@ -58,13 +58,13 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
       }
 
       s"Wait for requests to the FileHashingActor for the ${activity.readWriteMode} activity" in {
-        val singleMetaInfoIdSet = Set(MetaInfoId(1))
+        val singleCallCachingEntryIdSet = Set(CallCachingEntryId(1))
         val replyTo = TestProbe()
         val fileHashingActor = TestProbe()
         val deathWatch = TestProbe()
 
-        val initialCacheLookupResponses: Map[String, Set[MetaInfoId]] = if (activity.readFromCache) standardCacheLookupResponses(singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet) else Map.empty
-        val fileCacheLookupResponses = Map("input: File inputFile1" -> singleMetaInfoIdSet, "input: File inputFile2" -> singleMetaInfoIdSet)
+        val initialCacheLookupResponses: Map[String, Set[CallCachingEntryId]] = if (activity.readFromCache) standardCacheLookupResponses(singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet) else Map.empty
+        val fileCacheLookupResponses = Map("input: File inputFile1" -> singleCallCachingEntryIdSet, "input: File inputFile2" -> singleCallCachingEntryIdSet)
 
         val jobDescriptor = templateJobDescriptor(inputs = Map(
             "inputFile1" -> WdlFile("path"),
@@ -87,7 +87,7 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
           }
         }
 
-        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(MetaInfoId(1))))
+        if (activity.readFromCache) replyTo.expectMsg(CacheHit(NonEmptyList.of(CallCachingEntryId(1))))
         if (activity.writeToCache) replyTo.expectMsgPF(max = 5 seconds, hint = "awaiting cache hit message") {
           case CallCacheHashes(hashes) => hashes.size should be(6)
           case x => fail(s"Cache hit anticipated! Instead got a ${x.getClass.getSimpleName}")
@@ -97,13 +97,13 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
       }
 
       s"Cache miss for bad FileHashingActor results but still return hashes in the ${activity.readWriteMode} activity" in {
-        val singleMetaInfoIdSet = Set(MetaInfoId(1))
+        val singleCallCachingEntryIdSet = Set(CallCachingEntryId(1))
         val replyTo = TestProbe()
         val fileHashingActor = TestProbe()
         val deathWatch = TestProbe()
 
-        val initialCacheLookupResponses: Map[String, Set[MetaInfoId]] = if (activity.readFromCache) standardCacheLookupResponses(singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet, singleMetaInfoIdSet) else Map.empty
-        val fileCacheLookupResponses = Map("input: File inputFile1" -> Set(MetaInfoId(2)), "input: File inputFile2" -> singleMetaInfoIdSet)
+        val initialCacheLookupResponses: Map[String, Set[CallCachingEntryId]] = if (activity.readFromCache) standardCacheLookupResponses(singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, singleCallCachingEntryIdSet) else Map.empty
+        val fileCacheLookupResponses = Map("input: File inputFile1" -> Set(CallCachingEntryId(2)), "input: File inputFile2" -> singleCallCachingEntryIdSet)
 
         val jobDescriptor = templateJobDescriptor(inputs = Map(
           "inputFile1" -> WdlFile("path"),
@@ -140,11 +140,11 @@ class EngineJobHashingActorSpec extends TestKit(new CromwellTestkitSpec.TestWork
       }
 
       s"Detect call cache misses for the ${activity.readWriteMode} activity" in {
-        val singleMetaInfoIdSet = Set(MetaInfoId(1))
+        val singleCallCachingEntryIdSet = Set(CallCachingEntryId(1))
         val replyTo = TestProbe()
         val deathWatch = TestProbe()
 
-        val cacheLookupResponses: Map[String, Set[MetaInfoId]] = if (activity.readFromCache) standardCacheLookupResponses(singleMetaInfoIdSet, singleMetaInfoIdSet, Set(MetaInfoId(2)), singleMetaInfoIdSet) else Map.empty
+        val cacheLookupResponses: Map[String, Set[CallCachingEntryId]] = if (activity.readFromCache) standardCacheLookupResponses(singleCallCachingEntryIdSet, singleCallCachingEntryIdSet, Set(CallCachingEntryId(2)), singleCallCachingEntryIdSet) else Map.empty
         val ejha = createEngineJobHashingActor(
           replyTo = replyTo.ref,
           activity = activity,
@@ -178,7 +178,7 @@ object EngineJobHashingActorSpec extends MockitoSugar {
     jobDescriptor: BackendJobDescriptor = templateJobDescriptor(),
     initializationData: Option[BackendInitializationData] = None,
     fileHashingActor: Option[ActorRef] = None,
-    cacheLookupResponses: Map[String, Set[MetaInfoId]] = Map.empty,
+    cacheLookupResponses: Map[String, Set[CallCachingEntryId]] = Map.empty,
     runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition] = Set.empty,
     backendName: String = "whatever"
   )(implicit system: ActorSystem) = {
@@ -207,10 +207,10 @@ object EngineJobHashingActorSpec extends MockitoSugar {
     jobDescriptor
   }
 
-  def standardCacheLookupResponses(commandTemplate: Set[MetaInfoId],
-                                   inputCount: Set[MetaInfoId],
-                                   backendName: Set[MetaInfoId],
-                                   outputCount: Set[MetaInfoId]) = Map(
+  def standardCacheLookupResponses(commandTemplate: Set[CallCachingEntryId],
+                                   inputCount: Set[CallCachingEntryId],
+                                   backendName: Set[CallCachingEntryId],
+                                   outputCount: Set[CallCachingEntryId]) = Map(
     "command template" -> commandTemplate,
     "input count" -> inputCount,
     "backend name" -> backendName,

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/PredictableCallCacheReadActor.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/PredictableCallCacheReadActor.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 /**
   * Has a set of responses which it will respond with. If it gets a request for anything that it's not expecting to respond to will generate a failure.
   */
-class PredictableCallCacheReadActor(responses: Map[String, Set[MetaInfoId]]) extends Actor with ActorLogging {
+class PredictableCallCacheReadActor(responses: Map[String, Set[CallCachingEntryId]]) extends Actor with ActorLogging {
 
   var responsesRemaining = responses
 
@@ -25,7 +25,7 @@ class PredictableCallCacheReadActor(responses: Map[String, Set[MetaInfoId]]) ext
       }
   }
 
-  private def respond(sndr: ActorRef, hashes: Set[HashResult], result: Try[Set[MetaInfoId]]) = result match {
+  private def respond(sndr: ActorRef, hashes: Set[HashResult], result: Try[Set[CallCachingEntryId]]) = result match {
     case Success(cacheMatches) => sndr ! CacheResultMatchesForHashes(hashes, cacheMatches)
     case Failure(t) => sndr ! CacheResultLookupFailure(t)
   }
@@ -35,7 +35,7 @@ class PredictableCallCacheReadActor(responses: Map[String, Set[MetaInfoId]]) ext
     case None => Failure(new Exception(s"Error looking up response $name!"))
   }
 
-  private def resultLookupFolder(current: Try[Set[MetaInfoId]], next: HashResult): Try[Set[MetaInfoId]] = current flatMap { c =>
+  private def resultLookupFolder(current: Try[Set[CallCachingEntryId]], next: HashResult): Try[Set[CallCachingEntryId]] = current flatMap { c =>
     val lookedUp = toTry(next.hashKey.key, responses.get(next.hashKey.key))
     lookedUp map { l => c.intersect(l) }
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -1,17 +1,19 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
+import cats.data.NonEmptyList
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import EngineJobExecutionActorSpec._
 import cromwell.core.callcaching.CallCachingMode
-import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CallCacheHashes, EJHAResponse, HashError}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CallCacheHashes, EJHAResponse, HashError}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
 import scala.util.{Failure, Success, Try}
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
 
-class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec with HasJobSuccessResponse with HasJobFailureResponses with CanExpectJobStoreWrites with CanExpectCacheWrites {
+class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec with HasJobSuccessResponse with HasJobFailureResponses with CanExpectJobStoreWrites with CanExpectCacheWrites with CanExpectCacheInvalidation {
 
   override implicit val stateUnderTest = BackendIsCopyingCachedOutputs
 
-  "An EJEA in FetchingCachedOutputsFromDatabase state" should {
+  "An EJEA in BackendIsCopyingCachedOutputs state" should {
 
     val hashErrorCause = new Exception("blah")
     val hashResultsDataValue = Some(Success(SuccessfulCallCacheHashes))
@@ -96,17 +98,17 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
         }
 
         RestartOrExecuteCommandTuples foreach { case RestartOrExecuteCommandTuple(operationName, restarting, expectedMessage) =>
-          s"$operationName the job immediately when it gets a failure result, and it was going to receive $hashComboName, if call caching is $mode" in {
+          s"invalidate a call for caching if backend coping failed when start mode is $operationName, and it was going to receive $hashComboName, if call caching is $mode" in {
             ejea = ejeaInBackendIsCopyingCachedOutputsState(initialHashData, mode, restarting = restarting)
             // Send the response from the copying actor
             ejea ! failureNonRetryableResponse
 
-            helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
-            ejea.stateName should be(RunningJob)
-            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, initialHashData))
+            expectInvalidateCallCacheActor(cacheId)
+            ejea.stateName should be(InvalidatingCacheEntry)
+            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, initialHashData, cacheHit))
           }
 
-          s"$operationName the job (preserving and received hashes) when call caching is $mode, the EJEA has $hashComboName and then gets a success result" in {
+          s"invalidate a call for caching if backend coping failed when start mode is $operationName (preserving and received hashes) when call caching is $mode, the EJEA has $hashComboName and then gets a success result" in {
             ejea = ejeaInBackendIsCopyingCachedOutputsState(initialHashData, mode, restarting = restarting)
             // Send the response from the EJHA (if there was one!):
             ejhaResponse foreach { ejea ! _ }
@@ -118,15 +120,17 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
             // Send the response from the copying actor
             ejea ! failureNonRetryableResponse
 
-            helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
-            ejea.stateName should be(RunningJob)
-            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, finalHashData))
+            expectInvalidateCallCacheActor(cacheId)
+            ejea.stateName should be(InvalidatingCacheEntry)
+            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, finalHashData, cacheHit))
           }
         }
       }
     }
   }
 
-  def standardResponsePendingData(hashes: Option[Try[CallCacheHashes]]) = ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, hashes)
+  private val cacheId: MetaInfoId = MetaInfoId(74)
+  private val cacheHit = Option(CacheHit(NonEmptyList.of(cacheId)))
+  def standardResponsePendingData(hashes: Option[Try[CallCacheHashes]]) = ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, hashes, cacheHit)
   def ejeaInBackendIsCopyingCachedOutputsState(initialHashes: Option[Try[CallCacheHashes]], callCachingMode: CallCachingMode, restarting: Boolean = false) = helper.buildEJEA(restarting = restarting, callCachingMode = callCachingMode).setStateInline(data = standardResponsePendingData(initialHashes))
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
@@ -8,7 +8,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashing
 import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
 import org.scalatest.concurrent.Eventually
 
-class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventually {
+class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventually with CanExpectFetchCachedResults {
 
   override implicit val stateUnderTest = CheckingCallCache
 
@@ -16,11 +16,7 @@ class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventua
     "Try to fetch the call cache outputs if it gets a CacheHit" in {
       createCheckingCallCacheEjea()
       ejea ! CacheHit(NonEmptyList.of(MetaInfoId(75)))
-      eventually { helper.fetchCachedResultsActorCreations.hasExactlyOne should be(true) }
-      helper.fetchCachedResultsActorCreations checkIt {
-        case (metainfoId, _) => metainfoId should be(MetaInfoId(75))
-        case _ => fail("Incorrect creation of the fetchCachedResultsActor")
-      }
+      expectFetchCachedResultsActor(MetaInfoId(75))
       ejea.stateName should be(FetchingCachedOutputsFromDatabase)
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
@@ -5,7 +5,7 @@ import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{Che
 import EngineJobExecutionActorSpec.EnhancedTestEJEA
 import cromwell.core.callcaching.{CallCachingActivity, CallCachingOff, ReadCache}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, HashError}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import org.scalatest.concurrent.Eventually
 
 class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventually with CanExpectFetchCachedResults {
@@ -15,8 +15,8 @@ class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventua
   "An EJEA in CheckingCallCache mode" should {
     "Try to fetch the call cache outputs if it gets a CacheHit" in {
       createCheckingCallCacheEjea()
-      ejea ! CacheHit(NonEmptyList.of(MetaInfoId(75)))
-      expectFetchCachedResultsActor(MetaInfoId(75))
+      ejea ! CacheHit(NonEmptyList.of(CallCachingEntryId(75)))
+      expectFetchCachedResultsActor(CallCachingEntryId(75))
       ejea.stateName should be(FetchingCachedOutputsFromDatabase)
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
+import cats.data.NonEmptyList
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{CheckingCallCache, FetchingCachedOutputsFromDatabase, ResponsePendingData, RunningJob}
 import EngineJobExecutionActorSpec.EnhancedTestEJEA
 import cromwell.core.callcaching.{CallCachingActivity, CallCachingOff, ReadCache}
@@ -14,10 +15,10 @@ class EjeaCheckingCallCacheSpec extends EngineJobExecutionActorSpec with Eventua
   "An EJEA in CheckingCallCache mode" should {
     "Try to fetch the call cache outputs if it gets a CacheHit" in {
       createCheckingCallCacheEjea()
-      ejea ! CacheHit(MetaInfoId(75))
+      ejea ! CacheHit(NonEmptyList.of(MetaInfoId(75)))
       eventually { helper.fetchCachedResultsActorCreations.hasExactlyOne should be(true) }
       helper.fetchCachedResultsActorCreations checkIt {
-        case (CacheHit(metainfoId), _) => metainfoId should be(MetaInfoId(75))
+        case (metainfoId, _) => metainfoId should be(MetaInfoId(75))
         case _ => fail("Incorrect creation of the fetchCachedResultsActor")
       }
       ejea.stateName should be(FetchingCachedOutputsFromDatabase)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
@@ -1,14 +1,14 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
-import cromwell.core.WorkflowId
-import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
-import EngineJobExecutionActorSpec._
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
+import cromwell.core.WorkflowId
 import cromwell.core.callcaching.{CallCachingActivity, ReadAndWriteCache}
 import cromwell.core.simpleton.WdlValueSimpleton
-import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, HashError}
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.HashError
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
+import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
 import wdl4s.values.WdlString
 
@@ -36,7 +36,7 @@ class EjeaFetchingCachedOutputsFromDatabaseSpec extends EngineJobExecutionActorS
         val detritusMap = Map("stdout" -> "//somePath")
         val cachedReturnCode = Some(17)
         val sourceCacheDetails = s"${WorkflowId.randomId}:call-someTask:1"
-        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, CacheHit(MetaInfoId(75)), sourceCacheDetails)
+        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, MetaInfoId(75), sourceCacheDetails)
         helper.callCacheHitCopyingProbe.expectMsg(CopyOutputsCommand(cachedSimpletons, detritusMap, cachedReturnCode))
 
         // Check we end up in the right state:

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
@@ -7,7 +7,7 @@ import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.HashError
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
 import wdl4s.values.WdlString
@@ -36,7 +36,7 @@ class EjeaFetchingCachedOutputsFromDatabaseSpec extends EngineJobExecutionActorS
         val detritusMap = Map("stdout" -> "//somePath")
         val cachedReturnCode = Some(17)
         val sourceCacheDetails = s"${WorkflowId.randomId}:call-someTask:1"
-        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, MetaInfoId(75), sourceCacheDetails)
+        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, CallCachingEntryId(75), sourceCacheDetails)
         helper.callCacheHitCopyingProbe.expectMsg(CopyOutputsCommand(cachedSimpletons, detritusMap, cachedReturnCode))
 
         // Check we end up in the right state:
@@ -61,7 +61,7 @@ class EjeaFetchingCachedOutputsFromDatabaseSpec extends EngineJobExecutionActorS
           // Send the response from the "Fetch" actor
           val failureReason = new Exception("You can't handle the truth!")
 
-          ejea ! CachedOutputLookupFailed(MetaInfoId(90210), failureReason)
+          ejea ! CachedOutputLookupFailed(CallCachingEntryId(90210), failureReason)
           helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
 
           // Check we end up in the right state:

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
@@ -1,0 +1,68 @@
+package cromwell.engine.workflow.lifecycle.execution.ejea
+
+import cats.data.NonEmptyList
+import cromwell.core.callcaching.{CallCachingActivity, ReadCache}
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CacheHit
+import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheInvalidatedFailure, CallCacheInvalidatedSuccess, MetaInfoId}
+import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
+
+class EjeaInvalidatingCacheEntrySpec extends EngineJobExecutionActorSpec with CanExpectFetchCachedResults {
+
+  override implicit val stateUnderTest = InvalidatingCacheEntry
+
+  "An EJEA in InvalidatingCacheEntry state" should {
+
+    val invalidationErrorCause = new Exception("blah")
+    val invalidateSuccess = CallCacheInvalidatedSuccess
+    val invalidateFailure = CallCacheInvalidatedFailure(invalidationErrorCause)
+
+    val metaInfo31: MetaInfoId = MetaInfoId(31)
+    val metaInfo32: MetaInfoId = MetaInfoId(32)
+    val cacheHitWithTwoIds = CacheHit(NonEmptyList.of(metaInfo32, metaInfo31))
+    val cacheHitWithSingleId = CacheHit(NonEmptyList.of(metaInfo31))
+    val noCacheHit = None
+
+    case class CacheHitAndNextExpected(name: String,
+                                       cacheHitData: CacheHit,
+                                       nextCacheHitToTry: MetaInfoId,
+                                       nextExpectedCacheHitData: Option[CacheHit])
+
+    val cacheHitCombinations = List(
+      CacheHitAndNextExpected("cache hit with single Id hit", cacheHitWithSingleId, metaInfo31, None),
+      CacheHitAndNextExpected("cache hit with two Id hits", cacheHitWithTwoIds, metaInfo32, Option(cacheHitWithSingleId))
+    )
+
+    RestartOrExecuteCommandTuples foreach { case RestartOrExecuteCommandTuple(operationName, restarting, expectedMessage) =>
+      List(invalidateSuccess, invalidateFailure) foreach { invalidateActorResponse =>
+        s"$operationName a job if cache invalidation succeeds and there are no other cache hits to try when invalidate response is $invalidateActorResponse" in {
+          ejea = ejeaInvalidatingCacheEntryState(noCacheHit, restarting = restarting)
+          // Send the response from the invalidate actor
+          ejea ! invalidateActorResponse
+
+          helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
+          ejea.stateName should be(RunningJob)
+          ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, None, None))
+        }
+      }
+    }
+
+    cacheHitCombinations foreach { case combo @ CacheHitAndNextExpected(hitComboName, initialHitData, nextHitToTry, finalHitData) =>
+        List(invalidateSuccess, invalidateFailure) foreach { invalidateActorResponse =>
+          s"try the next available hit when there is a $hitComboName when response is $invalidateActorResponse" in {
+            ejea = ejeaInvalidatingCacheEntryState(Option(initialHitData), restarting = false)
+            // Send the response from the invalidate actor
+            ejea ! invalidateActorResponse
+
+            helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
+            expectFetchCachedResultsActor(nextHitToTry)
+            ejea.stateName should be(FetchingCachedOutputsFromDatabase)
+            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, finalHitData))
+          }
+        }
+    }
+  }
+
+  def standardResponsePendingData(hit: Option[CacheHit]) = ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, hit)
+  def ejeaInvalidatingCacheEntryState(hit: Option[CacheHit], restarting: Boolean = false) = helper.buildEJEA(restarting = restarting, callCachingMode = CallCachingActivity(ReadCache)).setStateInline(data = standardResponsePendingData(hit))
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cromwell.core.callcaching.{CallCachingActivity, ReadCache}
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CacheHit
-import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheInvalidatedFailure, CallCacheInvalidatedSuccess, MetaInfoId}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheInvalidatedFailure, CallCacheInvalidatedSuccess, CallCachingEntryId}
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 
 class EjeaInvalidatingCacheEntrySpec extends EngineJobExecutionActorSpec with CanExpectFetchCachedResults {
@@ -17,49 +17,36 @@ class EjeaInvalidatingCacheEntrySpec extends EngineJobExecutionActorSpec with Ca
     val invalidateSuccess = CallCacheInvalidatedSuccess
     val invalidateFailure = CallCacheInvalidatedFailure(invalidationErrorCause)
 
-    val metaInfo31: MetaInfoId = MetaInfoId(31)
-    val metaInfo32: MetaInfoId = MetaInfoId(32)
+    val metaInfo31: CallCachingEntryId = CallCachingEntryId(31)
+    val metaInfo32: CallCachingEntryId = CallCachingEntryId(32)
     val cacheHitWithTwoIds = CacheHit(NonEmptyList.of(metaInfo32, metaInfo31))
     val cacheHitWithSingleId = CacheHit(NonEmptyList.of(metaInfo31))
-    val noCacheHit = None
-
-    case class CacheHitAndNextExpected(name: String,
-                                       cacheHitData: CacheHit,
-                                       nextCacheHitToTry: MetaInfoId,
-                                       nextExpectedCacheHitData: Option[CacheHit])
-
-    val cacheHitCombinations = List(
-      CacheHitAndNextExpected("cache hit with single Id hit", cacheHitWithSingleId, metaInfo31, None),
-      CacheHitAndNextExpected("cache hit with two Id hits", cacheHitWithTwoIds, metaInfo32, Option(cacheHitWithSingleId))
-    )
 
     RestartOrExecuteCommandTuples foreach { case RestartOrExecuteCommandTuple(operationName, restarting, expectedMessage) =>
       List(invalidateSuccess, invalidateFailure) foreach { invalidateActorResponse =>
         s"$operationName a job if cache invalidation succeeds and there are no other cache hits to try when invalidate response is $invalidateActorResponse" in {
-          ejea = ejeaInvalidatingCacheEntryState(noCacheHit, restarting = restarting)
+          ejea = ejeaInvalidatingCacheEntryState(Option(cacheHitWithSingleId), restarting = restarting)
           // Send the response from the invalidate actor
           ejea ! invalidateActorResponse
 
           helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
-          ejea.stateName should be(RunningJob)
+          eventually { ejea.stateName should be(RunningJob) }
           ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper. bjeaProps, None, None))
         }
       }
     }
 
-    cacheHitCombinations foreach { case combo @ CacheHitAndNextExpected(hitComboName, initialHitData, nextHitToTry, finalHitData) =>
-        List(invalidateSuccess, invalidateFailure) foreach { invalidateActorResponse =>
-          s"try the next available hit when there is a $hitComboName when response is $invalidateActorResponse" in {
-            ejea = ejeaInvalidatingCacheEntryState(Option(initialHitData), restarting = false)
-            // Send the response from the invalidate actor
-            ejea ! invalidateActorResponse
+    List(invalidateSuccess, invalidateFailure) foreach { invalidateActorResponse =>
+      s"try the next available hit when response is $invalidateActorResponse" in {
+        ejea = ejeaInvalidatingCacheEntryState(Option(cacheHitWithTwoIds), restarting = false)
+        // Send the response from the invalidate actor
+        ejea ! invalidateActorResponse
 
-            helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
-            expectFetchCachedResultsActor(nextHitToTry)
-            ejea.stateName should be(FetchingCachedOutputsFromDatabase)
-            ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, finalHitData))
-          }
-        }
+        helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
+        expectFetchCachedResultsActor(cacheHitWithSingleId.cacheResultIds.head)
+        eventually { ejea.stateName should be(FetchingCachedOutputsFromDatabase) }
+        ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, Option(cacheHitWithSingleId)))
+      }
     }
   }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
@@ -40,6 +40,7 @@ trait EngineJobExecutionActorSpec extends CromwellTestkitSpec
     List(
       ("FetchCachedResultsActor", helper.fetchCachedResultsActorCreations),
       ("JobHashingActor", helper.jobHashingInitializations),
+      ("JobHashingActor", helper.invalidateCacheActorCreations),
       ("CallCacheWriteActor", helper.callCacheWriteActorCreations)) foreach {
       case (name, GotTooMany(list)) => fail(s"Too many $name creations (${list.size})")
       case _ => // Fine.

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
@@ -40,7 +40,7 @@ trait EngineJobExecutionActorSpec extends CromwellTestkitSpec
     List(
       ("FetchCachedResultsActor", helper.fetchCachedResultsActorCreations),
       ("JobHashingActor", helper.jobHashingInitializations),
-      ("JobHashingActor", helper.invalidateCacheActorCreations),
+      ("CallCacheInvalidateActor", helper.invalidateCacheActorCreations),
       ("CallCacheWriteActor", helper.callCacheWriteActorCreations)) foreach {
       case (name, GotTooMany(list)) => fail(s"Too many $name creations (${list.size})")
       case _ => // Fine.

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
@@ -5,7 +5,7 @@ import cromwell.core.JobOutput
 import cromwell.core.callcaching._
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{EJEAData, SucceededResponseData, UpdatingCallCache, UpdatingJobStore}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
-import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
 import cromwell.jobstore.{JobResultSuccess, JobStoreKey}
 import org.scalatest.concurrent.Eventually
@@ -62,17 +62,17 @@ private[ejea] trait CanExpectHashingInitialization extends Eventually { self: En
 }
 
 private[ejea] trait CanExpectFetchCachedResults extends Eventually { self: EngineJobExecutionActorSpec =>
-  def expectFetchCachedResultsActor(expectedMetainfoId: MetaInfoId): Unit = {
+  def expectFetchCachedResultsActor(expectedCallCachingEntryId: CallCachingEntryId): Unit = {
     eventually { helper.fetchCachedResultsActorCreations.hasExactlyOne should be(true) }
     helper.fetchCachedResultsActorCreations.checkIt {
-      case (metainfoId, _) => metainfoId should be(expectedMetainfoId)
+      case (callCachingEntryId, _) => callCachingEntryId should be(expectedCallCachingEntryId)
       case _ => fail("Incorrect creation of the fetchCachedResultsActor")
     }
   }
 }
 
 private[ejea] trait CanExpectCacheInvalidation extends Eventually { self: EngineJobExecutionActorSpec =>
-  def expectInvalidateCallCacheActor(expectedCacheId: MetaInfoId): Unit = {
+  def expectInvalidateCallCacheActor(expectedCacheId: CallCachingEntryId): Unit = {
     eventually { helper.invalidateCacheActorCreations.hasExactlyOne should be(true) }
     helper.invalidateCacheActorCreations.checkIt { cacheId =>
       cacheId shouldBe expectedCacheId

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
@@ -5,6 +5,7 @@ import cromwell.core.JobOutput
 import cromwell.core.callcaching._
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{EJEAData, SucceededResponseData, UpdatingCallCache, UpdatingJobStore}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
+import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
 import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
 import cromwell.jobstore.{JobResultSuccess, JobStoreKey}
 import org.scalatest.concurrent.Eventually
@@ -56,6 +57,25 @@ private[ejea] trait CanExpectHashingInitialization extends Eventually { self: En
     helper.jobHashingInitializations.checkIt { initialization =>
       initialization._1 should be(helper.backendJobDescriptor)
       initialization._2 should be(mode)
+    }
+  }
+}
+
+private[ejea] trait CanExpectFetchCachedResults extends Eventually { self: EngineJobExecutionActorSpec =>
+  def expectFetchCachedResultsActor(expectedMetainfoId: MetaInfoId): Unit = {
+    eventually { helper.fetchCachedResultsActorCreations.hasExactlyOne should be(true) }
+    helper.fetchCachedResultsActorCreations.checkIt {
+      case (metainfoId, _) => metainfoId should be(expectedMetainfoId)
+      case _ => fail("Incorrect creation of the fetchCachedResultsActor")
+    }
+  }
+}
+
+private[ejea] trait CanExpectCacheInvalidation extends Eventually { self: EngineJobExecutionActorSpec =>
+  def expectInvalidateCallCacheActor(expectedCacheId: MetaInfoId): Unit = {
+    eventually { helper.invalidateCacheActorCreations.hasExactlyOne should be(true) }
+    helper.invalidateCacheActorCreations.checkIt { cacheId =>
+      cacheId shouldBe expectedCacheId
     }
   }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -10,10 +10,10 @@ import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.core.callcaching.{CallCachingActivity, CallCachingMode, CallCachingOff}
 import cromwell.core.{ExecutionStore, JobExecutionToken, OutputStore, WorkflowId}
 import cromwell.engine.EngineWorkflowDescriptor
-import cromwell.engine.backend.BackendSingletonCollection
+import cromwell.engine.workflow.lifecycle.execution.callcaching.MetaInfoId
 import cromwell.engine.workflow.lifecycle.execution.{EngineJobExecutionActor, WorkflowExecutionActorData}
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{EJEAData, EngineJobExecutionActorState}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CallCacheHashes}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 import org.specs2.mock.Mockito
 import wdl4s.WdlExpression.ScopedLookupFunction
 import wdl4s.expression.{NoFunctions, WdlFunctions, WdlStandardLibraryFunctions}
@@ -62,7 +62,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
   val backendWorkflowDescriptor = BackendWorkflowDescriptor(workflowId, null, null, null)
   val backendJobDescriptor = BackendJobDescriptor(backendWorkflowDescriptor, jobDescriptorKey, runtimeAttributes = Map.empty, inputs = Map.empty)
 
-  var fetchCachedResultsActorCreations: ExpectOne[(CacheHit, Seq[TaskOutput])] = NothingYet
+  var fetchCachedResultsActorCreations: ExpectOne[(MetaInfoId, Seq[TaskOutput])] = NothingYet
   var jobHashingInitializations: ExpectOne[(BackendJobDescriptor, CallCachingActivity)] = NothingYet
   var callCacheWriteActorCreations: ExpectOne[(CallCacheHashes, SucceededResponse)] = NothingYet
 
@@ -146,7 +146,7 @@ private[ejea] class MockEjea(helper: PerTestHelper,
                              backendName: String,
                              callCachingMode: CallCachingMode) extends EngineJobExecutionActor(replyTo, jobDescriptorKey, executionData, factory, initializationData, restarting, serviceRegistryActor, jobStoreActor, callCacheReadActor, jobTokenDispenserActor, None, backendName, callCachingMode) {
 
-  override def makeFetchCachedResultsActor(cacheHit: CacheHit, taskOutputs: Seq[TaskOutput]) = helper.fetchCachedResultsActorCreations = helper.fetchCachedResultsActorCreations.foundOne((cacheHit, taskOutputs))
+  override def makeFetchCachedResultsActor(cacheId: MetaInfoId, taskOutputs: Seq[TaskOutput]) = helper.fetchCachedResultsActorCreations = helper.fetchCachedResultsActorCreations.foundOne((cacheId, taskOutputs))
   override def initializeJobHashing(jobDescriptor: BackendJobDescriptor, activity: CallCachingActivity) = helper.jobHashingInitializations = helper.jobHashingInitializations.foundOne((jobDescriptor, activity))
   override def createSaveCacheResultsActor(hashes: CallCacheHashes, success: SucceededResponse) = helper.callCacheWriteActorCreations = helper.callCacheWriteActorCreations.foundOne((hashes, success))
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -65,6 +65,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
   var fetchCachedResultsActorCreations: ExpectOne[(MetaInfoId, Seq[TaskOutput])] = NothingYet
   var jobHashingInitializations: ExpectOne[(BackendJobDescriptor, CallCachingActivity)] = NothingYet
   var callCacheWriteActorCreations: ExpectOne[(CallCacheHashes, SucceededResponse)] = NothingYet
+  var invalidateCacheActorCreations: ExpectOne[MetaInfoId] = NothingYet
 
   val deathwatch = TestProbe()
   val bjeaProbe = TestProbe()
@@ -149,6 +150,8 @@ private[ejea] class MockEjea(helper: PerTestHelper,
   override def makeFetchCachedResultsActor(cacheId: MetaInfoId, taskOutputs: Seq[TaskOutput]) = helper.fetchCachedResultsActorCreations = helper.fetchCachedResultsActorCreations.foundOne((cacheId, taskOutputs))
   override def initializeJobHashing(jobDescriptor: BackendJobDescriptor, activity: CallCachingActivity) = helper.jobHashingInitializations = helper.jobHashingInitializations.foundOne((jobDescriptor, activity))
   override def createSaveCacheResultsActor(hashes: CallCacheHashes, success: SucceededResponse) = helper.callCacheWriteActorCreations = helper.callCacheWriteActorCreations.foundOne((hashes, success))
-
+  override def invalidateCacheHit(cacheId: MetaInfoId): Unit = {
+    helper.invalidateCacheActorCreations = helper.invalidateCacheActorCreations.foundOne(cacheId)
+  }
   override def createJobPreparationActor(jobPrepProps: Props, name: String) = jobPreparationProbe.ref
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -2,15 +2,15 @@ package cromwell.engine.workflow.tokens
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem, Kill, PoisonPill}
-import org.scalatest._
+import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import cromwell.core.JobExecutionToken
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDenied, JobExecutionTokenDispensed, JobExecutionTokenRequest, JobExecutionTokenReturn}
-import JobExecutionTokenDispenserActorSpec._
-import cromwell.core.JobExecutionToken
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActorSpec._
 import cromwell.engine.workflow.tokens.TestTokenGrabbingActor.StoppingSupervisor
 import cromwell.util.AkkaTestUtil
+import org.scalatest._
 import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.duration._

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesCacheHitCopyingActor.scala
@@ -13,7 +13,7 @@ case class JesCacheHitCopyingActor(override val jobDescriptor: BackendJobDescrip
                                    initializationData: JesBackendInitializationData,
                                    serviceRegistryActor: ActorRef)
   extends BackendCacheHitCopyingActor with CacheHitDuplicating with JesJobCachingActorHelper with JobLogging {
-  override protected def duplicate(source: Path, destination: Path) = PathCopier.copy(source, destination)
+  override protected def duplicate(source: Path, destination: Path) = PathCopier.copy(source, destination).get
 
   override protected def destinationCallRootPath = jesCallPaths.callRootPath
 


### PR DESCRIPTION
When a backend fails to copy outputs from a cache hit, invalidates that cache hit for the future - and try potential other hits found. Otherwise run the job normally. 