### PR TITLE
Health monitor: Flock of Pregulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A [Workflow Management System](https://en.wikipedia.org/wiki/Workflow_management
   * [GET /api/workflows/:version/callcaching/diff](#get-apiworkflowsversioncallcachingdiff)
   * [GET /engine/:version/stats](#get-engineversionstats)
   * [GET /engine/:version/version](#get-engineversionversion)
+  * [GET /engine/:version/status](#get-engineversionstatus)
   * [Error handling](#error-handling)
 * [Developer](#developer)
   * [Generating table of contents on Markdown files](#generating-table-of-contents-on-markdown-files)
@@ -3989,6 +3990,31 @@ Response:
   "cromwell": 23-8be799a-SNAP
 }
 ```
+
+## GET /engine/:version/status
+
+Cromwell will track the status of underlying systems on which it depends, typically connectivity to the database and to Dockerhub. The `status` endpoint will return the current status of these systems. 
+
+Response:
+
+This endpoint will return an `Internal Server Error` if any systems are marked as failing or `OK` otherwise. The exact response will vary based on what is being monitored but adheres to the following pattern. Each system has a boolean `ok` field and an optional array field named `messages` which will be populated with any known errors if the `ok` status is `false`:
+
+```
+{
+  "System Name 1": {
+    "ok": false,
+    "messages": [
+      "Unknown status"
+    ]
+  },
+  "System Name 2": {
+    "ok": true
+  }
+}
+
+```
+ 
+
 
 ## Error handling
 Requests that Cromwell can't process return a failure in the form of a JSON response respecting the following JSON schema:

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ lazy val gcsFileSystem = (project in file("filesystems/gcs"))
   .withTestSettings
   .dependsOn(core)
   .dependsOn(core % "test->test")
+  .dependsOn(cloudSupport)
+  .dependsOn(cloudSupport % "test->test")
 
 lazy val databaseSql = (project in file("database/sql"))
   .settings(databaseSqlSettings:_*)
@@ -36,6 +38,7 @@ lazy val services = (project in file("services"))
   .dependsOn(core)
   .dependsOn(databaseSql)
   .dependsOn(databaseMigration)
+  .dependsOn(cloudSupport)
   .dependsOn(core % "test->test")
 
 lazy val backendRoot = Path("supportedBackends")
@@ -72,6 +75,7 @@ lazy val jesBackend = (project in backendRoot / "jes")
   .withTestSettings
   .dependsOn(backend)
   .dependsOn(gcsFileSystem)
+  .dependsOn(cloudSupport)
   .dependsOn(backend % "test->test")
   .dependsOn(gcsFileSystem % "test->test")
   .dependsOn(services % "test->test")
@@ -90,6 +94,12 @@ lazy val engine = (project in file("engine"))
   // For now, all the engine tests run on the "Local" backend, an implementation of an impl.sfs.config backend.
   .dependsOn(sfsBackend % "test->compile")
   .dependsOn(gcsFileSystem % "test->test")
+
+lazy val cloudSupport = (project in file("cloudSupport"))
+    .settings(cloudSupportSettings: _*)
+    .withTestSettings
+    .dependsOn(core)
+    .dependsOn(core % "test->test")
 
 lazy val root = (project in file("."))
   .settings(rootSettings: _*)

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/GoogleConfiguration.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/GoogleConfiguration.scala
@@ -1,4 +1,4 @@
-package cromwell.filesystems.gcs
+package cromwell.cloudSupport.gcp
 
 import java.io.IOException
 
@@ -11,8 +11,8 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
 import com.google.api.services.storage.StorageScopes
 import com.typesafe.config.{Config, ConfigException}
-import cromwell.filesystems.gcs.auth.ServiceAccountMode.{JsonFileFormat, PemFileFormat}
-import cromwell.filesystems.gcs.auth._
+import cromwell.cloudSupport.gcp.auth.ServiceAccountMode.{JsonFileFormat, PemFileFormat}
+import cromwell.cloudSupport.gcp.auth._
 import lenthall.exception.MessageAggregation
 import lenthall.validation.ErrorOr._
 import lenthall.validation.Validation._
@@ -127,7 +127,7 @@ object GoogleConfiguration {
       case Invalid(f) =>
         val errorMessages = f.toList.mkString(", ")
         log.error(errorMessages)
-        throw new GoogleConfigurationException(f.toList)
+        throw GoogleConfigurationException(f.toList)
     }
   }
 }

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthMode.scala
@@ -1,10 +1,10 @@
-package cromwell.filesystems.gcs.auth
+package cromwell.cloudSupport.gcp.auth
 
 import java.io.FileNotFoundException
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
-import better.files._
+import better.files.File
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
@@ -13,10 +13,10 @@ import com.google.auth.Credentials
 import com.google.auth.http.HttpTransportFactory
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials, UserCredentials}
 import com.google.cloud.NoCredentials
+import cromwell.cloudSupport.gcp.auth.ServiceAccountMode.{CredentialFileFormat, JsonFileFormat, PemFileFormat}
+import GoogleAuthMode.checkReadable
 import cromwell.core.WorkflowOptions
 import cromwell.core.retry.Retry
-import cromwell.filesystems.gcs.auth.GoogleAuthMode._
-import cromwell.filesystems.gcs.auth.ServiceAccountMode.{CredentialFileFormat, JsonFileFormat, PemFileFormat}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -74,6 +74,8 @@ sealed trait GoogleAuthMode {
   def name: String
   // Create a Credential object from the google.api.client.auth library (https://github.com/google/google-api-java-client)
   def credential(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials]
+
+  def credential()(implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials] = credential(WorkflowOptions.empty)
 
   def requiresAuthFile: Boolean = false
 

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthMode.scala
@@ -75,8 +75,6 @@ sealed trait GoogleAuthMode {
   // Create a Credential object from the google.api.client.auth library (https://github.com/google/google-api-java-client)
   def credential(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials]
 
-  def credential()(implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials] = credential(WorkflowOptions.empty)
-
   def requiresAuthFile: Boolean = false
 
   protected def validateCredential(credential: Credentials) = {

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
@@ -17,11 +17,9 @@ object GcsStorage {
   val JsonFactory = JacksonFactory.getDefaultInstance
   val HttpTransport = GoogleNetHttpTransport.newTrustedTransport
 
-  private[this] lazy val UploadBufferBytes = {
-    ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
-  }
-
   val DefaultCloudStorageConfiguration = {
+    val UploadBufferBytes = ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
+    
     CloudStorageConfiguration.builder()
       .blockSize(UploadBufferBytes)
       .permitEmptyPathComponents(true)

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
@@ -1,0 +1,58 @@
+package cromwell.cloudSupport.gcp.gcs
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.googleapis.media.MediaHttpUploader
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.gax.retrying.RetrySettings
+import com.google.cloud.storage.StorageOptions
+import com.google.api.services.storage.Storage
+import com.google.auth.Credentials
+import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
+import com.typesafe.config.ConfigFactory
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.http.GoogleHttpTransportOptions.TransportOptions
+import net.ceedubs.ficus.Ficus._
+
+object GcsStorage {
+  val JsonFactory = JacksonFactory.getDefaultInstance
+  val HttpTransport = GoogleNetHttpTransport.newTrustedTransport
+
+  private[this] lazy val UploadBufferBytes = {
+    ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
+  }
+
+  val DefaultCloudStorageConfiguration = {
+    CloudStorageConfiguration.builder()
+      .blockSize(UploadBufferBytes)
+      .permitEmptyPathComponents(true)
+      .stripPrefixSlash(true)
+      .usePseudoDirectories(true)
+      .build()
+  }
+
+  def gcsStorage(applicationName: String,
+                 storageOptions: StorageOptions): Storage = {
+    new Storage.Builder(HttpTransport,
+      JsonFactory,
+      GoogleConfiguration.withCustomTimeouts(TransportOptions.getHttpRequestInitializer(storageOptions)))
+      .setApplicationName(applicationName)
+      .build()
+  }
+
+  def gcsStorage(applicationName: String, credentials: Credentials): Storage = {
+    gcsStorage(applicationName, gcsStorageOptions(credentials))
+  }
+
+  def gcsStorageOptions(credentials: Credentials,
+                        project: Option[String] = None,
+                        retrySettings: Option[RetrySettings] = None): StorageOptions = {
+    val storageOptionsBuilder = StorageOptions.newBuilder()
+      .setTransportOptions(TransportOptions)
+      .setCredentials(credentials)
+
+    retrySettings foreach storageOptionsBuilder.setRetrySettings
+    project map storageOptionsBuilder.setProjectId
+
+    storageOptionsBuilder.build()
+  }
+}

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
@@ -51,7 +51,7 @@ object GcsStorage {
       .setCredentials(credentials)
 
     retrySettings foreach storageOptionsBuilder.setRetrySettings
-    project map storageOptionsBuilder.setProjectId
+    project foreach storageOptionsBuilder.setProjectId
 
     storageOptionsBuilder.build()
   }

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/gcs/GcsStorage.scala
@@ -19,7 +19,7 @@ object GcsStorage {
 
   val DefaultCloudStorageConfiguration = {
     val UploadBufferBytes = ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
-    
+
     CloudStorageConfiguration.builder()
       .blockSize(UploadBufferBytes)
       .permitEmptyPathComponents(true)

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/genomics/GenomicsFactory.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/genomics/GenomicsFactory.scala
@@ -1,4 +1,4 @@
-package cromwell.backend.impl.jes
+package cromwell.cloudSupport.gcp.genomics
 
 import java.net.URL
 
@@ -6,11 +6,10 @@ import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
 import com.google.api.services.genomics.Genomics
 import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
-import cromwell.filesystems.gcs.auth.GoogleAuthMode
+import cromwell.cloudSupport.gcp.auth.GoogleAuthMode
 
 
 case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, endpointUrl: URL) {
-
   def fromCredentials(credentials: Credentials) = {
     val httpRequestInitializer = {
       val delegate = new HttpCredentialsAdapter(credentials)

--- a/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/http/GoogleHttpTransportOptions.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudSupport/gcp/http/GoogleHttpTransportOptions.scala
@@ -1,0 +1,10 @@
+package cromwell.cloudSupport.gcp.http
+
+import com.google.cloud.http.HttpTransportOptions
+import scala.concurrent.duration._
+
+object GoogleHttpTransportOptions {
+  val TransportOptions = HttpTransportOptions.newBuilder()
+    .setReadTimeout(3.minutes.toMillis.toInt)
+    .build()
+}

--- a/cloudSupport/src/test/scala/cromwell/cloudSupport/gcp/GoogleConfigurationSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudSupport/gcp/GoogleConfigurationSpec.scala
@@ -1,10 +1,10 @@
-package cromwell.filesystems.gcs
+package cromwell.cloudSupport.gcp
 
 import better.files.File
 import com.typesafe.config.{ConfigException, ConfigFactory}
-import cromwell.filesystems.gcs.GoogleConfiguration.GoogleConfigurationException
-import cromwell.filesystems.gcs.auth.ServiceAccountMode.{JsonFileFormat, PemFileFormat}
-import cromwell.filesystems.gcs.auth.{ApplicationDefaultMode, RefreshTokenMode, ServiceAccountMode, UserMode}
+import cromwell.cloudSupport.gcp.GoogleConfiguration.GoogleConfigurationException
+import cromwell.cloudSupport.gcp.auth.ServiceAccountMode.{JsonFileFormat, PemFileFormat}
+import cromwell.cloudSupport.gcp.auth.{ApplicationDefaultMode, RefreshTokenMode, ServiceAccountMode, UserMode}
 import org.scalatest.{FlatSpec, Matchers}
 
 

--- a/cloudSupport/src/test/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudSupport/gcp/auth/GoogleAuthModeSpec.scala
@@ -1,4 +1,4 @@
-package cromwell.filesystems.gcs.auth
+package cromwell.cloudSupport.gcp.auth
 
 import com.google.auth.oauth2.GoogleCredentials
 import org.scalatest.Assertions._

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -59,6 +59,17 @@ akka {
       executor = "fork-join-executor"
     }
 
+    # A dispatcher to bulkhead the health monitor from the rest of the system. Sets throughput low in order to
+    # ensure the monitor is fairly low priority
+    health-monitor-dispatcher {
+      type = Dispatcher
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        fixed-pool-size = 4
+      }
+
+      throughput = 1
+    }
     # Note that without further configuration, all other actors run on the default dispatcher
   }
 
@@ -313,6 +324,17 @@ services {
       # with no new events being generated. The default value is currently 5 seconds
       # db-flush-rate = 5 seconds
     }
+  }
+  HealthMonitor {
+    class = "cromwell.services.healthmonitor.impl.standard.StandardHealthMonitorServiceActor"
+    # Override the standard dispatcher. In particular this one has a low throughput so as to be lower in priority
+    dispatcher = "akka.dispatchers.health-monitor-dispatcher"
+    # How long to wait between status check sweeps
+    # check-refresh-time = 5 minutes
+    # For any given status check, how long to wait before assuming failure
+    # check-timeout = 1 minute
+    # For any given status datum, the maximum time a value will be kept before reverting back to "Unknown"
+    # status-ttl = 15 minutes
   }
 }
 

--- a/core/src/main/scala/cromwell/core/docker/DockerCliClient.scala
+++ b/core/src/main/scala/cromwell/core/docker/DockerCliClient.scala
@@ -1,4 +1,4 @@
-package cromwell.docker.local
+package cromwell.core.docker
 
 import scala.util.Try
 
@@ -36,6 +36,10 @@ trait DockerCliClient {
     forRun("docker", "pull", dockerCliKey.fullName) { _ => () }
   }
 
+  def rmi(dockerCliKey: DockerCliKey): Try[Unit] = {
+    forRun("docker", "rmi", dockerCliKey.fullName) { _ => () }
+  }
+
   /**
     * Tries to run the command, then feeds the stdout to `f`. If the exit code is non-zero, returns a `Failure` with
     * a `RuntimeException` containing the stderr.
@@ -66,7 +70,7 @@ trait DockerCliClient {
     * @param cmd The command to run.
     * @return The results of the run wrapped in a DockerCliResult.
     */
-  private[local] def run(cmd: Seq[String]): DockerCliResult = {
+  private[docker] def run(cmd: Seq[String]): DockerCliResult = {
     import sys.process._
     var stdout = List.empty[String]
     var stderr = List.empty[String]
@@ -79,7 +83,7 @@ trait DockerCliClient {
     * @param hashLine The line output by the stdout of the `lookupHash` command.
     * @return An optional `DockerCliHash`, if the all the columns are found.
     */
-  private[local] def parseHashLine(hashLine: String): Option[DockerCliHash] = {
+  private def parseHashLine(hashLine: String): Option[DockerCliHash] = {
     val none = "<none>"
     val tokens = hashLine.split("\t").lift
     for {

--- a/core/src/main/scala/cromwell/core/docker/DockerCliKey.scala
+++ b/core/src/main/scala/cromwell/core/docker/DockerCliKey.scala
@@ -1,4 +1,4 @@
-package cromwell.docker.local
+package cromwell.core.docker
 
 /**
   * Used by the docker cli for lookups or pulls.

--- a/core/src/test/scala/cromwell/core/docker/DockerCliClientSpec.scala
+++ b/core/src/test/scala/cromwell/core/docker/DockerCliClientSpec.scala
@@ -1,4 +1,4 @@
-package cromwell.docker.local
+package cromwell.core.docker
 
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpecLike, Matchers}
@@ -50,5 +50,5 @@ class DockerCliClientSpec extends FlatSpecLike with Matchers with TableDrivenPro
 }
 
 class TestDockerCliClient(dockerCliResult: DockerCliResult) extends DockerCliClient {
-  override private[local] def run(cmd: Seq[String]) = dockerCliResult
+  override private[docker] def run(cmd: Seq[String]) = dockerCliResult
 }

--- a/dockerHashing/src/main/scala/cromwell/docker/local/DockerCliFlow.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/local/DockerCliFlow.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeoutException
 import akka.actor.Scheduler
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition}
 import akka.stream.FlowShape
+import cromwell.core.docker.{DockerCliClient, DockerCliKey}
 import cromwell.docker.DockerHashActor._
 import cromwell.docker.{DockerFlow, DockerHashActor, DockerHashResult, DockerImageIdentifierWithoutHash}
 

--- a/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
@@ -6,10 +6,11 @@ import cats.instances.future._
 import cats.instances.list._
 import cats.syntax.traverse._
 import com.typesafe.config.{Config, ConfigFactory}
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.auth.GoogleAuthMode
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.auth.GoogleAuthMode
-import cromwell.filesystems.gcs.{GcsPathBuilderFactory, GoogleConfiguration}
+import cromwell.filesystems.gcs.GcsPathBuilderFactory
 import lenthall.exception.MessageAggregation
 import lenthall.validation.ErrorOr.ErrorOr
 import net.ceedubs.ficus.Ficus._
@@ -46,5 +47,4 @@ object EngineFilesystems {
     case Success(maybeBuilderFactory) => maybeBuilderFactory.toList.traverse(_.withOptions(workflowOptions)).map(_ ++ defaultFileSystem)
     case Failure(failure) => Future.failed(failure)
   }
-
 }

--- a/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
@@ -7,10 +7,11 @@ import akka.stream._
 import akka.stream.scaladsl.{Flow, GraphDSL, MergePreferred, Partition}
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.gcs.GcsStorage
 import cromwell.engine.io.IoActor
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.engine.io.gcs.GcsBatchFlow.BatchFailedException
-import cromwell.filesystems.gcs.{GcsPathBuilder, GoogleConfiguration}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,7 +38,7 @@ class GcsBatchFlow(batchSize: Int, scheduler: Scheduler)(implicit ec: ExecutionC
     }
   }
   
-  private val batch: BatchRequest = new BatchRequest(GcsPathBuilder.HttpTransport, httpRequestInitializer)
+  private val batch: BatchRequest = new BatchRequest(GcsStorage.HttpTransport, httpRequestInitializer)
   
   val flow = GraphDSL.create() { implicit builder =>
     import GraphDSL.Implicits._

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -32,6 +32,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffAct
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheDiffActor, CallCacheDiffQueryParameter}
 import cromwell.engine.workflow.workflowstore.WorkflowStoreEngineActor.WorkflowStoreEngineAbortResponse
 import cromwell.server.CromwellShutdown
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.{GetCurrentStatus, StatusCheckResponse}
 import cromwell.webservice.LabelsManagerActor._
 import lenthall.exception.AggregatedMessageException
 import spray.json.JsObject
@@ -63,9 +64,16 @@ trait CromwellApiService {
         }
       }
     },
-
     path("engine" / Segment / "version") { version =>
       get { complete(versionResponse) }
+    },
+    path("engine" / Segment / "status") { version =>
+      onComplete(serviceRegistryActor.ask(GetCurrentStatus).mapTo[StatusCheckResponse]) {
+        case Success(status) =>
+          val httpCode = if (status.ok) StatusCodes.OK else StatusCodes.InternalServerError
+          complete((httpCode, status.systems))
+        case Failure(_) => new RuntimeException("Unable to gather engine status").failRequest(StatusCodes.InternalServerError)
+      }
     }
   )
 

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -10,6 +10,7 @@ import MetadataService._
 import cromwell.util.JsonFormatting.WdlValueJsonFormatter
 import WdlValueJsonFormatter._
 import better.files.File
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.{StatusCheckResponse, SubsystemStatus}
 import cromwell.webservice.CromwellApiService.BackendResponse
 import cromwell.webservice.metadata.MetadataBuilderActor.BuiltMetadataResponse
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
@@ -25,6 +26,8 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val BuiltStatusResponseFormat = jsonFormat1(BuiltMetadataResponse)
   implicit val callAttempt = jsonFormat2(CallAttempt)
   implicit val workflowSourceData = jsonFormat6(WorkflowSourceFilesWithoutImports)
+  implicit val subsystemStatusFormat = jsonFormat2(SubsystemStatus)
+  implicit val statusCheckResponseFormat = jsonFormat2(StatusCheckResponse)
 
   implicit object fileJsonFormat extends RootJsonFormat[File] {
     override def write(obj: File) = JsString(obj.path.toAbsolutePath.toString)

--- a/engine/src/test/scala/cromwell/engine/io/IoActorGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorGcsBatchSpec.scala
@@ -4,10 +4,10 @@ import java.util.UUID
 
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestActorRef}
+import cromwell.cloudSupport.gcp.auth.ApplicationDefaultMode
 import cromwell.core.Tags.IntegrationTest
 import cromwell.core.io._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.auth.ApplicationDefaultMode
 import cromwell.filesystems.gcs.batch.{GcsBatchCopyCommand, GcsBatchCrc32Command, GcsBatchDeleteCommand, GcsBatchSizeCommand}
 import cromwell.filesystems.gcs.{GcsPathBuilder, GcsPathBuilderFactory}
 import org.scalatest.concurrent.Eventually

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -1,39 +1,20 @@
 package cromwell.filesystems.gcs
 
 import akka.actor.ActorSystem
-import com.google.api.client.googleapis.media.MediaHttpUploader
 import com.google.api.gax.retrying.RetrySettings
 import com.google.auth.Credentials
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
-import com.typesafe.config.ConfigFactory
+import cromwell.cloudSupport.gcp.auth.GoogleAuthMode
+import cromwell.cloudSupport.gcp.gcs.GcsStorage
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.PathBuilderFactory
-import cromwell.filesystems.gcs.auth.GoogleAuthMode
-import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.ExecutionContext
 
-object GcsPathBuilderFactory {
-
-  private[this] lazy val UploadBufferBytes = {
-    ConfigFactory.load().as[Option[Int]]("google.upload-buffer-bytes").getOrElse(MediaHttpUploader.MINIMUM_CHUNK_SIZE)
-  }
-
-  val DefaultCloudStorageConfiguration = {
-    CloudStorageConfiguration.builder()
-      .blockSize(UploadBufferBytes)
-      .permitEmptyPathComponents(true)
-      .stripPrefixSlash(true)
-      .usePseudoDirectories(true)
-      .build()
-  }
-}
-
-case class GcsPathBuilderFactory(authMode: GoogleAuthMode,
-                                 applicationName: String,
-                                 retrySettings: Option[RetrySettings] = None,
-                                 cloudStorageConfiguration: CloudStorageConfiguration = GcsPathBuilderFactory.DefaultCloudStorageConfiguration)
-
+final case class GcsPathBuilderFactory(authMode: GoogleAuthMode,
+                                       applicationName: String,
+                                       retrySettings: Option[RetrySettings] = None,
+                                       cloudStorageConfiguration: CloudStorageConfiguration = GcsStorage.DefaultCloudStorageConfiguration)
   extends PathBuilderFactory {
 
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -2,9 +2,9 @@ package cromwell.filesystems.gcs
 
 import com.google.cloud.NoCredentials
 import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
+import cromwell.cloudSupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.path._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{FlatSpecLike, Matchers}
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   lazy val lenthallV = "0.27"
   lazy val wdl4sV = "0.16-8e70bee-SNAP"
 
-  lazy val akkaV = "2.5.3"
+  lazy val akkaV = "2.5.4"
   lazy val akkaHttpV = "10.0.9"
 
   lazy val slickV = "3.2.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -203,6 +203,11 @@ object Settings {
     libraryDependencies ++= engineDependencies
   ) ++ commonSettings ++ versionConfCompileSettings
 
+  val cloudSupportSettings = List(
+    name := "cromwell-cloud-support",
+    libraryDependencies ++= gcsFileSystemDependencies
+  ) ++ commonSettings
+
   val rootSettings = List(
     name := "cromwell",
     libraryDependencies ++= rootDependencies

--- a/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
@@ -88,10 +88,10 @@ object HealthMonitorServiceActor {
   private case object CheckTickKey
 
   val OkStatus = SubsystemStatus(true, None)
-  val UnknownStatus = SubsystemStatus(false, Some(List("Unknown status")))
-  def failedStatus(message: String) = SubsystemStatus(false, Some(List(message)))
+  val UnknownStatus = SubsystemStatus(false, Option(List("Unknown status")))
+  def failedStatus(message: String) = SubsystemStatus(false, Option(List(message)))
 
-  final case class MonitoredSubsystem(name: String, check: () => Future[SubsystemStatus])
+  final case class MonitoredSubsystem(name: String, check: Unit => Future[SubsystemStatus])
   final case class SubsystemStatus(ok: Boolean, messages: Option[List[String]])
   final case class CachedSubsystemStatus(status: SubsystemStatus, created: Long) // created is time in millis when status was captured
 

--- a/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
@@ -83,7 +83,7 @@ trait HealthMonitorServiceActor extends Actor with LazyLogging with Timers {
 object HealthMonitorServiceActor {
   val DefaultFutureTimeout: FiniteDuration = 1 minute
   val DefaultStaleThreshold: FiniteDuration = 15 minutes
-  val DefaultSweepTime: FiniteDuration = 5 minutes
+  val DefaultSweepTime: FiniteDuration = 1 minute // 5 minutes
 
   private case object CheckTickKey
 

--- a/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/HealthMonitorServiceActor.scala
@@ -1,0 +1,119 @@
+package cromwell.services.healthmonitor
+
+import java.util.concurrent.TimeoutException
+
+import akka.actor.{Actor, Scheduler, Timers}
+import akka.pattern.{after, pipe}
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+import scala.language.postfixOps
+import HealthMonitorServiceActor._
+import com.typesafe.config.Config
+import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
+import net.ceedubs.ficus.Ficus._
+
+trait HealthMonitorServiceActor extends Actor with LazyLogging with Timers {
+  val serviceConfig: Config
+  def subsystems: List[MonitoredSubsystem]
+
+  implicit val ec: ExecutionContext = context.system.dispatcher
+
+  lazy val futureTimeout: FiniteDuration = serviceConfig.as[Option[FiniteDuration]]("services.HealthMonitor.check-timeout").getOrElse(DefaultFutureTimeout)
+  lazy val staleThreshold: FiniteDuration = serviceConfig.as[Option[FiniteDuration]]("services.HealthMonitor.status-ttl").getOrElse(DefaultStaleThreshold)
+
+  override def preStart(): Unit = {
+    val sweepTime = serviceConfig.as[Option[FiniteDuration]]("services.HealthMonitor.check-refresh-time").getOrElse(DefaultSweepTime)
+    timers.startPeriodicTimer(CheckTickKey, CheckAll, sweepTime)
+    logger.info("Starting health monitor with the following checks: " + subsystems.map(_.name).mkString(", "))
+  }
+
+  /**
+    * Contains each subsystem status along with a timestamp of when the entry was made so we know when the status
+    * goes stale. Initialized with unknown status.
+    */
+  private var data: Map[MonitoredSubsystem, CachedSubsystemStatus] = {
+    val now = System.currentTimeMillis
+    subsystems.map((_, CachedSubsystemStatus(UnknownStatus, now))).toMap
+  }
+
+  override def receive: Receive = {
+    case CheckAll => subsystems.foreach(checkSubsystem)
+    case Store(subsystem, status) => store(subsystem, status)
+    case GetCurrentStatus => sender ! getCurrentStatus
+    case ShutdownCommand => context.stop(self) // Not necessary but service registry requires it. See #2575
+  }
+
+  private def checkSubsystem(subsystem: MonitoredSubsystem): Unit = {
+    val result = subsystem.check()
+    val errMsg = s"Timed out after ${futureTimeout.toString} waiting for a response from ${subsystem.toString}"
+    result.withTimeout(futureTimeout, errMsg, context.system.scheduler)
+      .recover { case NonFatal(ex) =>
+        failedStatus(ex.getMessage)
+      } map {
+      Store(subsystem, _)
+    } pipeTo self
+
+    ()
+  }
+
+  private def store(subsystem: MonitoredSubsystem, status: SubsystemStatus): Unit = {
+    data = data + ((subsystem, CachedSubsystemStatus(status, System.currentTimeMillis)))
+    logger.debug(s"New health monitor state: $data")
+  }
+
+  private def getCurrentStatus: StatusCheckResponse = {
+    val now = System.currentTimeMillis()
+    // Convert any expired statuses to unknown
+    val processed = data map {
+      case (s, c) if now - c.created > staleThreshold.toMillis => s.name -> UnknownStatus
+      case (s, c) => s.name -> c.status
+    }
+
+    // overall status is ok iff all subsystems are ok
+    val overall = processed.forall(_._2.ok)
+    
+    StatusCheckResponse(overall, processed)
+  }
+}
+
+object HealthMonitorServiceActor {
+  val DefaultFutureTimeout: FiniteDuration = 1 minute
+  val DefaultStaleThreshold: FiniteDuration = 15 minutes
+  val DefaultSweepTime: FiniteDuration = 5 minutes
+
+  private case object CheckTickKey
+
+  val OkStatus = SubsystemStatus(true, None)
+  val UnknownStatus = SubsystemStatus(false, Some(List("Unknown status")))
+  def failedStatus(message: String) = SubsystemStatus(false, Some(List(message)))
+
+  final case class MonitoredSubsystem(name: String, check: () => Future[SubsystemStatus])
+  final case class SubsystemStatus(ok: Boolean, messages: Option[List[String]])
+  final case class CachedSubsystemStatus(status: SubsystemStatus, created: Long) // created is time in millis when status was captured
+
+  sealed abstract class HealthMonitorServiceActorRequest
+  case object CheckAll extends HealthMonitorServiceActorRequest
+  final case class Store(subsystem: MonitoredSubsystem, status: SubsystemStatus) extends HealthMonitorServiceActorRequest
+  case object GetCurrentStatus extends HealthMonitorServiceActorRequest with ServiceRegistryMessage { override val serviceName = "HealthMonitor" }
+
+  sealed abstract class HealthMonitorServiceActorResponse
+  final case class StatusCheckResponse(ok: Boolean, systems: Map[String, SubsystemStatus]) extends HealthMonitorServiceActorResponse
+
+  /**
+    * Adds non-blocking timeout support to futures.
+    * Example usage:
+    * {{{
+    *   val future = Future(Thread.sleep(1000*60*60*24*365)) // 1 year
+    *   Await.result(future.withTimeout(5 seconds, "Timed out"), 365 days)
+    *   // returns in 5 seconds
+    * }}}
+    */
+  private implicit class FutureWithTimeout[A](f: Future[A]) {
+    def withTimeout(duration: FiniteDuration, errMsg: String, scheduler: Scheduler)(implicit ec: ExecutionContext): Future[A] =
+      Future.firstCompletedOf(List(f, after(duration, scheduler)(Future.failed(new TimeoutException(errMsg)))))
+  }
+}

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
@@ -17,23 +17,33 @@ trait CommonMonitoredSubsystems {
     * order to ensure that subsequent attempts aren't showing a false positive
     */
   private def checkDockerhub(): Future[SubsystemStatus] = {
-    Future {
+    println("DOCKER")
+ //   Future {
       // Using a tiny docker image the user is very unlikely to be actively using
+      println("YO")
       val alpine = DockerCliKey("alpine", "latest") // FIXME: make a clone of alpine in our dockerhub and use that
+      println("HO")
 
-      val res = for {
-        p <- DockerCliClient.pull(alpine)
-        r <- DockerCliClient.rmi(alpine)
-      } yield r
+    val res = DockerCliClient.pull(alpine) flatMap { _ => DockerCliClient.rmi(alpine) }
 
-      res.get
-    } map { _ => OkStatus }
+//      val res = for {
+//        p <- DockerCliClient.pull(alpine)
+//        r <- DockerCliClient.rmi(alpine)
+//      } yield r
+
+      println("FOO: " + res)
+
+//      res.get
+ //   } map { _ => OkStatus }
+
+    Future.fromTry(res) map { _ => OkStatus }
   }
 
   /**
     * Demonstrates connectivity to the engine database by periodically making a small query
     */
   private def checkEngineDb(): Future[SubsystemStatus] = {
+    println("DB")
     EngineServicesStore.engineDatabaseInterface.queryDockerHashStoreEntries("DOESNOTEXIST") map { _ => OkStatus }
   }
 }

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
@@ -1,0 +1,39 @@
+package cromwell.services.healthmonitor.impl
+
+import cromwell.core.docker.{DockerCliClient, DockerCliKey}
+import cromwell.services.EngineServicesStore
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.{MonitoredSubsystem, OkStatus, SubsystemStatus}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait CommonMonitoredSubsystems {
+  implicit val ec: ExecutionContext
+
+  lazy val DockerHub = MonitoredSubsystem("DockerHub", checkDockerhub _)
+  lazy val EngineDb = MonitoredSubsystem("Engine Database", checkEngineDb _)
+
+  /**
+    * Demonstrates connectivity to DockerHub by periodically pulling a small image. Remove the image afterwards in
+    * order to ensure that subsequent attempts aren't showing a false positive
+    */
+  private def checkDockerhub(): Future[SubsystemStatus] = {
+    Future {
+      // Using a tiny docker image the user is very unlikely to be actively using
+      val alpine = DockerCliKey("alpine", "latest") // FIXME: make a clone of alpine in our dockerhub and use that
+
+      val res = for {
+        p <- DockerCliClient.pull(alpine)
+        r <- DockerCliClient.rmi(alpine)
+      } yield r
+
+      res.get
+    } map { _ => OkStatus }
+  }
+
+  /**
+    * Demonstrates connectivity to the engine database by periodically making a small query
+    */
+  private def checkEngineDb(): Future[SubsystemStatus] = {
+    EngineServicesStore.engineDatabaseInterface.queryDockerHashStoreEntries("DOESNOTEXIST") map { _ => OkStatus }
+  }
+}

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/CommonMonitoredSubsystems.scala
@@ -4,6 +4,9 @@ import cromwell.core.docker.{DockerCliClient, DockerCliKey}
 import cromwell.services.EngineServicesStore
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.{MonitoredSubsystem, OkStatus, SubsystemStatus}
 
+import cats.instances.future._
+import cats.syntax.functor._
+
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -30,7 +33,7 @@ trait CommonMonitoredSubsystems {
       } yield r
 
       res.get
-    } map { _ => OkStatus }
+    } as OkStatus
 
   }
 
@@ -38,6 +41,6 @@ trait CommonMonitoredSubsystems {
     * Demonstrates connectivity to the engine database by periodically making a small query
     */
   private def checkEngineDb(): Future[SubsystemStatus] = {
-    EngineServicesStore.engineDatabaseInterface.queryDockerHashStoreEntries("DOESNOTEXIST") map { _ => OkStatus }
+    EngineServicesStore.engineDatabaseInterface.queryDockerHashStoreEntries("DOESNOTEXIST") as OkStatus
   }
 }

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/noop/NoopHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/noop/NoopHealthMonitorServiceActor.scala
@@ -1,0 +1,13 @@
+package cromwell.services.healthmonitor.impl.noop
+
+import com.typesafe.config.Config
+import cromwell.services.healthmonitor.HealthMonitorServiceActor
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.MonitoredSubsystem
+
+/**
+  * A health monitor which performs no checks
+  */
+class NoopHealthMonitorServiceActor (val serviceConfig: Config, globalConfig: Config)
+  extends HealthMonitorServiceActor {
+  override val subsystems: List[MonitoredSubsystem] = List.empty[MonitoredSubsystem]
+}

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/standard/StandardHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/standard/StandardHealthMonitorServiceActor.scala
@@ -1,0 +1,15 @@
+package cromwell.services.healthmonitor.impl.standard
+
+import com.typesafe.config.Config
+import cromwell.services.healthmonitor.HealthMonitorServiceActor
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.MonitoredSubsystem
+import cromwell.services.healthmonitor.impl.CommonMonitoredSubsystems
+
+/**
+  * A health monitor implementation which only monitors things available to out of the box Cromwell installations
+  */
+class StandardHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
+  extends HealthMonitorServiceActor
+    with CommonMonitoredSubsystems {
+  override lazy val subsystems: List[MonitoredSubsystem] = List(DockerHub, EngineDb)
+}

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -7,6 +7,7 @@ import com.typesafe.config.Config
 import cromwell.cloudSupport.gcp.GoogleConfiguration
 import cromwell.cloudSupport.gcp.gcs.GcsStorage
 import cromwell.cloudSupport.gcp.genomics.GenomicsFactory
+import cromwell.core.WorkflowOptions
 import cromwell.services.healthmonitor.HealthMonitorServiceActor
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.{MonitoredSubsystem, OkStatus, SubsystemStatus}
 import cromwell.services.healthmonitor.impl.CommonMonitoredSubsystems
@@ -40,7 +41,7 @@ class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig
     val rootExecutionBucket = papiConfig.as[String]("root").replace("gs://", "")
 
     val cred = googleConfig.auth(gcsAuthName) match {
-      case Valid(a) => a.credential
+      case Valid(a) => a.credential(WorkflowOptions.empty)
       case Invalid(e) => throw new IllegalArgumentException("Unable to configure WorkbenchHealthMonitor: " + e.toList.mkString(", "))
     }
 
@@ -61,7 +62,7 @@ class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig
     }
 
     val genomicsFactory = GenomicsFactory(googleConfig.applicationName, papiAuthMode, endpointUrl)
-    val genomicsInterface = papiAuthMode.credential() map genomicsFactory.fromCredentials
+    val genomicsInterface = papiAuthMode.credential(WorkflowOptions.empty) map genomicsFactory.fromCredentials
 
     genomicsInterface map { gi =>
       gi.pipelines().list().setProjectId(papiProjectId).setPageSize(1).execute()

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
   extends HealthMonitorServiceActor
     with CommonMonitoredSubsystems {
-  implicit val as = context.system
+  implicit val actorSystem = context.system
 
   override lazy val subsystems: List[MonitoredSubsystem] = List(DockerHub, EngineDb, Papi, Gcs)
 

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -1,0 +1,70 @@
+package cromwell.services.healthmonitor.impl.workbench
+
+import java.net.URL
+
+import cats.data.Validated.{Invalid, Valid}
+import com.typesafe.config.Config
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.gcs.GcsStorage
+import cromwell.cloudSupport.gcp.genomics.GenomicsFactory
+import cromwell.services.healthmonitor.HealthMonitorServiceActor
+import cromwell.services.healthmonitor.HealthMonitorServiceActor.{MonitoredSubsystem, OkStatus, SubsystemStatus}
+import cromwell.services.healthmonitor.impl.CommonMonitoredSubsystems
+import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.Future
+
+/**
+  * A health monitor implementation which will monitor external services used in the Workbench ecosystem, such
+  * as GCS and PAPI
+  */
+class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
+  extends HealthMonitorServiceActor
+    with CommonMonitoredSubsystems {
+  implicit val as = context.system
+
+  override lazy val subsystems: List[MonitoredSubsystem] = List(DockerHub, EngineDb, Papi, Gcs)
+
+  private lazy val Gcs = MonitoredSubsystem("GCS", checkGcs _)
+  private lazy val Papi = MonitoredSubsystem("PAPI", checkPapi _)
+
+  val googleConfig = GoogleConfiguration(globalConfig)
+  val papiBackendName = serviceConfig.as[Option[String]]("services.HealthMonitor.PapiBackendName").getOrElse("Jes")
+  val papiConfig: Config = globalConfig.as[Config]("backend.providers.Jes.config")
+
+  /**
+    * Demonstrates connectivity to GCS by stat-ing the root execution bucket for Cromwell
+    */
+  private def checkGcs(): Future[SubsystemStatus] = {
+    val gcsAuthName = papiConfig.as[String]("filesystems.gcs.auth")
+    val rootExecutionBucket = papiConfig.as[String]("root").replace("gs://", "")
+
+    val cred = googleConfig.auth(gcsAuthName) match {
+      case Valid(a) => a.credential
+      case Invalid(e) => throw new IllegalArgumentException("Unable to configure WorkbenchHealthMonitor: " + e.toList.mkString(", "))
+    }
+
+    val storage = cred map { c => GcsStorage.gcsStorage(googleConfig.applicationName, c) }
+    storage map { _.buckets.get(rootExecutionBucket).execute() } map { _ => OkStatus }
+  }
+
+  /**
+    * Demonstrates connectivity to Google Pipelines API (PAPI) by making sure it can access an authenticated endpoint
+    */
+  private def checkPapi(): Future[SubsystemStatus] = {
+    val endpointUrl = new URL(papiConfig.as[String]("genomics.endpoint-url"))
+    val papiProjectId = papiConfig.as[String]("project")
+    val papiAuthName = papiConfig.as[String]("genomics.auth")
+    val papiAuthMode = googleConfig.auth(papiAuthName) match {
+      case Valid(a) => a
+      case Invalid(e) => throw new IllegalArgumentException("Unable to configure WorkbenchHealthMonitor: " + e.toList.mkString(", "))
+    }
+
+    val genomicsFactory = GenomicsFactory(googleConfig.applicationName, papiAuthMode, endpointUrl)
+    val genomicsInterface = papiAuthMode.credential() map genomicsFactory.fromCredentials
+
+    genomicsInterface map { gi =>
+      gi.pipelines().list().setProjectId(papiProjectId).setPageSize(1).execute()
+    } map { _ => OkStatus }
+  }
+}

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -13,6 +13,9 @@ import cromwell.services.healthmonitor.HealthMonitorServiceActor.{MonitoredSubsy
 import cromwell.services.healthmonitor.impl.CommonMonitoredSubsystems
 import net.ceedubs.ficus.Ficus._
 
+import cats.instances.future._
+import cats.syntax.functor._
+
 import scala.concurrent.Future
 
 /**
@@ -46,7 +49,7 @@ class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig
     }
 
     val storage = cred map { c => GcsStorage.gcsStorage(googleConfig.applicationName, c) }
-    storage map { _.buckets.get(rootExecutionBucket).execute() } map { _ => OkStatus }
+    storage map { _.buckets.get(rootExecutionBucket).execute() } as OkStatus
   }
 
   /**
@@ -64,8 +67,6 @@ class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig
     val genomicsFactory = GenomicsFactory(googleConfig.applicationName, papiAuthMode, endpointUrl)
     val genomicsInterface = papiAuthMode.credential(WorkflowOptions.empty) map genomicsFactory.fromCredentials
 
-    genomicsInterface map { gi =>
-      gi.pipelines().list().setProjectId(papiProjectId).setPageSize(1).execute()
-    } map { _ => OkStatus }
+    genomicsInterface map { _.pipelines().list().setProjectId(papiProjectId).setPageSize(1).execute() } as OkStatus
   }
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -54,12 +54,12 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config)
   val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate), "WriteMetadataActor")
   implicit val ec = context.dispatcher
   private var summaryRefreshCancellable: Option[Cancellable] = None
-  
+
   summaryActor foreach { _ => self ! RefreshSummary }
 
   private def scheduleSummary(): Unit = {
     MetadataSummaryRefreshInterval foreach { interval =>
-      summaryRefreshCancellable = Option(context.system.scheduler.scheduleOnce(interval, self, RefreshSummary)(context.dispatcher, self)) 
+      summaryRefreshCancellable = Option(context.system.scheduler.scheduleOnce(interval, self, RefreshSummary)(context.dispatcher, self))
     }
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAttributes.scala
@@ -8,7 +8,7 @@ import cats.syntax.validated._
 import com.typesafe.config.{Config, ConfigValue}
 import cromwell.backend.impl.jes.authentication.JesAuths
 import cromwell.backend.impl.jes.callcaching.{CopyCachedOutputs, JesCacheHitDuplicationStrategy, UseOriginalCachedOutputs}
-import cromwell.filesystems.gcs.GoogleConfiguration
+import cromwell.cloudSupport.gcp.GoogleConfiguration
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import lenthall.exception.MessageAggregation

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
@@ -2,8 +2,10 @@ package cromwell.backend.impl.jes
 
 import cromwell.backend.BackendConfigurationDescriptor
 import cromwell.backend.impl.jes.authentication.JesDockerCredentials
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.genomics.GenomicsFactory
 import cromwell.core.BackendDockerConfiguration
-import cromwell.filesystems.gcs.{GcsPathBuilderFactory, GoogleConfiguration}
+import cromwell.filesystems.gcs.GcsPathBuilderFactory
 
 class JesConfiguration(val configurationDescriptor: BackendConfigurationDescriptor) {
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -12,9 +12,9 @@ import com.google.cloud.storage.contrib.nio.CloudStorageOptions
 import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject, JesDockerCredentials}
 import cromwell.backend.standard.{StandardInitializationActor, StandardInitializationActorParams, StandardValidatedRuntimeAttributesBuilder}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
+import cromwell.cloudSupport.gcp.auth.{ClientSecrets, GoogleAuthMode}
 import cromwell.core.CromwellFatalException
 import cromwell.core.io.AsyncIo
-import cromwell.filesystems.gcs.auth.{ClientSecrets, GoogleAuthMode}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import spray.json.{JsObject, JsTrue}
 import wdl4s.wdl.WdlTaskCall

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -6,9 +6,10 @@ import com.typesafe.config.Config
 import cromwell.backend.impl.jes.JesAsyncBackendJobExecutionActor.WorkflowOptionKeys
 import cromwell.backend.io.WorkflowPaths
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.cloudSupport.gcp.gcs.GcsStorage
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.{Path, PathBuilder}
-import cromwell.filesystems.gcs.{GcsPathBuilder, GcsPathBuilderFactory}
+import cromwell.filesystems.gcs.GcsPathBuilder
 
 import scala.language.postfixOps
 
@@ -42,7 +43,7 @@ case class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
       genomicsCredentials,
       jesConfiguration.googleConfig.applicationName,
       None,
-      GcsPathBuilderFactory.DefaultCloudStorageConfiguration,
+      GcsStorage.DefaultCloudStorageConfiguration,
       workflowOptions
     )
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesAuths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesAuths.scala
@@ -1,5 +1,5 @@
 package cromwell.backend.impl.jes.authentication
 
-import cromwell.filesystems.gcs.auth.GoogleAuthMode
+import cromwell.cloudSupport.gcp.auth.GoogleAuthMode
 
 case class JesAuths(genomics: GoogleAuthMode, gcs: GoogleAuthMode)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesVMAuthentication.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/authentication/JesVMAuthentication.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.impl.jes.authentication
 
+import cromwell.cloudSupport.gcp.auth.ClientSecrets
 import cromwell.core.DockerCredentials
-import cromwell.filesystems.gcs.auth.ClientSecrets
 import spray.json.{JsString, JsValue}
 
 /**

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -25,6 +25,7 @@ import cromwell.services.keyvalue.InMemoryKvServiceActor
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.util.SampleWdl
 import _root_.io.grpc.Status
+import cromwell.cloudSupport.gcp.gcs.GcsStorage
 import org.scalatest._
 import org.scalatest.prop.Tables.Table
 import org.slf4j.Logger
@@ -43,7 +44,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
   with FlatSpecLike with Matchers with ImplicitSender with Mockito with BackendSpec with BeforeAndAfter {
 
   val mockPathBuilder: GcsPathBuilder = GcsPathBuilder.fromCredentials(NoCredentials.getInstance(),
-    "test-cromwell", None, GcsPathBuilderFactory.DefaultCloudStorageConfiguration, WorkflowOptions.empty)
+    "test-cromwell", None, GcsStorage.DefaultCloudStorageConfiguration, WorkflowOptions.empty)
   
   var kvService: ActorRef = system.actorOf(Props(new InMemoryKvServiceActor))
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -20,7 +20,7 @@ import cromwell.core.callcaching.NoDocker
 import cromwell.core.labels.Labels
 import cromwell.core.logging.JobLogger
 import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.{GcsPath, GcsPathBuilder, GcsPathBuilderFactory}
+import cromwell.filesystems.gcs.{GcsPath, GcsPathBuilder}
 import cromwell.services.keyvalue.InMemoryKvServiceActor
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.util.SampleWdl

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAttributesSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAttributesSpec.scala
@@ -3,8 +3,8 @@ package cromwell.backend.impl.jes
 import java.net.URL
 
 import com.typesafe.config.ConfigFactory
+import cromwell.cloudSupport.gcp.GoogleConfiguration
 import cromwell.core.Tags._
-import cromwell.filesystems.gcs.GoogleConfiguration
 import lenthall.exception.MessageAggregation
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
@@ -2,8 +2,8 @@ package cromwell.backend.impl.jes
 
 import com.google.cloud.NoCredentials
 import cromwell.backend.BackendSpec
+import cromwell.cloudSupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.TestKitSuite
-import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -15,7 +15,6 @@ import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.Tags.IntegrationTest
 import cromwell.core.logging.LoggingTest._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.auth.SimpleClientSecrets
 import cromwell.util.{EncryptionSpec, SampleWdl}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -9,12 +9,13 @@ import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed
 import cromwell.backend.async.RuntimeAttributeValidationFailures
 import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendSpec, BackendWorkflowDescriptor}
+import cromwell.cloudSupport.gcp.GoogleConfiguration
+import cromwell.cloudSupport.gcp.auth.{GoogleAuthModeSpec, RefreshTokenMode, SimpleClientSecrets}
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.Tags.IntegrationTest
 import cromwell.core.logging.LoggingTest._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
-import cromwell.filesystems.gcs.GoogleConfiguration
-import cromwell.filesystems.gcs.auth.{GoogleAuthModeSpec, RefreshTokenMode, SimpleClientSecrets}
+import cromwell.filesystems.gcs.auth.SimpleClientSecrets
 import cromwell.util.{EncryptionSpec, SampleWdl}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
@@ -2,8 +2,8 @@ package cromwell.backend.impl.jes
 
 import com.google.cloud.NoCredentials
 import cromwell.backend.BackendSpec
+import cromwell.cloudSupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.TestKitSuite
-import cromwell.filesystems.gcs.auth.GoogleAuthModeSpec
 import cromwell.util.SampleWdl
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
@@ -8,8 +8,9 @@ import cromwell.backend.BackendInitializationData
 import cromwell.backend.io.WorkflowPaths
 import cromwell.backend.standard.{StandardExpressionFunctions, StandardInitializationActor, StandardInitializationActorParams}
 import cromwell.backend.wfs.WorkflowPathBuilder
+import cromwell.cloudSupport.gcp.GoogleConfiguration
 import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.{GcsPathBuilderFactory, GoogleConfiguration}
+import cromwell.filesystems.gcs.GcsPathBuilderFactory
 import lenthall.exception.MessageAggregation
 import net.ceedubs.ficus.Ficus._
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
@@ -7,8 +7,9 @@ import cats.instances.list._
 import cats.syntax.traverse._
 import cromwell.backend.standard._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
+import cromwell.cloudSupport.gcp.GoogleConfiguration
 import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.{GcsPathBuilderFactory, GoogleConfiguration}
+import cromwell.filesystems.gcs.GcsPathBuilderFactory
 import lenthall.exception.MessageAggregation
 import net.ceedubs.ficus.Ficus._
 import wdl4s.wdl.WdlTaskCall


### PR DESCRIPTION
Note that there's no documentation nor testing for this atm. Yes I'm aware of that :)

Initial health monitor support
o Provide health monitor infrastructure to provide ability to attach checks for underlying subsystems
o Provide status endpoint which will query current contents of health monitor implementation
o Moved some google code to a new cloudSupport project
o Moved some general docker code to core from the dockerHashing project