### PR TITLE
Cromwell's failure is now complete (develop edition). Closes #2201

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -61,6 +61,7 @@
     <include file="changesets/add_attempt_in_call_caching_entry.xml" relativeToChangelogFile="true" />
     <include file="changesets/replace_empty_custom_labels.xml" relativeToChangelogFile="true" />
     <include file="changesets/failure_metadata.xml" relativeToChangelogFile="true" />
+    <include file="changesets/failure_metadata_2.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>
 <!--
 

--- a/database/migration/src/main/resources/changesets/failure_metadata_2.xml
+++ b/database/migration/src/main/resources/changesets/failure_metadata_2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="cjllanwarne" id="expand_single_failure_strings" dbms="mysql">
+        <customChange class="cromwell.database.migration.failuremetadata.ExpandSingleFailureStrings"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/migration/src/main/scala/cromwell/database/migration/failuremetadata/DeduplicateFailureMessageIds.scala
+++ b/database/migration/src/main/scala/cromwell/database/migration/failuremetadata/DeduplicateFailureMessageIds.scala
@@ -39,9 +39,10 @@ class DeduplicateFailureMessageIds extends BatchedTaskChange {
         |            )
         |""".stripMargin
 
-  override def migrateBatchQuery = s"UPDATE $tableName SET $metadataKeyColumn = ? WHERE $primaryKeyColumn = ?;"
+  override def migrateBatchQueries = List(s"UPDATE $tableName SET $metadataKeyColumn = ? WHERE $primaryKeyColumn = ?;")
 
-  override def migrateBatchRow(readRow: ResultSet, migrateStatement: PreparedStatement): Int = {
+  override def migrateBatchRow(readRow: ResultSet, migrateStatements: List[PreparedStatement]): Int = {
+    val migrateStatement = migrateStatements.head
     val rowId = readRow.getInt(1)
     val oldKey = readRow.getString(3)
     val newRandomInt = Random.nextInt(Int.MaxValue)

--- a/database/migration/src/main/scala/cromwell/database/migration/failuremetadata/ExpandSingleFailureStrings.scala
+++ b/database/migration/src/main/scala/cromwell/database/migration/failuremetadata/ExpandSingleFailureStrings.scala
@@ -1,0 +1,70 @@
+package cromwell.database.migration.failuremetadata
+
+import java.sql.{PreparedStatement, ResultSet}
+import cromwell.database.migration.custom.BatchedTaskChange
+
+/**
+  * Turns individual '| failures[0] | "blah" |' entries into '| failures[0]:message | "blah" |' and '| failures[0]:causedBy[] | NULL |'
+  */
+class ExpandSingleFailureStrings extends BatchedTaskChange {
+  val tableName = "METADATA_ENTRY"
+  val primaryKeyColumn = "METADATA_JOURNAL_ID"
+  val workflowIdColumn = "WORKFLOW_EXECUTION_UUID"
+  val metadataKeyColumn = "METADATA_KEY"
+  val callFqnColumn = "CALL_FQN"
+  val jobScatterIndexColumn = "JOB_SCATTER_INDEX"
+  val retryAttemptColumn = "JOB_RETRY_ATTEMPT"
+  val metadataTimestampColumn = "METADATA_TIMESTAMP"
+
+  val fixableFailureMessageFilter = "METADATA_KEY REGEXP '^failures\\\\[[0-9]*\\\\]$'"
+
+  override def readCountQuery: String = s"SELECT MAX($primaryKeyColumn) FROM $tableName;"
+
+  /**
+    * Find metadata keys in this range which can be fixed up.
+    */
+  override val readBatchQuery: String =
+    s"""|SELECT $primaryKeyColumn, $workflowIdColumn, $metadataKeyColumn, $callFqnColumn, $jobScatterIndexColumn, $retryAttemptColumn, $metadataTimestampColumn
+        | FROM $tableName
+        | WHERE $primaryKeyColumn >= ? AND $primaryKeyColumn < ?
+        | AND $fixableFailureMessageFilter
+        |""".stripMargin
+
+  override val migrateBatchQueries = List(
+    // Modify the existing element, changing failures[x] to failures[x]:message
+    s"UPDATE $tableName SET $metadataKeyColumn = ? WHERE $primaryKeyColumn = ?;",
+    // Insert a new element, to contain the empty causedBy[]
+    s"""INSERT INTO $tableName ($workflowIdColumn, $metadataKeyColumn, $callFqnColumn, $jobScatterIndexColumn, $retryAttemptColumn, $metadataTimestampColumn)
+       | VALUES (?, ?, ?, ?, ?, ?);
+     """.stripMargin
+  )
+
+  override def migrateBatchRow(readRow: ResultSet, migrateStatements: List[PreparedStatement]): Int = {
+    val (modifyStatement :: insertStatement :: Nil) = migrateStatements
+
+    val rowId = readRow.getInt(primaryKeyColumn)
+    val workflowId = readRow.getString(workflowIdColumn)
+    val oldKey = readRow.getString(metadataKeyColumn)
+    val callFqn = readRow.getString(callFqnColumn)
+    val jobScatterIndex = readRow.getObject(jobScatterIndexColumn)
+    val retryAttempt = readRow.getInt(retryAttemptColumn)
+    val metadataTimestamp = readRow.getObject(metadataTimestampColumn)
+
+    val modifiedKey = oldKey + ":message"
+    val insertKey = oldKey + ":causedBy[]"
+
+    modifyStatement.setString(1, modifiedKey)
+    modifyStatement.setInt(2, rowId)
+    modifyStatement.addBatch()
+
+    insertStatement.setString(1, workflowId)
+    insertStatement.setString(2, insertKey)
+    insertStatement.setString(3, callFqn)
+    insertStatement.setObject(4, jobScatterIndex)
+    insertStatement.setInt(5, retryAttempt)
+    insertStatement.setObject(6, metadataTimestamp)
+    insertStatement.addBatch()
+
+    2
+  }
+}

--- a/database/migration/src/main/scala/cromwell/database/migration/metadata/table/symbol/SymbolTableMigration.scala
+++ b/database/migration/src/main/scala/cromwell/database/migration/metadata/table/symbol/SymbolTableMigration.scala
@@ -24,7 +24,7 @@ trait SymbolTableMigration extends BatchedTaskChange {
 
   override val readCountQuery = SymbolTableMigration.NbRowsQuery
 
-  override val readBatchQuery = """
+  override val readBatchQuery: String = """
       |SELECT
       |    WORKFLOW_EXECUTION_UUID,
       |    SYMBOL_NAME,
@@ -37,12 +37,13 @@ trait SymbolTableMigration extends BatchedTaskChange {
       |   WHERE TMP_SYMBOL_ID >= ? AND TMP_SYMBOL_ID < ?;
     """.stripMargin
 
-  override val migrateBatchQuery = MetadataStatement.InsertSql
+  override val migrateBatchQueries = List(MetadataStatement.InsertSql)
 
   /**
     * Migrate a row to the metadata table
     */
-  override def migrateBatchRow(row: ResultSet, statement: PreparedStatement): Int = {
+  override def migrateBatchRow(row: ResultSet, statements: List[PreparedStatement]): Int = {
+    val statement = statements.head
     // Try to coerce the value to a WdlValue
     val value = for {
       wdlType <- Try(WdlType.fromWdlString(row.getString("WDL_TYPE")))

--- a/database/migration/src/main/scala/cromwell/database/migration/workflowoptions/RenameWorkflowOptionsInMetadata.scala
+++ b/database/migration/src/main/scala/cromwell/database/migration/workflowoptions/RenameWorkflowOptionsInMetadata.scala
@@ -20,9 +20,10 @@ class RenameWorkflowOptionsInMetadata extends BatchedTaskChange {
         |  WHERE $primaryKeyColumn >= ? AND $primaryKeyColumn < ? $additionalReadBatchFilters;
         |""".stripMargin
 
-  override def migrateBatchQuery = s"UPDATE $tableName SET $workflowOptionsColumn = ? WHERE $primaryKeyColumn = ?;"
+  override def migrateBatchQueries = List(s"UPDATE $tableName SET $workflowOptionsColumn = ? WHERE $primaryKeyColumn = ?;")
 
-  override def migrateBatchRow(readRow: ResultSet, migrateStatement: PreparedStatement): Int = {
+  override def migrateBatchRow(readRow: ResultSet, migrateStatements: List[PreparedStatement]): Int = {
+    val migrateStatement = migrateStatements.head
     val rowId = readRow.getInt(1)
     
     val migratedJson = readRow.getString(2).parseJson match {

--- a/database/migration/src/main/scala/cromwell/database/migration/workflowoptions/WorkflowOptionsChange.scala
+++ b/database/migration/src/main/scala/cromwell/database/migration/workflowoptions/WorkflowOptionsChange.scala
@@ -47,9 +47,10 @@ trait WorkflowOptionsChange extends BatchedTaskChange {
         |  WHERE $primaryKeyColumn >= ? AND $primaryKeyColumn < ? $additionalReadBatchFilters;
         |""".stripMargin
 
-  override def migrateBatchQuery = s"UPDATE $tableName SET $workflowOptionsColumn = ? WHERE $primaryKeyColumn = ?;"
+  override def migrateBatchQueries = List(s"UPDATE $tableName SET $workflowOptionsColumn = ? WHERE $primaryKeyColumn = ?;")
 
-  override def migrateBatchRow(readRow: ResultSet, migrateStatement: PreparedStatement): Int = {
+  override def migrateBatchRow(readRow: ResultSet, migrateStatements: List[PreparedStatement]): Int = {
+    val migrateStatement = migrateStatements.head
     val rowId = readRow.getInt(1)
     val workflowOptionsJson = readRow.getString(2)
     WorkflowOptions.fromJsonString(workflowOptionsJson) match {


### PR DESCRIPTION
- Modifies existing migrations since I had to support multiple statements per migrating row.
- Done in Scala so we only need to do a single pass over everything, but I'm still open to "it'd be better to use **this** SQL command!" comments.
- Tested against things that look like Joel's example inconsistency.