### PR TITLE
Reinstate simple conditionals

### DIFF
--- a/core/src/main/scala/cromwell/core/JobKey.scala
+++ b/core/src/main/scala/cromwell/core/JobKey.scala
@@ -10,7 +10,7 @@ trait JobKey {
 
   override def toString = {
     import ExecutionIndex.IndexEnhancedIndex
-    s"${node.fullyQualifiedName}:${index.fromIndex}:$attempt"
+    s"${getClass.getSimpleName}_${node.getClass.getSimpleName}_${node.fullyQualifiedName}:${index.fromIndex}:$attempt"
   }
   
  def isShard = index.isDefined

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -151,7 +151,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
 
     val wf = decodeAllCwl(rootPath/"three_step.cwl").map {
       _.select[Workflow].get
-    }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse! msg was $error"), identity)
+    }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse: $error"), identity)
 
     wf.id should include("three_step")
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
@@ -133,8 +133,10 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
     def calculateUpstreamDone(upstream: GraphNode, index: ExecutionIndex): Boolean = upstream match {
         // OuterGraphInputNode signals that an input comes from outside the graph.
         // Depending on whether or not this input is outside of a scatter graph will change the index which we need to look at
-      case outerNode: OuterGraphInputNode if key.node.isInstanceOf[ScatterNode] => calculateUpstreamDone(outerNode, None)
-      case outerNode: OuterGraphInputNode => calculateUpstreamDone(outerNode, index)
+      case outerNode: ScatterVariableNode =>
+        calculateUpstreamDone(outerNode.linkToOuterGraph.graphNode, None)
+      case outerNode: OuterGraphInputNode =>
+        calculateUpstreamDone(outerNode.linkToOuterGraph.graphNode, index)
       case _: CallNode | _: ScatterNode | _: ExpressionNode | _: ConditionalNode => doneKeys.contains(upstream, index)
       case _ => true
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStore.scala
@@ -75,12 +75,6 @@ final case class ExecutionStore(private val statusStore: Map[JobKey, ExecutionSt
 
   private def keysWithStatus(status: ExecutionStatus) = store.getOrElse(status, List.empty)
 
-  def isInBypassedConditional(jobKey: JobKey): Boolean = keysWithStatus(Bypassed).exists {
-    case conditional: ConditionalKey if conditional.node.innerGraph.nodes.contains(jobKey.node)
-      && conditional.index.equals(jobKey.index) => true
-    case _ => false
-  }
-
   def hasActiveJob: Boolean = {
     def upstreamFailed(node: GraphNode): Boolean = node.upstreamAncestry exists hasFailedNode
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ValueStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ValueStore.scala
@@ -88,13 +88,11 @@ case class ValueStore(store: Table[OutputPort, ExecutionIndex, WomValue]) {
     }
   }
 
-  final def collectConditional(collector: ConditionalCollectorKey, isInBypassed: Boolean): ErrorOr[Map[ValueKey, WomOptionalValue]] = {
+  final def collectConditional(collector: ConditionalCollectorKey): ErrorOr[Map[ValueKey, WomOptionalValue]] = {
     val conditionalPort = collector.conditionalOutputPort
     val sourcePort = conditionalPort.outputToExpose.source
     store.getValue(sourcePort, collector.index) match {
-      case Some(womValue: WomOptionalValue) if isInBypassed && womValue.value.isEmpty => Map(ValueKey(conditionalPort, collector.index) -> womValue).validNel
-      case Some(womValue) if !isInBypassed  => Map(ValueKey(conditionalPort, collector.index) -> WomOptionalValue(womValue)).validNel
-      case Some(_)  => s"Found a non empty value in a bypassed conditional node ${sourcePort.identifier.fullyQualifiedName.value}".invalidNel
+      case Some(womValue) => Map(ValueKey(conditionalPort, collector.index) -> WomOptionalValue(womValue)).validNel
       case None => s"Cannot find a value for output port ${sourcePort.identifier.fullyQualifiedName.value}".invalidNel
     }
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ValueStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/ValueStore.scala
@@ -25,9 +25,17 @@ object ValueStore {
 
 case class ValueStore(store: Table[OutputPort, ExecutionIndex, WomValue]) {
 
-  override def toString: String = store.valuesTriplet.map {
-    case (node, index, value) => s"${node.identifier.fullyQualifiedName}:${index.fromIndex} -> ${value.valueString}"
-  } mkString System.lineSeparator
+  override def toString: String = {
+    val values = store.valuesTriplet.map {
+      case (node, index, value) => s"$node:${index.fromIndex} -> $value"
+    }
+
+    s"""
+      |ValueStore {
+      |  ${values.mkString("," + System.lineSeparator + "  ")}
+      |}
+    """.stripMargin
+  }
 
   final def add(values: Map[ValueKey, WomValue]): ValueStore = {
     this.copy(store = store.addAll(values.map({ case (key, value) => (key.port, key.index, value) })))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -440,14 +440,6 @@ case class WorkflowExecutionActor(workflowDescriptor: EngineWorkflowDescriptor,
     if (truncated || diffs.exists(_.containsNewEntry)) newData else newData.resetCheckRunnable
   }
 
-
-
-//  private def bypassedScopeResults(jobKey: JobKey): Map[ValueKey, WomOptionalValue] = {
-//    jobKey.node.outputPorts.map({ outputPort =>
-//      ValueKey(outputPort, jobKey.index) ->  WomOptionalValue.none(outputPort.womType)
-//    }).toMap
-//  }
-
   private def processRunnableExpression(expression: ExpressionKey, data: WorkflowExecutionActorData) = {
     import common.validation.ErrorOr._
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -35,10 +35,6 @@ case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescript
 
   val expressionLanguageFunctions = new WdlFunctions(workflowDescriptor.pathBuilders)
 
-  def isInBypassedScope(jobKey: JobKey): Boolean = {
-    executionStore.isInBypassedConditional(jobKey)
-  }
-
   def callExecutionSuccess(jobKey: JobKey, outputs: CallOutputs): WorkflowExecutionActorData = {
     val (newJobExecutionActors, newSubWorkflowExecutionActors) = jobKey match {
       case jobKey: BackendJobDescriptorKey => (backendJobExecutionActors - jobKey, subWorkflowExecutionActors)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
@@ -15,18 +15,19 @@ private [execution] case class ConditionalKey(node: ConditionalNode, index: Exec
   override val attempt = 1
 
   /**
-    * Creates a sub-ExecutionStore with entries for each of the scoped children.
+    * Creates ExecutionStore entries for each of the scoped children.
     *
     * @return ExecutionStore of scattered children.
     */
-  def populate: Map[JobKey, ExecutionStatus.Value] = {
+  def populate(bypassed: Boolean): Map[JobKey, ExecutionStatus.Value] = {
     val conditionalKeys = node.innerGraph.nodes.flatMap({ node => keyify(node) })
 
     val collectors = node.conditionalOutputPorts map {
       ConditionalCollectorKey(_, index, node)
     }
 
-    (conditionalKeys ++ collectors).map({ _ -> ExecutionStatus.NotStarted }).toMap
+    val finalStatus = if (bypassed) ExecutionStatus.NotStarted else ExecutionStatus.Bypassed
+    (conditionalKeys ++ collectors).map({ _ -> finalStatus }).toMap
   }
 
   /**

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -130,7 +130,7 @@ object CallNode {
     * Helps making input ports and building the node while making sure node references are set properly.
     */
   class CallNodeBuilder {
-    private val graphNodeSetter = new GraphNode.GraphNodeSetter()
+    private val graphNodeSetter = new GraphNode.GraphNodeSetter[CallNode]()
 
     /**
       * Makes an input port for this call.

--- a/wom/src/main/scala/wom/graph/ConditionalNode.scala
+++ b/wom/src/main/scala/wom/graph/ConditionalNode.scala
@@ -30,7 +30,7 @@ object ConditionalNode  {
   }
 
   def wireInConditional(innerGraph: Graph, expressionNode: ExpressionNode): ConditionalNodeWithNewNodes = {
-    val graphNodeSetter = new GraphNode.GraphNodeSetter()
+    val graphNodeSetter = new GraphNode.GraphNodeSetter[ConditionalNode]()
 
     val outputPorts: Set[ConditionalOutputPort] = innerGraph.nodes.collect { case gon: PortBasedGraphOutputNode =>
       ConditionalOutputPort(WomOptionalType(gon.womType), gon, graphNodeSetter.get)

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -60,7 +60,7 @@ object OuterGraphInputNode {
 /**
   * Used to represent an input to any GraphNode's inner graph which is a link to a value somewhere in the outer graph.
   */
-class OuterGraphInputNode(override val identifier: WomIdentifier, linkToOuterGraph: GraphNodePort.OutputPort) extends GraphInputNode {
+class OuterGraphInputNode(override val identifier: WomIdentifier, val linkToOuterGraph: GraphNodePort.OutputPort) extends GraphInputNode {
   override def womType: WomType = linkToOuterGraph.womType
 }
 

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -70,10 +70,10 @@ object GraphNode {
     * Allows a level of indirection, so that GraphNodePorts can be constructed before their associated GraphNode is
     * constructed. If used, the _graphNode must be set before anything tries to apply 'get'.
     */
-  class GraphNodeSetter {
-    var _graphNode: GraphNode = _
+  class GraphNodeSetter[A <: GraphNode] {
+    var _graphNode: A = _
     private def getGraphNode = _graphNode
-    def get: Unit => GraphNode = _ => getGraphNode
+    def get: Unit => A = _ => getGraphNode
   }
 
   private[wom] implicit class EnhancedGraphNodeSet(val nodes: Set[GraphNode]) extends AnyVal {

--- a/wom/src/main/scala/wom/graph/GraphNodeInputExpression.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodeInputExpression.scala
@@ -17,7 +17,7 @@ case class GraphNodeInputExpression(inputName: String, expression: WomExpression
   /**
     * Instantiate the expression and connect its input ports to the appropriate graphNode.
     */
-  private[graph] def instantiateExpression(graphNodeSetter: GraphNodeSetter): ErrorOr[InstantiatedExpression] = InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping)
+  private[graph] def instantiateExpression(graphNodeSetter: GraphNodeSetter[_ <: GraphNode]): ErrorOr[InstantiatedExpression] = InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping)
 
   private[graph] lazy val evaluateType: ErrorOr[WomType] = expression.evaluateType(inputMapping.map { case (name, port) => (name, port.womType) })
 }

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -22,6 +22,7 @@ object GraphNodePort {
 
   sealed trait OutputPort extends GraphNodePort {
     def identifier: WomIdentifier
+    override def toString: String = s"${getClass.getSimpleName}(${identifier.fullyQualifiedName.value})"
 
     /**
       * Alias for identifier.localName.asString
@@ -62,7 +63,7 @@ object GraphNodePort {
   /**
     * Represents the conditional output from a call or declaration in a ConditionalNode
     */
-  final case class ConditionalOutputPort(womType: WomOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+  final case class ConditionalOutputPort(womType: WomOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => ConditionalNode) extends OutputPort with DelayedGraphNodePort {
     // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToExpose.identifier
   }

--- a/wom/src/main/scala/wom/graph/InstantiatedExpression.scala
+++ b/wom/src/main/scala/wom/graph/InstantiatedExpression.scala
@@ -16,7 +16,7 @@ class InstantiatedExpression private(val expression: WomExpression, val womRetur
 object InstantiatedExpression {
 
   private[graph] def instantiateExpressionForNode[ExpressionBasedNode <: GraphNode, Identifier <: WomIdentifier](nodeConstructor: (Identifier, InstantiatedExpression) => ExpressionBasedNode)(nodeIdentifier: Identifier, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedNode] = {
-    val graphNodeSetter = new GraphNode.GraphNodeSetter()
+    val graphNodeSetter = new GraphNode.GraphNodeSetter[ExpressionBasedNode]()
 
     for {
       linkedInputs <- InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping)
@@ -25,7 +25,7 @@ object InstantiatedExpression {
     } yield expressionNode
   }
 
-  def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[InstantiatedExpression] = {
+  def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter[_ <: GraphNode], expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[InstantiatedExpression] = {
     def linkInput(input: String): ErrorOr[(String, InputPort)] = if (inputMapping.contains(input)) {
       val upstreamPort = inputMapping(input)
       Valid((input, ConnectedInputPort(input, upstreamPort.womType, upstreamPort, graphNodeSetter.get)))

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -52,7 +52,7 @@ object ScatterNode {
   def scatterOverGraph(innerGraph: Graph,
                        scatterCollectionExpressionNode: ExpressionNode,
                        scatterVariableInnerGraphInputNode: ScatterVariableNode): ScatterNodeWithNewNodes = {
-    val graphNodeSetter = new GraphNode.GraphNodeSetter()
+    val graphNodeSetter = new GraphNode.GraphNodeSetter[ScatterNode]()
 
     val outputPorts: Set[ScatterGathererPort] = innerGraph.nodes.collect { case gon: PortBasedGraphOutputNode =>
       ScatterGathererPort(WomArrayType(gon.womType), gon, graphNodeSetter.get)

--- a/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
+++ b/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
@@ -67,7 +67,7 @@ object ExpressionNode {
   /**
     * Attempts to find an output port for all referenced variables in the expression, and created input ports to connect them together.
     */
-  private def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter[_ <: GraphNode], expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[(WomType, Map[String, InputPort])] = {
+  private def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter[ExpressionNode], expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[(WomType, Map[String, InputPort])] = {
     def linkInput(input: String): ErrorOr[(String, InputPort)] = inputMapping.get(input) match {
       case Some(upstreamPort) => (input, ConnectedInputPort(input, upstreamPort.womType, upstreamPort, graphNodeSetter.get)).validNel
       case None => s"Expression cannot be connected without the input $input (provided: ${inputMapping.toString})".invalidNel

--- a/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
+++ b/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
@@ -54,7 +54,7 @@ object ExpressionNode {
     */
   def buildFromConstructor[E <: ExpressionNode](constructor: ExpressionNodeConstructor[E])
   (identifier: WomIdentifier, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[E] = {
-    val graphNodeSetter = new GraphNode.GraphNodeSetter()
+    val graphNodeSetter = new GraphNode.GraphNodeSetter[ExpressionNode]()
 
     for {
       combined <- linkWithInputs(graphNodeSetter, expression, inputMapping)
@@ -67,7 +67,7 @@ object ExpressionNode {
   /**
     * Attempts to find an output port for all referenced variables in the expression, and created input ports to connect them together.
     */
-  private def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[(WomType, Map[String, InputPort])] = {
+  private def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter[_ <: GraphNode], expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[(WomType, Map[String, InputPort])] = {
     def linkInput(input: String): ErrorOr[(String, InputPort)] = inputMapping.get(input) match {
       case Some(upstreamPort) => (input, ConnectedInputPort(input, upstreamPort.womType, upstreamPort, graphNodeSetter.get)).validNel
       case None => s"Expression cannot be connected without the input $input (provided: ${inputMapping.toString})".invalidNel

--- a/wom/src/main/scala/wom/types/WomOptionalType.scala
+++ b/wom/src/main/scala/wom/types/WomOptionalType.scala
@@ -15,14 +15,16 @@ case class WomOptionalType(memberType: WomType) extends WomType {
     */
   override protected def coercion: PartialFunction[Any, WomValue] = {
 
-    // It's safe to box up values implicitly:
-    case womValue: WomValue if memberType.equals(womValue.womType) => WomOptionalValue(womValue)
-    case coerceable: Any if memberType.coercionDefined(coerceable) => WomOptionalValue(memberType.coerceRawValue(coerceable).get)
+    case alreadyGood @ WomOptionalValue(WomOptionalType(`memberType`), _) => alreadyGood
 
     // Coercing inner values:
     case WomOptionalValue(otherMemberType, Some(value)) if memberType.isCoerceableFrom(otherMemberType) => WomOptionalValue(memberType, Option(memberType.coerceRawValue(value).get))
     case WomOptionalValue(otherMemberType, None) if memberType.isCoerceableFrom(otherMemberType) => WomOptionalValue(memberType, None)
-      
+
+    // It's safe to box up values implicitly:
+    case womValue: WomValue if memberType.equals(womValue.womType) => WomOptionalValue(womValue)
+    case coerceable: Any if memberType.coercionDefined(coerceable) => WomOptionalValue(memberType.coerceRawValue(coerceable).get)
+
     // Javascript null coerces to empty value
     case JsNull => WomOptionalValue(memberType, None)
   }


### PR DESCRIPTION
Reinstates the ability to run at least the `simple_if` WDL from centaur:
```wdl
task runMe {
  command {
    echo "done"
  }
  output {
    String s = read_string(stdout())
  }
  runtime {
    docker: "ubuntu:latest"
  }
}

workflow simple_if {
  if (true) {
    call runMe as runMeTrue
  }

  if (false) {
    call runMe as runMeFalse
  }

  output {
    runMeTrue.s
    runMeFalse.s
  }
}
```