### PR TITLE
Use mktemp to make temporary directory Fixes #2047

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -176,7 +176,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     val globFiles = backendEngineFunctions.findGlobOutputs(call, jobDescriptor)
 
     s"""|#!/bin/bash
-        |tmpDir=$$(mktemp -d -p $cwd) 
+        |tmpDir=$$(mktemp -d $cwd/tmp.XXXXXX) 
         |export _JAVA_OPTIONS=-Djava.io.tmpdir=$$tmpDir
         |export TMPDIR=$$tmpDir
         |$commandScriptPreamble

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -170,16 +170,15 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     jobLogger.info(s"`$instantiatedCommand`")
 
     val cwd = commandDirectory
-    val tmpDir = cwd./("tmp")
     val rcPath = cwd./(jobPaths.returnCodeFilename)
     val rcTmpPath = rcPath.plusExt("tmp")
 
     val globFiles = backendEngineFunctions.findGlobOutputs(call, jobDescriptor)
 
     s"""|#!/bin/bash
-        |export _JAVA_OPTIONS=-Djava.io.tmpdir=$tmpDir
-        |export TMPDIR=$tmpDir
-        |mkdir -p $tmpDir
+        |tmpDir=$$(mktemp -d -p $cwd) 
+        |export _JAVA_OPTIONS=-Djava.io.tmpdir=$$tmpDir
+        |export TMPDIR=$$tmpDir
         |$commandScriptPreamble
         |(
         |cd $cwd


### PR DESCRIPTION
`mktemp` exists on all mainstream Linux distros, also BSD and OSX. It creates a temporary file or directory with a name containing a random string so you won't get the name clash.