### PR TITLE
temporary directory should be world writeable

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -177,6 +177,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
 
     s"""|#!/bin/bash
         |tmpDir=$$(mktemp -d $cwd/tmp.XXXXXX) 
+        |chmod 777 $$tmpDir
         |export _JAVA_OPTIONS=-Djava.io.tmpdir=$$tmpDir
         |export TMPDIR=$$tmpDir
         |$commandScriptPreamble


### PR DESCRIPTION
Not a huge deal, but otherwise the temp directory may only be accessible by the container user (likely root) without a `sudo`.  This can be an issue when trying to scan or clean up the workflow directory.