### PR TITLE
Minor Tes updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
   or the Config backend could pass an optional `"-u username"` as part of the `submit-docker` command.
 * In some cases the SFS backend, used for Local, SGE, etc., coerced `WdlFile` to `WdlString` by using `.toUri`. This
 resulted in strings prepended with `file:///path/to/file`. Now absolute file paths will not contain the uri scheme.
+* Launch jobs on servers that support the GA4GH Task Execution Schema using the TES backend.
 
 ### Database schema changes
 * Added CUSTOM_LABELS as a field of WORKFLOW_STORE_ENTRY, to store workflow store entries.

--- a/src/bin/travis/testCentaurTes.sh
+++ b/src/bin/travis/testCentaurTes.sh
@@ -40,7 +40,7 @@ git checkout ${CENTAUR_BRANCH}
 cd ..
 
 TES_CONF="$(pwd)/src/bin/travis/resources/tes.conf"
-git clone https://github.com/broadinstitute/funnel.git
+git clone https://github.com/ohsu-comp-bio/funnel.git
 cd funnel
 make
 cd ..

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
@@ -3,7 +3,6 @@ package cromwell.backend.impl.tes
 import akka.actor.ActorRef
 import cromwell.backend.standard._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
-import cromwell.core.path.Obsolete._
 import wdl4s.TaskCall
 
 import scala.concurrent.Future
@@ -33,7 +32,7 @@ class TesInitializationActor(params: TesInitializationActorParams)
   override def beforeAll(): Future[Option[BackendInitializationData]] = {
     Future.fromTry(Try {
       publishWorkflowRoot(workflowPaths.workflowRoot.toString)
-      File(workflowPaths.workflowRoot).createPermissionedDirectories()
+      workflowPaths.workflowRoot.createPermissionedDirectories()
       Option(TesBackendInitializationData(workflowPaths, runtimeAttributesBuilder, tesConfiguration))
     })
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -3,8 +3,7 @@ package cromwell.backend.impl.tes
 import com.typesafe.config.Config
 import cromwell.backend.io.{JobPaths, WorkflowPaths}
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
-import cromwell.core.path.Obsolete._
-import cromwell.core.path.{Path, PathBuilder}
+import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 
 class TesJobPaths(val jobKey: BackendJobDescriptorKey,
                   workflowDescriptor: BackendWorkflowDescriptor,
@@ -33,7 +32,7 @@ class TesJobPaths(val jobKey: BackendJobDescriptorKey,
   }
 
   def containerInput(path: String): String = {
-    cleanContainerInputPath(callInputsDockerRoot, Paths.get(path))
+    cleanContainerInputPath(callInputsDockerRoot, DefaultPathBuilder.get(path))
   }
 
   // Given an output path, return a path localized to the container file system

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -3,8 +3,7 @@ package cromwell.backend.impl.tes
 import cromwell.backend.standard.StandardExpressionFunctions
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor}
 import cromwell.core.logging.JobLogger
-import cromwell.core.path.Obsolete.Paths
-import cromwell.core.path.Path
+import cromwell.core.path.{DefaultPathBuilder, Path}
 import wdl4s.FullyQualifiedName
 import wdl4s.expression.NoFunctions
 import wdl4s.parser.MemoryUnit
@@ -55,10 +54,10 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
 
   val inputs: Seq[TaskParameter] = (callInputFiles ++ writeFunctionFiles)
     .flatMap {
-      case (name, files) => files.zipWithIndex.map {
+      case (fullyQualifiedName, files) => files.zipWithIndex.map {
         case (f, index) => TaskParameter(
-          Option(name + "." + index),
-          Option(workflowName + "." + name + "." + index),
+          Option(fullyQualifiedName + "." + index),
+          Option(workflowName + "." + fullyQualifiedName + "." + index),
           tesPaths.storageInput(f.value),
           tesPaths.containerInput(f.value),
           "File",
@@ -92,7 +91,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
   // if output paths are absolute we will ignore them here and assume they are redirects
   private val outputWdlFiles: Seq[WdlFile] = jobDescriptor.call.task
     .findOutputFiles(jobDescriptor.fullyQualifiedInputs, NoFunctions)
-    .filter(o => !Paths.get(o.valueString).isAbsolute)
+    .filter(o => !DefaultPathBuilder.get(o.valueString).isAbsolute)
 
   private val wdlOutputs = outputWdlFiles
     .zipWithIndex


### PR DESCRIPTION
Added note to the changelog.
Replaced usages of `cromwell.core.path.Obsolete._`.
Moved travis centaur tes back to using funnel from ohsu.