### PR TITLE
Log configured batch size and max flush intervals.

### DIFF
--- a/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
+++ b/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
@@ -69,9 +69,13 @@ trait BatchingDbWriterActor { this: FSM[BatchingDbWriterState, BatchingDbWriterD
   
   def isShuttingDown: Boolean = shuttingDown
   def dbFlushRate: FiniteDuration
+  def dbBatchSize: Int
+  def writeActorName: String
+
   var periodicFlush: Option[Cancellable] = None
 
   override def preStart(): Unit = {
+    log.info("{} configured to write to the database with batch size {} and flush rate {}.", writeActorName, dbBatchSize, dbFlushRate)
     periodicFlush = Option(context.system.scheduler.schedule(0.seconds, dbFlushRate, self, ScheduledFlushToDb)(context.dispatcher))
   }
 

--- a/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
+++ b/core/src/main/scala/cromwell/core/actor/BatchingDbWriter.scala
@@ -70,12 +70,11 @@ trait BatchingDbWriterActor { this: FSM[BatchingDbWriterState, BatchingDbWriterD
   def isShuttingDown: Boolean = shuttingDown
   def dbFlushRate: FiniteDuration
   def dbBatchSize: Int
-  def writeActorName: String
 
   var periodicFlush: Option[Cancellable] = None
 
   override def preStart(): Unit = {
-    log.info("{} configured to write to the database with batch size {} and flush rate {}.", writeActorName, dbBatchSize, dbFlushRate)
+    log.info("{} configured to write to the database with batch size {} and flush rate {}.", self.path.name, dbBatchSize, dbFlushRate)
     periodicFlush = Option(context.system.scheduler.schedule(0.seconds, dbFlushRate, self, ScheduledFlushToDb)(context.dispatcher))
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -19,6 +19,7 @@ case class CallCacheWriteActor(callCache: CallCache) extends LoggingFSM[Batching
   implicit val ec: ExecutionContext = context.dispatcher
   
   override val dbFlushRate = CallCacheWriteActor.dbFlushRate
+  log.info("CallCacheWriteActor configured to write to the database with batch size {} and flush rate {}.", dbBatchSize, dbFlushRate)
 
   startWith(WaitingToWrite, NoData)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -20,7 +20,6 @@ case class CallCacheWriteActor(callCache: CallCache) extends LoggingFSM[Batching
   
   override val dbFlushRate = CallCacheWriteActor.dbFlushRate
   override val dbBatchSize = CallCacheWriteActor.dbBatchSize
-  override val writeActorName = "CallCacheWriteActor"
 
   startWith(WaitingToWrite, NoData)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -8,7 +8,7 @@ import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.actor.BatchingDbWriter._
 import cromwell.core.actor.{BatchingDbWriter, BatchingDbWriterActor}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCacheHashBundle
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheWriteActor.{SaveCallCacheHashes, _}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheWriteActor.SaveCallCacheHashes
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -19,7 +19,8 @@ case class CallCacheWriteActor(callCache: CallCache) extends LoggingFSM[Batching
   implicit val ec: ExecutionContext = context.dispatcher
   
   override val dbFlushRate = CallCacheWriteActor.dbFlushRate
-  log.info("CallCacheWriteActor configured to write to the database with batch size {} and flush rate {}.", dbBatchSize, dbFlushRate)
+  override val dbBatchSize = CallCacheWriteActor.dbBatchSize
+  override val writeActorName = "CallCacheWriteActor"
 
   startWith(WaitingToWrite, NoData)
 

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -16,8 +16,6 @@ case class JobStoreWriterActor(jsd: JobStore, override val dbBatchSize: Int, ove
 
   implicit val ec = context.dispatcher
 
-  override val writeActorName = "JobStoreWriterActor"
-
   startWith(WaitingToWrite, NoData)
 
   when(WaitingToWrite) {

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -12,11 +12,11 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 
-case class JobStoreWriterActor(jsd: JobStore, dbBatchSize: Int, override val dbFlushRate: FiniteDuration) extends LoggingFSM[BatchingDbWriterState, BatchingDbWriter.BatchingDbWriterData] with BatchingDbWriterActor {
+case class JobStoreWriterActor(jsd: JobStore, override val dbBatchSize: Int, override val dbFlushRate: FiniteDuration) extends LoggingFSM[BatchingDbWriterState, BatchingDbWriter.BatchingDbWriterData] with BatchingDbWriterActor {
 
   implicit val ec = context.dispatcher
 
-  log.info(s"JobStoreWriterActor configured to write to the database with batch size {} and flush rate {}.", dbBatchSize, dbFlushRate)
+  override val writeActorName = "JobStoreWriterActor"
 
   startWith(WaitingToWrite, NoData)
 

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -16,6 +16,8 @@ case class JobStoreWriterActor(jsd: JobStore, dbBatchSize: Int, override val dbF
 
   implicit val ec = context.dispatcher
 
+  log.info(s"JobStoreWriterActor configured to write to the database with batch size {} and flush rate {}.", dbBatchSize, dbFlushRate)
+
   startWith(WaitingToWrite, NoData)
 
   when(WaitingToWrite) {

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -51,7 +51,7 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config)
 
   val dbFlushRate = serviceConfig.as[Option[FiniteDuration]]("services.MetadataService.db-flush-rate").getOrElse(5 seconds)
   val dbBatchSize = serviceConfig.as[Option[Int]]("services.MetadataService.db-batch-size").getOrElse(200)
-  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate), "write-metadata-actor")
+  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate), "WriteMetadataActor")
   implicit val ec = context.dispatcher
   private var summaryRefreshCancellable: Option[Cancellable] = None
   

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -19,7 +19,6 @@ class WriteMetadataActor(override val dbBatchSize: Int, override val dbFlushRate
   import WriteMetadataActor._
 
   implicit val ec: ExecutionContext = context.dispatcher
-  override val writeActorName = "WriteMetadataActor"
 
   startWith(WaitingToWrite, NoData)
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -20,6 +20,8 @@ class WriteMetadataActor(batchSize: Int, override val dbFlushRate: FiniteDuratio
 
   implicit val ec: ExecutionContext = context.dispatcher
 
+  log.info("WriteMetadataActor configured to write to the database with batch size {} and flush rate {}.", batchSize, dbFlushRate)
+
   startWith(WaitingToWrite, NoData)
 
   when(WaitingToWrite) {

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.services.metadata.impl
 
 import java.time.OffsetDateTime
+import java.util.UUID
 
 import akka.testkit.TestFSMRef
 import cats.data.NonEmptyVector
@@ -23,7 +24,7 @@ class WriteMetadataActorSpec extends ServicesSpec("Metadata") with Eventually wi
   var actor: TestFSMRef[BatchingDbWriterState, BatchingDbWriter.BatchingDbWriterData, DelayingWriteMetadataActor] = _
 
   before {
-    actor = TestFSMRef(new DelayingWriteMetadataActor(), "DelayingWriteMetadataActor")
+    actor = TestFSMRef(new DelayingWriteMetadataActor(), "DelayingWriteMetadataActor-" + UUID.randomUUID())
   }
 
   "WriteMetadataActor" should {

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -23,7 +23,7 @@ class WriteMetadataActorSpec extends ServicesSpec("Metadata") with Eventually wi
   var actor: TestFSMRef[BatchingDbWriterState, BatchingDbWriter.BatchingDbWriterData, DelayingWriteMetadataActor] = _
 
   before {
-    actor = TestFSMRef(new DelayingWriteMetadataActor())
+    actor = TestFSMRef(new DelayingWriteMetadataActor(), "DelayingWriteMetadataActor")
   }
 
   "WriteMetadataActor" should {


### PR DESCRIPTION
Note that there is already `debug` level logging for the actual flush events, which might be a good idea to turn on to see if the settings we've chosen are reasonable or whether we're just flushing constantly and blowing up the Slick queue.