### PR TITLE
Various patches.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -144,4 +144,11 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
     initializationData.get.asInstanceOf[StandardInitializationData].workflowPaths.workflowRoot
   }
 
+  override def runtimeAttributeDefinitions(initializationDataOption: Option[BackendInitializationData]):
+  Set[RuntimeAttributeDefinition] = {
+    val initializationData = BackendInitializationData.
+      as[StandardInitializationData](initializationDataOption)
+
+    initializationData.runtimeAttributesBuilder.definitions.toSet
+  }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -8,6 +8,7 @@
 webservice {
   port = 8000
   interface = 0.0.0.0
+  timeout = 5s
   instance.name = "reference"
 }
 

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -2,8 +2,7 @@ package cromwell.server
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.Props
-import akka.util.Timeout
+import akka.actor.{ActorContext, ActorSystem, Props}
 import com.typesafe.config.Config
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.webservice.WorkflowJsonSupport._
@@ -11,28 +10,29 @@ import cromwell.webservice.{APIResponse, CromwellApiService, SwaggerService}
 import lenthall.spray.SprayCanHttpService._
 import lenthall.spray.WrappedRoute._
 import net.ceedubs.ficus.Ficus._
-import spray.http.{ContentType, MediaTypes, _}
+import spray.http._
 import spray.json._
+import spray.routing.Route
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success}
 
 // Note that as per the language specification, this is instantiated lazily and only used when necessary (i.e. server mode)
 object CromwellServer {
-  implicit val timeout = Timeout(5.seconds)
-  import scala.concurrent.ExecutionContext.Implicits.global
-
 
   def run(cromwellSystem: CromwellSystem): Future[Any] = {
-    implicit val actorSystem = cromwellSystem.actorSystem
+    implicit val executionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+    val actorSystem: ActorSystem = cromwellSystem.actorSystem
 
     val service = actorSystem.actorOf(CromwellServerActor.props(cromwellSystem.conf), "cromwell-service")
     val webserviceConf = cromwellSystem.conf.getConfig("webservice")
 
     val interface = webserviceConf.getString("interface")
     val port = webserviceConf.getInt("port")
-    val futureBind = service.bind(interface = interface, port = port)
+    val timeout = webserviceConf.as[FiniteDuration]("timeout")
+    val futureBind = service.bind(interface, port)(implicitly, timeout, actorSystem, implicitly)
     futureBind andThen {
       case Success(_) =>
         actorSystem.log.info("Cromwell service started...")
@@ -52,16 +52,18 @@ object CromwellServer {
 }
 
 class CromwellServerActor(config: Config) extends CromwellRootActor with CromwellApiService with SwaggerService {
-  implicit def executionContext = actorRefFactory.dispatcher
+  implicit def executionContext: ExecutionContextExecutor = actorRefFactory.dispatcher
 
   override val serverMode = true
   override val abortJobsOnTerminate = false
 
-  override def actorRefFactory = context
-  override def receive = handleTimeouts orElse runRoute(possibleRoutes)
+  override def actorRefFactory: ActorContext = context
+  override def receive: PartialFunction[Any, Unit] = handleTimeouts orElse runRoute(possibleRoutes)
 
-  val possibleRoutes = workflowRoutes.wrapped("api", config.as[Option[Boolean]]("api.routeUnwrapped").getOrElse(false)) ~ swaggerUiResourceRoute
-  val timeoutError = APIResponse.error(new TimeoutException("The server was not able to produce a timely response to your request.")).toJson.prettyPrint
+  val routeUnwrapped: Boolean = config.as[Option[Boolean]]("api.routeUnwrapped").getOrElse(false)
+  val possibleRoutes: Route = workflowRoutes.wrapped("api", routeUnwrapped) ~ swaggerUiResourceRoute
+  val timeoutError: String = APIResponse.error(new TimeoutException(
+    "The server was not able to produce a timely response to your request.")).toJson.prettyPrint
 
   def handleTimeouts: Receive = {
     case Timedout(_: HttpRequest) =>

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -5,16 +5,16 @@ import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import cromwell.core.path.CustomRetryParams
 import cromwell.core.path.proxy.RetryableFileSystemProviderProxy
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.auth.GoogleAuthMode
+import cromwell.filesystems.gcs.auth.{GoogleAuthMode, GoogleAuthModeSpec}
 import org.scalatest.{FlatSpecLike, Matchers}
 
 class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers {
 
-  implicit val as = system
-
   behavior of "GcsPathBuilderSpec"
 
   it should "create a path with a retryable provider" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     val retryablePathBuilder = new RetryableGcsPathBuilder(
       GoogleAuthMode.NoAuthMode,
       RetryParams.defaultInstance(),

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/auth/GoogleAuthModeSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/auth/GoogleAuthModeSpec.scala
@@ -1,0 +1,18 @@
+package cromwell.filesystems.gcs.auth
+
+import cromwell.core.WorkflowOptions
+import org.scalatest.Assertions._
+
+object GoogleAuthModeSpec {
+  def assumeHasApplicationDefaultCredentials(): Unit = {
+    try {
+      val authMode = ApplicationDefaultMode("application-default")
+      val workflowOptions = WorkflowOptions.empty
+      authMode.authCredentials(workflowOptions)
+      authMode.credential(workflowOptions)
+      ()
+    } catch {
+      case exception: Exception => cancel(exception.getMessage)
+    }
+  }
+}

--- a/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
@@ -6,7 +6,7 @@ import java.time.OffsetDateTime
 import cats.data.NonEmptyList
 import cromwell.core.WorkflowId
 import cromwell.core.path.PathImplicits._
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.values.{WdlBoolean, WdlFloat, WdlInteger, WdlOptionalValue, WdlValue}
 
 case class MetadataJobKey(callFqn: String, index: Option[Int], attempt: Int)
@@ -21,7 +21,7 @@ object MetadataKey {
     new MetadataKey(workflowId, jobKey, compositeKey(keys:_*))
   }
 
-  def compositeKey(keys: String*) = keys.toList.mkString(KeySeparator.toString)
+  def compositeKey(keys: String*): String = keys.toList.mkString(KeySeparator.toString)
 }
 
 object MetadataEvent {
@@ -48,15 +48,15 @@ object MetadataValue {
       case _: Double | Float => new MetadataValue(value.toString, MetadataNumber)
       case _: Boolean => new MetadataValue(value.toString, MetadataBoolean)
       case path: Path => new MetadataValue(path.toRealString, MetadataString)
-      case _ => new MetadataValue(value.toString, MetadataString)
+      case other => new MetadataValue(other.toString, MetadataString)
     }
   }
 }
 
 object MetadataType {
-  val log = LoggerFactory.getLogger("Metadata Type")
+  val log: Logger = LoggerFactory.getLogger("Metadata Type")
 
-  def fromString(s: String) = s match {
+  def fromString(s: String): MetadataType = s match {
     case MetadataString.typeName => MetadataString
     case MetadataInt.typeName => MetadataInt
     case MetadataNumber.typeName => MetadataNumber
@@ -85,11 +85,11 @@ case class MetadataQuery(workflowId: WorkflowId, jobKey: Option[MetadataQueryJob
 object MetadataQuery {
   def forWorkflow(workflowId: WorkflowId) = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
 
-  def forJob(workflowId: WorkflowId, jobKey: MetadataJobKey) = {
+  def forJob(workflowId: WorkflowId, jobKey: MetadataJobKey): MetadataQuery = {
     MetadataQuery(workflowId, Option(MetadataQueryJobKey.forMetadataJobKey(jobKey)), None, None, None, expandSubWorkflows = false)
   }
 
-  def forKey(key: MetadataKey) = {
+  def forKey(key: MetadataKey): MetadataQuery = {
     MetadataQuery(key.workflowId, key.jobKey map MetadataQueryJobKey.forMetadataJobKey, Option(key.key), None, None, expandSubWorkflows = false)
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeAttributes.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesRuntimeAttributes.scala
@@ -86,8 +86,9 @@ object JesRuntimeAttributes {
     val memory: MemorySize = RuntimeAttributesValidation.extract(memoryValidation, validatedRuntimeAttributes)
     val disks: Seq[JesAttachedDisk] = RuntimeAttributesValidation.extract(disksValidation, validatedRuntimeAttributes)
     val docker: String = RuntimeAttributesValidation.extract(dockerValidation, validatedRuntimeAttributes)
-    val failOnStderr = RuntimeAttributesValidation.extract(FailOnStderrValidation.default, validatedRuntimeAttributes)
-    val continueOnReturnCode =
+    val failOnStderr: Boolean =
+      RuntimeAttributesValidation.extract(FailOnStderrValidation.default, validatedRuntimeAttributes)
+    val continueOnReturnCode: ContinueOnReturnCode =
       RuntimeAttributesValidation.extract(ContinueOnReturnCodeValidation.default, validatedRuntimeAttributes)
     val noAddress: Boolean = RuntimeAttributesValidation.extract(noAddressValidation, validatedRuntimeAttributes)
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
@@ -3,6 +3,7 @@ package cromwell.backend.impl.jes
 import cromwell.backend.BackendSpec
 import cromwell.core.TestKitSuite
 import cromwell.core.path.PathImplicits._
+import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -15,6 +16,8 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
   behavior of "JesCallPaths"
 
   it should "map the correct filenames" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
@@ -28,6 +31,8 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
   }
 
   it should "map the correct paths" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
@@ -44,6 +49,8 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
   }
 
   it should "map the correct call context" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -11,7 +11,7 @@ import cromwell.core.Tags.IntegrationTest
 import cromwell.core.logging.LoggingTest._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
 import cromwell.filesystems.gcs.GoogleConfiguration
-import cromwell.filesystems.gcs.auth.{RefreshTokenMode, SimpleClientSecrets}
+import cromwell.filesystems.gcs.auth.{GoogleAuthModeSpec, RefreshTokenMode, SimpleClientSecrets}
 import cromwell.util.{EncryptionSpec, SampleWdl}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -145,6 +145,8 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
   behavior of "JesInitializationActor"
 
   it should "log a warning message when there are unsupported runtime attributes" taggedAs IntegrationTest in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     within(Timeout) {
       val workflowDescriptor = buildWorkflowDescriptor(HelloWorld,
         runtime = """runtime { docker: "ubuntu/latest" test: true }""")

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesRuntimeAttributesSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesRuntimeAttributesSpec.scala
@@ -190,7 +190,8 @@ class JesRuntimeAttributesSpec extends WordSpecLike with Matchers with Mockito {
   }
 
   private def assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WdlValue], expectedRuntimeAttributes: JesRuntimeAttributes, workflowOptions: WorkflowOptions = emptyWorkflowOptions): Unit = {
-    val withDefaults = RuntimeAttributeDefinition.addDefaultsToAttributes(JesBackendLifecycleActorFactory.staticRuntimeAttributeDefinitions, workflowOptions) _
+    val withDefaults = RuntimeAttributeDefinition.addDefaultsToAttributes(
+      staticRuntimeAttributeDefinitions, workflowOptions) _
     try {
       assert(JesRuntimeAttributes(withDefaults(runtimeAttributes), NOPLogger.NOP_LOGGER) == expectedRuntimeAttributes)
     } catch {
@@ -200,7 +201,8 @@ class JesRuntimeAttributesSpec extends WordSpecLike with Matchers with Mockito {
   }
 
   private def assertJesRuntimeAttributesFailedCreation(runtimeAttributes: Map[String, WdlValue], exMsg: String, workflowOptions: WorkflowOptions = emptyWorkflowOptions): Unit = {
-    val withDefaults = RuntimeAttributeDefinition.addDefaultsToAttributes(JesBackendLifecycleActorFactory.staticRuntimeAttributeDefinitions, workflowOptions) _
+    val withDefaults = RuntimeAttributeDefinition.addDefaultsToAttributes(
+      staticRuntimeAttributeDefinitions, workflowOptions) _
     try {
       JesRuntimeAttributes(withDefaults(runtimeAttributes), NOPLogger.NOP_LOGGER)
       fail("A RuntimeException was expected.")
@@ -211,4 +213,6 @@ class JesRuntimeAttributesSpec extends WordSpecLike with Matchers with Mockito {
   }
 
   private val emptyWorkflowOptions = WorkflowOptions.fromMap(Map.empty).get
+  private val staticRuntimeAttributeDefinitions: Set[RuntimeAttributeDefinition] =
+    JesRuntimeAttributes.runtimeAttributesBuilder.definitions.toSet
 }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
@@ -3,6 +3,7 @@ package cromwell.backend.impl.jes
 import cromwell.backend.BackendSpec
 import cromwell.core.TestKitSuite
 import cromwell.core.path.PathImplicits._
+import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -14,6 +15,8 @@ class JesWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with Matchers 
   behavior of "JesWorkflowPaths"
 
   it should "map the correct paths" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendLifecycleActorFactory.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendLifecycleActorFactory.scala
@@ -1,11 +1,10 @@
 package cromwell.backend.impl.sfs.config
 
 import com.typesafe.config.Config
+import cromwell.backend.BackendConfigurationDescriptor
 import cromwell.backend.callcaching.FileHashingActor.FileHashingFunction
 import cromwell.backend.impl.sfs.config.ConfigConstants._
 import cromwell.backend.sfs._
-import cromwell.backend.standard.StandardInitializationData
-import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, RuntimeAttributeDefinition}
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import net.ceedubs.ficus.Ficus._
 import org.slf4j.{Logger, LoggerFactory}
@@ -31,14 +30,6 @@ class ConfigBackendLifecycleActorFactory(name: String, val configurationDescript
       classOf[BackgroundConfigAsyncJobExecutionActor]
     else
       classOf[DispatchedConfigAsyncJobExecutionActor]
-  }
-
-  override def runtimeAttributeDefinitions(initializationDataOption: Option[BackendInitializationData]):
-  Set[RuntimeAttributeDefinition] = {
-    val initializationData = BackendInitializationData.
-      as[StandardInitializationData](initializationDataOption)
-
-    initializationData.runtimeAttributesBuilder.definitions.toSet
   }
 
   override lazy val fileHashingFunction: Option[FileHashingFunction] = {


### PR DESCRIPTION
MetadataValue.apply was throwing an NPE exception when passed null, even though it had a call to .getOrElse("").
Consolidated standard backend runtimeAttributeDefinitions implementation.
Added a GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials in tests that use application default credentials.
Refactored away JesBackendLifecycleActorFactory's toJes, only used in one place where a similar standard method now exists.
Refactored away JesBackendLifecycleActorFactory's staticRuntimeAttributeDefinitions, only used in specs.
CromwellServer no longer hard codes the binding timeout.
