### PR TITLE
Default workflow type is now configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2628,6 +2628,10 @@ All web server requests include an API version in the url. The current version i
 This endpoint accepts a POST request with a `multipart/form-data` encoded body.  The form fields that may be included are:
 
 * `workflowSource` - *Required* Contains the workflow source file to submit for execution.
+* `workflowType` - *Optional* The type of the `workflowSource`.
+   If not specified, returns the `workflow-options.default.workflow-type` configuration value with a default of `WDL`.
+* `workflowTypeVersion` - *Optional* The version of the `workflowType`, for example "draft-2".
+   If not specified, returns the `workflow-options.default.workflow-type-version` configuration value with no default.
 * `workflowInputs` - *Optional* JSON file containing the inputs.  For WDL workflows a skeleton file can be generated from [wdltool](https://github.com/broadinstitute/wdltool) using the "inputs" subcommand.
 * `workflowInputs_n` - *Optional* Where `n` is an integer. JSON file containing the 'n'th set of auxiliary inputs.
 * `workflowOptions` - *Optional* JSON file containing options for this workflow execution.  See the [run](#run) CLI sub-command for some more information about this.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -160,6 +160,9 @@ workflow-options {
   # Workflow-failure-mode determines what happens to other calls when a call fails. Can be either ContinueWhilePossible or NoNewCalls.
   # Can also be overridden in workflow options. Defaults to NoNewCalls. Uncomment to change:
   #workflow-failure-mode: "ContinueWhilePossible"
+
+  # When a workflow type is not provided on workflow submission, this specifies the default type.
+  default.workflow-type: "WDL"
 }
 
 # Optional call-caching configuration.

--- a/core/src/main/scala/cromwell/core/WorkflowOptions.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowOptions.scala
@@ -3,6 +3,7 @@ package cromwell.core
 import com.typesafe.config.ConfigFactory
 import lenthall.util.TryUtil
 import spray.json._
+import net.ceedubs.ficus.Ficus._
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -131,6 +132,10 @@ object WorkflowOptions {
   }
 
   val empty = WorkflowOptions.fromMap(Map.empty).get
+
+  lazy val defaultWorkflowType: Option[String] = Option(WorkflowOptionsConf.getString("default.workflow-type"))
+  lazy val defaultWorkflowTypeVersion: Option[String] =
+    WorkflowOptionsConf.as[Option[String]]("default.workflow-type-version")
 }
 
 case class WorkflowOptions(jsObject: JsObject) {

--- a/core/src/main/scala/cromwell/core/WorkflowSourceFilesCollection.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowSourceFilesCollection.scala
@@ -14,6 +14,8 @@ sealed trait WorkflowSourceFilesCollection {
   def workflowType: Option[WorkflowType]
   def workflowTypeVersion: Option[WorkflowTypeVersion]
 
+  def warnings: Seq[String]
+
   def importsZipFileOption: Option[Array[Byte]] = this match {
     case _: WorkflowSourceFilesWithoutImports => None
     case w: WorkflowSourceFilesWithDependenciesZip => Option(w.importsZip) // i.e. Some(importsZip) if our wiring is correct
@@ -32,11 +34,27 @@ object WorkflowSourceFilesCollection {
             inputsJson: WorkflowJson,
             workflowOptionsJson: WorkflowOptionsJson,
             labelsJson: WorkflowJson,
-            importsFile: Option[Array[Byte]]): WorkflowSourceFilesCollection = importsFile match {
+            importsFile: Option[Array[Byte]],
+            warnings: Seq[String]): WorkflowSourceFilesCollection = importsFile match {
     case Some(imports) =>
-      WorkflowSourceFilesWithDependenciesZip(workflowSource, workflowType, workflowTypeVersion, inputsJson, workflowOptionsJson, labelsJson, imports)
+      WorkflowSourceFilesWithDependenciesZip(
+        workflowSource,
+        workflowType,
+        workflowTypeVersion,
+        inputsJson,
+        workflowOptionsJson,
+        labelsJson,
+        imports,
+        warnings)
     case None =>
-      WorkflowSourceFilesWithoutImports(workflowSource, workflowType, workflowTypeVersion, inputsJson, workflowOptionsJson, labelsJson)
+      WorkflowSourceFilesWithoutImports(
+        workflowSource,
+        workflowType,
+        workflowTypeVersion,
+        inputsJson,
+        workflowOptionsJson,
+        labelsJson,
+        warnings)
   }
 }
 
@@ -45,7 +63,8 @@ final case class WorkflowSourceFilesWithoutImports(workflowSource: WorkflowSourc
                                                    workflowTypeVersion: Option[WorkflowTypeVersion],
                                                    inputsJson: WorkflowJson,
                                                    workflowOptionsJson: WorkflowOptionsJson,
-                                                   labelsJson: WorkflowJson) extends WorkflowSourceFilesCollection
+                                                   labelsJson: WorkflowJson,
+                                                   warnings: Seq[String]) extends WorkflowSourceFilesCollection
 
 final case class WorkflowSourceFilesWithDependenciesZip(workflowSource: WorkflowSource,
                                                         workflowType: Option[WorkflowType],
@@ -53,6 +72,10 @@ final case class WorkflowSourceFilesWithDependenciesZip(workflowSource: Workflow
                                                         inputsJson: WorkflowJson,
                                                         workflowOptionsJson: WorkflowOptionsJson,
                                                         labelsJson: WorkflowJson,
-                                                        importsZip: Array[Byte]) extends WorkflowSourceFilesCollection {
-  override def toString = s"WorkflowSourceFilesWithDependenciesZip($workflowSource, $inputsJson, $workflowOptionsJson, $labelsJson, <<ZIP BINARY CONTENT>>)"
+                                                        importsZip: Array[Byte],
+                                                        warnings: Seq[String]) extends WorkflowSourceFilesCollection {
+  override def toString = {
+    s"WorkflowSourceFilesWithDependenciesZip($workflowSource, $workflowType, $workflowTypeVersion," +
+      s" $inputsJson, $workflowOptionsJson, $labelsJson, <<ZIP BINARY CONTENT>>, $warnings)"
+  }
 }

--- a/core/src/test/scala/cromwell/util/SampleWdl.scala
+++ b/core/src/test/scala/cromwell/util/SampleWdl.scala
@@ -24,7 +24,8 @@ trait SampleWdl extends TestFileUtil {
       workflowOptionsJson = workflowOptions,
       labelsJson = labels,
       workflowType = workflowType,
-      workflowTypeVersion = workflowTypeVersion)
+      workflowTypeVersion = workflowTypeVersion,
+      warnings = Vector.empty)
   }
 
   val rawInputs: WorkflowRawInputs

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -92,6 +92,14 @@ workflow-options {
   # Workflow-failure-mode determines what happens to other calls when a call fails. Can be either ContinueWhilePossible or NoNewCalls.
   # Can also be overridden in workflow options. Defaults to NoNewCalls. Uncomment to change:
   #workflow-failure-mode: "ContinueWhilePossible"
+
+  default {
+    # When a workflow type is not provided on workflow submission, this specifies the default type.
+    #workflow-type: WDL
+
+    # When a workflow type version is not provided on workflow submission, this specifies the default type version.
+    #workflow-type-version: "draft-2"
+  }
 }
 
 # Optional call-caching configuration.

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -505,7 +505,7 @@ paths:
           required: true
           type: string
           in: path
-          default: v2
+          default: v1
         - name: id
           description: Workflow ID
           required: true

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -63,7 +63,8 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
       inputsJson = workflowStoreEntry.workflowInputs.toRawString,
       workflowOptionsJson = workflowStoreEntry.workflowOptions.toRawString,
       labelsJson = workflowStoreEntry.customLabels.toRawString,
-      importsFile = workflowStoreEntry.importsZip.toBytesOption
+      importsFile = workflowStoreEntry.importsZip.toBytesOption,
+      warnings = Vector.empty
     )
     WorkflowToStart(
       WorkflowId.fromString(workflowStoreEntry.workflowExecutionUuid),

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -24,7 +24,7 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val BackendResponseFormat = jsonFormat2(BackendResponse)
   implicit val BuiltStatusResponseFormat = jsonFormat1(BuiltMetadataResponse)
   implicit val callAttempt = jsonFormat2(CallAttempt)
-  implicit val workflowSourceData = jsonFormat6(WorkflowSourceFilesWithoutImports)
+  implicit val workflowSourceData = jsonFormat7(WorkflowSourceFilesWithoutImports)
 
   implicit object fileJsonFormat extends RootJsonFormat[File] {
     override def write(obj: File) = JsString(obj.path.toAbsolutePath.toString)
@@ -34,7 +34,7 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit val workflowSourceDataWithImports = jsonFormat7(WorkflowSourceFilesWithDependenciesZip)
+  implicit val workflowSourceDataWithImports = jsonFormat8(WorkflowSourceFilesWithDependenciesZip)
   implicit val errorResponse = jsonFormat3(FailureResponse)
   implicit val successResponse = jsonFormat3(SuccessResponse)
 

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -336,7 +336,8 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
       workflowTypeVersion = None,
       inputsJson = sampleWdl.workflowJson,
       workflowOptionsJson = workflowOptions,
-      labelsJson = customLabels)
+      labelsJson = customLabels,
+      warnings = Vector.empty)
     val workflowId = rootActor.underlyingActor.submitWorkflow(sources)
     eventually { verifyWorkflowState(rootActor.underlyingActor.serviceRegistryActor, workflowId, terminalState) } (config = patienceConfig, pos = implicitly[org.scalactic.source.Position])
     val outcome = getWorkflowOutputsFromMetadata(workflowId, rootActor.underlyingActor.serviceRegistryActor)

--- a/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/engine/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -41,7 +41,8 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
       workflowTypeVersion = None,
       inputsJson = rawInputsOverride,
       workflowOptionsJson = "{}",
-      labelsJson = "{}"
+      labelsJson = "{}",
+      warnings = Vector.empty
     )
     val promise = Promise[Unit]()
     val watchActor = system.actorOf(MetadataWatchActor.props(promise, matchers: _*), s"service-registry-$workflowId-${UUID.randomUUID()}")

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
@@ -64,7 +64,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -122,7 +123,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, differentDefaultBackendConf)
 
       within(Timeout) {
@@ -163,7 +165,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = "{}")
+        labelsJson = "{}",
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, differentDefaultBackendConf)
 
       within(Timeout) {
@@ -188,7 +191,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -218,7 +222,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -249,7 +254,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(badWdlSources, minimumConf)
 
       within(Timeout) {
@@ -274,7 +280,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = unstructuredFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -298,7 +305,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = unstructuredFile)
+        labelsJson = unstructuredFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -324,7 +332,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = validInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = badCustomLabelsFile)
+        labelsJson = badCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -354,7 +363,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = unstructuredFile,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -379,7 +389,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = noInputsJson,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(badOptionsSources, minimumConf)
 
       within(Timeout) {
@@ -411,7 +422,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {
@@ -446,7 +458,8 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         workflowTypeVersion = None,
         inputsJson = jsonInput,
         workflowOptionsJson = validOptionsFile,
-        labelsJson = validCustomLabelsFile)
+        labelsJson = validCustomLabelsFile,
+        warnings = Vector.empty)
       materializeWfActor ! MaterializeWorkflowDescriptorCommand(sources, minimumConf)
 
       within(Timeout) {

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -50,7 +50,9 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
         workflowTypeVersion = None,
         inputsJson = "{}",
         workflowOptionsJson = "{}",
-        labelsJson = "{}"))
+        labelsJson = "{}",
+        warnings = Vector.empty)
+      )
       val rootWorkflowId = expectMsgType[WorkflowSubmittedToStore](10 seconds).workflowId
 
       // Query for non existing sub workflow

--- a/src/main/scala/cromwell/CommandLineParser.scala
+++ b/src/main/scala/cromwell/CommandLineParser.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import com.typesafe.config.ConfigFactory
+import cromwell.core.WorkflowOptions
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import scopt.OptionParser
 
@@ -14,8 +15,8 @@ object CommandLineParser extends App {
                                   workflowSource: Option[Path] = None,
                                   workflowInputs: Option[Path] = None,
                                   workflowOptions: Option[Path] = None,
-                                  workflowType: Option[String] = Option("WDL"),
-                                  workflowTypeVersion: Option[String] = Option("v2.0-draft"),
+                                  workflowType: Option[String] = WorkflowOptions.defaultWorkflowType,
+                                  workflowTypeVersion: Option[String] = WorkflowOptions.defaultWorkflowTypeVersion,
                                   workflowLabels: Option[Path] = None,
                                   imports: Option[Path] = None,
                                   metadataOutput: Option[Path] = None

--- a/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -17,7 +17,7 @@ import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.{Duration, _}
+import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, TimeoutException}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -139,21 +139,23 @@ object CromwellEntryPoint extends GracefulStopSupport {
       case Some(p) => (workflowSource, inputsJson, optionsJson, labelsJson) mapN { (w, i, o, l) =>
         WorkflowSourceFilesWithDependenciesZip.apply(
           workflowSource = w,
-          workflowType = Option("WDL"),
-          workflowTypeVersion = None,
+          workflowType = args.workflowType,
+          workflowTypeVersion = args.workflowTypeVersion,
           inputsJson = i,
           workflowOptionsJson = o,
           labelsJson = l,
-          importsZip = p.loadBytes)
+          importsZip = p.loadBytes,
+          warnings = Vector.empty)
       }
       case None => (workflowSource, inputsJson, optionsJson, labelsJson) mapN { (w, i, o, l) =>
         WorkflowSourceFilesWithoutImports.apply(
           workflowSource = w,
-          workflowType = Option("WDL"),
-          workflowTypeVersion = None,
+          workflowType = args.workflowType,
+          workflowTypeVersion = args.workflowTypeVersion,
           inputsJson = i,
           workflowOptionsJson = o,
-          labelsJson = l
+          labelsJson = l,
+          warnings = Vector.empty
         )
       }
     }


### PR DESCRIPTION
Submission api returns an HTTP warning when using older form data names.
Switched PWS if statements to case statements.
Switched unused version for metadata endpoint back to v1 in swagger.