### PR TITLE
Create placeholder file when appropriate

### DIFF
--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendCacheHitCopyingActor.scala
@@ -53,13 +53,17 @@ class JesBackendCacheHitCopyingActor(standardParams: StandardCacheHitCopyingActo
                                               newOutputs: CallOutputs,
                                               originalDetritus:  Map[String, String],
                                               newDetritus: Map[String, Path]): List[Set[IoCommand[_]]] = {
-    val content =
-      s"""
-         |This directory does not contain any output files because this job matched an identical job that was previously run, thus it was a cache-hit.
-         |Cromwell is configured to not copy outputs during call caching. To change this, edit the filesystems.gcs.caching.duplication-strategy field in your backend configuration.
-         |The original outputs can be found at this location: ${sourceCallRootPath.pathAsString}
+    cachingStrategy match {
+      case UseOriginalCachedOutputs =>
+        val content =
+          s"""
+             |This directory does not contain any output files because this job matched an identical job that was previously run, thus it was a cache-hit.
+             |Cromwell is configured to not copy outputs during call caching. To change this, edit the filesystems.gcs.caching.duplication-strategy field in your backend configuration.
+             |The original outputs can be found at this location: ${sourceCallRootPath.pathAsString}
       """.stripMargin
 
-    List(Set(writeCommand(jobPaths.callExecutionRoot / "call_caching_placeholder.txt", content, Seq(CloudStorageOptions.withMimeType("text/plain")))))
+        List(Set(writeCommand(jobPaths.callExecutionRoot / "call_caching_placeholder.txt", content, Seq(CloudStorageOptions.withMimeType("text/plain")))))
+      case CopyCachedOutputs => List.empty
+    }
   }
 }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemCacheHitCopyingActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemCacheHitCopyingActor.scala
@@ -16,7 +16,7 @@ class SharedFileSystemCacheHitCopyingActor(standardParams: StandardCacheHitCopyi
       case (source, destination) => 
         sharedFileSystem.cacheCopy(source, destination)
     }
-    
+
     TryUtil.sequence(copies.toList).void recoverWith {
       case failure =>
         // If one or more of the copies failed, we want to delete all the files that were successfully copied


### PR DESCRIPTION
Issue: Currently, regardless of the duplication strategy in JES, the call cache placeholder file is created in case of cache hits. 

Fix: Added a statement that confirms the caching strategy is set to reference in order to upload the call_caching_placeholder.txt.