### PR TITLE
27 / 26 Docker hash consistency, develop edition.

### DIFF
--- a/dockerHashing/src/main/scala/cromwell/docker/local/DockerCliFlow.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/local/DockerCliFlow.scala
@@ -130,14 +130,14 @@ object DockerCliFlow {
   private def cliKeyFromImageId(context: DockerHashContext): DockerCliKey = {
     val imageId = context.dockerImageID
     (imageId.host, imageId.repository) match {
-      case (None, "library") =>
+      case (None, None) =>
         // For docker hub images (host == None), and don't include "library".
         val repository = imageId.image
         val tag = imageId.reference
         DockerCliKey(repository, tag)
       case _ =>
         // For all other images, include the host and repository.
-        val repository = s"${imageId.hostAsString}${imageId.repository}/${imageId.image}"
+        val repository = s"${imageId.hostAsString}${imageId.nameWithDefaultRepository}"
         val tag = imageId.reference
         DockerCliKey(repository, tag)
     }

--- a/dockerHashing/src/main/scala/cromwell/docker/registryv2/DockerRegistryV2AbstractFlow.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/registryv2/DockerRegistryV2AbstractFlow.scala
@@ -144,7 +144,7 @@ abstract class DockerRegistryV2AbstractFlow(httpClientFlow: HttpDockerFlow)(impl
     */
   protected def buildTokenRequestUri(dockerImageID: DockerImageIdentifierWithoutHash): String = {
     val service = serviceName map { name => s"service=$name&" } getOrElse ""
-    s"https://$authorizationServerHostName/token?${service}scope=repository:${dockerImageID.name}:pull"
+    s"https://$authorizationServerHostName/token?${service}scope=repository:${dockerImageID.nameWithDefaultRepository}:pull"
   }
 
   /**
@@ -252,7 +252,7 @@ abstract class DockerRegistryV2AbstractFlow(httpClientFlow: HttpDockerFlow)(impl
     * Builds the manifest URI to be queried based on a DockerImageID
     */
   private def buildManifestUri(dockerImageID: DockerImageIdentifierWithoutHash): String = {
-    s"https://$registryHostName/v2/${dockerImageID.name}/manifests/${dockerImageID.reference}"
+    s"https://$registryHostName/v2/${dockerImageID.nameWithDefaultRepository}/manifests/${dockerImageID.reference}"
   }
 
   /**

--- a/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
@@ -8,19 +8,17 @@ class DockerImageIdentifierSpec extends FlatSpec with Matchers with TableDrivenP
   
   it should "parse valid docker images" in {
     val valid = Table(
-      ("sourceString",                            "host",              "repo",          "image",     "reference"),
-      
+      ("sourceString",                            "host",             "repo",                 "image",     "reference"),
       // Without tags -> latest
-      ("ubuntu",                                  None,               "library",        "ubuntu",     "latest"),
-      ("broad/cromwell",                          None,               "broad",          "cromwell",   "latest"),
-      ("index.docker.io/ubuntu",         Option("index.docker.io"),   "library",        "ubuntu",     "latest"),
-      ("broad/cromwell/submarine",                None,               "broad/cromwell", "submarine",  "latest"),
-      ("gcr.io/google/alpine",              Option("gcr.io"),         "google",         "alpine",     "latest"),
-
+      ("ubuntu",                                  None,               None,                   "ubuntu",     "latest"),
+      ("broad/cromwell",                          None,               Some("broad"),          "cromwell",   "latest"),
+      ("index.docker.io/ubuntu",         Option("index.docker.io"),   None,                   "ubuntu",     "latest"),
+      ("broad/cromwell/submarine",                None,               Some("broad/cromwell"), "submarine",  "latest"),
+      ("gcr.io/google/alpine",              Option("gcr.io"),         Some("google"),         "alpine",     "latest"),
       // With tags
-      ("ubuntu:latest",                           None,               "library",        "ubuntu",     "latest"),
-      ("ubuntu:1235-SNAP",                        None,               "library",        "ubuntu",     "1235-SNAP"),
-      ("ubuntu:V3.8-5_1",                         None,               "library",        "ubuntu",     "V3.8-5_1")
+      ("ubuntu:latest",                           None,               None,                   "ubuntu",     "latest"),
+      ("ubuntu:1235-SNAP",                        None,               None,                   "ubuntu",     "1235-SNAP"),
+      ("ubuntu:V3.8-5_1",                         None,               None,                   "ubuntu",     "V3.8-5_1")
     )
     
     forAll(valid) { (dockerString, host, repo, image, reference) =>
@@ -38,7 +36,7 @@ class DockerImageIdentifierSpec extends FlatSpec with Matchers with TableDrivenP
     withDigest.isSuccess shouldBe true
     val successfulDigest = withDigest.get
     successfulDigest.host shouldBe None
-    successfulDigest.repository shouldBe "library"
+    successfulDigest.repository shouldBe None
     successfulDigest.image shouldBe "ubuntu"
     successfulDigest.reference shouldBe "sha256:45168651"
     successfulDigest.isInstanceOf[DockerImageIdentifierWithHash] shouldBe true
@@ -49,7 +47,7 @@ class DockerImageIdentifierSpec extends FlatSpec with Matchers with TableDrivenP
     withTagDigest.isSuccess shouldBe true
     val successfulTagDigest = withTagDigest.get
     successfulTagDigest.host shouldBe None
-    successfulTagDigest.repository shouldBe "library"
+    successfulTagDigest.repository shouldBe None
     successfulTagDigest.image shouldBe "ubuntu"
     successfulTagDigest.reference shouldBe "latest@sha256:45168651"
     successfulTagDigest.isInstanceOf[DockerImageIdentifierWithHash] shouldBe true

--- a/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
@@ -124,7 +124,7 @@ class WorkflowDockerLookupActorSpec extends TestKitSuite("WorkflowDockerLookupAc
     val mixedResponses = results collect {
       case msg: DockerHashSuccessResponse => msg
       // Scoop out the request here since we can't match the exception on the whole message.
-      case msg: WorkflowDockerLookupFailure if msg.reason.getMessage == "Failed to get docker hash for library/ubuntu:older Lookup failed" => msg.request
+      case msg: WorkflowDockerLookupFailure if msg.reason.getMessage == "Failed to get docker hash for ubuntu:older Lookup failed" => msg.request
     }
 
     Set(LatestSuccessResponse, OlderRequest) should equal(mixedResponses)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
@@ -22,8 +22,8 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
   behavior of "JobPreparationActor"
 
   // Generated fresh for each test case in 'before'
-  var helper: JobPreparationTestHelper = null
-  var inputs: Map[Declaration, WdlValue] = null
+  var helper: JobPreparationTestHelper = _
+  var inputs: Map[Declaration, WdlValue] = _
 
   before {
     helper = new JobPreparationTestHelper()
@@ -63,7 +63,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe dockerValue
-        success.jobDescriptor.maybeCallCachingEligible shouldBe DockerWithHash("library/ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950")
+        success.jobDescriptor.maybeCallCachingEligible shouldBe DockerWithHash("ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950")
     }
     helper.workflowDockerLookupActor.expectNoMsg(1 second)
   }
@@ -110,7 +110,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     )
     val hashResult = DockerHashResult("sha256", "71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950")
     val inputsAndAttributes = Success((inputs, attributes))
-    val finalValue = "library/ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    val finalValue = "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     val actor = TestActorRef(helper.buildTestJobPreparationActor(1 minute, 1 minutes, List.empty, inputsAndAttributes, List.empty), self)
     actor ! Start
     helper.workflowDockerLookupActor.expectMsgClass(classOf[DockerHashRequest])
@@ -136,7 +136,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe dockerValue
-        success.jobDescriptor.maybeCallCachingEligible shouldBe FloatingDockerTagWithoutHash("library/ubuntu:latest")
+        success.jobDescriptor.maybeCallCachingEligible shouldBe FloatingDockerTagWithoutHash("ubuntu:latest")
     }
   }
 }


### PR DESCRIPTION
Don't implicitly add a library/ repo prefix to Docker images as that breaks 26-era call caches.