### PR TITLE
Add sync command to force flush of disk writes

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -185,6 +185,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |cd $cwd
         |${globManipulations(globFiles)}
         |)
+        |sync
         |mv $rcTmpPath $rcPath
         |""".stripMargin.replace("INSTANTIATED_COMMAND", instantiatedCommand)
   }


### PR DESCRIPTION
I know there is a more serious ticket for this issue, but it seems like a number of centaur local tests have been failing again lately due to `expected "hello" but got ""` kind of errors.
I found this https://linux.die.net/man/2/sync and have been restarting centaur local on this branch a few times and none of them have failed so far. I don't think it entirely fixes the issue though.