### PR TITLE
To fix #2579 added dependency to akka-stream

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -142,6 +142,7 @@ object Dependencies {
   val cromwellApiClientDependencies = List(
     "com.typesafe.akka" %% "akka-actor" % akkaV,
     "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-stream" % akkaV,
     "com.github.pathikrit" %% "better-files" % betterFilesV,
     "org.scalatest" %% "scalatest" % scalatestV % Test,
     "org.pegdown" % "pegdown" % pegdownV % Test


### PR DESCRIPTION
as per http://akka.io/blog/news/2017/05/03/akka-http-10.0.6-released#compatibility-notes, to use akka-actor and akka-http together
#2579 