### PR TITLE
[HtCondor] Semicolon in WDL command allows execution on host system

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -259,7 +259,7 @@ backend {
     #    #6. Job command.
     #    docker {
     #      #Allow soft links in dockerized jobs
-    #      cmd = "docker run -w %s %s %s %s --rm %s %s"
+    #      cmd = "docker run -w %s %s %s %s --rm %s /bin/bash -c \"%s\""
     #      defaultWorkingDir = "/workingDir/"
     #      defaultOutputDir = "/output/"
     #    }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -102,7 +102,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
         |  root = "local-cromwell-executions"
         |
         |  docker {
-        |    cmd = "docker run -w %s %s %s %s --rm %s %s"
+        |    cmd = "docker run -w %s %s %s %s --rm %s /bin/bash -c \\"%s\\""
         |    defaultWorkingDir = "/workingDir/"
         |    defaultOutputDir = "/output/"
         |  }
@@ -318,7 +318,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
       assert(bashScript.contains("docker run -w /workingDir/ -v"))
       assert(bashScript.contains(":/workingDir/"))
       assert(bashScript.contains(":ro"))
-      assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest echo"))
+      assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest /bin/bash -c \"echo"))
 
       cleanUpJob(jobPaths)
     }

--- a/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
+++ b/supportedBackends/htcondor/src/test/scala/cromwell/backend/impl/htcondor/HtCondorJobExecutionActorSpec.scala
@@ -403,7 +403,7 @@ class HtCondorJobExecutionActorSpec extends TestKitSuite("HtCondorJobExecutionAc
     assert(bashScript.contains(":/workingDir/"))
     assert(bashScript.contains(tempDir1.toAbsolutePath.toString))
     assert(bashScript.contains(tempDir2.toAbsolutePath.toString))
-    assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest echo"))
+    assert(bashScript.contains("/call-hello/execution:/outputDir/ --rm ubuntu/latest /bin/bash -c \"echo"))
 
     cleanUpJob(jobPaths)
   }


### PR DESCRIPTION
This affects to HtCondor backend.

Given:
Following WDL task

``` 
task Example {
     command {
         echo foo;
         mkdir testFolder
      }
} 
```

When:
Runs workflow using HtCondor backend.

Then:
It creates testFolder in docker host machine.

Expected result:
Whole command executed within the container.