### PR TITLE
Knob for script epilogue. (hotfix edition)

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -16,6 +16,7 @@ import cromwell.core.{CallOutputs, CromwellAggregatedException, CromwellFatalExc
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.metadata.CallMetadataKeys
 import lenthall.util.TryUtil
+import net.ceedubs.ficus.Ficus._
 import wdl4s._
 import wdl4s.values.{WdlFile, WdlGlobFile, WdlSingleFile, WdlValue}
 
@@ -87,6 +88,8 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   /** @see [[Command.instantiate]] */
   lazy val backendEngineFunctions: StandardExpressionFunctions =
     standardInitializationData.expressionFunctions(jobPaths)
+
+  lazy val scriptEpilogue = configurationDescriptor.backendConfig.as[Option[String]]("script-epilogue").getOrElse("sync")
 
   /**
     * Maps WdlFile objects for use in the commandLinePreProcessor.
@@ -189,9 +192,9 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |cd $cwd
         |${globManipulations(globFiles)}
         |)
-        |sync
+        |SCRIPT_EPILOGUE
         |mv $rcTmpPath $rcPath
-        |""".stripMargin.replace("INSTANTIATED_COMMAND", instantiatedCommand)
+        |""".stripMargin.replace("INSTANTIATED_COMMAND", instantiatedCommand).replace("SCRIPT_EPILOGUE", scriptEpilogue)
   }
 
   /** The instantiated command. */

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -177,6 +177,14 @@ backend {
         #concurrent-job-limit = 5
 
         run-in-background = true
+        # `script-epilogue` configures a shell command to run after the execution of every command block.
+        #
+        # If this value is not set explicitly, the default value is `sync`, equivalent to:
+        # script-epilogue = "sync"
+        #
+        # To turn off the default `sync` behavior set this value to an empty string:
+        # script-epilogue = ""
+
         runtime-attributes = """
         String? docker
         String? docker_user


### PR DESCRIPTION
Epilogue defaults to empty string, overridden to `sync` to keep Centaur Local happy.  The knob is currently undocumented, that can certainly change if desired.