### PR TITLE
Execution Store and JobPaths optimizations

### DIFF
--- a/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
@@ -24,16 +24,17 @@ object JobPaths {
   }
 }
 
-trait JobPaths { this: WorkflowPaths =>
+trait JobPaths {
   import JobPaths._
 
+  def workflowPaths: WorkflowPaths
   def returnCodeFilename: String = "rc"
   def stdoutFilename: String = "stdout"
   def stderrFilename: String = "stderr"
   def scriptFilename: String = "script"
   
   def jobKey: JobKey
-  lazy val callRoot = callPathBuilder(workflowRoot, jobKey)
+  lazy val callRoot = callPathBuilder(workflowPaths.workflowRoot, jobKey)
   lazy val callExecutionRoot = callRoot
   lazy val stdout = callExecutionRoot.resolve(stdoutFilename)
   lazy val stderr = callExecutionRoot.resolve(stderrFilename)

--- a/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
@@ -6,17 +6,17 @@ import cromwell.core.path.{Path, PathBuilder}
 
 object JobPathsWithDocker {
   def apply(jobKey: BackendJobDescriptorKey,
-  workflowDescriptor: BackendWorkflowDescriptor,
-  config: Config,
-  pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) = {
+            workflowDescriptor: BackendWorkflowDescriptor,
+            config: Config,
+            pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) = {
     val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, config, pathBuilders)
     new JobPathsWithDocker(workflowPaths, jobKey)
   }
 }
 
-case class JobPathsWithDocker(override val workflowPaths: WorkflowPathsWithDocker, jobKey: BackendJobDescriptorKey) extends JobPaths {
+case class JobPathsWithDocker private[io] (override val workflowPaths: WorkflowPathsWithDocker, jobKey: BackendJobDescriptorKey) extends JobPaths {
   import JobPaths._
-  
+
   override lazy val callExecutionRoot = { callRoot.resolve("execution") }
   val callDockerRoot = callPathBuilder(workflowPaths.dockerWorkflowRoot, jobKey)
   val callExecutionDockerRoot = callDockerRoot.resolve("execution")

--- a/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
@@ -13,7 +13,8 @@ object JobPathsWithDocker {
     new JobPathsWithDocker(workflowPaths, jobKey)
   }
 }
-class JobPathsWithDocker(override val workflowPaths: WorkflowPathsWithDocker, val jobKey: BackendJobDescriptorKey) extends JobPaths {
+
+case class JobPathsWithDocker(override val workflowPaths: WorkflowPathsWithDocker, jobKey: BackendJobDescriptorKey) extends JobPaths {
   import JobPaths._
   
   override lazy val callExecutionRoot = { callRoot.resolve("execution") }

--- a/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
@@ -4,15 +4,20 @@ import com.typesafe.config.Config
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.{Path, PathBuilder}
 
-class JobPathsWithDocker(val jobKey: BackendJobDescriptorKey,
-                         workflowDescriptor: BackendWorkflowDescriptor,
-                         config: Config,
-                         pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPathsWithDocker(
-  workflowDescriptor, config, pathBuilders) with JobPaths {
+object JobPathsWithDocker {
+  def apply(jobKey: BackendJobDescriptorKey,
+  workflowDescriptor: BackendWorkflowDescriptor,
+  config: Config,
+  pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) = {
+    val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, config, pathBuilders)
+    new JobPathsWithDocker(workflowPaths, jobKey)
+  }
+}
+class JobPathsWithDocker(override val workflowPaths: WorkflowPathsWithDocker, val jobKey: BackendJobDescriptorKey) extends JobPaths {
   import JobPaths._
   
   override lazy val callExecutionRoot = { callRoot.resolve("execution") }
-  val callDockerRoot = callPathBuilder(dockerWorkflowRoot, jobKey)
+  val callDockerRoot = callPathBuilder(workflowPaths.dockerWorkflowRoot, jobKey)
   val callExecutionDockerRoot = callDockerRoot.resolve("execution")
   val callInputsRoot = callRoot.resolve("inputs")
 
@@ -30,7 +35,7 @@ class JobPathsWithDocker(val jobKey: BackendJobDescriptorKey,
           *
           * TODO: this assumes that p.startsWith(localExecutionRoot)
           */
-        val subpath = p.subpath(executionRoot.getNameCount, p.getNameCount)
+        val subpath = p.subpath(workflowPaths.executionRoot.getNameCount, p.getNameCount)
         WorkflowPathsWithDocker.DockerRoot.resolve(subpath)
     }
   }

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
@@ -45,5 +45,13 @@ trait WorkflowPaths extends PathFactory {
     * @param jobWorkflowDescriptor The workflow descriptor for the job.
     * @return The paths for the job.
     */
-  def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JobPaths
+  def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JobPaths = {
+    // If the descriptors are the same, no need to create a new WorkflowPaths
+    if (workflowDescriptor == jobWorkflowDescriptor) toJobPaths(this, jobKey)
+    else toJobPaths(withDescriptor(jobWorkflowDescriptor), jobKey)
+  }
+  
+  protected def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JobPaths
+  
+  protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths
 }

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -8,7 +8,7 @@ object WorkflowPathsWithDocker {
   val DockerRoot: Path = DefaultPathBuilder.get("/cromwell-executions")
 }
 
-case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
+final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerWorkflowRoot: Path = workflowPathBuilder(WorkflowPathsWithDocker.DockerRoot)
 
   override def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JobPathsWithDocker = {

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -8,8 +8,12 @@ object WorkflowPathsWithDocker {
   val DockerRoot: Path = DefaultPathBuilder.get("/cromwell-executions")
 }
 
-class WorkflowPathsWithDocker(val workflowDescriptor: BackendWorkflowDescriptor, val config: Config, val pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
+case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerWorkflowRoot: Path = workflowPathBuilder(WorkflowPathsWithDocker.DockerRoot)
 
-  override def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JobPathsWithDocker = new JobPathsWithDocker(this, jobKey)
+  override def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JobPathsWithDocker = {
+    new JobPathsWithDocker(workflowPaths.asInstanceOf[WorkflowPathsWithDocker], jobKey)
+  }
+
+  override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
 }

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -11,8 +11,5 @@ object WorkflowPathsWithDocker {
 class WorkflowPathsWithDocker(val workflowDescriptor: BackendWorkflowDescriptor, val config: Config, val pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerWorkflowRoot: Path = workflowPathBuilder(WorkflowPathsWithDocker.DockerRoot)
 
-  override def toJobPaths(jobKey: BackendJobDescriptorKey,
-                          jobWorkflowDescriptor: BackendWorkflowDescriptor): JobPathsWithDocker = {
-    new JobPathsWithDocker(jobKey, jobWorkflowDescriptor, config, pathBuilders)
-  }
+  override def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JobPathsWithDocker = new JobPathsWithDocker(this, jobKey)
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardCachingActorHelper.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardCachingActorHelper.scala
@@ -36,7 +36,7 @@ trait StandardCachingActorHelper extends JobCachingActorHelper {
   def serviceRegistryActor: ActorRef
 
   // So... JobPaths doesn't extend WorkflowPaths, but does contain a self-type
-  lazy val workflowPaths: WorkflowPaths = jobPaths.asInstanceOf[WorkflowPaths]
+  lazy val workflowPaths: WorkflowPaths = jobPaths.workflowPaths
 
   def getPath(str: String): Try[Path] = workflowPaths.getPath(str)
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
@@ -15,7 +15,7 @@ class StandardInitializationData
     standardExpressionFunctionsClass.getConstructor(classOf[StandardExpressionFunctionsParams])
 
   def expressionFunctions(jobPaths: JobPaths): StandardExpressionFunctions = {
-    val pathBuilders = jobPaths.asInstanceOf[WorkflowPaths].pathBuilders
+    val pathBuilders = jobPaths.workflowPaths.pathBuilders
     val callContext = jobPaths.callContext
     val standardParams = DefaultStandardExpressionFunctionsParams(pathBuilders, callContext)
     standardExpressionFunctionsConstructor.newInstance(standardParams)

--- a/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
@@ -31,7 +31,8 @@ class JobPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val wd = buildWorkflowDescriptor(TestWorkflows.HelloWorld)
     val call: TaskCall = wd.workflow.taskCalls.head
     val jobKey = BackendJobDescriptorKey(call, None, 1)
-    val jobPaths = new JobPathsWithDocker(jobKey, wd, backendConfig)
+    val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
+    val jobPaths = new JobPathsWithDocker(workflowPaths, jobKey)
     val id = wd.id
     jobPaths.callRoot.pathAsString shouldBe
       fullPath(s"local-cromwell-executions/wf_hello/$id/call-hello")
@@ -58,17 +59,17 @@ class JobPathsSpec extends FlatSpec with Matchers with BackendSpec {
       fullPath("/cromwell-executions/dock/path")
 
     val jobKeySharded = BackendJobDescriptorKey(call, Option(0), 1)
-    val jobPathsSharded = new JobPathsWithDocker(jobKeySharded, wd, backendConfig)
+    val jobPathsSharded = new JobPathsWithDocker(workflowPaths, jobKeySharded)
     jobPathsSharded.callExecutionRoot.pathAsString shouldBe
       fullPath(s"local-cromwell-executions/wf_hello/$id/call-hello/shard-0/execution")
 
     val jobKeyAttempt = BackendJobDescriptorKey(call, None, 2)
-    val jobPathsAttempt = new JobPathsWithDocker(jobKeyAttempt, wd, backendConfig)
+    val jobPathsAttempt = new JobPathsWithDocker(workflowPaths, jobKeyAttempt)
     jobPathsAttempt.callExecutionRoot.pathAsString shouldBe
       fullPath(s"local-cromwell-executions/wf_hello/$id/call-hello/attempt-2/execution")
 
     val jobKeyShardedAttempt = BackendJobDescriptorKey(call, Option(0), 2)
-    val jobPathsShardedAttempt = new JobPathsWithDocker(jobKeyShardedAttempt, wd, backendConfig)
+    val jobPathsShardedAttempt = new JobPathsWithDocker(workflowPaths, jobKeyShardedAttempt)
     jobPathsShardedAttempt.callExecutionRoot.pathAsString shouldBe
       fullPath(s"local-cromwell-executions/wf_hello/$id/call-hello/shard-0/attempt-2/execution")
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
@@ -3,11 +3,15 @@ package cromwell.engine.workflow.lifecycle.execution
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionStatus._
 import cromwell.core.{CallKey, JobKey}
+import cromwell.engine.workflow.lifecycle.execution.ExecutionStore.FqnIndex
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{apply => _, _}
 import wdl4s._
 
+import scala.language.postfixOps
 
 object ExecutionStore {
+  type FqnIndex = (String, Option[Int])
+
   def empty = ExecutionStore(Map.empty[JobKey, ExecutionStatus], hasNewRunnables = false)
 
   def apply(workflow: Workflow, workflowCoercedInputs: WorkflowCoercedInputs) = {
@@ -29,7 +33,12 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
 
   // View of the statusStore more suited for lookup based on status
   lazy val store: Map[ExecutionStatus, List[JobKey]] = statusStore.groupBy(_._2).mapValues(_.keys.toList)
-  lazy val doneKeys = store.filterKeys(_.isDoneOrBypassed).values.toList.flatten
+  // Takes only keys that are done, and creates a map such that they're indexed by fqn and index
+  // This allows for quicker lookup (by hash) instead of traversing the whole list and yields
+  // significant improvements at large scale (run ExecutionStoreBenchmark)
+  lazy val doneKeys: Map[(String, Option[Int]), JobKey] = store.filterKeys(_.isDoneOrBypassed).values.flatten.map { key =>
+    (key.scope.fullyQualifiedName, key.index) -> key
+  } toMap
 
   private def keysWithStatus(status: ExecutionStatus) = store.getOrElse(status, List.empty)
 
@@ -71,48 +80,35 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
     this.copy(statusStore = statusStore ++ values, hasNewRunnables = hasNewRunnables || values.values.exists(_.isTerminal))
   }
 
-  def runnableScopes = keysWithStatus(NotStarted) filter arePrerequisitesDone(doneKeys)
+  def runnableScopes = keysWithStatus(NotStarted) filter arePrerequisitesDone
 
-  def findCompletedShardsForOutput(key: CollectorKey): List[JobKey] = doneKeys collect {
+  def findCompletedShardsForOutput(key: CollectorKey): List[JobKey] = doneKeys.values.toList collect {
     case k @ (_: CallKey | _:DynamicDeclarationKey) if k.scope == key.scope && k.isShard => k
   }
 
-  // Just used to decide whether a collector can be run. In case the shard entries haven't been populated into the
-  // execution store yet.
-  private final case class TempJobKey(scope: Scope with GraphNode, index: Option[Int]) extends JobKey {
-    // If these are ever used, we've done something wrong...
-    override def attempt: Int = throw new NotImplementedError("We've done something wrong.")
-    override def tag: String = throw new NotImplementedError("We've done something wrong.")
-  }
-
-  private def emulateShardEntries(key: CollectorKey): List[JobKey] = {
-    (0 until key.scatterWidth).toList flatMap { i => key.scope match {
-      case c: Call => List(TempJobKey(c, Option(i)))
-      case d: Declaration => List(TempJobKey(d, Option(i)))
+  private def emulateShardEntries(key: CollectorKey): Set[FqnIndex] = {
+    (0 until key.scatterWidth).toSet map { i: Int => key.scope match {
+      case c: Call => c.fullyQualifiedName -> Option(i)
+      case d: Declaration => d.fullyQualifiedName -> Option(i)
       case _ => throw new RuntimeException("Don't collect that.")
     }}
   }
 
-  private def arePrerequisitesDone(doneKeys: List[JobKey])(key: JobKey): Boolean = {
-    val upstreamAreDone = key.scope.upstream forall {
-      case n @ (_: Call | _: Scatter | _: Declaration) => upstreamIsDone(key, n, doneKeys)
+  private def arePrerequisitesDone(key: JobKey): Boolean = {
+    lazy val upstreamAreDone = key.scope.upstream forall {
+      case n @ (_: Call | _: Scatter | _: Declaration) => upstreamIsDone(key, n)
       case _ => true
     }
 
-    lazy val shardEntriesForCollectorAreDone: Boolean = key match {
-      case collector: CollectorKey =>
-        emulateShardEntries(collector)
-          .map(shard => (shard.scope.fullyQualifiedName, shard.index))
-          .diff(
-            doneKeys.map(key => (key.scope.fullyQualifiedName, key.index))
-          ).isEmpty
+    val shardEntriesForCollectorAreDone: Boolean = key match {
+      case collector: CollectorKey => emulateShardEntries(collector).diff(doneKeys.keys.toSet).isEmpty
       case _ => true
     }
 
-    upstreamAreDone && shardEntriesForCollectorAreDone
+    shardEntriesForCollectorAreDone && upstreamAreDone
   }
 
-  private def upstreamIsDone(entry: JobKey, prerequisiteScope: Scope, doneKeys: List[JobKey]): Boolean = {
+  private def upstreamIsDone(entry: JobKey, prerequisiteScope: Scope): Boolean = {
     prerequisiteScope.closestCommonAncestor(entry.scope) match {
       /*
         * If this entry refers to a Scope which has a common ancestor with prerequisiteScope
@@ -123,19 +119,13 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
         * NOTE: this algorithm was designed for ONE-LEVEL of scattering and probably does not
         * work as-is for nested scatter blocks
         */
-      case Some(ancestor: Scatter) =>
-        doneKeys exists { k =>
-          k.scope == prerequisiteScope && k.index == entry.index
-        }
+      case Some(ancestor: Scatter) => doneKeys.contains(prerequisiteScope.fullyQualifiedName -> entry.index)
 
       /*
         * Otherwise, simply refer to the collector entry.  This means that 'entry' depends
         * on every shard of the pre-requisite scope to finish.
         */
-      case _ =>
-        doneKeys exists { k =>
-          k.scope == prerequisiteScope && k.index.isEmpty
-        }
+      case _ => doneKeys.contains(prerequisiteScope.fullyQualifiedName -> None)
     }
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
@@ -36,7 +36,7 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
   // Takes only keys that are done, and creates a map such that they're indexed by fqn and index
   // This allows for quicker lookup (by hash) instead of traversing the whole list and yields
   // significant improvements at large scale (run ExecutionStoreBenchmark)
-  lazy val doneKeys: Map[(String, Option[Int]), JobKey] = store.filterKeys(_.isDoneOrBypassed).values.flatten.map { key =>
+  lazy val doneKeys: Map[FqnIndex, JobKey] = store.filterKeys(_.isDoneOrBypassed).values.flatten.map { key =>
     (key.scope.fullyQualifiedName, key.index) -> key
   } toMap
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -19,7 +19,6 @@ import cromwell.util.StopAndLogSupervisor
 import cromwell.webservice.EngineStatsActor
 import lenthall.exception.ThrowableAggregation
 import lenthall.util.TryUtil
-import wdl4s.values.{WdlArray, WdlBoolean, WdlOptionalValue, WdlValue, WdlString}
 import org.apache.commons.lang3.StringUtils
 import wdl4s.WdlExpression.ScopedLookupFunction
 import wdl4s.expression.WdlFunctions

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -1,0 +1,52 @@
+package cromwell.engine.workflow.lifecycle.execution
+
+import cromwell.backend.BackendJobDescriptorKey
+import cromwell.core.ExecutionStatus.{apply => _, _}
+import cromwell.core.{ExecutionStatus, JobKey}
+import cromwell.util.SampleWdl
+import org.scalameter.api._
+import wdl4s.{TaskCall, WdlNamespaceWithWorkflow}
+import org.scalameter.picklers.Implicits._
+
+/**
+  * Benchmarks the performance of the execution store.
+  */
+object ExecutionStoreBenchmark extends Bench[Double] {
+
+  /* Benchmark configuration */
+  lazy val measurer = new Measurer.Default
+  lazy val executor = SeparateJvmsExecutor(new Executor.Warmer.Default, Aggregator.average, measurer)
+  lazy val reporter = new LoggingReporter[Double]
+  lazy val persistor = Persistor.None
+  
+  val wdl = WdlNamespaceWithWorkflow.load(SampleWdl.PrepareScatterGatherWdl().wdlSource(), Seq.empty).get
+  val prepareCall: TaskCall = wdl.workflow.findCallByName("do_prepare").get.asInstanceOf[TaskCall]
+  val scatterCall: TaskCall = wdl.workflow.findCallByName("do_scatter").get.asInstanceOf[TaskCall]
+  
+  def makeKey(call: TaskCall, executionStatus: ExecutionStatus)(index: Int) = {
+    BackendJobDescriptorKey(call, Option(index), 1) -> executionStatus
+  }
+  
+  // Generates numbers from 1000 to 10000 with 1000 gap:
+  // 1000, 2000, ..., 10000
+  val sizes: Gen[Int] = Gen.range("size")(1000, 10000, 1000)
+  
+  // Generates executionStores using the given above sizes
+  // Each execution store contains X simulated shards of "prepareCall" in status Done and X simulated shards of "scatterCall" in status NotStarted
+  // This provides a good starting point to evaluate the speed of "runnableCalls", as it needs to iterate over all "NotStarted" keys, and for each one
+  // look for their upstreams keys in status "Done"
+  val executionStores: Gen[ExecutionStore] = for {
+    size <- sizes
+    doneMap = (0 until size map makeKey(prepareCall, ExecutionStatus.Done)).toMap
+    notStartedMap = (0 until size map makeKey(scatterCall, ExecutionStatus.NotStarted)).toMap
+    finalMap: Map[JobKey, ExecutionStatus] = doneMap ++ notStartedMap
+  } yield new ExecutionStore(finalMap, true)
+  
+  performance of "ExecutionStore" in {
+    measure method "runnableCalls" in {
+      using(executionStores) in { es =>
+        es.runnableScopes
+      }
+    }
+  }
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -9,7 +9,10 @@ import wdl4s.{TaskCall, WdlNamespaceWithWorkflow}
 import org.scalameter.picklers.Implicits._
 
 /**
-  * Benchmarks the performance of the execution store.
+  * Benchmarks the performance of the execution store using ScalaMeter (http://scalameter.github.io/)
+  * This is not run automatically by "sbt test". To run this test specifically, either use intellij integration, or run
+  * sbt "project engine"  "benchmark:test-only cromwell.engine.workflow.lifecycle.execution.ExecutionStoreBenchmark"
+  * sbt benchmark:test will run all ScalaMeter tests
   */
 object ExecutionStoreBenchmark extends Bench[Double] {
 
@@ -43,6 +46,8 @@ object ExecutionStoreBenchmark extends Bench[Double] {
   } yield new ExecutionStore(finalMap, true)
   
   performance of "ExecutionStore" in {
+    // Measures how fast the execution store can find runnable calls with lots of "Done" calls and "NotStarted" calls.
+    // Other "shapes" would be valuable to get a better sense of how this method behaves in various situations (with Collector Keys etc...)  
     measure method "runnableCalls" in {
       using(executionStores) in { es =>
         es.runnableScopes

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -163,6 +163,7 @@ object Dependencies {
   val engineDependencies = List(
     "commons-codec" % "commons-codec" % "1.10",
     "commons-io" % "commons-io" % "2.5",
+    "com.storm-enroute" %% "scalameter" % "0.8.2",
     "io.swagger" % "swagger-parser" % "1.0.22" % Test,
     "org.yaml" % "snakeyaml" % "1.17" % Test
   ) ++ sprayServerDependencies

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -6,6 +6,7 @@ object Testing {
   lazy val DockerTest = config("docker") extend Test
   lazy val NoDockerTest = config("nodocker") extend Test
   lazy val CromwellIntegrationTest = config("integration") extend Test
+  lazy val CromwellBenchmarkTest = config("benchmark") extend Test
   lazy val CromwellNoIntegrationTest = config("nointegration") extend Test
   lazy val DbmsTest = config("dbms") extend Test
 
@@ -14,10 +15,8 @@ object Testing {
   lazy val DontUseDockerTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", DockerTestTag)
 
   lazy val CromwellIntegrationTestTag = "CromwellIntegrationTest"
-  lazy val UseCromwellIntegrationTaggedTests =
-    Tests.Argument(TestFrameworks.ScalaTest, "-n", CromwellIntegrationTestTag)
-  lazy val DontUseCromwellIntegrationTaggedTests =
-    Tests.Argument(TestFrameworks.ScalaTest, "-l", CromwellIntegrationTestTag)
+  lazy val UseCromwellIntegrationTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-n", CromwellIntegrationTestTag)
+  lazy val DontUseCromwellIntegrationTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-l", CromwellIntegrationTestTag)
 
   lazy val GcsIntegrationTestTag = "GcsIntegrationTest"
   lazy val UseGcsIntegrationTaggedTests = Tests.Argument(TestFrameworks.ScalaTest, "-n", GcsIntegrationTestTag)
@@ -54,7 +53,11 @@ object Testing {
     // `nointegration:test` - Run all tests, except integration
     testOptions in CromwellNoIntegrationTest := (testOptions in AllTests).value ++ Seq(DontUseCromwellIntegrationTaggedTests, DontUseGcsIntegrationTaggedTests, DontUsePostMVPTaggedTests),
     // `dbms:test` - Run database management tests.
-    testOptions in DbmsTest := (testOptions in AllTests).value ++ Seq(UseDbmsTaggedTests)
+    testOptions in DbmsTest := (testOptions in AllTests).value ++ Seq(UseDbmsTaggedTests),
+    // Add scalameter as a test framework in the CromwellBenchmarkTest scope
+    testFrameworks in CromwellBenchmarkTest += new TestFramework("org.scalameter.ScalaMeterFramework"),
+    // Don't execute benchmarks in parallel
+    parallelExecution in CromwellBenchmarkTest := false
   )
   /*
     TODO: This syntax of test in (NoTests, assembly) isn't correct
@@ -84,6 +87,7 @@ object Testing {
       .configs(DockerTest).settings(inConfig(DockerTest)(Defaults.testTasks): _*)
       .configs(NoDockerTest).settings(inConfig(NoDockerTest)(Defaults.testTasks): _*)
       .configs(CromwellIntegrationTest).settings(inConfig(CromwellIntegrationTest)(Defaults.testTasks): _*)
+      .configs(CromwellBenchmarkTest).settings(inConfig(CromwellBenchmarkTest)(Defaults.testTasks): _*)
       .configs(CromwellNoIntegrationTest).settings(inConfig(CromwellNoIntegrationTest)(Defaults.testTasks): _*)
       .configs(DbmsTest).settings(inConfig(DbmsTest)(Defaults.testTasks): _*)
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -115,7 +115,7 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   private def gcsAuthParameter: Option[JesInput] = {
     if (jesAttributes.auths.gcs.requiresAuthFile || dockerConfiguration.isDefined)
-      Option(JesLiteralInput(ExtraConfigParamName, jesCallPaths.gcsAuthFilePath.pathAsString))
+      Option(JesLiteralInput(ExtraConfigParamName, jesCallPaths.workflowPaths.gcsAuthFilePath.pathAsString))
     else None
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
@@ -40,7 +40,7 @@ trait JesJobCachingActorHelper extends StandardCachingActorHelper {
 
   lazy val jesAttributes: JesAttributes = jesConfiguration.jesAttributes
   lazy val monitoringScript: Option[JesInput] = {
-    jesCallPaths.monitoringPath map { path =>
+    jesCallPaths.workflowPaths.monitoringPath map { path =>
       JesFileInput(s"$MonitoringParamName-in", path.pathAsString,
         JesWorkingDisk.MountPoint.resolve(JesMonitoringScript), workingDisk)
     }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
@@ -7,10 +7,6 @@ import cromwell.core.path.Path
 import cromwell.services.metadata.CallMetadataKeys
 
 object JesJobPaths {
-  def apply(workflowPaths: JesWorkflowPaths, jobKey: BackendJobDescriptorKey)(implicit actorSystem: ActorSystem): JesJobPaths = {
-    new JesJobPaths(workflowPaths, jobKey)
-  }
-  
   def apply(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor,
             jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem): JesJobPaths = {
     val workflowPath = new JesWorkflowPaths(workflowDescriptor, jesConfiguration)
@@ -21,7 +17,7 @@ object JesJobPaths {
   val GcsExecPathKey = "gcsExec"
 }
 
-class JesJobPaths(override val workflowPaths: JesWorkflowPaths, val jobKey: BackendJobDescriptorKey)(implicit actorSystem: ActorSystem) extends JobPaths {
+case class JesJobPaths(override val workflowPaths: JesWorkflowPaths, jobKey: BackendJobDescriptorKey)(implicit actorSystem: ActorSystem) extends JobPaths {
 
   val jesLogBasename = {
     val index = jobKey.index.map(s => s"-$s").getOrElse("")

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -14,14 +14,9 @@ import scala.language.postfixOps
 object JesWorkflowPaths {
   private val GcsRootOptionKey = "jes_gcs_root"
   private val AuthFilePathOptionKey = "auth_bucket"
-
-  def apply(workflowDescriptor: BackendWorkflowDescriptor,
-            jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem): JesWorkflowPaths = {
-    new JesWorkflowPaths(workflowDescriptor, jesConfiguration)
-  }
 }
 
-class JesWorkflowPaths(val workflowDescriptor: BackendWorkflowDescriptor,
+case class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
                        jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
 
   override lazy val executionRootString: String =
@@ -52,7 +47,12 @@ class JesWorkflowPaths(val workflowDescriptor: BackendWorkflowDescriptor,
     getPath(path).get
   }
 
-  override def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JesJobPaths = JesJobPaths(this, jobKey)
+  override def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JesJobPaths = {
+    new JesJobPaths(workflowPaths.asInstanceOf[JesWorkflowPaths], jobKey)
+  }
+
+  override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
+
   override def config: Config = jesConfiguration.configurationDescriptor.backendConfig
   override def pathBuilders: List[PathBuilder] = List(gcsPathBuilder)
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -52,10 +52,7 @@ class JesWorkflowPaths(val workflowDescriptor: BackendWorkflowDescriptor,
     getPath(path).get
   }
 
-  override def toJobPaths(jobKey: BackendJobDescriptorKey,
-                          jobWorkflowDescriptor: BackendWorkflowDescriptor): JesJobPaths = {
-    JesJobPaths(jobKey, jobWorkflowDescriptor, jesConfiguration)
-  }
+  override def toJobPaths(jobKey: BackendJobDescriptorKey, jobWorkflowDescriptor: BackendWorkflowDescriptor): JesJobPaths = JesJobPaths(this, jobKey)
   override def config: Config = jesConfiguration.configurationDescriptor.backendConfig
   override def pathBuilders: List[PathBuilder] = List(gcsPathBuilder)
 }

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -113,7 +113,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
       val jobDescriptor: BackendJobDescriptor = jobDescriptorFromSingleCallWorkflow(workflowDescriptor, inputs, WorkflowOptions.empty, runtimeAttributeDefinitions)
       val expectedResponse = JobSucceededResponse(jobDescriptor.key, Some(0), expectedOutputs, None, Seq.empty)
 
-      val jobPaths = new JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, conf.backendConfig)
+      val jobPaths = JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, conf.backendConfig)
 
       whenReady(backend.execute) { executionResponse =>
         assertResponse(executionResponse, expectedResponse)
@@ -161,7 +161,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val backendRef = createBackendRef(jobDescriptor, TestConfig.backendRuntimeConfigDescriptor)
     val backend = backendRef.underlyingActor
 
-    val jobPaths = new JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, ConfigFactory.empty)
+    val jobPaths = JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, ConfigFactory.empty)
     jobPaths.callExecutionRoot.createPermissionedDirectories()
     jobPaths.stdout.write("Hello stubby ! ")
     jobPaths.stderr.touch()
@@ -252,7 +252,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val workflowDescriptor = buildWorkflowDescriptor(OutputProcess, inputs)
     val jobDescriptor: BackendJobDescriptor = jobDescriptorFromSingleCallWorkflow(workflowDescriptor, inputs, WorkflowOptions.empty, runtimeAttributeDefinitions)
     val backend = createBackend(jobDescriptor, TestConfig.backendRuntimeConfigDescriptor)
-    val jobPaths = new JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, TestConfig.backendRuntimeConfigDescriptor.backendConfig)
+    val jobPaths = JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, TestConfig.backendRuntimeConfigDescriptor.backendConfig)
     val expectedA = WdlFile(jobPaths.callExecutionRoot.resolve("a").toAbsolutePath.pathAsString)
     val expectedB = WdlFile(jobPaths.callExecutionRoot.resolve("dir").toAbsolutePath.resolve("b").pathAsString)
     val expectedOutputs = Map(

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -2,7 +2,7 @@ package cromwell.backend.impl.spark
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import cromwell.backend._
-import cromwell.backend.io.JobPathsWithDocker
+import cromwell.backend.io.{JobPathsWithDocker, WorkflowPathsWithDocker}
 import cromwell.backend.sfs.SharedFileSystemExpressionFunctions
 import cromwell.core.CallContext
 import wdl4s.TaskCall
@@ -23,8 +23,9 @@ case class SparkBackendFactory(name: String, configurationDescriptor: BackendCon
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor, jobKey: BackendJobDescriptorKey,
                                            initializationData: Option[BackendInitializationData]): WdlStandardLibraryFunctions = {
-    val jobPaths = new JobPathsWithDocker(jobKey, workflowDescriptor, configurationDescriptor.backendConfig)
-    val callContext = new CallContext(
+    val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, configurationDescriptor.backendConfig)
+    val jobPaths = new JobPathsWithDocker(workflowPaths, jobKey)
+    val callContext = CallContext(
       jobPaths.callExecutionRoot,
       jobPaths.stdout.toAbsolutePath.toString,
       jobPaths.stderr.toAbsolutePath.toString

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -2,7 +2,7 @@ package cromwell.backend.impl.spark
 
 import akka.actor.{ActorRef, ActorSystem, Props}
 import cromwell.backend._
-import cromwell.backend.io.{JobPathsWithDocker, WorkflowPathsWithDocker}
+import cromwell.backend.io.JobPathsWithDocker
 import cromwell.backend.sfs.SharedFileSystemExpressionFunctions
 import cromwell.core.CallContext
 import wdl4s.TaskCall
@@ -23,8 +23,7 @@ case class SparkBackendFactory(name: String, configurationDescriptor: BackendCon
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor, jobKey: BackendJobDescriptorKey,
                                            initializationData: Option[BackendInitializationData]): WdlStandardLibraryFunctions = {
-    val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, configurationDescriptor.backendConfig)
-    val jobPaths = new JobPathsWithDocker(workflowPaths, jobKey)
+    val jobPaths = JobPathsWithDocker(jobKey, workflowDescriptor, configurationDescriptor.backendConfig)
     val callContext = CallContext(
       jobPaths.callExecutionRoot,
       jobPaths.stdout.toAbsolutePath.toString,

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -5,7 +5,7 @@ import java.nio.file.attribute.PosixFilePermission
 import akka.actor.Props
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobFailedNonRetryableResponse, JobSucceededResponse}
 import cromwell.backend.impl.spark.SparkClusterProcess._
-import cromwell.backend.io.{JobPathsWithDocker, WorkflowPathsWithDocker}
+import cromwell.backend.io.JobPathsWithDocker
 import cromwell.backend.sfs.{SharedFileSystem, SharedFileSystemExpressionFunctions}
 import cromwell.backend.wdl.Command
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobExecutionActor}
@@ -44,8 +44,7 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
   private val sparkDeployMode = configurationDescriptor.backendConfig.getString("deployMode").toLowerCase
   override val sharedFileSystemConfig = fileSystemsConfig.getConfig("local")
   private val workflowDescriptor = jobDescriptor.workflowDescriptor
-  private val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, configurationDescriptor.backendConfig)
-  private val jobPaths = new JobPathsWithDocker(workflowPaths, jobDescriptor.key)
+  private val jobPaths = JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, configurationDescriptor.backendConfig)
 
   // Files
   private val executionDir = jobPaths.callExecutionRoot

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -5,7 +5,7 @@ import java.nio.file.attribute.PosixFilePermission
 import akka.actor.Props
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobFailedNonRetryableResponse, JobSucceededResponse}
 import cromwell.backend.impl.spark.SparkClusterProcess._
-import cromwell.backend.io.JobPathsWithDocker
+import cromwell.backend.io.{JobPathsWithDocker, WorkflowPathsWithDocker}
 import cromwell.backend.sfs.{SharedFileSystem, SharedFileSystemExpressionFunctions}
 import cromwell.backend.wdl.Command
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobExecutionActor}
@@ -44,7 +44,8 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
   private val sparkDeployMode = configurationDescriptor.backendConfig.getString("deployMode").toLowerCase
   override val sharedFileSystemConfig = fileSystemsConfig.getConfig("local")
   private val workflowDescriptor = jobDescriptor.workflowDescriptor
-  private val jobPaths = new JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, configurationDescriptor.backendConfig)
+  private val workflowPaths = new WorkflowPathsWithDocker(workflowDescriptor, configurationDescriptor.backendConfig)
+  private val jobPaths = new JobPathsWithDocker(workflowPaths, jobDescriptor.key)
 
   // Files
   private val executionDir = jobPaths.callExecutionRoot

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
@@ -438,7 +438,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
   }
 
   private def cleanUpJob(jobPaths: JobPathsWithDocker): Unit = {
-    File(jobPaths.workflowRoot).delete(true)
+    File(jobPaths.workflowPaths.workflowRoot).delete(true)
     ()
   }
 
@@ -446,7 +446,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
     val backendWorkflowDescriptor = buildWorkflowDescriptor(wdl = wdlSource, inputs = inputFiles.getOrElse(Map.empty), runtime = runtimeString)
     val backendConfigurationDescriptor = if (isCluster) BackendConfigurationDescriptor(backendClusterConfig, ConfigFactory.load) else BackendConfigurationDescriptor(backendClientConfig, ConfigFactory.load)
     val jobDesc = jobDescriptorFromSingleCallWorkflow(backendWorkflowDescriptor, inputFiles.getOrElse(Map.empty), WorkflowOptions.empty, Set.empty)
-    val jobPaths = if (isCluster) new JobPathsWithDocker(jobDesc.key, backendWorkflowDescriptor, backendClusterConfig) else new JobPathsWithDocker(jobDesc.key, backendWorkflowDescriptor, backendClientConfig)
+    val jobPaths = if (isCluster) JobPathsWithDocker(jobDesc.key, backendWorkflowDescriptor, backendClusterConfig) else JobPathsWithDocker(jobDesc.key, backendWorkflowDescriptor, backendClientConfig)
     val executionDir = jobPaths.callExecutionRoot
     val stdout = File(executionDir.toString, "stdout")
     stdout.createIfNotExists(asDirectory = false, createParents = true)

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -70,7 +70,7 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
   override def mapCommandLineWdlFile(wdlFile: WdlFile): WdlFile = {
     val localPath = DefaultPathBuilder.get(wdlFile.valueString).toAbsolutePath
     localPath match {
-      case p if p.startsWith(tesJobPaths.DockerRoot) =>
+      case p if p.startsWith(tesJobPaths.workflowPaths.DockerRoot) =>
         val containerPath = p.pathAsString
         WdlFile(containerPath)
       case p if p.startsWith(tesJobPaths.callExecutionRoot) =>

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -1,22 +1,29 @@
 package cromwell.backend.impl.tes
 
 import com.typesafe.config.Config
-import cromwell.backend.io.{JobPaths, WorkflowPaths}
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.backend.io.{JobPaths, WorkflowPaths}
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 
-class TesJobPaths(val jobKey: BackendJobDescriptorKey,
-                  workflowDescriptor: BackendWorkflowDescriptor,
-                  config: Config,
-                  pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends TesWorkflowPaths(
-  workflowDescriptor, config, pathBuilders) with JobPaths {
+object TesJobPaths {
+  def apply(jobKey: BackendJobDescriptorKey,
+  workflowDescriptor: BackendWorkflowDescriptor,
+  config: Config,
+  pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) = {
+    val workflowPaths = new TesWorkflowPaths(workflowDescriptor, config, pathBuilders)
+    new TesJobPaths(workflowPaths, jobKey)
+  }
+}
+
+class TesJobPaths(override val workflowPaths: TesWorkflowPaths,
+                  val jobKey: BackendJobDescriptorKey) extends JobPaths {
 
   import JobPaths._
 
   override lazy val callExecutionRoot = {
     callRoot.resolve("execution")
   }
-  val callDockerRoot = callPathBuilder(dockerWorkflowRoot, jobKey)
+  val callDockerRoot = callPathBuilder(workflowPaths.dockerWorkflowRoot, jobKey)
   val callExecutionDockerRoot = callDockerRoot.resolve("execution")
   val callInputsDockerRoot = callDockerRoot.resolve("inputs")
   val callInputsRoot = callRoot.resolve("inputs")

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -10,12 +10,12 @@ object TesJobPaths {
   workflowDescriptor: BackendWorkflowDescriptor,
   config: Config,
   pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) = {
-    val workflowPaths = new TesWorkflowPaths(workflowDescriptor, config, pathBuilders)
+    val workflowPaths = TesWorkflowPaths(workflowDescriptor, config, pathBuilders)
     new TesJobPaths(workflowPaths, jobKey)
   }
 }
 
-case class TesJobPaths(override val workflowPaths: TesWorkflowPaths,
+case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPaths,
                   jobKey: BackendJobDescriptorKey) extends JobPaths {
 
   import JobPaths._

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -15,8 +15,8 @@ object TesJobPaths {
   }
 }
 
-class TesJobPaths(override val workflowPaths: TesWorkflowPaths,
-                  val jobKey: BackendJobDescriptorKey) extends JobPaths {
+case class TesJobPaths(override val workflowPaths: TesWorkflowPaths,
+                  jobKey: BackendJobDescriptorKey) extends JobPaths {
 
   import JobPaths._
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesWorkflowPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesWorkflowPaths.scala
@@ -6,7 +6,7 @@ import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.{PathBuilder, PathFactory}
 import net.ceedubs.ficus.Ficus._
 
-class TesWorkflowPaths(override val workflowDescriptor: BackendWorkflowDescriptor,
+case class TesWorkflowPaths(override val workflowDescriptor: BackendWorkflowDescriptor,
                        override val config: Config,
                        override val pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
 
@@ -17,8 +17,10 @@ class TesWorkflowPaths(override val workflowDescriptor: BackendWorkflowDescripto
   }
   val dockerWorkflowRoot = workflowPathBuilder(DockerRoot)
 
-  override def toJobPaths(jobKey: BackendJobDescriptorKey,
-                          jobWorkflowDescriptor: BackendWorkflowDescriptor): TesJobPaths = {
-    new TesJobPaths(this, jobKey)
+  override def toJobPaths(workflowPaths: WorkflowPaths,
+                          jobKey: BackendJobDescriptorKey): TesJobPaths = {
+    new TesJobPaths(workflowPaths.asInstanceOf[TesWorkflowPaths], jobKey)
   }
+
+  override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesWorkflowPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesWorkflowPaths.scala
@@ -19,6 +19,6 @@ class TesWorkflowPaths(override val workflowDescriptor: BackendWorkflowDescripto
 
   override def toJobPaths(jobKey: BackendJobDescriptorKey,
                           jobWorkflowDescriptor: BackendWorkflowDescriptor): TesJobPaths = {
-    new TesJobPaths(jobKey, jobWorkflowDescriptor, config, pathBuilders)
+    new TesJobPaths(this, jobKey)
   }
 }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
@@ -12,7 +12,7 @@ class TesJobPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val wd = buildWorkflowDescriptor(TestWorkflows.HelloWorld)
     val call: TaskCall = wd.workflow.taskCalls.head
     val jobKey = BackendJobDescriptorKey(call, None, 1)
-    val jobPaths = new TesJobPaths(jobKey, wd, TesTestConfig.backendConfig)
+    val jobPaths = TesJobPaths(jobKey, wd, TesTestConfig.backendConfig)
     val id = wd.id
     jobPaths.callRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id/call-hello").pathAsString
@@ -34,17 +34,17 @@ class TesJobPathsSpec extends FlatSpec with Matchers with BackendSpec {
       File(s"/cromwell-executions/wf_hello/$id/call-hello/execution").pathAsString
 
     val jobKeySharded = BackendJobDescriptorKey(call, Option(0), 1)
-    val jobPathsSharded = new TesJobPaths(jobKeySharded, wd, TesTestConfig.backendConfig)
+    val jobPathsSharded = TesJobPaths(jobKeySharded, wd, TesTestConfig.backendConfig)
     jobPathsSharded.callExecutionRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id/call-hello/shard-0/execution").pathAsString
 
     val jobKeyAttempt = BackendJobDescriptorKey(call, None, 2)
-    val jobPathsAttempt = new TesJobPaths(jobKeyAttempt, wd, TesTestConfig.backendConfig)
+    val jobPathsAttempt = TesJobPaths(jobKeyAttempt, wd, TesTestConfig.backendConfig)
     jobPathsAttempt.callExecutionRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id/call-hello/attempt-2/execution").pathAsString
 
     val jobKeyShardedAttempt = BackendJobDescriptorKey(call, Option(0), 2)
-    val jobPathsShardedAttempt = new TesJobPaths(jobKeyShardedAttempt, wd, TesTestConfig.backendConfig)
+    val jobPathsShardedAttempt = TesJobPaths(jobKeyShardedAttempt, wd, TesTestConfig.backendConfig)
     jobPathsShardedAttempt.callExecutionRoot.toString shouldBe
       File(s"local-cromwell-executions/wf_hello/$id/call-hello/shard-0/attempt-2/execution").pathAsString
   }


### PR DESCRIPTION
2 other minor things popped up while call caching the 10K joint genotyping: 
- We spend a fair amount of time creating `GcsPathBuilder`s, which we shouldn't since we only need one per workflow in theory. In practice we need to create a few more because we can't quite propagate the same one around everywhere. But before this PR we would create one per job which seems inefficient. One reason for this is that `JobPaths` extends `WorkflowPaths`, so when we convert the latter to the former we effectively re-instantiate a new `WorkflowPaths` every time. This PR changes that so that `JobPaths` takes a `WorkflowPaths` instead as one of its attribute to avoid unnecessary re-allocations.
- A small optimization to the execution store which allows quicker lookup of "Done" jobs which we do a lot in `runnableCalls`. Also added a benchmark test that measures the performance of `runnableCalls`. Below are the results before and after this change. The "size" corresponds to how many jobs in "Done" and "NotStarted" states are inserted in the execution store before calling `runnableCalls`. Results are in ms.

Before:
![screen shot 2017-04-19 at 3 24 15 pm](https://cloud.githubusercontent.com/assets/2978948/25305440/fcca5418-2748-11e7-8d2a-6f2c645f2ef3.png)

After:
![screen shot 2017-04-19 at 3 25 18 pm](https://cloud.githubusercontent.com/assets/2978948/25305444/06de3f00-2749-11e7-860f-a1c077f3243f.png)
