### PR TITLE
Users other than root. Closes #472

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ cd <container_call_root>
 echo $? > rc
 ```
 
-`<container_call_root>` would be equal to `<call_dir>` for non-Docker jobs, or it would be under `/root/<workflow_uuid>/call-<call_name>` if this is running in a Docker container.
+`<container_call_root>` would be equal to `<call_dir>` for non-Docker jobs, or it would be under `/cromwell-executions/<workflow_uuid>/call-<call_name>` if this is running in a Docker container.
 
 When running without docker, the subprocess command that the local backend will launch is:
 

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -7,7 +7,7 @@ import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.PathBuilder
 
 object WorkflowPathsWithDocker {
-  val DockerRoot: Path = Paths.get("/root")
+  val DockerRoot: Path = Paths.get("/cromwell-executions")
 }
 
 class WorkflowPathsWithDocker(val workflowDescriptor: BackendWorkflowDescriptor, val config: Config, val pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {

--- a/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
@@ -2,11 +2,13 @@ package cromwell.backend.wdl
 
 import java.nio.file.Path
 
+import cromwell.core.path.FileImplicits._
 import wdl4s.TsvSerializable
 import wdl4s.expression.WdlStandardLibraryFunctions
 import wdl4s.types._
 import wdl4s.values._
 
+import scala.language.existentials
 import scala.util.{Failure, Try}
 
 trait WriteFunctions { this: WdlStandardLibraryFunctions =>
@@ -17,7 +19,7 @@ trait WriteFunctions { this: WdlStandardLibraryFunctions =>
     */
   def writeDirectory: Path
 
-  private lazy val _writeDirectory = File(writeDirectory).createDirectories()
+  private lazy val _writeDirectory = File(writeDirectory).createPermissionedDirectories()
 
   def writeTempFile(path: String,prefix: String,suffix: String,content: String): String = throw new NotImplementedError("This method is not used anywhere and should be removed")
 

--- a/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
@@ -51,13 +51,13 @@ class JobPathsSpec extends FlatSpec with Matchers with BackendSpec {
     jobPaths.callExecutionRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id/call-hello/execution").pathAsString
     jobPaths.callDockerRoot.toString shouldBe
-      File(s"/root/wf_hello/$id/call-hello").pathAsString
+      File(s"/cromwell-executions/wf_hello/$id/call-hello").pathAsString
     jobPaths.callExecutionDockerRoot.toString shouldBe
-      File(s"/root/wf_hello/$id/call-hello/execution").pathAsString
+      File(s"/cromwell-executions/wf_hello/$id/call-hello/execution").pathAsString
     jobPaths.toDockerPath(Paths.get(s"local-cromwell-executions/wf_hello/$id/call-hello/execution/stdout")).toString shouldBe
-      File(s"/root/wf_hello/$id/call-hello/execution/stdout").pathAsString
-    jobPaths.toDockerPath(Paths.get("/root/dock/path")).toString shouldBe
-      File("/root/dock/path").pathAsString
+      File(s"/cromwell-executions/wf_hello/$id/call-hello/execution/stdout").pathAsString
+    jobPaths.toDockerPath(Paths.get("/cromwell-executions/dock/path")).toString shouldBe
+      File("/cromwell-executions/dock/path").pathAsString
 
     val jobKeySharded = BackendJobDescriptorKey(call, Option(0), 1)
     val jobPathsSharded = new JobPathsWithDocker(jobKeySharded, wd, backendConfig)

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -21,7 +21,7 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     workflowPaths.workflowRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id").pathAsString
     workflowPaths.dockerWorkflowRoot.toString shouldBe
-      s"/root/wf_hello/$id"
+      s"/cromwell-executions/wf_hello/$id"
   }
 
   "WorkflowPaths" should "provide correct paths for a sub workflow" in {
@@ -59,6 +59,6 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     
     val workflowPaths = new WorkflowPathsWithDocker(subWd, backendConfig)
     workflowPaths.workflowRoot.toString shouldBe File(s"local-cromwell-executions/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId").pathAsString
-    workflowPaths.dockerWorkflowRoot.toString shouldBe s"/root/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
+    workflowPaths.dockerWorkflowRoot.toString shouldBe s"/cromwell-executions/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -163,9 +163,12 @@ backend {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
       config {
         run-in-background = true
-        runtime-attributes = "String? docker"
+        runtime-attributes = """
+        String? docker
+        String? docker_user
+        """
         submit = "/bin/bash ${script}"
-        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash ${docker_cwd}/execution/script"
+        submit-docker = """docker run --rm ${"--user " + docker_user} -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash ${docker_cwd}/execution/script"""
 
         # Root directory where Cromwell writes job results.  This directory must be
         # visible and writeable by the Cromwell process as well as the jobs that Cromwell

--- a/core/src/main/scala/cromwell/core/logging/WorkflowLogger.scala
+++ b/core/src/main/scala/cromwell/core/logging/WorkflowLogger.scala
@@ -10,6 +10,7 @@ import ch.qos.logback.classic.{Level, LoggerContext}
 import ch.qos.logback.core.FileAppender
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.WorkflowId
+import cromwell.core.path.FileImplicits._
 import net.ceedubs.ficus.Ficus._
 import org.slf4j.helpers.NOPLogger
 import org.slf4j.{Logger, LoggerFactory}
@@ -116,7 +117,7 @@ class WorkflowLogger(loggerName: String,
   import WorkflowLogger._
 
   lazy val workflowLogPath = workflowLogConfiguration.map(workflowLogConfigurationActual =>
-    File(workflowLogConfigurationActual.dir).createDirectories() / s"workflow.$workflowId.log").map(_.path)
+    File(workflowLogConfigurationActual.dir).createPermissionedDirectories() / s"workflow.$workflowId.log").map(_.path)
 
   lazy val fileLogger = workflowLogPath match {
     case Some(path) => makeFileLogger(path, Level.toLevel(sys.props.getOrElse("LOG_LEVEL", "debug")))

--- a/core/src/main/scala/cromwell/core/path/FileImplicits.scala
+++ b/core/src/main/scala/cromwell/core/path/FileImplicits.scala
@@ -1,0 +1,36 @@
+package cromwell.core.path
+
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.attribute.PosixFilePermission
+
+import better.files.File
+
+object FileImplicits {
+
+  implicit class EnhancedFile(val directory: File) extends AnyVal {
+    def createPermissionedDirectories(): directory.type = {
+      if (!directory.exists) {
+        directory.parent.createPermissionedDirectories()
+        try {
+          directory.createDirectory()
+          // When using PosixFilePermissions/FileAttributes with createDirectories, the umask Cromwell happens to be using
+          // affects the resulting directory permissions.  This is not the desired behavior, these directories should be
+          // world readable/writable/executable irrespective of the umask.
+          directory.addPermission(PosixFilePermission.OTHERS_READ)
+          directory.addPermission(PosixFilePermission.OTHERS_WRITE)
+          directory.addPermission(PosixFilePermission.OTHERS_EXECUTE)
+        }
+        catch {
+          // Race condition that's particularly likely with scatters.  Ignore.
+          case _: FileAlreadyExistsException =>
+          // The GCS filesystem does not support setting permissions and will throw an `UnsupportedOperationException`.
+          // Evaluating expressions like `write_lines` in a command block will cause the above permission-manipulating
+          // code to run against a GCS Path. Fortunately creating directories in GCS is also unnecessary, so this
+          // exception type is just ignored.
+          case _: UnsupportedOperationException =>
+        }
+      }
+      directory
+    }
+  }
+}

--- a/core/src/main/scala/cromwell/core/path/PathCopier.scala
+++ b/core/src/main/scala/cromwell/core/path/PathCopier.scala
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import better.files._
 
 import scala.util.{Failure, Try}
+import FileImplicits._
 
 object PathCopier {
 
@@ -44,7 +45,7 @@ object PathCopier {
     * Copies from source to destination. NOTE: Copies are not atomic, and may create a partial copy.
     */
   def copy(sourceFilePath: Path, destinationFilePath: Path): Try[Unit] = {
-    Option(File(destinationFilePath).parent).foreach(_.createDirectories())
+    Option(File(destinationFilePath).parent).foreach(_.createPermissionedDirectories())
     Try {
       File(sourceFilePath).copyTo(destinationFilePath, overwrite = true)
 

--- a/core/src/test/scala/cromwell/util/TestFileUtil.scala
+++ b/core/src/test/scala/cromwell/util/TestFileUtil.scala
@@ -1,18 +1,24 @@
 package cromwell.util
 
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 
 import better.files._
 import wdl4s.values._
+import cromwell.core.path.FileImplicits._
 
 trait TestFileUtil {
   def createCannedFile(prefix: String, contents: String, dir: Option[Path] = None): Path = {
     val suffix = ".out"
-    File.newTemporaryFile(prefix, suffix, dir.map(File.apply)).write(contents).path
+    val tempFile = File.newTemporaryFile(prefix, suffix, dir.map(File.apply))
+    tempFile.createPermissionedDirectories()
+    tempFile.addPermission(PosixFilePermission.OTHERS_READ)
+    tempFile.addPermission(PosixFilePermission.OTHERS_WRITE)
+    tempFile.write(contents).path
   }
 
   def createFile(name: String, dir: Path, contents: String): Path = {
-    File(dir).createDirectories()./(name).write(contents).path
+    File(dir).createPermissionedDirectories()./(name).write(contents).path
   }
 }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/CopyWorkflowLogsActor.scala
@@ -9,6 +9,7 @@ import better.files._
 import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core._
 import cromwell.core.logging.WorkflowLogger
+import cromwell.core.path.FileImplicits._
 import cromwell.services.metadata.MetadataService.PutMetadataAction
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 
@@ -30,7 +31,7 @@ class CopyWorkflowLogsActor(serviceRegistryActor: ActorRef)
     with ActorLogging {
 
   def copyAndClean(src: Path, dest: Path) = {
-    File(dest).parent.createDirectories()
+    File(dest).parent.createPermissionedDirectories()
 
     File(src).copyTo(dest, overwrite = true)
     if (WorkflowLogger.isTemporary) {

--- a/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalization.scala
+++ b/supportedBackends/htcondor/src/main/scala/cromwell/backend/impl/htcondor/caching/localization/CachedResultLocalization.scala
@@ -3,6 +3,7 @@ package cromwell.backend.impl.htcondor.caching.localization
 import java.nio.file.{Files, Path, Paths}
 
 import better.files.File
+import cromwell.core.path.FileImplicits._
 import cromwell.core.{JobOutput, _}
 import wdl4s.types.{WdlArrayType, WdlFileType}
 import wdl4s.values.{WdlArray, WdlSingleFile, WdlValue}
@@ -11,7 +12,7 @@ trait CachedResultLocalization {
   private[localization] def localizePathViaSymbolicLink(originalPath: Path, executionPath: Path): Path = {
     if (File(originalPath).isDirectory) throw new UnsupportedOperationException("Cannot localize directory with symbolic links.")
     else {
-      File(executionPath).parent.createDirectories()
+      File(executionPath).parent.createPermissionedDirectories()
       Files.createSymbolicLink(executionPath, originalPath.toAbsolutePath)
     }
   }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend.io.JobPaths
 import cromwell.core.CromwellFatalExceptionMarker
+import cromwell.core.path.FileImplicits._
 import cromwell.core.path.PathFactory
 import cromwell.core.path.PathFactory._
 import lenthall.util.TryUtil
@@ -47,7 +48,7 @@ object SharedFileSystem extends StrictLogging {
 
   private def localizePathViaCopy(originalPath: File, executionPath: File): Try[Unit] = {
     val action = Try {
-      executionPath.parent.createDirectories()
+      executionPath.parent.createPermissionedDirectories()
       val executionTmpPath = pathPlusSuffix(executionPath, "tmp")
       originalPath.copyTo(executionTmpPath, overwrite = true).moveTo(executionPath, overwrite = true)
     }.void
@@ -56,7 +57,7 @@ object SharedFileSystem extends StrictLogging {
 
   private def localizePathViaHardLink(originalPath: File, executionPath: File): Try[Unit] = {
     val action = Try {
-      executionPath.parent.createDirectories()
+      executionPath.parent.createPermissionedDirectories()
       executionPath.linkTo(originalPath, symbolic = false)
     }.void
     logOnFailure(action, "hard link")
@@ -67,7 +68,7 @@ object SharedFileSystem extends StrictLogging {
       else if (!originalPath.exists) Failure(new FileNotFoundException(originalPath.pathAsString))
       else {
         val action = Try {
-          executionPath.parent.createDirectories()
+          executionPath.parent.createPermissionedDirectories()
           executionPath.linkTo(originalPath, symbolic = true)
         }.void
         logOnFailure(action, "symbolic link")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -9,6 +9,7 @@ import cromwell.backend.io.JobPathsWithDocker
 import cromwell.backend.standard.{StandardAsyncExecutionActor, StandardAsyncJob, StandardInitializationData}
 import cromwell.backend.validation._
 import cromwell.backend.wdl.OutputEvaluator
+import cromwell.core.path.FileImplicits._
 import cromwell.core.path.PathFactory._
 import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
 import cromwell.core.retry.SimpleExponentialBackoff
@@ -126,7 +127,7 @@ trait SharedFileSystemAsyncJobExecutionActor
   override def execute(): ExecutionHandle = {
     val script = instantiatedCommand
     jobLogger.info(s"`$script`")
-    File(jobPaths.callExecutionRoot).createDirectories()
+    File(jobPaths.callExecutionRoot).createPermissionedDirectories()
     val cwd = if (isDockerRun) jobPathsWithDocker.callExecutionDockerRoot else jobPaths.callExecutionRoot
     writeScript(script, cwd, backendEngineFunctions.findGlobOutputs(call, jobDescriptor))
     jobLogger.info(s"command: $processArgs")
@@ -179,6 +180,7 @@ trait SharedFileSystemAsyncJobExecutionActor
 
     val scriptBody =
       s"""|#!/bin/sh
+          |umask 0000
           |(
           |cd $cwd
           |INSTANTIATED_COMMAND

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
@@ -13,7 +13,7 @@ import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.Future
 import scala.util.Try
-
+import cromwell.core.path.FileImplicits._
 /**
   * Initializes a shared file system actor factory and creates initialization data to pass to the execution actors.
   *
@@ -56,7 +56,7 @@ class SharedFileSystemInitializationActor(params: DefaultInitializationActorPara
   override def beforeAll(): Future[Option[BackendInitializationData]] = {
     Future.fromTry(Try {
       publishWorkflowRoot(workflowPaths.workflowRoot.toString)
-      File(workflowPaths.workflowRoot).createDirectories()
+      File(workflowPaths.workflowRoot).createPermissionedDirectories()
       Option(initializationData)
     })
   }

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -12,9 +12,10 @@ import cromwell.backend.io.TestWorkflows._
 import cromwell.backend.io.{JobPathsWithDocker, TestWorkflows}
 import cromwell.backend.sfs.TestLocalAsyncJobExecutionActor._
 import cromwell.backend.standard.StandardValidatedRuntimeAttributesBuilder
-import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobDescriptorKey, BackendSpec, RuntimeAttributeDefinition}
+import cromwell.backend._
 import cromwell.core.Tags._
 import cromwell.core._
+import cromwell.core.path.FileImplicits._
 import cromwell.services.keyvalue.KeyValueServiceActor.{KvJobKey, KvPair, ScopedKey}
 import lenthall.exception.AggregatedException
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -161,7 +162,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val backend = backendRef.underlyingActor
 
     val jobPaths = new JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, ConfigFactory.empty)
-    File(jobPaths.callExecutionRoot).createDirectories()
+    File(jobPaths.callExecutionRoot).createPermissionedDirectories()
     File(jobPaths.stdout).write("Hello stubby ! ")
     File(jobPaths.stderr).touch()
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.backend.BackendSpec
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.path.DefaultPathBuilder
+import cromwell.core.path.FileImplicits._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import org.specs2.mock.Mockito
@@ -33,7 +34,7 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
     val dest = if (fileInCallDir) orig else callDir./(orig.pathAsString.drop(1))
     orig.touch()
     if (fileAlreadyExists) {
-      dest.parent.createDirectories()
+      dest.parent.createPermissionedDirectories()
       dest.touch()
     }
 


### PR DESCRIPTION
Note these fixes only apply to the config backend; JES does not currently seem to have a provision for specifying users other than root.  This uses `/cromwell-executions` rather than `/root` as the execution root inside the container.  Permissions of files and directories are liberalized for the users inside and outside of the container.

All tests pass if I change `reference.conf` to say `String docker_user = "nobody"`, but I've currently left `docker_user` as an unfilled (old-fashioned) `String?`.

