### PR TITLE
Add retries to credential validation

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardInitializationActor.scala
@@ -47,18 +47,18 @@ class StandardInitializationActor(val standardParams: StandardInitializationActo
   override lazy val calls: Set[TaskCall] = standardParams.calls
 
   override def beforeAll(): Future[Option[BackendInitializationData]] = {
-    Future.fromTry(Try(Option(initializationData)))
+    initializationData map Option.apply
   }
 
-  lazy val initializationData: StandardInitializationData =
-    new StandardInitializationData(workflowPaths, runtimeAttributesBuilder, classOf[StandardExpressionFunctions])
+  lazy val initializationData: Future[StandardInitializationData] =
+    workflowPaths map { new StandardInitializationData(_, runtimeAttributesBuilder, classOf[StandardExpressionFunctions]) }
 
   lazy val expressionFunctions: Class[_ <: StandardExpressionFunctions] = classOf[StandardExpressionFunctions]
 
-  lazy val pathBuilders: List[PathBuilder] = List(DefaultPathBuilder)
+  lazy val pathBuilders: Future[List[PathBuilder]] = Future.successful(List(DefaultPathBuilder))
 
-  lazy val workflowPaths: WorkflowPaths =
-    WorkflowPathBuilder.workflowPaths(configurationDescriptor, workflowDescriptor, pathBuilders)
+  lazy val workflowPaths: Future[WorkflowPaths] =
+    pathBuilders map { WorkflowPathBuilder.workflowPaths(configurationDescriptor, workflowDescriptor, _) }
 
   /**
     * Returns the runtime attribute builder for this backend.

--- a/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
@@ -3,6 +3,8 @@ package cromwell.core.path
 import akka.actor.ActorSystem
 import cromwell.core.WorkflowOptions
 
+import scala.concurrent.{ExecutionContext, Future}
+
 case object DefaultPathBuilderFactory extends PathBuilderFactory {
-  override def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem) = DefaultPathBuilder
+  override def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = Future.successful(DefaultPathBuilder)
 }

--- a/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
@@ -6,5 +6,5 @@ import cromwell.core.WorkflowOptions
 import scala.concurrent.{ExecutionContext, Future}
 
 case object DefaultPathBuilderFactory extends PathBuilderFactory {
-  override def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = Future.successful(DefaultPathBuilder)
+  override def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem, ec: ExecutionContext) = Future.successful(DefaultPathBuilder)
 }

--- a/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
@@ -3,9 +3,11 @@ package cromwell.core.path
 import akka.actor.ActorSystem
 import cromwell.core.WorkflowOptions
 
+import scala.concurrent.{ExecutionContext, Future}
+
 /**
   * Provide a method that can instantiate a path builder with the specified workflow options.
   */
 trait PathBuilderFactory {
-  def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem): PathBuilder
+  def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[PathBuilder]
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActor.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle
 
-import akka.actor.{ActorRef, FSM, LoggingFSM, Props}
+import akka.actor.{ActorRef, FSM, LoggingFSM, Props, Status}
+import akka.pattern.pipe
 import cats.data.NonEmptyList
 import cats.data.Validated._
 import cats.instances.list._
@@ -21,7 +22,7 @@ import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 import cromwell.engine._
 import cromwell.engine.backend.CromwellBackends
-import cromwell.engine.workflow.lifecycle.MaterializeWorkflowDescriptorActor.{MaterializeWorkflowDescriptorActorData, MaterializeWorkflowDescriptorActorState}
+import cromwell.engine.workflow.lifecycle.MaterializeWorkflowDescriptorActor.MaterializeWorkflowDescriptorActorState
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 import lenthall.exception.MessageAggregation
@@ -32,6 +33,7 @@ import wdl4s._
 import wdl4s.expression.NoFunctions
 import wdl4s.values.{WdlSingleFile, WdlString, WdlValue}
 
+import scala.concurrent.Future
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
@@ -72,14 +74,10 @@ object MaterializeWorkflowDescriptorActor {
     override val terminal = true
   }
   case object ReadyToMaterializeState extends MaterializeWorkflowDescriptorActorState
+  case object MaterializingState extends MaterializeWorkflowDescriptorActorState
   case object MaterializationSuccessfulState extends MaterializeWorkflowDescriptorActorTerminalState
   case object MaterializationFailedState extends MaterializeWorkflowDescriptorActorTerminalState
   case object MaterializationAbortedState extends MaterializeWorkflowDescriptorActorTerminalState
-
-  /*
-  Data
-   */
-  case class MaterializeWorkflowDescriptorActorData()
 
   private val DefaultWorkflowFailureMode = NoNewCalls.toString
 
@@ -116,32 +114,48 @@ object MaterializeWorkflowDescriptorActor {
 class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
                                          val workflowIdForLogging: WorkflowId,
                                          cromwellBackends: => CromwellBackends,
-                                         importLocalFilesystem: Boolean) extends LoggingFSM[MaterializeWorkflowDescriptorActorState, MaterializeWorkflowDescriptorActorData] with LazyLogging with WorkflowLogging {
+                                         importLocalFilesystem: Boolean) extends LoggingFSM[MaterializeWorkflowDescriptorActorState, Unit] with LazyLogging with WorkflowLogging {
 
   import MaterializeWorkflowDescriptorActor._
 
   val tag = self.path.name
 
   val iOExecutionContext = context.system.dispatchers.lookup("akka.dispatchers.io-dispatcher")
-
-  startWith(ReadyToMaterializeState, MaterializeWorkflowDescriptorActorData())
+  implicit val ec = context.dispatcher
+  
+  startWith(ReadyToMaterializeState, ())
 
   when(ReadyToMaterializeState) {
     case Event(MaterializeWorkflowDescriptorCommand(workflowSourceFiles, conf), _) =>
-      buildWorkflowDescriptor(workflowIdForLogging, workflowSourceFiles, conf) match {
-        case Valid(descriptor) =>
-          sender() ! MaterializeWorkflowDescriptorSuccessResponse(descriptor)
-          goto(MaterializationSuccessfulState)
-        case Invalid(error) =>
-          sender() ! MaterializeWorkflowDescriptorFailureResponse(
-            new IllegalArgumentException with MessageAggregation {
-              val exceptionContext = s"Workflow input processing failed"
-              val errorMessages = error.toList
-            })
-          goto(MaterializationFailedState)
+      val replyTo = sender()
+
+      workflowOptionsAndPathBuilders(workflowSourceFiles) match {
+        case Valid((workflowOptions, pathBuilders)) =>
+          val futureDescriptor = pathBuilders map {
+            buildWorkflowDescriptor(workflowIdForLogging, workflowSourceFiles, conf, workflowOptions, _)
+          }
+
+          // Pipe the response to self, but make it look like it comes from the sender of the command
+          // This way we can access it through sender() in the next state and don't have to store the value
+          // of replyTo in the data
+          pipe(futureDescriptor).to(self, replyTo)
+        case Invalid(error) => workflowInitializationFailed(error, replyTo)
       }
+      goto(MaterializingState)
     case Event(MaterializeWorkflowDescriptorAbortCommand, _) =>
       goto(MaterializationAbortedState)
+  }
+
+  when(MaterializingState) {
+    case Event(Valid(descriptor: EngineWorkflowDescriptor), _) =>
+      sender() ! MaterializeWorkflowDescriptorSuccessResponse(descriptor)
+      goto(MaterializationSuccessfulState)
+    case Event(Invalid(error: NonEmptyList[String]@unchecked), _) =>
+      workflowInitializationFailed(error, sender())
+      goto(MaterializationFailedState)
+    case Event(Status.Failure(failure), _) =>
+      workflowInitializationFailed(NonEmptyList.of(failure.getMessage), sender())
+      goto(MaterializationFailedState)
   }
 
   // Let these fall through to the whenUnhandled handler:
@@ -165,18 +179,34 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
       stay
   }
 
+  private def workflowInitializationFailed(errors: NonEmptyList[String], replyTo: ActorRef) = {
+    sender() ! MaterializeWorkflowDescriptorFailureResponse(
+      new IllegalArgumentException with MessageAggregation {
+        val exceptionContext = s"Workflow input processing failed"
+        val errorMessages = errors.toList
+      })
+  }
+
+  private def workflowOptionsAndPathBuilders(sourceFiles: WorkflowSourceFilesCollection): ErrorOr[(WorkflowOptions, Future[List[PathBuilder]])] = {
+    val workflowOptionsValidation = validateWorkflowOptions(sourceFiles.workflowOptionsJson)
+    workflowOptionsValidation map { workflowOptions =>
+      val pathBuilders = EngineFilesystems.pathBuildersForWorkflow(workflowOptions)(context.system, context.dispatcher)
+      (workflowOptions, pathBuilders)
+    }
+  }
+
   private def buildWorkflowDescriptor(id: WorkflowId,
                                       sourceFiles: WorkflowSourceFilesCollection,
-                                      conf: Config): ErrorOr[EngineWorkflowDescriptor] = {
+                                      conf: Config,
+                                      workflowOptions: WorkflowOptions,
+                                      pathBuilders: List[PathBuilder]): ErrorOr[EngineWorkflowDescriptor] = {
     val namespaceValidation = validateNamespace(sourceFiles)
-    val workflowOptionsValidation = validateWorkflowOptions(sourceFiles.workflowOptionsJson)
     val labelsValidation = validateLabels(sourceFiles.labelsJson)
-    (namespaceValidation |@| workflowOptionsValidation |@| labelsValidation) map {
-      (_, _, _)
-    } flatMap { case (namespace, workflowOptions, labels) =>
+    (namespaceValidation |@| labelsValidation) map {
+      (_, _)
+    } flatMap { case (namespace, labels) =>
       pushWfNameMetadataService(namespace.workflow.unqualifiedName)
       publishLabelsToMetadata(id, namespace.workflow.unqualifiedName, labels)
-      val pathBuilders = EngineFilesystems(context.system).pathBuildersForWorkflow(workflowOptions)
       buildWorkflowDescriptor(id, sourceFiles, namespace, workflowOptions, labels, conf, pathBuilders)
     }
   }
@@ -200,7 +230,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
 
   protected def labelsToMetadata(labels: Map[String, String], workflowId: WorkflowId): Unit = {
     labels foreach { case (k, v) =>
-      serviceRegistryActor ! PutMetadataAction(MetadataEvent(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Labels}:${k}"), MetadataValue(v)))
+      serviceRegistryActor ! PutMetadataAction(MetadataEvent(MetadataKey(workflowId, None, s"${WorkflowMetadataKeys.Labels}:$k"), MetadataValue(v)))
     }
   }
 
@@ -471,8 +501,8 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
     }
 
     modeString flatMap WorkflowFailureMode.tryParse match {
-        case Success(mode) => mode.validNel
-        case Failure(t) => t.getMessage.invalidNel
+      case Success(mode) => mode.validNel
+      case Failure(t) => t.getMessage.invalidNel
     }
   }
 }

--- a/engine/src/test/scala/cromwell/engine/io/IoActorGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorGcsBatchSpec.scala
@@ -13,7 +13,7 @@ import cromwell.filesystems.gcs.{GcsPathBuilder, GcsPathBuilderFactory}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
@@ -34,7 +34,7 @@ class IoActorGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers w
   }
   
   lazy val gcsPathBuilder = GcsPathBuilderFactory(ApplicationDefaultMode("default"), "cromwell-test")
-  lazy val pathBuilder: GcsPathBuilder = gcsPathBuilder.withOptions(WorkflowOptions.empty)
+  lazy val pathBuilder: GcsPathBuilder = Await.result(gcsPathBuilder.withOptions(WorkflowOptions.empty), 1 second)
 
   lazy val randomUUID = UUID.randomUUID().toString
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -1,13 +1,14 @@
 package cromwell.filesystems.gcs
 
 import java.net.URI
-import java.nio.file.spi.FileSystemProvider
 
+import akka.actor.ActorSystem
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.gax.retrying.RetrySettings
+import com.google.auth.Credentials
 import com.google.cloud.http.HttpTransportOptions
-import com.google.cloud.storage.contrib.nio.{CloudStorageConfiguration, CloudStorageFileSystem, CloudStoragePath}
+import com.google.cloud.storage.contrib.nio.{CloudStorageConfiguration, CloudStorageFileSystem, CloudStorageFileSystemProvider, CloudStoragePath}
 import com.google.cloud.storage.{BlobId, StorageOptions}
 import com.google.common.base.Preconditions._
 import com.google.common.net.UrlEscapers
@@ -16,6 +17,7 @@ import cromwell.core.path.{NioPath, Path, PathBuilder}
 import cromwell.filesystems.gcs.GcsPathBuilder._
 import cromwell.filesystems.gcs.auth.GoogleAuthMode
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -44,55 +46,71 @@ object GcsPathBuilder {
   }
 
   def getUri(string: String) = URI.create(UrlEscapers.urlFragmentEscaper().escape(string))
+  
+  def fromAuthMode(authMode: GoogleAuthMode,
+                   applicationName: String,
+                   retrySettings: Option[RetrySettings],
+                   cloudStorageConfiguration: CloudStorageConfiguration,
+                   options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[GcsPathBuilder] = {
+    authMode.credential(options) map { credentials =>
+      fromCredentials(credentials,
+        applicationName,
+        retrySettings,
+        cloudStorageConfiguration,
+        options
+      )
+    }
+  }
+  
+  def fromCredentials(credentials: Credentials,
+                      applicationName: String,
+                      retrySettings: Option[RetrySettings],
+                      cloudStorageConfiguration: CloudStorageConfiguration,
+                      options: WorkflowOptions): GcsPathBuilder = {
+    val transportOptions = HttpTransportOptions.newBuilder()
+      .setReadTimeout(3.minutes.toMillis.toInt)
+      .build()
+
+    val storageOptionsBuilder = StorageOptions.newBuilder()
+      .setTransportOptions(transportOptions)
+      .setCredentials(credentials)
+
+    retrySettings foreach storageOptionsBuilder.setRetrySettings
+
+    // Grab the google project from Workflow Options if specified and set
+    // that to be the project used by the StorageOptions Builder
+    options.get("google_project") map storageOptionsBuilder.setProjectId
+
+
+    val storageOptions = storageOptionsBuilder.build()
+
+    // Create a com.google.api.services.storage.Storage
+    // This is the underlying api used by com.google.cloud.storage
+    // By bypassing com.google.cloud.storage, we can create low level requests that can be batched
+    val apiStorage: com.google.api.services.storage.Storage = {
+      new com.google.api.services.storage.Storage
+      .Builder(HttpTransport, JsonFactory, GoogleConfiguration.withCustomTimeouts(transportOptions.getHttpRequestInitializer(storageOptions)))
+        .setApplicationName(applicationName)
+        .build()
+    }
+
+    // Create a com.google.cloud.storage.Storage
+    // This is the "relatively" high level API, and recommended one. The nio implementation sits on top of this.
+    val cloudStorage: com.google.cloud.storage.Storage = storageOptions.getService
+
+    // The CloudStorageFileSystemProvider constructor is not public. Currently the only way to obtain one is through a CloudStorageFileSystem
+    // Moreover at this point we can use the same provider for all operations as we have usable credentials
+    // In order to avoid recreating a provider with every getPath call, create a dummy FileSystem just to get its provider
+    val provider: CloudStorageFileSystemProvider = CloudStorageFileSystem.forBucket("dummy", cloudStorageConfiguration, storageOptions).provider()
+    
+    new GcsPathBuilder(apiStorage, cloudStorage, provider, storageOptions.getProjectId)
+  }
 }
 
-class GcsPathBuilder(authMode: GoogleAuthMode,
-                     applicationName: String,
-                     retrySettings: Option[RetrySettings],
-                     cloudStorageConfiguration: CloudStorageConfiguration,
-                     options: WorkflowOptions) extends PathBuilder {
-  authMode.validate(options)
-
-  protected val transportOptions = HttpTransportOptions.newBuilder()
-    .setReadTimeout(3.minutes.toMillis.toInt)
-    .build()
-
-  protected val storageOptionsBuilder = StorageOptions.newBuilder()
-    .setTransportOptions(transportOptions)
-    .setCredentials(authMode.credential(options))
-
-  retrySettings foreach storageOptionsBuilder.setRetrySettings
-
-  // Grab the google project from Workflow Options if specified and set
-  // that to be the project used by the StorageOptions Builder
-  options.get("google_project") map storageOptionsBuilder.setProjectId
-
-
-  protected val storageOptions = storageOptionsBuilder.build()
-
-  // Create a com.google.api.services.storage.Storage
-  // This is the underlying api used by com.google.cloud.storage
-  // By bypassing com.google.cloud.storage, we can create low level requests that can be batched
-  val apiStorage: com.google.api.services.storage.Storage = {
-    new com.google.api.services.storage.Storage
-    .Builder(HttpTransport, JsonFactory, GoogleConfiguration.withCustomTimeouts(transportOptions.getHttpRequestInitializer(storageOptions)))
-      .setApplicationName(applicationName)
-      .build()
-  }
-
-  // Create a com.google.cloud.storage.Storage
-  // This is the "relatively" high level API, and recommended one. The nio implementation sits on top of this.
-  val cloudStorage: com.google.cloud.storage.Storage = storageOptions.getService
-
-  // The CloudStorageFileSystemProvider constructor is not public. Currently the only way to obtain one is through a CloudStorageFileSystem
-  // Moreover at this point we can use the same provider for all operations as we have usable credentials
-  // In order to avoid recreating a provider with every getPath call, create a dummy FileSystem just to get its provider
-  protected val _provider = CloudStorageFileSystem.forBucket("dummy", cloudStorageConfiguration, storageOptions).provider()
-
-  protected def provider: FileSystemProvider = _provider
-
-  def getProjectId = storageOptions.getProjectId
-
+class GcsPathBuilder(val apiStorage: com.google.api.services.storage.Storage,
+                     val cloudStorage: com.google.cloud.storage.Storage,
+                     provider: CloudStorageFileSystemProvider,
+                     val projectId: String) extends PathBuilder {
   def build(string: String): Try[GcsPath] = {
     Try {
       val uri = getUri(string)

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -3,12 +3,15 @@ package cromwell.filesystems.gcs
 import akka.actor.ActorSystem
 import com.google.api.client.googleapis.media.MediaHttpUploader
 import com.google.api.gax.retrying.RetrySettings
+import com.google.auth.Credentials
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import com.typesafe.config.ConfigFactory
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.PathBuilderFactory
 import cromwell.filesystems.gcs.auth.GoogleAuthMode
 import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.ExecutionContext
 
 object GcsPathBuilderFactory {
 
@@ -33,5 +36,15 @@ case class GcsPathBuilderFactory(authMode: GoogleAuthMode,
 
   extends PathBuilderFactory {
 
-  def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem) = new GcsPathBuilder(authMode, applicationName, retrySettings, cloudStorageConfiguration, options)
+  def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {
+    GcsPathBuilder.fromAuthMode(authMode, applicationName, retrySettings, cloudStorageConfiguration, options)
+  }
+
+  /**
+    * Ignores the authMode and creates a GcsPathBuilder using the passed credentials directly.
+    * Can be used when the Credentials are already available.
+    */
+  def fromCredentials(options: WorkflowOptions, credentials: Credentials) = {
+    GcsPathBuilder.fromCredentials(credentials, applicationName, retrySettings, cloudStorageConfiguration, options)
+  }
 }

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -1,9 +1,10 @@
 package cromwell.filesystems.gcs
 
+import com.google.cloud.NoCredentials
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
 import cromwell.core.path._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.auth.{GoogleAuthMode, GoogleAuthModeSpec}
+import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{FlatSpecLike, Matchers}
 
@@ -16,15 +17,15 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
 
     val wfOptionsWithProject = WorkflowOptions.fromMap(Map("google_project" -> "my_project")).get
 
-    val gcsPathBuilderWithProjectInfo = new GcsPathBuilder(
-      GoogleAuthMode.MockAuthMode,
+    val gcsPathBuilderWithProjectInfo = GcsPathBuilder.fromCredentials(
+      NoCredentials.getInstance(),
       "cromwell-test",
       None,
       CloudStorageConfiguration.DEFAULT,
       wfOptionsWithProject
     )
 
-    gcsPathBuilderWithProjectInfo.getProjectId shouldBe "my_project"
+    gcsPathBuilderWithProjectInfo.projectId shouldBe "my_project"
   }
 
   it should behave like truncateCommonRoots(pathBuilder, pathsToTruncate)
@@ -357,8 +358,8 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   private lazy val pathBuilder = {
     GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
 
-    new GcsPathBuilder(
-      GoogleAuthMode.MockAuthMode,
+    GcsPathBuilder.fromCredentials(
+      NoCredentials.getInstance(),
       "cromwell-test",
       None,
       CloudStorageConfiguration.DEFAULT,

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/auth/GoogleAuthModeSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/auth/GoogleAuthModeSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.filesystems.gcs.auth
 
-import cromwell.core.WorkflowOptions
+import com.google.auth.oauth2.GoogleCredentials
 import org.scalatest.Assertions._
 
 import scala.util.{Failure, Try}
@@ -15,9 +15,7 @@ object GoogleAuthModeSpec {
   }
 
   private lazy val tryApplicationDefaultCredentials: Try[Unit] = Try {
-    val authMode = ApplicationDefaultMode("application-default")
-    val workflowOptions = WorkflowOptions.empty
-    authMode.credential(workflowOptions)
+    GoogleCredentials.getApplicationDefault
     ()
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/GenomicsFactory.scala
@@ -4,18 +4,16 @@ import java.net.URL
 
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
 import com.google.api.services.genomics.Genomics
+import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
-import cromwell.core.WorkflowOptions
 import cromwell.filesystems.gcs.auth.GoogleAuthMode
 
 
 case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, endpointUrl: URL) {
 
-  def withOptions(options: WorkflowOptions) = {
-    val scopedCredentials = authMode.credential(options)
-    
+  def fromCredentials(credentials: Credentials) = {
     val httpRequestInitializer = {
-      val delegate = new HttpCredentialsAdapter(scopedCredentials)
+      val delegate = new HttpCredentialsAdapter(credentials)
       new HttpRequestInitializer() {
         def initialize(httpRequest: HttpRequest) = {
           delegate.initialize(httpRequest)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
@@ -1,18 +1,12 @@
 package cromwell.backend.impl.jes
 
 import akka.actor.ActorSystem
-import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.backend.BackendJobDescriptorKey
 import cromwell.backend.io.JobPaths
 import cromwell.core.path.Path
 import cromwell.services.metadata.CallMetadataKeys
 
 object JesJobPaths {
-  def apply(jobKey: BackendJobDescriptorKey, workflowDescriptor: BackendWorkflowDescriptor,
-            jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem): JesJobPaths = {
-    val workflowPath = new JesWorkflowPaths(workflowDescriptor, jesConfiguration)
-    new JesJobPaths(workflowPath, jobKey)
-  }
-
   val JesLogPathKey = "jesLog"
   val GcsExecPathKey = "gcsExec"
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.impl.jes
 
 import akka.actor.ActorSystem
+import com.google.auth.Credentials
 import com.typesafe.config.Config
 import cromwell.backend.impl.jes.JesAsyncBackendJobExecutionActor.WorkflowOptionKeys
 import cromwell.backend.io.WorkflowPaths
@@ -17,25 +18,35 @@ object JesWorkflowPaths {
 }
 
 case class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
-                       jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
+                            gcsCredentials: Credentials,
+                            genomicsCredentials: Credentials,
+                            jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
 
   override lazy val executionRootString: String =
     workflowDescriptor.workflowOptions.getOrElse(JesWorkflowPaths.GcsRootOptionKey, jesConfiguration.root)
+
   private val workflowOptions: WorkflowOptions = workflowDescriptor.workflowOptions
-  val gcsPathBuilder: GcsPathBuilder = jesConfiguration.gcsPathBuilderFactory.withOptions(workflowOptions)
+
+  private val gcsPathBuilder: GcsPathBuilder = jesConfiguration.gcsPathBuilderFactory.fromCredentials(workflowOptions, gcsCredentials)
 
   val gcsAuthFilePath: Path = {
+    // The default auth file bucket is always at the root of the root workflow
+    val defaultBucket = executionRoot.resolve(workflowDescriptor.rootWorkflow.unqualifiedName).resolve(workflowDescriptor.rootWorkflowId.toString)
+    val bucket = workflowDescriptor.workflowOptions.get(JesWorkflowPaths.AuthFilePathOptionKey) getOrElse defaultBucket.pathAsString
+
     /*
      * This is an "exception". The filesystem used here is built from genomicsAuth
      * unlike everywhere else where the filesystem used is built from gcsFileSystemAuth
      */
-    val genomicsCredentials = jesConfiguration.jesAuths.genomics
+    val pathBuilderWithGenomicsAuth = GcsPathBuilder.fromCredentials(
+      genomicsCredentials,
+      jesConfiguration.googleConfig.applicationName,
+      None,
+      GcsPathBuilderFactory.DefaultCloudStorageConfiguration,
+      workflowOptions
+    )
 
-    // The default auth file bucket is always at the root of the root workflow
-    val defaultBucket = executionRoot.resolve(workflowDescriptor.rootWorkflow.unqualifiedName).resolve(workflowDescriptor.rootWorkflowId.toString)
-
-    val bucket = workflowDescriptor.workflowOptions.get(JesWorkflowPaths.AuthFilePathOptionKey) getOrElse defaultBucket.pathAsString
-    val authBucket = GcsPathBuilderFactory(genomicsCredentials, jesConfiguration.googleConfig.applicationName).withOptions(workflowOptions).build(bucket) recover {
+    val authBucket = pathBuilderWithGenomicsAuth.build(bucket) recover {
       case ex => throw new Exception(s"Invalid gcs auth_bucket path $bucket", ex)
     } get
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.jes
 
+import com.google.cloud.NoCredentials
 import cromwell.backend.BackendSpec
 import cromwell.core.TestKitSuite
 import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
@@ -20,9 +21,10 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
-
-    val callPaths = JesJobPaths(jobDescriptorKey, workflowDescriptor,
-      jesConfiguration)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
+    
+    val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
+    
     callPaths.returnCodeFilename should be("hello-rc.txt")
     callPaths.stderrFilename should be("hello-stderr.log")
     callPaths.stdoutFilename should be("hello-stdout.log")
@@ -35,8 +37,10 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
 
-    val callPaths = JesJobPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration)
+    val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
+    
     callPaths.returnCode.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/hello-rc.txt")
     callPaths.stdout.pathAsString should
@@ -53,8 +57,10 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
 
-    val callPaths = JesJobPaths(jobDescriptorKey, workflowDescriptor, jesConfiguration)
+    val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
+    
     callPaths.callContext.root.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello")
     callPaths.callContext.stdout should

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.jes
 
+import com.google.cloud.NoCredentials
 import cromwell.backend.BackendSpec
 import cromwell.core.TestKitSuite
 import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
@@ -19,7 +20,7 @@ class JesWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with Matchers 
     val workflowDescriptor = buildWorkflowDescriptor(SampleWdl.HelloWorld.wdlSource())
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, jesConfiguration)(system)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)(system)
     workflowPaths.executionRoot.pathAsString should be("gs://my-cromwell-workflows-bucket/")
     workflowPaths.workflowRoot.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigInitializationActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigInitializationActor.scala
@@ -5,6 +5,8 @@ import cromwell.backend.sfs._
 import cromwell.backend.standard.{StandardInitializationActorParams, StandardInitializationData, StandardValidatedRuntimeAttributesBuilder}
 import wdl4s.WdlNamespace
 
+import scala.concurrent.Future
+
 /**
   * Extension of the SharedFileSystemBackendInitializationData with declarations of extra runtime attributes, and a
   * wdl namespace containing various tasks for submitting, killing, etc.
@@ -40,9 +42,11 @@ class ConfigInitializationActor(params: StandardInitializationActorParams)
     DeclarationValidation.fromDeclarations(configWdlNamespace.runtimeDeclarations)
   }
 
-  override lazy val initializationData: ConfigInitializationData = {
+  override lazy val initializationData: Future[ConfigInitializationData] = {
     val wdlNamespace = configWdlNamespace.wdlNamespace
-    new ConfigInitializationData(workflowPaths, runtimeAttributesBuilder, declarationValidations, wdlNamespace)
+    workflowPaths map {
+      new ConfigInitializationData(_, runtimeAttributesBuilder, declarationValidations, wdlNamespace)
+    }
   }
 
   override lazy val runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
@@ -29,6 +29,8 @@ class TesInitializationActor(params: TesInitializationActorParams)
   extends StandardInitializationActor(params) {
 
   private val tesConfiguration = params.tesConfiguration
+  
+  private implicit val system = context.system
 
   /**
     * If the backend sets a gcs authentication mode, try to create a PathBuilderFactory with it.


### PR DESCRIPTION
Specifically to "refresh token" mode credential validation.
Other modes should only be validated once at Cromwell startup, since they don't change for every workflow.
Only "refresh token mode" generates different credentials for every workflow (with the refresh token passed in), that need to be validated.

Retrying this asynchronously means turning into `Future`s a bunch of methods that were previously synchronous.