### PR TITLE
Failure metadata redux

### DIFF
--- a/engine/src/main/scala/cromwell/engine/engine.scala
+++ b/engine/src/main/scala/cromwell/engine/engine.scala
@@ -1,7 +1,5 @@
 package cromwell.engine
 
-import java.time.OffsetDateTime
-
 import wdl4s._
 
 import scala.util.{Failure, Success, Try}
@@ -9,7 +7,6 @@ import scala.util.{Failure, Success, Try}
 final case class AbortFunction(function: () => Unit)
 final case class AbortRegistrationFunction(register: AbortFunction => Unit)
 
-final case class FailureEventEntry(failure: String, timestamp: OffsetDateTime)
 final case class CallAttempt(fqn: FullyQualifiedName, attempt: Int)
 
 object WorkflowFailureMode {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -85,7 +85,7 @@ trait CallMetadataHelper {
     val failedState = if (retryableFailure) ExecutionStatus.Preempted else ExecutionStatus.Failed
     val completionEvents = completedCallMetadataEvents(jobKey, failedState, returnCode)
     val retryableFailureEvent = MetadataEvent(metadataKeyForCall(jobKey, CallMetadataKeys.RetryableFailure), MetadataValue(retryableFailure))
-    val failureEvents = throwableToMetadataEvents(metadataKeyForCall(jobKey, s"${CallMetadataKeys.Failures}[$randomNumberString]"), failure).+:(retryableFailureEvent)
+    val failureEvents = throwableToMetadataEvents(metadataKeyForCall(jobKey, s"${CallMetadataKeys.Failures}"), failure).+:(retryableFailureEvent)
 
     serviceRegistryActor ! PutMetadataAction(completionEvents ++ failureEvents)
   }
@@ -137,5 +137,5 @@ trait CallMetadataHelper {
   private def metadataKeyForCall(jobKey: JobKey, myKey: String) = MetadataKey(workflowIdForCallMetadata, Option(MetadataJobKey(jobKey.scope.fullyQualifiedName, jobKey.index, jobKey.attempt)), myKey)
 
   private def randomNumberString: String = Random.nextInt.toString.stripPrefix("-")
-  
+
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowMetadataHelper.scala
@@ -7,8 +7,6 @@ import cromwell.core.{WorkflowId, WorkflowMetadataKeys, WorkflowState}
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 
-import scala.util.Random
-
 trait WorkflowMetadataHelper {
 
   def serviceRegistryActor: ActorRef
@@ -24,7 +22,7 @@ trait WorkflowMetadataHelper {
   }
   
   def pushWorkflowFailures(workflowId: WorkflowId, failures: List[Throwable]) = {
-    val failureEvents = failures flatMap { r => throwableToMetadataEvents(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Failures}[${Random.nextInt(Int.MaxValue)}]"), r) }
+    val failureEvents = failures flatMap { r => throwableToMetadataEvents(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Failures}"), r) }
     serviceRegistryActor ! PutMetadataAction(failureEvents)
   }
   

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -43,7 +43,6 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit val unqualifiedFailureEventEntry = jsonFormat2(FailureEventEntry)
   implicit val workflowQueryResult = jsonFormat5(WorkflowQueryResult)
   implicit val workflowQueryResponse = jsonFormat1(WorkflowQueryResponse)
 }

--- a/engine/src/test/scala/cromwell/MetadataWatchActor.scala
+++ b/engine/src/test/scala/cromwell/MetadataWatchActor.scala
@@ -23,7 +23,7 @@ final case class MetadataWatchActor(promise: Promise[Unit], matchers: Matcher*) 
         ()
       }
     case PutMetadataAction(_) => // Superfluous message. Ignore
-    case _ => throw new Exception("Invalid message to MetadataWatchActor")
+    case other => throw new Exception(s"Invalid message to MetadataWatchActor: $other")
   }
 }
 
@@ -69,6 +69,7 @@ object MetadataWatchActor {
     }
   }
 
-  val failurePattern = """failures\[\d*\].message"""
+  val failurePattern = """failures\[\d*\].*\:message"""
+  // val failurePattern = """failures\[\d*\]\:message"""
   final case class FailureMatcher(value: String) extends KeyMatchesRegexAndValueContainsStringMatcher(failurePattern, value) { }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -41,7 +41,7 @@ object SingleWorkflowRunnerActorSpec {
 
   implicit class OptionJsValueEnhancer(val jsValue: Option[JsValue]) extends AnyVal {
     def toOffsetDateTime = OffsetDateTime.parse(jsValue.toStringValue)
-    def toStringValue = jsValue.get.asInstanceOf[JsString].value
+    def toStringValue = jsValue.getOrElse(JsString("{}")).asInstanceOf[JsString].value
     def toFields = jsValue.get.asJsObject.fields
   }
 

--- a/services/src/test/scala/cromwell/services/metadata/MetadataServiceSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataServiceSpec.scala
@@ -1,6 +1,9 @@
 package cromwell.services.metadata
 
+import java.util.UUID
+
 import cromwell.core.WorkflowId
+import lenthall.exception.AggregatedException
 import org.scalactic.Equality
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
@@ -74,4 +77,135 @@ class MetadataServiceSpec extends FlatSpec with Matchers with TableDrivenPropert
     }
   }
 
+  // For the metadata event tests!
+  val failureMessageRegex = "([^\\[]*)\\[([0-9]+)\\](.*)\\:message".r
+  val pathToFailures = "path:to:failures"
+
+  it should "convert an exception into a failure event with an empty causedBy block" in {
+    import MetadataService.throwableToMetadataEvents
+
+    val workflowId = WorkflowId(UUID.randomUUID())
+    val mdkey = MetadataKey(workflowId, None, pathToFailures)
+
+    val tMsg = "The Oscars suck!"
+    val t = new RuntimeException(tMsg)
+
+    val events = throwableToMetadataEvents(mdkey, t)
+    events.size should be(2)
+    val (keyPrefix, causedBys, failureIndex) = validateExceptionMessage(events.head, workflowId, tMsg)
+    keyPrefix should be(pathToFailures)
+    causedBys should be("")
+    events(1).key.key should be(s"$keyPrefix[$failureIndex]:causedBy[]")
+    events(1).key.workflowId should be(workflowId)
+    events(1).value should be(None)
+
+  }
+
+  it should "convert nested exceptions into a sequence of failure events" in {
+    import MetadataService.throwableToMetadataEvents
+
+    val workflowId = WorkflowId(UUID.randomUUID())
+    val mdkey = MetadataKey(workflowId, None, pathToFailures)
+
+    val innerCauseMsg = "Envelope malfunctions"
+    val innerCause = new RuntimeException(innerCauseMsg)
+
+    val causeMsg = "Wrong recipients"
+    val cause = new RuntimeException(causeMsg, innerCause)
+
+    val tMsg = "The Oscars suck!"
+    val t = new RuntimeException(tMsg, cause)
+
+    val events = throwableToMetadataEvents(mdkey, t)
+    events.size should be(4)
+
+    val (outerPrefix, outerCausedBys, outerFailureId) = validateExceptionMessage(events.head, workflowId, tMsg)
+    val (cause1Prefix, cause1CausedBys, cause1FailureId) = validateExceptionMessage(events(1), workflowId, causeMsg)
+    val (cause2Prefix, cause2CausedBys, cause2FailureId) = validateExceptionMessage(events(2), workflowId, innerCauseMsg)
+    events(3).key.key should be(s"$cause2Prefix[$cause2FailureId]$cause2CausedBys:causedBy[]")
+
+    outerPrefix should be(pathToFailures)
+    cause1Prefix should be(pathToFailures)
+    cause2Prefix should be(pathToFailures)
+    outerCausedBys should be("")
+    cause1CausedBys should be(":causedBy[0]")
+    cause2CausedBys should be(":causedBy[0]:causedBy[0]")
+    cause1FailureId should be(outerFailureId)
+    cause2FailureId should be(cause1FailureId)
+  }
+
+  it should "convert aggregated exceptions into a sequence of failure events" in {
+    import MetadataService.throwableToMetadataEvents
+
+    val workflowId = WorkflowId(UUID.randomUUID())
+    val mdkey = MetadataKey(workflowId, None, "path:to:failures")
+
+    val innerCauseMsg = "Envelope malfunctions"
+    val innerCause = new RuntimeException(innerCauseMsg)
+
+    val cause1Msg = "Wrong recipients"
+    val cause1 = new RuntimeException(cause1Msg)
+    val cause2Msg = "Self congratulation"
+    val cause2 = new RuntimeException(cause2Msg, innerCause)
+    val cause3Msg = "The Globes are better anyway"
+    val cause3 = new RuntimeException(cause3Msg)
+
+    val causeContext = "Compound Entertainment Failure"
+    val cause = new AggregatedException(causeContext, List(cause1, cause2, cause3))
+
+    val tMsg = "The Oscars suck!"
+    val t = new RuntimeException(tMsg, cause)
+
+    val events = throwableToMetadataEvents(mdkey, t)
+    events.size should be(9)
+
+    // Outer runtime exception:
+    val (runtimePrefix, runtimeCausedBys, runtimeFailureId) = validateExceptionMessage(events.head, workflowId, tMsg)
+    runtimePrefix should be(pathToFailures)
+    runtimeCausedBys should be("")
+
+    // Aggregate exception:
+    val (aggregatePrefix, aggregateCausedBys, aggregateFailureId) = validateExceptionMessage(events(1), workflowId, causeContext)
+    aggregatePrefix should be(pathToFailures)
+    aggregateCausedBys should be(":causedBy[0]")
+    aggregateFailureId should be(runtimeFailureId)
+
+    // cause1, caused by []
+    val (cause1Prefix, cause1CausedBys, cause1FailureId) = validateExceptionMessage(events(2), workflowId, cause1Msg)
+    cause1Prefix should be(pathToFailures)
+    cause1CausedBys should be(":causedBy[0]:causedBy[0]")
+    cause1FailureId should be(runtimeFailureId)
+    events(3).key.key should be(s"$cause1Prefix[$runtimeFailureId]$cause1CausedBys:causedBy[]")
+
+    // cause2, caused by innerCause caused by []
+    val (cause2Prefix, cause2CausedBys, cause2FailureId) = validateExceptionMessage(events(4), workflowId, cause2Msg)
+    val (innerCausePrefix, innerCauseCausedBys, innerCauseFailureIds) = validateExceptionMessage(events(5), workflowId, innerCauseMsg)
+    cause2Prefix should be(pathToFailures)
+    cause2CausedBys should be(":causedBy[0]:causedBy[1]")
+    cause2FailureId should be(runtimeFailureId)
+    innerCausePrefix should be(pathToFailures)
+    innerCauseCausedBys should be(":causedBy[0]:causedBy[1]:causedBy[0]")
+    innerCauseFailureIds should be(runtimeFailureId)
+    events(6).key.key should be(s"$innerCausePrefix[$runtimeFailureId]$innerCauseCausedBys:causedBy[]")
+
+    // cause3, caused by []
+    val (cause3Prefix, cause3CausedBys, cause3FailureId) = validateExceptionMessage(events(7), workflowId, cause3Msg)
+    cause3Prefix should be(pathToFailures)
+    cause3CausedBys should be(":causedBy[0]:causedBy[2]")
+    cause3FailureId should be(runtimeFailureId)
+    events(8).key.key should be(s"$cause3Prefix[$cause3FailureId]$cause3CausedBys:causedBy[]")
+  }
+
+  def validateExceptionMessage(event: MetadataEvent, workflowId: WorkflowId, message: String) = event match {
+    case MetadataEvent(k, Some(MetadataValue(v, _)), _) =>
+      k.workflowId should be(workflowId)
+      v should be(message)
+
+      // Return the ID so that we can check for uniqueness later:
+      k.key match {
+        case failureMessageRegex(prefix, failureIndex, causedBys) => (prefix, causedBys, failureIndex)
+        case _ => fail("Unexpected failure key format: " + k.key)
+      }
+    case _ => fail("throwableToMetadataEvents generated a metadata event without a metadata value! Bad throwableToMetadataEvents! Very bad!")
+  }
 }


### PR DESCRIPTION
For example, test 3 represents:
```
E1
 caused By A1
  - E2
      caused by E3
  - E4
  - E5
```

Being converted into this:
```
failures: [{
  message: "E1",
  causedBy: [{
    message: "A1",
    causedBy: [{
      message: "E2",
      causedBy: [{
        message: "E3",
        causedBy: []
      }]
    }, {
      message: "E4",
      causedBy: []
    }, {
      message: "E5",
      causedBy: []
    }]
  }]
}]
```