### PR TITLE
Update google nio + small optimization for copy workflow outputs

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -3,7 +3,6 @@ package cromwell.backend.standard
 import akka.actor.{ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.backend._
-import cromwell.backend.io.WorkflowPathsWithDocker
 import cromwell.backend.standard.callcaching._
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.path.Path
@@ -183,18 +182,16 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,
                                     initializationData: Option[BackendInitializationData]): Path = {
     initializationData match {
-      // Try to use the initializationData if present to avoid recreating a WorkflowPath
       case Some(data) => data.asInstanceOf[StandardInitializationData].workflowPaths.executionRoot
-      case None => new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).executionRoot
+      case None => super.getWorkflowExecutionRootPath(workflowDescriptor, backendConfig, initializationData)
     }
   }
 
   override def getWorkflowExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,
                                             initializationData: Option[BackendInitializationData]): Path = {
     initializationData match {
-        // Try to use the initializationData if present to avoid recreating a WorkflowPath
       case Some(data) => data.asInstanceOf[StandardInitializationData].workflowPaths.workflowRoot
-      case None => new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).workflowRoot
+      case None => super.getWorkflowExecutionRootPath(workflowDescriptor, backendConfig, initializationData)
     }
   }
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -3,6 +3,7 @@ package cromwell.backend.standard
 import akka.actor.{ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.backend._
+import cromwell.backend.io.WorkflowPathsWithDocker
 import cromwell.backend.standard.callcaching._
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.path.Path
@@ -181,12 +182,20 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
 
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,
                                     initializationData: Option[BackendInitializationData]): Path = {
-    initializationData.get.asInstanceOf[StandardInitializationData].workflowPaths.executionRoot
+    initializationData match {
+      // Try to use the initializationData if present to avoid recreating a WorkflowPath
+      case Some(data) => data.asInstanceOf[StandardInitializationData].workflowPaths.executionRoot
+      case None => new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).executionRoot
+    }
   }
 
   override def getWorkflowExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,
                                             initializationData: Option[BackendInitializationData]): Path = {
-    initializationData.get.asInstanceOf[StandardInitializationData].workflowPaths.workflowRoot
+    initializationData match {
+        // Try to use the initializationData if present to avoid recreating a WorkflowPath
+      case Some(data) => data.asInstanceOf[StandardInitializationData].workflowPaths.workflowRoot
+      case None => new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).workflowRoot
+    }
   }
 
   override def runtimeAttributeDefinitions(initializationDataOption: Option[BackendInitializationData]):

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -351,13 +351,14 @@ class WorkflowActor(val workflowId: WorkflowId,
       case _ => Option(CopyWorkflowOutputsActor.props(workflowIdForLogging, ioActor, workflowDescriptor, workflowOutputs, stateData.initializationData))
     }
     
-    context.actorOf(WorkflowFinalizationActor.props(workflowId,
-      workflowDescriptor,
-      ioActor,
-      jobExecutionMap,
-      workflowOutputs,
-      stateData.initializationData,
-      copyWorkflowOutputsActorProps
+    context.actorOf(WorkflowFinalizationActor.props(
+      workflowId = workflowId,
+      workflowDescriptor = workflowDescriptor,
+      ioActor = ioActor,
+      jobExecutionMap = jobExecutionMap,
+      workflowOutputs = workflowOutputs,
+      initializationData = stateData.initializationData,
+      copyWorkflowOutputsActor = copyWorkflowOutputsActorProps
     ), name = s"WorkflowFinalizationActor")
   }
   /**

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -346,7 +346,19 @@ class WorkflowActor(val workflowId: WorkflowId,
   }
 
   private[workflow] def makeFinalizationActor(workflowDescriptor: EngineWorkflowDescriptor, jobExecutionMap: JobExecutionMap, workflowOutputs: CallOutputs) = {
-    context.actorOf(WorkflowFinalizationActor.props(workflowId, workflowDescriptor, ioActor, jobExecutionMap, workflowOutputs, stateData.initializationData), name = s"WorkflowFinalizationActor")
+    val copyWorkflowOutputsActorProps = stateName match {
+      case InitializingWorkflowState => None
+      case _ => Option(CopyWorkflowOutputsActor.props(workflowIdForLogging, ioActor, workflowDescriptor, workflowOutputs, stateData.initializationData))
+    }
+    
+    context.actorOf(WorkflowFinalizationActor.props(workflowId,
+      workflowDescriptor,
+      ioActor,
+      jobExecutionMap,
+      workflowOutputs,
+      stateData.initializationData,
+      copyWorkflowOutputsActorProps
+    ), name = s"WorkflowFinalizationActor")
   }
   /**
     * Run finalization actor and transition to FinalizingWorkflowState.

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowFinalizationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowFinalizationActor.scala
@@ -63,7 +63,7 @@ case class WorkflowFinalizationActor(workflowIdForLogging: WorkflowId,
   override def successResponse(data: WorkflowLifecycleActorData) = WorkflowFinalizationSucceededResponse
   override def failureResponse(reasons: Seq[Throwable]) = WorkflowFinalizationFailedResponse(reasons)
 
-  // If a finalization actor dies, send ourselves the failure and stop the child actor
+  // If an engine or backend finalization actor (children of this actor) dies, send ourselves the failure and stop the child actor
   override def supervisorStrategy = OneForOneStrategy() {
     case failure => 
       self.tell(FinalizationFailed(failure), sender())

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
@@ -69,7 +69,7 @@ trait WorkflowLifecycleActor[S <: WorkflowLifecycleActorState] extends LoggingFS
   def successResponse(data: WorkflowLifecycleActorData): WorkflowLifecycleSuccessResponse
   def failureResponse(reasons: Seq[Throwable]): WorkflowLifecycleFailureResponse
 
-  override def supervisorStrategy = AllForOneStrategy() {
+  override def supervisorStrategy: SupervisorStrategy = AllForOneStrategy() {
     case ex: ActorInitializationException =>
       context.parent ! failureResponse(Seq(ex))
       context.stop(self)

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -48,7 +48,7 @@ object GcsPathBuilder {
 
 class GcsPathBuilder(authMode: GoogleAuthMode,
                      applicationName: String,
-                     retrySettings: RetrySettings,
+                     retrySettings: Option[RetrySettings],
                      cloudStorageConfiguration: CloudStorageConfiguration,
                      options: WorkflowOptions) extends PathBuilder {
   authMode.validate(options)
@@ -60,7 +60,8 @@ class GcsPathBuilder(authMode: GoogleAuthMode,
   protected val storageOptionsBuilder = StorageOptions.newBuilder()
     .setTransportOptions(transportOptions)
     .setCredentials(authMode.credential(options))
-    .setRetrySettings(retrySettings)
+
+  retrySettings foreach storageOptionsBuilder.setRetrySettings
 
   // Grab the google project from Workflow Options if specified and set
   // that to be the project used by the StorageOptions Builder

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -2,7 +2,7 @@ package cromwell.filesystems.gcs
 
 import akka.actor.ActorSystem
 import com.google.api.client.googleapis.media.MediaHttpUploader
-import com.google.cloud.RetryParams
+import com.google.api.gax.retrying.RetrySettings
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import com.typesafe.config.ConfigFactory
 import cromwell.core.WorkflowOptions
@@ -16,7 +16,8 @@ object GcsPathBuilderFactory {
     ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
   }
 
-  val DefaultRetryParams = RetryParams.getDefaultInstance
+  val DefaultRetryParams = RetrySettings.newBuilder().build()
+
   val DefaultCloudStorageConfiguration = {
     CloudStorageConfiguration.builder()
       .blockSize(UploadBufferBytes)
@@ -29,10 +30,10 @@ object GcsPathBuilderFactory {
 
 case class GcsPathBuilderFactory(authMode: GoogleAuthMode,
                                  applicationName: String,
-                                 retryParams: RetryParams = GcsPathBuilderFactory.DefaultRetryParams,
+                                 retrySettings: RetrySettings = GcsPathBuilderFactory.DefaultRetryParams,
                                  cloudStorageConfiguration: CloudStorageConfiguration = GcsPathBuilderFactory.DefaultCloudStorageConfiguration)
 
   extends PathBuilderFactory {
 
-  def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem) = new GcsPathBuilder(authMode, applicationName, retryParams, cloudStorageConfiguration, options)
+  def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem) = new GcsPathBuilder(authMode, applicationName, retrySettings, cloudStorageConfiguration, options)
 }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -16,8 +16,6 @@ object GcsPathBuilderFactory {
     ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
   }
 
-  val DefaultRetryParams = RetrySettings.newBuilder().build()
-
   val DefaultCloudStorageConfiguration = {
     CloudStorageConfiguration.builder()
       .blockSize(UploadBufferBytes)
@@ -30,7 +28,7 @@ object GcsPathBuilderFactory {
 
 case class GcsPathBuilderFactory(authMode: GoogleAuthMode,
                                  applicationName: String,
-                                 retrySettings: RetrySettings = GcsPathBuilderFactory.DefaultRetryParams,
+                                 retrySettings: Option[RetrySettings] = None,
                                  cloudStorageConfiguration: CloudStorageConfiguration = GcsPathBuilderFactory.DefaultCloudStorageConfiguration)
 
   extends PathBuilderFactory {

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.filesystems.gcs
 
-import com.google.cloud.RetryParams
+import com.google.api.gax.retrying.RetrySettings
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import cromwell.core.path._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
@@ -20,7 +20,7 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     val gcsPathBuilderWithProjectInfo = new GcsPathBuilder(
       GoogleAuthMode.MockAuthMode,
       "cromwell-test",
-      RetryParams.getDefaultInstance,
+      RetrySettings.newBuilder().build(),
       CloudStorageConfiguration.DEFAULT,
       wfOptionsWithProject
     )
@@ -361,7 +361,7 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     new GcsPathBuilder(
       GoogleAuthMode.MockAuthMode,
       "cromwell-test",
-      RetryParams.getDefaultInstance,
+      RetrySettings.newBuilder().build(),
       CloudStorageConfiguration.DEFAULT,
       WorkflowOptions.empty
     )

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -1,6 +1,5 @@
 package cromwell.filesystems.gcs
 
-import com.google.api.gax.retrying.RetrySettings
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import cromwell.core.path._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
@@ -20,7 +19,7 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     val gcsPathBuilderWithProjectInfo = new GcsPathBuilder(
       GoogleAuthMode.MockAuthMode,
       "cromwell-test",
-      RetrySettings.newBuilder().build(),
+      None,
       CloudStorageConfiguration.DEFAULT,
       wfOptionsWithProject
     )
@@ -361,7 +360,7 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     new GcsPathBuilder(
       GoogleAuthMode.MockAuthMode,
       "cromwell-test",
-      RetrySettings.newBuilder().build(),
+      None,
       CloudStorageConfiguration.DEFAULT,
       WorkflowOptions.empty
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,7 +86,7 @@ object Dependencies {
 
   private val googleCloudDependencies = List(
     "com.google.apis" % "google-api-services-genomics" % ("v1alpha2-rev64-" + googleGenomicsServicesApiV),
-    "com.google.cloud" % "google-cloud-nio" % "0.9.4-alpha"
+    "com.google.cloud" % "google-cloud-nio" % "0.17.2-alpha"
       exclude("com.google.api.grpc", "grpc-google-common-protos")
       exclude("com.google.cloud.datastore", "datastore-v1-protos")
       exclude("org.apache.httpcomponents", "httpclient"),


### PR DESCRIPTION
- Upgrade google store nio library
- While testing this I found myself in the situation where the workflow initialization would fail, in which case we still do finalization (which is fine), but as part of this finalization we stand up a `CopyWorkflowOutputs` actor, which was failing and making my workflow hang. This fixes the hanging and fails the workflow + don't even run CopyWorkflowOutputs if we failed at Initialization stage