### PR TITLE
Limit the batch request size

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -687,7 +687,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     serviceRegistryActor.putMetadata(jobDescriptor.workflowDescriptor.id, Option(jobDescriptor.key), metadataKeyValues)
   }
 
-  override protected implicit def ec: ExecutionContextExecutor = context.dispatcher
+  override protected implicit lazy val ec: ExecutionContextExecutor = context.dispatcher
 }
 
 /**

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -5,11 +5,11 @@ import java.io.IOException
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
 import cats.data.NonEmptyList
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.{HttpHeaders, HttpRequest}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.RunPipelineRequest
 import cromwell.backend.impl.jes.Run
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiException, _}
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
@@ -17,6 +17,7 @@ import cromwell.util.StopAndLogSupervisor
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
 
+import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.collection.immutable.Queue
 
@@ -26,7 +27,14 @@ import scala.collection.immutable.Queue
 class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with ActorLogging with StopAndLogSupervisor {
 
   private implicit val ec = context.dispatcher
-  private val maxRetries = 10
+  private val maxRetries = 0
+  // FIXME: Determined empirically that we start to get errors when the batch request approaches 15MB.
+  // Find out what the real value is
+  private val maxBatchRequestSize = 14 * 1024 * 1024
+  private val requestTooLargeException = new JesApiException(new IllegalArgumentException(
+    "The JES creation request exceeds the maximum size allowed. " +
+      "If you have a task with a very large number of inputs and / or outputs in your workflow you should try to reduce it."
+  ))
 
   // workQueue is protected for the unit tests, not intended to be generally overridden
   protected[statuspolling] var workQueue: Queue[JesApiQuery] = Queue.empty
@@ -42,7 +50,11 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
   override def receive = {
     case DoPoll(run) => workQueue :+= JesStatusPollQuery(sender, run)
     case DoCreateRun(genomics, rpr) =>
-      workQueue :+= JesRunCreationQuery(sender, genomics, rpr)
+      val creationQuery = JesRunCreationQuery(sender(), genomics, rpr)
+
+      if (creationQuery.contentLength > maxBatchRequestSize) {
+        creationQuery.requester ! JesApiRunCreationQueryFailed(creationQuery, requestTooLargeException)
+      } else workQueue :+= creationQuery
     case q: JesApiQuery => workQueue :+= q
     case RequestJesPollingWork(maxBatchSize) =>
       log.debug("Request for JES Polling Work received (max batch: {}, current queue size is {})", maxBatchSize, workQueue.size)
@@ -82,8 +94,27 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
   private case class BeheadedWorkQueue(workToDo: Option[NonEmptyList[JesApiQuery]], newWorkQueue: Queue[JesApiQuery])
   private def beheadWorkQueue(maxBatchSize: Int): BeheadedWorkQueue = {
 
-    val head = workQueue.take(maxBatchSize).toList
-    val tail = workQueue.drop(maxBatchSize)
+    /**
+      * Take the head of the queue, making sure it stays under maxBatchSize as well as maxBatchRequestSize.
+      * Assumes that each query in the queue can fit in an empty batch (queries with a size > maxBatchSize should no be added to the queue)
+      *
+      * This is a naive approach where we keep adding queries to the head as long as they don't overflow it, and then we stop.
+      * This could leave us with half empty batches and is not very efficient.
+      *
+      * A somewhat less naive approach would be to keep looking in the queue for another query that would fit.
+      *
+      * More generally this is the knapsack problem (https://en.wikipedia.org/wiki/Knapsack_problem) which is NP-Complete.
+      * If this needs further optimization, finding an approximation algorithm that fits well this case would be a place to start.
+      */
+    @tailrec
+    def behead(queue: Queue[JesApiQuery], head: Vector[JesApiQuery]): Vector[JesApiQuery]  = queue.headOption match {
+      case Some(query) if head.size < maxBatchSize && (head :+ query).map(_.contentLength).sum < maxBatchRequestSize =>
+        behead(queue.tail, head :+ query)
+      case _ => head
+    }
+
+    val head = behead(workQueue, Vector.empty).toList
+    val tail = workQueue.drop(head.size)
 
     head match {
       case h :: t => BeheadedWorkQueue(Option(NonEmptyList(h, t)), tail)
@@ -147,6 +178,8 @@ object JesApiQueryManager {
     def genomicsInterface: Genomics
     def withFailedAttempt: JesApiQuery
     def backoff: Backoff
+    def httpRequest: HttpRequest
+    def contentLength = httpRequest.getContent.getLength
   }
   private object JesApiQuery {
     // This must be a def, we want a new one each time (they're mutable! Boo!)
@@ -154,10 +187,12 @@ object JesApiQueryManager {
   }
   private[statuspolling] final case class JesStatusPollQuery(requester: ActorRef, run: Run, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
     override val genomicsInterface = run.genomicsInterface
+    override val httpRequest = run.getOperationCommand.buildHttpRequest()
     override def withFailedAttempt = this.copy(failedAttempts = failedAttempts + 1, backoff = backoff.next)
   }
   private[statuspolling] final case class JesRunCreationQuery(requester: ActorRef, genomicsInterface: Genomics, rpr: RunPipelineRequest, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
     override def withFailedAttempt = this.copy(failedAttempts = failedAttempts + 1, backoff = backoff.next)
+    override val httpRequest = genomicsInterface.pipelines().run(rpr).buildHttpRequest()
   }
 
   trait JesApiQueryFailed {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -27,13 +27,15 @@ import scala.collection.immutable.Queue
 class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with ActorLogging with StopAndLogSupervisor {
 
   private implicit val ec = context.dispatcher
-  private val maxRetries = 0
+  private val maxRetries = 10
   // FIXME: Determined empirically that we start to get errors when the batch request approaches 15MB.
   // Find out what the real value is
   private val maxBatchRequestSize = 14 * 1024 * 1024
   private val requestTooLargeException = new JesApiException(new IllegalArgumentException(
-    "The JES creation request exceeds the maximum size allowed. " +
-      "If you have a task with a very large number of inputs and / or outputs in your workflow you should try to reduce it."
+    "The task run request has exceeded the maximum PAPI request size." +
+      "If you have a task with a very large number of inputs and / or outputs in your workflow you should try to reduce it. " +
+      "Depending on your case you could: 1) Zip your input files together and unzip them in the command. 2) Use a file of file names " +
+      "and localize the files yourself."
   ))
 
   // workQueue is protected for the unit tests, not intended to be generally overridden
@@ -48,9 +50,9 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
   resetWorker()
 
   override def receive = {
-    case DoPoll(run) => workQueue :+= JesStatusPollQuery(sender, run)
+    case DoPoll(run) => workQueue :+= makePollQuery(sender, run)
     case DoCreateRun(genomics, rpr) =>
-      val creationQuery = JesRunCreationQuery(sender(), genomics, rpr)
+      val creationQuery = makeCreateQuery(sender, genomics, rpr)
 
       if (creationQuery.contentLength > maxBatchRequestSize) {
         creationQuery.requester ! JesApiRunCreationQueryFailed(creationQuery, requestTooLargeException)
@@ -62,6 +64,14 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
     case failure: JesApiQueryFailed => handleQueryFailure(failure)
     case Terminated(actorRef) => handleTerminated(actorRef)
     case other => log.error(s"Unexpected message to JesPollingManager: $other")
+  }
+
+  private [statuspolling] def makeCreateQuery(replyTo: ActorRef, genomics: Genomics, rpr: RunPipelineRequest) = {
+    JesRunCreationQuery(replyTo, genomics, rpr)
+  }
+
+  private [statuspolling] def makePollQuery(replyTo: ActorRef, run: Run) = {
+    JesStatusPollQuery(replyTo, run)
   }
 
   private def handleQueryFailure(failure: JesApiQueryFailed) = if (failure.query.failedAttempts < maxRetries) {
@@ -94,8 +104,8 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
   private case class BeheadedWorkQueue(workToDo: Option[NonEmptyList[JesApiQuery]], newWorkQueue: Queue[JesApiQuery])
   private def beheadWorkQueue(maxBatchSize: Int): BeheadedWorkQueue = {
 
-    /**
-      * Take the head of the queue, making sure it stays under maxBatchSize as well as maxBatchRequestSize.
+    /*
+      * Keep taking from the head of the queue, making sure it stays under maxBatchSize as well as maxBatchRequestSize.
       * Assumes that each query in the queue can fit in an empty batch (queries with a size > maxBatchSize should no be added to the queue)
       *
       * This is a naive approach where we keep adding queries to the head as long as they don't overflow it, and then we stop.
@@ -108,12 +118,14 @@ class JesApiQueryManager(val qps: Int Refined Positive) extends Actor with Actor
       */
     @tailrec
     def behead(queue: Queue[JesApiQuery], head: Vector[JesApiQuery]): Vector[JesApiQuery]  = queue.headOption match {
-      case Some(query) if head.size < maxBatchSize && (head :+ query).map(_.contentLength).sum < maxBatchRequestSize =>
+      case Some(query) if head.size < maxBatchSize && head.map(_.contentLength).sum + query.contentLength < maxBatchRequestSize =>
         behead(queue.tail, head :+ query)
       case _ => head
     }
 
-    val head = behead(workQueue, Vector.empty).toList
+    // Initialize the head with workQueue.head to avoid deadlocking if the first element is > maxBatchRequestSize, 
+    // which should NOT happen as they should not be inserted in the queue in the first place
+    val head = if (workQueue.isEmpty) Vector.empty else behead(workQueue.tail, workQueue.headOption.toVector).toList
     val tail = workQueue.drop(head.size)
 
     head match {
@@ -179,20 +191,22 @@ object JesApiQueryManager {
     def withFailedAttempt: JesApiQuery
     def backoff: Backoff
     def httpRequest: HttpRequest
-    def contentLength = httpRequest.getContent.getLength
+    def contentLength: Long = Option(httpRequest.getContent).map(_.getLength).getOrElse(0L)
   }
   private object JesApiQuery {
     // This must be a def, we want a new one each time (they're mutable! Boo!)
     def backoff: Backoff = SimpleExponentialBackoff(1.second, 1000.seconds, 1.5d)
   }
-  private[statuspolling] final case class JesStatusPollQuery(requester: ActorRef, run: Run, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
+
+  private[statuspolling] case class JesStatusPollQuery(requester: ActorRef, run: Run, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
     override val genomicsInterface = run.genomicsInterface
-    override val httpRequest = run.getOperationCommand.buildHttpRequest()
+    override lazy val httpRequest = run.getOperationCommand.buildHttpRequest()
     override def withFailedAttempt = this.copy(failedAttempts = failedAttempts + 1, backoff = backoff.next)
   }
-  private[statuspolling] final case class JesRunCreationQuery(requester: ActorRef, genomicsInterface: Genomics, rpr: RunPipelineRequest, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
+
+  private[statuspolling] case class JesRunCreationQuery(requester: ActorRef, genomicsInterface: Genomics, rpr: RunPipelineRequest, failedAttempts: Int = 0, backoff: Backoff = JesApiQuery.backoff) extends JesApiQuery {
     override def withFailedAttempt = this.copy(failedAttempts = failedAttempts + 1, backoff = backoff.next)
-    override val httpRequest = genomicsInterface.pipelines().run(rpr).buildHttpRequest()
+    override lazy val httpRequest = genomicsInterface.pipelines().run(rpr).buildHttpRequest()
   }
 
   trait JesApiQueryFailed {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
@@ -34,12 +34,13 @@ private[statuspolling] trait RunCreation { this: JesPollingActor =>
     completionPromise.future
   }
 
-  private def addRunCreationToBatch(request: HttpRequest, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]) = {
+  private def addRunCreationToBatch(request: HttpRequest, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]): Unit = {
     /*
       * Manually enqueue the request instead of doing it through the RunPipelineRequest
       * as it would unnecessarily rebuild the request (which we already have)
      */
     batch.queue(request, classOf[Operation], classOf[GoogleJsonErrorContainer], resultHandler)
+    ()
   }
 
   private def getJob(operation: Operation) = StandardAsyncJob(operation.getName)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/StatusPolling.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Try, Success => TrySuccess}
 
 private[statuspolling] trait StatusPolling { this: JesPollingActor =>
 
-  private def statusPollResultHandler(originalRequest: JesStatusPollQuery, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
+  private [statuspolling] def statusPollResultHandler(originalRequest: JesStatusPollQuery, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
     override def onSuccess(operation: Operation, responseHeaders: HttpHeaders): Unit = {
       originalRequest.requester ! interpretOperationStatus(operation)
       completionPromise.trySuccess(TrySuccess(()))
@@ -36,7 +36,7 @@ private[statuspolling] trait StatusPolling { this: JesPollingActor =>
     }
   }
 
-  def enqueueStatusPollInBatch(pollingRequest: JesStatusPollQuery, batch: BatchRequest): Future[Try[Unit]] = {
+  private [statuspolling] def enqueueStatusPollInBatch(pollingRequest: JesStatusPollQuery, batch: BatchRequest): Future[Try[Unit]] = {
     val completionPromise = Promise[Try[Unit]]()
     val resultHandler = statusPollResultHandler(pollingRequest, completionPromise)
     addStatusPollToBatch(pollingRequest.httpRequest, batch, resultHandler)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
@@ -12,6 +12,7 @@ import cats.data.NonEmptyList
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.batch.json.JsonBatchCallback
 import com.google.api.client.googleapis.json.GoogleJsonError
+import com.google.api.client.http.HttpRequest
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.Operation
 import cromwell.backend.impl.jes.{JesConfiguration, Run, RunStatus}
@@ -124,7 +125,7 @@ class TestJesPollingActor(manager: ActorRef, qps: Int Refined Positive) extends 
         handler.onFailure(error, null)
     }}
   }
-  override def addStatusPollToBatch(run: Run, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]): Unit = resultHandlers :+= resultHandler
+  override def addStatusPollToBatch(httpRequest: HttpRequest, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]): Unit = resultHandlers :+= resultHandler
   override def interpretOperationStatus(operation: Operation): RunStatus = {
     val (status, newQueue) = operationStatusResponses.dequeue
     operationStatusResponses = newQueue


### PR DESCRIPTION
This is a proposal on how to solve the "insufficient data written" error that is due to the batch request doing PAPI job creation / polling being too large. The actual limit number is unknown yet (ticket is open with google).
Depending on their answer the solution might look different but this would be one way to fix it.
I tested it with @ruchim's WDL that reproduces this problem and didn't see it.