### PR TITLE
Backend configuration for SLURM added in beta state. #1750

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -287,6 +287,28 @@ backend {
     #    job-id-regex = "Job <(\\d+)>.*"
     #  }
     #}
+    
+    #SLURM {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #    runtime-attributes = """
+    #    Int runtime_minutes = 600
+    #    Int cpus = 2
+    #    Int requested_memory_mb_per_core = 8000
+    #    String queue = "short"
+    #    """
+    #  
+    #    submit = """
+    #        sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
+    #        ${"-n " + cpus} \
+    #        --mem-per-cpu=${requested_memory_mb_per_core} \
+    #        --wrap "/bin/bash ${script}"
+    #    """
+    #    kill = "scancel ${job_id}"
+    #    check-alive = "squeue -j ${job_id}"
+    #    job-id-regex = "Submitted batch job (\\d+).*"
+    #  }
+    #}
 
     # Example backend that _only_ runs workflows that specify docker for every command.
     #Docker {


### PR DESCRIPTION
This is the SLURM configuration I have been using for workflow development on Harvard Medical School's Orchestra 2 SLURM system. You should adjust the runtime-attributes for consistency with other platforms. (see #2068). 