### PR TITLE
Don't append to lists

### DIFF
--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -57,10 +57,10 @@ class WriteMetadataActor(batchSize: Int, flushRate: FiniteDuration)
     case Event(ScheduledFlushToDb, curData) => stay using curData
     case Event(PutMetadataAction(events), curData) => stay using curData.addData(events)
     case Event(FlushBatchToDb, NoData) =>
-      log.info("Attempted metadata flush to DB but had nothing to write")
+      log.debug("Attempted metadata flush to DB but had nothing to write")
       goto(WaitingToWrite) using NoData
     case Event(FlushBatchToDb, HasData(e)) =>
-      log.info("Flushing {} metadata events to the DB", e.length)
+      log.debug("Flushing {} metadata events to the DB", e.length)
       // blech
       //Partitioning the current data into put events that require a response and those that don't
       val empty = (Vector.empty[MetadataEvent], Map.empty[Iterable[MetadataEvent], ActorRef])
@@ -83,7 +83,7 @@ class WriteMetadataActor(batchSize: Int, flushRate: FiniteDuration)
       }
       stay using NoData
     case Event(DbWriteComplete, curData) =>
-      log.info("Flush of metadata events complete")
+      log.debug("Flush of metadata events complete")
       goto(WaitingToWrite) using curData
     // When receiving a put&respond message, add it to the current data so that when flushing metadata events, we have
     // enough information to be able to send an acknowledgement of success/failure of metadata event writes to the original requester.

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -67,7 +67,7 @@ class WriteMetadataActor(batchSize: Int, flushRate: FiniteDuration)
       val (putWithoutResponse, putWithResponse) = e.toVector.foldLeft(empty)({
         case ((putEvents, putAndRespondEvents), events) =>
           events match {
-            case putEvent: MetadataEvent => (putEvents  :+ putEvent, putAndRespondEvents)
+            case putEvent: MetadataEvent => (putEvents :+ putEvent, putAndRespondEvents)
             case PutMetadataActionAndRespond(ev, replyTo) => (putEvents, putAndRespondEvents + (ev -> replyTo))
           }
       })

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -57,17 +57,17 @@ class WriteMetadataActor(batchSize: Int, flushRate: FiniteDuration)
     case Event(ScheduledFlushToDb, curData) => stay using curData
     case Event(PutMetadataAction(events), curData) => stay using curData.addData(events)
     case Event(FlushBatchToDb, NoData) =>
-      log.debug("Attempted metadata flush to DB but had nothing to write")
+      log.info("Attempted metadata flush to DB but had nothing to write")
       goto(WaitingToWrite) using NoData
     case Event(FlushBatchToDb, HasData(e)) =>
-      log.debug("Flushing {} metadata events to the DB", e.length)
+      log.info("Flushing {} metadata events to the DB", e.length)
       // blech
       //Partitioning the current data into put events that require a response and those that don't
-      val empty = (List.empty[MetadataEvent], Map.empty[Iterable[MetadataEvent], ActorRef])
+      val empty = (Vector.empty[MetadataEvent], Map.empty[Iterable[MetadataEvent], ActorRef])
       val (putWithoutResponse, putWithResponse) = e.toVector.foldLeft(empty)({
         case ((putEvents, putAndRespondEvents), events) =>
           events match {
-            case putEvent: MetadataEvent => (putEvents :+ putEvent, putAndRespondEvents)
+            case putEvent: MetadataEvent => (putEvents  :+ putEvent, putAndRespondEvents)
             case PutMetadataActionAndRespond(ev, replyTo) => (putEvents, putAndRespondEvents + (ev -> replyTo))
           }
       })
@@ -83,7 +83,7 @@ class WriteMetadataActor(batchSize: Int, flushRate: FiniteDuration)
       }
       stay using NoData
     case Event(DbWriteComplete, curData) =>
-      log.debug("Flush of metadata events complete")
+      log.info("Flush of metadata events complete")
       goto(WaitingToWrite) using curData
     // When receiving a put&respond message, add it to the current data so that when flushing metadata events, we have
     // enough information to be able to send an acknowledgement of success/failure of metadata event writes to the original requester.


### PR DESCRIPTION
Swapping out List for Vector because appending to the list of metadata events takes a long time and the db is waiting to flush forever.