### PR TITLE
Made call cache hash endpoint more JSONic

### DIFF
--- a/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
@@ -68,7 +68,7 @@ class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
     val oops = readLike.size(Seq(Success(WdlInteger(7))))
     oops match {
       case Success(x) => fail(s"Expected a string to not have a file length but instead got $x")
-      case Failure(e) => e.getMessage should be("The 'size' method expects a File argument but instead got Int.")
+      case Failure(e) => e.getMessage should be("The 'size' method expects a 'File' or 'File?' argument but instead got Int.")
     }
   }
 
@@ -77,7 +77,7 @@ class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
     val oops = readLike.size(Seq(Success(WdlOptionalValue(WdlIntegerType, None))))
     oops match {
       case Success(x) => fail(s"Expected a string to not have a file length but instead got $x")
-      case Failure(e) => e.getMessage should be("The 'size' method expects a File argument but instead got Int?.")
+      case Failure(e) => e.getMessage should be("The 'size' method expects a 'File' or 'File?' argument but instead got Int?.")
     }
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -214,11 +214,10 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
       case None => MetadataNull
     }
 
-    MetadataObject(key.trim ->
-      MetadataObject(
-        "callA" -> makeFinalValue(valueA),
-        "callB" -> makeFinalValue(valueB)
-      )
+    MetadataObject(
+      "hashKey" -> MetadataPrimitive(MetadataValue(key.trim, MetadataString)),
+      "callA" -> makeFinalValue(valueA),
+      "callB" -> makeFinalValue(valueB)
     )
   }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -159,22 +159,19 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
          |   },
          |   "hashDifferential":[  
          |      {  
-         |         "hash in only in A":{  
-         |            "callA":"hello",
-         |            "callB":null
-         |         }
+         |         "hashKey": "hash in only in A",
+         |         "callA":"hello",
+         |         "callB":null
          |      },
          |      {  
-         |         "hash in A and B with different value":{  
-         |            "callA":"I'm the hash for A !",
-         |            "callB":"I'm the hash for B !"
-         |         }
+         |         "hashKey": "hash in A and B with different value",
+         |         "callA":"I'm the hash for A !",
+         |         "callB":"I'm the hash for B !"
          |      },
          |      {  
-         |         "hash in only in B":{  
-         |            "callA":null,
-         |            "callB":"hello"
-         |         }
+         |         "hashKey": "hash in only in B",
+         |         "callA":null,
+         |         "callB":"hello"
          |      }
          |   ]
          |}


### PR DESCRIPTION
Previously:
```
"hashDifferential": [
  { "output expression:String hi”: 
    {
      "callA": "935C6E7EB2068B83C40B788575747EFB”, 
      "callB": “0183144CF6617D5341681C6B2F756046"
    }
  },
  …
]
```

This PR :
```
"hashDifferential": [
        "hashKey": "output expression:String hi",
        "callA": "935C6E7EB2068B83C40B788575747EFB",
        "callB": "0183144CF6617D5341681C6B2F756046"
    },
    ...
]
```