### PR TITLE
String only stdout/stderr redirection

### DIFF
--- a/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.io
 
+import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.path.Path
 import cromwell.core.{CallContext, JobKey}
 import cromwell.services.metadata.CallMetadataKeys
@@ -30,12 +31,15 @@ trait JobPaths {
 
   def workflowPaths: WorkflowPaths
   def returnCodeFilename: String = "rc"
-  def stdoutFilename: String = "stdout"
-  def stderrFilename: String = "stderr"
+  def defaultStdoutFilename = "stdout"
+  def defaultStderrFilename = "stderr"
+
+  final def stdoutFilename: String = jobKey.node.callable.stdoutRedirection.getOrElse(defaultStdoutFilename)
+  final def stderrFilename: String = jobKey.node.callable.stderrRedirection.getOrElse(defaultStderrFilename)
   def scriptFilename: String = "script"
   def dockerCidFilename: String = "docker_cid"
-  
-  def jobKey: JobKey
+
+  def jobKey: BackendJobDescriptorKey
   lazy val callRoot = callPathBuilder(workflowPaths.workflowRoot, jobKey)
   lazy val callExecutionRoot = callRoot
   lazy val stdout = callExecutionRoot.resolve(stdoutFilename)

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -86,6 +86,11 @@ case class CommandLineTool private(
         RequiredInputDefinition(FullyQualifiedName(cip.id).id, tpe)
       }.toList
 
+    def stringOrExpressionToString(soe: Option[StringOrExpression]): Option[String] = soe flatMap {
+      case StringOrExpression.String(str) => Some(str)
+      case StringOrExpression.Expression(_) => None // ... for now!
+    }
+
     TaskDefinition(
       id,
       commandTemplate,
@@ -96,7 +101,9 @@ case class CommandLineTool private(
       inputs,
       // TODO: This doesn't work in all cases and it feels clunky anyway - find a way to sort that out
       prefixSeparator = "#",
-      commandPartSeparator = " "
+      commandPartSeparator = " ",
+      stdoutRedirection = stringOrExpressionToString(stdout),
+      stderrRedirection = stringOrExpressionToString(stderr)
     )
   }
 

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -122,9 +122,9 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
   }
 
   private lazy val commandLineTool: CommandLineTool = {
-    val wf = decodeAllCwl(rootPath / "three_step.cwl").map {
-      _.select[Workflow].get
-    }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse! msg was $error"), identity)
+    val wf = decodeAllCwl(rootPath / "three_step.cwl").map { wf =>
+      wf.select[Workflow].get
+    }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse! msg was ${error.toList.mkString(", ")}"), identity)
 
     wf.id should include("three_step")
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobPaths.scala
@@ -19,8 +19,8 @@ final case class JesJobPaths(override val workflowPaths: JesWorkflowPaths, jobKe
   }
 
   override val returnCodeFilename: String = s"$jesLogBasename-rc.txt"
-  override val stdoutFilename: String = s"$jesLogBasename-stdout.log"
-  override val stderrFilename: String = s"$jesLogBasename-stderr.log"
+  override val defaultStdoutFilename: String = s"$jesLogBasename-stdout.log"
+  override val defaultStderrFilename: String = s"$jesLogBasename-stderr.log"
   override val scriptFilename: String = s"${JesJobPaths.JesExecParamName}.sh"
 
   val jesLogFilename: String = s"$jesLogBasename.log"

--- a/wom/src/main/scala/wom/callable/TaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/TaskDefinition.scala
@@ -18,7 +18,9 @@ case class TaskDefinition(name: String,
                           outputs: List[Callable.OutputDefinition],
                           inputs: List[_ <: Callable.InputDefinition],
                           prefixSeparator: String = ".",
-                          commandPartSeparator: String = "") extends Callable {
+                          commandPartSeparator: String = "",
+                          stdoutRedirection: Option[String] = None,
+                          stderrRedirection: Option[String] = None) extends Callable {
 
   val unqualifiedName: LocallyQualifiedName = name
 


### PR DESCRIPTION
Expression-based `stdout` and `stderr` is a bit of a can of worms (TL;DR, which came first, the expression chicken or the stdout path egg?) and probably less valuable to our alpha than string-based stdout/stderr redirection (which is crucial).

For future reference: [a partially opened can of worms](https://github.com/broadinstitute/cromwell/tree/cjl_stdout_as_a_runtime_attr).