### PR TITLE
Allow "AbortedResponse" even when not aborting

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -284,6 +284,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     case Event(response: JobSucceededResponse, data: ResponsePendingData) =>
       eventList ++= response.executionEvents
       saveJobCompletionToJobStore(data.withSuccessResponse(response))
+
+    // Non-success:
     case Event(response: BackendJobExecutionResponse, data: ResponsePendingData) =>
       saveJobCompletionToJobStore(data.withResponse(response))
   }
@@ -328,7 +330,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       writeToMetadata(hashMap)
     case _ =>
   }
-
 
   private def handleReadFromCacheOn(jobDescriptor: BackendJobDescriptor, activity: CallCachingActivity, updatedData: ResponsePendingData) = {
     jobDescriptor.maybeCallCachingEligible match {


### PR DESCRIPTION
Because sometimes things other than cromwell can cancel jobs.

Also might make restarts after aborts a little more resilient in case of unexpected race conditions (not a guarantee TM)