### PR TITLE
Update docker lookup

### DIFF
--- a/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
@@ -25,7 +25,7 @@ trait RobustClientHelper { this: Actor with ActorLogging =>
   protected def backpressureRandomizerFactor: Double = 0.5D
   
   private [core] def robustReceive: Receive = {
-    case Backpressure(request) => 
+    case BackPressure(request) => 
       val snd = sender()
       newTimer(request, snd, generateBackpressureTime)
       resetTimeout(request, snd)

--- a/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
@@ -67,7 +67,7 @@ trait StreamActorHelper[T <: StreamContext] { this: Actor with ActorLogging =>
   
   private def backpressure(commandContext: StreamContext) = {
     val originalRequest = commandContext.clientContext map { _ -> commandContext.request } getOrElse commandContext.request
-    commandContext.replyTo ! Backpressure(originalRequest)
+    commandContext.replyTo ! BackPressure(originalRequest)
   }
 
   private def streamReceive: Receive = {

--- a/core/src/main/scala/cromwell/core/actor/StreamIntegration.scala
+++ b/core/src/main/scala/cromwell/core/actor/StreamIntegration.scala
@@ -10,6 +10,6 @@ object StreamIntegration {
     def clientContext: Option[Any] = None
   }
   case class EnqueueResponse(response: QueueOfferResult, request: StreamContext)
-  case class Backpressure(request: Any)
+  case class BackPressure(request: Any)
   case class FailedToEnqueue(failure: Throwable, request: StreamContext)
 }

--- a/core/src/main/scala/cromwell/core/callcaching/docker/DockerClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/DockerClientHelper.scala
@@ -1,0 +1,27 @@
+package cromwell.core.callcaching.docker
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import cromwell.core.actor.RobustClientHelper
+import cromwell.core.callcaching.docker.DockerHashActor.DockerHashResponse
+
+import scala.concurrent.duration.FiniteDuration
+
+trait DockerClientHelper extends RobustClientHelper { this: Actor with ActorLogging =>
+  
+  protected def dockerHashingActor: ActorRef
+  
+  private [core] def dockerResponseReceive: Receive = {
+    case dockerResponse: DockerHashResponse if hasTimeout(dockerResponse.request) =>
+      cancelTimeout(dockerResponse.request)
+      receive.apply(dockerResponse)
+    case (context: Any, dockerResponse: DockerHashResponse) if hasTimeout(context -> dockerResponse.request) =>
+      cancelTimeout(context -> dockerResponse.request)
+      receive.apply(context -> dockerResponse)
+  }
+
+  def sendDockerCommand(dockerHashRequest: DockerHashRequest, timeout: FiniteDuration = RobustClientHelper.DefaultRequestLostTimeout) = {
+    robustSend(dockerHashRequest, dockerHashingActor, timeout)
+  }
+
+  def dockerReceive = robustReceive orElse dockerResponseReceive
+}

--- a/core/src/main/scala/cromwell/core/callcaching/docker/DockerHashActor.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/DockerHashActor.scala
@@ -1,16 +1,14 @@
 package cromwell.core.callcaching.docker
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import akka.pattern.pipe
-import akka.stream.QueueOfferResult.{Dropped, Enqueued, QueueClosed}
 import akka.stream._
 import akka.stream.scaladsl.{GraphDSL, Merge, Partition, Sink, Source}
 import com.google.common.cache.CacheBuilder
-import cromwell.core.actor.StreamActorHelper.ActorRestartException
+import cromwell.core.actor.StreamActorHelper
+import cromwell.core.actor.StreamIntegration.StreamContext
 import cromwell.core.callcaching.docker.DockerHashActor._
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
 final class DockerHashActor(
@@ -18,10 +16,9 @@ final class DockerHashActor(
                            queueBufferSize: Int,
                            cacheEntryTTL: FiniteDuration,
                            cacheSize: Long
-                          )(implicit val materializer: ActorMaterializer) extends Actor with ActorLogging {
+                          )(implicit val materializer: ActorMaterializer) extends Actor with ActorLogging with StreamActorHelper[DockerHashContext] {
 
   implicit val system = context.system
-  implicit val ec = context.dispatcher
   
   /* Use the guava CacheBuilder class that implements a thread safe map with built in cache features.
    * https://google.github.io/guava/releases/20.0/api/docs/com/google/common/cache/CacheBuilder.html
@@ -48,13 +45,6 @@ final class DockerHashActor(
     .expireAfterWrite(cacheEntryTTL._1, cacheEntryTTL._2)
     .maximumSize(cacheSize)
     .build[DockerImageIdentifierWithoutHash, DockerHashResult]()
-  
-  /*
-   * Never fail the stream, if an exception occurs just drop the element
-   * The sender is responsible for sending a new message if it didn't get a response
-   * within a reasonable amount of time
-   */
-  private val decider: Supervision.Decider = _ => Supervision.Resume
 
   /*
    * Intermediate sink responsible for updating the cache as soon as a successful hash is retrieved
@@ -63,13 +53,6 @@ final class DockerHashActor(
     case (response: DockerHashResponseSuccess, dockerHashContext) => 
       cache.put(dockerHashContext.dockerImageID, response.dockerHash)
     case _ => // Only put successful hashes in the cache
-  }
-  
-  /*
-   * Final sink of the stream. Sends the response to the caller.
-   */
-  private val replySink = Sink.foreach[(DockerHashResponse, DockerHashContext)] {
-    case (response, dockerHashContext) => dockerHashContext.replyTo ! response
   }
 
   /*
@@ -105,65 +88,32 @@ final class DockerHashActor(
       partitionFlows.out(i) ~> flows(i) ~> mergeFlows.in(i)
     }
 
-    val noMatch = partitionFlows.out(dockerRegistryFlows.size).map(dockerContext => (DockerHashUnknownRegistry(dockerContext.dockerImageID), dockerContext)).outlet
+    val noMatch = partitionFlows.out(dockerRegistryFlows.size).map(dockerContext => (DockerHashUnknownRegistry(dockerContext.request), dockerContext)).outlet
     
     noMatch ~> mergeFlows.in(dockerRegistryFlows.size)
     
     FlowShape(partitionFlows.in, mergeFlows.out)
   }
 
-  private val queue = Source.queue[DockerHashContext](queueBufferSize, OverflowStrategy.dropNew)
-    .via(dockerFlow)
-    .alsoTo(updateCacheSink)
-    .to(replySink)
-    .withAttributes(ActorAttributes.supervisionStrategy(decider))
-    .run()
-  
-  override def receive: Receive = {
-    // When receiving a request, just enqueue it and pipe the result back to self
-    // Note: could be worth having another actor to send it to, to prevent overflowing this mailbox
+  private def checkCache(dockerHashRequest: DockerHashRequest) = {
+    Option(cache.getIfPresent(dockerHashRequest.dockerImageID)) map { hashResult => 
+      DockerHashResponseSuccess(hashResult, dockerHashRequest) 
+    }
+  }
+
+  override protected def actorReceive: Receive = {
     case request: DockerHashRequest =>
       val replyTo = sender()
-      
-      checkCache(request.dockerImageID) match {
+
+      checkCache(request) match {
         case Some(cacheHit) => replyTo ! cacheHit
         case None => sendToStream(DockerHashContext(request, replyTo))
       }
-    case EnqueueResponse(Enqueued, dockerHashContext) => // All good !
-    case EnqueueResponse(Dropped, dockerHashContext) => dockerHashContext.replyTo ! DockerHashBackPressure(dockerHashContext.request)
-      // In any of the below case, the stream is in a state where it will not be able to receive new elements.
-      // This means something blew off so we can just restart the actor to re-instantiate a new stream
-    case EnqueueResponse(QueueClosed, dockerHashContext) =>
-      val exception = new RuntimeException(s"Failed to enqueue docker hash request ${dockerHashContext.request}. Queue was closed")
-      logAndRestart(exception)
-    case EnqueueResponse(QueueOfferResult.Failure(failure), dockerHashContext) => 
-      logAndRestart(failure)
-    case FailedToEnqueue(throwable, dockerHashContext) =>
-      logAndRestart(throwable)
   }
-  
-  private def logAndRestart(throwable: Throwable) = {
-    log.warning("Failed to process docker hash request", throwable)
-    // Throw the exception that will be caught by supervisor and restart the actor
-    throw DockerHashActorException(throwable)
-  }
-  
-  private def checkCache(dockerImageIdentifierWithoutHash: DockerImageIdentifierWithoutHash) = {
-    Option(cache.getIfPresent(dockerImageIdentifierWithoutHash)) map { hashResult => 
-      DockerHashResponseSuccess(hashResult) 
-    }
-  }
-  
-  private def sendToStream(dockerHashContext: DockerHashContext) = {
-    val enqueue = queue offer dockerHashContext map { result =>
-      EnqueueResponse(result, dockerHashContext)
-    } recoverWith {
-      case t => Future.successful(FailedToEnqueue(t, dockerHashContext))
-    }
 
-    pipe(enqueue) to self
-    ()
-  }
+  override protected def streamSource = Source.queue[DockerHashContext](queueBufferSize, OverflowStrategy.dropNew)
+    .via(dockerFlow)
+    .alsoTo(updateCacheSink)
 }
 
 object DockerHashActor {
@@ -171,31 +121,30 @@ object DockerHashActor {
   val logger = LoggerFactory.getLogger("DockerRegistry")
 
   /* Response Messages */
-  sealed trait DockerHashResponse
+  sealed trait DockerHashResponse {
+    def request: DockerHashRequest
+  }
   
-  case class DockerHashResponseSuccess(dockerHash: DockerHashResult) extends DockerHashResponse
+  case class DockerHashResponseSuccess(dockerHash: DockerHashResult, request: DockerHashRequest) extends DockerHashResponse
   
   sealed trait DockerHashFailureResponse extends DockerHashResponse {
     def reason: String
   }
-  case class DockerHashFailedResponse(failure: Throwable, dockerIdentifier: DockerImageIdentifierWithoutHash) extends DockerHashFailureResponse {
-    override val reason = s"Failed to get docker hash for ${dockerIdentifier.fullName} ${failure.getMessage}"
+  case class DockerHashFailedResponse(failure: Throwable, request: DockerHashRequest) extends DockerHashFailureResponse {
+    override val reason = s"Failed to get docker hash for ${request.dockerImageID.fullName} ${failure.getMessage}"
   }
-  case class DockerHashUnknownRegistry(dockerImageId: DockerImageIdentifierWithoutHash) extends DockerHashFailureResponse {
-    override val reason = s"Registry ${dockerImageId.host} is not supported"
+  case class DockerHashUnknownRegistry(request: DockerHashRequest) extends DockerHashFailureResponse {
+    override val reason = s"Registry ${request.dockerImageID.host} is not supported"
   }
-  case class DockerHashNotFound(dockerImageId: DockerImageIdentifierWithoutHash) extends DockerHashFailureResponse {
-    override val reason = s"Docker image ${dockerImageId.fullName} not found"
+  case class DockerHashNotFound(request: DockerHashRequest) extends DockerHashFailureResponse {
+    override val reason = s"Docker image ${request.dockerImageID.fullName} not found"
   }
-  case class DockerHashUnauthorized(dockerImageId: DockerImageIdentifierWithoutHash) extends DockerHashFailureResponse {
-    override val reason = s"Unauthorized to get docker hash ${dockerImageId.fullName}"
+  case class DockerHashUnauthorized(request: DockerHashRequest) extends DockerHashFailureResponse {
+    override val reason = s"Unauthorized to get docker hash ${request.dockerImageID.fullName}"
   }
 
-  case class DockerHashBackPressure(originalRequest: DockerHashRequest) extends DockerHashResponse
-  case class DockerHashActorException(failure: Throwable) extends ActorRestartException(failure)
-  
   /* Internal ADTs */
-  case class DockerHashContext(request: DockerHashRequest, replyTo: ActorRef) {
+  case class DockerHashContext(request: DockerHashRequest, replyTo: ActorRef) extends StreamContext {
     val dockerImageID = request.dockerImageID
     val credentials = request.credentials
   }

--- a/core/src/main/scala/cromwell/core/callcaching/docker/DockerHashActor.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/DockerHashActor.scala
@@ -4,6 +4,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.stream._
 import akka.stream.scaladsl.{GraphDSL, Merge, Partition, Sink, Source}
 import com.google.common.cache.CacheBuilder
+import cromwell.core.Dispatcher
 import cromwell.core.actor.StreamActorHelper
 import cromwell.core.actor.StreamIntegration.StreamContext
 import cromwell.core.callcaching.docker.DockerHashActor._
@@ -114,6 +115,7 @@ final class DockerHashActor(
   override protected def streamSource = Source.queue[DockerHashContext](queueBufferSize, OverflowStrategy.dropNew)
     .via(dockerFlow)
     .alsoTo(updateCacheSink)
+    .withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
 }
 
 object DockerHashActor {

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/HttpFlowWithRetry.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/HttpFlowWithRetry.scala
@@ -1,30 +1,53 @@
 package cromwell.core.callcaching.docker.registryv2.flows
 
 import akka.NotUsed
+import akka.actor.Scheduler
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
-import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
-import akka.stream.{FanOutShape2, OverflowStrategy}
+import akka.stream.FanOutShape2
+import akka.stream.javadsl.MergePreferred
+import akka.stream.scaladsl.{Flow, GraphDSL, Partition}
 import cromwell.core.callcaching.docker.registryv2.flows.FlowUtils._
 import cromwell.core.callcaching.docker.registryv2.flows.HttpFlowWithRetry._
+import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
 
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 import scala.util.Try
 
 object HttpFlowWithRetry {
-  def defaultIsRetryable(response: HttpResponse) = {
+  def isRetryable(response: HttpResponse) = {
+    response.status match {
+      case StatusCodes.InternalServerError => true
+      case StatusCodes.ServiceUnavailable => true
+      case StatusCodes.BadGateway => true
+      case StatusCodes.GatewayTimeout => true
+      case StatusCodes.RequestTimeout => true
+      case other => isTransient(response)
+    }
+  }
+
+  def isTransient(response: HttpResponse) = {
     response.status match {
       case StatusCodes.TooManyRequests => true
-      case StatusCodes.InternalServerError => true
       case _ => false
     }
   }
 
+  def defaultRequestBackoff(): Backoff = SimpleExponentialBackoff(1 second, 2 minutes, 3D)
+  
   /**
     * In order to allow for retries, the http context object needs to encapsulate the original request,
     * so that it can be re-submitted if necessary.
     * This type provides this encapsulation by creating a pair of (T, HttpRequest) where T is the custom type that
     * the user wishes to use as a context for their specific use case.
     */
-  type ContextWithRequest[T] = (T, HttpRequest)
+  case class ContextWithRequest[T](userContext: T, request: HttpRequest, currentAttempt: Int, backoff: Backoff) {
+    // Backoff is mutable ! This will change every time !
+    def retryIn = backoff.backoffMillis.millis
+    
+    def withNextAttempt = copy(currentAttempt = currentAttempt + 1)
+  }
 
   /**
     * Type for a http flow using ContextWithRequest as context type.
@@ -37,16 +60,16 @@ object HttpFlowWithRetry {
   * @param httpClientFlow The akka http flow to use underneath
   * @param retryBufferSize size of the buffer for requests to be retried. When the buffer is full, requests WILL BE DROPPED
   *                        Act accordingly by resubmitting requests after a certain amount of time with no response for example.
-  * @param isRetryable function to determine weather or not an http request should be retried based on the http response                        
   * @tparam T Type of the context data to be passed along with the request
   * @return A http flow that will retry on request failures and on failed responses as seen fit by the isRetryable method
   */
 case class HttpFlowWithRetry[T](
                             httpClientFlow: RetryableHttpFlow[T],
-                            retryBufferSize: Int = 1000,
-                            isRetryable: HttpResponse => Boolean = defaultIsRetryable
-                          ) {
-
+                            retryBufferSize: Int = 100,
+                            requestBackoff: () => Backoff = defaultRequestBackoff,
+                            maxAttempts: Int = 3
+                          )(implicit val scheduler: Scheduler, ec: ExecutionContext) {
+  
   lazy val flow = GraphDSL.create() { implicit builder =>
     import GraphDSL.Implicits._
 
@@ -55,66 +78,77 @@ case class HttpFlowWithRetry[T](
     
     // Wrap the user context into a pair of (flowContext, httpRequest) to allow for retries
     val source = builder.add(Flow[(HttpRequest, T)] map {
-      case (httpRequest, flowContext) => (httpRequest, (flowContext, httpRequest))
+      case (httpRequest, flowContext) => (httpRequest, ContextWithRequest(flowContext, httpRequest, 1, requestBackoff()))
     })
     
     // Partition Try[HttpResponse] into Success and Failure
-    val partitionResponseTry = builder.add(fanOutTry[HttpResponse, (T, HttpRequest)])
+    val partitionResponseTry = builder.add(fanOutTry[HttpResponse, ContextWithRequest[T]])
     
+    // Those are pairs like: (HttpResponse, Context) 
     val requestSuccessful = partitionResponseTry.out0
-    // Extract the request from the failed try so it can be resubmitted
-    val requestFailed = partitionResponseTry.out1.log("request failed") map toRetryableRequest
+    
+    // Those are pairs like: (Throwable, Context) 
+    // -> akka-http already retries request if they fail, so we won't retry this and send it to the failure port
+    val requestFailed = partitionResponseTry.out1 map {
+      case (failure, ContextWithRequest(flowContext, _, _, _)) => failure -> flowContext
+    }
+
+    // Splits successful http response into 2 categories:
+    // - out(0) emits terminal http resonse (successful or unsuccessful non-retryable)
+    // - out(1) emits unsusccessful but retryable responses
+    val partitionHttpResponse = builder.add(Partition[(HttpResponse, ContextWithRequest[T])](2, {
+      // Successful return code
+      case (httpResponse, flowContext) if httpResponse.status.isSuccess() || !shouldRetry(httpResponse, flowContext) => 0
+      // Failed return code but retryable
+      case (httpResponse, flowContext) => 1
+    }))
     
     // Merges requests coming from 3 input ports:
     // - in(0) takes requests from the outside
-    // - in(1) takes retryable failed requests
-    // - in(2) takes retryable failed responses (with non successful and retryable status code)
-    val mergeRequests = builder.add(Merge[(HttpRequest, (T, HttpRequest))](3))
-    
-    // Splits http response into 3 categories:
-    // - out(0) emits successful responses
-    // - out(1) emits failed but retryable responses
-    // - out(2) emits failed, non-retryable responses
-    val partitionHttpResponse = builder.add(Partition[(HttpResponse, (T, HttpRequest))](3, {
-      // Successful return code
-      case (httpResponse, flowContext) if httpResponse.status.isSuccess() => 0
-      // Failed return code but retryable
-      case (httpResponse, flowContext) if isRetryable(httpResponse) => 1
-      // Failed return code and non retryable
-      case (httpResponse, flowContext) => 2
-    }))
+    // - in(1) takes retryable failed responses (with non successful and retryable status code)
+    val mergeRequests = builder.add(MergePreferred.create[(HttpRequest, ContextWithRequest[T])](1))
 
-    val responseSuccessful = partitionHttpResponse.out(0) map toTerminalResponse
-    val responseRetryable = partitionHttpResponse.out(1) map toRetryableRequest
-    val responseFailed = partitionHttpResponse.out(2) map toTerminalResponse
+    // Either success or non retryable unsuccessful http response, either way it won't be retried
+    val terminalResponse = partitionHttpResponse.out(0) map {
+      case (response, ContextWithRequest(flowContext, _, _, _)) => response -> flowContext
+    }
     
-    // Buffer for retryable requests. Will DROP requests when full
-    // Will also delay re submission
-    val retryBuffer = Flow[(HttpRequest, (T, HttpRequest))]
-      .buffer(retryBufferSize, OverflowStrategy.dropHead)
-
-    // Submit outside requests to the first port of the mergeRequests merger 
+    // Retryable http response
+    val retryableResponse = partitionHttpResponse.out(1)
+      // Create a new request, yields a future that will complete after the appropriate backoff time
+      .map(toRetryableRequest)
+      // wait for the future to complete, retryBufferSize sets how many retryable future we can wait for in parallel
+      .mapAsync(retryBufferSize)(identity)
+    
+    // Outside requests coming in
     source ~> mergeRequests.in(0)
     
     // Submit request to underlying http flow  -  Partition responses: Failure | Success
     mergeRequests     ~>     http      ~>         partitionResponseTry.in
-                                                  // Success -> analyze response and partition into 3 (see above)
+    
+                                                  // Success -> analyze response and partition into 2 (see above)
                                                   requestSuccessful ~> partitionHttpResponse
-    // Retry failed requests (Try[HttpResponse] was a Failure)
-    mergeRequests.in(1)     <~ retryBuffer <~     requestFailed.outlet
-    // Retry retryable failed responses (the HttpResponse had a non successful return code and was deemed retryable)
-    mergeRequests.in(2)        <~        retryBuffer         <~        responseRetryable.outlet
+    
+    // Retryable http response are sent back for retry
+    mergeRequests.preferred          <~           retryableResponse.outlet
 
-    new FanOutShape2(source.in, responseSuccessful.outlet, responseFailed.outlet)
+    new FanOutShape2(source.in, terminalResponse.outlet, requestFailed.outlet)
+  }
+  
+  private def shouldRetry(httpResponse: HttpResponse, contextWithRequest2: ContextWithRequest[T]) = {
+    isRetryable(httpResponse) && contextWithRequest2.currentAttempt <= maxAttempts
   }
 
-  // create a re-submittable request from a failed retryable
-  private def toRetryableRequest(value: (Any, (T, HttpRequest))) = value match {
-    case (_, (flowContext, request)) => (request, (flowContext, request))
-  }
-
-  // extract only the response and the context so it can be emitted through the output port
-  private def toTerminalResponse(value: (HttpResponse, (T, HttpRequest))) = value match {
-    case (response, (flowContext, _)) => (response, flowContext)
+  /**
+    * Create a re-submittable request from a failed retryable
+    * @return a future that will complete after the appropriate backoff time
+    */
+  private def toRetryableRequest(value: (Any, ContextWithRequest[T])) = value match {
+    case (_, contextWithRequest) => 
+      val nextRetryIn = contextWithRequest.retryIn
+      val nextRequest = (contextWithRequest.request, contextWithRequest.withNextAttempt)
+      akka.pattern.after(nextRetryIn, scheduler) { 
+        Future.successful(nextRequest)
+      }
   }
 }

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/HttpFlowWithRetry.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/HttpFlowWithRetry.scala
@@ -43,7 +43,7 @@ object HttpFlowWithRetry {
     * the user wishes to use as a context for their specific use case.
     */
   case class ContextWithRequest[T](userContext: T, request: HttpRequest, currentAttempt: Int, backoff: Backoff) {
-    // Backoff is mutable ! This will change every time !
+    // Back off is mutable ! This will change every time !
     def retryIn = backoff.backoffMillis.millis
     
     def withNextAttempt = copy(currentAttempt = currentAttempt + 1)

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
@@ -1,5 +1,6 @@
 package cromwell.core.callcaching.docker.registryv2.flows.dockerhub
 
+import akka.actor.Scheduler
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
 import akka.http.scaladsl.model.{HttpMethod, HttpMethods}
 import akka.stream.ActorMaterializer
@@ -19,8 +20,8 @@ object DockerHubFlow {
   private val ServiceName = Option("registry.docker.io")
 }
 
-class DockerHubFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer) 
-  extends DockerRegistryV2AbstractFlow(httpClientFlow)(ec, materializer) {
+class DockerHubFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) 
+  extends DockerRegistryV2AbstractFlow(httpClientFlow)(ec, materializer, scheduler) {
 
   override val registryHostName = RegistryHostName
   override val authorizationServerHostName = AuthorizationServerHostName

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrAbstractFlow.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrAbstractFlow.scala
@@ -1,5 +1,6 @@
 package cromwell.core.callcaching.docker.registryv2.flows.gcr
 
+import akka.actor.Scheduler
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import akka.stream.ActorMaterializer
 import com.google.auth.oauth2.OAuth2Credentials
@@ -10,7 +11,7 @@ import cromwell.core.callcaching.docker.registryv2.DockerRegistryV2AbstractFlow.
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-abstract class GcrAbstractFlow(httpClientFlow: HttpDockerFlow, host: String)(implicit ec: ExecutionContext, materializer: ActorMaterializer) extends DockerRegistryV2AbstractFlow(httpClientFlow)(ec, materializer) {
+abstract class GcrAbstractFlow(httpClientFlow: HttpDockerFlow, host: String)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) extends DockerRegistryV2AbstractFlow(httpClientFlow)(ec, materializer, scheduler) {
   
   private val AccessTokenAcceptableTTL = 1.minute
   

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrEuFlow.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrEuFlow.scala
@@ -1,8 +1,9 @@
 package cromwell.core.callcaching.docker.registryv2.flows.gcr
 
+import akka.actor.Scheduler
 import akka.stream.ActorMaterializer
 import cromwell.core.callcaching.docker.registryv2.DockerRegistryV2AbstractFlow.HttpDockerFlow
 
 import scala.concurrent.ExecutionContext
 
-private class GcrEuFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer) extends GcrAbstractFlow(httpClientFlow, "eu.gcr.io")
+private class GcrEuFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) extends GcrAbstractFlow(httpClientFlow, "eu.gcr.io")

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrFlow.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrFlow.scala
@@ -1,8 +1,9 @@
 package cromwell.core.callcaching.docker.registryv2.flows.gcr
 
+import akka.actor.Scheduler
 import akka.stream.ActorMaterializer
 import cromwell.core.callcaching.docker.registryv2.DockerRegistryV2AbstractFlow.HttpDockerFlow
 
 import scala.concurrent.ExecutionContext
 
-private class GcrFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer) extends GcrAbstractFlow(httpClientFlow, "gcr.io")
+private class GcrFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) extends GcrAbstractFlow(httpClientFlow, "gcr.io")

--- a/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrUsFlow.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/docker/registryv2/flows/gcr/GcrUsFlow.scala
@@ -1,8 +1,9 @@
 package cromwell.core.callcaching.docker.registryv2.flows.gcr
 
+import akka.actor.Scheduler
 import akka.stream.ActorMaterializer
 import cromwell.core.callcaching.docker.registryv2.DockerRegistryV2AbstractFlow.HttpDockerFlow
 
 import scala.concurrent.ExecutionContext
 
-private class GcrUsFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer) extends GcrAbstractFlow(httpClientFlow, "us.gcr.io")
+private class GcrUsFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) extends GcrAbstractFlow(httpClientFlow, "us.gcr.io")

--- a/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
@@ -3,7 +3,7 @@ package cromwell.core.actor
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import cromwell.core.TestKitSuite
-import cromwell.core.actor.StreamIntegration.Backpressure
+import cromwell.core.actor.StreamIntegration.BackPressure
 import org.scalatest.{FlatSpecLike, Matchers}
 
 import scala.concurrent.duration._
@@ -30,7 +30,7 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     remoteActor.expectMsg(messageToSend)
     
     // remote actor sends a backpressure message
-    remoteActor.reply(Backpressure(messageToSend))
+    remoteActor.reply(BackPressure(messageToSend))
     
     // remote actor expects request again after backpressureTimeout
     remoteActor.expectMsg(backpressureTimeout + margin, messageToSend)
@@ -121,7 +121,7 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     remoteActor.expectMsg(messageToSend)
 
     // remote actor sends a backpressure message
-    remoteActor.reply(Backpressure(messageToSend))
+    remoteActor.reply(BackPressure(messageToSend))
 
     // remote actor expects request again after backpressureTimeout
     remoteActor.expectMsg(backpressureTimeout + margin, messageToSend)

--- a/core/src/test/scala/cromwell/core/actor/StreamActorHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/actor/StreamActorHelperSpec.scala
@@ -29,7 +29,7 @@ class StreamActorHelperSpec extends TestKitSuite with FlatSpecLike with Matchers
 
     actor ! EnqueueResponse(Dropped, TestStreamActorContext(command, self, None))
 
-    expectMsg(Backpressure(command))
+    expectMsg(BackPressure(command))
 
     system stop actor
   }
@@ -40,7 +40,7 @@ class StreamActorHelperSpec extends TestKitSuite with FlatSpecLike with Matchers
 
     actor ! EnqueueResponse(Dropped, TestStreamActorContext(command, self, Option("context")))
 
-    expectMsg(Backpressure("context" -> command))
+    expectMsg(BackPressure("context" -> command))
 
     system stop actor
   }

--- a/core/src/test/scala/cromwell/core/callcaching/docker/DockerHashMocks.scala
+++ b/core/src/test/scala/cromwell/core/callcaching/docker/DockerHashMocks.scala
@@ -3,6 +3,7 @@ package cromwell.core.callcaching.docker
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.Flow
 import cromwell.core.callcaching.docker.DockerHashActor.{DockerHashContext, DockerHashResponse}
+import cromwell.core.callcaching.docker.registryv2.flows.HttpFlowWithRetry.ContextWithRequest
 
 import scala.util.Try
 
@@ -11,7 +12,7 @@ case class MockHttpResponse(httpResponse: Try[HttpResponse], nb: Int)
 class HttpMock[T](responses: MockHttpResponse*) {
   private var responsesLeft = responses.toBuffer
   
-  private def nextResponse(value: (HttpRequest, (T, HttpRequest))): (Try[HttpResponse], (T, HttpRequest)) = value match {
+  private def nextResponse(value: (HttpRequest, ContextWithRequest[T])): (Try[HttpResponse], ContextWithRequest[T]) = value match {
     case (request, context) =>
       responsesLeft.headOption match {
         case Some(mockResponse) =>
@@ -27,7 +28,7 @@ class HttpMock[T](responses: MockHttpResponse*) {
       }
   }
   
-  def httpMock() = Flow[(HttpRequest, (T, HttpRequest))] map nextResponse
+  def httpMock() = Flow[(HttpRequest, ContextWithRequest[T])] map nextResponse
 }
 
 case class MockHashResponse(hashResponse: DockerHashResponse, nb: Int)

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -8,6 +8,7 @@ import akka.stream._
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Source}
 import com.google.cloud.storage.StorageException
 import com.typesafe.config.ConfigFactory
+import cromwell.core.Dispatcher
 import cromwell.core.actor.StreamActorHelper
 import cromwell.core.actor.StreamIntegration.StreamContext
 import cromwell.core.io.{IoAck, IoCommand, Throttle}
@@ -73,7 +74,7 @@ final class IoActor(queueSize: Int, throttle: Option[Throttle])(implicit val mat
       .via(flow)
   } getOrElse flow
   
-  override protected lazy val streamSource = source.via(throttledFlow)
+  override protected lazy val streamSource = source.via(throttledFlow).withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
   
   override def actorReceive: Receive = {
     /* GCS Batch command with context */

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActor.scala
@@ -35,7 +35,7 @@ case class JobPreparationActor(executionData: WorkflowExecutionActorData,
   // Amount of time to wait when we get a Backpressure response before sending the request again
   override protected def backpressureRandomizerFactor: Double = 0.5D
   
-  protected lazy val noResponsTimeout: FiniteDuration = 3 minutes
+  protected lazy val noResponseTimeout: FiniteDuration = 3 minutes
   
   private lazy val workflowDescriptor = executionData.workflowDescriptor
   private lazy val expressionLanguageFunctions = factory.expressionLanguageFunctions(workflowDescriptor.backendDescriptor, jobKey, initializationData)
@@ -80,7 +80,7 @@ case class JobPreparationActor(executionData: WorkflowExecutionActorData,
     def sendDockerRequest(dockerImageId: DockerImageIdentifierWithoutHash) = {
       val dockerHashRequest = DockerHashRequest(dockerImageId, dockerHashCredentials)
       val newData = JobPreparationActorData(dockerHashRequest, inputs, attributes)
-      sendDockerCommand(dockerHashRequest, noResponsTimeout)
+      sendDockerCommand(dockerHashRequest, noResponseTimeout)
       goto(WaitingForDockerHash) using Option(newData)
     }
     

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -480,7 +480,7 @@ object EmptyCallCacheReadActor {
 
 class EmptyDockerHashActor extends Actor {
   override def receive: Receive = {
-    case DockerHashRequest(image, _) => sender ! DockerHashResponseSuccess(DockerHashResult("alg", "hash"))
+    case request @ DockerHashRequest(image, _) => sender ! DockerHashResponseSuccess(DockerHashResult("alg", "hash"), request)
   }
 }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
@@ -1,7 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.preparation
 
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
-import cromwell.core.actor.StreamIntegration.Backpressure
+import cromwell.core.actor.StreamIntegration.BackPressure
 import cromwell.core.callcaching.docker.DockerHashActor.{DockerHashFailedResponse, DockerHashResponseSuccess}
 import cromwell.core.callcaching.docker.{DockerHashRequest, DockerHashResult, DockerImageIdentifier, DockerImageIdentifierWithoutHash}
 import cromwell.core.callcaching.{CallCachingEligible, CallCachingIneligible}
@@ -125,7 +125,7 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
     val request = DockerHashRequest(dockerId)
     actor ! Start
     dockerHashingActor.expectMsg(request)
-    dockerHashingActor.reply(Backpressure(request))
+    dockerHashingActor.reply(BackPressure(request))
     // Give a couple of seconds of margin to account for test latency etc...
     dockerHashingActor.expectMsg(backpresureWaitTime.+(2 seconds), request)
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
@@ -1,20 +1,22 @@
 package cromwell.engine.workflow.lifecycle.execution.preparation
 
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
-import cromwell.core.callcaching.{CallCachingEligible, CallCachingIneligible}
-import cromwell.core.callcaching.docker.DockerHashActor.{DockerHashBackPressure, DockerHashFailedResponse, DockerHashResponseSuccess}
+import cromwell.core.actor.StreamIntegration.Backpressure
+import cromwell.core.callcaching.docker.DockerHashActor.{DockerHashFailedResponse, DockerHashResponseSuccess}
 import cromwell.core.callcaching.docker.{DockerHashRequest, DockerHashResult, DockerImageIdentifier, DockerImageIdentifierWithoutHash}
+import cromwell.core.callcaching.{CallCachingEligible, CallCachingIneligible}
 import cromwell.core.{LocallyQualifiedName, TestKitSuite}
 import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation.{BackendJobPreparationSucceeded, CallPreparationFailed, Start}
 import org.scalatest.{FlatSpecLike, Matchers}
+import org.specs2.mock.Mockito
 import wdl4s.Declaration
 import wdl4s.values.{WdlString, WdlValue}
 
-import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.{Failure, Success}
 
-class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender {
+class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Mockito {
 
   behavior of "JobPreparationActor"
   
@@ -72,7 +74,7 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
     val actor = TestActorRef(helper.buildJobPreparationMock(1 minute, 1 minutes, List.empty, dockerHashingActor.ref, inputsAndAttributes), self)
     actor ! Start
     dockerHashingActor.expectMsgClass(classOf[DockerHashRequest])
-    dockerHashingActor.reply(DockerHashResponseSuccess(hashResult))
+    dockerHashingActor.reply(DockerHashResponseSuccess(hashResult, mock[DockerHashRequest]))
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe finalValue
@@ -87,7 +89,7 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
 
   it should "make a job ineligible for caching if it can't get the docker hash" in {
     val dockerValue = "ubuntu:latest"
-    val dockerId = DockerImageIdentifier.fromString(dockerValue).get.asInstanceOf[DockerImageIdentifierWithoutHash]
+    val request = DockerHashRequest(DockerImageIdentifier.fromString(dockerValue).get.asInstanceOf[DockerImageIdentifierWithoutHash])
     val attributes = Map (
       "docker" -> WdlString(dockerValue)
     )
@@ -96,7 +98,7 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
     val actor = TestActorRef(helper.buildJobPreparationMock(1 minute, 1 minutes, List.empty, dockerHashingActor.ref, inputsAndAttributes), self)
     actor ! Start
     dockerHashingActor.expectMsgClass(classOf[DockerHashRequest])
-    dockerHashingActor.reply(DockerHashFailedResponse(new Exception("Failed to get docker hash - part of test flow"), dockerId))
+    dockerHashingActor.reply(DockerHashFailedResponse(new Exception("Failed to get docker hash - part of test flow"), request))
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe dockerValue
@@ -123,12 +125,12 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
     val request = DockerHashRequest(dockerId)
     actor ! Start
     dockerHashingActor.expectMsg(request)
-    dockerHashingActor.reply(DockerHashBackPressure(request))
+    dockerHashingActor.reply(Backpressure(request))
     // Give a couple of seconds of margin to account for test latency etc...
     dockerHashingActor.expectMsg(backpresureWaitTime.+(2 seconds), request)
   }
 
-  it should "automatically re submit the docker request if no answer and finally give up" in {
+  it should "time out if no answer is received from the docker hash actor" in {
     val dockerValue = "ubuntu:latest"
     val dockerId = DockerImageIdentifier.fromString(dockerValue).get.asInstanceOf[DockerImageIdentifierWithoutHash]
     val attributes = Map (
@@ -142,9 +144,6 @@ class JobPreparationActorSpec extends TestKitSuite with FlatSpecLike with Matche
     actor ! Start
     
     within(10 seconds) {
-      dockerHashingActor.expectMsg(request)
-      dockerHashingActor.expectMsg(request)
-      dockerHashingActor.expectMsg(request)
       dockerHashingActor.expectMsg(request)
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
@@ -24,8 +24,8 @@ class JobPreparationTestHelper(implicit val system: ActorSystem) extends Mockito
   val ioActor = TestProbe()
 
   def buildJobPreparationMock(
-                               backpressureTimeout: FiniteDuration,
-                               noResponseTimeout: FiniteDuration,
+                               backpressureTimeoutValue: FiniteDuration,
+                               noResponsTimeoutValue: FiniteDuration,
                                dockerHashCredentials: List[Any],
                                dockerHashingActor: ActorRef,
                                inputsAndAttributes: Try[(Map[Declaration, WdlValue], Map[wdl4s.LocallyQualifiedName, WdlValue])]
@@ -50,9 +50,9 @@ class JobPreparationTestHelper(implicit val system: ActorSystem) extends Mockito
       serviceRegistryProbe.ref,
       None
     ) {
-      override lazy val dockerNoResponseTimeout = noResponseTimeout
-      override lazy val backpressureWaitTime = backpressureTimeout
+      override protected def backpressureTimeout: FiniteDuration = backpressureTimeoutValue
       override def evaluateInputsAndAttributes = inputsAndAttributes
+      override protected lazy val noResponsTimeout = noResponsTimeoutValue
     })
   }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
@@ -52,7 +52,7 @@ class JobPreparationTestHelper(implicit val system: ActorSystem) extends Mockito
     ) {
       override protected def backpressureTimeout: FiniteDuration = backpressureTimeoutValue
       override def evaluateInputsAndAttributes = inputsAndAttributes
-      override protected lazy val noResponsTimeout = noResponsTimeoutValue
+      override protected lazy val noResponseTimeout = noResponsTimeoutValue
     })
   }
 }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -74,9 +74,8 @@ class GcsPathBuilder(authMode: GoogleAuthMode,
       .build()
   }
 
-  // Create a com.google.api.services.storage.Storage
-  // This is the underlying api used by com.google.cloud.storage
-  // By bypassing com.google.cloud.storage, we can create low level requests that can be batched
+  // Create a com.google.cloud.storage.Storage
+  // This is the "relatively" high level API, and recommended one. The nio implementation sits on top of this.
   val cloudStorage: com.google.cloud.storage.Storage = storageOptions.getService
 
   // The CloudStorageFileSystemProvider constructor is not public. Currently the only way to obtain one is through a CloudStorageFileSystem


### PR DESCRIPTION
Makes use of the helper traits created in the I/O actor PR to abstract managing of backpressure messages etc.. 

Creates a `DockerClientHelper` trait to isolate the timeout management logic (if the docker actor never responds, ensures that we don't hang forever).

The changes in `HttpFlowWithRetry` add exponential backoff retries (previously they were simple immediate retries) to HTTP responses, and list explicitly the HTTP codes that are retryable.
More specifically, Http "failures", as in "the http request itself failed", are not retried, since akka already does that by default under the hood. Only Http responses with a retryable error code are retried asynchronously, following the same model as the I/O actor.
