### PR TITLE
[HtCondor] Add support for native specifications in HtCondor backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,18 @@ This backend supports CPU, memory and disk size configuration through the use of
 
 It they are not set, HtCondor backend will use default values.
 
+### Native Specifications
+The use of runtime attribute 'nativeSpecs' allows to the user to attach custom HtCondor configuration to tasks.
+An example of this is when there is a need to work with 'requirements' or 'rank' configuration.
+
+```
+"runtimeAttributes": {
+    "nativeSpecs": ["requirements = Arch == \"INTEL\"", "rank = Memory >= 64"]
+}
+```
+
+nativeSpecs attribute needs to be specified as an array of strings to work.
+
 ## Spark Backend
 
 This backend adds support for execution of spark jobs in a workflow using the existing wdl format. 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A [Workflow Management System](https://en.wikipedia.org/wiki/Workflow_management
     * [Caching configuration](#caching-configuration)
     * [Docker](#docker)
     * [CPU, Memory and Disk](#cpu-memory-and-disk)
+    * [Native Specifications](#native-specifications)
   * [Spark Backend](#spark-backend)
     * [Configuring Spark Project](#configuring-spark-project)
     * [Configuring Spark Master and Deploy Mode](#configuring-spark-master-and-deploy-mode)

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActor.scala
@@ -298,7 +298,7 @@ class HtCondorJobExecutionActor(override val jobDescriptor: BackendJobDescriptor
           HtCondorRuntimeKeys.Disk -> runtimeAttributes.disk.to(MemoryUnit.KB).amount.toLong
         )
 
-      cmds.generateSubmitFile(submitFilePath, attributes) // This writes the condor submit file
+      cmds.generateSubmitFile(submitFilePath, attributes, runtimeAttributes.nativeSpecs) // This writes the condor submit file
       ()
 
     } catch {

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
@@ -68,13 +68,21 @@ echo $$? > rc
     ()
   }
 
-  def generateSubmitFile(path: Path, attributes: Map[String, Any]): String = {
+  def generateSubmitFile(path: Path, attributes: Map[String, Any], nativeSpecs: Option[Array[String]]): String = {
     def htCondorSubmitCommand(filePath: Path) = {
       s"${HtCondorCommands.Submit} ${filePath.toString}"
     }
 
     val submitFileWriter = path.untailed
     attributes.foreach(attribute => submitFileWriter.writeWithNewline(s"${attribute._1}=${attribute._2}"))
+    //Native specs is intended for attaching HtCondor native configuration such as 'requirements' and 'rank' definition
+    //directly to the submit file.
+    nativeSpecs match {
+      case Some(ns) => ns foreach { value =>
+        submitFileWriter.writeWithNewline(value)
+      }
+      case None => //Do nothing
+    }
     submitFileWriter.writeWithNewline(HtCondorRuntimeKeys.Queue)
     submitFileWriter.writer.flushAndClose()
     logger.debug(s"submit file name is : $path")

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/HtCondorWrapper.scala
@@ -74,15 +74,10 @@ echo $$? > rc
     }
 
     val submitFileWriter = path.untailed
-    attributes.foreach(attribute => submitFileWriter.writeWithNewline(s"${attribute._1}=${attribute._2}"))
+    attributes.foreach { attribute => submitFileWriter.writeWithNewline(s"${attribute._1}=${attribute._2}") }
     //Native specs is intended for attaching HtCondor native configuration such as 'requirements' and 'rank' definition
     //directly to the submit file.
-    nativeSpecs match {
-      case Some(ns) => ns foreach { value =>
-        submitFileWriter.writeWithNewline(value)
-      }
-      case None => //Do nothing
-    }
+    nativeSpecs foreach { _.foreach { submitFileWriter.writeWithNewline } }
     submitFileWriter.writeWithNewline(HtCondorRuntimeKeys.Queue)
     submitFileWriter.writer.flushAndClose()
     logger.debug(s"submit file name is : $path")

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
@@ -5,16 +5,17 @@ import better.files._
 import org.scalatest.{Matchers, WordSpecLike}
 
 class HtCondorCommandSpec extends WordSpecLike with Matchers {
-  val attributes = Map("executable" -> "test.sh", "input" -> "/temp/test", "error"->"stderr")
-  val resultAttributes = List("executable=test.sh","input=/temp/test","error=stderr", "queue")
-  val htCondorCommands = new HtCondorCommands
+  private val attributes = Map("executable" -> "test.sh", "input" -> "/temp/test", "error"->"stderr")
+  private val resultAttributes = List("executable=test.sh","input=/temp/test","error=stderr", "spec1", "spec2", "queue")
+  private val htCondorCommands = new HtCondorCommands
+  private val nativeSpecs = Option(Array("spec1", "spec2"))
 
   "submitCommand method" should {
     "return submit file with content passed to it" in {
       val dir = File.newTemporaryFile()
-      val command = htCondorCommands.generateSubmitFile(dir.path,attributes)
+      val command = htCondorCommands.generateSubmitFile(dir.path, attributes, nativeSpecs)
       val file = dir
-      resultAttributes shouldEqual  dir.lines.toList
+      resultAttributes shouldEqual dir.lines.toList
       dir.delete()
       command shouldEqual s"condor_submit ${file.path}"
     }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorCommandSpec.scala
@@ -12,11 +12,10 @@ class HtCondorCommandSpec extends WordSpecLike with Matchers {
 
   "submitCommand method" should {
     "return submit file with content passed to it" in {
-      val dir = File.newTemporaryFile()
-      val command = htCondorCommands.generateSubmitFile(dir.path, attributes, nativeSpecs)
-      val file = dir
-      resultAttributes shouldEqual dir.lines.toList
-      dir.delete()
+      val file = File.newTemporaryFile()
+      val command = htCondorCommands.generateSubmitFile(file.path, attributes, nativeSpecs)
+      resultAttributes shouldEqual file.lines.toList
+      file.delete()
       command shouldEqual s"condor_submit ${file.path}"
     }
   }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
@@ -33,7 +33,6 @@ class MongoCacheActorSpec extends TestKit(ActorSystem("MongoCacheProviderActorSp
   val mongoDbCollectionMock = mock[MongoCollection]
   val memorySize = MemorySize.parse("0.512 GB").get
   val diskSize = MemorySize.parse("1.024 GB").get
-  val nativeSpecs = None
   val runtimeConfig = HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), Some("tool-name"), Some("/workingDir"), Some("/outputDir"), true, 1, memorySize, diskSize, None)
   val jobHash = "88dde49db10f1551299fb9937f313c10"
   val taskStatus = "done"

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/caching/provider/mongodb/MongoCacheActorSpec.scala
@@ -33,7 +33,8 @@ class MongoCacheActorSpec extends TestKit(ActorSystem("MongoCacheProviderActorSp
   val mongoDbCollectionMock = mock[MongoCollection]
   val memorySize = MemorySize.parse("0.512 GB").get
   val diskSize = MemorySize.parse("1.024 GB").get
-  val runtimeConfig = HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), Some("tool-name"), Some("/workingDir"), Some("/outputDir"), true, 1, memorySize, diskSize)
+  val nativeSpecs = None
+  val runtimeConfig = HtCondorRuntimeAttributes(ContinueOnReturnCodeSet(Set(0)), Some("tool-name"), Some("/workingDir"), Some("/outputDir"), true, 1, memorySize, diskSize, None)
   val jobHash = "88dde49db10f1551299fb9937f313c10"
   val taskStatus = "done"
   val succeededResponseMock = SucceededResponse(BackendJobDescriptorKey(Call(Option("taskName"), null, null, null), None, 0), None, Map("test" -> JobOutput(WdlString("Test"))), None, Seq.empty)


### PR DESCRIPTION
The idea of this change is to allow the user to add custom htcondor configuration to the submit file.