### PR TITLE
Remove unneeded SubWorkflowStoreCompleteSuccess message. Closes #2185

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -92,9 +92,6 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     case Event(SubWorkflowStoreRegisterSuccess(command), _) =>
       // Nothing to do here
       stay()
-    case Event(SubWorkflowStoreCompleteSuccess(command), _) =>
-      // Nothing to do here
-      stay()
     case Event(SubWorkflowStoreFailure(command, reason), _) =>
       jobLogger.error(reason, s"SubWorkflowStore failure for command $command")
       stay()

--- a/engine/src/main/scala/cromwell/subworkflowstore/EmptySubWorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/subworkflowstore/EmptySubWorkflowStoreActor.scala
@@ -7,7 +7,7 @@ class EmptySubWorkflowStoreActor extends Actor with ActorLogging {
   override def receive: Receive = {
     case register: RegisterSubWorkflow => sender() ! SubWorkflowStoreRegisterSuccess(register) 
     case query: QuerySubWorkflow => sender() ! SubWorkflowNotFound(query)
-    case complete: WorkflowComplete =>sender() ! SubWorkflowStoreCompleteSuccess(complete)
+    case complete: WorkflowComplete => // No-op!
     case unknown => log.error(s"SubWorkflowStoreActor received unknown message: $unknown")
   }
 }

--- a/engine/src/main/scala/cromwell/subworkflowstore/SubWorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/subworkflowstore/SubWorkflowStoreActor.scala
@@ -46,7 +46,7 @@ class SubWorkflowStoreActor(database: SubWorkflowStore) extends Actor with Actor
 
   private def workflowComplete(replyTo: ActorRef, command: WorkflowComplete) = {
     database.removeSubWorkflowStoreEntries(command.workflowExecutionUuid.toString) onComplete {
-      case Success(_) => replyTo ! SubWorkflowStoreCompleteSuccess(command)
+      case Success(_) => // No-op
       case Failure(ex) => replyTo ! SubWorkflowStoreFailure(command, ex)
     }
   }
@@ -63,7 +63,6 @@ object SubWorkflowStoreActor {
   case class SubWorkflowStoreRegisterSuccess(command: RegisterSubWorkflow) extends SubWorkflowStoreActorResponse
   case class SubWorkflowFound(subWorkflowStoreEntry: SubWorkflowStoreEntry) extends SubWorkflowStoreActorResponse
   case class SubWorkflowNotFound(command: QuerySubWorkflow) extends SubWorkflowStoreActorResponse
-  case class SubWorkflowStoreCompleteSuccess(command: SubWorkflowStoreActorCommand) extends SubWorkflowStoreActorResponse
   
   case class SubWorkflowStoreFailure(command: SubWorkflowStoreActorCommand, failure: Throwable) extends SubWorkflowStoreActorResponse
   

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -72,17 +72,22 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
       
       // Delete root workflow
       subWorkflowStoreService ! WorkflowComplete(rootWorkflowId)
-      expectMsgType[SubWorkflowStoreCompleteSuccess](MaxWait)
 
-      // Verify that everything is gone
-      subWorkflowStoreService ! QuerySubWorkflow(rootWorkflowId, jobKey)
-      expectMsgType[SubWorkflowNotFound](MaxWait)
+      // Verify that everything is gone (eventually!)
+      eventually {
+        subWorkflowStoreService ! QuerySubWorkflow(rootWorkflowId, jobKey)
+        expectMsgType[SubWorkflowNotFound](MaxWait)
+      }
 
-      subWorkflowStoreService ! QuerySubWorkflow(parentWorkflowId, jobKey)
-      expectMsgType[SubWorkflowNotFound](MaxWait)
+      eventually {
+        subWorkflowStoreService ! QuerySubWorkflow(parentWorkflowId, jobKey)
+        expectMsgType[SubWorkflowNotFound](MaxWait)
+      }
 
-      subWorkflowStoreService ! QuerySubWorkflow(subWorkflowId, jobKey)
-      expectMsgType[SubWorkflowNotFound](MaxWait)
+      eventually {
+        subWorkflowStoreService ! QuerySubWorkflow(subWorkflowId, jobKey)
+        expectMsgType[SubWorkflowNotFound](MaxWait)
+      }
     }
   }
 }


### PR DESCRIPTION
It turns out that "Complete Success" just wasn't quite right for Cromwell.

EDIT: the actual motivation for this is that this was the cause for some of our `dead letter` errors appearing at the end of `cromwell run` commands.