### PR TITLE
stage required config changes for funnel (TES Backend)

### DIFF
--- a/src/bin/travis/resources/tes.conf
+++ b/src/bin/travis/resources/tes.conf
@@ -7,9 +7,13 @@ Storage:
         - /cromwell-executions
         - /tmp/
 DBPath: /tmp/tes_task.db
-Schedulers:
-  Local:
-    NumWorkers: 4
+Scheduler: local
 Worker:
   LogLevel: info
-  Timeout: 1
+  Timeout: -1
+  # Funnel (TES implementation) respects resource reqs
+  # Defaults 1 cpu 2 GB ram would make centaur take too long to run
+  Resources:
+    cpus: 100
+    ram: 200
+    disk: 1000


### PR DESCRIPTION
Once we merge PR #15, funnel is going to start respecting resource requests from tasks.  The defaults in the Cromwell TES backend are 1 cpu and 2 GB of RAM.  So if we want the centaur tests to finish in a reasonable timeframe we need to hard code in local resources into Funnel's config. 

