### PR TITLE
Double Quoted file inputs cause PipelineAPI workflows to run forever. Closes #2178

### DIFF
--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -103,7 +103,7 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
           case statusQuery: JesStatusPollQuery =>
             self ! JesApiStatusQueryFailed(statusQuery, new JesApiException(cause))
           case runCreationQuery: JesRunCreationQuery =>
-             self ! JesApiRunCreationQueryFailed(runCreationQuery, new JesApiException(cause))
+            self ! JesApiRunCreationQueryFailed(runCreationQuery, new JesApiException(cause))
         }
       case None =>
         // It managed to die while doing absolutely nothing...!?

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -58,11 +58,8 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
       val delay = nextRequest.backoff.backoffMillis.millis
       context.system.scheduler.scheduleOnce(delay, self, nextRequest)
       ()
-    case JesApiQueryStatusFailed(request, cause) =>
-      request.requester ! JesApiQueryStatusFailed(request, cause)
-      ()
-    case JesApiQueryCreationFailed(request, cause) =>
-      request.requester ! JesApiQueryCreationFailed(request, cause)
+    case failure: JesApiQueryFailed =>
+      failure.query.requester ! failure
       ()
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -59,7 +59,6 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
     ()
   } else {
     failure.query.requester ! failure
-    ()
   }
 
   private def handleJesPollingRequest(workPullingJesPollingActor: ActorRef, maxBatchSize: Int) = {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
@@ -3,7 +3,7 @@ package cromwell.backend.impl.jes.statuspolling
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.RunPipelineRequest
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryCreationFailed}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiRunCreationQueryFailed}
 import cromwell.backend.standard.StandardAsyncJob
 
 import scala.concurrent.{Future, Promise}
@@ -24,7 +24,7 @@ trait JesRunCreationClient { this: Actor with ActorLogging =>
   def runCreationClientReceive: Actor.Receive = {
     case job: StandardAsyncJob =>
       completePromise(Success(job))
-    case JesApiQueryCreationFailed(_, e) => completePromise(Failure(e))
+    case JesApiRunCreationQueryFailed(_, e) => completePromise(Failure(e))
   }
 
   private def completePromise(job: Try[StandardAsyncJob]) = {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
@@ -3,7 +3,7 @@ package cromwell.backend.impl.jes.statuspolling
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.RunPipelineRequest
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiQueryFailed
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryCreationFailed}
 import cromwell.backend.standard.StandardAsyncJob
 
 import scala.concurrent.{Future, Promise}
@@ -24,7 +24,7 @@ trait JesRunCreationClient { this: Actor with ActorLogging =>
   def runCreationClientReceive: Actor.Receive = {
     case job: StandardAsyncJob =>
       completePromise(Success(job))
-    case JesApiQueryFailed(_, e) => completePromise(Failure(e))
+    case JesApiQueryCreationFailed(_, e) => completePromise(Failure(e))
   }
 
   private def completePromise(job: Try[StandardAsyncJob]) = {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesStatusRequestClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesStatusRequestClient.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiQueryFailed
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryStatusFailed}
 import cromwell.backend.impl.jes.{Run, RunStatus}
 
 import scala.concurrent.{Future, Promise}
@@ -23,7 +23,7 @@ trait JesStatusRequestClient { this: Actor with ActorLogging =>
     case r: RunStatus =>
       log.debug(s"Polled status received: $r")
       completePromise(Success(r))
-    case JesApiQueryFailed(_, e) =>
+    case JesApiQueryStatusFailed(_, e) =>
       log.debug("JES poll failed!")
       completePromise(Failure(e))
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesStatusRequestClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesStatusRequestClient.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryStatusFailed}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiStatusQueryFailed}
 import cromwell.backend.impl.jes.{Run, RunStatus}
 
 import scala.concurrent.{Future, Promise}
@@ -23,7 +23,7 @@ trait JesStatusRequestClient { this: Actor with ActorLogging =>
     case r: RunStatus =>
       log.debug(s"Polled status received: $r")
       completePromise(Success(r))
-    case JesApiQueryStatusFailed(_, e) =>
+    case JesApiStatusQueryFailed(_, e) =>
       log.debug("JES poll failed!")
       completePromise(Failure(e))
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
@@ -22,7 +22,7 @@ private[statuspolling] trait RunCreation { this: JesPollingActor =>
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiQueryCreationFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiRunCreationQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
@@ -22,7 +22,7 @@ private[statuspolling] trait RunCreation { this: JesPollingActor =>
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiQueryCreationFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -29,7 +29,7 @@ private[statuspolling] trait StatusPolling { this: JesPollingActor =>
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiQueryStatusFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiStatusQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -11,7 +11,7 @@ import com.google.api.client.http.HttpHeaders
 import com.google.api.services.genomics.model.Operation
 import cromwell.backend.impl.jes.RunStatus._
 import cromwell.backend.impl.jes.{JesAsyncBackendJobExecutionActor, Run, RunStatus}
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{GoogleJsonException, JesApiException, JesApiQueryFailed, JesStatusPollQuery}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
 import cromwell.core.ExecutionEvent
 
 import scala.language.postfixOps
@@ -29,7 +29,7 @@ private[statuspolling] trait StatusPolling { this: JesPollingActor =>
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiQueryCreationFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -29,7 +29,7 @@ private[statuspolling] trait StatusPolling { this: JesPollingActor =>
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiQueryCreationFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiQueryStatusFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
@@ -119,7 +119,7 @@ class TestJesPollingActor(manager: ActorRef, qps: Int Refined Positive) extends 
     resultHandlers.zip(callbackResponses) foreach { case (handler, response) => response match {
       case CallbackSuccess => handler.onSuccess(null, null)
       case CallbackFailure =>
-        val error: GoogleJsonError = null
+        val error: GoogleJsonError = new GoogleJsonError()
         handler.onFailure(error, null)
     }}
   }


### PR DESCRIPTION
JesApi run creation failures were being caught by the JesApi status handler and not getting handled correctly.