### PR TITLE
Fixed issue regarding getting request body on query POST API.

### DIFF
--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -77,11 +77,18 @@ trait CromwellApiService {
     path("workflows" / Segment / Segment / "logs") { (version, possibleWorkflowId) =>
       get { metadataBuilderRequest(possibleWorkflowId, (w: WorkflowId) => GetLogs(w)) }
     } ~
-    path("workflows" / Segment / "query") { version =>
-      (post | get) {
+    path("workflows" / Segment / "query") { _ =>
+      get {
         parameterSeq { parameters =>
           extractUri { uri =>
             metadataQueryRequest(parameters, uri)
+          }
+        }
+      } ~
+      post {
+        entity(as[Seq[Map[String, String]]]) { parameterMap =>
+          extractUri { uri =>
+            metadataQueryRequest(parameterMap.flatMap(_.toSeq), uri)
           }
         }
       }


### PR DESCRIPTION
There is a need to integrate query API with some of the components I'm developing and while I was testing with different versions of Cromwell (0.24, 0.28 and 0.29) I found out the following:
- 0.24/0.28: when Cromwell is under load and trying to query +100 workflows, Cromwell (Slick) throws stack overflow exception.
- 0.29: seems to work fine but I found that query POST API was returning everything since query params where empty and request body was parsed.

This is the fix that worked for me.