### PR TITLE
publish metadata for all imports

### DIFF
--- a/centaur/README.md
+++ b/centaur/README.md
@@ -19,12 +19,12 @@ Tag names are all lower case, so a test named "tagFoo" has a tag "tagfoo".
 
 To run only those tests which have been tagged with a specified tag `tagFoo`:
 ```
-sbt "testOnly * -- -n tagfoo"
+sbt "project centaur" "it:testOnly * -- -n tagfoo"
 ```
 
 Or to instead exclude all tests which have been tagged with a specified tag `tagFoo`:
 ```
-sbt "testOnly * -- -l tagfoo"
+sbt "project centaur" "it:testOnly * -- -l tagfoo"
 ```
 
 # Adding custom tests

--- a/centaur/src/main/resources/standardTestCases/invalid_wdl.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_wdl.test
@@ -8,5 +8,5 @@ files {
 
 metadata {
   "failures.0.message": "Workflow input processing failed"
-  "failures.0.causedBy.0.message": "Unable to load namespace from workflow: ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got }.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
+  "failures.0.causedBy.0.message": "ERROR: Unexpected symbol (line 1, col 15) when parsing 'task'.\n\nExpected lbrace, got }.\n\ntask blahblah }{\n              ^\n\n$task = :task :identifier :lbrace $_gen3 $_gen4 :rbrace -> Task( name=$1, declarations=$3, sections=$4 )\n     "
 }

--- a/centaur/src/main/resources/standardTestCases/public_http_import/public_http_import.wdl
+++ b/centaur/src/main/resources/standardTestCases/public_http_import/public_http_import.wdl
@@ -1,4 +1,4 @@
-import "https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl" as subworkflow
+import "https://raw.githubusercontent.com/broadinstitute/cromwell/f2d1c3bdd5535d9f6a997eadaf136742d86adbe5/centaur/src/main/resources/standardTestCases/aliased_subworkflows/aliased_subworkflows.wdl" as subworkflow
 
 workflow public_http_import {
 

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf.test
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf.test
@@ -1,0 +1,20 @@
+ignore: false
+name: recursive_imports_no_subwf
+testFormat: workflowsuccess
+
+
+files {
+  wdl: recursive_imports_no_subwf/recursive_imports_no_subwf.wdl
+  imports: [
+    recursive_imports_no_subwf/recimp_nosubwf_inner.wdl,
+    recursive_imports_no_subwf/recimp_nosubwf_outer.wdl
+  ]
+}
+
+metadata {
+  workflowName: void
+  status: Succeeded
+  "submittedFiles.imports.recimp_nosubwf_inner.wdl": "import \"https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl\" as subworkflow\n\n# Nothing at all\ntask inner {\n  command {}\n  output {}\n}\n",
+  "submittedFiles.imports.https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl": "task increment {\n  Int i\n  command {\n    echo $(( ${i} + 1 ))\n  }\n  output {\n    Int j = read_int(stdout())\n  }\n  runtime {\n    docker: \"ubuntu:latest\"\n  }\n}\n\nworkflow subwf {\n  Array[Int] is\n  scatter (i in is) {\n    call increment { input: i = i }\n  }\n  output {\n    Array[Int] js = increment.j\n  }\n}\n",
+  "submittedFiles.imports.recimp_nosubwf_outer.wdl": "import \"recimp_nosubwf_inner.wdl\" as inner\n\n# Nothing at all\ntask outer {\n  command {}\n  output {}\n}\n"
+}

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recimp_nosubwf_inner.wdl
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recimp_nosubwf_inner.wdl
@@ -1,0 +1,7 @@
+import "https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl" as subworkflow
+
+# Nothing at all
+task inner {
+  command {}
+  output {}
+}

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recimp_nosubwf_outer.wdl
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recimp_nosubwf_outer.wdl
@@ -1,0 +1,7 @@
+import "recimp_nosubwf_inner.wdl" as inner
+
+# Nothing at all
+task outer {
+  command {}
+  output {}
+}

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recursive_imports_no_subwf.wdl
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_no_subwf/recursive_imports_no_subwf.wdl
@@ -1,0 +1,5 @@
+import "recimp_nosubwf_outer.wdl" as outer
+
+# The sole purpose of this test is to check import metadata.
+workflow void {
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
@@ -200,7 +200,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
       within(Timeout) {
         expectMsgPF() {
           case MaterializeWorkflowDescriptorFailureResponse(reason) =>
-            reason.getMessage should startWith("Workflow input processing failed:\nUnable to load namespace from workflow: ERROR: Finished parsing without consuming all tokens.")
+            reason.getMessage should startWith("Workflow input processing failed:\nERROR: Finished parsing without consuming all tokens.")
           case _: MaterializeWorkflowDescriptorSuccessResponse => fail("This materialization should not have succeeded!")
           case unknown =>
             fail(s"Unexpected materialization response: $unknown")
@@ -231,7 +231,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
       within(Timeout) {
         expectMsgPF() {
           case MaterializeWorkflowDescriptorFailureResponse(reason) =>
-            reason.getMessage should startWith("Workflow input processing failed:\nUnable to load namespace from workflow: Namespace does not have a local workflow to run")
+            reason.getMessage should startWith("Workflow input processing failed:\nNamespace does not have a local workflow to run")
           case _: MaterializeWorkflowDescriptorSuccessResponse => fail("This materialization should not have succeeded!")
           case unknown =>
             fail(s"Unexpected materialization response: $unknown")
@@ -431,7 +431,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
       within(Timeout) {
         expectMsgPF() {
           case MaterializeWorkflowDescriptorFailureResponse(reason) =>
-            reason.getMessage should startWith("Workflow input processing failed:\nUnable to load namespace from workflow: ERROR: Value for j is not coerceable into a Int")
+            reason.getMessage should startWith("Workflow input processing failed:\nERROR: Value for j is not coerceable into a Int")
           case _: MaterializeWorkflowDescriptorSuccessResponse => fail("This materialization should not have succeeded!")
           case unknown => fail(s"Unexpected materialization response: $unknown")
         }


### PR DESCRIPTION
Still looking at a Centaur test for this but I thought I'd let the seafowl have at it. Metadata looks like:

```
{
  "workflowName": "three_step",
  "submittedFiles": {
    "workflow": "import \"3step-tasks.wdl\" as tasks\nimport \"https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl\" as subworkflow\n\n\nworkflow three_step {\n  call tasks.ps as ps\n  call tasks.cgrep as cgrep {\n    input: in_file = ps.procs\n  }\n  call tasks.wc as wc {\n    input: in_file = ps.procs\n  }\n  output {\n    cgrep.*\n    wc.*\n  }\n}\n",
    "workflowType": "WDL",
    "options": "{\n\n}",
    "inputs": "{\"three_step.cgrep.pattern\":\"mcovarr\"}",
    "labels": "{}",
    "imports": {
      "https://raw.githubusercontent.com/broadinstitute/centaur/591beaf8422af7c3faf51e437a91d94d13b76eba/src/main/resources/standardTestCases/aliased_subworkflows/subworkflow.wdl": "task increment {\n  Int i\n  command {\n    echo $(( ${i} + 1 ))\n  }\n  output {\n    Int j = read_int(stdout())\n  }\n  runtime {\n    docker: \"ubuntu:latest\"\n  }\n}\n\nworkflow subwf {\n  Array[Int] is\n  scatter (i in is) {\n    call increment { input: i = i }\n  }\n  output {\n    Array[Int] js = increment.j\n  }\n}\n",
      "3step-tasks.wdl": "task ps {\n  command {\n    ps\n  }\n  output {\n    File procs = stdout()\n  }\n  runtime {\n    docker: \"ubuntu:latest\"\n  }\n}\n\ntask cgrep {\n  String pattern\n  File in_file\n  command {\n    grep '${pattern}' ${in_file} | wc -l\n  }\n  output {\n    Int count = read_int(stdout())\n  }\n  runtime {\n    docker: \"ubuntu:latest\"\n  }\n}\n\ntask wc {\n  File in_file\n  command {\n    cat ${in_file} | wc -l\n  }\n  output {\n    Int count = read_int(stdout())\n  }\n  runtime {\n    docker: \"ubuntu:latest\"\n  }\n}\n\n"
    }
  },
.
.
.
```

So the http imports come in under "submittedFiles" which is maybe a little weird. But other options would have http imports either not being next to the file imports and/or having to change the metadata schema.
