### PR TITLE
Fixing Travis / Mysql interaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 services:
   - docker
+  - mysql
 language: scala
 scala:
   - 2.12.2
@@ -20,6 +21,8 @@ before_cache:
 before_install:
   # https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-310759657
   - sudo rm -f /etc/boto.cfg
+  - mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES';"
+  - mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
 env:
   global:
     - CENTAUR_BRANCH=develop

--- a/build.sbt
+++ b/build.sbt
@@ -116,3 +116,5 @@ lazy val root = (project in file("."))
   .dependsOn(sparkBackend)
   // Dependencies for tests
   .dependsOn(engine % "test->test")
+
+  //Noop

--- a/build.sbt
+++ b/build.sbt
@@ -116,5 +116,3 @@ lazy val root = (project in file("."))
   .dependsOn(sparkBackend)
   // Dependencies for tests
   .dependsOn(engine % "test->test")
-
-  //Noop

--- a/src/bin/travis/testCentaurLocal.sh
+++ b/src/bin/travis/testCentaurLocal.sh
@@ -78,13 +78,7 @@ printTravisHeartbeat
 set -x
 set -e
 
-sudo apt-get update -qq
-sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
 docker pull ubuntu:latest
-mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES';"
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
-mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY '';"
-mysql -u root -e "GRANT ALL PRIVILEGES ON cromwell_test . * TO 'travis'@'localhost';"
 
 sbt assembly
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")

--- a/src/bin/travis/testCentaurTes.sh
+++ b/src/bin/travis/testCentaurTes.sh
@@ -31,13 +31,7 @@ printTravisHeartbeat
 set -x
 set -e
 
-sudo apt-get update -qq
-sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
 docker pull ubuntu:latest
-mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES';"
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
-mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY '';"
-mysql -u root -e "GRANT ALL PRIVILEGES ON cromwell_test . * TO 'travis'@'localhost';"
 
 WORKDIR=$(pwd)
 

--- a/src/bin/travis/testSbt.sh
+++ b/src/bin/travis/testSbt.sh
@@ -3,11 +3,7 @@
 set -e
 set -x
 
-sudo apt-get update -qq
-sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
 docker pull ubuntu:latest
-mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES';"
-mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
 
 sbt -Dbackend.providers.Local.config.filesystems.local.localization.0=copy clean coverage nointegration:test coverageReport
 sbt coverageAggregate

--- a/src/bin/travis/testSbt.sh
+++ b/src/bin/travis/testSbt.sh
@@ -8,8 +8,6 @@ sudo apt-get install -qq mysql-server-5.6 mysql-client-5.6 mysql-client-core-5.6
 docker pull ubuntu:latest
 mysql -u root -e "SET GLOBAL sql_mode = 'STRICT_ALL_TABLES';"
 mysql -u root -e "CREATE DATABASE IF NOT EXISTS cromwell_test;"
-mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY '';"
-mysql -u root -e "GRANT ALL PRIVILEGES ON cromwell_test . * TO 'travis'@'localhost';"
 
 sbt -Dbackend.providers.Local.config.filesystems.local.localization.0=copy clean coverage nointegration:test coverageReport
 sbt coverageAggregate


### PR DESCRIPTION
according to https://github.com/travis-ci/travis-ci/issues/8364

Travis now grants permissions equivalent to what we were doing manually.

Also with the "trusty" distribution [we get mysql 5.6](https://docs.travis-ci.com/user/database-setup/#MySQL-5.6) so we're using the built-in service instead.