### PR TITLE
Updates for memory validations.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
@@ -115,6 +115,8 @@ object RuntimeAttributesValidation {
       override protected def missingValueMessage: String = validation.missingValueMessage
 
       override protected def usedInCallCaching: Boolean = validation.usedInCallCachingPackagePrivate
+
+      override protected def staticDefaultOption = validation.staticDefaultOption
     }
   }
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -246,7 +246,7 @@ backend {
     #    -o ${out} \
     #    -e ${err} \
     #    -pe smp ${cpu} \
-    #    ${"-l m_mem_free=" + memory_gb + "gb"} \
+    #    ${"-l mem_free=" + memory_gb + "g"} \
     #    ${"-q " + sge_queue} \
     #    ${"-P " + sge_project} \
     #    ${script}

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
@@ -1,12 +1,9 @@
 package cromwell.backend.impl.sfs.config
 
-import cromwell.backend.MemorySize
-import cromwell.backend.impl.sfs.config.ConfigConstants._
 import cromwell.backend.validation._
 import wdl4s.expression.NoFunctions
-import wdl4s.parser.MemoryUnit
 import wdl4s.types._
-import wdl4s.values.{WdlFloat, WdlInteger, WdlValue}
+import wdl4s.values.WdlValue
 import wdl4s.{Declaration, NoLookup, WdlExpression}
 
 /**
@@ -105,101 +102,5 @@ class DeclarationValidation(declaration: Declaration, instanceValidation: Runtim
     RuntimeAttributesValidation.extractOption(instanceValidation, validatedRuntimeAttributes) map {
       declaration.wdlType.coerceRawValue(_).get
     }
-  }
-}
-
-/**
-  * Maps declarations of memory in WDL runtime attributes to the commands used to submit.
-  *
-  * The wdl runtime attributes for memory specified as strings such as:
-  *
-  * {{{
-  *   runtime {
-  *     memory: "500 MB"
-  *   }
-  * }}}
-  *
-  * However, the backend configuration only supports specifying memory in amounts in Float or Int. To specify the unit
-  * of the amount, the string "memory_" is suffixed with the unit, for example "memory_mb" or "memory_gb", or even
-  * "memory_ki".
-  *
-  * This class and companion object will do the conversion. The backend configuration should use the runtime attribute
-  * "Float? memory_gb", meaning that "memory" is now an optional runtime attribute, and will be converted to GB.
-  *
-  * Just like the runtime attribute, when no units are specified the config, the default unit is bytes.
-  *
-  * @param declaration The declaration used to create this memory validation.
-  */
-class MemoryDeclarationValidation(declaration: Declaration)
-  extends DeclarationValidation(declaration, MemoryValidation.instance) {
-
-  import MemoryDeclarationValidation._
-
-  /**
-    * Converts the validation to a version with the default from the memory expression.
-    *
-    * If the backend configuration contains a runtime attribute such as "Float memory_gb = 1.0", then the default will
-    * be set to 1 GB of memory when the attribute is not set.
-    *
-    * @param validation    The validation to set the default for.
-    * @param wdlExpression The declaration expression to retrieve the default.
-    * @return The new validation.
-    */
-  override protected def default(validation: RuntimeAttributesValidation[_],
-                                 wdlExpression: WdlExpression): RuntimeAttributesValidation[_] = {
-    val wdlValue = declaration.expression.get.evaluate(NoLookup, NoFunctions).get
-    val amount: Double = wdlValue match {
-      case WdlInteger(value) => value.toDouble
-      case WdlFloat(value) => value
-      case other => throw new RuntimeException(s"Unsupported memory default: $other")
-    }
-    val memorySize = MemorySize(amount, declarationMemoryUnit)
-    validation.withDefault(WdlInteger(memorySize.bytes.toInt))
-  }
-
-  private lazy val declarationMemoryUnit: MemoryUnit = {
-    val suffix = memoryUnitSuffix(declaration.unqualifiedName)
-    val memoryUnitOption = MemoryUnit.values.find(_.suffixes.map(_.toLowerCase).contains(suffix.toLowerCase))
-    memoryUnitOption match {
-      case Some(memoryUnit) => memoryUnit
-      case None => throw new IllegalArgumentException(s"MemoryUnit with suffix $suffix was not found.")
-    }
-  }
-
-  /**
-    * Converts the memory value from a `MemorySize` to a `Float` or `Int` based on the units.
-    *
-    * @param validatedRuntimeAttributes The validated attributes.
-    * @return The value from the collection wrapped in `Some`, or `None` if the value wasn't found.
-    */
-  override def extractWdlValueOption(validatedRuntimeAttributes: ValidatedRuntimeAttributes): Option[WdlValue] = {
-    RuntimeAttributesValidation.extractOption(MemoryValidation.instance, validatedRuntimeAttributes) map { value =>
-      declaration.wdlType match {
-        case WdlIntegerType => WdlInteger(value.to(declarationMemoryUnit).amount.toInt)
-        case WdlFloatType => WdlFloat(value.to(declarationMemoryUnit).amount)
-        case other => throw new RuntimeException(s"Unsupported wdl type for memory: $other")
-      }
-    }
-  }
-}
-
-object MemoryDeclarationValidation {
-  def isMemoryDeclaration(name: String): Boolean = {
-    name match {
-      case MemoryRuntimeAttribute => true
-      case prefixed if prefixed.startsWith(MemoryRuntimeAttributePrefix) =>
-        val suffix = memoryUnitSuffix(name)
-        MemoryUnit.values exists {
-          _.suffixes.map(_.toLowerCase).contains(suffix)
-        }
-      case _ => false
-    }
-  }
-
-  private def memoryUnitSuffix(name: String) = {
-    if (name == MemoryRuntimeAttribute)
-      MemoryUnit.Bytes.suffixes.head
-    else
-      name.substring(MemoryRuntimeAttributePrefix.length)
   }
 }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/MemoryDeclarationValidation.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/MemoryDeclarationValidation.scala
@@ -1,0 +1,115 @@
+package cromwell.backend.impl.sfs.config
+
+import cromwell.backend.MemorySize
+import cromwell.backend.impl.sfs.config.ConfigConstants._
+import cromwell.backend.validation._
+import wdl4s.expression.NoFunctions
+import wdl4s.parser.MemoryUnit
+import wdl4s.types._
+import wdl4s.values.{WdlFloat, WdlInteger, WdlOptionalValue, WdlValue}
+import wdl4s.{Declaration, NoLookup, WdlExpression}
+
+/**
+  * Maps declarations of memory in WDL runtime attributes to the commands used to submit.
+  *
+  * The wdl runtime attributes for memory specified as strings such as:
+  *
+  * {{{
+  *   runtime {
+  *     memory: "500 MB"
+  *   }
+  * }}}
+  *
+  * However, the backend configuration only supports specifying memory in amounts in Float or Int. To specify the unit
+  * of the amount, the string "memory_" is suffixed with the unit, for example "memory_mb" or "memory_gb", or even
+  * "memory_ki".
+  *
+  * This class and companion object will do the conversion. The backend configuration should use the runtime attribute
+  * "Float? memory_gb", meaning that "memory" is now an optional runtime attribute, and will be converted to GB.
+  *
+  * Just like the runtime attribute, when no units are specified the config, the default unit is bytes.
+  *
+  * @param declaration The declaration used to create this memory validation.
+  */
+class MemoryDeclarationValidation(declaration: Declaration)
+  extends DeclarationValidation(declaration, MemoryValidation.instance) {
+
+  import MemoryDeclarationValidation._
+
+  /**
+    * Converts the validation to a version with the default from the memory expression.
+    *
+    * If the backend configuration contains a runtime attribute such as "Float memory_gb = 1.0", then the default will
+    * be set to 1 GB of memory when the attribute is not set.
+    *
+    * @param validation    The validation to set the default for.
+    * @param wdlExpression The declaration expression to retrieve the default.
+    * @return The new validation.
+    */
+  override protected def default(validation: RuntimeAttributesValidation[_],
+                                 wdlExpression: WdlExpression): RuntimeAttributesValidation[_] = {
+    val wdlValue = declaration.expression.get.evaluate(NoLookup, NoFunctions).get
+    val amount: Double = defaultAmount(wdlValue)
+    val memorySize = MemorySize(amount, declarationMemoryUnit)
+    validation.withDefault(WdlInteger(memorySize.bytes.toInt))
+  }
+
+  private def defaultAmount(wdlValue: WdlValue): Double = {
+    wdlValue match {
+      case WdlInteger(value) => value.toDouble
+      case WdlFloat(value) => value
+      case WdlOptionalValue(_, Some(optionalWdlValue)) => defaultAmount(optionalWdlValue)
+      case other => throw new RuntimeException(s"Unsupported memory default: $other")
+    }
+  }
+
+  private lazy val declarationMemoryUnit: MemoryUnit = {
+    val suffix = memoryUnitSuffix(declaration.unqualifiedName)
+    val memoryUnitOption = MemoryUnit.values.find(_.suffixes.map(_.toLowerCase).contains(suffix.toLowerCase))
+    memoryUnitOption match {
+      case Some(memoryUnit) => memoryUnit
+      case None => throw new IllegalArgumentException(s"MemoryUnit with suffix $suffix was not found.")
+    }
+  }
+
+  /**
+    * Converts the memory value from a `MemorySize` to a `Float` or `Int` based on the units.
+    *
+    * @param validatedRuntimeAttributes The validated attributes.
+    * @return The value from the collection wrapped in `Some`, or `None` if the value wasn't found.
+    */
+  override def extractWdlValueOption(validatedRuntimeAttributes: ValidatedRuntimeAttributes): Option[WdlValue] = {
+    RuntimeAttributesValidation.extractOption(MemoryValidation.instance, validatedRuntimeAttributes) map
+      coerceMemorySize(declaration.wdlType)
+  }
+
+  private def coerceMemorySize(wdlType: WdlType)(value: MemorySize): WdlValue = {
+    wdlType match {
+      case WdlIntegerType => WdlInteger(value.to(declarationMemoryUnit).amount.toInt)
+      case WdlFloatType => WdlFloat(value.to(declarationMemoryUnit).amount)
+      case WdlOptionalType(optionalType) => coerceMemorySize(optionalType)(value)
+      case other => throw new RuntimeException(s"Unsupported wdl type for memory: $other")
+    }
+  }
+}
+
+object MemoryDeclarationValidation {
+  def isMemoryDeclaration(name: String): Boolean = {
+    name match {
+      case MemoryRuntimeAttribute => true
+      case prefixed if prefixed.startsWith(MemoryRuntimeAttributePrefix) =>
+        val suffix = memoryUnitSuffix(name)
+        MemoryUnit.values exists {
+          _.suffixes.map(_.toLowerCase).contains(suffix)
+        }
+      case _ => false
+    }
+  }
+
+  private def memoryUnitSuffix(name: String) = {
+    if (name == MemoryRuntimeAttribute)
+      MemoryUnit.Bytes.suffixes.head
+    else
+      name.substring(MemoryRuntimeAttributePrefix.length)
+  }
+}

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/MemoryDeclarationValidationSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/MemoryDeclarationValidationSpec.scala
@@ -1,0 +1,98 @@
+package cromwell.backend.impl.sfs.config
+
+import com.typesafe.config.ConfigFactory
+import cromwell.backend.MemorySize
+import cromwell.backend.validation.{RuntimeAttributesKeys, ValidatedRuntimeAttributes}
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.parser.MemoryUnit
+import wdl4s.values.{WdlFloat, WdlInteger}
+
+class MemoryDeclarationValidationSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
+  behavior of "MemoryDeclarationValidation"
+
+  val validDeclaredAmounts = Table(
+    ("declaration", "runtimeAmount", "expectedDefaultAmount", "expectedExtracted"),
+    ("Int memory", Option(2), None, Option(WdlInteger(2 * 1000 * 1000 * 1000))),
+    ("Int memory_gb", Option(2), None, Option(WdlInteger(2))),
+    ("Int memory_gb = 3", None, Option(3), None),
+    ("Int memory_gb = 3", Option(2), Option(3), Option(WdlInteger(2))),
+    ("Int? memory_gb", None, None, None),
+    ("Int? memory_gb", Option(2), None, Option(WdlInteger(2))),
+    ("Int? memory_gb = 3", None, Option(3), None),
+    ("Int? memory_gb = 3", Option(2), Option(3), Option(WdlInteger(2))),
+    ("Float memory", Option(2), None, Option(WdlFloat(2 * 1000 * 1000 * 1000))),
+    ("Float memory_gb", Option(2), None, Option(WdlFloat(2))),
+    ("Float memory_gb = 3.0", None, Option(3), None),
+    ("Float memory_gb = 3.0", Option(2), Option(3), Option(WdlFloat(2))),
+    ("Float? memory_gb", None, None, None),
+    ("Float? memory_gb", Option(2), None, Option(WdlFloat(2))),
+    ("Float? memory_gb = 3.0", None, Option(3), None),
+    ("Float? memory_gb = 3.0", Option(2), Option(3), Option(WdlFloat(2)))
+  )
+
+  forAll(validDeclaredAmounts) { (declaration, runtimeAmount, expectedDefaultAmount, expectedExtracted) =>
+    it should s"extract memory from declared $declaration with memory set to ${runtimeAmount.getOrElse("none")}" in {
+      val config = ConfigFactory.parseString(
+        s"""|submit = "anything"
+            |${ConfigConstants.RuntimeAttributesConfig} = "$declaration"
+            |""".stripMargin)
+
+      val configWdlNamespace = new ConfigWdlNamespace(config)
+      val runtimeDeclaration = configWdlNamespace.runtimeDeclarations.head
+      val memoryDeclarationValidation = new MemoryDeclarationValidation(runtimeDeclaration)
+      val attributes = runtimeAmount
+        .map(amount => RuntimeAttributesKeys.MemoryKey -> MemorySize(amount.toDouble, MemoryUnit.GB))
+        .toMap
+      val validatedRuntimeAttributes = ValidatedRuntimeAttributes(attributes)
+
+      val default = memoryDeclarationValidation.makeValidation().runtimeAttributeDefinition.factoryDefault
+      val extracted = memoryDeclarationValidation.extractWdlValueOption(validatedRuntimeAttributes)
+
+      val expectedDefault = expectedDefaultAmount
+        .map(amount => WdlInteger(MemorySize(amount.toDouble, MemoryUnit.GB).bytes.toInt))
+
+      MemoryDeclarationValidation.isMemoryDeclaration(runtimeDeclaration.unqualifiedName) should be(true)
+      default should be(expectedDefault)
+      extracted should be(expectedExtracted)
+    }
+  }
+
+  val badSyntaxDeclarations = Table(
+    "declaration",
+    "Int memory_gb = 3.0",
+    "Float memory_gb = 3"
+  )
+
+  forAll(badSyntaxDeclarations) { declaration =>
+    it should s"throw a syntax error for memory declaration $declaration" in {
+      val config = ConfigFactory.parseString(
+        s"""|submit = "anything"
+            |${ConfigConstants.RuntimeAttributesConfig} = "$declaration"
+            |""".stripMargin)
+
+      val expectedException = intercept[RuntimeException](new ConfigWdlNamespace(config))
+      expectedException.getMessage should startWith("Error parsing generated wdl:\n")
+    }
+  }
+
+  val invalidDeclarations = Table(
+    "declaration",
+    "Int mem",
+    "Int memory_badunit",
+    "Float memory_badunit"
+  )
+
+  forAll(invalidDeclarations) { declaration =>
+    it should s"not identify $declaration as a memory declaration" in {
+      val config = ConfigFactory.parseString(
+        s"""|submit = "anything"
+            |${ConfigConstants.RuntimeAttributesConfig} = "$declaration"
+            |""".stripMargin)
+
+      val configWdlNamespace = new ConfigWdlNamespace(config)
+      val runtimeDeclaration = configWdlNamespace.runtimeDeclarations.head
+      MemoryDeclarationValidation.isMemoryDeclaration(runtimeDeclaration.unqualifiedName) should be(false)
+    }
+  }
+}


### PR DESCRIPTION
Fixed SGE memory parameter in reference.conf.
Split `MemoryDeclarationValidation` out of `DeclarationValidation`.
Added tests for `MemoryDeclarationValidation`.
`OptionalRuntimeAttributesValidation` were not returning the defaults from the underlying `RuntimeAttributesValidation`.