### PR TITLE
Quieten down that localization switchover

### DIFF
--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -72,7 +72,7 @@ object SharedFileSystem extends StrictLogging {
   }
 
   private def logOnFailure(action: Try[Unit], actionLabel: String): Try[Unit] = {
-    if (action.isFailure) logger.warn(s"Localization via $actionLabel has failed: ${action.failed.get.getMessage}", action.failed.get)
+    if (action.isFailure) logger.warn(s"Localization via $actionLabel has failed: ${action.failed.get.getMessage}")
     action
   }
 


### PR DESCRIPTION
This change is because we're seeing in Travis:
```
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).

The job has been terminated
```