### PR TITLE
* lost a few hours debugging this test, made it more robust

### DIFF
--- a/src/test/scala/cromwell/CromwellCommandLineSpec.scala
+++ b/src/test/scala/cromwell/CromwellCommandLineSpec.scala
@@ -73,7 +73,7 @@ class CromwellCommandLineSpec extends FlatSpec with Matchers with BeforeAndAfter
   }
 
   it should "fail if input files do not exist" in {
-    val parsedArgs = parser.parse(Array("run", "3step.wdl", "--inputs", "3step.inputs", "--options", "3step.options"), CommandLineArguments()).get
+    val parsedArgs = parser.parse(Array("run", "xyzshouldnotexist.wdl", "--inputs", "xyzshouldnotexist.inputs", "--options", "xyzshouldnotexist.options"), CommandLineArguments()).get
     val validation = Try(CromwellEntryPoint.validateRunArguments(parsedArgs))
 
     validation.isFailure shouldBe true


### PR DESCRIPTION
* if you happen to have a 3step.wdl[options or inputs] in your local working directory, this test fails because it expects NOT to find them there.  This isn't so crazy since (a) 3step is real workflow name and (b) people might (as I did) run it to test out cromwell from their local working directory