### PR TITLE
Gather completed shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - openssl aes-256-cbc -K "$encrypted_5ebd3ff04788_key" -iv "$encrypted_5ebd3ff04788_iv" -in src/bin/travis/resources/jesConf.tar.enc -out jesConf.tar -d || true
 env:
   global:
-    - CENTAUR_BRANCH=develop
+    - CENTAUR_BRANCH=rm-2297
   matrix:
     # Setting this variable twice will cause the 'script' section to run twice with the respective env var invoked
     - BUILD_TYPE=sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - openssl aes-256-cbc -K "$encrypted_5ebd3ff04788_key" -iv "$encrypted_5ebd3ff04788_iv" -in src/bin/travis/resources/jesConf.tar.enc -out jesConf.tar -d || true
 env:
   global:
-    - CENTAUR_BRANCH=rm-2297
+    - CENTAUR_BRANCH=develop
   matrix:
     # Setting this variable twice will cause the 'script' section to run twice with the respective env var invoked
     - BUILD_TYPE=sbt

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -332,7 +332,7 @@ case class WorkflowExecutionActor(workflowDescriptor: EngineWorkflowDescriptor,
       case Some(ExecutionStatus.Done) =>
         handleWorkflowSuccessful(data)
       case Some(_) =>
-        context.parent ! WorkflowExecutionFailedResponse(data.jobExecutionMap, new Exception("One or more jobs failed in fail-slow mode"))
+        context.parent ! WorkflowExecutionFailedResponse(data.jobExecutionMap, new Exception("One or more jobs failed in ContinueWhilePossible mode"))
         goto(WorkflowExecutionFailedState) using data
       case _ =>
         scheduleStartRunnableCalls()

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -3,6 +3,7 @@ package cromwell.engine.workflow.lifecycle.execution
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionStatus.{apply => _, _}
 import cromwell.core.{ExecutionStatus, JobKey}
+import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.CollectorKey
 import cromwell.util.SampleWdl
 import org.scalameter.api._
 import wdl4s.{TaskCall, WdlNamespaceWithWorkflow}
@@ -25,6 +26,7 @@ object ExecutionStoreBenchmark extends Bench[Double] {
   val wdl = WdlNamespaceWithWorkflow.load(SampleWdl.PrepareScatterGatherWdl().workflowSource(), Seq.empty).get
   val prepareCall: TaskCall = wdl.workflow.findCallByName("do_prepare").get.asInstanceOf[TaskCall]
   val scatterCall: TaskCall = wdl.workflow.findCallByName("do_scatter").get.asInstanceOf[TaskCall]
+  val scatter = wdl.workflow.namespace.scatters.head
   
   def makeKey(call: TaskCall, executionStatus: ExecutionStatus)(index: Int) = {
     BackendJobDescriptorKey(call, Option(index), 1) -> executionStatus
@@ -32,7 +34,7 @@ object ExecutionStoreBenchmark extends Bench[Double] {
   
   // Generates numbers from 1000 to 10000 with 1000 gap:
   // 1000, 2000, ..., 10000
-  val sizes: Gen[Int] = Gen.range("size")(1000, 10000, 1000)
+  val sizes: Gen[Int] = Gen.range("size")(10000, 100000, 10000)
   
   // Generates executionStores using the given above sizes
   // Each execution store contains X simulated shards of "prepareCall" in status Done and X simulated shards of "scatterCall" in status NotStarted
@@ -41,7 +43,8 @@ object ExecutionStoreBenchmark extends Bench[Double] {
   val executionStores: Gen[ExecutionStore] = for {
     size <- sizes
     doneMap = (0 until size map makeKey(prepareCall, ExecutionStatus.Done)).toMap
-    notStartedMap = (0 until size map makeKey(scatterCall, ExecutionStatus.NotStarted)).toMap
+    collectorKey = Map(CollectorKey(scatterCall, scatter, size) -> ExecutionStatus.NotStarted)
+    notStartedMap: Map[JobKey, ExecutionStatus] = (0 until size map makeKey(scatterCall, ExecutionStatus.NotStarted)).toMap ++ collectorKey
     finalMap: Map[JobKey, ExecutionStatus] = doneMap ++ notStartedMap
   } yield new ExecutionStore(finalMap, true)
   


### PR DESCRIPTION
Previously, we processed the gather step once all the shards in a scatter reached the Done state--and now a gather step is initiated when all the shards in a scatter have reached a Terminal status.