### PR TITLE
Changed "webservice.timeout" to "webservice.binding-timeout".

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# This file can always be added to, line additions should never collide.
-CHANGELOG.MD merge=union
-
 # These files are text and should be normalized (Convert crlf => lf)
 *.scala text
 *.MD text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@
 * Added ability to override the default zone(s) used by JES via the config structure by setting `genomics.default-zones` in the JES configuration
 * Added support for new WDL functions:
   * `length: (Array[X]) => Integer` - report the length of the specified array 
-* The cromwell server TCP binding timeout is now configurable via the config key `webservice.timeout`, defaulted to the
-  previous value `5s` (five seconds) via the reference.conf.
-  * `length: (Array[X]) => Integer` - report the length of the specified array.
+* The cromwell server TCP binding timeout is now configurable via the config key `webservice.binding-timeout`, defaulted
+  to the previous value `5s` (five seconds) via the reference.conf.
 
 ### Database schema changes
 * Added CUSTOM_LABELS as a field of WORKFLOW_STORE_ENTRY, to store workflow store entries.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -8,7 +8,7 @@
 webservice {
   port = 8000
   interface = 0.0.0.0
-  timeout = 5s
+  binding-timeout = 5s
   instance.name = "reference"
 }
 

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -31,7 +31,7 @@ object CromwellServer {
 
     val interface = webserviceConf.getString("interface")
     val port = webserviceConf.getInt("port")
-    val timeout = webserviceConf.as[FiniteDuration]("timeout")
+    val timeout = webserviceConf.as[FiniteDuration]("binding-timeout")
     val futureBind = service.bind(interface, port)(implicitly, timeout, actorSystem, implicitly)
     futureBind andThen {
       case Success(_) =>


### PR DESCRIPTION
Also no longer auto-merging the changelog, as we couldn't quite get auto-merging to work with our flow, requiring further manual intervention anyway.