### PR TITLE
Allow CommandLineTools to run directly

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendJobBreadCrumb.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendJobBreadCrumb.scala
@@ -3,11 +3,11 @@ package cromwell.backend
 import cromwell.backend.io.JobPaths
 import cromwell.core.path.Path
 import cromwell.core.{JobKey, WorkflowId}
-import wom.callable.WorkflowDefinition
+import wom.callable.Callable
 
-case class BackendJobBreadCrumb(workflow: WorkflowDefinition, id: WorkflowId, jobKey: JobKey) {
+case class BackendJobBreadCrumb(callable: Callable, id: WorkflowId, jobKey: JobKey) {
   def toPath(root: Path): Path = {
-    val workflowPart = root.resolve(workflow.name).resolve(id.toString)
+    val workflowPart = root.resolve(callable.name).resolve(id.toString)
     JobPaths.callPathBuilder(workflowPart, jobKey)
   }
 }

--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -7,10 +7,10 @@ import cromwell.core.callcaching.MaybeCallCachingEligible
 import cromwell.core.labels.Labels
 import cromwell.core.{CallKey, WorkflowId, WorkflowOptions}
 import cromwell.services.keyvalue.KeyValueServiceActor.KvResponse
-import wom.callable.WorkflowDefinition
+import wom.callable.ExecutableCallable
 import wom.graph.GraphNodePort.OutputPort
 import wom.graph.TaskCallNode
-import wom.values.{WomValue, WomEvaluatedCallInputs}
+import wom.values.{WomEvaluatedCallInputs, WomValue}
 
 import scala.util.Try
 
@@ -45,11 +45,11 @@ case class BackendJobDescriptor(workflowDescriptor: BackendWorkflowDescriptor,
 
 object BackendWorkflowDescriptor {
   def apply(id: WorkflowId,
-            workflow: WorkflowDefinition,
+            callable: ExecutableCallable,
             knownValues: Map[OutputPort, WomValue],
             workflowOptions: WorkflowOptions,
             customLabels: Labels) = {
-    new BackendWorkflowDescriptor(id, workflow, knownValues, workflowOptions, customLabels, List.empty)
+    new BackendWorkflowDescriptor(id, callable, knownValues, workflowOptions, customLabels, List.empty)
   }
 }
 
@@ -57,16 +57,16 @@ object BackendWorkflowDescriptor {
   * For passing to a BackendActor construction time
   */
 case class BackendWorkflowDescriptor(id: WorkflowId,
-                                     workflow: WorkflowDefinition,
+                                     callable: ExecutableCallable,
                                      knownValues: Map[OutputPort, WomValue],
                                      workflowOptions: WorkflowOptions,
                                      customLabels: Labels,
                                      breadCrumbs: List[BackendJobBreadCrumb]) {
-  
-  val rootWorkflow = breadCrumbs.headOption.map(_.workflow).getOrElse(workflow)
+
+  val rootWorkflow = breadCrumbs.headOption.map(_.callable).getOrElse(callable)
   val rootWorkflowId = breadCrumbs.headOption.map(_.id).getOrElse(id)
-  
-  override def toString: String = s"[BackendWorkflowDescriptor id=${id.shortString} workflowName=${workflow.name}]"
+
+  override def toString: String = s"[BackendWorkflowDescriptor id=${id.shortString} workflowName=${callable.name}]"
   def getWorkflowOption(key: WorkflowOption) = workflowOptions.get(key).toOption
 }
 

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
@@ -24,7 +24,7 @@ trait WorkflowPaths extends PathFactory {
   protected def workflowPathBuilder(root: Path): Path = {
     workflowDescriptor.breadCrumbs.foldLeft(root)((acc, breadCrumb) => {
       breadCrumb.toPath(acc)
-    }).resolve(workflowDescriptor.workflow.name).resolve(workflowDescriptor.id.toString + "/")
+    }).resolve(workflowDescriptor.callable.name).resolve(workflowDescriptor.id.toString + "/")
   }
 
   lazy val executionRoot: Path = PathFactory.buildPath(executionRootString, pathBuilders).toAbsolutePath

--- a/backend/src/test/scala/cromwell/backend/BackendSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/BackendSpec.scala
@@ -73,7 +73,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
                                           inputs: Map[String, WomValue],
                                           options: WorkflowOptions,
                                           runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition]): BackendJobDescriptor = {
-    val call = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({ case t: TaskCallNode => t}).get
+    val call = workflowDescriptor.callable.graph.nodes.collectFirst({ case t: TaskCallNode => t}).get
     val jobKey = BackendJobDescriptorKey(call, None, 1)
     
     val inputDeclarations: Map[InputDefinition, WomValue] = call.inputDefinitionMappings.map {
@@ -100,7 +100,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
                                           options: WorkflowOptions,
                                           runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition]): BackendJobDescriptor = {
     val workflowDescriptor = buildWdlWorkflowDescriptor(wdl)
-    val call = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({ case t: TaskCallNode => t}).get
+    val call = workflowDescriptor.callable.graph.nodes.collectFirst({ case t: TaskCallNode => t}).get
     val jobKey = BackendJobDescriptorKey(call, None, 1)
     val inputDeclarations = fqnMapToDeclarationMap(workflowDescriptor.knownValues)
     val evaluatedAttributes = RuntimeAttributeDefinition.evaluateRuntimeAttributes(call.callable.runtimeAttributes, NoIoFunctionSet, inputDeclarations).getOrElse(fail("Failed to evaluate runtime attributes")) // .get is OK here because this is a test
@@ -114,7 +114,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
                                           options: WorkflowOptions,
                                           runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition]): BackendJobDescriptor = {
     val workflowDescriptor = buildWdlWorkflowDescriptor(wdl, runtime = runtime)
-    val call = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({ case t: TaskCallNode => t}).get
+    val call = workflowDescriptor.callable.graph.nodes.collectFirst({ case t: TaskCallNode => t}).get
     val jobKey = BackendJobDescriptorKey(call, None, attempt)
     val inputDeclarations = fqnMapToDeclarationMap(workflowDescriptor.knownValues)
     val evaluatedAttributes = RuntimeAttributeDefinition.evaluateRuntimeAttributes(call.callable.runtimeAttributes, NoIoFunctionSet, inputDeclarations).getOrElse(fail("Failed to evaluate runtime attributes")) // .get is OK here because this is a test
@@ -155,7 +155,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
   }
 
   def firstJobDescriptorKey(workflowDescriptor: BackendWorkflowDescriptor): BackendJobDescriptorKey = {
-    val call = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({ case t: TaskCallNode => t}).get
+    val call = workflowDescriptor.callable.graph.nodes.collectFirst({ case t: TaskCallNode => t}).get
     BackendJobDescriptorKey(call, None, 1)
   }
 }

--- a/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/JobPathsSpec.scala
@@ -29,7 +29,7 @@ class JobPathsSpec extends FlatSpec with Matchers with BackendSpec {
   "JobPaths" should "provide correct paths for a job" in {
 
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
-    val call: TaskCallNode = wd.workflow.taskCallNodes.head
+    val call: TaskCallNode = wd.callable.taskCallNodes.head
     val jobKey: BackendJobDescriptorKey = BackendJobDescriptorKey(call, None, 1)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val jobPaths = new JobPathsWithDocker(workflowPaths, jobKey)

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -32,13 +32,13 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")
     val rootWorkflowId = WorkflowId.randomId()
-    rootWd.workflow returns rootWorkflow
+    rootWd.callable returns rootWorkflow
     rootWd.id returns rootWorkflowId
 
     val subWd = mock[BackendWorkflowDescriptor]
     val subWorkflow = WomMocks.mockWorkflowDefinition("subWorkflow")
     val subWorkflowId = WorkflowId.randomId()
-    subWd.workflow returns subWorkflow
+    subWd.callable returns subWorkflow
     subWd.id returns subWorkflowId
     
     val call1 = WomMocks.mockTaskCall(WomIdentifier("call1"))

--- a/core/src/test/scala/cromwell/util/WomMocks.scala
+++ b/core/src/test/scala/cromwell/util/WomMocks.scala
@@ -1,11 +1,11 @@
 package cromwell.util
 
 import wom.RuntimeAttributes
-import wom.callable.{TaskDefinition, WorkflowDefinition}
+import wom.callable.{CallableTaskDefinition, TaskDefinition, WorkflowDefinition}
 import wom.graph.{Graph, TaskCallNode, WomIdentifier, WorkflowCallNode}
 
 object WomMocks {
-  val EmptyTaskDefinition = TaskDefinition("emptyTask", List.empty, RuntimeAttributes(Map.empty),
+  val EmptyTaskDefinition = CallableTaskDefinition("emptyTask", List.empty, RuntimeAttributes(Map.empty),
     Map.empty, Map.empty, List.empty, List.empty)
 
   val EmptyWorkflowDefinition = mockWorkflowDefinition("emptyWorkflow")
@@ -23,7 +23,7 @@ object WomMocks {
   }
 
   def mockTaskDefinition(name: String) = {
-    TaskDefinition(name, List.empty, RuntimeAttributes(Map.empty),
+    CallableTaskDefinition(name, List.empty, RuntimeAttributes(Map.empty),
       Map.empty, Map.empty, List.empty, List.empty)
   }
 }

--- a/cwl/src/main/scala-2.11/cwl/CwlExecutableValidation.scala
+++ b/cwl/src/main/scala-2.11/cwl/CwlExecutableValidation.scala
@@ -11,11 +11,13 @@ import io.circe.yaml
 import io.circe.literal._
 import common.Checked
 import common.validation.Checked._
-import wom.callable.Callable
+import wom.callable.ExecutableCallable
 import wom.executable.Executable
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
 
-// See explanation as to why there are 2 versions of this in ExecutableValidation
+// WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
+// If you're making changes here, you'll also need to update ../../scala-2.12/cwl/CwlExecutableValidation.scala
+// (ExecutableValidation.scala has more info on why this was necessary)
 object CwlExecutableValidation {
 
   implicit val f = implicitly[Decoder[File]]
@@ -29,7 +31,7 @@ object CwlExecutableValidation {
       }
     }
 
-  def buildWomExecutable(callable: Checked[Callable], inputFile: Option[String]): Checked[Executable] = {
+  def buildWomExecutable(callable: Checked[ExecutableCallable], inputFile: Option[String]): Checked[Executable] = {
     for {
       womDefinition <- callable
       executable <- Executable.withInputs(womDefinition, inputCoercionFunction, inputFile)

--- a/cwl/src/main/scala-2.12/cwl/CwlExecutableValidation.scala
+++ b/cwl/src/main/scala-2.12/cwl/CwlExecutableValidation.scala
@@ -9,11 +9,13 @@ import io.circe.yaml
 import io.circe.literal._
 import common.Checked
 import common.validation.Checked._
-import wom.callable.Callable
+import wom.callable.ExecutableCallable
 import wom.executable.Executable
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
 
-// See explanation as to why there are 2 versions of this in ExecutableValidation
+// WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
+// If you're making changes here, you'll also need to update ../../scala-2.11/cwl/CwlExecutableValidation.scala
+// (ExecutableValidation.scala has more info on why this was necessary)
 object CwlExecutableValidation {
 
   implicit val f = implicitly[Decoder[File]]
@@ -27,7 +29,7 @@ object CwlExecutableValidation {
       }
     }
 
-  def buildWomExecutable(callable: Checked[Callable], inputFile: Option[String]): Checked[Executable] = {
+  def buildWomExecutable(callable: Checked[ExecutableCallable], inputFile: Option[String]): Checked[Executable] = {
     for {
       womDefinition <- callable
       executable <- Executable.withInputs(womDefinition, inputCoercionFunction, inputFile)

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -59,7 +59,6 @@ case class Workflow private(
         }.toMap
 
     val graphFromInputs: Set[ExternalGraphInputNode] = inputs.map {
-      // TODO WOM: need to be able to transform this default value to a WomExpression
       case inputParameter if inputParameter.default.isDefined =>
         val parsedInputId = FileAndId(inputParameter.id).id
         val womType = wdlTypeForInputParameter(inputParameter).get

--- a/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
@@ -50,7 +50,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
 
   lazy val graph = cwlWorkflow.womDefinition match {
     case Left(errors) => fail(s"Failed to build wom definition: ${errors.toList.mkString(", ")}")
-    case Right(womDef) => womDef.graph.getOrElse(fail("Failed to build wom graph"))
+    case Right(womDef) => womDef.graph
   }
 
   lazy val w0OutputPort = graph.inputNodes.find(_.localName == "w0").getOrElse(fail("Failed to find an input node for w0")).singleOutputPort

--- a/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
@@ -4,11 +4,10 @@ import cromwell.backend.BackendWorkflowDescriptor
 import cromwell.core.WorkflowOptions.WorkflowOption
 import cromwell.core.callcaching.CallCachingMode
 import cromwell.core.path.PathBuilder
-import wom.callable.WorkflowDefinition
+import wom.callable.Callable
 import wom.graph.TaskCallNode
 
-// TODO WOM: rename namespace to workflow
-case class EngineWorkflowDescriptor(namespace: WorkflowDefinition,
+case class EngineWorkflowDescriptor(topLevelCallable: Callable,
                                     backendDescriptor: BackendWorkflowDescriptor,
                                     backendAssignments: Map[TaskCallNode, String],
                                     failureMode: WorkflowFailureMode,
@@ -24,8 +23,8 @@ case class EngineWorkflowDescriptor(namespace: WorkflowDefinition,
   def isRootWorkflow: Boolean = rootWorkflow.parentWorkflow.isEmpty
 
   lazy val id = backendDescriptor.id
-  lazy val workflow = backendDescriptor.workflow
-  lazy val name = workflow.name
+  lazy val callable = backendDescriptor.callable
+  lazy val name = callable.name
   lazy val knownValues = backendDescriptor.knownValues
 
   def getWorkflowOption(key: WorkflowOption): Option[String] = backendDescriptor.getWorkflowOption(key)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
@@ -8,7 +8,7 @@ import cromwell.engine.workflow.lifecycle.execution.ExecutionStore.{RunnableScop
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{apply => _}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import common.collections.Table
-import wom.callable.WorkflowDefinition
+import wom.callable.ExecutableCallable
 import wom.graph.GraphNodePort.{ConditionalOutputPort, OutputPort, ScatterGathererPort}
 import wom.graph._
 import wom.graph.expression.ExpressionNode
@@ -33,9 +33,9 @@ object ExecutionStore {
 
   def empty = ExecutionStore(Map.empty[JobKey, ExecutionStatus], hasNewRunnables = false)
 
-  def apply(workflow: WorkflowDefinition): ExecutionStore = {
+  def apply(callable: ExecutableCallable): ExecutionStore = {
     // Keys that are added in a NotStarted Status
-    val notStartedKeys = workflow.innerGraph.nodes collect {
+    val notStartedKeys = callable.graph.nodes collect {
       case call: TaskCallNode => List(BackendJobDescriptorKey(call, None, 1))
       case expression: ExpressionNode => List(ExpressionKey(expression, None))
       case scatterNode: ScatterNode => List(ScatterKey(scatterNode))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/SubWorkflowPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/SubWorkflowPreparationActor.scala
@@ -25,10 +25,10 @@ class SubWorkflowPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
 
     val newBackendDescriptor = oldBackendDescriptor.copy(
       id = subWorkflowId,
-      workflow = callKey.node.callable,
+      callable = callKey.node.callable,
       // TODO WOM: need FQN for input definitions somehow ? For now don't worry about subWF
       knownValues = Map.empty,//workflowDescriptor.knownValues ++ (inputEvaluation map { case (k, v) => k.fullyQualifiedName -> v }),
-      breadCrumbs = oldBackendDescriptor.breadCrumbs :+ BackendJobBreadCrumb(workflowDescriptor.workflow, workflowDescriptor.id, callKey)
+      breadCrumbs = oldBackendDescriptor.breadCrumbs :+ BackendJobBreadCrumb(workflowDescriptor.callable, workflowDescriptor.id, callKey)
     )
     val engineDescriptor = workflowDescriptor.copy(backendDescriptor = newBackendDescriptor, parentWorkflow = Option(workflowDescriptor))
     SubWorkflowPreparationSucceeded(engineDescriptor, inputEvaluation)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
@@ -74,7 +74,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
           case MaterializeWorkflowDescriptorSuccessResponse(wfDesc) =>
             wfDesc.id shouldBe workflowId
             wfDesc.name shouldBe "wf_hello"
-            wfDesc.namespace.taskCallNodes.size shouldBe 1
+            wfDesc.callable.taskCallNodes.size shouldBe 1
             wfDesc.knownValues.head._1.fullyQualifiedName shouldBe "wf_hello.hello.addressee"
             wfDesc.knownValues.head._2 shouldBe WomString("world")
             wfDesc.getWorkflowOption(WorkflowOptions.WriteToCache) shouldBe Option("true")
@@ -131,7 +131,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
       within(Timeout) {
         expectMsgPF() {
           case MaterializeWorkflowDescriptorSuccessResponse(wfDesc) =>
-            wfDesc.namespace.taskCallNodes foreach {
+            wfDesc.callable.taskCallNodes foreach {
               case call if call.callable.name.equals("a") =>
                 wfDesc.backendAssignments(call) shouldBe "SpecifiedBackend"
               case call if call.callable.name.equals("b") =>

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -28,8 +28,7 @@ object ExecutionStoreBenchmark extends Bench[Double] with DefaultJsonProtocol {
   
   val inputJson = Option(SampleWdl.PrepareScatterGatherWdl().rawInputs.toJson.compactPrint)
   val wdl = WdlNamespaceWithWorkflow.load(SampleWdl.PrepareScatterGatherWdl().workflowSource(), Seq.empty).get
-  val graph = wdl.womExecutable(inputJson).getOrElse(throw new Exception("Failed to build womExecutable"))
-    .graph.getOrElse(throw new Exception("Failed to build wom graph"))
+  val graph = wdl.womExecutable(inputJson).getOrElse(throw new Exception("Failed to build womExecutable")).graph
   val prepareCall: TaskCallNode = graph.calls.find(_.localName == "do_prepare").get.asInstanceOf[TaskCallNode]
   val scatterCall: TaskCallNode = graph.allNodes.find(_.localName == "do_scatter").get.asInstanceOf[TaskCallNode]
   val scatter: ScatterNode = graph.scatters.head

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
@@ -40,7 +40,7 @@ trait JesJobCachingActorHelper extends StandardCachingActorHelper {
   lazy val defaultLabels: Labels = {
     val workflow = jobDescriptor.workflowDescriptor
     val call = jobDescriptor.call
-    val subWorkflow = workflow.workflow
+    val subWorkflow = workflow.callable
     val subWorkflowLabels = if (!subWorkflow.equals(workflow.rootWorkflow))
       Labels("cromwell-sub-workflow-name" -> subWorkflow.name)
     else

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
@@ -40,7 +40,7 @@ object Run {
       .setProjectId(projectId)
       .setDocker(pipelineInfo.docker)
       .setResources(pipelineInfo.resources)
-      .setName(workflow.workflow.name)
+      .setName(workflow.callable.name)
       .setInputParameters(jesParameters.collect({ case i: JesInput => i.toGooglePipelineParameter }).toVector.asJava)
       .setOutputParameters(jesParameters.collect({ case i: JesFileOutput => i.toGooglePipelineParameter }).toVector.asJava)
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -164,7 +164,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val job = workflowDescriptor.workflow.taskCallNodes.head
+        val job = workflowDescriptor.callable.taskCallNodes.head
         val key = BackendJobDescriptorKey(job, None, attempt)
         val runtimeAttributes = makeRuntimeAttributes(job)
         val prefetchedKvEntries = Map(
@@ -369,7 +369,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val call: TaskCallNode = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({ case t: TaskCallNode => t }).get
+        val call: TaskCallNode = workflowDescriptor.callable.graph.nodes.collectFirst({ case t: TaskCallNode => t }).get
         val key = BackendJobDescriptorKey(call, None, 1)
         val runtimeAttributes = makeRuntimeAttributes(call)
         val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(inputs), NoDocker, Map.empty)
@@ -442,7 +442,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val job: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+        val job: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
         val runtimeAttributes = makeRuntimeAttributes(job)
         val key = BackendJobDescriptorKey(job, None, 1)
         val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(inputs), NoDocker, Map.empty)
@@ -490,7 +490,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val call: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.find(_.localName == callName).get
+        val call: TaskCallNode = workflowDescriptor.callable.taskCallNodes.find(_.localName == callName).get
         val key = BackendJobDescriptorKey(call, None, 1)
         val runtimeAttributes = makeRuntimeAttributes(call)
         val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(inputs), NoDocker, Map.empty)
@@ -557,7 +557,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val job: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+        val job: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
         val runtimeAttributes = makeRuntimeAttributes(job)
         val key = BackendJobDescriptorKey(job, None, 1)
         val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(inputs), NoDocker, Map.empty)
@@ -592,7 +592,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           Labels.empty
         )
 
-        val job: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+        val job: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
         val runtimeAttributes = makeRuntimeAttributes(job)
         val key = BackendJobDescriptorKey(job, None, 1)
         val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(inputs), NoDocker, Map.empty)
@@ -641,7 +641,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Labels.empty
     )
 
-    val call: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+    val call: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
     val key = BackendJobDescriptorKey(call, None, 1)
     val runtimeAttributes = makeRuntimeAttributes(call)
     val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, Map.empty, NoDocker, Map.empty)
@@ -675,7 +675,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Labels.empty
     )
 
-    val job: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+    val job: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
     val runtimeAttributes = makeRuntimeAttributes(job)
     val key = BackendJobDescriptorKey(job, None, 1)
     val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, Map.empty, NoDocker, Map.empty)
@@ -698,7 +698,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Labels.empty
     )
 
-    val job: TaskCallNode = workflowDescriptor.workflow.innerGraph.nodes.collectFirst({case t: TaskCallNode => t}).get
+    val job: TaskCallNode = workflowDescriptor.callable.graph.nodes.collectFirst({case t: TaskCallNode => t}).get
     val key = BackendJobDescriptorKey(job, None, 1)
     val runtimeAttributes = makeRuntimeAttributes(job)
     val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, Map.empty, NoDocker, Map.empty)
@@ -721,7 +721,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Labels.empty
     )
 
-    val call: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.find(_.localName == "hello").get
+    val call: TaskCallNode = workflowDescriptor.callable.taskCallNodes.find(_.localName == "hello").get
     val key = BackendJobDescriptorKey(call, None, 1)
     val runtimeAttributes = makeRuntimeAttributes(call)
     val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, Map.empty, NoDocker, Map.empty)
@@ -754,7 +754,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Labels.empty
     )
 
-    val call: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.find(_.localName == "B").get
+    val call: TaskCallNode = workflowDescriptor.callable.taskCallNodes.find(_.localName == "B").get
     val key = BackendJobDescriptorKey(call, Option(2), 1)
     val runtimeAttributes = makeRuntimeAttributes(call)
     val jobDescriptor = BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, Map.empty, NoDocker, Map.empty)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -190,7 +190,7 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
     within(Timeout) {
       val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld,
         runtime = """runtime { docker: "ubuntu/latest" test: true }""")
-      val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes,
+      val backend = getJesBackend(workflowDescriptor, workflowDescriptor.callable.taskCallNodes,
         defaultBackendConfig)
       val eventPattern =
         "Key/s [test] is/are not supported by backend. Unsupported attributes will not be part of job executions."
@@ -208,7 +208,7 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
   it should "return InitializationFailed when docker runtime attribute key is not present" taggedAs PostWomTest ignore {
     within(Timeout) {
       val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { }""")
-      val backend = getJesBackend(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes,
+      val backend = getJesBackend(workflowDescriptor, workflowDescriptor.callable.taskCallNodes,
         defaultBackendConfig)
       backend ! Initialize
       expectMsgPF() {
@@ -231,7 +231,7 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint),
       options = workflowOptions
     )
-    val calls = workflowDescriptor.workflow.taskCallNodes
+    val calls = workflowDescriptor.callable.taskCallNodes
     val backendConfigurationDescriptor = BackendConfigurationDescriptor(backendConfig, globalConfig)
     val jesConfiguration = new JesConfiguration(backendConfigurationDescriptor)
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
@@ -49,7 +49,7 @@ class SharedFileSystemInitializationActorSpec extends TestKitSuite("SharedFileSy
       within(Timeout) {
         val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { unsupported: 1 }""")
         val conf = BackendConfigurationDescriptor(TestConfig.sampleBackendRuntimeConfig, ConfigFactory.empty())
-        val backend: ActorRef = getActorRef(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes, conf)
+        val backend: ActorRef = getActorRef(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, conf)
         val pattern = "Key/s [unsupported] is/are not supported by backend. " +
           "Unsupported attributes will not be part of job executions."
         EventFilter.warning(pattern = escapePattern(pattern), occurrences = 1) intercept {

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -239,7 +239,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
   it should "execute shards from a scatter" in {
     val workflowDescriptor = buildWdlWorkflowDescriptor(TestWorkflows.Scatter)
 
-    val call: TaskCallNode = workflowDescriptor.workflow.taskCallNodes.head
+    val call: TaskCallNode = workflowDescriptor.callable.taskCallNodes.head
 
     0 to 2 foreach { shard =>
       // This assumes that engine will give us the evaluated value of the scatter item at the correct index

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkInitializationActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkInitializationActorSpec.scala
@@ -42,7 +42,7 @@ class SparkInitializationActorSpec  extends  TestKitSuite("SparkInitializationAc
       within(Timeout) {
         EventFilter.warning(message = s"Key/s [memory] is/are not supported by SparkBackend. Unsupported attributes will not be part of jobs executions.", occurrences = 1) intercept {
           val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { memory: 1 %s: "%s"}""".format("appMainClass", "test"))
-          val backend = getSparkBackend(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes, TestConfig.emptyBackendConfigDescriptor)
+          val backend = getSparkBackend(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, TestConfig.emptyBackendConfigDescriptor)
           backend ! Initialize
         }
       }

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkRuntimeAttributesSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkRuntimeAttributesSpec.scala
@@ -138,7 +138,7 @@ class SparkRuntimeAttributesSpec extends WordSpecLike with Matchers {
   private def createRuntimeAttributes(workflowSource: WorkflowSource, runtimeAttributes: String): List[Map[String, WomValue]] = {
     val workflowDescriptor = buildWorkflowDescriptor(workflowSource, runtime = runtimeAttributes)
 
-    workflowDescriptor.workflow.taskCallNodes.toList map {
+    workflowDescriptor.callable.taskCallNodes.toList map {
       call =>
         val staticValues = workflowDescriptor.knownValues.map {
           case (outputPort, resolvedInput) => outputPort.name -> resolvedInput

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -23,7 +23,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
                          dockerImageUsed: String) {
 
   private val workflowDescriptor = jobDescriptor.workflowDescriptor
-  private val workflowName = workflowDescriptor.workflow.name
+  private val workflowName = workflowDescriptor.callable.name
   private val fullyQualifiedTaskName = jobDescriptor.call.fullyQualifiedName
   val name: String = fullyQualifiedTaskName
   val description: String = jobDescriptor.toString

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
@@ -81,7 +81,7 @@ class TesInitializationActorSpec extends TestKitSuite("TesInitializationActorSpe
       within(Timeout) {
         val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld,
           runtime = """runtime { docker: "ubuntu/latest" test: true }""")
-        val backend = getActorRef(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes, conf)
+        val backend = getActorRef(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, conf)
         val eventPattern =
           "Key/s [test] is/are not supported by backend. Unsupported attributes will not be part of job executions."
         EventFilter.warning(pattern = escapePattern(eventPattern), occurrences = 1) intercept {
@@ -97,7 +97,7 @@ class TesInitializationActorSpec extends TestKitSuite("TesInitializationActorSpe
     "return InitializationFailed when docker runtime attribute key is not present" taggedAs PostWomTest ignore {
       within(Timeout) {
         val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { }""")
-        val backend = getActorRef(workflowDescriptor, workflowDescriptor.workflow.taskCallNodes, conf)
+        val backend = getActorRef(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, conf)
         backend ! Initialize
         expectMsgPF() {
           case InitializationFailed(failure) =>

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
@@ -10,7 +10,7 @@ class TesJobPathsSpec extends FlatSpec with Matchers with BackendSpec {
   "JobPaths" should "provide correct paths for a job" in {
 
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
-    val call: TaskCallNode = wd.workflow.taskCallNodes.head
+    val call: TaskCallNode = wd.callable.taskCallNodes.head
     val jobKey = BackendJobDescriptorKey(call, None, 1)
     val jobPaths = TesJobPaths(jobKey, wd, TesTestConfig.backendConfig)
     val id = wd.id

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesWorkflowPathsSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesWorkflowPathsSpec.scala
@@ -23,13 +23,13 @@ class TesWorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")
     val rootWorkflowId = WorkflowId.randomId()
-    rootWd.workflow returns rootWorkflow
+    rootWd.callable returns rootWorkflow
     rootWd.id returns rootWorkflowId
 
     val subWd = mock[BackendWorkflowDescriptor]
     val subWorkflow = WomMocks.mockWorkflowDefinition("subWorkflow")
     val subWorkflowId = WorkflowId.randomId()
-    subWd.workflow returns subWorkflow
+    subWd.callable returns subWorkflow
     subWd.id returns subWorkflowId
     
     val call1 = WomMocks.mockTaskCall(WomIdentifier("call1"))

--- a/wdl/src/main/scala/wdl/WdlTask.scala
+++ b/wdl/src/main/scala/wdl/WdlTask.scala
@@ -10,7 +10,7 @@ import wdl.expression.{WdlFunctions, WdlStandardLibraryFunctions}
 import wdl.util.StringUtil
 import wdl4s.parser.WdlParser._
 import wom.callable.Callable.{InputDefinitionWithDefault, OptionalInputDefinition, RequiredInputDefinition}
-import wom.callable.{Callable, TaskDefinition}
+import wom.callable.{Callable, CallableTaskDefinition, TaskDefinition}
 import wom.graph.LocalName
 import wom.types.WomOptionalType
 import wom.values.{WomFile, WomValue}
@@ -212,7 +212,7 @@ case class WdlTask(name: String,
     } toMap
   }
 
-  private def buildWomTaskDefinition: TaskDefinition = TaskDefinition(
+  private def buildWomTaskDefinition: TaskDefinition = CallableTaskDefinition(
     name,
     commandTemplate,
     runtimeAttributes.toWomRuntimeAttributes,

--- a/wdl/src/test/scala/wom/WdlAliasWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlAliasWomSpec.scala
@@ -26,8 +26,7 @@ class WdlAliasWomSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(conditionalTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val conditionalTestGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val conditionalTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
     conditionalTestGraph match {
       case Valid(g) => validateGraph(g)

--- a/wdl/src/test/scala/wom/WdlConditionalWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlConditionalWomSpec.scala
@@ -31,8 +31,7 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(conditionalTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val conditionalTestGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val conditionalTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
     conditionalTestGraph match {
       case Valid(g) => validateGraph(g)

--- a/wdl/src/test/scala/wom/WdlInputValidationSpec.scala
+++ b/wdl/src/test/scala/wom/WdlInputValidationSpec.scala
@@ -38,8 +38,8 @@ class WdlInputValidationSpec extends FlatSpec with Matchers with BeforeAndAfterA
 
   val namespace = WdlNamespace.loadUsingSource(wdlWorkflow, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
   val graph = namespace.workflow.womDefinition
-    .getOrElse(fail("Failed to build a wom definition"))
-    .graph.valueOr(errors => fail(s"Failed to build a wom graph: ${errors.toList.mkString(", ")}"))
+    .valueOr(errors => fail(s"Failed to build a wom definition: ${errors.toList.mkString(", ")}"))
+    .graph
 
   val w1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
   val w2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort

--- a/wdl/src/test/scala/wom/WdlNamespaceWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlNamespaceWomSpec.scala
@@ -56,8 +56,7 @@ class WdlNamespaceWomSpec extends FlatSpec with Matchers {
       """.stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(threeStep, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val wom3Step = namespace.workflow.womDefinition.flatMap(_.graph)
+    val wom3Step = namespace.workflow.womDefinition.map(_.graph)
 
     val workflowGraph = wom3Step match {
       case Valid(g) => g

--- a/wdl/src/test/scala/wom/WdlScatterWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlScatterWomSpec.scala
@@ -31,8 +31,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val scatterTestGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val scatterTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
     scatterTestGraph match {
       case Valid(g) => validateGraph(g)
@@ -133,8 +132,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
         |}""".stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val scatterTestGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val scatterTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
     scatterTestGraph match {
       case Valid(g) => validateGraph(g)
@@ -176,8 +174,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
         |""".stripMargin
 
     val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val scatterTestGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val scatterTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
     scatterTestGraph match {
       case Valid(g) => validateGraph(g)

--- a/wdl/src/test/scala/wom/WdlSubworkflowWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlSubworkflowWomSpec.scala
@@ -51,9 +51,8 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       workflowSource = outerWdl,
       resource = None,
       importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
     
-    val outerWorkflowGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val outerWorkflowGraph = namespace.workflow.womDefinition.map(_.graph)
 
     outerWorkflowGraph match {
       case Valid(g) => validateOuter(g)
@@ -143,9 +142,8 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       workflowSource = outerWdl,
       resource = None,
       importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
 
-    val outerWorkflowGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val outerWorkflowGraph = namespace.workflow.womDefinition.map(_.graph)
 
     outerWorkflowGraph match {
       case Valid(g) => validateOuter(g)
@@ -207,8 +205,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       resource = None,
       importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
 
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val outerWorkflowGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+    val outerWorkflowGraph = namespace.workflow.womDefinition.map(_.graph)
 
     outerWorkflowGraph match {
       case Valid(g) => validateOuter(g)

--- a/wdl/src/test/scala/wom/WdlWomExpressionsAsInputsSpec.scala
+++ b/wdl/src/test/scala/wom/WdlWomExpressionsAsInputsSpec.scala
@@ -55,8 +55,7 @@ class WdlWomExpressionsAsInputsSpec extends FlatSpec with Matchers {
   it should "wire up input expressions for a WDL workflow" in {
 
     val namespace = WdlNamespace.loadUsingSource(Wdl, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    import common.validation.ErrorOr.ShortCircuitingFlatMap
-    val workflowGraph = namespace.workflow.womDefinition.flatMap(_.graph) match {
+    val workflowGraph = namespace.workflow.womDefinition.map(_.graph) match {
       case Valid(g) => g
       case Invalid(errors) => fail(s"Unable to build wom graph from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
     }

--- a/wom/src/main/scala-2.11/wom/executable/ExecutableValidation.scala
+++ b/wom/src/main/scala-2.11/wom/executable/ExecutableValidation.scala
@@ -4,25 +4,20 @@ import cats.syntax.either._
 import common.Checked
 import common.validation.Checked._
 import common.validation.ErrorOr.ErrorOr
-import wom.callable.Callable
+import wom.callable.ExecutableCallable
 import wom.executable.Executable.{DelayedCoercionFunction, InputParsingFunction, ResolvedExecutableInputs}
 import wom.graph.Graph
 
+// WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
+// If you're making changes here, you'll also need to update ../../../scala-2.12/wom/executable/ExecutableValidation.scala
+// (More info in the 2.12 version on why this was necessary)
 private [executable] object ExecutableValidation {
-  /*
-    * Validates and build an executable.
-    * Note: There is a 2.12 and 2.11 version of this function.
-    * This is because scala 2.12 has right biased Either whereas scala 2.11 has not
-    * Because of this we can map and flatMap Eithers in scala 2.12 without any external librabry,
-    * but we need cats.syntax.either._ in 2.11. Because we warn on unused imports and warnings are fatal,
-    * the same implementation cannot compile on 2.11 and 2.12 at the same time.
-   */
-  private [executable] def validateExecutable(entryPoint: Callable,
+
+  private [executable] def validateExecutable(entryPoint: ExecutableCallable,
                                               inputParsingFunction: InputParsingFunction,
                                               parseGraphInputs: (Graph, Map[String, DelayedCoercionFunction]) => ErrorOr[ResolvedExecutableInputs],
                                               inputFile: Option[String]): Checked[Executable] = for {
-    validGraph <- entryPoint.graph.toEither
     parsedInputs <- inputFile.map(inputParsingFunction).getOrElse(Map.empty[String, DelayedCoercionFunction].validNelCheck)
-    validatedInputs <- parseGraphInputs(validGraph, parsedInputs).toEither
+    validatedInputs <- parseGraphInputs(entryPoint.graph, parsedInputs).toEither
   } yield Executable(entryPoint, validatedInputs)
 }

--- a/wom/src/main/scala-2.12/wom/executable/ExecutableValidation.scala
+++ b/wom/src/main/scala-2.12/wom/executable/ExecutableValidation.scala
@@ -3,25 +3,27 @@ package wom.executable
 import common.Checked
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Checked._
-import wom.callable.Callable
+import wom.callable.ExecutableCallable
 import wom.executable.Executable.{DelayedCoercionFunction, InputParsingFunction, ResolvedExecutableInputs}
 import wom.graph.Graph
 
+// WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
+// If you're making changes here, you'll also need to update ../../../scala-2.11/wom/executable/ExecutableValidation.scala
+// (More info below on why this was necessary)
 private [executable] object ExecutableValidation {
   /*
     * Validates and build an executable.
-    * Note: There is a 2.12 and 2.11 version of this function.
-    * This is because scala 2.12 has right biased Either whereas scala 2.11 has not
-    * Because of this we can map and flatMap Eithers in scala 2.12 without any external librabry,
+    *
+    * There is a 2.12 and 2.11 version of this function because scala 2.12 has right biased Either whereas
+    * scala 2.11 has not. Because of this we can map and flatMap Eithers in scala 2.12 without any external library,
     * but we need cats.syntax.either._ in 2.11. Because we warn on unused imports and warnings are fatal,
     * the same implementation cannot compile on 2.11 and 2.12 at the same time.
    */
-  private [executable] def validateExecutable(entryPoint: Callable,
-                             inputParsingFunction: InputParsingFunction,
-                             parseGraphInputs: (Graph, Map[String, DelayedCoercionFunction]) => ErrorOr[ResolvedExecutableInputs],
-                             inputFile: Option[String]): Checked[Executable] = for {
-    validGraph <- entryPoint.graph.toEither
+  private [executable] def validateExecutable(entryPoint: ExecutableCallable,
+                                              inputParsingFunction: InputParsingFunction,
+                                              parseGraphInputs: (Graph, Map[String, DelayedCoercionFunction]) => ErrorOr[ResolvedExecutableInputs],
+                                              inputFile: Option[String]): Checked[Executable] = for {
     parsedInputs <- inputFile.map(inputParsingFunction).getOrElse(Map.empty[String, DelayedCoercionFunction].validNelCheck)
-    validatedInputs <- parseGraphInputs(validGraph, parsedInputs).toEither
+    validatedInputs <- parseGraphInputs(entryPoint.graph, parsedInputs).toEither
   } yield Executable(entryPoint, validatedInputs)
 }

--- a/wom/src/main/scala/wom/callable/Callable.scala
+++ b/wom/src/main/scala/wom/callable/Callable.scala
@@ -1,18 +1,22 @@
 package wom.callable
 
-import common.validation.ErrorOr.ErrorOr
 import wom.callable.Callable._
 import wom.expression.WomExpression
-import wom.graph.{Graph, LocalName}
+import wom.graph.{Graph, LocalName, TaskCallNode}
 import wom.types.{WomOptionalType, WomType}
-
 
 trait Callable {
   def name: String
 
-  def graph: ErrorOr[Graph]
   def inputs: List[_ <: InputDefinition]
   def outputs: List[_ <: OutputDefinition]
+}
+
+trait ExecutableCallable extends Callable {
+  def graph: Graph
+  lazy val taskCallNodes: Set[TaskCallNode] = graph.allNodes collect {
+    case taskNode: TaskCallNode => taskNode
+  }
 }
 
 object Callable {

--- a/wom/src/main/scala/wom/callable/TaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/TaskDefinition.scala
@@ -5,84 +5,89 @@ import common.validation.ErrorOr.ErrorOr
 import wdl.util.StringUtil
 import wom.expression.IoFunctionSet
 import wom.graph.{Graph, TaskCall}
-import wom.values.{WomValue, WomEvaluatedCallInputs}
+import wom.values.{WomEvaluatedCallInputs, WomValue}
 import wom.{CommandPart, RuntimeAttributes}
 
 import scala.util.Try
 
-case class TaskDefinition(name: String,
-                          commandTemplate: Seq[CommandPart],
-                          runtimeAttributes: RuntimeAttributes,
-                          meta: Map[String, String],
-                          parameterMeta: Map[String, String],
-                          outputs: List[Callable.OutputDefinition],
-                          inputs: List[_ <: Callable.InputDefinition],
-                          prefixSeparator: String = ".",
-                          commandPartSeparator: String = "",
-                          stdoutRedirection: Option[String] = None,
-                          stderrRedirection: Option[String] = None) extends Callable {
+sealed trait TaskDefinition extends Callable {
 
-  val unqualifiedName: LocallyQualifiedName = name
+  def commandTemplate: Seq[CommandPart]
+  def runtimeAttributes: RuntimeAttributes
+  def meta: Map[String, String]
+  def parameterMeta: Map[String, String]
+  def prefixSeparator: String
+  def commandPartSeparator: String
+  def stdoutRedirection: Option[String]
+  def stderrRedirection: Option[String]
 
-  override lazy val graph: ErrorOr[Graph] = TaskCall.graphFromDefinition(this)
-
-//  def lookupFunction(knownInputs: WorkflowCoercedInputs,
-//                     wdlFunctions: WdlFunctions[WomValue],
-//                     outputResolver: OutputResolver = NoOutputResolver,
-//                     shards: Map[Scatter, Int] = Map.empty[Scatter, Int],
-//                     relativeTo: Scope = null): String => WomValue = ???
+  lazy val unqualifiedName: LocallyQualifiedName = name
 
   def instantiateCommand(taskInputs: WomEvaluatedCallInputs,
                          functions: IoFunctionSet,
                          valueMapper: WomValue => WomValue = identity[WomValue],
                          separate: Boolean = false): Try[String] = {
     val mappedInputs = taskInputs.map({case (k, v) => k.localName -> v})
-    // TODO: Bring back inputs: Try(StringUtil.normalize(commandTemplate.map(_.instantiate(declarations, taskInputs, functions, valueMapper)).mkString("")))
-    // TODO WOM this is super WDL specific and doesn't belong here.
     Try(StringUtil.normalize(commandTemplate.map(_.instantiate(mappedInputs, functions, valueMapper)).mkString(commandPartSeparator)))
   }
 
   def commandTemplateString: String = StringUtil.normalize(commandTemplate.map(_.toString).mkString)
 
   override def toString: String = s"[Task name=$name commandTemplate=$commandTemplate}]"
+}
 
+/**
+  * A task definition only.
+  * Can be called but cannot be used in an Executable as a standalone execution.
+  */
+final case class CallableTaskDefinition(name: String,
+                                        commandTemplate: Seq[CommandPart],
+                                        runtimeAttributes: RuntimeAttributes,
+                                        meta: Map[String, String],
+                                        parameterMeta: Map[String, String],
+                                        outputs: List[Callable.OutputDefinition],
+                                        inputs: List[_ <: Callable.InputDefinition],
+                                        prefixSeparator: String = ".",
+                                        commandPartSeparator: String = "",
+                                        stdoutRedirection: Option[String] = None,
+                                        stderrRedirection: Option[String] = None
+                                       ) extends TaskDefinition
 
-  // TODO: fixup? The general version in Callable might not be good enough for Task:
-//  def evaluateOutputs(inputs: EvaluatedTaskInputs,
-//                      wdlFunctions: WdlStandardLibraryFunctions,
-//                      postMapper: WomValue => Try[WomValue] = v => Success(v)): Try[Map[TaskOutput, WomValue]] = {
-//    val fqnInputs = inputs map { case (d, v) => d.fullyQualifiedName -> v }
-//    val evaluatedOutputs = outputs.foldLeft(Map.empty[TaskOutput, Try[WomValue]])((outputMap, output) => {
-//      val currentOutputs = outputMap collect {
-//        case (outputName, value) if value.isSuccess => outputName.fullyQualifiedName -> value.get
-//      }
-//      def knownValues = currentOutputs ++ fqnInputs
-//      val lookup = NoLookup // TODO: Reinstate: val lookup = lookupFunction(knownValues, wdlFunctions, relativeTo = output)
-//      val coerced = output.expression.evaluate(lookup, wdlFunctions) flatMap output.womType.coerceRawValue
-//      val jobOutput = output -> (coerced flatMap postMapper).recoverWith {
-//        case t: Throwable => Failure(new RuntimeException(s"Could not evaluate ${output.name} = ${output.expression.toWdlString}", t))
-//      }
-//      outputMap + jobOutput
-//    }) map { case (k, v) => k -> v }
-//
-//    TryUtil.sequenceMap(evaluatedOutputs, "Failed to evaluate outputs.")
-//  }
+/**
+  * A task definition with an embedded graph.
+  * Can be called from a workflow but can also be run as a standalone execution.
+  */
+final case class ExecutableTaskDefinition private (callableTaskDefinition: CallableTaskDefinition,
+                                                   override val graph: Graph
+                                                  ) extends TaskDefinition with ExecutableCallable {
+  override def name = callableTaskDefinition.name
+  override def inputs = callableTaskDefinition.inputs
+  override def outputs = callableTaskDefinition.outputs
 
-  /**
-    * Assign declaration values from the given input map.
-    * Fqn must be task declaration fqns
-    * e.g.:
-    * task t {
-    *   String s
-    * }
-    * inputMap = Map("t.s" -> WdlString("hello"))
-    */
-//  def inputsFromMap(suppliedInputs: Map[FullyQualifiedName, WomValue]): EvaluatedTaskInputs = {
-    // TODO: Reinstate:
-//    inputs flatMap { i =>
-//      suppliedInputs collectFirst {
-//        case (fqn, value) if fqn == i.name => i -> value }
-//    } toMap
-//    Map.empty
-//  }
+  override def commandTemplate = callableTaskDefinition.commandTemplate
+  override def runtimeAttributes = callableTaskDefinition.runtimeAttributes
+  override def meta = callableTaskDefinition.meta
+  override def parameterMeta = callableTaskDefinition.parameterMeta
+  override def prefixSeparator = callableTaskDefinition.prefixSeparator
+  override def commandPartSeparator = callableTaskDefinition.commandPartSeparator
+  override def stdoutRedirection = callableTaskDefinition.stdoutRedirection
+  override def stderrRedirection = callableTaskDefinition.stderrRedirection
+}
+
+object ExecutableTaskDefinition {
+  def tryApply(callableTaskDefinition: CallableTaskDefinition): ErrorOr[ExecutableTaskDefinition] =
+    TaskCall.graphFromDefinition(callableTaskDefinition) map { ExecutableTaskDefinition(callableTaskDefinition, _) }
+
+  def tryApply(name: String,
+               commandTemplate: Seq[CommandPart],
+               runtimeAttributes: RuntimeAttributes,
+               meta: Map[String, String],
+               parameterMeta: Map[String, String],
+               outputs: List[Callable.OutputDefinition],
+               inputs: List[_ <: Callable.InputDefinition],
+               prefixSeparator: String = ".",
+               commandPartSeparator: String = "",
+               stdoutRedirection: Option[String] = None,
+               stderrRedirection: Option[String] = None): ErrorOr[ExecutableTaskDefinition] =
+    tryApply(CallableTaskDefinition(name, commandTemplate, runtimeAttributes, meta, parameterMeta, outputs, inputs, prefixSeparator, commandPartSeparator, stdoutRedirection, stderrRedirection))
 }

--- a/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
+++ b/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
@@ -1,7 +1,5 @@
 package wom.callable
 
-import cats.syntax.validated._
-import common.validation.ErrorOr.ErrorOr
 import wom.expression.WomExpression
 import wom.graph.GraphNode._
 import wom.graph.{Graph, TaskCallNode}
@@ -10,17 +8,17 @@ final case class WorkflowDefinition(name: String,
                                     innerGraph: Graph,
                                     meta: Map[String, String],
                                     parameterMeta: Map[String, String],
-                                    declarations: List[(String, WomExpression)]) extends Callable {
+                                    declarations: List[(String, WomExpression)]) extends ExecutableCallable {
 
   override lazy val toString = s"[Workflow $name]"
-  override val graph: ErrorOr[Graph] = innerGraph.validNel
+  override val graph: Graph = innerGraph
 
   // FIXME: how to get a meaningful order from the node set ?
   override lazy val inputs: List[_ <: Callable.InputDefinition] = innerGraph.nodes.inputDefinitions.toList
   
   override lazy val outputs: List[_ <: Callable.OutputDefinition] = innerGraph.nodes.outputDefinitions.toList
 
-  lazy val taskCallNodes: Set[TaskCallNode] = innerGraph.allNodes collect {
+  override lazy val taskCallNodes: Set[TaskCallNode] = innerGraph.allNodes collect {
     case taskNode: TaskCallNode => taskNode
   }
 }

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -4,7 +4,7 @@ import cats.syntax.validated._
 import common.Checked
 import common.validation.ErrorOr._
 import shapeless.Coproduct
-import wom.callable.Callable
+import wom.callable.ExecutableCallable
 import wom.executable.Executable.ResolvedExecutableInputs
 import wom.executable.ExecutableValidation._
 import wom.graph.Graph.ResolvedExecutableInput
@@ -33,7 +33,7 @@ object Executable {
    */
   type ResolvedExecutableInputs = Map[OutputPort, ResolvedExecutableInput]
 
-  def withInputs(entryPoint: Callable, inputParsingFunction: InputParsingFunction, inputFile: Option[String]): Checked[Executable] = {
+  def withInputs(entryPoint: ExecutableCallable, inputParsingFunction: InputParsingFunction, inputFile: Option[String]): Checked[Executable] = {
     validateExecutable(entryPoint, inputParsingFunction, parseGraphInputs, inputFile)
   }
 
@@ -64,6 +64,6 @@ object Executable {
   * @param entryPoint callable that this executable wraps
   * @param resolvedExecutableInputs Resolved values for the ExternalGraphInputNodes of the entryPoint's graph
   */
-final case class Executable(entryPoint: Callable, resolvedExecutableInputs: ResolvedExecutableInputs) {
-  val graph: ErrorOr[Graph] = entryPoint.graph
+final case class Executable(entryPoint: ExecutableCallable, resolvedExecutableInputs: ResolvedExecutableInputs) {
+  val graph: Graph = entryPoint.graph
 }

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import shapeless.Coproduct
 import wom.RuntimeAttributes
 import wom.callable.Callable.{OutputDefinition, RequiredInputDefinition}
-import wom.callable.{TaskDefinition, WorkflowDefinition}
+import wom.callable.{CallableTaskDefinition, WorkflowDefinition}
 import wom.graph.CallNode.{CallNodeAndNewNodes, CallNodeBuilder, InputDefinitionFold, InputDefinitionPointer}
 import wom.graph.GraphNodePort.OutputPort
 import wom.types.{WomFileType, WomIntegerType, WomStringType}
@@ -14,7 +14,7 @@ class GraphSpec extends FlatSpec with Matchers {
   behavior of "Graph"
 
   def makeThreeStep: Graph = {
-    val taskDefinition_ps = TaskDefinition(
+    val taskDefinition_ps = CallableTaskDefinition(
       name = "ps",
       commandTemplate = null,
       runtimeAttributes = RuntimeAttributes(attributes = Map.empty),
@@ -27,7 +27,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val cgrepInFile = RequiredInputDefinition("in_file", WomFileType)
     val cgrepPattern = RequiredInputDefinition("pattern", WomStringType)
     
-    val taskDefinition_cgrep = TaskDefinition(
+    val taskDefinition_cgrep = CallableTaskDefinition(
       name = "cgrep",
       commandTemplate = null,
       runtimeAttributes = RuntimeAttributes(attributes = Map.empty),
@@ -38,7 +38,7 @@ class GraphSpec extends FlatSpec with Matchers {
     )
 
     val wcInFile = RequiredInputDefinition("in_file", WomFileType)
-    val taskDefinition_wc = TaskDefinition(
+    val taskDefinition_wc = CallableTaskDefinition(
       name = "wc",
       commandTemplate = null,
       runtimeAttributes = RuntimeAttributes(attributes = Map.empty),

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import shapeless.Coproduct
 import wom.RuntimeAttributes
 import wom.callable.Callable.{OutputDefinition, RequiredInputDefinition}
-import wom.callable.TaskDefinition
+import wom.callable.CallableTaskDefinition
 import wom.expression.PlaceholderWomExpression
 import wom.graph.CallNode.{CallNodeAndNewNodes, CallNodeBuilder, InputDefinitionFold, InputDefinitionPointer}
 import wom.graph.GraphNodePort.OutputPort
@@ -17,7 +17,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
   behavior of "ScatterNode"
 
   val fooInputDef = RequiredInputDefinition("i", WomIntegerType)
-  val task_foo = TaskDefinition(name = "foo",
+  val task_foo = CallableTaskDefinition(name = "foo",
     commandTemplate = null,
     runtimeAttributes = RuntimeAttributes(Map.empty),
     meta = Map.empty,

--- a/womtool/src/main/scala/womtool/Main.scala
+++ b/womtool/src/main/scala/womtool/Main.scala
@@ -2,7 +2,6 @@ package womtool
 
 import java.nio.file.Paths
 
-import cats.data.Validated.{Invalid, Valid}
 import wdl.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
 import wdl._
 import spray.json._
@@ -95,13 +94,8 @@ object Main extends App {
 
   def womGraph(args: Seq[String]): Termination = {
     continueIf(args.nonEmpty) {
-
       val (mainFile, auxFiles) = (args.head, args.tail)
-
-      WomGraph.fromFiles(mainFile, auxFiles) match {
-        case Valid(womGraph) => SuccessfulTermination(womGraph.digraphDot)
-        case Invalid(errors) => UnsuccessfulTermination("Unable to construct wom graph:" + errors.toList.mkString("\n", "\n", "\n"))
-      }
+      SuccessfulTermination(WomGraph.fromFiles(mainFile, auxFiles).digraphDot)
     }
   }
 


### PR DESCRIPTION
This PR is a lot less scary than it looks. Most of the changed lines spring from two changes (and the changes are actually make everything a lot simpler!):

- `TaskDefinition` is split into two: `CallableTaskDefinition` which can be called, and `ExecutableTaskDefinition` which can be executed.
- `Callable` now doesn't have a `graph: ErrorOr[Graph]`. Instead the new, more specific `ExecutableCallable` has a `graph: Graph` method.