### PR TITLE
Test and build updates Closes #1516

### DIFF
--- a/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
@@ -34,7 +34,3 @@ sealed trait ReadWriteMode {
 case object ReadCache extends ReadWriteMode { override val w = false }
 case object WriteCache extends ReadWriteMode { override val r = false }
 case object ReadAndWriteCache extends ReadWriteMode
-
-sealed trait DockerHashingType
-case object HashDockerName extends DockerHashingType
-case object HashDockerNameAndLookupDockerHash extends DockerHashingType

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val lenthallV = "0.19"
-  lazy val wdl4sV = "0.7-a990675-SNAPSHOT"
+  lazy val wdl4sV = "0.7-90945ea-SNAPSHOT"
   lazy val sprayV = "1.3.3"
   /*
   spray-json is an independent project from the "spray suite"
@@ -22,11 +22,20 @@ object Dependencies {
 
   private val baseDependencies = List(
     "org.broadinstitute" %% "lenthall" % lenthallV,
-    "org.typelevel" %% "cats" % catsV,
+    /*
+    Exclude test framework cats-laws and its transitive dependency scalacheck.
+    If sbt detects scalacheck, it tries to run it.
+    Explicitly excluding the two problematic artifacts instead of including the three (or four?).
+    https://github.com/typelevel/cats/tree/v0.7.2#getting-started
+     */
+    "org.typelevel" %% "cats" % "0.7.2"
+      exclude("org.typelevel", "cats-laws_2.11")
+      exclude("org.typelevel", "cats-kernel-laws_2.11"),
     "com.github.benhutchison" %% "mouse" % "0.5",
     "com.iheart" %% "ficus" % "1.3.0",
     "org.scalatest" %% "scalatest" % "3.0.0" % Test,
-    "org.specs2" %% "specs2" % "3.7" % Test
+    "org.pegdown" % "pegdown" % "1.6.0" % Test,
+    "org.specs2" %% "specs2-mock" % "3.8.5" % Test
   )
 
   private val slf4jBindingDependencies = List(
@@ -90,11 +99,6 @@ object Dependencies {
 
   val databaseSqlDependencies = baseDependencies ++ slickDependencies ++ dbmsDependencies
 
-  val databaseMigrationDependencies = List(
-    "org.broadinstitute" %% "wdl4s" % wdl4sV, // Used in migration scripts
-    "com.github.pathikrit" %% "better-files" % betterFilesV % Test
-  ) ++ baseDependencies ++ liquibaseDependencies ++ dbmsDependencies
-
   val coreDependencies = List(
     "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
     "org.broadinstitute" %% "wdl4s" % wdl4sV,
@@ -107,6 +111,10 @@ object Dependencies {
   ) ++ baseDependencies ++ googleApiClientDependencies ++
     // TODO: We're not using the "F" in slf4j. Core only supports logback, specifically the WorkflowLogger.
     slf4jBindingDependencies
+
+  val databaseMigrationDependencies = List(
+    "com.github.pathikrit" %% "better-files" % betterFilesV % Test
+  ) ++ liquibaseDependencies ++ dbmsDependencies
 
   val htCondorBackendDependencies = List(
     "com.twitter" %% "chill" % "0.8.0",
@@ -122,11 +130,9 @@ object Dependencies {
   ) ++ sprayServerDependencies
 
   val engineDependencies = List(
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
     "org.webjars" % "swagger-ui" % "2.1.1",
     "commons-codec" % "commons-codec" % "1.10",
     "commons-io" % "commons-io" % "2.5",
-    "org.typelevel" %% "cats" % catsV,
     "com.github.pathikrit" %% "better-files" % betterFilesV,
     "io.swagger" % "swagger-parser" % "1.0.22" % Test,
     "org.yaml" % "snakeyaml" % "1.17" % Test

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -6,8 +6,8 @@ import Version._
 import sbt.Keys._
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
-import sbtrelease.ReleasePlugin
 import sbtdocker.DockerPlugin.autoImport._
+import sbtrelease.ReleasePlugin
 
 object Settings {
 
@@ -59,14 +59,14 @@ object Settings {
     logLevel in assembly := Level.Info,
     assemblyMergeStrategy in assembly := customMergeStrategy
   )
-  
+
   lazy val dockerSettings = Seq(
     imageNames in docker := Seq(
-        ImageName(
-          namespace = Option("broadinstitute"),
-          repository = name.value,
-          tag = Some(s"${version.value}")
-        )
+      ImageName(
+        namespace = Option("broadinstitute"),
+        repository = name.value,
+        tag = Some(s"${version.value}")
+      )
     ),
     dockerfile in docker := {
       // The assembly task generates a fat JAR file
@@ -78,7 +78,7 @@ object Settings {
         expose(8000)
         add(artifact, artifactTargetPath)
         runRaw(s"ln -s $artifactTargetPath /app/cromwell.jar")
-        
+
         // If you use the 'exec' form for an entry point, shell processing is not performed and 
         // environment variable substitution does not occur.  Thus we have to /bin/bash here
         // and pass along any subsequent command line arguments
@@ -90,8 +90,7 @@ object Settings {
       cache = false,
       removeIntermediateContainers = BuildOptions.Remove.Always
     )
-    )
-  
+  )
 
   val commonSettings = ReleasePlugin.projectSettings ++ testSettings ++ assemblySettings ++
     dockerSettings ++ cromwellVersionWithGit ++ publishingSettings ++ List(

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -10,23 +10,25 @@ object Testing {
   lazy val DbmsTest = config("dbms") extend Test
 
   lazy val DockerTestTag = "DockerTest"
-  lazy val UseDockerTaggedTests = Tests.Argument("-n", DockerTestTag)
-  lazy val DontUseDockerTaggedTests = Tests.Argument("-l", DockerTestTag)
+  lazy val UseDockerTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-n", DockerTestTag)
+  lazy val DontUseDockerTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", DockerTestTag)
 
   lazy val CromwellIntegrationTestTag = "CromwellIntegrationTest"
-  lazy val UseCromwellIntegrationTaggedTests = Tests.Argument("-n", CromwellIntegrationTestTag)
-  lazy val DontUseCromwellIntegrationTaggedTests = Tests.Argument("-l", CromwellIntegrationTestTag)
+  lazy val UseCromwellIntegrationTaggedTests =
+    Tests.Argument(TestFrameworks.ScalaTest, "-n", CromwellIntegrationTestTag)
+  lazy val DontUseCromwellIntegrationTaggedTests =
+    Tests.Argument(TestFrameworks.ScalaTest, "-l", CromwellIntegrationTestTag)
 
   lazy val GcsIntegrationTestTag = "GcsIntegrationTest"
-  lazy val UseGcsIntegrationTaggedTests = Tests.Argument("-n", GcsIntegrationTestTag)
-  lazy val DontUseGcsIntegrationTaggedTests = Tests.Argument("-l", GcsIntegrationTestTag)
+  lazy val UseGcsIntegrationTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-n", GcsIntegrationTestTag)
+  lazy val DontUseGcsIntegrationTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", GcsIntegrationTestTag)
 
   lazy val DbmsTestTag = "DbmsTest"
-  lazy val UseDbmsTaggedTests = Tests.Argument("-n", DbmsTestTag)
-  lazy val DontUseDbmsTaggedTests = Tests.Argument("-l", DbmsTestTag)
+  lazy val UseDbmsTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-n", DbmsTestTag)
+  lazy val DontUseDbmsTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", DbmsTestTag)
 
   lazy val PostMVPTag = "PostMVP"
-  lazy val DontUsePostMVPTaggedTests = Tests.Argument("-l", PostMVPTag)
+  lazy val DontUsePostMVPTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", PostMVPTag)
 
   lazy val TestReportArgs = Tests.Argument(TestFrameworks.ScalaTest, "-oDSI", "-h", "target/test-reports")
 

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -160,6 +160,7 @@ object ServicesStoreSpec {
       s"""
          |db.url = "jdbc:hsqldb:mem:$${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
          |db.driver = "org.hsqldb.jdbcDriver"
+         |db.connectionTimeout = 3000
          |driver = "slick.driver.HsqldbDriver$$"
          |liquibase.updateSchema = false
          |""".stripMargin)


### PR DESCRIPTION
**Commit 1**
Stop invoking scalacheck during the sbt build by replacing a) specs2 with specs2-mock plus pegdown, and b) excluding cats dependencies (also in wdl4s).
Removed cromwell dependency duplications (see the verboseness in excising cats' duplicated dependencies).
Just in case, pass scalatest arguments only to scalatest.

**Commit 2**
3 seconds timeout (instead of the 1 second default) for each of the slick and liquibase databases being compared.
Removed dead docker case class.
Formatting updates for sbt-docker.