### PR TITLE
Enable declarations as graph nodes Closes #1523

### DIFF
--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -6,7 +6,7 @@ import cromwell.backend.{BackendJobBreadCrumb, BackendSpec, BackendWorkflowDescr
 import cromwell.core.{JobKey, WorkflowId}
 import org.mockito.Mockito._
 import org.scalatest.{FlatSpec, Matchers}
-import wdl4s.{Call, Scope, Workflow}
+import wdl4s.{Call, Workflow}
 
 class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
@@ -48,7 +48,7 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     call2.unqualifiedName returns "call2"
     
     val jobKey = new JobKey {
-      override def scope: Scope = call1
+      override def scope = call1
       override def tag: String = "tag1"
       override def index: Option[Int] = Option(1)
       override def attempt: Int = 2

--- a/core/src/main/scala/cromwell/core/JobKey.scala
+++ b/core/src/main/scala/cromwell/core/JobKey.scala
@@ -1,9 +1,9 @@
 package cromwell.core
 
-import wdl4s.Scope
+import wdl4s.{GraphNode, Scope}
 
 trait JobKey {
-  def scope: Scope
+  def scope: Scope with GraphNode
   def index: Option[Int]
   def attempt: Int
   def tag: String

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -6,7 +6,7 @@ import cromwell.services.SingletonServicesStore
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import org.scalatest.Matchers
 import org.specs2.mock.Mockito
-import wdl4s.{Scope, TaskCall, WdlExpression}
+import wdl4s.{TaskCall, WdlExpression}
 import cromwell.core.ExecutionIndex._
 
 import scala.concurrent.duration._
@@ -38,7 +38,7 @@ class SubWorkflowStoreSpec extends CromwellTestKitSpec with Matchers with Mockit
       val call = mock[TaskCall]
       call.fullyQualifiedName returns "foo.bar"
       val jobKey = new JobKey {
-        override def scope: Scope = call
+        override def scope = call
         override def index: Option[Int] = None
         override def attempt: Int = 0
         override def tag: String = "foobar"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val lenthallV = "0.19"
-  lazy val wdl4sV = "0.7-4a9e61e-SNAP"
+  lazy val wdl4sV = "0.7-8df3f25-SNAP"
   lazy val sprayV = "1.3.3"
   /*
   spray-json is an independent project from the "spray suite"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val lenthallV = "0.19"
-  lazy val wdl4sV = "0.7-8df3f25-SNAP"
+  lazy val wdl4sV = "0.7-4a9e61e-SNAP"
   lazy val sprayV = "1.3.3"
   /*
   spray-json is an independent project from the "spray suite"


### PR DESCRIPTION
Will need https://github.com/broadinstitute/wdl4s/pull/52 merged

Enables WDL like 

```
task t {
    String i
    command {
        echo "lol"
    }
    output {
        String o = read_string(stdout())
    }
}

workflow w {
    call t {input: i = "hello"}
    String a = t.o # This currently would not work
    call t as u {input: i = a }
    String b = u.o
        
    output {
        String wo = b
    }
}
```