### PR TITLE
Synced database schema and added more specs.

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -56,6 +56,7 @@
     <include file="changesets/workflow_store_imports_file.xml" relativeToChangelogFile="true" />
     <include file="changesets/workflow_store_labels_file.xml" relativeToChangelogFile="true" />
     <include file="changesets/embiggen_detritus_value.xml" relativeToChangelogFile="true" />
+    <include file="changesets/standardize_column_names_patches.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>
 <!--
 

--- a/database/migration/src/main/resources/changesets/standardize_column_names_patches.xml
+++ b/database/migration/src/main/resources/changesets/standardize_column_names_patches.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="kshakir" id="standardize_column_names_patches">
+        <comment>
+            Columns now all match standardized naming.
+            FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID must be dropped and re-added so that
+            UC_CALL_CACHING_HASH_ENTRY_CCEI may be renamed.
+        </comment>
+        <dropForeignKeyConstraint baseTableName="CALL_CACHING_HASH_ENTRY"
+                                  constraintName="FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID"/>
+        <dropForeignKeyConstraint baseTableName="JOB_STORE_SIMPLETON_ENTRY"
+                                  constraintName="FK_JOB_STORE_RESULT_SIMPLETON_JOB_STORE_ENTRY_ID"/>
+        <dropForeignKeyConstraint baseTableName="SUB_WORKFLOW_STORE_ENTRY"
+                                  constraintName="FK_SUB_WORKFLOW_STORE_ROOT_WORKFLOW_ID_WORKFLOW_STORE_ENTRY_ID"/>
+
+        <dropUniqueConstraint tableName="CALL_CACHING_ENTRY"
+                              constraintName="UC_CALL_CACHING_ENTRY_WEU_CQFN_JI"/>
+        <dropUniqueConstraint tableName="CALL_CACHING_HASH_ENTRY"
+                              constraintName="UC_CALL_CACHING_HASH_ENTRY_CCEI"/>
+
+        <addUniqueConstraint
+                tableName="CALL_CACHING_ENTRY"
+                constraintName="UC_CALL_CACHING_ENTRY_WEU_CFQN_JI"
+                columnNames="WORKFLOW_EXECUTION_UUID, CALL_FULLY_QUALIFIED_NAME, JOB_INDEX"/>
+        <addUniqueConstraint
+                tableName="CALL_CACHING_HASH_ENTRY"
+                constraintName="UC_CALL_CACHING_HASH_ENTRY_CCEI_HK"
+                columnNames="CALL_CACHING_ENTRY_ID, HASH_KEY"/>
+
+        <addForeignKeyConstraint constraintName="FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID"
+                                 baseTableName="CALL_CACHING_HASH_ENTRY"
+                                 baseColumnNames="CALL_CACHING_ENTRY_ID"
+                                 referencedTableName="CALL_CACHING_ENTRY"
+                                 referencedColumnNames="CALL_CACHING_ENTRY_ID"/>
+        <addForeignKeyConstraint constraintName="FK_JOB_STORE_SIMPLETON_ENTRY_JOB_STORE_ENTRY_ID" onDelete="CASCADE"
+                                 baseTableName="JOB_STORE_SIMPLETON_ENTRY"
+                                 baseColumnNames="JOB_STORE_ENTRY_ID"
+                                 referencedTableName="JOB_STORE_ENTRY"
+                                 referencedColumnNames="JOB_STORE_ENTRY_ID"/>
+        <addForeignKeyConstraint constraintName="FK_SUB_WORKFLOW_STORE_ENTRY_ROOT_WORKFLOW_ID" onDelete="CASCADE"
+                                 baseTableName="SUB_WORKFLOW_STORE_ENTRY"
+                                 baseColumnNames="ROOT_WORKFLOW_ID"
+                                 referencedTableName="WORKFLOW_STORE_ENTRY"
+                                 referencedColumnNames="WORKFLOW_STORE_ENTRY_ID"/>
+    </changeSet>
+
+    <changeSet author="kshakir" id="hsqldb_longvarchar_to_longtext" dbms="hsqldb">
+        <comment>
+            HSQLDB can handle longtext just fine. Instead of using very wide varchars, use clob.
+        </comment>
+        <modifyDataType newDataType="LONGTEXT" tableName="CALL_CACHING_DETRITUS_ENTRY" columnName="DETRITUS_VALUE"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="CALL_CACHING_SIMPLETON_ENTRY" columnName="SIMPLETON_VALUE"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="JOB_STORE_ENTRY" columnName="EXCEPTION_MESSAGE"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="JOB_STORE_SIMPLETON_ENTRY" columnName="SIMPLETON_VALUE"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="WORKFLOW_STORE_ENTRY" columnName="CUSTOM_LABELS"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="WORKFLOW_STORE_ENTRY" columnName="WORKFLOW_DEFINITION"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="WORKFLOW_STORE_ENTRY" columnName="WORKFLOW_INPUTS"/>
+        <modifyDataType newDataType="LONGTEXT" tableName="WORKFLOW_STORE_ENTRY" columnName="WORKFLOW_OPTIONS"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -1,7 +1,6 @@
 package cromwell.database.slick.tables
 
 import cromwell.database.sql.tables.CallCachingEntry
-import slick.profile.RelationalProfile.ColumnOption.Default
 
 trait CallCachingEntryComponent {
 
@@ -20,13 +19,13 @@ trait CallCachingEntryComponent {
 
     def returnCode = column[Option[Int]]("RETURN_CODE")
 
-    def allowResultReuse = column[Boolean]("ALLOW_RESULT_REUSE", Default(true))
+    def allowResultReuse = column[Boolean]("ALLOW_RESULT_REUSE", O.Default(true))
 
     override def * = (workflowExecutionUuid, callFullyQualifiedName, jobIndex, returnCode, allowResultReuse,
       callCachingEntryId.?) <> (CallCachingEntry.tupled, CallCachingEntry.unapply)
 
-    def ucCallCachingEntryWeuCqfnJi =
-      index("UC_CALL_CACHING_ENTRY_WEU_CQFN_JI", (workflowExecutionUuid, callFullyQualifiedName, jobIndex),
+    def ucCallCachingEntryWeuCfqnJi =
+      index("UC_CALL_CACHING_ENTRY_WEU_CFQN_JI", (workflowExecutionUuid, callFullyQualifiedName, jobIndex),
         unique = true)
   }
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
@@ -24,8 +24,8 @@ trait CallCachingHashEntryComponent {
     def fkCallCachingHashEntryCallCachingEntryId = foreignKey("FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID",
       callCachingEntryId, callCachingEntries)(_.callCachingEntryId)
 
-    def ucCallCachingHashEntryCcei =
-      index("UC_CALL_CACHING_HASH_ENTRY_CCEI", (callCachingEntryId, hashKey), unique = true)
+    def ucCallCachingHashEntryCceiHk =
+      index("UC_CALL_CACHING_HASH_ENTRY_CCEI_HK", (callCachingEntryId, hashKey), unique = true)
   }
 
   protected val callCachingHashEntries = TableQuery[CallCachingHashEntries]

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
@@ -1,5 +1,7 @@
 package cromwell.database.slick.tables
 
+import java.sql.Clob
+
 import cromwell.database.sql.tables.CallCachingSimpletonEntry
 
 trait CallCachingSimpletonEntryComponent {
@@ -14,7 +16,7 @@ trait CallCachingSimpletonEntryComponent {
 
     def simpletonKey = column[String]("SIMPLETON_KEY")
 
-    def simpletonValue = column[String]("SIMPLETON_VALUE")
+    def simpletonValue = column[Clob]("SIMPLETON_VALUE")
 
     def wdlType = column[String]("WDL_TYPE")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreEntryComponent.scala
@@ -1,5 +1,7 @@
 package cromwell.database.slick.tables
 
+import java.sql.Clob
+
 import cromwell.database.sql.tables.JobStoreEntry
 
 trait JobStoreEntryComponent {
@@ -24,7 +26,7 @@ trait JobStoreEntryComponent {
     def returnCode = column[Option[Int]]("RETURN_CODE")
 
     // Only set for failure:
-    def exceptionMessage = column[Option[String]]("EXCEPTION_MESSAGE")
+    def exceptionMessage = column[Option[Clob]]("EXCEPTION_MESSAGE")
 
     def retryableFailure = column[Option[Boolean]]("RETRYABLE_FAILURE")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
@@ -1,5 +1,7 @@
 package cromwell.database.slick.tables
 
+import java.sql.Clob
+
 import cromwell.database.sql.tables.JobStoreSimpletonEntry
 import slick.model.ForeignKeyAction.Cascade
 
@@ -14,7 +16,7 @@ trait JobStoreSimpletonEntryComponent {
 
     def simpletonKey = column[String]("SIMPLETON_KEY")
 
-    def simpletonValue = column[String]("SIMPLETON_VALUE")
+    def simpletonValue = column[Clob]("SIMPLETON_VALUE")
 
     def wdlType = column[String]("WDL_TYPE")
 
@@ -23,7 +25,7 @@ trait JobStoreSimpletonEntryComponent {
     override def * = (simpletonKey, simpletonValue, wdlType, jobStoreEntryId.?, jobStoreSimpletonEntryId.?) <>
       (JobStoreSimpletonEntry.tupled, JobStoreSimpletonEntry.unapply)
 
-    def fkJobStoreResultSimpletonJobStoreEntryId = foreignKey("FK_JOB_STORE_RESULT_SIMPLETON_JOB_STORE_ENTRY_ID",
+    def fkJobStoreSimpletonEntryJobStoreEntryId = foreignKey("FK_JOB_STORE_SIMPLETON_ENTRY_JOB_STORE_ENTRY_ID",
       jobStoreEntryId, jobStoreEntries)(_.jobStoreEntryId, onDelete = Cascade)
 
     def ucJobStoreSimpletonEntryJseiSk =

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -1,6 +1,6 @@
 package cromwell.database.slick.tables
 
-import java.sql.Timestamp
+import java.sql.{Clob, Timestamp}
 
 import cats.data.NonEmptyList
 import cromwell.database.sql.tables.MetadataEntry
@@ -36,9 +36,9 @@ trait MetadataEntryComponent {
 
     def metadataKey = column[String]("METADATA_KEY")
 
-    def metadataValue = column[Option[String]]("METADATA_VALUE")
+    def metadataValue = column[Option[Clob]]("METADATA_VALUE")
 
-    def metadataValueType = column[Option[String]]("METADATA_VALUE_TYPE")
+    def metadataValueType = column[Option[String]]("METADATA_VALUE_TYPE", O.Length(10))
 
     def metadataTimestamp = column[Timestamp]("METADATA_TIMESTAMP")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/SubWorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/SubWorkflowStoreEntryComponent.scala
@@ -26,10 +26,10 @@ trait SubWorkflowStoreEntryComponent {
 
     override def * = (rootWorkflowId.?, parentWorkflowExecutionUuid, callFullyQualifiedName, callIndex, callAttempt, subWorkflowExecutionUuid, subWorkflowStoreEntryId.?) <> (SubWorkflowStoreEntry.tupled, SubWorkflowStoreEntry.unapply)
 
-    def ucSubWorkflowStoreEntryPweuCfqnJiJa = index("UC_SUB_WORKFLOW_STORE_ENTRY_PWEU_CFQN_CI_CA",
+    def ucSubWorkflowStoreEntryPweuCfqnCiCa = index("UC_SUB_WORKFLOW_STORE_ENTRY_PWEU_CFQN_CI_CA",
       (parentWorkflowExecutionUuid, callFullyQualifiedName, callIndex, callAttempt), unique = true)
 
-    def fkSubWorkflowStoreRootWorkflowStoreEntryId = foreignKey("FK_SUB_WORKFLOW_STORE_ROOT_WORKFLOW_ID_WORKFLOW_STORE_ENTRY_ID",
+    def fkSubWorkflowStoreEntryRootWorkflowId = foreignKey("FK_SUB_WORKFLOW_STORE_ENTRY_ROOT_WORKFLOW_ID",
       rootWorkflowId, workflowStoreEntries)(_.workflowStoreEntryId, onDelete = Cascade)
 
     def ixSubWorkflowStoreEntryPweu = index("IX_SUB_WORKFLOW_STORE_ENTRY_PWEU", parentWorkflowExecutionUuid, unique = false)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
@@ -14,11 +14,11 @@ trait WorkflowMetadataSummaryEntryComponent {
     extends Table[WorkflowMetadataSummaryEntry](tag, "WORKFLOW_METADATA_SUMMARY_ENTRY") {
     def workflowMetadataSummaryEntryId = column[Long]("WORKFLOW_METADATA_SUMMARY_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(100))
 
-    def workflowName = column[Option[String]]("WORKFLOW_NAME")
+    def workflowName = column[Option[String]]("WORKFLOW_NAME", O.Length(100))
 
-    def workflowStatus = column[Option[String]]("WORKFLOW_STATUS")
+    def workflowStatus = column[Option[String]]("WORKFLOW_STATUS", O.Length(50))
 
     def startTimestamp = column[Option[Timestamp]]("START_TIMESTAMP")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -23,14 +23,14 @@ trait WorkflowStoreEntryComponent {
 
     def customLabels = column[Clob]("CUSTOM_LABELS")
 
-    def workflowState = column[String]("WORKFLOW_STATE")
+    def workflowState = column[String]("WORKFLOW_STATE", O.Length(15))
 
     def submissionTime = column[Timestamp]("SUBMISSION_TIME")
 
-    def importsZipFile = column[Option[Blob]]("IMPORTS_ZIP")
+    def importsZip = column[Option[Blob]]("IMPORTS_ZIP")
 
     override def * = (workflowExecutionUuid, workflowDefinition, workflowInputs, workflowOptions, workflowState,
-      submissionTime, importsZipFile, customLabels, workflowStoreEntryId.?) <> (WorkflowStoreEntry.tupled, WorkflowStoreEntry.unapply)
+      submissionTime, importsZip, customLabels, workflowStoreEntryId.?) <> (WorkflowStoreEntry.tupled, WorkflowStoreEntry.unapply)
 
     def ucWorkflowStoreEntryWeu = index("UC_WORKFLOW_STORE_ENTRY_WEU", workflowExecutionUuid, unique = true)
 

--- a/database/sql/src/main/scala/cromwell/database/sql/SqlConverters.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/SqlConverters.scala
@@ -1,8 +1,8 @@
 package cromwell.database.sql
 
-import java.sql.{Clob, Timestamp}
+import java.sql.{Blob, Clob, Timestamp}
 import java.time.{OffsetDateTime, ZoneId}
-import javax.sql.rowset.serial.SerialClob
+import javax.sql.rowset.serial.{SerialBlob, SerialClob}
 
 object SqlConverters {
 
@@ -20,12 +20,19 @@ object SqlConverters {
 
   implicit class ClobToRawString(val clob: Clob) extends AnyVal {
     def toRawString: String = clob.getSubString(1, clob.length.toInt) // yes, it starts at 1
+
+    def parseSystemTimestamp: Timestamp = OffsetDateTime.parse(toRawString).toSystemTimestamp
   }
 
   implicit class StringToClob(val str: String) extends AnyVal {
     def toClob: Clob = new SerialClob(str.toCharArray)
-
-    def toNonEmptyClob: Option[Clob] = if (str.isEmpty) None else Option(new SerialClob(str.toCharArray))
   }
 
+  implicit class BlobToBytes(val blob: Blob) extends AnyVal {
+    def toBytes: Array[Byte] = blob.getBytes(1, blob.length.toInt) // yes, it starts at 1
+  }
+
+  implicit class StringToBlob(val bytes: Array[Byte]) extends AnyVal {
+    def toBlob: Blob = new SerialBlob(bytes)
+  }
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
@@ -7,5 +7,5 @@ case class CallCachingDetritusEntry
   detritusKey: String,
   detritusValue: Clob,
   callCachingEntryId: Option[Int] = None,
-  callCachingDetritusId: Option[Int] = None
+  callCachingDetritusEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
@@ -1,9 +1,11 @@
 package cromwell.database.sql.tables
 
+import java.sql.Clob
+
 case class CallCachingSimpletonEntry
 (
   simpletonKey: String,
-  simpletonValue: String,
+  simpletonValue: Clob,
   wdlType: String,
   callCachingEntryId: Option[Int] = None,
   callCachingSimpletonEntryId: Option[Int] = None

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/JobStoreEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/JobStoreEntry.scala
@@ -1,5 +1,7 @@
 package cromwell.database.sql.tables
 
+import java.sql.Clob
+
 case class JobStoreEntry
 (
   workflowExecutionUuid: String,
@@ -8,7 +10,7 @@ case class JobStoreEntry
   jobAttempt: Int,
   jobSuccessful: Boolean,
   returnCode: Option[Int],
-  exceptionMessage: Option[String],
+  exceptionMessage: Option[Clob],
   retryableFailure: Option[Boolean],
   jobStoreEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/JobStoreSimpletonEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/JobStoreSimpletonEntry.scala
@@ -1,9 +1,11 @@
 package cromwell.database.sql.tables
 
+import java.sql.Clob
+
 case class JobStoreSimpletonEntry
 (
   simpletonKey: String,
-  simpletonValue: String,
+  simpletonValue: Clob,
   wdlType: String,
   jobStoreEntryId: Option[Int] = None,
   jobStoreSimpletonEntryId: Option[Int] = None

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/MetadataEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/MetadataEntry.scala
@@ -1,6 +1,6 @@
 package cromwell.database.sql.tables
 
-import java.sql.Timestamp
+import java.sql.{Clob, Timestamp}
 
 case class MetadataEntry
 (
@@ -9,7 +9,7 @@ case class MetadataEntry
   jobIndex: Option[Int],
   jobAttempt: Option[Int],
   metadataKey: String,
-  metadataValue: Option[String],
+  metadataValue: Option[Clob],
   metadataValueType: Option[String],
   metadataTimestamp: Timestamp,
   metadataEntryId: Option[Long] = None

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/SubWorkflowStoreEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/SubWorkflowStoreEntry.scala
@@ -5,8 +5,8 @@ case class SubWorkflowStoreEntry
   rootWorkflowId: Option[Int],
   parentWorkflowExecutionUuid: String,
   callFullyQualifiedName: String,
-  jobIndex: Int,
-  jobAttempt: Int,
+  callIndex: Int,
+  callAttempt: Int,
   subWorkflowExecutionUuid: String,
   subWorkflowStoreEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/WorkflowStoreEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/WorkflowStoreEntry.scala
@@ -10,7 +10,7 @@ case class WorkflowStoreEntry
   workflowOptions: Clob,
   workflowState: String,
   submissionTime: Timestamp,
-  importsZipFile: Option[Blob],
+  importsZip: Option[Blob],
   customLabels: Clob,
   workflowStoreEntryId: Option[Int] = None
 )

--- a/engine/src/main/scala/cromwell/Simpletons.scala
+++ b/engine/src/main/scala/cromwell/Simpletons.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import cromwell.core.simpleton.WdlValueSimpleton
+import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.tables.{CallCachingSimpletonEntry, JobStoreSimpletonEntry}
 import wdl4s.types.{WdlBooleanType, WdlFloatType, WdlIntegerType, WdlStringType}
 import wdl4s.values.{WdlPrimitive, WdlSingleFile, WdlValue}
@@ -12,11 +13,11 @@ import scala.util.Try
   */
 object Simpletons {
   def toSimpleton(entry: CallCachingSimpletonEntry): WdlValueSimpleton = {
-    toSimpleton(entry.wdlType, entry.simpletonKey, entry.simpletonValue)
+    toSimpleton(entry.wdlType, entry.simpletonKey, entry.simpletonValue.toRawString)
   }
 
   def toSimpleton(entry: JobStoreSimpletonEntry): WdlValueSimpleton = {
-    toSimpleton(entry.wdlType, entry.simpletonKey, entry.simpletonValue)
+    toSimpleton(entry.wdlType, entry.simpletonKey, entry.simpletonValue.toRawString)
   }
 
   private def toSimpleton(wdlType: String, simpletonKey: String, simpletonValue: String): WdlValueSimpleton = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -7,8 +7,8 @@ import cromwell.backend.BackendJobExecutionActor.JobSucceededResponse
 import cromwell.core.ExecutionIndex.IndexEnhancedIndex
 import cromwell.core.WorkflowId
 import cromwell.core.callcaching.HashResult
-import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.core.path.PathImplicits._
+import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql._
 import cromwell.database.sql.joins.CallCachingJoin
@@ -49,7 +49,7 @@ class CallCache(database: CallCachingSqlDatabase) {
     val resultToInsert: Iterable[CallCachingSimpletonEntry] = {
       result map {
         case WdlValueSimpleton(simpletonKey, wdlPrimitive) =>
-          CallCachingSimpletonEntry(simpletonKey, wdlPrimitive.valueString, wdlPrimitive.wdlType.toWdlString)
+          CallCachingSimpletonEntry(simpletonKey, wdlPrimitive.valueString.toClob, wdlPrimitive.wdlType.toWdlString)
       }
     }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -1,16 +1,15 @@
 package cromwell.engine.workflow.workflowstore
 
 import java.time.OffsetDateTime
-import javax.sql.rowset.serial.SerialBlob
 
 import cats.data.NonEmptyList
 import com.typesafe.config.ConfigFactory
-import net.ceedubs.ficus.Ficus._
 import cromwell.core.{WorkflowId, WorkflowSourceFilesCollection}
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.WorkflowStoreSqlDatabase
 import cromwell.database.sql.tables.WorkflowStoreEntry
 import cromwell.engine.workflow.workflowstore.WorkflowStoreState.StartableState
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -58,7 +57,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
       workflowStoreEntry.workflowInputs.toRawString,
       workflowStoreEntry.workflowOptions.toRawString,
       workflowStoreEntry.customLabels.toRawString,
-      workflowStoreEntry.importsZipFile.map(b => b.getBytes(1, b.length.asInstanceOf[Int]))
+      workflowStoreEntry.importsZip.map(_.toBytes)
     )
     WorkflowToStart(
       WorkflowId.fromString(workflowStoreEntry.workflowExecutionUuid),
@@ -75,7 +74,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
       customLabels = workflowSourceFiles.labelsJson.toClob,
       workflowState = WorkflowStoreState.Submitted.toString,
       submissionTime = OffsetDateTime.now.toSystemTimestamp,
-      importsZipFile = workflowSourceFiles.importsZipFileOption.map(new SerialBlob(_))
+      importsZip = workflowSourceFiles.importsZipFileOption.map(_.toBlob)
     )
   }
 

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -6,25 +6,29 @@ import java.sql.Connection
 import better.files._
 import com.typesafe.config.ConfigFactory
 import cromwell.core.Tags._
+import cromwell.core.WorkflowId
 import cromwell.database.migration.liquibase.LiquibaseUtils
 import cromwell.database.slick.SlickDatabase
+import cromwell.database.sql.joins.JobStoreJoin
+import cromwell.database.sql.tables.JobStoreEntry
 import liquibase.diff.DiffResult
 import liquibase.diff.output.DiffOutputControl
 import liquibase.diff.output.changelog.DiffToChangeLog
 import org.hsqldb.persist.HsqlDatabaseProperties
 import org.scalactic.StringNormalizations
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 import slick.driver.JdbcProfile
+import slick.jdbc.meta._
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.Try
 import scala.xml._
 
 class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with StringNormalizations {
-
-  behavior of "ServicesStore"
 
   import ServicesStoreSpec._
 
@@ -32,81 +36,184 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
 
-  it should "have the same liquibase and slick schema" in {
+  behavior of "ServicesStore"
+
+  it should "not deadlock" in {
+    // Test based on https://github.com/kwark/slick-deadlock/blob/82525fc/src/main/scala/SlickDeadlock.scala
+    val databaseConfig = ConfigFactory.parseString(
+      s"""|db.url = "jdbc:hsqldb:mem:$${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
+          |db.driver = "org.hsqldb.jdbcDriver"
+          |db.connectionTimeout = 3000
+          |db.numThreads = 2
+          |driver = "slick.driver.HsqldbDriver$$"
+          |""".stripMargin)
+    import ServicesStore.EnhancedSqlDatabase
     for {
-      liquibaseDatabase <- databaseForSchemaManager("liquibase").autoClosed
-      slickDatabase <- databaseForSchemaManager("slick").autoClosed
+      database <- new SlickDatabase(databaseConfig).initialized.autoClosed
     } {
-      compare(
-        liquibaseDatabase.dataAccess.driver, liquibaseDatabase.database,
-        slickDatabase.dataAccess.driver, slickDatabase.database) { diffResult =>
-
-        // TODO PBE get rid of this after the migration of #789 has run.
-        val oldeTables = Seq(
-          "EXECUTION",
-          "EXECUTION_INFO",
-          "EXECUTION_EVENT",
-          "FAILURE_EVENT",
-          "RUNTIME_ATTRIBUTES",
-          "SYMBOL",
-          "WORKFLOW_EXECUTION",
-          "WORKFLOW_EXECUTION_AUX"
-        )
-
-        import cromwell.database.migration.liquibase.DiffResultFilter._
-        val diffFilters = StandardTypeFilters :+ UniqueIndexFilter
-        val filteredDiffResult = diffResult
-          .filterLiquibaseObjects
-          .filterTableObjects(oldeTables)
-          .filterChangedObjects(diffFilters)
-
-        val totalChanged =
-          filteredDiffResult.getChangedObjects.size +
-            filteredDiffResult.getMissingObjects.size +
-            filteredDiffResult.getUnexpectedObjects.size
-
-        if (totalChanged > 0) {
-          val outputStream = new ByteArrayOutputStream
-          val printStream = new PrintStream(outputStream, true)
-          val diffOutputControl = new DiffOutputControl(false, false, false, Array.empty)
-          val diffToChangeLog = new DiffToChangeLog(filteredDiffResult, diffOutputControl)
-          diffToChangeLog.print(printStream)
-          val changeSetsScoped = XML.loadString(outputStream.toString) \ "changeSet" \ "_"
-          val changeSets = changeSetsScoped map stripNodeScope
-          fail(changeSets.mkString(
-            "The following changes are in liquibase but not in slick:\n  ",
-            "\n  ",
-            "\nEither add the changes to slick or remove them from liquibase."))
-        }
+      val futures = 1 to 20 map { _ =>
+        val workflowUuid = WorkflowId.randomId().toString
+        val callFqn = "call.fqn"
+        val jobIndex = 1
+        val jobAttempt = 1
+        val jobSuccessful = false
+        val jobStoreEntry = JobStoreEntry(workflowUuid, callFqn, jobIndex, jobAttempt, jobSuccessful, None, None, None)
+        val jobStoreJoins = Seq(JobStoreJoin(jobStoreEntry, Seq()))
+        // NOTE: This test just needs to repeatedly read/write from a table that acts as a PK for a FK.
+        for {
+          _ <- database.addJobStores(jobStoreJoins)
+          queried <- database.queryJobStores(workflowUuid, callFqn, jobIndex, jobAttempt)
+          _ = queried.get.jobStoreEntry.workflowExecutionUuid should be(workflowUuid)
+        } yield ()
       }
+      Future.sequence(futures).futureValue(Timeout(10.seconds))
     }
   }
 
-  it should "not deadlock" taggedAs PostMVP ignore {
-    //    // Test based on https://github.com/kwark/slick-deadlock/blob/82525fc/src/main/scala/SlickDeadlock.scala
-    //    val databaseConfig = ConfigFactory.parseString(
-    //      s"""
-    //         |db.url = "jdbc:hsqldb:mem:$${slick.uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
-    //         |db.driver = "org.hsqldb.jdbcDriver"
-    //         |db.numThreads = 2
-    //         |driver = "slick.driver.HsqldbDriver$$"
-    //         |""".stripMargin)
-    //
-    //    for {
-    //      dataAccess <- (new SlickDatabase(databaseConfig) with DataAccess).autoClosed
-    //    } {
-    //      val futures = 1 to 20 map { _ =>
-    //        val workflowId = WorkflowId.randomId()
-    //        val workflowInfo = createMaterializedEngineWorkflowDescriptor(id = workflowId, workflowSources = test1Sources)
-    //        for {
-    //          _ <- dataAccess.createWorkflow(workflowInfo, test1Sources, Nil, Nil, localBackend)
-    //          _ <- dataAccess.getWorkflowExecutionAndAux(workflowInfo.id) map { result =>
-    //            result.execution.workflowExecutionUuid should be(workflowId.toString)
-    //          }
-    //        } yield ()
-    //      }
-    //      Future.sequence(futures).futureValue(Timeout(10.seconds))
-    //    }
+  "Slick" should behave like testSchemaManager("slick")
+
+  "Liquibase" should behave like testSchemaManager("liquibase")
+
+  def testSchemaManager(schemaManager: String): Unit = {
+    val otherSchemaManager = if (schemaManager == "slick") "liquibase" else "slick"
+
+    it should s"have the same schema as $otherSchemaManager" in {
+      for {
+        actualDatabase <- databaseForSchemaManager(schemaManager).autoClosed
+        expectedDatabase <- databaseForSchemaManager(otherSchemaManager).autoClosed
+      } {
+        compare(
+          actualDatabase.dataAccess.driver, actualDatabase.database,
+          expectedDatabase.dataAccess.driver, expectedDatabase.database) { diffResult =>
+
+          import cromwell.database.migration.liquibase.DiffResultFilter._
+
+          /*
+          NOTE: Unique indexes no longer need to be filtered, as WE SHOULD NOT BE USING THEM!
+          See notes at the bottom of changelog.xml
+           */
+          val diffFilters = StandardTypeFilters
+          val filteredDiffResult = diffResult
+            .filterLiquibaseObjects
+            .filterTableObjects(oldeTables)
+            .filterChangedObjects(diffFilters)
+
+          val totalChanged =
+            filteredDiffResult.getChangedObjects.size +
+              filteredDiffResult.getMissingObjects.size +
+              filteredDiffResult.getUnexpectedObjects.size
+
+          if (totalChanged > 0) {
+            val outputStream = new ByteArrayOutputStream
+            val printStream = new PrintStream(outputStream, true)
+            val diffOutputControl = new DiffOutputControl(false, false, false, Array.empty)
+            val diffToChangeLog = new DiffToChangeLog(filteredDiffResult, diffOutputControl)
+            diffToChangeLog.print(printStream)
+            val changeSetsScoped = XML.loadString(outputStream.toString) \ "changeSet" \ "_"
+            val changeSets = changeSetsScoped map stripNodeScope
+            fail(changeSets.mkString(
+              s"The following changes are in $schemaManager but not in $otherSchemaManager:\n  ",
+              "\n  ",
+              "\nEnsure that the columns/fields exist, with the same lengths in " +
+                s"$schemaManager and $otherSchemaManager and synchronize the two."))
+          }
+        }
+      }
+    }
+
+    it should "match expected generated names" in {
+      var schemaMetadata: SchemaMetadata = null
+
+      for {
+        slickDatabase <- databaseForSchemaManager(schemaManager).autoClosed
+      } {
+        import slickDatabase.dataAccess.driver.api._
+        val schemaMetadataFuture =
+          for {
+            tables <- slickDatabase.database.run(MTable.getTables(Option("PUBLIC"), Option("PUBLIC"), None, None))
+            workingTables = tables
+              .filterNot(_.name.name.startsWith("DATABASECHANGELOG"))
+              .filterNot(table => oldeTables.contains(table.name.name))
+              // NOTE: MetadataEntry column names are perma-busted due to the large size of the table.
+              .filterNot(_.name.name == "METADATA_ENTRY")
+            columns <- slickDatabase.database.run(DBIO.sequence(workingTables.map(_.getColumns)))
+            indexes <- slickDatabase.database.run(DBIO.sequence(workingTables.map(_.getIndexInfo())))
+            primaryKeys <- slickDatabase.database.run(DBIO.sequence(workingTables.map(_.getPrimaryKeys)))
+            foreignKeys <- slickDatabase.database.run(DBIO.sequence(workingTables.map(_.getExportedKeys)))
+          } yield SchemaMetadata(tables, columns.flatten, indexes.flatten.filterNot(isGenerated),
+            primaryKeys.flatten.filterNot(isGenerated), foreignKeys.flatten)
+
+        schemaMetadata = schemaMetadataFuture.futureValue
+      }
+
+      var misnamed = Seq.empty[String]
+
+      schemaMetadata.primaryKeyMetadata foreach { primaryKey =>
+        val actual = primaryKey.pkName.get
+        val expected = s"PK_${primaryKey.table.name}"
+        if (actual != expected) {
+          misnamed :+=
+            s"""|PrimaryKey: $actual
+                |Should Be:  $expected
+                |""".stripMargin
+        }
+      }
+
+      schemaMetadata.foreignKeyMetadata foreach { foreignKey =>
+        val actual = foreignKey.fkName.get
+        val expected = s"FK_${foreignKey.fkTable.name}_${foreignKey.fkColumn}"
+        if (actual != expected) {
+          misnamed :+=
+            s"""|ForeignKey: $actual
+                |Should Be:  $expected
+                |""".stripMargin
+        }
+      }
+
+      schemaMetadata.indexMetadata.groupBy(getIndexName) foreach {
+        case (indexName, indexColumns) =>
+          val index = indexColumns.head
+          val prefix = if (index.nonUnique) "IX" else "UC"
+          val tableName = index.table.name
+          val sortedColumns = indexColumns.sortBy(_.ordinalPosition)
+          val abbrColumns = sortedColumns.map(indexColumn => snakeAbbreviate(indexColumn.column.get))
+
+          val actual = indexName
+          val expected = abbrColumns.mkString(s"${prefix}_${tableName}_", "_", "")
+
+          if (actual != expected) {
+            misnamed :+=
+              s"""|Index:     $actual
+                  |Should Be: $expected
+                  |""".stripMargin
+          }
+      }
+
+      if (misnamed.nonEmpty) {
+        fail(misnamed.mkString(s"The following items are misnamed in $schemaManager:\n", "\n", ""))
+      }
+
+      var missing = Seq.empty[String]
+
+      schemaMetadata.columns foreach { column =>
+        if (!schemaMetadata.existsTableItem(column)) {
+          missing :+= s"${tableClassName(column.tableName)}.${column.itemName}"
+        }
+      }
+
+      schemaMetadata.slickItems foreach { databaseItem =>
+        if (!schemaMetadata.existsSlickMapping(databaseItem)) {
+          missing :+= s"${slickClassName(databaseItem.tableName)}.${databaseItem.itemName}"
+        }
+      }
+
+      if (missing.nonEmpty) {
+        fail(missing.mkString(
+          s"Based on the schema in $schemaManager, please ensure that the following tables/columns exist:\n  ",
+          "\n  ",
+          ""))
+      }
+    }
   }
 
   "SlickDatabase (hsqldb)" should behave like testWith("database")
@@ -147,6 +254,18 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 }
 
 object ServicesStoreSpec {
+  // TODO PBE get rid of this after the migration of #789 has run.
+  private val oldeTables = Seq(
+    "EXECUTION",
+    "EXECUTION_EVENT",
+    "EXECUTION_INFO",
+    "FAILURE_EVENT",
+    "RUNTIME_ATTRIBUTES",
+    "SYMBOL",
+    "WORKFLOW_EXECUTION",
+    "WORKFLOW_EXECUTION_AUX"
+  )
+
   // strip the namespace from elems and their children
   private def stripNodeScope(node: Node): Node = {
     node match {
@@ -226,6 +345,94 @@ object ServicesStoreSpec {
       withConnection(profile2, database2) { connection2 =>
         block(connection1, connection2)
       }
+    }
+  }
+
+  private val SnakeRegex = "_([a-z])".r
+
+  private def snakeToCamel(value: String): String = {
+    SnakeRegex.replaceAllIn(value.toLowerCase, _.group(1).toUpperCase)
+  }
+
+  private def snakeAbbreviate(value: String): String = {
+    SnakeRegex.findAllMatchIn("_" + value.toLowerCase).map(_.group(1)).mkString("").toUpperCase
+  }
+
+  private val SlickPrimaryKeyRegex = """SYS_PK_\d+""".r
+
+  private def isGenerated(primaryKey: MPrimaryKey): Boolean = {
+    primaryKey.pkName.get match {
+      case SlickPrimaryKeyRegex(_*) => true
+      case _ => false
+    }
+  }
+
+  private val LiquibasePrimaryKeyIndexRegex = """SYS_IDX_PK_[A-Z_]+_\d+""".r
+  private val SlickPrimaryKeyIndexRegex = """SYS_IDX_SYS_PK_\d+_\d+""".r
+  private val SlickForeignKeyIndexRegex = """SYS_IDX_\d+""".r
+
+  private def isGenerated(index: MIndexInfo): Boolean = {
+    index.indexName.get match {
+      case LiquibasePrimaryKeyIndexRegex(_*) => true
+      case SlickPrimaryKeyIndexRegex(_*) => true
+      case SlickForeignKeyIndexRegex(_*) => true
+      case _ => false
+    }
+  }
+
+  private def tableClassName(tableName: String) = s"cromwell.database.sql.tables.$tableName"
+
+  private def slickClassName(tableName: String) =
+    s"cromwell.database.slick.tables.${tableName}Component$$${tableName.replace("Entry", "Entries")}"
+
+  private def getIndexName(index: MIndexInfo) = index.indexName.get.replaceAll("(^SYS_IDX_|_\\d+$)", "")
+
+  case class TableClass(tableName: String) {
+    private def getClass(name: String): Try[Class[_]] = Try(Class.forName(name))
+
+    private lazy val tableColumns = getClass(tableClassName(tableName)).map(_.getDeclaredFields).getOrElse(Array.empty)
+    private lazy val slickMapping = getClass(slickClassName(tableName)).map(_.getDeclaredMethods).getOrElse(Array.empty)
+
+    def existsTableField(name: String): Boolean = tableColumns.exists(_.getName == name)
+
+    def existsSlickMapping(name: String): Boolean = slickMapping.exists(_.getName == name)
+  }
+
+  case class DatabaseItem(tableName: String, itemName: String)
+
+  case class SchemaMetadata(tableMetadata: Seq[MTable], columnMetadata: Seq[MColumn], indexMetadata: Seq[MIndexInfo],
+                            primaryKeyMetadata: Seq[MPrimaryKey], foreignKeyMetadata: Seq[MForeignKey]) {
+    lazy val tables: Seq[TableClass] = tableMetadata.map({ table =>
+      val tableName = snakeToCamel(table.name.name).capitalize
+      TableClass(tableName)
+    }).distinct
+
+    lazy val columns: Seq[DatabaseItem] = columnMetadata.map({ column =>
+      val tableName = snakeToCamel(column.table.name).capitalize
+      val columnName = snakeToCamel(column.name)
+      DatabaseItem(tableName, columnName)
+    }).distinct
+
+    lazy val indexes: Seq[DatabaseItem] = indexMetadata.map({ index =>
+      val tableName = snakeToCamel(index.table.name).capitalize
+      val indexName = snakeToCamel(getIndexName(index))
+      DatabaseItem(tableName, indexName)
+    }).distinct
+
+    lazy val foreignKeys: Seq[DatabaseItem] = foreignKeyMetadata.map({ foreignKey =>
+      val tableName = snakeToCamel(foreignKey.fkTable.name).capitalize
+      val indexName = snakeToCamel(foreignKey.fkName.get)
+      DatabaseItem(tableName, indexName)
+    }).distinct
+
+    lazy val slickItems: Seq[DatabaseItem] = columns ++ indexes ++ foreignKeys
+
+    def existsTableItem(tableItem: DatabaseItem): Boolean = {
+      tables.find(_.tableName == tableItem.tableName).exists(_.existsTableField(tableItem.itemName))
+    }
+
+    def existsSlickMapping(tableItem: DatabaseItem): Boolean = {
+      tables.find(_.tableName == tableItem.tableName).exists(_.existsSlickMapping(tableItem.itemName))
     }
   }
 }

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -8,6 +8,10 @@ import cromwell.core.WorkflowId
 import cromwell.services.ServicesSpec
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+
+import scala.concurrent.duration._
 
 class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
   import MetadataServiceActorSpec.Config
@@ -47,23 +51,25 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
       val query4 = MetadataQuery.forWorkflow(workflowId)
       val query5 = MetadataQuery.forJob(workflowId, supJob)
 
-      (for {
-        response1 <- (actor ? GetMetadataQueryAction(query1)).mapTo[MetadataServiceResponse]
-        _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
+      eventually(Timeout(10.seconds), Interval(2.seconds)) {
+        (for {
+          response1 <- (actor ? GetMetadataQueryAction(query1)).mapTo[MetadataServiceResponse]
+          _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
 
-        response2 <- (actor ? GetMetadataQueryAction(query2)).mapTo[MetadataServiceResponse]
-        _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
+          response2 <- (actor ? GetMetadataQueryAction(query2)).mapTo[MetadataServiceResponse]
+          _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
 
-        response3 <- (actor ? GetMetadataQueryAction(query3)).mapTo[MetadataServiceResponse]
-        _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
+          response3 <- (actor ? GetMetadataQueryAction(query3)).mapTo[MetadataServiceResponse]
+          _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
 
-        response4 <- (actor ? GetMetadataQueryAction(query4)).mapTo[MetadataServiceResponse]
-        _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
+          response4 <- (actor ? GetMetadataQueryAction(query4)).mapTo[MetadataServiceResponse]
+          _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
 
-        response5 <- (actor ? GetMetadataQueryAction(query5)).mapTo[MetadataServiceResponse]
-        _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
+          response5 <- (actor ? GetMetadataQueryAction(query5)).mapTo[MetadataServiceResponse]
+          _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
 
-      } yield ()).futureValue
+        } yield ()).futureValue
+      }
     }
   }
 }


### PR DESCRIPTION
PK, FK, UC, and IX names all use a standard naming pattern, and synced up clob/varchar lengths.
Added specs that check for the above.
Removed checks for unique index mismatches, as we have none.
Added blob implicits to match clob implicits.
Reimplemented database deadlock test.
Added an eventually wrapper within MetadataServiceActorSpec.