### PR TITLE
v2 submission api requires type and type version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 30 Release Notes
 
+### Breaking Changes
+
+* All endpoints now require valid version numbers.
+
+* `POST /api/workflows/v2` now requires a `workflowType` and a `workflowTypeVersion`. These are optional for the `v1`
+api. See the [README](https://github.com/broadinstitute/cromwell#post-apiworkflowsversion) for more information.
+
 ### Other changes
 
 * **Database**  

--- a/README.md
+++ b/README.md
@@ -2590,7 +2590,7 @@ This endpoint accepts a POST request with a `multipart/form-data` encoded body. 
 * `workflowSource` - *Required* Contains the workflow source file to submit for execution.
 * `workflowType` - *Required* The type of the `workflowSource`, for example "WDL".
    Required starting with api version "v2".
-* `workflowTypeVersion` - *Required* The version of the `workflowType`, for example "1".
+* `workflowTypeVersion` - *Required* The version of the `workflowType`, for example "draft-2".
    Required starting with api version "v2".
 * `workflowInputs` - *Optional* JSON file containing the inputs.  For WDL workflows a skeleton file can be generated from [wdltool](https://github.com/broadinstitute/wdltool) using the "inputs" subcommand.
 * `workflowInputs_n` - *Optional* Where `n` is an integer. JSON file containing the 'n'th set of auxiliary inputs.

--- a/README.md
+++ b/README.md
@@ -2588,6 +2588,10 @@ All web server requests include an API version in the url. The current version i
 This endpoint accepts a POST request with a `multipart/form-data` encoded body.  The form fields that may be included are:
 
 * `workflowSource` - *Required* Contains the workflow source file to submit for execution.
+* `workflowType` - *Required* The type of the `workflowSource`, for example "WDL".
+   Required starting with api version "v2".
+* `workflowTypeVersion` - *Required* The version of the `workflowType`, for example "1".
+   Required starting with api version "v2".
 * `workflowInputs` - *Optional* JSON file containing the inputs.  For WDL workflows a skeleton file can be generated from [wdltool](https://github.com/broadinstitute/wdltool) using the "inputs" subcommand.
 * `workflowInputs_n` - *Optional* Where `n` is an integer. JSON file containing the 'n'th set of auxiliary inputs.
 * `workflowOptions` - *Optional* JSON file containing options for this workflow execution.  See the [run](#run) CLI sub-command for some more information about this.

--- a/core/src/main/scala/cromwell/core/WorkflowSourceFilesCollection.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowSourceFilesCollection.scala
@@ -14,6 +14,8 @@ sealed trait WorkflowSourceFilesCollection {
   def workflowType: Option[WorkflowType]
   def workflowTypeVersion: Option[WorkflowTypeVersion]
 
+  def warnings: Seq[String]
+
   def importsZipFileOption: Option[Array[Byte]] = this match {
     case _: WorkflowSourceFilesWithoutImports => None
     case w: WorkflowSourceFilesWithDependenciesZip => Option(w.importsZip) // i.e. Some(importsZip) if our wiring is correct
@@ -32,11 +34,27 @@ object WorkflowSourceFilesCollection {
             inputsJson: WorkflowJson,
             workflowOptionsJson: WorkflowOptionsJson,
             labelsJson: WorkflowJson,
-            importsFile: Option[Array[Byte]]): WorkflowSourceFilesCollection = importsFile match {
+            importsFile: Option[Array[Byte]],
+            warnings: Seq[String]): WorkflowSourceFilesCollection = importsFile match {
     case Some(imports) =>
-      WorkflowSourceFilesWithDependenciesZip(workflowSource, workflowType, workflowTypeVersion, inputsJson, workflowOptionsJson, labelsJson, imports)
+      WorkflowSourceFilesWithDependenciesZip(
+        workflowSource,
+        workflowType,
+        workflowTypeVersion,
+        inputsJson,
+        workflowOptionsJson,
+        labelsJson,
+        imports,
+        warnings)
     case None =>
-      WorkflowSourceFilesWithoutImports(workflowSource, workflowType, workflowTypeVersion, inputsJson, workflowOptionsJson, labelsJson)
+      WorkflowSourceFilesWithoutImports(
+        workflowSource,
+        workflowType,
+        workflowTypeVersion,
+        inputsJson,
+        workflowOptionsJson,
+        labelsJson,
+        warnings)
   }
 }
 
@@ -45,7 +63,8 @@ final case class WorkflowSourceFilesWithoutImports(workflowSource: WorkflowSourc
                                                    workflowTypeVersion: Option[WorkflowTypeVersion],
                                                    inputsJson: WorkflowJson,
                                                    workflowOptionsJson: WorkflowOptionsJson,
-                                                   labelsJson: WorkflowJson) extends WorkflowSourceFilesCollection
+                                                   labelsJson: WorkflowJson,
+                                                   warnings: Seq[String]) extends WorkflowSourceFilesCollection
 
 final case class WorkflowSourceFilesWithDependenciesZip(workflowSource: WorkflowSource,
                                                         workflowType: Option[WorkflowType],
@@ -53,6 +72,9 @@ final case class WorkflowSourceFilesWithDependenciesZip(workflowSource: Workflow
                                                         inputsJson: WorkflowJson,
                                                         workflowOptionsJson: WorkflowOptionsJson,
                                                         labelsJson: WorkflowJson,
-                                                        importsZip: Array[Byte]) extends WorkflowSourceFilesCollection {
-  override def toString = s"WorkflowSourceFilesWithDependenciesZip($workflowSource, $inputsJson, $workflowOptionsJson, $labelsJson, <<ZIP BINARY CONTENT>>)"
+                                                        importsZip: Array[Byte],
+                                                        warnings: Seq[String]) extends WorkflowSourceFilesCollection {
+  override def toString = {
+    s"WorkflowSourceFilesWithDependenciesZip($workflowSource, $workflowType, $workflowTypeVersion, $inputsJson, $workflowOptionsJson, $labelsJson, <<ZIP BINARY CONTENT>>, $warnings)"
+  }
 }

--- a/core/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/core/src/test/scala/cromwell/util/SampleWdl.scala
@@ -24,7 +24,8 @@ trait SampleWdl extends TestFileUtil {
       workflowOptionsJson = workflowOptions,
       labelsJson = labels,
       workflowType = workflowType,
-      workflowTypeVersion = workflowTypeVersion)
+      workflowTypeVersion = workflowTypeVersion,
+      warnings = Vector.empty)
   }
 
   val rawInputs: WorkflowRawInputs

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -61,7 +61,8 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
       inputsJson = workflowStoreEntry.workflowInputs.toRawString,
       workflowOptionsJson = workflowStoreEntry.workflowOptions.toRawString,
       labelsJson = workflowStoreEntry.customLabels.toRawString,
-      importsFile = workflowStoreEntry.importsZip.toBytesOption
+      importsFile = workflowStoreEntry.importsZip.toBytesOption,
+      warnings = Vector.empty
     )
     WorkflowToStart(
       WorkflowId.fromString(workflowStoreEntry.workflowExecutionUuid),

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -3,40 +3,39 @@ package cromwell.webservice
 import java.util.UUID
 
 import akka.actor.{ActorRef, ActorRefFactory}
-import akka.http.scaladsl.server.Directives._
-
-import scala.concurrent.{ExecutionContext, Future}
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.Multipart.BodyPart
-import akka.stream.ActorMaterializer
-import cromwell.engine.backend.BackendConfiguration
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import cromwell.core.{WorkflowAborted, WorkflowId, WorkflowSubmitted}
-import cromwell.core.Dispatcher.ApiDispatcher
-import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStoreEngineActor, WorkflowStoreSubmitActor}
-import akka.pattern.{AskTimeoutException, ask}
-import akka.util.{ByteString, Timeout}
-import net.ceedubs.ficus.Ficus._
-import cromwell.engine.workflow.WorkflowManagerActor
-import cromwell.services.metadata.MetadataService._
-import cromwell.webservice.metadata.{MetadataBuilderActor, WorkflowQueryPagination}
-import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
-import WorkflowJsonSupport._
+import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallable}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.pattern.{AskTimeoutException, ask}
+import akka.stream.ActorMaterializer
+import akka.util.{ByteString, Timeout}
 import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.config.ConfigFactory
+import cromwell.core.Dispatcher.ApiDispatcher
 import cromwell.core.labels.Labels
+import cromwell.core.{WorkflowAborted, WorkflowId, WorkflowSubmitted}
+import cromwell.engine.backend.BackendConfiguration
+import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{BuiltCallCacheDiffResponse, CachedCallNotFoundException, CallCacheDiffActorResponse, FailedCallCacheDiffResponse}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheDiffActor, CallCacheDiffQueryParameter}
 import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor.WorkflowStoreEngineAbortResponse
+import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStoreEngineActor, WorkflowStoreSubmitActor}
 import cromwell.server.CromwellShutdown
+import cromwell.services.metadata.MetadataService._
 import cromwell.webservice.LabelsManagerActor._
+import cromwell.webservice.WorkflowJsonSupport._
+import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.webservice.metadata.{MetadataBuilderActor, WorkflowQueryPagination}
 import lenthall.exception.AggregatedMessageException
-import spray.json.JsObject
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 trait CromwellApiService {
@@ -55,34 +54,34 @@ trait CromwellApiService {
   implicit val timeout: Timeout = duration
 
   val engineRoutes = concat(
-    path("engine" / Segment / "stats") { version =>
+    path("engine" / "v1" / "stats") {
       get {
         onComplete(workflowManagerActor.ask(WorkflowManagerActor.EngineStatsCommand).mapTo[EngineStatsActor.EngineStats]) {
-          case Success(stats) => complete(stats)
+          case Success(stats) => complete(ToResponseMarshallable(stats))
           case Failure(_) => new RuntimeException("Unable to gather engine stats").failRequest(StatusCodes.InternalServerError)
         }
       }
     },
 
-    path("engine" / Segment / "version") { version =>
+    path("engine" / "v1" / "version") {
       get { complete(versionResponse) }
     }
   )
 
   val workflowRoutes =
-    path("workflows" / Segment / "backends") { version =>
-      get { complete(backendResponse) }
+    path("workflows" / "v1" / "backends") {
+      get { complete(ToResponseMarshallable(backendResponse)) }
     } ~
-    path("workflows" / Segment / Segment / "status") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "status") { possibleWorkflowId =>
       get { metadataBuilderRequest(possibleWorkflowId, (w: WorkflowId) => GetStatus(w)) }
     } ~
-    path("workflows" / Segment / Segment / "outputs") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "outputs") { possibleWorkflowId =>
       get { metadataBuilderRequest(possibleWorkflowId, (w: WorkflowId) => WorkflowOutputs(w)) }
     } ~
-    path("workflows" / Segment / Segment / "logs") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "logs") { possibleWorkflowId =>
       get { metadataBuilderRequest(possibleWorkflowId, (w: WorkflowId) => GetLogs(w)) }
     } ~
-    path("workflows" / Segment / "query") { _ =>
+      path("workflows" / "v1" / "query") {
       get {
         parameterSeq { parameters =>
           extractUri { uri =>
@@ -99,7 +98,8 @@ trait CromwellApiService {
       }
     } ~
     encodeResponse {
-      path("workflows" / Segment / Segment / "metadata") { (version, possibleWorkflowId) =>
+      (path("workflows" / "v1" / Segment / "metadata") |
+        path("workflows" / "v2" / Segment / "metadata")) { possibleWorkflowId =>
         parameters(('includeKey.*, 'excludeKey.*, 'expandSubWorkflows.as[Boolean].?)) { (includeKeys, excludeKeys, expandSubWorkflowsOption) =>
           val includeKeysOption = NonEmptyList.fromList(includeKeys.toList)
           val excludeKeysOption = NonEmptyList.fromList(excludeKeys.toList)
@@ -114,7 +114,7 @@ trait CromwellApiService {
         }
       }
     } ~
-    path("workflows" / Segment / "callcaching" / "diff") { version =>
+      path("workflows" / "v1" / "callcaching" / "diff") {
       parameterSeq { parameters =>
         get {
           CallCacheDiffQueryParameter.fromParameters(parameters) match {
@@ -134,20 +134,21 @@ trait CromwellApiService {
         }
       }
     } ~
-    path("workflows" / Segment / Segment / "timing") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "timing") { possibleWorkflowId =>
       onComplete(validateWorkflowId(possibleWorkflowId)) {
         case Success(_) => getFromResource("workflowTimings/workflowTimings.html")
         case Failure(e) => e.failRequest(StatusCodes.InternalServerError)
       }
     } ~
-    path("workflows" / Segment / Segment / "abort") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "abort") { possibleWorkflowId =>
       post {
         val response = validateWorkflowId(possibleWorkflowId) flatMap { w =>
           workflowStoreActor.ask(WorkflowStoreActor.AbortWorkflow(w, workflowManagerActor)).mapTo[WorkflowStoreEngineAbortResponse]
         }
 
         onComplete(response) {
-          case Success(WorkflowStoreEngineActor.WorkflowAborted(id)) => complete(WorkflowAbortResponse(id.toString, WorkflowAborted.toString))
+          case Success(WorkflowStoreEngineActor.WorkflowAborted(id)) =>
+            complete(ToResponseMarshallable(WorkflowAbortResponse(id.toString, WorkflowAborted.toString)))
           case Success(WorkflowStoreEngineActor.WorkflowAbortFailed(_, e: IllegalStateException)) => e.errorRequest(StatusCodes.Forbidden)
           case Success(WorkflowStoreEngineActor.WorkflowAbortFailed(_, e: WorkflowNotFoundException)) => e.errorRequest(StatusCodes.NotFound)
           case Success(WorkflowStoreEngineActor.WorkflowAbortFailed(_, e)) => e.errorRequest(StatusCodes.InternalServerError)
@@ -158,7 +159,7 @@ trait CromwellApiService {
         }
       }
     } ~
-    path("workflows" / Segment / Segment / "labels") { (version, possibleWorkflowId) =>
+      path("workflows" / "v1" / Segment / "labels") { possibleWorkflowId =>
       entity(as[Map[String, String]]) { parameterMap =>
         patch {
           Labels.validateMapOfLabels(parameterMap) match {
@@ -180,59 +181,73 @@ trait CromwellApiService {
         }
       }
     } ~
-  path("workflows" / Segment) { version =>
+      path("workflows" / Segment) { version =>
       post {
         entity(as[Multipart.FormData]) { formData =>
-          submitRequest(formData, true)
+          submitRequest(formData, isSingleSubmission = true, version)
         }
       }
     } ~
-  path("workflows" / Segment / "batch") { version =>
+      path("workflows" / Segment / "batch") { version =>
     post {
       entity(as[Multipart.FormData]) { formData =>
-        submitRequest(formData, false)
+        submitRequest(formData, isSingleSubmission = false, version)
       }
     }
   }
 
-  private def submitRequest(formData: Multipart.FormData, isSingleSubmission: Boolean): Route = {
+  private def submitRequest(formData: Multipart.FormData, isSingleSubmission: Boolean, version: String): Route = {
+    val versionRegex = """v(\d+)""".r
+    version match {
+      case versionRegex(number) if number == "1" || number == "2" =>
+        submitRequest(formData, isSingleSubmission, number.toInt)
+      case _ => reject
+    }
+  }
+
+  private def submitRequest(formData: Multipart.FormData, isSingleSubmission: Boolean, version: Int): Route = {
     val allParts: Future[Map[String, ByteString]] = formData.parts.mapAsync[(String, ByteString)](1) {
-      case b: BodyPart => b.toStrict(duration).map(strict => b.name -> strict.entity.data)
+      bodyPart => bodyPart.toStrict(duration).map(strict => bodyPart.name -> strict.entity.data)
     }.runFold(Map.empty[String, ByteString])((map, tuple) => map + tuple)
 
     def toResponse(workflowId: WorkflowId): WorkflowSubmitResponse = {
       WorkflowSubmitResponse(workflowId.toString, WorkflowSubmitted.toString)
     }
 
-    def askSubmit(command: WorkflowStoreActor.WorkflowStoreActorSubmitCommand): Route = {
+    def askSubmit(command: WorkflowStoreActor.WorkflowStoreActorSubmitCommand, warnings: Seq[String]): Route = {
       // NOTE: Do not blindly coppy the akka-http -to- ask-actor pattern below without knowing the pros and cons.
       onComplete(workflowStoreActor.ask(command).mapTo[WorkflowStoreSubmitActor.WorkflowStoreSubmitActorResponse]) {
         case Success(w) =>
           w match {
             case WorkflowStoreSubmitActor.WorkflowSubmittedToStore(workflowId) =>
-              complete((StatusCodes.Created, toResponse(workflowId)))
+              completeResponse(StatusCodes.Created, toResponse(workflowId), warnings)
             case WorkflowStoreSubmitActor.WorkflowsBatchSubmittedToStore(workflowIds) =>
-              complete((StatusCodes.Created, workflowIds.toList map toResponse))
+              completeResponse(StatusCodes.Created, workflowIds.toList map toResponse, warnings)
             case WorkflowStoreSubmitActor.WorkflowSubmitFailed(throwable) =>
-              throwable.failRequest(StatusCodes.BadRequest)
+              throwable.failRequest(StatusCodes.BadRequest, warnings)
           }
         case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
         case Failure(e) =>
-          e.failRequest(StatusCodes.InternalServerError)
+          e.failRequest(StatusCodes.InternalServerError, warnings)
       }
     }
 
     onComplete(allParts) {
       case Success(data) =>
-        PartialWorkflowSources.fromSubmitRoute(data, allowNoInputs = isSingleSubmission) match {
+        PartialWorkflowSources.fromSubmitRoute(data, allowNoInputs = isSingleSubmission, version) match {
           case Success(workflowSourceFiles) if isSingleSubmission && workflowSourceFiles.size == 1 =>
-            askSubmit(WorkflowStoreActor.SubmitWorkflow(workflowSourceFiles.head))
+            val warnings = workflowSourceFiles.flatMap(_.warnings)
+            askSubmit(WorkflowStoreActor.SubmitWorkflow(workflowSourceFiles.head), warnings)
           // Catches the case where someone has gone through the single submission endpoint w/ more than one workflow
-          case Success(_) if isSingleSubmission =>
+          case Success(workflowSourceFiles) if isSingleSubmission =>
+            val warnings = workflowSourceFiles.flatMap(_.warnings)
             val e = new IllegalArgumentException("To submit more than one workflow at a time, use the batch endpoint.")
-            e.failRequest(StatusCodes.BadRequest)
+            e.failRequest(StatusCodes.BadRequest, warnings)
           case Success(workflowSourceFiles) =>
-            askSubmit(WorkflowStoreActor.BatchSubmitWorkflows(NonEmptyList.fromListUnsafe(workflowSourceFiles.toList)))
+            val warnings = workflowSourceFiles.flatMap(_.warnings)
+            askSubmit(
+              WorkflowStoreActor.BatchSubmitWorkflows(NonEmptyList.fromListUnsafe(workflowSourceFiles.toList)),
+              warnings)
           case Failure(t) => t.failRequest(StatusCodes.BadRequest)
         }
       case Failure(e) => e.failRequest(StatusCodes.InternalServerError)
@@ -272,7 +287,7 @@ trait CromwellApiService {
       case Success(w: WorkflowQuerySuccess) =>
         val headers = WorkflowQueryPagination.generateLinkHeaders(uri, w.meta)
         respondWithHeaders(headers) {
-          complete(w.response)
+          complete(ToResponseMarshallable(w.response))
         }
       case Success(w: WorkflowQueryFailure) => w.reason.failRequest(StatusCodes.BadRequest)
       case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
@@ -285,8 +300,31 @@ object CromwellApiService {
   import spray.json._
 
   implicit class EnhancedThrowable(val e: Throwable) extends AnyVal {
-    def failRequest(statusCode: StatusCode): Route = complete((statusCode, APIResponse.fail(e).toJson.prettyPrint))
-    def errorRequest(statusCode: StatusCode): Route = complete((statusCode, APIResponse.error(e).toJson.prettyPrint))
+    def failRequest(statusCode: StatusCode, warnings: Seq[String] = Vector.empty): Route = {
+      completeResponse(statusCode, APIResponse.fail(e).toJson.prettyPrint, warnings)
+    }
+    def errorRequest(statusCode: StatusCode, warnings: Seq[String] = Vector.empty): Route = {
+      completeResponse(statusCode, APIResponse.error(e).toJson.prettyPrint, warnings)
+    }
+  }
+
+  def completeResponse[A](statusCode: StatusCode, value: A, warnings: Seq[String])
+                         (implicit mt: ToEntityMarshaller[A]): Route = {
+    val warningHeaders = warnings.toIndexedSeq map { warning =>
+      /*
+      Need a quoted string.
+      https://stackoverflow.com/questions/7886782
+
+      Using a poor version of ~~#!
+      https://github.com/akka/akka-http/blob/v10.0.9/akka-http-core/src/main/scala/akka/http/impl/util/Rendering.scala#L206
+       */
+      val quotedString = "\"" + warning.replaceAll("\"","\\\\\"").replaceAll("[\\r\\n]+", " ").trim + "\""
+
+      // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46
+      RawHeader("Warning", s"299 cromwell/$cromwellVersion $quotedString")
+    }
+
+    complete((statusCode, warningHeaders, value))
   }
 
   final case class BackendResponse(supportedBackends: List[String], defaultBackend: String)
@@ -294,7 +332,8 @@ object CromwellApiService {
   final case class UnrecognizedWorkflowException(message: String) extends Exception(message)
   final case class InvalidWorkflowException(message: String) extends Exception(message)
 
+  val cromwellVersion = ConfigFactory.load("cromwell-version.conf").getConfig("version").getString("cromwell")
   val backendResponse = BackendResponse(BackendConfiguration.AllBackendEntries.map(_.name).sorted, BackendConfiguration.DefaultBackendEntry.name)
-  val versionResponse = JsObject(Map("cromwell" -> ConfigFactory.load("cromwell-version.conf").getConfig("version").getString("cromwell").toJson))
+  val versionResponse = JsObject(Map("cromwell" -> cromwellVersion.toJson))
   val serviceShuttingDownResponse = new Exception("Cromwell service is shutting down.").failRequest(StatusCodes.ServiceUnavailable)
 }

--- a/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
+++ b/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
@@ -20,30 +20,35 @@ final case class PartialWorkflowSources(workflowSource: Option[WorkflowSource],
                                         workflowInputsAux: Map[Int, WorkflowJson],
                                         workflowOptions: Option[WorkflowOptionsJson],
                                         customLabels: Option[WorkflowJson],
-                                        zippedImports: Option[Array[Byte]])
+                                        zippedImports: Option[Array[Byte]],
+                                        warnings: Seq[String])
 
 object PartialWorkflowSources {
   val log = LoggerFactory.getLogger(classOf[PartialWorkflowSources])
 
   def empty = PartialWorkflowSources(
     workflowSource = None,
-    // TODO do not hardcode, especially not out here at the boundary layer good gravy
-    workflowType = Option("WDL"),
+    workflowType = None,
     workflowTypeVersion = None,
     workflowInputs = Vector.empty,
     workflowInputsAux = Map.empty,
     workflowOptions = None,
     customLabels = None,
-    zippedImports = None
+    zippedImports = None,
+    warnings = Vector.empty
   )
 
-  def fromSubmitRoute(formData: Map[String, ByteString], allowNoInputs: Boolean): Try[Seq[WorkflowSourceFilesCollection]] = {
+  def fromSubmitRoute(formData: Map[String, ByteString],
+                      allowNoInputs: Boolean,
+                      version: Int): Try[Seq[WorkflowSourceFilesCollection]] = {
     val partialSources = Try(formData.foldLeft(PartialWorkflowSources.empty) { (partialSources: PartialWorkflowSources, kv: (String, ByteString)) =>
-      val name = kv._1
-      val data = kv._2
+      val (name, data) = kv
 
-      if (name == "wdlSource" || name == "workflowSource") {
-        if (name == "wdlSource") deprecationWarning(out = "wdlSource", in = "workflowSource")
+      if (name == "wdlSource" && version == 1) {
+        val warning = deprecationWarning(out = "wdlSource", in = "workflowSource")
+        val warnings = warning +: partialSources.warnings
+        partialSources.copy(workflowSource = Option(data.utf8String), warnings = warnings)
+      } else if (name == "workflowSource") {
         partialSources.copy(workflowSource = Option(data.utf8String))
       } else if (name == "workflowType") {
         partialSources.copy(workflowType = Option(data.utf8String))
@@ -56,8 +61,11 @@ object PartialWorkflowSources {
         partialSources.copy(workflowInputsAux = partialSources.workflowInputsAux + (index -> data.utf8String))
       } else if (name == "workflowOptions") {
         partialSources.copy(workflowOptions = Option(data.utf8String))
-      } else if (name == "wdlDependencies" || name == "workflowDependencies") {
-        if (name == "wdlDependencies") deprecationWarning(out = "wdlDependencies", in = "workflowDependencies")
+      } else if (name == "wdlDependencies" && version == 1) {
+        val warning = deprecationWarning(out = "wdlDependencies", in = "workflowDependencies")
+        val warnings = warning +: partialSources.warnings
+        partialSources.copy(zippedImports = Option(data.toArray), warnings = warnings)
+      } else if (name == "workflowDependencies") {
         partialSources.copy(zippedImports = Option(data.toArray))
       } else if (name == "customLabels") {
         partialSources.copy(customLabels = Option(data.utf8String))
@@ -66,7 +74,7 @@ object PartialWorkflowSources {
       }
     })
 
-    partialSourcesToSourceCollections(partialSources.tryToErrorOr, allowNoInputs).errorOrToTry
+    partialSourcesToSourceCollections(partialSources.tryToErrorOr, allowNoInputs, version).errorOrToTry
   }
 
   private def workflowInputs(data: String): Vector[WorkflowJson] = {
@@ -78,7 +86,9 @@ object PartialWorkflowSources {
     }
   }
 
-  private def partialSourcesToSourceCollections(partialSources: ErrorOr[PartialWorkflowSources], allowNoInputs: Boolean): ErrorOr[Seq[WorkflowSourceFilesCollection]] = {
+  private def partialSourcesToSourceCollections(partialSources: ErrorOr[PartialWorkflowSources],
+                                                allowNoInputs: Boolean,
+                                                version: Int): ErrorOr[Seq[WorkflowSourceFilesCollection]] = {
     def validateInputs(pws: PartialWorkflowSources): ErrorOr[Seq[WorkflowJson]] =
       (pws.workflowInputs.isEmpty, allowNoInputs) match {
         case (true, true) => Vector("{}").validNel
@@ -96,23 +106,46 @@ object PartialWorkflowSources {
       case _ => s"Incomplete workflow submission: $partialSource".invalidNel
     }
 
+    def validateWorkflowType(partialSource: PartialWorkflowSources, version: Int): ErrorOr[Option[WorkflowType]] = {
+      (partialSource.workflowType, version) match {
+        case (Some(src), _) => Option(src).validNel
+        case (None, 1) => None.validNel
+        case (None, _) => s"Workflow type is mandatory for v$version".invalidNel
+      }
+    }
+
+    def validateWorkflowTypeVersion(partialSource: PartialWorkflowSources,
+                                    version: Int): ErrorOr[Option[WorkflowTypeVersion]] = {
+      (partialSource.workflowTypeVersion, version) match {
+        case (Some(src), _) => Option(src).validNel
+        case (None, 1) => None.validNel
+        case (None, _) => s"Workflow type version is mandatory for v$version".invalidNel
+      }
+    }
+
     partialSources match {
       case Valid(partialSource) =>
-        (validateWorkflowSource(partialSource) |@| validateInputs(partialSource) |@| validateOptions(partialSource.workflowOptions)) map {
-          case (wfSource, wfInputs, wfOptions) =>
+        (validateWorkflowSource(partialSource) |@|
+          validateInputs(partialSource) |@|
+          validateOptions(partialSource.workflowOptions) |@|
+          validateWorkflowType(partialSource, version) |@|
+          validateWorkflowTypeVersion(partialSource, version)) map {
+          case (wfSource, wfInputs, wfOptions, workflowType, workflowTypeVersion) =>
             wfInputs.map(inputsJson => WorkflowSourceFilesCollection(
               workflowSource = wfSource,
-              workflowType = partialSource.workflowType,
-              workflowTypeVersion = partialSource.workflowTypeVersion,
+              workflowType = workflowType,
+              workflowTypeVersion = workflowTypeVersion,
               inputsJson = inputsJson,
               workflowOptionsJson = wfOptions.asPrettyJson,
               labelsJson = partialSource.customLabels.getOrElse("{}"),
-              importsFile = partialSource.zippedImports))        }
+              importsFile = partialSource.zippedImports,
+              warnings = partialSource.warnings))
+        }
       case Invalid(err) => err.invalid
     }
   }
 
-  private def deprecationWarning(out: String, in: String): Unit = {
+  private def deprecationWarning(out: String, in: String): String = {
     val warning =
       s"""
          |The '$out' parameter name has been deprecated in favor of '$in'.
@@ -120,6 +153,7 @@ object PartialWorkflowSources {
          |Please switch to using '$in' in future submissions.
          """.stripMargin
     log.warn(warning)
+    warning
   }
 
   def mergeMaps(allInputs: Seq[Option[String]]): JsObject = {

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -24,7 +24,7 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val BackendResponseFormat = jsonFormat2(BackendResponse)
   implicit val BuiltStatusResponseFormat = jsonFormat1(BuiltMetadataResponse)
   implicit val callAttempt = jsonFormat2(CallAttempt)
-  implicit val workflowSourceData = jsonFormat6(WorkflowSourceFilesWithoutImports)
+  implicit val workflowSourceData = jsonFormat7(WorkflowSourceFilesWithoutImports)
 
   implicit object fileJsonFormat extends RootJsonFormat[File] {
     override def write(obj: File) = JsString(obj.path.toAbsolutePath.toString)
@@ -34,7 +34,7 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit val workflowSourceDataWithImports = jsonFormat7(WorkflowSourceFilesWithDependenciesZip)
+  implicit val workflowSourceDataWithImports = jsonFormat8(WorkflowSourceFilesWithDependenciesZip)
   implicit val errorResponse = jsonFormat3(FailureResponse)
   implicit val successResponse = jsonFormat3(SuccessResponse)
 

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -336,7 +336,8 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
       workflowTypeVersion = None,
       inputsJson = sampleWdl.workflowJson,
       workflowOptionsJson = workflowOptions,
-      labelsJson = customLabels)
+      labelsJson = customLabels,
+      warnings = Vector.empty)
     val workflowId = rootActor.underlyingActor.submitWorkflow(sources)
     eventually { verifyWorkflowState(rootActor.underlyingActor.serviceRegistryActor, workflowId, terminalState) } (config = patienceConfig, pos = implicitly[org.scalactic.source.Position])
     val outcome = getWorkflowOutputsFromMetadata(workflowId, rootActor.underlyingActor.serviceRegistryActor)

--- a/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -40,7 +40,8 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
       workflowTypeVersion = None,
       inputsJson = rawInputsOverride,
       workflowOptionsJson = "{}",
-      labelsJson = "{}"
+      labelsJson = "{}",
+      warnings = Vector.empty
     )
     val promise = Promise[Unit]()
     val watchActor = system.actorOf(MetadataWatchActor.props(promise, matchers: _*), s"service-registry-$workflowId-${UUID.randomUUID()}")

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
@@ -64,7 +64,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -122,7 +123,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, differentDefaultBackendConf)
 
       within(Timeout) {
@@ -163,7 +165,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = "{}")
+        labelsJson = "{}",
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, differentDefaultBackendConf)
 
       within(Timeout) {
@@ -188,7 +191,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -218,7 +222,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -249,7 +254,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(badWdlSources, minimumConf)
 
       within(Timeout) {
@@ -274,7 +280,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = unstructuredFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -298,7 +305,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = unstructuredFile)
+        labelsJson = unstructuredFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -324,7 +332,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = badCustomLabelsFile)
+        labelsJson = badCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -354,7 +363,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = unstructuredFile,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -379,7 +389,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = noInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(badOptionsSources, minimumConf)
 
       within(Timeout) {
@@ -411,7 +422,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -446,7 +458,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = jsonInput,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -50,7 +50,9 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = "{}"))
+        labelsJson = "{}",
+        warnings = Vector.empty)
+      )
       val rootWorkflowId = expectMsgType[WorkflowSubmittedToStore](10 seconds).workflowId
 
       // Query for non existing sub workflow

--- a/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -144,7 +144,8 @@ object CromwellEntryPoint extends GracefulStopSupport {
           inputsJson = i,
           workflowOptionsJson = o,
           labelsJson = l,
-          importsZip = p.loadBytes)
+          importsZip = p.loadBytes,
+          warnings = Vector.empty)
       }
       case None => (workflowSource |@| inputsJson |@| optionsJson |@| labelsJson) map { (w, i, o, l) =>
         WorkflowSourceFilesWithoutImports.apply(
@@ -153,7 +154,8 @@ object CromwellEntryPoint extends GracefulStopSupport {
           workflowTypeVersion = None,
           inputsJson = i,
           workflowOptionsJson = o,
-          labelsJson = l
+          labelsJson = l,
+          warnings = Vector.empty
         )
       }
     }


### PR DESCRIPTION
v1 submission api returns an HTTP warning when using older form data names.
All unrecognized api versions return bad statuses.
Added additional specs.