### PR TITLE
Fix timing diagram for preempted calls

### DIFF
--- a/engine/src/main/resources/workflowTimings/workflowTimings.html
+++ b/engine/src/main/resources/workflowTimings/workflowTimings.html
@@ -69,7 +69,7 @@
                     var firstEventStart = null;
                     var finalEventEnd = null;
 
-                    if(callStatus == "Done" || callStatus == "Failed" || callStatus == "Preempted") {
+                    if(callStatus == "Done" || callStatus == "Failed" || callStatus == "RetryableFailure") {
                         executionCallsCount++;
                         for (var executionEventIndex in executionEvents) {
                             var executionEvent = callList[callIndex].executionEvents[executionEventIndex];


### PR DESCRIPTION
26 has removed the "Preempted" status and replaced it with "RetraybleFailure", which breaks the timing diagram which only displays the last attempt.
This fixes on 26_hotfix.