### PR TITLE
Kill Docker processes for realz [PREGULL]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ should be manually replicated from one database instance to another using the to
 database types. Cromwell will not move any existing data automatically. This feature should be considered experimental
 and likely to change in the future.
 
+* **Bugfixes**
+Abort of Dockerized tasks on the Local backend should now work as expected as `docker kill` is used to kill the Docker container.
+
 ## 29 Release Notes
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -1214,10 +1214,11 @@ backend {
 }
 ```
 
-If the backend supports docker, another optional configuration key `backend.providers.<backend>.config.submit-docker` may be specified. When the WDL contains a docker runtime attribute, this command will be provided the two additional variables:
+If the backend supports docker, another optional configuration key `backend.providers.<backend>.config.submit-docker` may be specified. When the WDL contains a docker runtime attribute, this command will be provided three additional variables:
 
 * `docker` - The docker image name.
 * `docker_cwd` - The path where `cwd` should be mounted within the docker container.
+* `docker_cid` - The host path to which the [container ID file](https://docs.docker.com/engine/reference/run/#pid-equivalent) should be written.
 
 ```
 backend {

--- a/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
@@ -13,6 +13,7 @@ object JobPaths {
   val StdErrPathKey = "stderr"
   val ReturnCodePathKey = "returnCode"
   val CallRootPathKey = "callRootPath"
+  val DockerCidPathKey = "dockerCidPath"
 
   def callPathBuilder(root: Path, jobKey: JobKey) = {
     val callName = jobKey.scope.unqualifiedName
@@ -32,6 +33,7 @@ trait JobPaths {
   def stdoutFilename: String = "stdout"
   def stderrFilename: String = "stderr"
   def scriptFilename: String = "script"
+  def dockerCidFilename: String = "docker_cid"
   
   def jobKey: JobKey
   lazy val callRoot = callPathBuilder(workflowPaths.workflowRoot, jobKey)
@@ -39,6 +41,7 @@ trait JobPaths {
   lazy val stdout = callExecutionRoot.resolve(stdoutFilename)
   lazy val stderr = callExecutionRoot.resolve(stderrFilename)
   lazy val script = callExecutionRoot.resolve(scriptFilename)
+  lazy val dockerCid = callExecutionRoot.resolve(dockerCidFilename)
   lazy val returnCode = callExecutionRoot.resolve(returnCodeFilename)
 
   private lazy val commonMetadataPaths: Map[String, Path] = Map(

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -242,12 +242,15 @@ backend {
         submit = "/bin/bash ${script}"
         submit-docker = """
         docker run \
+          --cidfile ${docker_cid} \
           --rm -i \
           ${"--user " + docker_user} \
           --entrypoint /bin/bash \
           -v ${cwd}:${docker_cwd} \
           ${docker} ${script}
         """
+
+        kill-docker = "docker kill `cat ${docker_cid}`"
 
         # Root directory where Cromwell writes job results.  This directory must be
         # visible and writeable by the Cromwell process as well as the jobs that Cromwell

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigConstants.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigConstants.scala
@@ -12,6 +12,7 @@ object ConfigConstants {
   val SubmitConfig = "submit"
   val SubmitDockerConfig = "submit-docker"
   val KillConfig = "kill"
+  val KillDockerConfig = "kill-docker"
   val CheckAliveConfig = "check-alive"
   val RuntimeAttributesConfig = "runtime-attributes"
   val JobIdRegexConfig = "job-id-regex"
@@ -35,6 +36,7 @@ object ConfigConstants {
   val SubmitTask = "submit"
   val SubmitDockerTask = "submit_docker"
   val KillTask = "kill"
+  val KillDockerTask = "kill_docker"
   val CheckAliveTask = "check_alive"
 
   /*
@@ -44,6 +46,7 @@ object ConfigConstants {
   val JobNameInput = "job_name"
   val CwdInput = "cwd"
   val DockerCwdInput = "docker_cwd"
+  val DockerCidInput = "docker_cid"
   val StdoutInput = "out"
   val StderrInput = "err"
   val ScriptInput = "script"

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigWdlNamespace.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigWdlNamespace.scala
@@ -29,6 +29,9 @@ class ConfigWdlNamespace(backendConfig: Config) {
   private val killCommandOption = backendConfig.as[Option[String]](KillConfig)
   private val killSourceOption = killCommandOption.map(makeWdlSource(KillTask, _, jobIdRuntimeAttributes))
 
+  private val killDockerCommandOption = backendConfig.as[Option[String]](KillDockerConfig)
+  private val killDockerSourceOption = killDockerCommandOption.map(makeWdlSource(KillDockerTask, _, jobIdRuntimeAttributes))
+
   private val checkAliveCommandOption = backendConfig.as[Option[String]](CheckAliveConfig)
   private val checkAliveSourceOption = checkAliveCommandOption.map(makeWdlSource(
     CheckAliveTask, _, jobIdRuntimeAttributes))
@@ -38,6 +41,7 @@ class ConfigWdlNamespace(backendConfig: Config) {
        |${submitSourceOption getOrElse ""}
        |${submitDockerSourceOption getOrElse ""}
        |${killSourceOption getOrElse ""}
+       |${killDockerSourceOption getOrElse ""}
        |${checkAliveSourceOption getOrElse ""}
        |""".stripMargin.trim
 
@@ -97,6 +101,7 @@ object ConfigWdlNamespace {
   private val submitDockerRuntimeAttributes =
     s"""
        |String $DockerCwdInput
+       |String $DockerCidInput
        |""".stripMargin
 
   /**
@@ -105,5 +110,6 @@ object ConfigWdlNamespace {
   private val jobIdRuntimeAttributes =
     s"""
        |String $JobIdInput
+       |String $DockerCidInput
        |""".stripMargin
 }


### PR DESCRIPTION
A different approach to #1126 from that proposed in the ticket.  This records the container ID at `docker run` time and uses that to `docker kill` the process on abort.  