### PR TITLE
Updated to Slick 3.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Cromwell Change Log
 
+## 27
+
+
+* The update to Slick 3.2 requires a database stanza to
+[switch](http://slick.lightbend.com/doc/3.2.0/upgrade.html#profiles-vs-drivers) from using `driver` to `profile`.
+
+```hocon
+database {
+  #driver = "slick.driver.MySQLDriver$" #old
+  profile = "slick.jdbc.MySQLProfile$"  #new
+  db {
+    driver = "com.mysql.jdbc.Driver"
+    url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
+    user = "user"
+    password = "pass"
+    connectionTimeout = 5000
+  }
+}
+```
+
 ## 26
 
 ### Breaking Changes
@@ -41,17 +61,6 @@ system.io {
   # Number of times an I/O operation should be attempted before giving up and failing it.
   number-of-attempts = 5
 }
-```
-
-* Added a `script-epilogue` configuration option to adjust the logic that runs at the end of the scripts which wrap call executions.
-  This option is adjustable on a per-backend basis.  If unspecified, the default value is `sync`.
-
-### WDL Features
-
-With Cromwell 26, Cromwell will support `if x then y else z` expressions (see: https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#if-then-else). For example: 
-```
-Boolean b = true
-String s = if b then "value if True" else "value if False"
 ```
 
 ## 25

--- a/README.md
+++ b/README.md
@@ -497,18 +497,13 @@ Then, edit the configuration file `database` stanza, as follows:
 
 ```
 database {
-
-  driver = "slick.driver.MySQLDriver$"
+  profile = "slick.jdbc.MySQLProfile$"
   db {
     driver = "com.mysql.jdbc.Driver"
     url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
     user = "user"
     password = "pass"
     connectionTimeout = 5000
-  }
-
-  test {
-    ...
   }
 }
 ```

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -488,7 +488,7 @@ services {
 
 database {
   # hsql default
-  driver = "slick.driver.HsqldbDriver$"
+  profile = "slick.jdbc.HsqldbProfile$"
   db {
     driver = "org.hsqldb.jdbcDriver"
     url = "jdbc:hsqldb:mem:${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -22,7 +22,7 @@ database.db.connectionTimeout = 3000
 database-test-mysql {
   # Run the following to (optionally) drop and (re-)create the database:
   # mysql -utravis -e "DROP DATABASE IF EXISTS cromwell_test" && mysql -utravis -e "CREATE DATABASE cromwell_test"
-  driver = "slick.driver.MySQLDriver$"
+  profile = "slick.jdbc.MySQLProfile$"
   db {
     driver = "com.mysql.jdbc.Driver"
     url = "jdbc:mysql://localhost/cromwell_test?useSSL=false"

--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -80,7 +80,7 @@ WHY
     In slick schemas, `index(unique = false)` always creates an index. Depending on the database type,
     `index(unique = true)` sometimes creates a unique _constraint_, not actually an index.
 
-    https://github.com/slick/slick/blob/3.1.1/slick/src/main/scala/slick/driver/HsqldbDriver.scala#L126
+    https://github.com/slick/slick/blob/3.2.0/slick/src/main/scala/slick/jdbc/HsqldbProfile.scala#L127
 
 -*-
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/DataAccessComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/DataAccessComponent.scala
@@ -1,6 +1,6 @@
 package cromwell.database.slick.tables
 
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 class DataAccessComponent(val driver: JdbcProfile)
   extends DriverComponent

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/DriverComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/DriverComponent.scala
@@ -1,6 +1,6 @@
 package cromwell.database.slick.tables
 
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 
 trait DriverComponent {
   val driver: JdbcProfile

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   lazy val sprayJsonV = "1.3.2"
   lazy val akkaV = "2.4.16"
   lazy val akkaHttpV = "2.4.11"
-  lazy val slickV = "3.1.1"
+  lazy val slickV = "3.2.0"
   lazy val googleClientApiV = "1.22.0"
   lazy val googleGenomicsServicesApiV = "1.22.0"
   lazy val betterFilesV = "2.17.1"

--- a/scripts/docker-compose-mysql/compose/cromwell/app-config/application.conf
+++ b/scripts/docker-compose-mysql/compose/cromwell/app-config/application.conf
@@ -51,5 +51,5 @@ database {
   db.user = "cromwell"
   db.password = "cromwell"
   db.driver = "com.mysql.jdbc.Driver"
-  driver = "slick.driver.MySQLDriver$"
+  profile = "slick.jdbc.MySQLProfile$"
 }

--- a/scripts/docker-compose-mysql/jes-cromwell/jes-config/application.conf
+++ b/scripts/docker-compose-mysql/jes-cromwell/jes-config/application.conf
@@ -64,5 +64,5 @@ database {
   db.user = "cromwell"
   db.password = "cromwell"
   db.driver = "com.mysql.jdbc.Driver"
-  driver = "slick.driver.MySQLDriver$"
+  profile = "slick.jdbc.MySQLProfile$"
 }

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -6,7 +6,7 @@ import java.time.OffsetDateTime
 import javax.sql.rowset.serial.{SerialBlob, SerialClob, SerialException}
 
 import better.files._
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.ConfigFactory
 import cromwell.core.Tags._
 import cromwell.core.WorkflowId
 import cromwell.database.migration.liquibase.LiquibaseUtils
@@ -14,8 +14,6 @@ import cromwell.database.slick.SlickDatabase
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.joins.JobStoreJoin
 import cromwell.database.sql.tables.{JobStoreEntry, JobStoreSimpletonEntry, WorkflowStoreEntry}
-import eu.timepit.refined.api.Refined
-import eu.timepit.refined.collection.NonEmpty
 import liquibase.diff.DiffResult
 import liquibase.diff.output.DiffOutputControl
 import liquibase.diff.output.changelog.DiffToChangeLog
@@ -25,11 +23,11 @@ import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 import slick.jdbc.meta._
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future, TimeoutException}
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
 import scala.xml._
 
@@ -43,53 +41,6 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 
   behavior of "ServicesStore"
 
-  it should "deadlock and timeout after 10 seconds" in {
-    /*
-    Tests that we still need our deadlock workaround in `database.run` to deal with problems in Slick 3.1.
-    If/when this test fails, the workaround should be removed.
-    */
-
-    class DeadlockingSlickDatabase(config: Config) extends SlickDatabase(config) {
-
-      import dataAccess.driver.api._
-
-      override protected[this] def runTransaction[R](action: DBIO[R]): Future[R] = {
-        database.run(action.transactionally) //<-- https://github.com/slick/slick/issues/1274
-      }
-    }
-
-    // Test based on https://github.com/kwark/slick-deadlock/blob/82525fc/src/main/scala/SlickDeadlock.scala
-    val databaseConfig = ConfigFactory.parseString(
-      s"""|db.url = "jdbc:hsqldb:mem:$${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
-          |db.driver = "org.hsqldb.jdbcDriver"
-          |db.connectionTimeout = 3000
-          |db.numThreads = 2
-          |driver = "slick.driver.HsqldbDriver$$"
-          |""".stripMargin)
-    import ServicesStore.EnhancedSqlDatabase
-    for {
-      database <- new DeadlockingSlickDatabase(databaseConfig).initialized.autoClosed
-    } {
-      val futures = 1 to 20 map { _ =>
-        val workflowUuid = WorkflowId.randomId().toString
-        val callFqn = "call.fqn"
-        val jobIndex = 1
-        val jobAttempt = 1
-        val jobSuccessful = false
-        val jobStoreEntry = JobStoreEntry(workflowUuid, callFqn, jobIndex, jobAttempt, jobSuccessful, None, None, None)
-        val jobStoreJoins = Seq(JobStoreJoin(jobStoreEntry, Seq()))
-        // NOTE: This test just needs to repeatedly read/write from a table that acts as a PK for a FK.
-        for {
-          _ <- database.addJobStores(jobStoreJoins)
-          queried <- database.queryJobStores(workflowUuid, callFqn, jobIndex, jobAttempt)
-          _ = queried.get.jobStoreEntry.workflowExecutionUuid should be(workflowUuid)
-        } yield ()
-      }
-
-      intercept[TimeoutException](Await.result(Future.sequence(futures), 10.seconds))
-    }
-  }
-
   it should "not deadlock" in {
     // Test based on https://github.com/kwark/slick-deadlock/blob/82525fc/src/main/scala/SlickDeadlock.scala
     val databaseConfig = ConfigFactory.parseString(
@@ -97,7 +48,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
           |db.driver = "org.hsqldb.jdbcDriver"
           |db.connectionTimeout = 3000
           |db.numThreads = 2
-          |driver = "slick.driver.HsqldbDriver$$"
+          |profile = "slick.jdbc.HsqldbProfile$$"
           |""".stripMargin)
     import ServicesStore.EnhancedSqlDatabase
     for {
@@ -307,11 +258,8 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
       } yield ()).futureValue
     }
 
-    it should "fail to store and retrieve empty clobs in MySQL" taggedAs DbmsTest in {
-      /*
-      Tests that we still need our empty clob workaround in `SqlConverters.toClob`. The current mysql jdbc driver throws
-      an exception when serializing an empty clob. If/when this test fails, the workaround should be removed.
-      */
+    it should "fail to store and retrieve empty clobs" taggedAs DbmsTest in {
+      // See notes in StringToClobOption
       val emptyClob = new SerialClob(Array.empty[Char])
 
       val workflowUuid = WorkflowId.randomId().toString
@@ -325,46 +273,47 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 
       val future = for {
         product <- dataAccess.database.run(getProduct)
-        _ = product match {
+        _ <- product match {
+          case "HSQL Database Engine" =>
+            // HSQLDB doesn't crash because it calls getCharacterStream instead of getSubString.
+            dataAccess.addJobStores(jobStoreJoins)
           case "MySQL" =>
-            val exception = intercept[SerialException] {
-              Await.result(dataAccess.addJobStores(jobStoreJoins), Duration.Inf)
+            dataAccess.addJobStores(jobStoreJoins).failed map { exception =>
+              exception should be(a[SerialException])
+              exception.getMessage should be("Invalid position in SerialClob object set")
             }
-            exception should be(a[SerialException])
-            exception.getMessage should be("Invalid position in SerialClob object set")
-          case _ => ()
         }
       } yield ()
 
       future.futureValue
     }
 
-    it should "fail to store and retrieve empty blobs in MySQL" taggedAs DbmsTest in {
-      /*
-      Tests that we still need our empty blob workaround in `SqlConverters.toBlob`. The current mysql jdbc driver throws
-      an exception when serializing an empty blob. If/when this test fails, the workaround should be removed.
-      */
-      import eu.timepit.refined._
-      val nonEmptyString: String Refined NonEmpty  = refineMV[NonEmpty]("{}")
+    it should "fail to store and retrieve empty blobs" taggedAs DbmsTest in {
+      // See notes in BytesToBlobOption
+      import eu.timepit.refined.auto._
+      import eu.timepit.refined.collection._
+      val clob = "".toClob(default = "{}")
+      val clobOption = "{}".toClobOption
       val emptyBlob = new SerialBlob(Array.empty[Byte])
 
       val workflowUuid = WorkflowId.randomId().toString
-      val workflowStoreEntry = WorkflowStoreEntry(workflowUuid, "{}".toClobOption, "{}".toClobOption, "{}".toClobOption,
-        "Testing", OffsetDateTime.now.toSystemTimestamp, Option(emptyBlob), "{}".toClob(nonEmptyString))
+      val workflowStoreEntry = WorkflowStoreEntry(workflowUuid, clobOption, clobOption, clobOption,
+        "Testing", OffsetDateTime.now.toSystemTimestamp, Option(emptyBlob), clob)
 
       val workflowStoreEntries = Seq(workflowStoreEntry)
 
       val future = for {
         product <- dataAccess.database.run(getProduct)
-        _ = product match {
+        _ <- product match {
+          case "HSQL Database Engine" =>
+            // HSQLDB doesn't crash because it calls getBinaryStream instead of getBytes.
+            dataAccess.addWorkflowStoreEntries(workflowStoreEntries)
           case "MySQL" =>
-            val exception = intercept[SerialException] {
-              Await.result(dataAccess.addWorkflowStoreEntries(workflowStoreEntries), Duration.Inf)
+            dataAccess.addWorkflowStoreEntries(workflowStoreEntries).failed map { exception =>
+              exception should be(a[SerialException])
+              exception.getMessage should
+                be("Invalid arguments: position cannot be less than 1 or greater than the length of the SerialBlob")
             }
-            exception should be(a[SerialException])
-            exception.getMessage should
-              be("Invalid arguments: position cannot be less than 1 or greater than the length of the SerialBlob")
-          case _ => ()
         }
       } yield ()
 
@@ -372,6 +321,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
     }
 
     it should "store and retrieve empty clobs" taggedAs DbmsTest in {
+      // See notes in StringToClobOption
       val workflowUuid = WorkflowId.randomId().toString
       val callFqn = "call.fqn"
       val jobIndex = 1
@@ -403,23 +353,28 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
     }
 
     it should "store and retrieve empty blobs" taggedAs DbmsTest in {
-      import eu.timepit.refined._
+      // See notes in BytesToBlobOption
+      import eu.timepit.refined.auto._
+      import eu.timepit.refined.collection._
 
-      val nonEmptyString: String Refined NonEmpty  = refineMV[NonEmpty]("{}")
       val testWorkflowState = "Testing"
+      val clob = "".toClob(default = "{}")
+      val clobOption = "{}".toClobOption
 
       val emptyWorkflowUuid = WorkflowId.randomId().toString
-      val emptyWorkflowStoreEntry = WorkflowStoreEntry(emptyWorkflowUuid, "{}".toClobOption, "{}".toClobOption, "{}".toClobOption,
-        testWorkflowState, OffsetDateTime.now.toSystemTimestamp, Option(Array.empty[Byte]).toBlobOption, "{}".toClob(nonEmptyString))
+      val emptyWorkflowStoreEntry = WorkflowStoreEntry(emptyWorkflowUuid, clobOption, clobOption,
+        clobOption, testWorkflowState, OffsetDateTime.now.toSystemTimestamp,
+        Option(Array.empty[Byte]).toBlobOption, clob)
 
       val noneWorkflowUuid = WorkflowId.randomId().toString
-      val noneWorkflowStoreEntry = WorkflowStoreEntry(noneWorkflowUuid, "{}".toClobOption, "{}".toClobOption, "{}".toClobOption,
-        testWorkflowState, OffsetDateTime.now.toSystemTimestamp, None, "{}".toClob(nonEmptyString))
+      val noneWorkflowStoreEntry = WorkflowStoreEntry(noneWorkflowUuid, clobOption, clobOption,
+        clobOption, testWorkflowState, OffsetDateTime.now.toSystemTimestamp, None, clob)
 
       val aByte = 'a'.toByte
       val aByteWorkflowUuid = WorkflowId.randomId().toString
-      val aByteWorkflowStoreEntry = WorkflowStoreEntry(aByteWorkflowUuid, "{}".toClobOption, "{}".toClobOption, "{}".toClobOption,
-        testWorkflowState, OffsetDateTime.now.toSystemTimestamp, Option(Array(aByte)).toBlobOption, "{}".toClob(nonEmptyString))
+      val aByteWorkflowStoreEntry = WorkflowStoreEntry(aByteWorkflowUuid, clobOption, clobOption,
+        clobOption, testWorkflowState, OffsetDateTime.now.toSystemTimestamp, Option(Array(aByte)).toBlobOption,
+        clob)
 
       val workflowStoreEntries = Seq(emptyWorkflowStoreEntry, noneWorkflowStoreEntry, aByteWorkflowStoreEntry)
 
@@ -476,7 +431,7 @@ object ServicesStoreSpec {
          |db.url = "jdbc:hsqldb:mem:$${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
          |db.driver = "org.hsqldb.jdbcDriver"
          |db.connectionTimeout = 3000
-         |driver = "slick.driver.HsqldbDriver$$"
+         |profile = "slick.jdbc.HsqldbProfile$$"
          |liquibase.updateSchema = false
          |""".stripMargin)
     val database = new SlickDatabase(databaseConfig)


### PR DESCRIPTION
Removed deadlock workaround.
Minimal updates to fix depracated usage.
Old Slick 3.1 style names are still used in scala, ex: `val driver: JdbcProfile`.
Added notes about SQL converters handling empty LOBs.