### PR TITLE
Modified the reference docker submit command to avoid bash redirection. Closes #1556

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -149,7 +149,7 @@ backend {
         run-in-background = true
         runtime-attributes = "String? docker"
         submit = "/bin/bash ${script}"
-        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${script}"
+        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash ${docker_cwd}/execution/script"
 
         # Root directory where Cromwell writes job results.  This directory must be
         # visible and writeable by the Cromwell process as well as the jobs that Cromwell


### PR DESCRIPTION
On behalf of @abuchanan. This modification seems to address an edge case in command redirection.

Would appreciate a review from at least @kshakir and one other.