### PR TITLE
Batching Job Store simpleton writes.  Closes #2085

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -38,7 +38,7 @@ akka {
     }
 
     # A dispatcher for engine actors
-    # Because backends behaviour is unpredictable (potentially blocking, slow) the engine runs
+    # Because backends behavior is unpredictable (potentially blocking, slow) the engine runs
     # on its own dispatcher to prevent backends from affecting its performance.
     engine-dispatcher {
       type = Dispatcher

--- a/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
+++ b/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
@@ -1,0 +1,51 @@
+package cromwell.core.actor
+
+import cats.data.NonEmptyVector
+import org.slf4j.LoggerFactory
+
+import scala.util.{Failure, Success, Try}
+
+
+/** A collection of state, data, and message types to support batched database writes. */
+object BatchingDbWriter {
+  val logger = LoggerFactory.getLogger("BatchingDbWriteActor")
+
+  /** Data for batched database writes. */
+  sealed trait BatchingDbWriterData {
+    def addData[D](datum: D): BatchingDbWriterData = addData(Vector(datum))
+    def addData[D](data: Iterable[D]): BatchingDbWriterData = {
+      Try(NonEmptyVector.fromVector(data.toVector)) match {
+        case Success(Some(v)) =>
+          val newEvents = this match {
+            case NoData => v
+            case HasData(e) => e.concatNev(v)
+          }
+          HasData(newEvents)
+        case Success(None) => this
+        case Failure(f) =>
+          val dataSample = data.take(3).mkString(", ") + (if (data.size > 3) ", ..." else "")
+          logger.error(s"Failed processing batched data: $dataSample. Data will be dropped and not be sent to the database.", f)
+          this
+      }
+    }
+
+    def length: Int = this match {
+      case NoData => 0
+      case HasData(e) => e.length
+    }
+  }
+
+  case object NoData extends BatchingDbWriterData
+  case class HasData[E](events: NonEmptyVector[E]) extends BatchingDbWriterData
+
+  /** The states for batched database writes. */
+  sealed trait BatchingDbWriterState
+  case object WaitingToWrite extends BatchingDbWriterState
+  case object WritingToDb extends BatchingDbWriterState
+
+  /** The message types for batched database writes. */
+  sealed trait BatchingDbWriterMessage
+  case object DbWriteComplete extends BatchingDbWriterMessage
+  case object FlushBatchToDb extends BatchingDbWriterMessage
+  case object ScheduledFlushToDb extends BatchingDbWriterMessage
+}

--- a/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
@@ -74,14 +74,14 @@ trait StreamActorHelper[T <: StreamContext] { this: Actor with ActorLogging =>
     case EnqueueResponse(Enqueued, commandContext: T @unchecked) => // Good !
     case EnqueueResponse(Dropped, commandContext) => backpressure(commandContext)
       
-      // In any of the cases below, the stream is in a failed state, which will he caught by the watchCompletion hook and the 
+      // In any of the cases below, the stream is in a failed state, which will be caught by the watchCompletion hook and the
       // actor will be restarted
     case EnqueueResponse(QueueClosed, commandContext) => backpressure(commandContext)
     case EnqueueResponse(QueueOfferResult.Failure(failure), commandContext) => backpressure(commandContext)
     case FailedToEnqueue(throwable, commandContext) => backpressure(commandContext)
       
       // Those 2 cases should never happen, as long as the strategy is Resume, but in case it does...
-    case StreamCompleted => restart(new IllegalStateException("Stream was completed unexepectedly"))
+    case StreamCompleted => restart(new IllegalStateException("Stream was completed unexpectedly"))
     case StreamFailed(failure) => restart(failure)
   }
 

--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -38,7 +38,7 @@ trait EvenBetterPathMethods {
 
   // betterFile.symbolicLink calls Files.readSymbolicLink, but then implicitly converts the java.nio.Path returned to a better.File
   // which calls toAbsolutePath. Consequently, if the path was relative, the current directory is used to make it absolute.
-  // This is not the desired behaviour to be able to follow relative symbolic links, so bypass better files method and directly use the java one.
+  // This is not the desired behavior to be able to follow relative symbolic links, so bypass better files method and directly use the java one.
   final def symbolicLinkRelative: Option[Path] = {
     if (betterFile.isSymbolicLink) {
       Option(newPath(Files.readSymbolicLink(betterFile.path)))

--- a/core/src/test/scala/cromwell/core/TestKitSuite.scala
+++ b/core/src/test/scala/cromwell/core/TestKitSuite.scala
@@ -55,7 +55,7 @@ object TestKitSuite {
       |    }
       |
       |    # A dispatcher for engine actors
-      |    # Because backends behaviour is unpredictable (potentially blocking, slow) the engine runs
+      |    # Because backends behavior is unpredictable (potentially blocking, slow) the engine runs
       |    # on its own dispatcher to prevent backends from affecting its performance.
       |    engine-dispatcher {
       |      type = Dispatcher

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
@@ -32,7 +32,7 @@ trait JobStoreSimpletonEntryComponent {
       index("UC_JOB_STORE_SIMPLETON_ENTRY_JSEI_SK", (jobStoreEntryId, simpletonKey), unique = true)
   }
 
-  protected val jobStoreSimpletonEntries = TableQuery[JobStoreSimpletonEntries]
+  val jobStoreSimpletonEntries = TableQuery[JobStoreSimpletonEntries]
 
   val jobStoreSimpletonEntryIdsAutoInc = jobStoreSimpletonEntries returning
     jobStoreSimpletonEntries.map(_.jobStoreSimpletonEntryId)

--- a/database/sql/src/main/scala/cromwell/database/sql/JobStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/JobStoreSqlDatabase.scala
@@ -7,7 +7,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait JobStoreSqlDatabase {
   this: SqlDatabase =>
 
-  def addJobStores(jobStoreJoins: Seq[JobStoreJoin])(implicit ec: ExecutionContext): Future[Unit]
+  def addJobStores(jobStoreJoins: Seq[JobStoreJoin], batchSize: Int)(implicit ec: ExecutionContext): Future[Unit]
 
   def queryJobStores(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int, jobScatterAttempt: Int)
                     (implicit ec: ExecutionContext): Future[Option[JobStoreJoin]]

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -20,7 +20,7 @@ import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation.
 import cromwell.engine.workflow.lifecycle.execution.preparation.{CallPreparation, JobPreparationActor}
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDenied, JobExecutionTokenDispensed, JobExecutionTokenRequest, JobExecutionTokenReturn}
 import cromwell.jobstore.JobStoreActor._
-import cromwell.jobstore.{Pending => _, _}
+import cromwell.jobstore._
 import cromwell.services.SingletonServicesStore
 import cromwell.services.metadata.{CallMetadataKeys, MetadataKey}
 import wdl4s.TaskOutput

--- a/engine/src/main/scala/cromwell/jobstore/JobStore.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStore.scala
@@ -1,11 +1,18 @@
 package cromwell.jobstore
 
 import cromwell.core.WorkflowId
+import cromwell.jobstore.JobStore.{JobCompletion, WorkflowCompletion}
 import wdl4s.TaskOutput
 
 import scala.concurrent.{ExecutionContext, Future}
 
 trait JobStore {
-  def writeToDatabase(jobCompletions: Map[JobStoreKey, JobResult], workflowCompletions: List[WorkflowId])(implicit ec: ExecutionContext): Future[Unit]
+  def writeToDatabase(workflowCompletions: Seq[WorkflowCompletion], jobCompletions: Seq[JobCompletion], batchSize: Int)(implicit ec: ExecutionContext): Future[Unit]
   def readJobResult(jobStoreKey: JobStoreKey, taskOutputs: Seq[TaskOutput])(implicit ec: ExecutionContext): Future[Option[JobResult]]
+}
+
+object JobStore {
+  sealed trait Completion
+  case class WorkflowCompletion(workflowId: WorkflowId) extends Completion
+  case class JobCompletion(key: JobStoreKey, result: JobResult) extends Completion
 }

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -99,7 +99,7 @@ object CromwellTestKitSpec {
       |    }
       |
       |    # A dispatcher for engine actors
-      |    # Because backends behaviour is unpredictable (potentially blocking, slow) the engine runs
+      |    # Because backends behavior is unpredictable (potentially blocking, slow) the engine runs
       |    # on its own dispatcher to prevent backends from affecting its performance.
       |    engine-dispatcher {
       |      type = Dispatcher

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpec.scala
@@ -3,7 +3,6 @@ package cromwell.engine.workflow.lifecycle.execution.ejea
 import akka.actor.Actor
 import akka.testkit.TestFSMRef
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
-import cromwell.jobstore.{Pending => _}
 import cromwell.CromwellTestKitWordSpec
 import cromwell.backend.BackendJobExecutionActor
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionActorCommand

--- a/services/src/test/scala/cromwell/services/ServicesSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesSpec.scala
@@ -40,7 +40,7 @@ object ServicesSpec {
       |    }
       |
       |    # A dispatcher for engine actors
-      |    # Because backends behaviour is unpredictable (potentially blocking, slow) the engine runs
+      |    # Because backends behavior is unpredictable (potentially blocking, slow) the engine runs
       |    # on its own dispatcher to prevent backends from affecting its performance.
       |    engine-dispatcher {
       |      type = Dispatcher

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -64,7 +64,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
         val jobStoreJoins = Seq(JobStoreJoin(jobStoreEntry, Seq()))
         // NOTE: This test just needs to repeatedly read/write from a table that acts as a PK for a FK.
         for {
-          _ <- database.addJobStores(jobStoreJoins)
+          _ <- database.addJobStores(jobStoreJoins, 10)
           queried <- database.queryJobStores(workflowUuid, callFqn, jobIndex, jobAttempt)
           _ = queried.get.jobStoreEntry.workflowExecutionUuid should be(workflowUuid)
         } yield ()
@@ -276,9 +276,9 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
         _ <- product match {
           case "HSQL Database Engine" =>
             // HSQLDB doesn't crash because it calls getCharacterStream instead of getSubString.
-            dataAccess.addJobStores(jobStoreJoins)
+            dataAccess.addJobStores(jobStoreJoins, 1)
           case "MySQL" =>
-            dataAccess.addJobStores(jobStoreJoins).failed map { exception =>
+            dataAccess.addJobStores(jobStoreJoins, 1).failed map { exception =>
               exception should be(a[SerialException])
               exception.getMessage should be("Invalid position in SerialClob object set")
             }
@@ -335,7 +335,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
       val jobStoreJoins = Seq(JobStoreJoin(jobStoreEntry, jobStoreSimpletonEntries))
 
       val future = for {
-        _ <- dataAccess.addJobStores(jobStoreJoins)
+        _ <- dataAccess.addJobStores(jobStoreJoins, 1)
         queried <- dataAccess.queryJobStores(workflowUuid, callFqn, jobIndex, jobAttempt)
         _ = {
           val jobStoreJoin = queried.get

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -42,7 +42,7 @@ private[statuspolling] trait StatusPolling { this: JesPollingActor =>
     completionPromise.future
   }
 
-  // Done so that the specs can override this behaviour
+  // Done so that the specs can override this behavior
   def interpretOperationStatus(op: Operation) = StatusPolling.interpretOperationStatus(op)
 
   def addStatusPollToBatch(run: Run, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]) =


### PR DESCRIPTION
Makes a common `BatchingDbWriter` object to hold types for batched writers.  For the time being at least I've refrained from a deeper refactor to pull commonality up to an abstract parent FSM, though that does mean a fair amount of repetition in the implementation classes.