### PR TITLE
Change exit codes for usage and version to 0. Closes #1870

### DIFF
--- a/src/main/scala/cromwell/Main.scala
+++ b/src/main/scala/cromwell/Main.scala
@@ -131,7 +131,7 @@ object Main extends App {
         |
       """.stripMargin)
 
-    System.exit(1)
+    System.exit(0)
   }
 
   def versionAndExit(): Unit = {
@@ -141,6 +141,6 @@ object Main extends App {
          |cromwell: ${versionConf.getString("cromwell")}
        """.stripMargin
     )
-    System.exit(1)
+    System.exit(0)
   }
 }


### PR DESCRIPTION
It turns out that I was the one who started the non-zero exit codes anyways.