### PR TITLE
Add logging to SFS localization functions.

### DIFF
--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -44,21 +44,30 @@ object SharedFileSystem extends StrictLogging {
   }
 
   private def localizePathViaCopy(originalPath: File, executionPath: File): Try[Unit] = {
-    executionPath.parent.createDirectories()
-    val executionTmpPath = pathPlusSuffix(executionPath, ".tmp")
-    logOnFailure(Try(originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)).void, "copy")
+    val action = Try {
+      executionPath.parent.createDirectories()
+      val executionTmpPath = pathPlusSuffix(executionPath, ".tmp")
+      originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)
+    }.void
+    logOnFailure(action, "copy")
   }
 
   private def localizePathViaHardLink(originalPath: File, executionPath: File): Try[Unit] = {
-    executionPath.parent.createDirectories()
-    logOnFailure(Try(executionPath.linkTo(originalPath, symbolic = false)).void, "hard link")
+    val action = Try {
+      executionPath.parent.createDirectories()
+      executionPath.linkTo(originalPath, symbolic = false)
+    }.void
+    logOnFailure(action, "hard link")
   }
 
   private def localizePathViaSymbolicLink(originalPath: File, executionPath: File): Try[Unit] = {
       if (originalPath.isDirectory) Failure(new UnsupportedOperationException("Cannot localize directory with symbolic links"))
       else {
-        executionPath.parent.createDirectories()
-        logOnFailure(Try(executionPath.linkTo(originalPath, symbolic = true)).void, "symbolic link")
+        val action = Try {
+          executionPath.parent.createDirectories()
+          executionPath.linkTo(originalPath, symbolic = true)
+        }.void
+        logOnFailure(action, "symbolic link")
       }
   }
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Path, Paths}
 import cats.instances.try_._
 import cats.syntax.functor._
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend.io.JobPaths
 import cromwell.core._
 import cromwell.core.path.PathFactory
@@ -33,91 +34,24 @@ object SharedFileSystem {
   }
 
   case class PairOfFiles(src: File, dst: File)
+
   type DuplicationStrategy = (File, File) => Try[Unit]
-
-  /**
-    * Return a `Success` result if the file has already been localized, otherwise `Failure`.
-    */
-  private def localizePathAlreadyLocalized(originalPath: File, executionPath: File): Try[Unit] = {
-    if (executionPath.exists) Success(()) else Failure(new RuntimeException(s"$originalPath doesn't exists"))
-  }
-
-  private def localizePathViaCopy(originalPath: File, executionPath: File): Try[Unit] = {
-    executionPath.parent.createDirectories()
-    val executionTmpPath = pathPlusSuffix(executionPath, ".tmp")
-    Try(originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)).void
-  }
-
-  private def localizePathViaHardLink(originalPath: File, executionPath: File): Try[Unit] = {
-    executionPath.parent.createDirectories()
-    Try { executionPath.linkTo(originalPath, symbolic = false) } void
-  }
-
-  private def localizePathViaSymbolicLink(originalPath: File, executionPath: File): Try[Unit] = {
-      if (originalPath.isDirectory) Failure(new UnsupportedOperationException("Cannot localize directory with symbolic links"))
-      else {
-        executionPath.parent.createDirectories()
-        Try { executionPath.linkTo(originalPath, symbolic = true) } void
-      }
-  }
-
-  private def duplicate(description: String, source: File, dest: File, strategies: Stream[DuplicationStrategy]) = {
-    import cromwell.util.FileUtil._
-
-    strategies.map(_ (source.followSymlinks, dest)).find(_.isSuccess) getOrElse {
-      Failure(new UnsupportedOperationException(s"Could not $description $source -> $dest"))
-    }
-  }
 
   def pathPlusSuffix(path: File, suffix: String) = path.sibling(s"${path.name}.$suffix")
 }
 
-trait SharedFileSystem extends PathFactory {
+trait SharedFileSystem extends PathFactory with StrictLogging {
   import SharedFileSystem._
   import better.files._
 
-  def sharedFileSystemConfig: Config
-
   lazy val DefaultStrategies = Seq("hard-link", "soft-link", "copy")
-
   lazy val LocalizationStrategies = getConfigStrategies("localization")
   lazy val Localizers = createStrategies(LocalizationStrategies, docker = false)
   lazy val DockerLocalizers = createStrategies(LocalizationStrategies, docker = true)
-
   lazy val CachingStrategies = getConfigStrategies("caching.duplication-strategy")
   lazy val Cachers = createStrategies(CachingStrategies, docker = false)
 
-  private def getConfigStrategies(configPath: String): Seq[String] = {
-    if (sharedFileSystemConfig.hasPath(configPath)) {
-      sharedFileSystemConfig.getStringList(configPath).asScala
-    } else {
-      DefaultStrategies
-    }
-  }
-
-  private def createStrategies(configStrategies: Seq[String], docker: Boolean): Seq[DuplicationStrategy] = {
-    // If localizing for a docker job, remove soft-link as an option
-    val filteredConfigStrategies = configStrategies filter {
-      case "soft-link" if docker => false
-      case _ => true
-    }
-
-    // Convert the (remaining) config strategies to duplication strategies
-    val mappedDuplicationStrategies = filteredConfigStrategies map {
-      case "hard-link" => localizePathViaHardLink _
-      case "soft-link" => localizePathViaSymbolicLink _
-      case "copy" => localizePathViaCopy _
-      case unsupported => throw new UnsupportedOperationException(s"Strategy $unsupported is not recognized")
-    }
-
-    // Prepend the default duplication strategy, and return the sequence
-    localizePathAlreadyLocalized _ +: mappedDuplicationStrategies
-  }
-
-  private def hostAbsoluteFilePath(callRoot: Path, pathString: String): File = {
-    val wdlPath = Paths.get(pathString)
-    callRoot.resolve(wdlPath).toAbsolutePath
-  }
+  def sharedFileSystemConfig: Config
 
   def outputMapper(job: JobPaths)(wdlValue: WdlValue): Try[WdlValue] = {
     wdlValue match {
@@ -184,6 +118,38 @@ trait SharedFileSystem extends PathFactory {
     }
   }
 
+  private def getConfigStrategies(configPath: String): Seq[String] = {
+    if (sharedFileSystemConfig.hasPath(configPath)) {
+      sharedFileSystemConfig.getStringList(configPath).asScala
+    } else {
+      DefaultStrategies
+    }
+  }
+
+  private def createStrategies(configStrategies: Seq[String], docker: Boolean): Seq[DuplicationStrategy] = {
+    // If localizing for a docker job, remove soft-link as an option
+    val filteredConfigStrategies = configStrategies filter {
+      case "soft-link" if docker => false
+      case _ => true
+    }
+
+    // Convert the (remaining) config strategies to duplication strategies
+    val mappedDuplicationStrategies = filteredConfigStrategies map {
+      case "hard-link" => localizePathViaHardLink _
+      case "soft-link" => localizePathViaSymbolicLink _
+      case "copy" => localizePathViaCopy _
+      case unsupported => throw new UnsupportedOperationException(s"Strategy $unsupported is not recognized")
+    }
+
+    // Prepend the default duplication strategy, and return the sequence
+    localizePathAlreadyLocalized _ +: mappedDuplicationStrategies
+  }
+
+  private def hostAbsoluteFilePath(callRoot: Path, pathString: String): File = {
+    val wdlPath = Paths.get(pathString)
+    callRoot.resolve(wdlPath).toAbsolutePath
+  }
+
   /**
    * Try to localize a WdlValue if it is or contains a WdlFile.
    *
@@ -224,4 +190,45 @@ trait SharedFileSystem extends PathFactory {
       case x => Success(x)
     }
   }
+
+  /**
+    * Return a `Success` result if the file has already been localized, otherwise `Failure`.
+    */
+  private def localizePathAlreadyLocalized(originalPath: File, executionPath: File): Try[Unit] = {
+    if (executionPath.exists) Success(()) else Failure(new RuntimeException(s"$originalPath doesn't exists"))
+  }
+
+  private def localizePathViaCopy(originalPath: File, executionPath: File): Try[Unit] = {
+    executionPath.parent.createDirectories()
+    val executionTmpPath = pathPlusSuffix(executionPath, ".tmp")
+    val result = Try(originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)).void
+    if (result.isFailure) logger.warn(s"Localization via copy has failed: ${result.failed.get.getMessage}")
+    result
+  }
+
+  private def localizePathViaHardLink(originalPath: File, executionPath: File): Try[Unit] = {
+    executionPath.parent.createDirectories()
+    val result = Try(executionPath.linkTo(originalPath, symbolic = false)).void
+    if (result.isFailure) logger.warn(s"Localization via hard link has failed: ${result.failed.get.getMessage}")
+    result
+  }
+
+  private def localizePathViaSymbolicLink(originalPath: File, executionPath: File): Try[Unit] = {
+    if (originalPath.isDirectory) Failure(new UnsupportedOperationException("Cannot localize directory with symbolic links"))
+    else {
+      executionPath.parent.createDirectories()
+      val result = Try(executionPath.linkTo(originalPath, symbolic = true)).void
+      if (result.isFailure) logger.warn(s"Localization via symbolic link has failed: ${result.failed.get.getMessage}")
+      result
+    }
+  }
+
+  private def duplicate(description: String, source: File, dest: File, strategies: Stream[DuplicationStrategy]) = {
+    import cromwell.util.FileUtil._
+
+    strategies.map(_ (source.followSymlinks, dest)).find(_.isSuccess) getOrElse {
+      Failure(new UnsupportedOperationException(s"Could not $description $source -> $dest"))
+    }
+  }
+
 }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -46,23 +46,23 @@ object SharedFileSystem extends StrictLogging {
   private def localizePathViaCopy(originalPath: File, executionPath: File): Try[Unit] = {
     executionPath.parent.createDirectories()
     val executionTmpPath = pathPlusSuffix(executionPath, ".tmp")
-    copyOrElseLog(Try(originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)).void, "copy")
+    logOnFailure(Try(originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)).void, "copy")
   }
 
   private def localizePathViaHardLink(originalPath: File, executionPath: File): Try[Unit] = {
     executionPath.parent.createDirectories()
-    copyOrElseLog(Try(executionPath.linkTo(originalPath, symbolic = false)).void, "hard link")
+    logOnFailure(Try(executionPath.linkTo(originalPath, symbolic = false)).void, "hard link")
   }
 
   private def localizePathViaSymbolicLink(originalPath: File, executionPath: File): Try[Unit] = {
       if (originalPath.isDirectory) Failure(new UnsupportedOperationException("Cannot localize directory with symbolic links"))
       else {
         executionPath.parent.createDirectories()
-        copyOrElseLog(Try(executionPath.linkTo(originalPath, symbolic = true)).void, "symbolic link")
+        logOnFailure(Try(executionPath.linkTo(originalPath, symbolic = true)).void, "symbolic link")
       }
   }
 
-  private def copyOrElseLog(action: => Try[Unit], actionLabel: String): Try[Unit] = {
+  private def logOnFailure(action: Try[Unit], actionLabel: String): Try[Unit] = {
     if (action.isFailure) logger.warn(s"Localization via $actionLabel has failed: ${action.failed.get.getMessage}", action.failed.get)
     action
   }

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -7,10 +7,11 @@ import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.path.DefaultPathBuilder
 import cromwell.backend.BackendSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, Matchers}
+import org.specs2.mock.Mockito
 import wdl4s.values.WdlFile
 
-class SharedFileSystemSpec extends FlatSpec with TableDrivenPropertyChecks with BackendSpec {
+class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with TableDrivenPropertyChecks with BackendSpec {
 
   behavior of "SharedFileSystem"
 
@@ -40,11 +41,11 @@ class SharedFileSystemSpec extends FlatSpec with TableDrivenPropertyChecks with 
       override val pathBuilders = localPathBuilder
       override val sharedFileSystemConfig = config
     }
-    val localizedInputs = Map(inputs.head._1 -> WdlFile(dest.pathAsString))
+    val localizedinputs = Map(inputs.head._1 -> WdlFile(dest.pathAsString))
     val result = sharedFS.localizeInputs(callDir.path, docker = docker)(inputs)
 
     result.isSuccess shouldBe true
-    result.get should contain theSameElementsAs localizedInputs
+    result.get should contain theSameElementsAs localizedinputs
 
     dest.exists shouldBe true
     countLinks(dest) should be(linkNb)

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -7,11 +7,10 @@ import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.path.DefaultPathBuilder
 import cromwell.backend.BackendSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
-import org.specs2.mock.Mockito
+import org.scalatest.FlatSpec
 import wdl4s.values.WdlFile
 
-class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with TableDrivenPropertyChecks with BackendSpec {
+class SharedFileSystemSpec extends FlatSpec with TableDrivenPropertyChecks with BackendSpec {
 
   behavior of "SharedFileSystem"
 
@@ -41,11 +40,11 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
       override val pathBuilders = localPathBuilder
       override val sharedFileSystemConfig = config
     }
-    val localizedinputs = Map(inputs.head._1 -> WdlFile(dest.pathAsString))
+    val localizedInputs = Map(inputs.head._1 -> WdlFile(dest.pathAsString))
     val result = sharedFS.localizeInputs(callDir.path, docker = docker)(inputs)
 
     result.isSuccess shouldBe true
-    result.get should contain theSameElementsAs localizedinputs
+    result.get should contain theSameElementsAs localizedInputs
 
     dest.exists shouldBe true
     countLinks(dest) should be(linkNb)


### PR DESCRIPTION
There is a requirement from CCC to be able to identify through logs why localization functionality fallback to an specific strategy.

A simple solution would be to log failures in each strategy invoke but I'm open to any other alternative.

OPEN: I made use of StrictLogging but if you think I should use a different implementation, just let me know and I will change it.