### PR TITLE
Better error reporting if an EJEA crashes unexpectedly

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendJobExecutionActor.scala
@@ -7,7 +7,7 @@ import akka.event.LoggingReceive
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor._
 import cromwell.backend.wdl.OutputEvaluator
-import cromwell.core.{ExecutionEvent, JobOutputs}
+import cromwell.core.{ExecutionEvent, JobKey, JobOutputs}
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.values.WdlValue
 
@@ -24,11 +24,11 @@ object BackendJobExecutionActor {
   // Responses
   sealed trait BackendJobExecutionActorResponse extends BackendWorkflowLifecycleActorResponse
 
-  sealed trait BackendJobExecutionResponse extends BackendJobExecutionActorResponse { def jobKey: BackendJobDescriptorKey }
+  sealed trait BackendJobExecutionResponse extends BackendJobExecutionActorResponse { def jobKey: JobKey }
   case class SucceededResponse(jobKey: BackendJobDescriptorKey, returnCode: Option[Int], jobOutputs: JobOutputs, jobDetritusFiles: Option[Map[String, Path]], executionEvents: Seq[ExecutionEvent]) extends BackendJobExecutionResponse
-  case class AbortedResponse(jobKey: BackendJobDescriptorKey) extends BackendJobExecutionResponse
+  case class AbortedResponse(jobKey: JobKey) extends BackendJobExecutionResponse
   sealed trait BackendJobFailedResponse extends BackendJobExecutionResponse {  def throwable: Throwable; def returnCode: Option[Int] }
-  case class FailedNonRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobFailedResponse
+  case class FailedNonRetryableResponse(jobKey: JobKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobFailedResponse
   case class FailedRetryableResponse(jobKey: BackendJobDescriptorKey, throwable: Throwable, returnCode: Option[Int]) extends BackendJobFailedResponse
 }
 

--- a/core/src/main/scala/cromwell/util/StopAndLogSupervisor.scala
+++ b/core/src/main/scala/cromwell/util/StopAndLogSupervisor.scala
@@ -1,0 +1,24 @@
+package cromwell.util
+
+import akka.actor.SupervisorStrategy.{Decider, Stop}
+import akka.actor.{Actor, ActorRef, OneForOneStrategy, SupervisorStrategy}
+import cromwell.core.logging.WorkflowLogging
+
+trait StopAndLogSupervisor { this: Actor with WorkflowLogging =>
+
+  private var failureLog: Map[ActorRef, Throwable] = Map.empty
+
+  final val stopAndLogStrategy: SupervisorStrategy = {
+    def stoppingDecider: Decider = {
+      case e: Exception =>
+        val failer = sender()
+        failureLog += failer -> e
+        Stop
+    }
+    OneForOneStrategy()(stoppingDecider)
+  }
+
+  final def getFailureCause(actorRef: ActorRef): Option[Throwable] = failureLog.get(actorRef)
+
+  override final val supervisorStrategy = stopAndLogStrategy
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -122,7 +122,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
         case CallCachingOff => runJob(updatedData)
       }
     case Event(response: BackendJobPreparationFailed, NoData) =>
-      forwardAndStop(response)
+      respondAndStop(FailedNonRetryableResponse(response.jobKey, response.throwable, None))
   }
 
   private val callCachingReadResultMetadataKey = "Call caching read result"

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -84,7 +84,7 @@ class JobExecutionTokenDispenserActor extends Actor with ActorLogging {
   private def onTerminate(terminee: ActorRef): Unit = {
     tokenAssignments.get(terminee) match {
       case Some(token) =>
-        log.error("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
+        log.debug("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
         self.tell(msg = JobExecutionTokenReturn(token), sender = terminee)
       case None =>
         log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaPreparingJobSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaPreparingJobSpec.scala
@@ -2,6 +2,7 @@ package cromwell.engine.workflow.lifecycle.execution.ejea
 
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
 import EngineJobExecutionActorSpec._
+import cromwell.backend.BackendJobExecutionActor.FailedNonRetryableResponse
 import cromwell.core.callcaching.CallCachingMode
 import cromwell.engine.workflow.lifecycle.execution.JobPreparationActor.{BackendJobPreparationFailed, BackendJobPreparationSucceeded}
 import org.scalatest.concurrent.Eventually
@@ -34,10 +35,11 @@ class EjeaPreparingJobSpec extends EngineJobExecutionActorSpec with CanExpectHas
       }
 
       s"Not proceed if Job Preparation fails ($mode)" in {
-        val prepFailedResponse = BackendJobPreparationFailed(helper.jobDescriptorKey, new Exception("The goggles! They do nothing!"))
+        val prepActorResponse = BackendJobPreparationFailed(helper.jobDescriptorKey, new Exception("The goggles! They do nothing!"))
+        val prepFailedEjeaResponse = FailedNonRetryableResponse(prepActorResponse.jobKey, prepActorResponse.throwable, None)
         ejea = ejeaInPreparingState(mode)
-        ejea ! prepFailedResponse
-        helper.replyToProbe.expectMsg(prepFailedResponse)
+        ejea ! prepActorResponse
+        helper.replyToProbe.expectMsg(prepFailedEjeaResponse)
         helper.deathwatch.expectTerminated(ejea, awaitTimeout)
       }
     }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -119,7 +119,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
       jobPreparationProbe = jobPreparationProbe,
       replyTo = replyToProbe.ref,
       jobDescriptorKey = jobDescriptorKey,
-      executionData = WorkflowExecutionActorData(descriptor, ExecutionStore(Map.empty), Map.empty, OutputStore(Map.empty)),
+      executionData = WorkflowExecutionActorData(descriptor, ExecutionStore(Map.empty), Map.empty, Map.empty, OutputStore(Map.empty)),
       factory = factory,
       initializationData = None,
       restarting = restarting,


### PR DESCRIPTION
Should be impossible for the EJEA to exit without the workflow noticing it now