### PR TITLE
Return 404 on CC Endpoint for old workflows + cleanup from previous version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 It is published even if the call failed. However if the call is attempted multiple times (because it has been preempted for example),
 since hash values are strictly identical for all attempts, they will only be published in the last attempt section of the metadata for this call.
 If the hashes fail to be calculated, the reason is indicated in a `hashFailures` field in the `callCaching` section of the call metadata.
+*Important*: Hashes are not retroactively published to the metadata. Which means only workflows run on Cromwell 28+ will have hashes in their metadata.
 
 See the [README](https://github.com/broadinstitute/cromwell#get-apiworkflowsversionidmetadata) for an example metadata response.
 

--- a/README.md
+++ b/README.md
@@ -3493,6 +3493,10 @@ Server: spray-can/1.3.3
 
 ## GET /api/workflows/:version/callcaching/diff
 
+**Disclaimer**: This endpoint depends on hash values being published ito the metadata, which only happens as of Crowmell 28.
+Workflows run with prior versions of Cromwell will not be able to benefit from this endpoint.
+A `404 NotFound` will be returned when trying to use this endpoint if either workflows have been run on a prior version.
+
 This endpoint returns the hash differences between 2 *completed* (successfully or not) calls.
 The following query parameters are supported:
 

--- a/README.md
+++ b/README.md
@@ -3493,7 +3493,7 @@ Server: spray-can/1.3.3
 
 ## GET /api/workflows/:version/callcaching/diff
 
-**Disclaimer**: This endpoint depends on hash values being published ito the metadata, which only happens as of Crowmell 28.
+**Disclaimer**: This endpoint depends on hash values being published to the metadata, which only happens as of Crowmell 28.
 Workflows run with prior versions of Cromwell will not be able to benefit from this endpoint.
 A `404 NotFound` will be returned when trying to use this endpoint if either workflows have been run on a prior version.
 

--- a/README.md
+++ b/README.md
@@ -3494,8 +3494,8 @@ Server: spray-can/1.3.3
 ## GET /api/workflows/:version/callcaching/diff
 
 **Disclaimer**: This endpoint depends on hash values being published to the metadata, which only happens as of Crowmell 28.
-Workflows run with prior versions of Cromwell will not be able to benefit from this endpoint.
-A `404 NotFound` will be returned when trying to use this endpoint if either workflows have been run on a prior version.
+Workflows run with prior versions of Cromwell cannot be used with this endpoint.
+A `404 NotFound` will be returned when trying to use this endpoint if either workflow has been run on a prior version.
 
 This endpoint returns the hash differences between 2 *completed* (successfully or not) calls.
 The following query parameters are supported:

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -364,7 +364,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   }
 
   private def disableCallCaching(reason: Option[Throwable] = None) = {
-    reason foreach { r => log.error(r, "{}: Hash error, disabling call caching for this job.", jobTag) }
+    reason foreach { log.error(_, "{}: Hash error, disabling call caching for this job.", jobTag) }
     effectiveCallCachingMode = CallCachingOff
     writeCallCachingModeToMetadata()
     writeToMetadata(Map(callCachingHitResultMetadataKey -> false))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -23,9 +23,9 @@ import scala.util.{Failure, Success, Try}
 
 object CallCacheDiffActor {
   private val PlaceholderMissingHashValue = MetadataPrimitive(MetadataValue("Error: there is a hash entry for this key but the value is null !"))
-  private val CallAAndBNotFoundException = new Exception("callA and callB have been run on a previous version of Cromwell on which this endpoint was not supported.")
-  private val CallANotFoundException = new Exception("callA has been run on a previous version of Cromwell on which this endpoint was not supported.")
-  private val CallBNotFoundException = new Exception("callB has been run on a previous version of Cromwell on which this endpoint was not supported.")
+  private val CallAAndBNotFoundException = new Exception("callA and callB were run run on a previous version of Cromwell on which this endpoint was not supported.")
+  private val CallANotFoundException = new Exception("callA was run on a previous version of Cromwell on which this endpoint was not supported.")
+  private val CallBNotFoundException = new Exception("callB was run on a previous version of Cromwell on which this endpoint was not supported.")
 
   sealed trait CallCacheDiffActorState
   case object Idle extends CallCacheDiffActorState

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success, Try}
 
 object CallCacheDiffActor {
   private val PlaceholderMissingHashValue = MetadataPrimitive(MetadataValue("Error: there is a hash entry for this key but the value is null !"))
-  private val CallAAndBNotFoundException = new Exception("callA and callB were run run on a previous version of Cromwell on which this endpoint was not supported.")
+  private val CallAAndBNotFoundException = new Exception("callA and callB were run on a previous version of Cromwell on which this endpoint was not supported.")
   private val CallANotFoundException = new Exception("callA was run on a previous version of Cromwell on which this endpoint was not supported.")
   private val CallBNotFoundException = new Exception("callB was run on a previous version of Cromwell on which this endpoint was not supported.")
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -233,7 +233,7 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
       case response: RequestComplete[(StatusCode, FailureResponse)]@unchecked => 
         response.response._1 shouldBe StatusCodes.NotFound
         response.response._2.status shouldBe "error"
-        response.response._2.message shouldBe "callA and callB have been run on a previous version of Cromwell on which this endpoint was not supported."
+        response.response._2.message shouldBe "callA and callB were run on a previous version of Cromwell on which this endpoint was not supported."
     }
     expectTerminated(actor)
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -11,7 +11,7 @@ import cromwell.webservice.FailureResponse
 import cromwell.webservice.PerRequest.RequestComplete
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
-import spray.http.StatusCodes
+import spray.http.{StatusCode, StatusCodes}
 
 class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
 
@@ -213,6 +213,28 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
         response.message shouldBe "Query lookup failed - but it's ok ! this is a test !"
     }
     
+    expectTerminated(actor)
+  }
+
+  it should "respond with 404 if hashes are missing" in {
+    import scala.concurrent.duration._
+    import scala.language.postfixOps
+    
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+
+    actor ! MetadataLookupResponse(queryA, eventsA.filterNot(_.key.key.contains("hashes")))
+
+    expectMsgPF(1 second) {
+      case response: RequestComplete[(StatusCode, FailureResponse)]@unchecked => 
+        response.response._1 shouldBe StatusCodes.NotFound
+        response.response._2.status shouldBe "error"
+        response.response._2.message shouldBe "callA and callB have been run on a previous version of Cromwell on which this endpoint was not supported."
+    }
     expectTerminated(actor)
   }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -58,7 +58,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           ejea ! successResponse
 
           if (cacheUpdateRequired) {
-            expectCacheWriteForSuccessfulJob(successResponse, finalHashData.get.get)
+            expectCacheWrite(successResponse, finalHashData.get.get)
           } else {
             expectJobStoreWrite(SucceededResponseData(successResponse, finalHashData))
           }
@@ -84,7 +84,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           }
 
           if (cacheUpdateRequired) {
-            expectCacheWriteForSuccessfulJob(successResponse, finalHashData.get.get)
+            expectCacheWrite(successResponse, finalHashData.get.get)
           } else {
             expectJobStoreWrite(SucceededResponseData(successResponse, finalHashData))
           }
@@ -112,7 +112,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           s"not invalidate a call for caching if backend coping failed when invalidation is disabled, when it was going to receive $hashComboName, if call caching is $mode" in {
             val invalidationDisabledOptions = CallCachingOptions(invalidateBadCacheResults = false)
             val cacheInvalidationDisabledMode = mode match {
-              case CallCachingActivity(rw, _) => CallCachingActivity(rw, invalidationDisabledOptions)
+              case CallCachingActivity(rw, options) => CallCachingActivity(rw, invalidationDisabledOptions)
               case _ => fail(s"Mode $mode not appropriate for cache invalidation tests")
             }
             ejea = ejeaInBackendIsCopyingCachedOutputsState(initialHashData, cacheInvalidationDisabledMode)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -112,7 +112,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           s"not invalidate a call for caching if backend coping failed when invalidation is disabled, when it was going to receive $hashComboName, if call caching is $mode" in {
             val invalidationDisabledOptions = CallCachingOptions(invalidateBadCacheResults = false)
             val cacheInvalidationDisabledMode = mode match {
-              case CallCachingActivity(rw, options) => CallCachingActivity(rw, invalidationDisabledOptions)
+              case CallCachingActivity(rw, _) => CallCachingActivity(rw, invalidationDisabledOptions)
               case _ => fail(s"Mode $mode not appropriate for cache invalidation tests")
             }
             ejea = ejeaInBackendIsCopyingCachedOutputsState(initialHashData, cacheInvalidationDisabledMode)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRunningJobSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRunningJobSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
-import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{FailedNonRetryableResponseData, ResponsePendingData, RunningJob, SucceededResponseData}
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{ResponsePendingData, RunningJob, SucceededResponseData}
 import cromwell.jobstore.JobResultFailure
 import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
 import EngineJobExecutionActorSpec.EnhancedTestEJEA
@@ -31,7 +31,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
 
           // When the hashes arrive, the state and data should update:
           ejea ! SuccessfulCallCacheHashes
-          expectCacheWriteForSuccessfulJob(successResponse, SuccessfulCallCacheHashes)
+          expectCacheWrite(successResponse, SuccessfulCallCacheHashes)
         } else {
           expectJobStoreWrite(SucceededResponseData(successResponse, None))
         }
@@ -44,7 +44,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
           eventually { ejea.stateData should be(initialData.copy(hashes = Some(Success(SuccessfulCallCacheHashes)))) }
           ejea.stateName should be(RunningJob)
           ejea ! successResponse
-          expectCacheWriteForSuccessfulJob(successResponse, SuccessfulCallCacheHashes)
+          expectCacheWrite(successResponse, SuccessfulCallCacheHashes)
         }
 
         s"Handle receiving SuccessResponse then HashError correctly in $mode mode" in {
@@ -64,63 +64,29 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
           ejea ! successResponse
           expectJobStoreWrite(SucceededResponseData(successResponse, Some(Failure(hashError.reason))))
         }
-
-        s"Handle receiving CallCacheHashes then FailedNonRetryable correctly in $mode mode" in {
-          ejea = ejeaInRunningState(mode)
-          ejea ! SuccessfulCallCacheHashes
-          eventually { ejea.stateData should be(initialData.copy(hashes = Some(Success(SuccessfulCallCacheHashes)))) }
-          ejea.stateName should be(RunningJob)
-          ejea ! failureNonRetryableResponse
-          expectCacheWriteForFailedNonRetryableJob(failureNonRetryableResponse, SuccessfulCallCacheHashes)
-        }
-
-        s"Handle receiving FailedNonRetryable then HashError correctly in $mode mode" in {
-          ejea = ejeaInRunningState(mode)
-          ejea ! failureNonRetryableResponse
-          eventually { ejea.stateData should be(FailedNonRetryableResponseData(failureNonRetryableResponse, None)) }
-          ejea.stateName should be(RunningJob)
-          ejea ! hashError
-          helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Job Store Write") {
-            case RegisterJobCompleted(jobKey, JobResultFailure(returnCode, reason, isRetryable)) =>
-              validateJobStoreKey(jobKey)
-              returnCode should be(failedRc)
-              reason should be(failureReason)
-              isRetryable should be(false)
-          }
-        }
-
-        s"Handle receiving HashError then FailedNonRetryable correctly in $mode mode" in {
-          ejea = ejeaInRunningState(mode)
-          ejea ! hashError
-          eventually { ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, Some(Failure(hashError.reason)))) }
-          ejea.stateName should be(RunningJob)
-          ejea ! failureNonRetryableResponse
-          helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Job Store Write") {
-            case RegisterJobCompleted(jobKey, JobResultFailure(returnCode, reason, isRetryable)) =>
-              validateJobStoreKey(jobKey)
-              returnCode should be(failedRc)
-              reason should be(failureReason)
-              isRetryable should be(false)
-          }
-        }
       }
     }
 
-    s"register 'FailedRetryableResponse's with the JobStore" in {
-      ejea = ejeaInRunningState()
-      val response = failureRetryableResponse
-      ejea.underlyingActor.receive.isDefinedAt(response) should be(true)
-      ejea ! response
+    // What's with all this maker stuff? You can't use the "helper" outside of spec tests so we can't instantiate these responses
+    // yet. So, we take the functions instead and call them when we need them
+    List(("FailedRetryableResponse", failureRetryableResponse _, true),
+         ("FailedNonRetryableResponse", failureNonRetryableResponse _, false)
+    ) foreach { case (name, responseMaker, retryable) =>
+      s"register '$name's with the JobStore" in {
+        ejea = ejeaInRunningState()
+        val response = responseMaker.apply
+        ejea.underlyingActor.receive.isDefinedAt(response) should be(true)
+        ejea ! response
 
-      helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Job Store Write") {
-        case RegisterJobCompleted(jobKey, JobResultFailure(returnCode, reason, isRetryable)) =>
-          validateJobStoreKey(jobKey)
-          returnCode should be(failedRc)
-          reason should be(failureReason)
-          isRetryable should be(true)
+        helper.jobStoreProbe.expectMsgPF(max = awaitTimeout, hint = "Job Store Write") {
+          case RegisterJobCompleted(jobKey, JobResultFailure(returnCode, reason, isRetryable)) =>
+            validateJobStoreKey(jobKey)
+            returnCode should be(failedRc)
+            reason should be(failureReason)
+            isRetryable should be(retryable)
+        }
       }
     }
-
 
     "not register aborted jobs in the job store, forward straight to parent instead" in {
       ejea = ejeaInRunningState()

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
@@ -4,7 +4,7 @@ import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.BackendJobExecutionActor.{AbortedResponse, JobFailedNonRetryableResponse, JobFailedRetryableResponse, JobSucceededResponse}
 import cromwell.core.JobOutput
 import cromwell.core.callcaching._
-import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{EJEAData, SucceededResponseData, UpdatingCallCache, UpdatingJobStore}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CallCacheHashes, FileHashes}
 import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
@@ -24,14 +24,9 @@ private[ejea] trait CanValidateJobStoreKey { self: EngineJobExecutionActorSpec =
 }
 
 private[ejea] trait CanExpectCacheWrites extends Eventually { self: EngineJobExecutionActorSpec =>
-  def expectCacheWriteForSuccessfulJob(expectedResponse: JobSucceededResponse, expectedCallCacheHashes: CallCacheHashes): Unit = {
+  def expectCacheWrite(expectedResponse: JobSucceededResponse, expectedCallCacheHashes: CallCacheHashes): Unit = {
     eventually { ejea.stateName should be(UpdatingCallCache) }
     ejea.stateData should be(SucceededResponseData(expectedResponse, Some(Success(expectedCallCacheHashes))))
-    ()
-  }
-  def expectCacheWriteForFailedNonRetryableJob(expectedResponse: JobFailedNonRetryableResponse, expectedCallCacheHashes: CallCacheHashes): Unit = {
-    eventually { ejea.stateName should be(UpdatingCallCache) }
-    ejea.stateData should be(FailedNonRetryableResponseData(expectedResponse, Some(Success(expectedCallCacheHashes))))
     ()
   }
 }


### PR DESCRIPTION
- There's no migration to move hashes from previous workflows to metadata. Which means the Call Caching Diff endpoint won't work for those. Instead of returning an empty diff which could be mistaken for "those calls are identical", return 404.
@katevoss @bradtaylor If that's a behavior we want to change please say so (cf email sent earlier this week).

- Reverts the code that was persisting failed jobs hashes to the hash table. We don't need it anymore because it's in the metadata and that's what the Call Caching endpoint is using.

- Update changelog / README