### PR TITLE
Switching GraphNode equality to reference-based

### DIFF
--- a/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
@@ -83,18 +83,20 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
         w7: true
       """.stripMargin
 
-    val validInputs = validate(inputFile)
+    val validInputs = validate(inputFile).map {
+      case (port, resolvedInput) => (port.name, resolvedInput)
+    }
 
     // w0 has no input value in the input file, so it should fallback to the default value
     // TODO WOM: when we have string value for wom expression, check that it's "hi !"
-    validInputs(w0OutputPort).select[WomExpression].isDefined shouldBe true
-    validInputs(w1OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlFile("my_file.txt"): WdlValue)
-    validInputs(w2OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlString("hello !"): WdlValue)
-    validInputs(w3OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlInteger(3): WdlValue)
-    validInputs(w4OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlInteger(4): WdlValue)
-    validInputs(w5OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlFloat(5.1F): WdlValue)
-    validInputs(w6OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlFloat(6.1F): WdlValue)
-    validInputs(w7OutputPort) shouldBe Coproduct[ResolvedExecutableInput](WdlBoolean(true): WdlValue)
+    validInputs(w0OutputPort.name).select[WomExpression].isDefined shouldBe true
+    validInputs(w1OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlFile("my_file.txt"): WdlValue)
+    validInputs(w2OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlString("hello !"): WdlValue)
+    validInputs(w3OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlInteger(3): WdlValue)
+    validInputs(w4OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlInteger(4): WdlValue)
+    validInputs(w5OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlFloat(5.1F): WdlValue)
+    validInputs(w6OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlFloat(6.1F): WdlValue)
+    validInputs(w7OutputPort.name) shouldBe Coproduct[ResolvedExecutableInput](WdlBoolean(true): WdlValue)
   }
 
   it should "not validate when required inputs are missing" in {

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -20,6 +20,9 @@ trait GraphNode {
     */
   final def fullyQualifiedName: String = identifier.fullyQualifiedName.value
 
+  final override def equals(other: Any): Boolean = super.equals(other)
+  final override def hashCode: Int = super.hashCode()
+
   /**
     * Inputs that must be available before this graph node can be run.
     */


### PR DESCRIPTION
Switching GraphNode.{equals, hashCode} from component-based to reference (object identity)-based. Update two unit tests to reflect the change.