### PR TITLE
JES in-command write_lines fixup. Closes #1906

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -61,7 +61,7 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   private val tesEndpoint = workflowDescriptor.workflowOptions.getOrElse("endpoint", tesConfiguration.endpointURL)
 
-  override lazy val jobTag = jobDescriptor.key.tag
+  override lazy val jobTag: String = jobDescriptor.key.tag
 
   private def pipeline[T: FromResponseUnmarshaller]: HttpRequest => Future[T] = sendReceive ~> unmarshal[T]
 
@@ -98,7 +98,7 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
       Option(task.name),
       Option(task.description),
       Option(task.project),
-      Option(task.inputs),
+      Option(task.inputs(commandLineValueMapper)),
       Option(task.outputs),
       task.resources,
       task.dockerExecutor

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -7,7 +7,7 @@ import cromwell.core.path.{DefaultPathBuilder, Path}
 import wdl4s.FullyQualifiedName
 import wdl4s.expression.NoFunctions
 import wdl4s.parser.MemoryUnit
-import wdl4s.values.{WdlFile, WdlGlobFile, WdlSingleFile}
+import wdl4s.values.{WdlFile, WdlGlobFile, WdlSingleFile, WdlValue}
 
 final case class TesTask(jobDescriptor: BackendJobDescriptor,
                          configurationDescriptor: BackendConfigurationDescriptor,
@@ -20,8 +20,8 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
   private val workflowDescriptor = jobDescriptor.workflowDescriptor
   private val workflowName = workflowDescriptor.workflow.unqualifiedName
   private val fullyQualifiedTaskName = jobDescriptor.call.fullyQualifiedName
-  val name = fullyQualifiedTaskName
-  val description = jobDescriptor.toString
+  val name: String = fullyQualifiedTaskName
+  val description: String = jobDescriptor.toString
 
   // TODO validate "project" field of workflowOptions
   val project = {
@@ -38,12 +38,18 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
     Option(false)
   )
 
-  private val writeFunctionFiles: Map[FullyQualifiedName, Seq[WdlFile]] = jobDescriptor
-    .call
-    .task
-    .evaluateFilesFromCommand(jobDescriptor.fullyQualifiedInputs, backendEngineFunctions)
-    .map {
-    case (expression, file) => expression.toWdlString -> Seq(file)
+  private def writeFunctionFiles(commandLineValueMapper: WdlValue => WdlValue): Map[FullyQualifiedName, Seq[WdlFile]] = {
+    val commandLineMappedInputs = jobDescriptor.inputDeclarations map {
+      case (declaration, value) => declaration.fullyQualifiedName -> commandLineValueMapper(value)
+    }
+
+    jobDescriptor
+      .call
+      .task
+      .evaluateFilesFromCommand(commandLineMappedInputs, backendEngineFunctions)
+      .map {
+        case (expression, file) => expression.toWdlString -> Seq(file)
+      }
   }
 
   private val callInputFiles: Map[FullyQualifiedName, Seq[WdlFile]] = jobDescriptor
@@ -52,7 +58,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
       _.collectAsSeq { case w: WdlFile => w }
     }
 
-  val inputs: Seq[TaskParameter] = (callInputFiles ++ writeFunctionFiles)
+  def inputs(commandLineValueMapper: WdlValue => WdlValue): Seq[TaskParameter] = (callInputFiles ++ writeFunctionFiles(commandLineValueMapper))
     .flatMap {
       case (fullyQualifiedName, files) => files.zipWithIndex.map {
         case (f, index) => TaskParameter(


### PR DESCRIPTION
In lieu of a real fix to `write_lines`'s odd behaviour, this PR at least brings it into consistency with the other backends