### PR TITLE
Do not leak out snapshots of the WEA data to other actors

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/EngineJobExecutionActor.scala
@@ -12,7 +12,9 @@ import cromwell.core.callcaching._
 import cromwell.core.logging.WorkflowLogging
 import cromwell.core.simpleton.WdlValueSimpleton
 import cromwell.database.sql.tables.CallCachingEntry
+import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.RequestOutputStore
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCacheHashBundle
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.NextHit
@@ -35,7 +37,7 @@ import scala.util.{Failure, Success, Try}
 
 class EngineJobExecutionActor(replyTo: ActorRef,
                               jobDescriptorKey: BackendJobDescriptorKey,
-                              executionData: WorkflowExecutionActorData,
+                              workflowDescriptor: EngineWorkflowDescriptor,
                               factory: BackendLifecycleActorFactory,
                               initializationData: Option[BackendInitializationData],
                               restarting: Boolean,
@@ -50,8 +52,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
                               backendName: String,
                               callCachingMode: CallCachingMode) extends LoggingFSM[EngineJobExecutionActorState, EJEAData] with WorkflowLogging with CallMetadataHelper {
 
-  override val workflowIdForLogging = executionData.workflowDescriptor.id
-  override val workflowIdForCallMetadata = executionData.workflowDescriptor.id
+  override val workflowIdForLogging = workflowDescriptor.id
+  override val workflowIdForCallMetadata = workflowDescriptor.id
 
   override val supervisorStrategy = OneForOneStrategy() {
     // If an actor fails to initialize, send the exception to self before stopping it so we can fail the job properly
@@ -111,7 +113,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
         jobStoreActor ! QueryJobCompletion(jobStoreKey, jobDescriptorKey.call.task.outputs)
         goto(CheckingJobStore)
       } else {
-        prepareJob()
+        requestOutputStore()
       }
     case Event(JobExecutionTokenDenied(positionInQueue), NoData) =>
       log.debug("Token denied so cannot start yet. Currently position {} in the queue", positionInQueue)
@@ -150,13 +152,23 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     case Event(HasCallCacheEntry(_), NoData) =>
       // Disable call caching
       effectiveCallCachingMode = CallCachingOff
-      prepareJob()
+      requestOutputStore()
     // No cache entry for this job - keep going
     case Event(NoCallCacheEntry(_), NoData) =>
-      prepareJob()
+      requestOutputStore()
     case Event(CacheResultLookupFailure(reason), NoData) =>
       log.error(reason, "{}: Failure checking for cache entry existence: {}. Attempting to resume job anyway.", jobTag, reason.getMessage)
-      prepareJob()
+      requestOutputStore()
+  }
+
+  /*
+  * ! Hot Potato Warning !
+  * We ask explicitly for the output store so we can use it on the fly and more importantly not store it as a
+  * variable in this actor, which would prevent it from being garbage collected for the duration of the
+  * job and would lead to memory leaks.
+  */
+  when(WaitingForOutputStore) {
+    case Event(outputStore: OutputStore, NoData) => prepareJob(outputStore)
   }
 
   // When PreparingJob, the FSM always has NoData
@@ -406,14 +418,19 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   }
 
   def createJobPreparationActor(jobPrepProps: Props, name: String): ActorRef = context.actorOf(jobPrepProps, name)
-  def prepareJob() = {
+  def prepareJob(outputStore: OutputStore) = {
     writeCallCachingModeToMetadata()
     val jobPreparationActorName = s"BackendPreparationActor_for_$jobTag"
-    val jobPrepProps = JobPreparationActor.props(executionData, jobDescriptorKey, factory, workflowDockerLookupActor = workflowDockerLookupActor,
+    val jobPrepProps = JobPreparationActor.props(workflowDescriptor, jobDescriptorKey, factory, workflowDockerLookupActor = workflowDockerLookupActor,
       initializationData, serviceRegistryActor = serviceRegistryActor, ioActor = ioActor, backendSingletonActor = backendSingletonActor)
     val jobPreparationActor = createJobPreparationActor(jobPrepProps, jobPreparationActorName)
-    jobPreparationActor ! CallPreparation.Start
+    jobPreparationActor ! CallPreparation.Start(outputStore)
     goto(PreparingJob)
+  }
+  
+  def requestOutputStore() = {
+    replyTo ! RequestOutputStore
+    goto(WaitingForOutputStore)
   }
 
   def initializeJobHashing(jobDescriptor: BackendJobDescriptor, activity: CallCachingActivity, callCachingEligible: CallCachingEligible): Try[ActorRef] = {
@@ -615,6 +632,7 @@ object EngineJobExecutionActor {
   case object CheckingCallCache extends EngineJobExecutionActorState
   case object FetchingCachedOutputsFromDatabase extends EngineJobExecutionActorState
   case object BackendIsCopyingCachedOutputs extends EngineJobExecutionActorState
+  case object WaitingForOutputStore extends EngineJobExecutionActorState
   case object PreparingJob extends EngineJobExecutionActorState
   case object RunningJob extends EngineJobExecutionActorState
   case object UpdatingCallCache extends EngineJobExecutionActorState
@@ -630,7 +648,7 @@ object EngineJobExecutionActor {
 
   def props(replyTo: ActorRef,
             jobDescriptorKey: BackendJobDescriptorKey,
-            executionData: WorkflowExecutionActorData,
+            workflowDescriptor: EngineWorkflowDescriptor,
             factory: BackendLifecycleActorFactory,
             initializationData: Option[BackendInitializationData],
             restarting: Boolean,
@@ -647,7 +665,7 @@ object EngineJobExecutionActor {
     Props(new EngineJobExecutionActor(
       replyTo = replyTo,
       jobDescriptorKey = jobDescriptorKey,
-      executionData = executionData,
+      workflowDescriptor = workflowDescriptor,
       factory = factory,
       initializationData = initializationData,
       restarting = restarting,

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -6,7 +6,7 @@ import cromwell.backend.{AllBackendInitializationData, BackendLifecycleActorFact
 import cromwell.core._
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.logging.JobLogging
-import cromwell.engine.EngineWorkflowDescriptor
+import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
 import cromwell.engine.backend.{BackendConfiguration, BackendSingletonCollection}
 import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation.{CallPreparationFailed, Start}
 import cromwell.engine.workflow.lifecycle.execution.SubWorkflowExecutionActor._
@@ -19,7 +19,8 @@ import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import wdl4s.wdl.EvaluatedTaskInputs
 
 class SubWorkflowExecutionActor(key: SubWorkflowKey,
-                                data: WorkflowExecutionActorData,
+                                parentWorkflow: EngineWorkflowDescriptor,
+                                expressionLanguageFunctions: WdlFunctions,
                                 factories: Map[String, BackendLifecycleActorFactory],
                                 ioActor: ActorRef,
                                 override val serviceRegistryActor: ActorRef,
@@ -35,7 +36,6 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
 
   override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() { case _ => Escalate }
 
-  private val parentWorkflow = data.workflowDescriptor
   override val workflowId = parentWorkflow.id
   override val workflowIdForCallMetadata = parentWorkflow.id
   override def jobTag: String = key.tag
@@ -50,18 +50,35 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
         subWorkflowStoreActor ! QuerySubWorkflow(parentWorkflow.id, key)
         goto(SubWorkflowCheckingStoreState)
       } else {
-        prepareSubWorkflow(createSubWorkflowId())
+        requestOutputStore(createSubWorkflowId())
       }
   }
 
   when(SubWorkflowCheckingStoreState) {
     case Event(SubWorkflowFound(entry), _) =>
-      prepareSubWorkflow(WorkflowId.fromString(entry.subWorkflowExecutionUuid))
+      requestOutputStore(WorkflowId.fromString(entry.subWorkflowExecutionUuid))
     case Event(_: SubWorkflowNotFound, _) =>
-      prepareSubWorkflow(createSubWorkflowId())
+      requestOutputStore(createSubWorkflowId())
     case Event(SubWorkflowStoreFailure(command, reason), _) =>
       jobLogger.error(reason, s"SubWorkflowStore failure for command $command, starting sub workflow with fresh ID.")
-      prepareSubWorkflow(createSubWorkflowId())
+      requestOutputStore(createSubWorkflowId())
+  }
+
+  /*
+    * ! Hot Potato Warning !
+    * We ask explicitly for the output store so we can use it on the fly and more importantly not store it as a
+    * variable in this actor, which would prevent it from being garbage collected for the duration of the
+    * subworkflow and would lead to memory leaks.
+    */
+  when(WaitingForOutputStore) {
+    case Event(outputStore: OutputStore, SubWorkflowExecutionActorData(Some(subWorkflowId))) =>
+      prepareSubWorkflow(subWorkflowId, outputStore)
+    case Event(_: OutputStore, _) =>
+      context.parent ! SubWorkflowFailedResponse(key, Map.empty, new IllegalStateException(
+        "This is a programmer error, we're ready to prepare the job and should have" +
+          " a SubWorkflowId to use by now but somehow haven't. Failing the workflow."))
+      context stop self
+      stay()
   }
 
   when(SubWorkflowPreparingState) {
@@ -128,17 +145,22 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     goto(SubWorkflowRunningState)
   }
 
-  private def prepareSubWorkflow(subWorkflowId: WorkflowId) = {
-    createSubWorkflowPreparationActor(subWorkflowId) ! Start
+  private def prepareSubWorkflow(subWorkflowId: WorkflowId, outputStore: OutputStore) = {
+    createSubWorkflowPreparationActor(subWorkflowId) ! Start(outputStore)
     context.parent ! JobStarting(key)
     pushCurrentStateToMetadataService(subWorkflowId, WorkflowRunning)
     pushWorkflowStart(subWorkflowId)
     goto(SubWorkflowPreparingState) using SubWorkflowExecutionActorData(Option(subWorkflowId))
   }
 
+  private def requestOutputStore(workflowId: WorkflowId) = {
+    context.parent ! RequestOutputStore
+    goto(WaitingForOutputStore) using SubWorkflowExecutionActorData(Option(workflowId))
+  }
+
   def createSubWorkflowPreparationActor(subWorkflowId: WorkflowId) = {
     context.actorOf(
-      SubWorkflowPreparationActor.props(data, key, subWorkflowId),
+      SubWorkflowPreparationActor.props(parentWorkflow, expressionLanguageFunctions, key, subWorkflowId),
       s"$subWorkflowId-SubWorkflowPreparationActor-${key.tag}"
     )
   }
@@ -146,19 +168,19 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   def createSubWorkflowActor(subWorkflowEngineDescriptor: EngineWorkflowDescriptor) = {
     context.actorOf(
       WorkflowExecutionActor.props(
-      subWorkflowEngineDescriptor,
-      ioActor = ioActor,
-      serviceRegistryActor = serviceRegistryActor,
-      jobStoreActor = jobStoreActor,
-      subWorkflowStoreActor = subWorkflowStoreActor,
-      callCacheReadActor = callCacheReadActor,
-      callCacheWriteActor = callCacheWriteActor,
-      workflowDockerLookupActor = workflowDockerLookupActor,
-      jobTokenDispenserActor = jobTokenDispenserActor,
-      backendSingletonCollection,
-      initializationData,
-      restarting
-    ),
+        subWorkflowEngineDescriptor,
+        ioActor = ioActor,
+        serviceRegistryActor = serviceRegistryActor,
+        jobStoreActor = jobStoreActor,
+        subWorkflowStoreActor = subWorkflowStoreActor,
+        callCacheReadActor = callCacheReadActor,
+        callCacheWriteActor = callCacheWriteActor,
+        workflowDockerLookupActor = workflowDockerLookupActor,
+        jobTokenDispenserActor = jobTokenDispenserActor,
+        backendSingletonCollection,
+        initializationData,
+        restarting
+      ),
       s"${subWorkflowEngineDescriptor.id}-SubWorkflowActor-${key.tag}"
     )
   }
@@ -166,7 +188,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   private def pushWorkflowRunningMetadata(subWorkflowDescriptor: BackendWorkflowDescriptor, workflowInputs: EvaluatedTaskInputs) = {
     val subWorkflowId = subWorkflowDescriptor.id
     val parentWorkflowMetadataKey = MetadataKey(parentWorkflow.id, Option(MetadataJobKey(key.scope.fullyQualifiedName, key.index, key.attempt)), CallMetadataKeys.SubWorkflowId)
-    
+
     val events = List(
       MetadataEvent(parentWorkflowMetadataKey, MetadataValue(subWorkflowId)),
       MetadataEvent(MetadataKey(subWorkflowId, None, WorkflowMetadataKeys.Name), MetadataValue(key.scope.callable.unqualifiedName)),
@@ -183,7 +205,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     }
 
     val workflowRootEvents = buildWorkflowRootMetadataEvents(subWorkflowDescriptor)
-    
+
     serviceRegistryActor ! PutMetadataAction(events ++ inputEvents ++ workflowRootEvents)
   }
 
@@ -200,7 +222,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
         MetadataEvent(MetadataKey(subWorkflowId, None, s"${WorkflowMetadataKeys.WorkflowRoot}[$backend]"), MetadataValue(wfRoot.toAbsolutePath))
     }
   }
-  
+
   private def createSubWorkflowId() = {
     val subWorkflowId = WorkflowId.randomId()
     // Register ID to the sub workflow store
@@ -214,7 +236,7 @@ object SubWorkflowExecutionActor {
     def workflowState: WorkflowState
   }
   sealed trait SubWorkflowTerminalState extends SubWorkflowExecutionActorState
-  
+
   case object SubWorkflowPendingState extends SubWorkflowExecutionActorState {
     override val workflowState = WorkflowRunning
   }
@@ -227,10 +249,13 @@ object SubWorkflowExecutionActor {
   case object SubWorkflowRunningState extends SubWorkflowExecutionActorState {
     override val workflowState = WorkflowRunning
   }
+  case object WaitingForOutputStore extends SubWorkflowExecutionActorState {
+    override val workflowState = WorkflowRunning
+  }
   case object SubWorkflowAbortingState extends SubWorkflowExecutionActorState {
     override val workflowState = WorkflowAborting
   }
-  
+
   case object SubWorkflowSucceededState extends SubWorkflowTerminalState {
     override val workflowState = WorkflowSucceeded
   }
@@ -250,7 +275,8 @@ object SubWorkflowExecutionActor {
   case object Execute
 
   def props(key: SubWorkflowKey,
-            data: WorkflowExecutionActorData,
+            parentWorkflow: EngineWorkflowDescriptor,
+            expressionLanguageFunctions: WdlFunctions,
             factories: Map[String, BackendLifecycleActorFactory],
             ioActor: ActorRef,
             serviceRegistryActor: ActorRef,
@@ -265,7 +291,8 @@ object SubWorkflowExecutionActor {
             restarting: Boolean) = {
     Props(new SubWorkflowExecutionActor(
       key,
-      data,
+      parentWorkflow,
+      expressionLanguageFunctions,
       factories,
       ioActor = ioActor,
       serviceRegistryActor = serviceRegistryActor,

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/CallPreparation.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/CallPreparation.scala
@@ -14,7 +14,7 @@ import scala.util.{Failure, Try}
 
 object CallPreparation {
   sealed trait CallPreparationActorCommands
-  case object Start extends CallPreparationActorCommands
+  case class Start(outputStore: OutputStore) extends CallPreparationActorCommands
 
   trait CallPreparationActorResponse
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/SubWorkflowPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/SubWorkflowPreparationActor.scala
@@ -5,24 +5,20 @@ import cromwell.backend.BackendJobBreadCrumb
 import cromwell.core.Dispatcher._
 import cromwell.core.WorkflowId
 import cromwell.core.logging.WorkflowLogging
-import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.SubWorkflowKey
-import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData
 import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation.{CallPreparationFailed, Start, _}
 import cromwell.engine.workflow.lifecycle.execution.preparation.SubWorkflowPreparationActor.SubWorkflowPreparationSucceeded
+import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
 import wdl4s.wdl._
 import wdl4s.wdl.values.WdlValue
 
-class SubWorkflowPreparationActor(executionData: WorkflowExecutionActorData,
-                                   callKey: SubWorkflowKey,
-                                   subWorkflowId: WorkflowId) extends Actor with WorkflowLogging {
-  
-  private val workflowDescriptor = executionData.workflowDescriptor
-  lazy val outputStore = executionData.outputStore
-  lazy val expressionLanguageFunctions = executionData.expressionLanguageFunctions
+class SubWorkflowPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
+                                  expressionLanguageFunctions: WdlFunctions,
+                                  callKey: SubWorkflowKey,
+                                  subWorkflowId: WorkflowId) extends Actor with WorkflowLogging {
 
   lazy val workflowIdForLogging = workflowDescriptor.id
-  
+
   def prepareExecutionActor(inputEvaluation: Map[Declaration, WdlValue]): CallPreparationActorResponse = {
     val oldBackendDescriptor = workflowDescriptor.backendDescriptor
 
@@ -37,7 +33,7 @@ class SubWorkflowPreparationActor(executionData: WorkflowExecutionActorData,
   }
 
   override def receive = {
-    case Start =>
+    case Start(outputStore) =>
       val evaluatedInputs = resolveAndEvaluateInputs(callKey, workflowDescriptor, expressionLanguageFunctions, outputStore)
       val response = evaluatedInputs map { prepareExecutionActor }
       context.parent ! (response recover { case f => CallPreparationFailed(callKey, f) }).get
@@ -50,11 +46,12 @@ class SubWorkflowPreparationActor(executionData: WorkflowExecutionActorData,
 object SubWorkflowPreparationActor {
   case class SubWorkflowPreparationSucceeded(workflowDescriptor: EngineWorkflowDescriptor, inputs: EvaluatedTaskInputs) extends CallPreparationActorResponse
 
-  def props(executionData: WorkflowExecutionActorData,
+  def props(workflowDescriptor: EngineWorkflowDescriptor,
+            expressionLanguageFunctions: WdlFunctions,
             key: SubWorkflowKey,
             subWorkflowId: WorkflowId) = {
     // Note that JobPreparationActor doesn't run on the engine dispatcher as it mostly executes backend-side code
     // (WDL expression evaluation using Backend's expressionLanguageFunctions)
-    Props(new SubWorkflowPreparationActor(executionData, key, subWorkflowId)).withDispatcher(EngineDispatcher)
+    Props(new SubWorkflowPreparationActor(workflowDescriptor, expressionLanguageFunctions, key, subWorkflowId)).withDispatcher(EngineDispatcher)
   }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaWaitingForOutputStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaWaitingForOutputStoreSpec.scala
@@ -1,0 +1,23 @@
+package cromwell.engine.workflow.lifecycle.execution.ejea
+
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor._
+import cromwell.engine.workflow.lifecycle.execution.OutputStore
+import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec.EnhancedTestEJEA
+import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation
+
+class EjeaWaitingForOutputStoreSpec extends EngineJobExecutionActorSpec {
+
+  override implicit val stateUnderTest = CheckingJobStore
+
+  "An EJEA in EjeaWaitingForOutputStore state should" should {
+    "prepare the job when receiving the output store" in {
+      createWaitingForOutputStoreEjea()
+      val outputStore = OutputStore.empty
+      ejea ! outputStore
+      helper.jobPreparationProbe.expectMsg(awaitTimeout, "expecting CallPreparation Start", CallPreparation.Start(outputStore))
+      ejea.stateName should be(PreparingJob)
+    }
+  }
+
+  private def createWaitingForOutputStoreEjea(): Unit = { ejea = helper.buildEJEA(restarting = true).setStateInline(state = WaitingForOutputStore, data = NoData) }
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -10,16 +10,16 @@ import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.core.callcaching._
 import cromwell.core.{CallOutputs, JobExecutionToken, WorkflowId}
 import cromwell.engine.EngineWorkflowDescriptor
+import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor
 import cromwell.engine.workflow.lifecycle.execution.EngineJobExecutionActor.{EJEAData, EngineJobExecutionActorState}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
-import cromwell.engine.workflow.lifecycle.execution.{EngineJobExecutionActor, WorkflowExecutionActorData}
 import cromwell.engine.workflow.mocks.{DeclarationMock, TaskMock, WdlExpressionMock}
 import cromwell.util.AkkaTestUtil._
 import org.specs2.mock.Mockito
+import wdl4s.parser.WdlParser.Ast
 import wdl4s.wdl._
 import wdl4s.wdl.expression.{NoFunctions, WdlStandardLibraryFunctions}
-import wdl4s.parser.WdlParser.Ast
 import wdl4s.wdl.types.{WdlIntegerType, WdlStringType}
 
 import scala.util.Success
@@ -133,7 +133,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
       jobPreparationProbe = jobPreparationProbe,
       replyTo = replyToProbe.ref,
       jobDescriptorKey = jobDescriptorKey,
-      executionData = WorkflowExecutionActorData.empty(descriptor),
+      workflowDescriptor = descriptor,
       factory = factory,
       initializationData = None,
       restarting = restarting,
@@ -157,7 +157,7 @@ private[ejea] class MockEjea(helper: PerTestHelper,
                              jobPreparationProbe: TestProbe,
                              replyTo: ActorRef,
                              jobDescriptorKey: BackendJobDescriptorKey,
-                             executionData: WorkflowExecutionActorData,
+                             workflowDescriptor: EngineWorkflowDescriptor,
                              factory: BackendLifecycleActorFactory,
                              initializationData: Option[BackendInitializationData],
                              restarting: Boolean,
@@ -169,7 +169,7 @@ private[ejea] class MockEjea(helper: PerTestHelper,
                              dockerHashActor: ActorRef,
                              jobTokenDispenserActor: ActorRef,
                              backendName: String,
-                             callCachingMode: CallCachingMode) extends EngineJobExecutionActor(replyTo, jobDescriptorKey, executionData, factory, initializationData, restarting, serviceRegistryActor, ioActor, jobStoreActor, callCacheReadActor, callCacheWriteActor, dockerHashActor, jobTokenDispenserActor, None, backendName, callCachingMode) {
+                             callCachingMode: CallCachingMode) extends EngineJobExecutionActor(replyTo, jobDescriptorKey, workflowDescriptor, factory, initializationData, restarting, serviceRegistryActor, ioActor, jobStoreActor, callCacheReadActor, callCacheWriteActor, dockerHashActor, jobTokenDispenserActor, None, backendName, callCachingMode) {
 
   implicit val system = context.system
   override def makeFetchCachedResultsActor(cacheId: CallCachingEntryId, taskOutputs: Seq[TaskOutput]) = helper.fetchCachedResultsActorCreations = helper.fetchCachedResultsActorCreations.foundOne((cacheId, taskOutputs))

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActorSpec.scala
@@ -6,6 +6,7 @@ import cromwell.core.{LocallyQualifiedName, TestKitSuite}
 import cromwell.docker.DockerHashActor.DockerHashSuccessResponse
 import cromwell.docker.{DockerHashRequest, DockerHashResult, DockerImageIdentifier, DockerImageIdentifierWithoutHash}
 import cromwell.engine.workflow.WorkflowDockerLookupActor.WorkflowDockerLookupFailure
+import cromwell.engine.workflow.lifecycle.execution.OutputStore
 import cromwell.engine.workflow.lifecycle.execution.preparation.CallPreparation.{BackendJobPreparationSucceeded, CallPreparationFailed, Start}
 import cromwell.services.keyvalue.KeyValueServiceActor.{KvGet, KvKeyLookupFailed, KvPair}
 import org.scalatest.{BeforeAndAfter, FlatSpecLike, Matchers}
@@ -35,7 +36,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val failure = Failure(exception)
     val expectedResponse = CallPreparationFailed(helper.jobKey, exception)
     val actor = TestActorRef(helper.buildTestJobPreparationActor(null, null, null, failure, List.empty), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
     expectMsg(expectedResponse)
     helper.workflowDockerLookupActor.expectNoMsg(100 millis)
   }
@@ -44,7 +45,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val attributes = Map.empty[LocallyQualifiedName, WdlValue]
     val inputsAndAttributes = Success((inputs, attributes))
     val actor = TestActorRef(helper.buildTestJobPreparationActor(null, null, null, inputsAndAttributes, List.empty), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.maybeCallCachingEligible.dockerHash shouldBe None
@@ -59,7 +60,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     )
     val inputsAndAttributes = Success((inputs, attributes))
     val actor = TestActorRef(helper.buildTestJobPreparationActor(null, null, null, inputsAndAttributes, List.empty), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe dockerValue
@@ -68,7 +69,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     helper.workflowDockerLookupActor.expectNoMsg(1 second)
   }
 
-  it should "lookup any requested key/value prefetches before (not) performing a docker hash lookup" in {
+  it should "lookup any requested key/value prefetches after (not) performing a docker hash lookup" in {
     val dockerValue = "ubuntu:latest"
     val attributes = Map (
       "docker" -> WdlString(dockerValue)
@@ -82,7 +83,10 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val prefetchedValues = Map(prefetchedKey1 -> prefetchedVal1, prefetchedKey2 -> prefetchedVal2)
     var keysToPrefetch = List(prefetchedKey1, prefetchedKey2)
     val actor = TestActorRef(helper.buildTestJobPreparationActor(1 minute, 1 minutes, List.empty, inputsAndAttributes, List(prefetchedKey1, prefetchedKey2)), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
+
+    val req = helper.workflowDockerLookupActor.expectMsgClass(classOf[DockerHashRequest])
+    helper.workflowDockerLookupActor.reply(DockerHashSuccessResponse(hashResult, req))
 
     def respondFromKv() = {
       helper.serviceRegistryProbe.expectMsgPF(max = 100 milliseconds) {
@@ -95,8 +99,6 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     helper.workflowDockerLookupActor.expectNoMsg(max = 100 milliseconds)
     respondFromKv()
 
-    val req = helper.workflowDockerLookupActor.expectMsgClass(classOf[DockerHashRequest])
-    helper.workflowDockerLookupActor.reply(DockerHashSuccessResponse(hashResult, req))
     expectMsgPF(5 seconds) {
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.prefetchedKvStoreEntries should be(Map(prefetchedKey1 -> prefetchedVal1, prefetchedKey2 -> prefetchedVal2))
@@ -112,7 +114,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val inputsAndAttributes = Success((inputs, attributes))
     val finalValue = "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     val actor = TestActorRef(helper.buildTestJobPreparationActor(1 minute, 1 minutes, List.empty, inputsAndAttributes, List.empty), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
     helper.workflowDockerLookupActor.expectMsgClass(classOf[DockerHashRequest])
     helper.workflowDockerLookupActor.reply(DockerHashSuccessResponse(hashResult, mock[DockerHashRequest]))
     expectMsgPF(5 seconds) {
@@ -130,7 +132,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     )
     val inputsAndAttributes = Success((inputs, attributes))
     val actor = TestActorRef(helper.buildTestJobPreparationActor(1 minute, 1 minutes, List.empty, inputsAndAttributes, List.empty), self)
-    actor ! Start
+    actor ! Start(OutputStore.empty)
     helper.workflowDockerLookupActor.expectMsgClass(classOf[DockerHashRequest])
     helper.workflowDockerLookupActor.reply(WorkflowDockerLookupFailure(new Exception("Failed to get docker hash - part of test flow"), request))
     expectMsgPF(5 seconds) {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationTestHelper.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestProbe
 import cromwell.backend._
 import cromwell.core.WorkflowId
 import cromwell.engine.EngineWorkflowDescriptor
-import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData
+import cromwell.engine.workflow.lifecycle.execution.{OutputStore, WorkflowExecutionActorData}
 import cromwell.services.keyvalue.KeyValueServiceActor.{KvJobKey, ScopedKey}
 import org.specs2.mock.Mockito
 import wdl4s.wdl._
@@ -43,7 +43,7 @@ class JobPreparationTestHelper(implicit val system: ActorSystem) extends Mockito
       backpressureWaitTimeInput = backpressureTimeout,
       dockerNoResponseTimeoutInput = noResponseTimeout,
       inputsAndAttributes = inputsAndAttributes,
-      executionData = executionData,
+      workflowDescriptor = workflowDescriptor,
       jobKey = jobKey,
       workflowDockerLookupActor = workflowDockerLookupActor.ref,
       serviceRegistryActor = serviceRegistryProbe.ref,
@@ -57,12 +57,12 @@ private[preparation] class TestJobPreparationActor(kvStoreKeysForPrefetch: List[
                                                    backpressureWaitTimeInput: FiniteDuration,
                                                    dockerNoResponseTimeoutInput: FiniteDuration,
                                                    inputsAndAttributes: Try[(Map[Declaration, WdlValue], Map[wdl4s.wdl.LocallyQualifiedName, WdlValue])],
-                                                   executionData: WorkflowExecutionActorData,
+                                                   workflowDescriptor: EngineWorkflowDescriptor,
                                                    jobKey: BackendJobDescriptorKey,
                                                    workflowDockerLookupActor: ActorRef,
                                                    serviceRegistryActor: ActorRef,
                                                    ioActor: ActorRef,
-                                                   scopedKeyMaker: ScopedKeyMaker) extends JobPreparationActor(executionData = executionData,
+                                                   scopedKeyMaker: ScopedKeyMaker) extends JobPreparationActor(workflowDescriptor = workflowDescriptor,
                                                                                                   jobKey = jobKey,
                                                                                                   factory = null,
                                                                                                   workflowDockerLookupActor = workflowDockerLookupActor,
@@ -79,7 +79,7 @@ private[preparation] class TestJobPreparationActor(kvStoreKeysForPrefetch: List[
   override private[preparation] lazy val hasDockerDefinition = true
 
   override def scopedKey(key: String) = scopedKeyMaker.apply(key)
-  override def evaluateInputsAndAttributes = inputsAndAttributes
+  override def evaluateInputsAndAttributes(outputStore: OutputStore) = inputsAndAttributes
 
   override private[preparation] def jobExecutionProps(jobDescriptor: BackendJobDescriptor,
                                                       initializationData: Option[BackendInitializationData],


### PR DESCRIPTION
Thanks to @mcovarr we *think* we figured out the cause of the memory leak.
The `WorkflowExecutionActor` was sending "snapshots" of its current internal data (including execution store and output store) to the `EJEA`and `SWEA` so they could pass it on to the JobPreparationActor (resp. `SubWorkflowPreparationActor`) so they could evaluate inputs using the OutputStore.
This PR rewires things so that the WEA data does not escape the WEA. Instead actors needing the OutputStore for input evaluation request it at the right time and it gets sent across but never stored in the downstream actors, therefore not holding references and allowing for proper GC.