### PR TITLE
Slightly better abort behavior in standard backend.

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -90,6 +90,12 @@ trait CallMetadataHelper {
     serviceRegistryActor ! PutMetadataAction(completionEvents ++ failureEvents)
   }
 
+  def pushAbortedCallMetadata(jobKey: JobKey) = {
+    val completionEvents = completedCallMetadataEvents(jobKey, ExecutionStatus.Aborted, None)
+
+    serviceRegistryActor ! PutMetadataAction(completionEvents)
+  }
+
   def pushExecutionEventsToMetadataService(jobKey: JobKey, eventList: Seq[ExecutionEvent]) = {
     def metadataEvent(k: String, value: Any) = {
       val metadataValue = MetadataValue(value)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -74,8 +74,6 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     Run(job.jobId, initializationData.genomics).abort()
   }
 
-  override def requestsAbortAndDiesImmediately: Boolean = true
-
   override def receive: Receive = pollingActorClientReceive orElse super.receive
 
   private def gcsAuthParameter: Option[JesInput] = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -143,8 +143,6 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     ()
   }
 
-  override def requestsAbortAndDiesImmediately: Boolean = true
-
   override def pollStatusAsync(handle: StandardAsyncPendingExecutionHandle)(implicit ec: ExecutionContext): Future[TesRunStatus] = {
     val pollTask = pipeline[TesGetResponse].apply(Get(s"$tesEndpoint/${handle.pendingJob.jobId}"))
 


### PR DESCRIPTION
Stopped closing a scala `Future` over akka's `context.become`.
Flipped the default for `requestsAbortAndDiesImmediately` from `false` to `true`.
When killing a Standard backend job with rADI false, both the rc and the standard error are required.
Writing the stderr on abort for the SFS backend.
When rADI is true, sending a backend status of `"Aborted"`.
In the engine, set and store the `ExecutionStatus.Aborted`.