### PR TITLE
Rework structure of workflow store and metadata, provides roughly 5-f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Cromwell's Config (Shared Filesystem) backend now supports invocation of commands which run in a Docker image as a non-root user.
   The non-root user could either be the default user for a given Docker image (e.g. specified in a Dockerfile via a `USER` directive),
   or the Config backend could pass an optional `"-u username"` as part of the `submit-docker` command.
+* For MySQL users, a massive scalability improvement via batched DB writing of internal metadata events. Note that one must add `rewriteBatchedStatements=true` to their JDBC URL in their config in order to take advantage of this
 
 ### Database schema changes
 * Added CUSTOM_LABELS as a field of WORKFLOW_STORE_ENTRY, to store workflow store entries.

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ database {
   driver = "slick.driver.MySQLDriver$"
   db {
     driver = "com.mysql.jdbc.Driver"
-    url = "jdbc:mysql://host/cromwell"
+    url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
     user = "user"
     password = "pass"
     connectionTimeout = 5000

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -397,6 +397,20 @@ services {
     config {
       # Set this value to "Inf" to turn off metadata summary refresh.  The default value is currently "2 seconds".
       # metadata-summary-refresh-interval = "Inf"
+      # For higher scale environments, e.g. many workflows and/or jobs, DB write performance for metadata events
+      # can improved by writing to the database in batches. Increasing this value can dramatically improve overall
+      # performance but will both lead to a higher memory usage as well as increase the risk that metadata events
+      # might not have been persisted in the event of a Cromwell crash.
+      #
+      # For normal usage the default value of 1 (effectively no batching) should be fine but for larger/production
+      # environments we recommend a value of at least 500. There'll be no one size fits all number here so we recommend
+      # benchmarking performance and tuning the value to match your environment
+      # db-batch-size = 1
+      #
+      # Periodically the stored metadata events will be forcibly written to the DB regardless of if the batch size
+      # has been reached. This is to prevent situations where events wind up never being written to an incomplete batch
+      # with no new events being generated. The default value is currently 5 seconds
+      # db-flush-rate = 5 seconds
     }
   }
 }
@@ -414,7 +428,7 @@ database {
   #driver = "slick.driver.MySQLDriver$"
   #db {
   #  driver = "com.mysql.jdbc.Driver"
-  #  url = "jdbc:mysql://host/cromwell"
+  #  url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
   #  user = "user"
   #  password = "pass"
   #  connectionTimeout = 5000

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -15,7 +15,7 @@ trait MetadataSlickDatabase extends MetadataSqlDatabase {
 
   override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
                                  (implicit ec: ExecutionContext): Future[Unit] = {
-    val action = dataAccess.metadataEntryIdsAutoInc ++= metadataEntries
+    val action = DBIO.seq(metadataEntries.grouped(2000).map(dataAccess.metadataEntries ++= _).toSeq:_*)
     runTransaction(action).map(_ => ())
   }
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -57,7 +57,7 @@ trait MetadataEntryComponent {
       (workflowExecutionUuid, metadataKey, callFullyQualifiedName, jobIndex, jobAttempt), unique = false)
   }
 
-  protected val metadataEntries = TableQuery[MetadataEntries]
+  val metadataEntries = TableQuery[MetadataEntries]
 
   val metadataEntryIdsAutoInc = metadataEntries returning metadataEntries.map(_.metadataEntryId)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -13,7 +13,7 @@ import cromwell.core._
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.engine.workflow.SingleWorkflowRunnerActor._
 import cromwell.engine.workflow.WorkflowManagerActor.RetrieveNewWorkflows
-import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreEngineActor, WorkflowStoreSubmitActor}
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
 import cromwell.jobstore.EmptyJobStoreActor
 import cromwell.server.CromwellRootActor
@@ -56,7 +56,7 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection, metadataO
   }
 
   when (SubmittedWorkflow) {
-    case Event(WorkflowStoreActor.WorkflowSubmittedToStore(id), SubmittedSwraData(replyTo)) =>
+    case Event(WorkflowStoreSubmitActor.WorkflowSubmittedToStore(id), SubmittedSwraData(replyTo)) =>
       log.info(s"$Tag: Workflow submitted UUID($id)")
       // Since we only have a single workflow, force the WorkflowManagerActor's hand in case the polling rate is long
       workflowManagerActor ! RetrieveNewWorkflows
@@ -103,7 +103,7 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection, metadataO
 
   whenUnhandled {
     // Handle failures for all failure responses generically.
-    case Event(r: WorkflowStoreActor.WorkflowAbortFailed, data) => failAndFinish(r.reason, data)
+    case Event(r: WorkflowStoreEngineActor.WorkflowAbortFailed, data) => failAndFinish(r.reason, data)
     case Event(Failure(e), data) => failAndFinish(e, data)
     case Event(Status.Failure(e), data) => failAndFinish(e, data)
     case Event(RequestComplete((_, snap)), data) => failAndFinish(new RuntimeException(s"Unexpected API completion message: $snap"), data)

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
@@ -1,242 +1,33 @@
 package cromwell.engine.workflow.workflowstore
 
-import java.time.OffsetDateTime
-
-import akka.actor.{ActorLogging, ActorRef, LoggingFSM, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
 import cromwell.core._
 import cromwell.core.Dispatcher.EngineDispatcher
-import cromwell.engine.workflow.WorkflowManagerActor
-import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
-import cromwell.engine.workflow.workflowstore.WorkflowStoreActor._
-import cromwell.engine.workflow.workflowstore.WorkflowStoreState.StartableState
-import cromwell.services.metadata.MetadataService.{MetadataPutAcknowledgement, PutMetadataAction}
-import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
-import lenthall.util.TryUtil
-import org.apache.commons.lang3.exception.ExceptionUtils
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+final case class WorkflowStoreActor(store: WorkflowStore, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+  import WorkflowStoreActor._
 
-case class WorkflowStoreActor(store: WorkflowStore, serviceRegistryActor: ActorRef)
-  extends LoggingFSM[WorkflowStoreActorState, WorkflowStoreActorData] with ActorLogging {
+  lazy val workflowStoreSubmitActor: ActorRef = context.actorOf(WorkflowStoreSubmitActor.props(store, serviceRegistryActor))
+  lazy val workflowStoreEngineActor: ActorRef = context.actorOf(WorkflowStoreEngineActor.props(store, serviceRegistryActor))
 
-  implicit val ec: ExecutionContext = context.dispatcher
-
-  startWith(Unstarted, WorkflowStoreActorData(None, List.empty))
-  self ! InitializerCommand
-
-  when(Unstarted) {
-    case Event(InitializerCommand, _) =>
-      val work = store.initialize map { _ =>
-        log.debug("Workflow store initialization successful")
-      }
-      addWorkCompletionHooks(InitializerCommand, work)
-      goto(Working) using stateData.withCurrentCommand(InitializerCommand, sender)
-    case Event(x: WorkflowStoreActorCommand, _) =>
-      stay using stateData.withPendingCommand(x, sender)
-  }
-
-  when(Idle) {
-    case Event(cmd: WorkflowStoreActorCommand, _) =>
-      if (stateData.currentOperation.nonEmpty || stateData.pendingOperations.nonEmpty) {
-        log.error("Non-empty WorkflowStoreActorData when in Idle state: {}", stateData)
-      }
-      startNewWork(cmd, sender, stateData.withCurrentCommand(cmd, sender))
-  }
-
-  when(Working) {
-    case Event(WorkDone, data) =>
-      val newData = data.pop
-      newData.currentOperation match {
-        case None => goto(Idle) using newData
-        case Some(WorkflowStoreActorCommandWithSender(cmd, sndr)) => startNewWork(cmd, sndr, newData)
-      }
-    case Event(cmd: WorkflowStoreActorCommand, data) => stay using data.withPendingCommand(cmd, sender)
-  }
-
-  whenUnhandled {
-    case Event(MetadataPutAcknowledgement(_), _) =>
-      stay // Ignored
-    case Event(msg, _) =>
-      log.warning("Unexpected message to WorkflowStoreActor in state {} with data {}: {}", stateName, stateData, msg)
-      stay
-  }
-
-  onTransition {
-    case fromState -> toState =>
-      log.debug("WorkflowStore moving from {} (using {}) to {} (using {})", fromState, stateData, toState, nextStateData)
-  }
-
-  private def startNewWork(command: WorkflowStoreActorCommand, sndr: ActorRef, nextData: WorkflowStoreActorData) = {
-    val work: Future[Any] = command match {
-      case cmd @ SubmitWorkflow(sourceFiles) =>
-        storeWorkflowSources(NonEmptyList.of(sourceFiles)) map { ids =>
-          val id = ids.head
-          registerSubmissionWithMetadataService(id, sourceFiles)
-          sndr ! WorkflowSubmittedToStore(id)
-          log.info("Workflow {} submitted.", id)
-        }
-      case cmd @ BatchSubmitWorkflows(sources) =>
-        storeWorkflowSources(sources) map { ids =>
-          val assignedSources = ids.toList.zip(sources.toList)
-          assignedSources foreach { case (id, sourceFiles) => registerSubmissionWithMetadataService(id, sourceFiles) }
-          sndr ! WorkflowsBatchSubmittedToStore(ids)
-          log.info("Workflows {} submitted.", ids.toList.mkString(", "))
-        }
-      case cmd @ FetchRunnableWorkflows(n) =>
-        newWorkflowMessage(n) map { nwm =>
-          nwm match {
-            case NewWorkflowsToStart(workflows) => log.info("{} new workflows fetched", workflows.toList.size)
-            case NoNewWorkflowsToStart => log.debug("No workflows fetched")
-            case _ => log.error("Unexpected response from newWorkflowMessage({}): {}", n, nwm)
-          }
-          sndr ! nwm
-        }
-      case cmd @ AbortWorkflow(id, manager) =>
-        store.remove(id) map { removed =>
-          if (removed) {
-            log.debug(s"Workflow $id aborted and removed from the workflow store.")
-            manager ! WorkflowManagerActor.AbortWorkflowCommand(id, sndr)
-          } else {
-            sndr ! WorkflowAbortFailed(id, new WorkflowNotFoundException(s"Couldn't abort $id because no workflow with that ID is in progress"))
-          }
-        }
-      case cmd @ RemoveWorkflow(id) =>
-        store.remove(id) map { removed =>
-          if (removed) {
-            log.debug("Workflow {} removed from store successfully.", id)
-          } else {
-            log.warning(s"Attempted to remove ID {} from the WorkflowStore but it didn't exist", id)
-          }
-        }
-      case oops =>
-        log.error("Unexpected type of start work command: {}", oops.getClass.getSimpleName)
-        Future.successful(self ! WorkDone)
-    }
-    addWorkCompletionHooks(command, work)
-    goto(Working) using nextData
-  }
-
-  private def storeWorkflowSources(sources: NonEmptyList[WorkflowSourceFilesCollection]): Future[NonEmptyList[WorkflowId]] = {
-    for {
-      processedSources <- Future.fromTry(processSources(sources, _.asPrettyJson))
-      workflowIds <- store.add(processedSources)
-    } yield workflowIds
-  }
-
-  private def processSources(sources: NonEmptyList[WorkflowSourceFilesCollection],
-                             processOptions: WorkflowOptions => WorkflowOptionsJson):
-  Try[NonEmptyList[WorkflowSourceFilesCollection]] = {
-    val nelTries: NonEmptyList[Try[WorkflowSourceFilesCollection]] = sources map processSource(processOptions)
-    val seqTries: Seq[Try[WorkflowSourceFilesCollection]] = nelTries.toList
-    val trySeqs: Try[Seq[WorkflowSourceFilesCollection]] = TryUtil.sequence(seqTries)
-    val tryNel: Try[NonEmptyList[WorkflowSourceFilesCollection]] = trySeqs.map(seq => NonEmptyList.fromList(seq.toList).get)
-    tryNel
-  }
-
-  /**
-    * Runs processing on workflow source files before they are stored.
-    *
-    * @param processOptions How to process the workflow options
-    * @param source         Original workflow source
-    * @return Attempted updated workflow source
-    */
-  private def processSource(processOptions: WorkflowOptions => WorkflowOptionsJson)
-                           (source: WorkflowSourceFilesCollection): Try[WorkflowSourceFilesCollection] = {
-    for {
-      processedWorkflowOptions <- WorkflowOptions.fromJsonString(source.workflowOptionsJson)
-    } yield source.copyOptions(processOptions(processedWorkflowOptions))
-  }
-
-  private def addWorkCompletionHooks[A](command: WorkflowStoreActorCommand, work: Future[A]) = {
-    work.onComplete {
-      case Success(_) =>
-        self ! WorkDone
-      case Failure(t) =>
-        log.error("Error occurred during {}: {} because {}", command.getClass.getSimpleName, t.toString, ExceptionUtils.getStackTrace(t))
-        self ! WorkDone
-    }
-  }
-
-  /**
-    * Fetches at most n workflows, and builds the correct response message based on if there were any workflows or not
-    */
-  private def newWorkflowMessage(maxWorkflows: Int): Future[WorkflowStoreActorResponse] = {
-    def fetchRunnableWorkflowsIfNeeded(maxWorkflowsInner: Int, state: StartableState) = {
-      if (maxWorkflows > 0) {
-        store.fetchRunnableWorkflows(maxWorkflowsInner, state)
-      } else {
-        Future.successful(List.empty[WorkflowToStart])
-      }
-    }
-
-    val runnableWorkflows = for {
-      restartableWorkflows <- fetchRunnableWorkflowsIfNeeded(maxWorkflows, WorkflowStoreState.Restartable)
-      submittedWorkflows <- fetchRunnableWorkflowsIfNeeded(maxWorkflows - restartableWorkflows.size, WorkflowStoreState.Submitted)
-    } yield restartableWorkflows ++ submittedWorkflows
-
-    runnableWorkflows map {
-      case x :: xs => NewWorkflowsToStart(NonEmptyList.of(x, xs: _*))
-      case _ => NoNewWorkflowsToStart
-    }
-  }
-
-  /**
-    * Takes the workflow id and sends it over to the metadata service w/ default empty values for inputs/outputs
-    */
-  private def registerSubmissionWithMetadataService(id: WorkflowId, originalSourceFiles: WorkflowSourceFilesCollection): Unit = {
-    val sourceFiles = processSource(_.clearEncryptedValues)(originalSourceFiles).get
-
-    val submissionEvents = List(
-      MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionTime), MetadataValue(OffsetDateTime.now.toString)),
-      MetadataEvent.empty(MetadataKey(id, None, WorkflowMetadataKeys.Inputs)),
-      MetadataEvent.empty(MetadataKey(id, None, WorkflowMetadataKeys.Outputs)),
-
-      MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Workflow), MetadataValue(sourceFiles.wdlSource)),
-      MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Inputs), MetadataValue(sourceFiles.inputsJson)),
-      MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Options), MetadataValue(sourceFiles.workflowOptionsJson))
-    )
-
-    serviceRegistryActor ! PutMetadataAction(submissionEvents)
+  override def receive = {
+    case cmd: WorkflowStoreActorSubmitCommand => workflowStoreSubmitActor forward cmd
+    case cmd: WorkflowStoreActorEngineCommand => workflowStoreEngineActor forward cmd
   }
 }
 
 object WorkflowStoreActor {
+  sealed trait WorkflowStoreActorEngineCommand
+  final case class FetchRunnableWorkflows(n: Int) extends WorkflowStoreActorEngineCommand
+  final case class RemoveWorkflow(id: WorkflowId) extends WorkflowStoreActorEngineCommand
+  final case class AbortWorkflow(id: WorkflowId, manager: ActorRef) extends WorkflowStoreActorEngineCommand
+  case object InitializerCommand extends WorkflowStoreActorEngineCommand
+  case object WorkDone extends WorkflowStoreActorEngineCommand
 
-  private[workflowstore] case class WorkflowStoreActorCommandWithSender(command: WorkflowStoreActorCommand, sender: ActorRef)
-
-  private[workflowstore] case class WorkflowStoreActorData(currentOperation: Option[WorkflowStoreActorCommandWithSender], pendingOperations: List[WorkflowStoreActorCommandWithSender]) {
-    def withCurrentCommand(command: WorkflowStoreActorCommand, sender: ActorRef) = this.copy(currentOperation = Option(WorkflowStoreActorCommandWithSender(command, sender)))
-    def withPendingCommand(newCommand: WorkflowStoreActorCommand, sender: ActorRef) = this.copy(pendingOperations = this.pendingOperations :+ WorkflowStoreActorCommandWithSender(newCommand, sender))
-    def pop = {
-      if (pendingOperations.isEmpty) { WorkflowStoreActorData(None, List.empty) }
-      else { WorkflowStoreActorData(Option(pendingOperations.head), pendingOperations.tail) }
-    }
-  }
-
-  private[workflowstore] sealed trait WorkflowStoreActorState
-  private[workflowstore] case object Unstarted extends WorkflowStoreActorState
-  private[workflowstore] case object Working extends WorkflowStoreActorState
-  private[workflowstore] case object Idle extends WorkflowStoreActorState
-
-  sealed trait WorkflowStoreActorCommand
-  final case class SubmitWorkflow(source: WorkflowSourceFilesCollection) extends WorkflowStoreActorCommand
-  final case class BatchSubmitWorkflows(sources: NonEmptyList[WorkflowSourceFilesCollection]) extends WorkflowStoreActorCommand
-  final case class FetchRunnableWorkflows(n: Int) extends WorkflowStoreActorCommand
-  final case class RemoveWorkflow(id: WorkflowId) extends WorkflowStoreActorCommand
-  final case class AbortWorkflow(id: WorkflowId, manager: ActorRef) extends WorkflowStoreActorCommand
-
-  private case object InitializerCommand extends WorkflowStoreActorCommand
-  private case object WorkDone
-
-  sealed trait WorkflowStoreActorResponse
-  final case class WorkflowSubmittedToStore(workflowId: WorkflowId) extends WorkflowStoreActorResponse
-  final case class WorkflowsBatchSubmittedToStore(workflowIds: NonEmptyList[WorkflowId]) extends WorkflowStoreActorResponse
-  case object NoNewWorkflowsToStart extends WorkflowStoreActorResponse
-  final case class NewWorkflowsToStart(workflows: NonEmptyList[WorkflowToStart]) extends WorkflowStoreActorResponse
-  final case class WorkflowAborted(workflowId: WorkflowId) extends WorkflowStoreActorResponse
-  final case class WorkflowAbortFailed(workflowId: WorkflowId, reason: Throwable) extends WorkflowStoreActorResponse
+  sealed trait WorkflowStoreActorSubmitCommand
+  final case class SubmitWorkflow(source: WorkflowSourceFilesCollection) extends WorkflowStoreActorSubmitCommand
+  final case class BatchSubmitWorkflows(sources: NonEmptyList[WorkflowSourceFilesCollection]) extends WorkflowStoreActorSubmitCommand
 
   def props(workflowStoreDatabase: WorkflowStore, serviceRegistryActor: ActorRef) = {
     Props(WorkflowStoreActor(workflowStoreDatabase, serviceRegistryActor)).withDispatcher(EngineDispatcher)

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreEngineActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreEngineActor.scala
@@ -1,0 +1,166 @@
+package cromwell.engine.workflow.workflowstore
+
+import akka.actor.{ActorLogging, ActorRef, LoggingFSM, Props}
+import cats.data.NonEmptyList
+import cromwell.core.Dispatcher._
+import cromwell.engine.workflow.WorkflowManagerActor
+import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
+import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor.WorkflowStoreActorState
+import cromwell.engine.workflow.workflowstore.WorkflowStoreState.StartableState
+import WorkflowStoreEngineActor._
+import cromwell.core.WorkflowId
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor._
+import cromwell.services.metadata.MetadataService.MetadataPutAcknowledgement
+import org.apache.commons.lang3.exception.ExceptionUtils
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+final case class WorkflowStoreEngineActor(store: WorkflowStore, serviceRegistryActor: ActorRef)
+  extends LoggingFSM[WorkflowStoreActorState, WorkflowStoreActorData] with ActorLogging {
+
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  startWith(Unstarted, WorkflowStoreActorData(None, List.empty))
+  self ! InitializerCommand
+
+  when(Unstarted) {
+    case Event(InitializerCommand, _) =>
+      val work = store.initialize map { _ =>
+        log.debug("Workflow store initialization successful")
+      }
+      addWorkCompletionHooks(InitializerCommand, work)
+      goto(Working) using stateData.withCurrentCommand(InitializerCommand, sender)
+    case Event(x: WorkflowStoreActorEngineCommand, _) =>
+      stay using stateData.withPendingCommand(x, sender)
+  }
+
+  when(Idle) {
+    case Event(cmd: WorkflowStoreActorEngineCommand, _) =>
+      if (stateData.currentOperation.nonEmpty || stateData.pendingOperations.nonEmpty) {
+        log.error("Non-empty WorkflowStoreActorData when in Idle state: {}", stateData)
+      }
+      startNewWork(cmd, sender, stateData.withCurrentCommand(cmd, sender))
+  }
+
+  when(Working) {
+    case Event(WorkDone, data) =>
+      val newData = data.pop
+      newData.currentOperation match {
+        case None => goto(Idle) using newData
+        case Some(WorkflowStoreActorCommandWithSender(cmd, sndr)) => startNewWork(cmd, sndr, newData)
+      }
+    case Event(cmd: WorkflowStoreActorEngineCommand, data) => stay using data.withPendingCommand(cmd, sender)
+  }
+
+  whenUnhandled {
+    case Event(MetadataPutAcknowledgement(_), _) =>
+      stay // Ignored
+    case Event(msg, _) =>
+      log.warning("Unexpected message to WorkflowStoreActor in state {} with data {}: {}", stateName, stateData, msg)
+      stay
+  }
+
+  onTransition {
+    case fromState -> toState =>
+      log.debug("WorkflowStore moving from {} (using {}) to {} (using {})", fromState, stateData, toState, nextStateData)
+  }
+
+  private def startNewWork(command: WorkflowStoreActorEngineCommand, sndr: ActorRef, nextData: WorkflowStoreActorData) = {
+    val work: Future[Any] = command match {
+      case cmd @ FetchRunnableWorkflows(n) =>
+        newWorkflowMessage(n) map { nwm =>
+          nwm match {
+            case NewWorkflowsToStart(workflows) => log.info("{} new workflows fetched", workflows.toList.size)
+            case NoNewWorkflowsToStart => log.debug("No workflows fetched")
+            case _ => log.error("Unexpected response from newWorkflowMessage({}): {}", n, nwm)
+          }
+          sndr ! nwm
+        }
+      case cmd @ AbortWorkflow(id, manager) =>
+        store.remove(id) map { removed =>
+          if (removed) {
+            log.debug(s"Workflow $id aborted and removed from the workflow store.")
+            manager ! WorkflowManagerActor.AbortWorkflowCommand(id, sndr)
+          } else {
+            sndr ! WorkflowAbortFailed(id, new WorkflowNotFoundException(s"Couldn't abort $id because no workflow with that ID is in progress"))
+          }
+        }
+      case cmd @ RemoveWorkflow(id) =>
+        store.remove(id) map { removed =>
+          if (removed) {
+            log.debug("Workflow {} removed from store successfully.", id)
+          } else {
+            log.warning(s"Attempted to remove ID {} from the WorkflowStore but it didn't exist", id)
+          }
+        }
+      case oops =>
+        log.error("Unexpected type of start work command: {}", oops.getClass.getSimpleName)
+        Future.successful(self ! WorkDone)
+    }
+    addWorkCompletionHooks(command, work)
+    goto(Working) using nextData
+  }
+
+  private def addWorkCompletionHooks[A](command: WorkflowStoreActorEngineCommand, work: Future[A]) = {
+    work.onComplete {
+      case Success(_) =>
+        self ! WorkDone
+      case Failure(t) =>
+        log.error("Error occurred during {}: {} because {}", command.getClass.getSimpleName, t.toString, ExceptionUtils.getStackTrace(t))
+        self ! WorkDone
+    }
+  }
+
+  /**
+    * Fetches at most n workflows, and builds the correct response message based on if there were any workflows or not
+    */
+  private def newWorkflowMessage(maxWorkflows: Int): Future[WorkflowStoreEngineActorResponse] = {
+    def fetchRunnableWorkflowsIfNeeded(maxWorkflowsInner: Int, state: StartableState) = {
+      if (maxWorkflows > 0) {
+        store.fetchRunnableWorkflows(maxWorkflowsInner, state)
+      } else {
+        Future.successful(List.empty[WorkflowToStart])
+      }
+    }
+
+    val runnableWorkflows = for {
+      restartableWorkflows <- fetchRunnableWorkflowsIfNeeded(maxWorkflows, WorkflowStoreState.Restartable)
+      submittedWorkflows <- fetchRunnableWorkflowsIfNeeded(maxWorkflows - restartableWorkflows.size, WorkflowStoreState.Submitted)
+    } yield restartableWorkflows ++ submittedWorkflows
+
+    runnableWorkflows map {
+      case x :: xs => NewWorkflowsToStart(NonEmptyList.of(x, xs: _*))
+      case _ => NoNewWorkflowsToStart
+    }
+  }
+}
+
+object WorkflowStoreEngineActor {
+  def props(workflowStoreDatabase: WorkflowStore, serviceRegistryActor: ActorRef) = {
+    Props(WorkflowStoreEngineActor(workflowStoreDatabase, serviceRegistryActor)).withDispatcher(EngineDispatcher)
+  }
+
+  sealed trait WorkflowStoreEngineActorResponse
+  case object NoNewWorkflowsToStart extends WorkflowStoreEngineActorResponse
+  final case class NewWorkflowsToStart(workflows: NonEmptyList[WorkflowToStart]) extends WorkflowStoreEngineActorResponse
+  final case class WorkflowAborted(workflowId: WorkflowId) extends WorkflowStoreEngineActorResponse
+  final case class WorkflowAbortFailed(workflowId: WorkflowId, reason: Throwable) extends WorkflowStoreEngineActorResponse
+
+
+  final case class WorkflowStoreActorCommandWithSender(command: WorkflowStoreActorEngineCommand, sender: ActorRef)
+
+  final case class WorkflowStoreActorData(currentOperation: Option[WorkflowStoreActorCommandWithSender], pendingOperations: List[WorkflowStoreActorCommandWithSender]) {
+    def withCurrentCommand(command: WorkflowStoreActorEngineCommand, sender: ActorRef) = this.copy(currentOperation = Option(WorkflowStoreActorCommandWithSender(command, sender)))
+    def withPendingCommand(newCommand: WorkflowStoreActorEngineCommand, sender: ActorRef) = this.copy(pendingOperations = this.pendingOperations :+ WorkflowStoreActorCommandWithSender(newCommand, sender))
+    def pop = {
+      if (pendingOperations.isEmpty) { WorkflowStoreActorData(None, List.empty) }
+      else { WorkflowStoreActorData(Option(pendingOperations.head), pendingOperations.tail) }
+    }
+  }
+
+  sealed trait WorkflowStoreActorState
+  case object Unstarted extends WorkflowStoreActorState
+  case object Working extends WorkflowStoreActorState
+  case object Idle extends WorkflowStoreActorState
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreSubmitActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreSubmitActor.scala
@@ -1,0 +1,102 @@
+package cromwell.engine.workflow.workflowstore
+
+import java.time.OffsetDateTime
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import cats.data.NonEmptyList
+import cromwell.core.Dispatcher._
+import cromwell.core._
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor._
+import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.{WorkflowSubmittedToStore, WorkflowsBatchSubmittedToStore}
+import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
+import cromwell.services.metadata.MetadataService.PutMetadataAction
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+final case class WorkflowStoreSubmitActor(store: WorkflowStore, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  override def receive = {
+    case cmd: SubmitWorkflow =>
+      val sndr = sender()
+      storeWorkflowSources(NonEmptyList.of(cmd.source)) foreach { ids =>
+        val id = ids.head
+        registerSubmissionWithMetadataService(id, cmd.source)
+        sndr ! WorkflowSubmittedToStore(id)
+        log.info("Workflow {} submitted.", id)
+      }
+    case cmd: BatchSubmitWorkflows =>
+      val sndr = sender()
+      storeWorkflowSources(cmd.sources) foreach { ids =>
+        val assignedSources = ids.toList.zip(cmd.sources.toList)
+        assignedSources foreach { case (id, sourceFiles) => registerSubmissionWithMetadataService(id, sourceFiles) }
+        sndr ! WorkflowsBatchSubmittedToStore(ids)
+        log.info("Workflows {} submitted.", ids.toList.mkString(", "))
+      }
+  }
+
+  private def storeWorkflowSources(sources: NonEmptyList[WorkflowSourceFilesCollection]): Future[NonEmptyList[WorkflowId]] = {
+    for {
+      processedSources <- processSources(sources, _.asPrettyJson)
+      workflowIds <- store.add(processedSources)
+    } yield workflowIds
+  }
+
+  private def processSources(sources: NonEmptyList[WorkflowSourceFilesCollection],
+                             processOptions: WorkflowOptions => WorkflowOptionsJson): Future[NonEmptyList[WorkflowSourceFilesCollection]] = {
+    val nelFutures: NonEmptyList[Future[WorkflowSourceFilesCollection]] = sources map processSource(processOptions)
+    val listFutures: List[Future[WorkflowSourceFilesCollection]] = nelFutures.toList
+    val futureLists: Future[List[WorkflowSourceFilesCollection]] = Future.sequence(listFutures)
+    futureLists.map(seq => NonEmptyList.fromList(seq).get)
+  }
+
+  /**
+    * Runs processing on workflow source files before they are stored.
+    *
+    * @param processOptions How to process the workflow options
+    * @param source         Original workflow source
+    * @return Attempted updated workflow source
+    */
+  private def processSource(processOptions: WorkflowOptions => WorkflowOptionsJson)
+                           (source: WorkflowSourceFilesCollection): Future[WorkflowSourceFilesCollection] = {
+    val options = Future {
+      WorkflowOptions.fromJsonString(source.workflowOptionsJson)
+    }.flatMap {
+      case Success(s) => Future.successful(s)
+      case Failure(regrets) => Future.failed(regrets)
+    }
+
+    options map {o => source.copyOptions(processOptions(o)) }
+  }
+
+  /**
+    * Takes the workflow id and sends it over to the metadata service w/ default empty values for inputs/outputs
+    */
+  private def registerSubmissionWithMetadataService(id: WorkflowId, originalSourceFiles: WorkflowSourceFilesCollection): Unit = {
+    processSource(_.clearEncryptedValues)(originalSourceFiles) foreach { sourceFiles =>
+      val submissionEvents = List(
+        MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionTime), MetadataValue(OffsetDateTime.now.toString)),
+        MetadataEvent.empty(MetadataKey(id, None, WorkflowMetadataKeys.Inputs)),
+        MetadataEvent.empty(MetadataKey(id, None, WorkflowMetadataKeys.Outputs)),
+
+        MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Workflow), MetadataValue(sourceFiles.wdlSource)),
+        MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Inputs), MetadataValue(sourceFiles.inputsJson)),
+        MetadataEvent(MetadataKey(id, None, WorkflowMetadataKeys.SubmissionSection, WorkflowMetadataKeys.SubmissionSection_Options), MetadataValue(sourceFiles.workflowOptionsJson))
+      )
+
+      serviceRegistryActor ! PutMetadataAction(submissionEvents)
+    }
+  }
+}
+
+object WorkflowStoreSubmitActor {
+  def props(workflowStoreDatabase: WorkflowStore, serviceRegistryActor: ActorRef) = {
+    Props(WorkflowStoreSubmitActor(workflowStoreDatabase, serviceRegistryActor)).withDispatcher(ApiDispatcher)
+  }
+
+  sealed trait WorkflowStoreSubmitActorResponse
+  final case class WorkflowSubmittedToStore(workflowId: WorkflowId) extends WorkflowStoreSubmitActorResponse
+  final case class WorkflowsBatchSubmittedToStore(workflowIds: NonEmptyList[WorkflowId]) extends WorkflowStoreSubmitActorResponse
+}
+

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -15,7 +15,7 @@ import cromwell.engine.backend.BackendConfigurationEntry
 import cromwell.engine.workflow.WorkflowManagerActor.RetrieveNewWorkflows
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor.{CacheLookupRequest, CacheResultMatchesForHashes}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
-import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowSubmittedToStore
+import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.WorkflowSubmittedToStore
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
 import cromwell.jobstore.JobStoreActor.{JobStoreWriteSuccess, JobStoreWriterCommand}
 import cromwell.server.{CromwellRootActor, CromwellSystem}

--- a/engine/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -4,6 +4,8 @@ import cats.data.NonEmptyList
 import cromwell.CromwellTestKitSpec
 import cromwell.core.{WorkflowId, WorkflowSourceFilesCollection}
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor._
+import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor.{NewWorkflowsToStart, NoNewWorkflowsToStart}
+import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.{WorkflowSubmittedToStore, WorkflowsBatchSubmittedToStore}
 import cromwell.engine.workflow.workflowstore._
 import cromwell.services.metadata.MetadataQuery
 import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, MetadataLookupResponse}

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -13,7 +13,8 @@ import scala.concurrent.duration._
 import SubWorkflowStoreSpec._
 import akka.testkit.TestProbe
 import cromwell.database.sql.tables.SubWorkflowStoreEntry
-import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.{SubmitWorkflow, WorkflowSubmittedToStore}
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
+import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.WorkflowSubmittedToStore
 import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowStoreActor}
 
 import scala.language.postfixOps

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -1,254 +1,147 @@
 package cromwell.webservice
 
-import java.time.OffsetDateTime
-import java.util.UUID
+import akka.actor.{Actor, ActorSystem, Props}
+import cromwell.core.{WorkflowId, WorkflowMetadataKeys, WorkflowSubmitted, WorkflowSucceeded}
 
-import akka.actor.{Actor, Props}
-import akka.pattern.ask
-import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
-import cromwell.CromwellTestKitSpec
-import cromwell.core._
-import cromwell.engine.workflow.workflowstore.WorkflowStoreActor
-import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.{WorkflowAborted => _, _}
-import cromwell.server.{CromwellServerActor, CromwellSystem}
+import scala.util.{Failure, Success, Try}
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.{AbortWorkflow, BatchSubmitWorkflows, SubmitWorkflow}
+import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor
+import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor.WorkflowAbortFailed
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.metadata._
-import cromwell.services.metadata.impl.MetadataSummaryRefreshActor.MetadataSummarySuccess
-import cromwell.util.SampleWdl.HelloWorld
-import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 import org.scalatest.{FlatSpec, Matchers}
-import org.specs2.mock.Mockito
-import spray.http.{DateTime => _, _}
+import spray.http._
 import spray.json.DefaultJsonProtocol._
-import spray.json._
+import spray.json.{JsString, _}
+import spray.routing._
+import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.{WorkflowSubmittedToStore, WorkflowsBatchSubmittedToStore}
+import cromwell.util.SampleWdl.HelloWorld
+import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
-object MockWorkflowStoreActor {
-  val submittedWorkflowId = WorkflowId(UUID.randomUUID())
-  val runningWorkflowId = WorkflowId.randomId()
-  val unknownId = WorkflowId.randomId()
-  val submittedScatterWorkflowId = WorkflowId.randomId()
-  val abortedWorkflowId = WorkflowId.randomId()
-}
+class CromwellApiServiceSpec extends FlatSpec with ScalatestRouteTest with Matchers {
+  import CromwellApiServiceSpec._
 
-class MockWorkflowStoreActor extends Actor {
-  import MockWorkflowStoreActor.submittedWorkflowId
-
-  override def receive = {
-    case SubmitWorkflow(source) => sender ! WorkflowSubmittedToStore(submittedWorkflowId)
-    case BatchSubmitWorkflows(sources) =>
-      val response = WorkflowsBatchSubmittedToStore(sources map { _ => submittedWorkflowId })
-      sender ! response
-    case AbortWorkflow(id, manager) =>
-      val message = id match {
-        case MockWorkflowStoreActor.runningWorkflowId =>
-          WorkflowStoreActor.WorkflowAborted(id)
-        case MockWorkflowStoreActor.abortedWorkflowId =>
-          WorkflowAbortFailed(id, new IllegalStateException(s"Workflow ID '$id' is in terminal state 'Aborted' and cannot be aborted."))
-      }
-      sender ! message
-  }
-}
-
-class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with ScalatestRouteTest with Matchers
-  with ScalaFutures with Mockito {
-  import spray.httpx.SprayJsonSupport._
-
-  // BUG: Must be called once to statically initialize the backends, otherwise this Spec won't run if run alone.
-  new CromwellSystem {}
-
-  import akka.testkit._
-
-  import scala.concurrent.duration._
-
-  // The submit route takes a bit longer than the default 1 s while things initialize, when this spec is run by itself
-  implicit val defaultTimeout = RouteTestTimeout(30.seconds.dilated)
-
-  override def actorRefFactory = system
-  override val serviceRegistryActor = CromwellTestKitSpec.ServiceRegistryActorInstance
-
-  override val workflowStoreActor = actorRefFactory.actorOf(Props(new MockWorkflowStoreActor()))
-  override val workflowManagerActor = actorRefFactory.actorOf(Props.empty)
-
+  val cromwellApiService = new MockApiService()
   val version = "v1"
 
-  def publishMetadata(events: Seq[MetadataEvent]): Unit = {
-    val timeout: Timeout = 5.seconds.dilated
-
-    import akka.pattern.ask
-    val putResult = serviceRegistryActor.ask(PutMetadataAction(events))(timeout)
-    putResult.futureValue(PatienceConfiguration.Timeout(timeout.duration)) shouldBe a[MetadataPutAcknowledgement]
-    ()
-  }
-
-  def forceSummary(): Unit = {
-    val timeout: Timeout = 5.seconds.dilated
-    val summaryResult = serviceRegistryActor.ask(RefreshSummary)(timeout)
-
-    val askResult = summaryResult.futureValue(PatienceConfiguration.Timeout(timeout.duration))
-    askResult match {
-      case MetadataSummarySuccess =>
-      case _ =>
-        fail()
-    }
-
-  }
-
   behavior of "REST API /status endpoint"
+  it should "return 200 for get of a known workflow id" in {
+    val workflowId = MockApiService.ExistingWorkflowId
+    Get(s"/workflows/$version/$workflowId/status") ~>
+      cromwellApiService.statusRoute ~>
+      check {
+          status should be(StatusCodes.OK)
+          val result = responseAs[JsObject]
+          result.fields(WorkflowMetadataKeys.Status) should be(JsString("Submitted"))
+      }
+  }
 
-  it should "return 500 errors as Json" in {
-    val apiActor = TestActorRef(new CromwellServerActor(ConfigFactory.empty()))
-    val probe = TestProbe()
-    probe.send(apiActor, Timedout(mock[HttpRequest]))
-    probe.expectMsgPF(defaultTimeout.duration) {
-      case response: HttpResponse =>
-        response.entity.toOption shouldBe defined
-        response.entity.toOption.get.contentType.toString() shouldBe ContentTypes.`application/json`.mediaType.value.toString
+    it should "return 404 for get of unknown workflow" in {
+      val workflowId = MockApiService.UnrecognizedWorkflowId
+
+      Get(s"/workflows/$version/$workflowId/status") ~>
+        cromwellApiService.statusRoute ~>
+        check {
+          assertResult(StatusCodes.NotFound) {
+            status
+          }
+        }
     }
 
-    system.stop(apiActor)
-    system.stop(probe.ref)
-  }
-
-  it should "return 404 for get of unknown workflow" in {
-    val workflowId = WorkflowId.randomId()
-
-    Get(s"/workflows/$version/$workflowId/status") ~>
-      statusRoute ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
+     it should "return 400 for get of a malformed workflow id's status" in {
+      Get(s"/workflows/$version/foobar/status") ~>
+        cromwellApiService.statusRoute ~>
+        check {
+          assertResult(StatusCodes.BadRequest) {
+            status
+          }
+          assertResult(
+            """{
+               |  "status": "fail",
+               |  "message": "Invalid workflow ID: 'foobar'."
+               |}""".stripMargin
+          ) {
+            responseAs[String]
+          }
         }
-      }
-  }
-
-   it should "return 400 for get of a malformed workflow id's status" in {
-    Get(s"/workflows/$version/foobar/status") ~>
-      statusRoute ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
-        assertResult(
-          """{
-             |  "status": "fail",
-             |  "message": "Invalid workflow ID: 'foobar'."
-             |}""".stripMargin
-        ) {
-          responseAs[String]
-        }
-      }
-  }
-
-  private def publishStatusAndSubmission(workflowId: WorkflowId, state: WorkflowState): Unit = {
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.SubmissionTime), MetadataValue(OffsetDateTime.now())),
-      MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.Status), MetadataValue(state))
-    )
-    publishMetadata(events)
-  }
-
-  it should "return 200 for get of a known workflow id" in {
-    val workflowId = WorkflowId.randomId()
-    publishStatusAndSubmission(workflowId, WorkflowSubmitted)
-
-    Get(s"/workflows/$version/$workflowId/status") ~>
-      statusRoute ~>
-      check {
-        status should be(StatusCodes.OK)
-        val result = responseAs[JsObject]
-        result.fields(WorkflowMetadataKeys.Status) should be(JsString("Submitted"))
-      }
-  }
+    }
 
   behavior of "REST API /abort endpoint"
-
   it should "return 404 for abort of unknown workflow" in {
-    Post(s"/workflows/$version/${MockWorkflowStoreActor.unknownId}/abort") ~>
-      abortRoute ~>
+    val workflowId = MockApiService.UnrecognizedWorkflowId
+
+    Post(s"/workflows/$version/$workflowId/abort") ~>
+      cromwellApiService.abortRoute ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
-        }
-        assertResult(
-          s"""{
-              |  "status": "fail",
-              |  "message": "Unrecognized workflow ID: ${MockWorkflowStoreActor.unknownId}"
-              |}""".stripMargin
-        ) {
-          responseAs[String]
         }
       }
   }
 
   it should "return 400 for abort of a malformed workflow id" in {
     Post(s"/workflows/$version/foobar/abort") ~>
-      abortRoute ~>
+      cromwellApiService.abortRoute ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
         }
         assertResult(
           """{
-              |  "status": "fail",
-              |  "message": "Invalid workflow ID: 'foobar'."
-              |}""".stripMargin
+            |  "status": "fail",
+            |  "message": "Invalid workflow ID: 'foobar'."
+            |}""".stripMargin
         ) {
           responseAs[String]
         }
       }
   }
 
-  it should "return 403 for abort of a workflow in a terminal state" in {
-    publishStatusAndSubmission(MockWorkflowStoreActor.abortedWorkflowId, WorkflowAborted)
-
-    Post(s"/workflows/$version/${MockWorkflowStoreActor.abortedWorkflowId}/abort") ~>
-    abortRoute ~>
-    check {
-      assertResult(StatusCodes.Forbidden) {
-        status
-      }
-      assertResult(
-        s"""{
-            |  "status": "error",
-            |  "message": "Workflow ID '${MockWorkflowStoreActor.abortedWorkflowId}' is in terminal state 'Aborted' and cannot be aborted."
-            |}""".stripMargin
-      ) {
-        responseAs[String]
-      }
-    }
-  }
-
-  it should "return 200 for abort of a known workflow id" in {
-    publishStatusAndSubmission(MockWorkflowStoreActor.runningWorkflowId, WorkflowRunning)
-
-    Post(s"/workflows/$version/${MockWorkflowStoreActor.runningWorkflowId}/abort") ~>
-      abortRoute ~>
+    it should "return 403 for abort of a workflow in a terminal state" in {
+      Post(s"/workflows/$version/${MockApiService.AbortedWorkflowId}/abort") ~>
+      cromwellApiService.abortRoute ~>
       check {
-        assertResult(
-          s"""{
-              |  "id": "${MockWorkflowStoreActor.runningWorkflowId.toString}",
-              |  "status": "Aborted"
-              |}"""
-            .stripMargin) {
-          responseAs[String]
-        }
-        assertResult(StatusCodes.OK) {
+        assertResult(StatusCodes.Forbidden) {
           status
         }
+        assertResult(
+          s"""{
+              |  "status": "error",
+              |  "message": "Workflow ID '${MockApiService.AbortedWorkflowId}' is in terminal state 'Aborted' and cannot be aborted."
+              |}""".stripMargin
+        ) {
+          responseAs[String]
+        }
       }
-  }
+    }
+
+    it should "return 200 for abort of a known workflow id" in {
+      Post(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/abort") ~>
+        cromwellApiService.abortRoute ~>
+        check {
+          assertResult(
+            s"""{
+                |  "id": "${MockApiService.ExistingWorkflowId.toString}",
+                |  "status": "Aborted"
+                |}"""
+              .stripMargin) {
+            responseAs[String]
+          }
+          assertResult(StatusCodes.OK) {
+            status
+          }
+        }
+    }
 
   behavior of "REST API submission endpoint"
   it should "return 201 for a successful workflow submission " in {
     val bodyParts: Map[String, BodyPart] = Map("wdlSource" -> BodyPart(HelloWorld.wdlSource()), "workflowInputs" -> BodyPart(HelloWorld.rawInputs.toJson.toString()))
     Post(s"/workflows/$version", MultipartFormData(bodyParts)) ~>
-      submitRoute ~>
+      cromwellApiService.submitRoute ~>
       check {
         assertResult(
           s"""{
-              |  "id": "${MockWorkflowStoreActor.submittedWorkflowId.toString}",
+              |  "id": "${MockApiService.ExistingWorkflowId.toString}",
               |  "status": "Submitted"
               |}""".stripMargin) {
           responseAs[String]
@@ -258,10 +151,11 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
         }
       }
   }
+
   it should "return 400 for an unrecognized form data request parameter " in {
     val bodyParts: Map[String, BodyPart] = Map("incorrectParameter" -> BodyPart(HelloWorld.wdlSource()))
     Post(s"/workflows/$version", MultipartFormData(bodyParts)) ~>
-      submitRoute ~>
+      cromwellApiService.submitRoute ~>
       check {
         assertResult(
           s"""{
@@ -275,12 +169,13 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
         }
       }
   }
+
   it should "succesfully merge and override multiple input files" in {
 
     val input1 = Map("wf.a1" -> "hello", "wf.a2" -> "world").toJson.toString
     val input2 = Map.empty[String, String].toJson.toString
     val overrideInput1 = Map("wf.a2" -> "universe").toJson.toString
-    val allInputs = mergeMaps(Seq(Option(input1), Option(input2), Option(overrideInput1)))
+    val allInputs = cromwellApiService.mergeMaps(Seq(Option(input1), Option(input2), Option(overrideInput1)))
 
     check {
       allInputs.fields.keys should contain allOf("wf.a1", "wf.a2")
@@ -294,14 +189,14 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
     val bodyParts = Map("wdlSource" -> BodyPart(HelloWorld.wdlSource()), "workflowInputs" -> BodyPart(s"[$inputs, $inputs]"))
 
     Post(s"/workflows/$version/batch", MultipartFormData(bodyParts)) ~>
-      submitBatchRoute ~>
+      cromwellApiService.submitBatchRoute ~>
       check {
         assertResult(
           s"""[{
-              |  "id": "${MockWorkflowStoreActor.submittedWorkflowId.toString}",
+              |  "id": "${MockApiService.ExistingWorkflowId.toString}",
               |  "status": "Submitted"
               |}, {
-              |  "id": "${MockWorkflowStoreActor.submittedWorkflowId.toString}",
+              |  "id": "${MockApiService.ExistingWorkflowId.toString}",
               |  "status": "Submitted"
               |}]""".stripMargin) {
           responseAs[String]
@@ -316,7 +211,7 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
     val bodyParts = Map("wdlSource" -> BodyPart(HelloWorld.wdlSource()))
 
     Post(s"/workflows/$version/batch", MultipartFormData(bodyParts)) ~>
-      submitBatchRoute ~>
+      cromwellApiService.submitBatchRoute ~>
       check {
         assertResult(
           s"""{
@@ -331,21 +226,10 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
       }
   }
 
-  // TODO: Test tha batch submission returns expected workflow ids in order
-  // TODO: Also (assuming we still validate on submit) test a batch of mixed inputs that return submitted and failed
-
   behavior of "REST API /outputs endpoint"
-
   it should "return 200 with GET of outputs on successful execution of workflow" in {
-    val workflowId = WorkflowId.randomId()
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Outputs}:myfirst"), MetadataValue("myOutput"))
-    )
-
-    publishMetadata(events)
-
-    Get(s"/workflows/$version/$workflowId/outputs") ~>
-      workflowOutputsRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/outputs") ~>
+      cromwellApiService.workflowOutputsRoute ~>
       check {
         status should be(StatusCodes.OK)
         val result = responseAs[JsObject]
@@ -354,8 +238,8 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   it should "return 404 with outputs on unknown workflow" in {
-    Get(s"/workflows/$version/${MockWorkflowStoreActor.unknownId}/outputs") ~>
-    workflowOutputsRoute ~>
+    Get(s"/workflows/$version/${MockApiService.UnrecognizedWorkflowId}/outputs") ~>
+    cromwellApiService.workflowOutputsRoute ~>
     check {
       assertResult(StatusCodes.NotFound) {
         status
@@ -364,8 +248,8 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   it should "return 405 with POST of outputs on successful execution of workflow" in {
-    Post(s"/workflows/$version/${MockWorkflowStoreActor.submittedWorkflowId.toString}/outputs") ~>
-      sealRoute(workflowOutputsRoute) ~>
+    Post(s"/workflows/$version/${MockApiService.UnrecognizedWorkflowId}/outputs") ~>
+      cromwellApiService.sealRoute(cromwellApiService.workflowOutputsRoute) ~>
       check {
         assertResult(StatusCodes.MethodNotAllowed) {
           status
@@ -374,21 +258,9 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   behavior of "REST API /logs endpoint"
-
   it should "return 200 with paths to stdout/stderr/backend log" in {
-
-    val workflowId = WorkflowId.randomId()
-    val jobKey = Option(MetadataJobKey("mycall", None, 1))
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, jobKey, CallMetadataKeys.Stdout), MetadataValue("stdout.txt")),
-      MetadataEvent(MetadataKey(workflowId, jobKey, CallMetadataKeys.Stderr), MetadataValue("stderr.txt")),
-      MetadataEvent(MetadataKey(workflowId, jobKey, s"${CallMetadataKeys.BackendLogsPrefix}:log"), MetadataValue("backend.log"))
-    )
-
-    publishMetadata(events)
-
-    Get(s"/workflows/$version/$workflowId/logs") ~>
-      workflowLogsRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/logs") ~>
+      cromwellApiService.workflowLogsRoute ~>
       check {
         status should be(StatusCodes.OK)
         val result = responseAs[JsObject]
@@ -402,8 +274,8 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   it should "return 404 with logs on unknown workflow" in {
-    Get(s"/workflows/$version/${MockWorkflowStoreActor.unknownId}/logs") ~>
-      workflowLogsRoute ~>
+    Get(s"/workflows/$version/${MockApiService.UnrecognizedWorkflowId}/logs") ~>
+      cromwellApiService.workflowLogsRoute ~>
       check {
         assertResult(StatusCodes.NotFound) {
           status
@@ -411,20 +283,10 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
       }
   }
 
-
   behavior of "REST API /metadata endpoint"
-
   it should "return with full metadata from the metadata route" in {
-    val workflowId = WorkflowId.randomId()
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, "testKey1"), MetadataValue("myValue1")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey2"), MetadataValue("myValue2"))
-    )
-
-    publishMetadata(events)
-
-    Get(s"/workflows/$version/$workflowId/metadata") ~>
-      metadataRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/metadata") ~>
+      cromwellApiService.metadataRoute ~>
       check {
         status should be(StatusCodes.OK)
         val result = responseAs[JsObject]
@@ -436,19 +298,8 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   it should "return with included metadata from the metadata route" in {
-    val workflowId = WorkflowId.randomId()
-
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, "testKey1a"), MetadataValue("myValue1a")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey1b"), MetadataValue("myValue1b")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey2a"), MetadataValue("myValue2a")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey2b"), MetadataValue("myValue2b"))
-    )
-
-    publishMetadata(events)
-
-    Get(s"/workflows/$version/$workflowId/metadata?includeKey=testKey1&includeKey=testKey2a") ~>
-      metadataRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/metadata?includeKey=testKey1&includeKey=testKey2a") ~>
+      cromwellApiService.metadataRoute ~>
       check {
         status should be(StatusCodes.OK)
         val result = responseAs[JsObject]
@@ -460,37 +311,23 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
       }
   }
 
-  it should "return with excluded metadata from the metadata route" in {
-    val workflowId = WorkflowId.randomId()
-
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, "testKey1a"), MetadataValue("myValue1a")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey1b"), MetadataValue("myValue1b")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey2a"), MetadataValue("myValue2a")),
-      MetadataEvent(MetadataKey(workflowId, None, "testKey2b"), MetadataValue("myValue2b"))
-    )
-
-    publishMetadata(events)
-
-    Get(s"/workflows/$version/$workflowId/metadata?excludeKey=testKey2b&excludeKey=testKey3") ~>
-      metadataRoute ~>
-      check {
-        status should be(StatusCodes.OK)
-        val result = responseAs[JsObject]
-        result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
-        result.fields.keys should contain noneOf("testKey2b", "testKey3")
-        result.fields("testKey1a") should be(JsString("myValue1a"))
-        result.fields("testKey1b") should be(JsString("myValue1b"))
-        result.fields("testKey2a") should be(JsString("myValue2a"))
-      }
-  }
+    it should "return with excluded metadata from the metadata route" in {
+     Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/metadata?excludeKey=testKey2b&excludeKey=testKey3") ~>
+        cromwellApiService.metadataRoute ~>
+        check {
+          status should be(StatusCodes.OK)
+          val result = responseAs[JsObject]
+          result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
+          result.fields.keys should contain noneOf("testKey2b", "testKey3")
+          result.fields("testKey1a") should be(JsString("myValue1a"))
+          result.fields("testKey1b") should be(JsString("myValue1b"))
+          result.fields("testKey2a") should be(JsString("myValue2a"))
+        }
+    }
 
   it should "return an error when included and excluded metadata requested from the metadata route" in {
-    val workflowId = WorkflowId.randomId()
-    publishStatusAndSubmission(workflowId, WorkflowSucceeded)
-
-    Get(s"/workflows/$version/$workflowId/metadata?includeKey=testKey1&excludeKey=testKey2") ~>
-      metadataRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/metadata?includeKey=testKey1&excludeKey=testKey2") ~>
+      cromwellApiService.metadataRoute ~>
       check {
         assertResult(StatusCodes.BadRequest) {
           status
@@ -507,12 +344,9 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   behavior of "REST API /timing endpoint"
-
   it should "return 200 with an HTML document for the timings route" in {
-    publishStatusAndSubmission(MockWorkflowStoreActor.submittedWorkflowId, WorkflowSucceeded)
-
-    Get(s"/workflows/$version/${MockWorkflowStoreActor.submittedWorkflowId}/timing") ~>
-      timingRoute ~>
+    Get(s"/workflows/$version/${MockApiService.ExistingWorkflowId}/timing") ~>
+      cromwellApiService.timingRoute ~>
       check {
         assertResult(StatusCodes.OK) { status }
         assertResult("<html>") {
@@ -522,141 +356,132 @@ class CromwellApiServiceSpec extends FlatSpec with CromwellApiService with Scala
   }
 
   behavior of "REST API /query GET endpoint"
-
-  it should "return 400 for a bad query" in {
-    Get(s"/workflows/$version/query?BadKey=foo") ~>
-      queryRoute ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
-        assertResult(
-          s"""{
-              |  "status": "fail",
-              |  "message": "Unrecognized query keys: BadKey"
-              |}""".stripMargin
-        ) {
-          responseAs[String]
-        }
-      }
-  }
-
   it should "return good results for a good query" in {
-    val workflowId = WorkflowId.randomId()
-    val runningId = WorkflowId.randomId()
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.Status), MetadataValue("Succeeded")),
-      MetadataEvent(MetadataKey(runningId, None, WorkflowMetadataKeys.Status), MetadataValue("Running"))
-    )
-
-    publishMetadata(events)
-    forceSummary()
-
-    Get(s"/workflows/$version/query?status=Succeeded&id=$workflowId") ~>
-      queryRoute ~>
+    Get(s"/workflows/$version/query?status=Succeeded&id=${MockApiService.ExistingWorkflowId}") ~>
+      cromwellApiService.queryRoute ~>
       check {
         status should be(StatusCodes.OK)
         val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
 
-        results.head.fields("id") should be(JsString(workflowId.toString))
+        results.head.fields("id") should be(JsString(MockApiService.ExistingWorkflowId.toString))
         results.head.fields("status") should be(JsString("Succeeded"))
-      }
-  }
-
-  it should "return link headers for pagination when page and pagesize are set for a good query" in {
-    val workflowId = WorkflowId.randomId()
-    val events = Seq(
-      MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.Status), MetadataValue("Succeeded"))
-    )
-
-    publishMetadata(events)
-    forceSummary()
-
-    Get(s"/workflows/$version/query?status=Succeeded&id=$workflowId&page=1&pagesize=5") ~>
-      queryRoute ~>
-      check {
-        status should be(StatusCodes.OK)
-        val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
-
-        results.head.fields("id") should be(JsString(workflowId.toString))
-        results.head.fields("status") should be(JsString("Succeeded"))
-
-        assertResult(4) {
-          headers count { header => header.is("link") }
-        }
       }
   }
 
   behavior of "REST API /query POST endpoint"
-
-  it should "return 400 for a bad query map body" in {
-    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"BadKey":"foo"}]""")) ~>
-      queryPostRoute ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
-        }
-        assertResult(
-          s"""{
-              |  "status": "fail",
-              |  "message": "Unrecognized query keys: BadKey"
-              |}""".stripMargin
-        ) {
-          responseAs[String]
-        }
-      }
-  }
-
   it should "return good results for a good query map body" in {
     Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"}]""")) ~>
-      queryPostRoute ~>
+      cromwellApiService.queryPostRoute ~>
       check {
         assertResult(StatusCodes.OK) {
           status
         }
         assertResult(true) {
           body.asString.contains("\"status\": \"Succeeded\"")
-        }
-      }
-  }
-
-  it should "return link headers for pagination when page and pagesize are set for a good query map body" in {
-    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"},  {"page": "1"}, {"pagesize": "5"}]""")) ~>
-      queryPostRoute ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(true) {
-          body.asString.contains("\"status\": \"Succeeded\"")
-          (headers count { header => header.is("link") }) == 4
-        }
-      }
-  }
-
-
-  it should "return good results for a multiple query map body" in {
-    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`,
-      """[{"status":"Succeeded"}, {"status":"Failed"}]""")) ~>
-      queryPostRoute ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult(true) {
-          body.asString.contains("\"status\": \"Succeeded\"")
-        }
-      }
-  }
-
-  it should "return 400 bad request for a bad query format body" in {
-    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":["Succeeded"]}]""")) ~>
-      sealRoute(queryPostRoute) ~>
-      check {
-        assertResult(StatusCodes.BadRequest) {
-          status
         }
       }
   }
 }
 
+object CromwellApiServiceSpec {
+  class MockApiService()(implicit val system: ActorSystem) extends CromwellApiService {
+    import MockApiService._
+
+    override def actorRefFactory = system
+    override val workflowStoreActor = actorRefFactory.actorOf(Props(new MockWorkflowStoreActor()))
+    override val serviceRegistryActor = actorRefFactory.actorOf(Props.empty)
+    override val workflowManagerActor = actorRefFactory.actorOf(Props.empty)
+
+    override def handleMetadataRequest(message: AnyRef): Route = {
+      message match {
+        case GetStatus(w) => complete(submittedStatusResponse(w))
+        case WorkflowOutputs(w) => complete(outputResponse(w))
+        case GetLogs(w) => complete(logsResponse(w))
+        case GetSingleWorkflowMetadataAction(w, None, None, _) => complete(fullMetadataResponse(w))
+        case GetSingleWorkflowMetadataAction(w, Some(i), None, _) => complete(filteredMetadataResponse(w))
+        case GetSingleWorkflowMetadataAction(w, None, Some(_), _) => complete(filteredMetadataResponse(w))
+        case _ => throw new IllegalArgumentException("Woopsie!")
+      }
+    }
+
+    override def handleQueryMetadataRequest(parameters: Seq[(String, String)]): Route = {
+      complete(QueryResponse)
+    }
+
+    override def withRecognizedWorkflowId(possibleWorkflowId: String)(recognizedWorkflowId: WorkflowId => Route): Route = {
+      requestContext =>
+        Try(WorkflowId.fromString(possibleWorkflowId)) match {
+          case Success(workflowId) =>
+              if (RecognizedWorkflowIds.contains(workflowId)) recognizedWorkflowId(workflowId)(requestContext)
+              else failBadRequest(new NoSuchElementException("A hollow voice says 'fool'"), StatusCodes.NotFound)(requestContext)
+          case Failure(e) =>
+            failBadRequest(new RuntimeException(s"Invalid workflow ID: '$possibleWorkflowId'."))(requestContext)
+        }
+    }
+  }
+
+  object MockApiService {
+    val ExistingWorkflowId = WorkflowId.fromString("c4c6339c-8cc9-47fb-acc5-b5cb8d2809f5")
+    val AbortedWorkflowId = WorkflowId.fromString("0574111c-c7d3-4145-8190-7a7ed8e8324a")
+    val UnrecognizedWorkflowId = WorkflowId.fromString("2bdd06cc-e794-46c8-a897-4c86cedb6a06")
+    val RecognizedWorkflowIds = Set(ExistingWorkflowId, AbortedWorkflowId)
+
+    val QueryResponse = JsObject(Map(
+      "results" -> JsArray(JsObject(Map(
+        WorkflowMetadataKeys.Id -> JsString(ExistingWorkflowId.toString),
+        WorkflowMetadataKeys.Status -> JsString(WorkflowSucceeded.toString)
+      )))
+    ))
+
+    def fullMetadataResponse(workflowId: WorkflowId) = JsObject(Map(
+      "testKey1" -> JsString("myValue1"),
+      "testKey2" -> JsString("myValue2")
+    ))
+
+    def filteredMetadataResponse(workflowId: WorkflowId) = JsObject(Map(
+      "testKey1a" -> JsString("myValue1a"),
+      "testKey1b" -> JsString("myValue1b"),
+      "testKey2a" -> JsString("myValue2a")
+    ))
+
+    def submittedStatusResponse(workflowId: WorkflowId) = JsObject(Map(
+      WorkflowMetadataKeys.Status -> JsString(WorkflowSubmitted.toString),
+      WorkflowMetadataKeys.Id -> JsString(workflowId.toString)
+    ))
+
+    def outputResponse(workflowId: WorkflowId) = JsObject(Map(
+      WorkflowMetadataKeys.Id -> JsString(workflowId.toString),
+      WorkflowMetadataKeys.Outputs -> JsString("Some random stuff")
+    ))
+
+    def logsResponse(workflowId: WorkflowId) = JsObject(Map(
+      "calls" -> JsObject(Map(
+        "mycall" -> JsArray(JsObject(Map(
+          "stdout" -> JsString("stdout.txt"),
+          "stderr" -> JsString("stderr.txt"),
+          "backendLogs" -> JsObject(Map(
+            "log" -> JsString("backend.log")
+          ))
+        )))
+      ))
+    ))
+  }
+
+  class MockWorkflowStoreActor extends Actor {
+    override def receive = {
+      case SubmitWorkflow(source) => sender ! WorkflowSubmittedToStore(MockApiService.ExistingWorkflowId)
+      case BatchSubmitWorkflows(sources) =>
+        val response = WorkflowsBatchSubmittedToStore(sources map { _ => MockApiService.ExistingWorkflowId })
+        sender ! response
+      case AbortWorkflow(id, manager) =>
+        val message = id match {
+          case MockApiService.ExistingWorkflowId =>
+            WorkflowStoreEngineActor.WorkflowAborted(id)
+          case MockApiService.AbortedWorkflowId   =>
+            WorkflowAbortFailed(id, new IllegalStateException(s"Workflow ID '$id' is in terminal state 'Aborted' and cannot be aborted."))
+        }
+
+        sender ! message
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   - http://doc.akka.io/docs/akka/2.4/scala/http/common/json-support.html#akka-http-spray-json
    */
   lazy val sprayJsonV = "1.3.2"
-  lazy val akkaV = "2.4.14"
+  lazy val akkaV = "2.4.16"
   lazy val slickV = "3.1.1"
   lazy val googleClientApiV = "1.22.0"
   lazy val googleGenomicsServicesApiV = "1.22.0"

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -78,10 +78,8 @@ trait MetadataDatabaseAccess {
       val value = metadataEvent.value map { _.value }
       val valueType = metadataEvent.value map { _.valueType.typeName }
       val jobKey = key.jobKey map { jk => (jk.callFqn, jk.index, jk.attempt) }
-      MetadataEntry(
-        workflowUuid, jobKey.map(_._1), jobKey.flatMap(_._2), jobKey.map(_._3), key.key, value, valueType, timestamp)
+      MetadataEntry(workflowUuid, jobKey.map(_._1), jobKey.flatMap(_._2), jobKey.map(_._3), key.key, value, valueType, timestamp)
     }
-
     databaseInterface.addMetadataEntries(metadata)
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -1,29 +1,93 @@
 package cromwell.services.metadata.impl
 
-import akka.actor.{Actor, ActorLogging, Props}
+import akka.actor.{ActorLogging, LoggingFSM, Props}
+import cats.data.NonEmptyVector
 import cromwell.core.Dispatcher.ServiceDispatcher
 import cromwell.services.SingletonServicesStore
-import cromwell.services.metadata.MetadataService.{MetadataPutAcknowledgement, MetadataPutFailed, PutMetadataAction}
+import cromwell.services.metadata.MetadataEvent
+import cromwell.services.metadata.MetadataService.PutMetadataAction
+import cromwell.services.metadata.impl.WriteMetadataActor.{WriteMetadataActorData, WriteMetadataActorState}
 
+import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-object WriteMetadataActor {
-  def props() = Props(new WriteMetadataActor()).withDispatcher(ServiceDispatcher)
-}
-
-class WriteMetadataActor extends Actor with ActorLogging with MetadataDatabaseAccess with SingletonServicesStore {
+final case class WriteMetadataActor(batchRate: Int, flushRate: FiniteDuration)
+  extends LoggingFSM[WriteMetadataActorState, WriteMetadataActorData] with ActorLogging with
+  MetadataDatabaseAccess with SingletonServicesStore {
+  import WriteMetadataActor._
 
   implicit val ec = context.dispatcher
 
-  def receive = {
-    case action@PutMetadataAction(events) =>
-      val sndr = sender()
-      addMetadataEvents(events) onComplete {
-        case Success(_) => sndr ! MetadataPutAcknowledgement(action)
-        case Failure(t) =>
-          val msg = MetadataPutFailed(action, t)
-          log.error(t, "Sending {} failure message {}", sndr, msg)
-          sndr ! msg
-      }
+  override def preStart(): Unit = {
+    context.system.scheduler.schedule(0.seconds, flushRate, self, ScheduledFlushToDb)
+    super.preStart()
   }
+
+  startWith(WaitingToWrite, NoEvents)
+
+  when(WaitingToWrite) {
+    case Event(PutMetadataAction(events), curData) =>
+      curData.addEvents(events) match {
+        case data@HasEvents(e) if e.length > batchRate => goto(WritingToDb) using data
+        case e => stay using e
+      }
+    case Event(ScheduledFlushToDb, curData) =>
+      log.debug("Initiating periodic metadata flush to DB")
+      goto(WritingToDb) using curData
+  }
+
+  when(WritingToDb) {
+    case Event(ScheduledFlushToDb, curData) => stay using curData
+    case Event(PutMetadataAction(events), curData) => stay using curData.addEvents(events)
+    case Event(FlushBatchToDb, NoEvents) =>
+      log.debug("Attempted metadata flush to DB but had nothing to write")
+      goto(WaitingToWrite) using NoEvents
+    case Event(FlushBatchToDb, HasEvents(e)) =>
+      log.debug("Flushing {} metadata events to the DB", e.length)
+      addMetadataEvents(e.toVector) onComplete {
+        case Success(_) => self ! DbWriteComplete
+        case Failure(regerts) =>
+          log.error("Failed to properly flush metadata to database", regerts)
+          self ! DbWriteComplete
+      }
+
+      stay using NoEvents
+    case Event(DbWriteComplete, curData) =>
+      log.debug("Flush of metadata events complete")
+      goto(WaitingToWrite) using curData
+  }
+
+  onTransition {
+    case WaitingToWrite -> WritingToDb => self ! FlushBatchToDb
+  }
+}
+
+object WriteMetadataActor {
+  def props(batchRate: Int, flushRate: FiniteDuration) = Props(new WriteMetadataActor(batchRate, flushRate)).withDispatcher(ServiceDispatcher)
+
+  sealed trait WriteMetadataActorMessage
+  case object DbWriteComplete extends WriteMetadataActorMessage
+  case object FlushBatchToDb extends WriteMetadataActorMessage
+  case object ScheduledFlushToDb extends WriteMetadataActorMessage
+
+  sealed trait WriteMetadataActorState
+  case object WaitingToWrite extends WriteMetadataActorState
+  case object WritingToDb extends WriteMetadataActorState
+
+  sealed trait WriteMetadataActorData {
+    def addEvents(newEvents: Iterable[MetadataEvent]): WriteMetadataActorData = {
+      NonEmptyVector.fromVector(newEvents.toVector) match {
+        case Some(v) =>
+          val newEvents = this match {
+            case NoEvents => v
+            case HasEvents(e) => e.concatNev(v)
+          }
+          HasEvents(newEvents)
+        case None => this
+      }
+    }
+  }
+
+  case object NoEvents extends WriteMetadataActorData
+  case class HasEvents(events: NonEmptyVector[MetadataEvent]) extends WriteMetadataActorData
 }

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataValueSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataValueSpec.scala
@@ -1,0 +1,11 @@
+package cromwell.services.metadata.impl
+
+import cromwell.services.metadata.MetadataValue
+import org.scalatest.{FlatSpec, Matchers}
+
+class MetadataValueSpec extends FlatSpec with Matchers {
+  "MetadataValue" should "not NPE with a null value" in {
+    val metadataValue = MetadataValue(null)
+    metadataValue.value shouldBe ""
+  }
+}

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -1,0 +1,44 @@
+package cromwell.services.metadata.impl
+
+import java.time.OffsetDateTime
+
+import akka.testkit.TestFSMRef
+import cats.data.NonEmptyVector
+import cromwell.core.WorkflowId
+import cromwell.services.ServicesSpec
+import cromwell.services.metadata.MetadataService.PutMetadataAction
+import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
+import cromwell.services.metadata.impl.WriteMetadataActor.{HasEvents, NoEvents, WaitingToWrite, WritingToDb}
+
+import scala.concurrent.duration._
+
+class WriteMetadataActorSpec extends ServicesSpec("Metadata") {
+  import WriteMetadataActorSpec.Action
+
+  val actor = TestFSMRef(WriteMetadataActor(10, 1.days)) // A WMA that won't (hopefully!) perform a time based flush during this test
+
+  "WriteMetadataActor" should {
+    "start with no events and waiting to write" in {
+      assert(actor.stateName == WaitingToWrite)
+      assert(actor.stateData == NoEvents)
+    }
+
+    "Have one event and be waiting after one event is sent" in {
+      actor ! Action
+      assert(actor.stateName == WaitingToWrite)
+      assert(actor.stateData == HasEvents(NonEmptyVector.fromVectorUnsafe(Action.events.toVector)))
+    }
+
+    "Have one event after batch size + 1 is reached" in {
+      1 to 10 foreach { _ => actor ! Action }
+      assert(actor.stateName == WritingToDb)
+      actor ! Action
+      assert(actor.stateData == HasEvents(NonEmptyVector.fromVectorUnsafe(Action.events.toVector)))
+    }
+  }
+}
+
+object WriteMetadataActorSpec {
+  val Event = MetadataEvent(MetadataKey(WorkflowId.randomId(), None, "key"), Option(MetadataValue("value")), OffsetDateTime.now)
+  val Action = PutMetadataAction(Event)
+}


### PR DESCRIPTION
…old performance increase under load prior to DB gumming up. 

Things to note:
- Effectively removes Metadata acks & failure notices (see #1811) via no longer emitting the messages but does not fully remove them. They still technically exist, I'll remove them as part of a separate PR
- Completely reworks `CromwellApiServiceSpec` to actually be testing `CromwellApiService` and not a general integration test of our REST endpoints. Two specific tests didn't make the cut (#1828 and #1829) I'll address in separate PRs. There were other tests which did not make the cut but were already effectively being tested in their appropriate units.
