### PR TITLE
Use the right failureMode value

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -8,7 +8,6 @@ import cromwell.backend.{AllBackendInitializationData, BackendJobDescriptorKey, 
 import cromwell.core.Dispatcher._
 import cromwell.core.ExecutionIndex._
 import cromwell.core.ExecutionStatus._
-import cromwell.core.WorkflowOptions.WorkflowFailureMode
 import cromwell.core._
 import cromwell.core.logging.WorkflowLogging
 import cromwell.engine.backend.{BackendSingletonCollection, CromwellBackends}
@@ -246,7 +245,7 @@ case class WorkflowExecutionActor(workflowDescriptor: EngineWorkflowDescriptor,
   private def handleExecutionFailure(failedJobKey: JobKey, data: WorkflowExecutionActorData, reason: Throwable, jobExecutionMap: JobExecutionMap) = {
     val newData = data.executionFailed(failedJobKey)
     
-    if (workflowDescriptor.getWorkflowOption(WorkflowFailureMode).contains(ContinueWhilePossible.toString)) {
+    if (workflowDescriptor.failureMode == ContinueWhilePossible) {
       newData.workflowCompletionStatus match {
         case Some(completionStatus) if completionStatus == Failed =>
           context.parent ! WorkflowExecutionFailedResponse(newData.jobExecutionMap, reason)


### PR DESCRIPTION
This would work if the failure mode is passed through workflow options but not if it's set in the config.