### PR TITLE
entrypoint fix to default docker configuration for #2256

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -214,10 +214,12 @@ backend {
         docker run \
           --rm -i \
           ${"--user " + docker_user} \
+          --entrypoint /bin/bash \
           -v ${cwd}:${docker_cwd} \
-          ${docker} \
-          /bin/bash ${script}
+          ${docker} ${script}
         """
+
+        
 
         # Root directory where Cromwell writes job results.  This directory must be
         # visible and writeable by the Cromwell process as well as the jobs that Cromwell


### PR DESCRIPTION
This PR fixes https://github.com/broadinstitute/cromwell/issues/2256 by overriding default entry-point with /bin/bash