### PR TITLE
Removed the dangerous and misleading 'Preempted' RunStatus

### DIFF
--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/RunStatus.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/RunStatus.scala
@@ -23,11 +23,6 @@ object RunStatus {
     def instanceName: Option[String]
   }
 
-  sealed trait UnsuccessfulRunStatus extends TerminalRunStatus {
-    def errorMessage: Option[String]
-    def errorCode: Int
-  }
-
   case class Success(eventList: Seq[ExecutionEvent],
                      machineType: Option[String],
                      zone: Option[String],
@@ -40,16 +35,7 @@ object RunStatus {
                           eventList: Seq[ExecutionEvent],
                           machineType: Option[String],
                           zone: Option[String],
-                          instanceName: Option[String]) extends UnsuccessfulRunStatus {
+                          instanceName: Option[String]) extends TerminalRunStatus {
     override def toString = "Failed"
-  }
-
-  final case class Preempted(errorCode: Int,
-                          errorMessage: Option[String],
-                          eventList: Seq[ExecutionEvent],
-                          machineType: Option[String],
-                          zone: Option[String],
-                          instanceName: Option[String]) extends UnsuccessfulRunStatus {
-    override def toString = "Preempted"
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -10,7 +10,7 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.google.api.services.genomics.model.Operation
 import cromwell.backend.impl.jes.RunStatus._
-import cromwell.backend.impl.jes.{JesAsyncBackendJobExecutionActor, Run, RunStatus}
+import cromwell.backend.impl.jes.{Run, RunStatus}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
 import cromwell.core.ExecutionEvent
 
@@ -73,8 +73,6 @@ private[statuspolling] object StatusPolling {
         // If there's an error, generate a Failed status. Otherwise, we were successful!
         Option(op.getError) match {
           case None => Success(eventList, machineType, zone, instanceName)
-          case Some(error) if error.getCode == JesAsyncBackendJobExecutionActor.JesPreemption =>
-            Preempted(error.getCode, Option(error.getMessage), eventList, machineType, zone, instanceName)
           case Some(error) =>
             Failed(error.getCode, Option(error.getMessage), eventList, machineType, zone, instanceName)
         }


### PR DESCRIPTION
The `Preempted` `RunStatus` was never created. And that's lucky, because if it ever had been, the task would have blown up and the workflow would have failed.

This PR removes `Preempted` so that it cannot be used to confuse anyone else in the future in the same way it confused me.  