### PR TITLE
Improving type evaluation and lookup

### DIFF
--- a/wdl/src/main/scala/wdl/WdlNamespace.scala
+++ b/wdl/src/main/scala/wdl/WdlNamespace.scala
@@ -464,9 +464,8 @@ object WdlNamespace {
       case Some(c: WdlCall) => WdlCallOutputsObjectType(c)
       case Some(s: Scatter) => s.collection.evaluateType(lookupType(s), new WdlStandardLibraryFunctionsType, Option(from)) match {
         case Success(WomArrayType(aType)) => aType
-        case Success(WomMapType(kType,vType)) =>
-          // Collection is a map
-          WomPairType(kType, vType)
+        // We don't need to check for a WOM map type, because
+        // of the custom unapply in object WomArrayType
         case _ => throw new VariableLookupException(s"Variable $n references a scatter block ${s.fullyQualifiedName}, but the collection does not evaluate to an array")
       }
       case Some(_: WdlNamespace) => WdlNamespaceType

--- a/wdl/src/main/scala/wdl/WdlNamespace.scala
+++ b/wdl/src/main/scala/wdl/WdlNamespace.scala
@@ -457,7 +457,7 @@ object WdlNamespace {
     invalidVariableReferences ++ typeMismatches
   }
 
-  def lookupType(from: Scope)(n: String): WomType = {
+  private [wdl] def lookupType(from: Scope)(n: String): WomType = {
     val resolved = from.resolveVariable(n)
     resolved match {
       case Some(d: DeclarationInterface) => d.relativeWdlType(from)

--- a/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
+++ b/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
@@ -85,10 +85,13 @@ case class TypeEvaluator(override val lookup: String => WomType, override val fu
           evaluate(a.getAttribute("lhs")).flatMap {
             case o: WdlCallOutputsObjectType =>
               o.call.outputs.find(_.unqualifiedName == rhs.getSourceString) match {
-                case Some(taskOutput) => 
-                  from map { source =>
-                    evaluate(taskOutput.requiredExpression.ast) map { t => DeclarationInterface.relativeWdlType(source, taskOutput, t) }
-                  } getOrElse evaluate(taskOutput.requiredExpression.ast)
+                case Some(taskOutput) =>
+                  val t = taskOutput.womType
+                  val relative = from match {
+                    case None => t
+                    case Some(scope) => DeclarationInterface.relativeWdlType(scope, taskOutput, t)
+                  }
+                  Success(relative)
                 case None => Failure(new WomExpressionException(s"Could not find key ${rhs.getSourceString}"))
               }
             case WomPairType(leftType, rightType) =>
@@ -132,4 +135,3 @@ case class TypeEvaluator(override val lookup: String => WomType, override val fu
     }
   }
 }
-

--- a/wdl/src/test/scala/wdl/expression/DNAxTypeEvalTest.scala
+++ b/wdl/src/test/scala/wdl/expression/DNAxTypeEvalTest.scala
@@ -1,0 +1,173 @@
+package wdl.expression
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.util.{Success, Try}
+import wdl.{Scope, Scatter, WdlCall, WdlExpression, WdlNamespace, WdlNamespaceWithWorkflow}
+import wom.types._
+
+class DNAxTypeEvalTest extends FlatSpec with Matchers {
+
+  val wdlCode =
+    """|task Add {
+       |  Int a
+       |  Int b
+       |
+       |  command {
+       |  }
+       |  output {
+       |    Int result = a + b
+       |  }
+       |}
+       |
+       |workflow dict {
+       |  Map[Int, Int] mII = {1: 10, 2: 11}
+       |  Map[Int, Float]  mIF = {1: 1.2, 10: 113.0}
+       |
+       |  scatter(pair in mII) {
+       |    Int valueII = pair.right
+       |  }
+       |
+       |  scatter(pair in mIF) {
+       |    call Add {
+       |      input: a=pair.left, b=5
+       |    }
+       |  }
+       |
+       |  output {
+       |    valueII
+       |  }
+       |}
+       |""".stripMargin
+
+
+  // Figure out the type of an expression
+  def evalType(expr: WdlExpression, parent: Scope) : Try[WomType] = {
+    expr.evaluateType(WdlNamespace.lookupType(parent),
+                      new WdlStandardLibraryFunctionsType,
+                      Some(parent))
+  }
+
+  it should "correctly evaluate expression types" in {
+    val ns = WdlNamespaceWithWorkflow.load(wdlCode, Seq.empty).get
+    val wf = ns.workflow
+
+    val call:WdlCall = wf.findCallByName("Add") match {
+      case None => throw new Exception(s"Call Add not found in WDL file")
+      case Some(call) => call
+    }
+    val ssc:Scatter = wf.scatters.head
+
+    call.inputMappings.foreach { case (_, expr) =>
+      val t:Try[WomType] = evalType(expr, ssc)
+      t should equal(Success(WomIntegerType))
+    }
+  }
+
+
+  val wdlCode2 =
+    """|task Copy {
+       |  File src
+       |  String basename
+       |
+       |  command <<<
+       |    cp ${src} ${basename}.txt
+       |    sort ${src} > ${basename}.sorted.txt
+       |  >>>
+       |  output {
+       |    File outf = "${basename}.txt"
+       |    File outf_sorted = "${basename}.sorted.txt"
+       |  }
+       |}
+       |
+       |
+       |workflow files {
+       |  File f
+       |
+       |  call Copy { input : src=f, basename="tearFrog" }
+       |  call Copy as Copy2 { input : src=Copy.outf, basename="mixing" }
+       |
+       |  output {
+       |    Copy2.outf_sorted
+       |  }
+       |}
+       |""".stripMargin
+
+  it should "correctly evaluate Strings and File types" in {
+    val ns = WdlNamespaceWithWorkflow.load(wdlCode2, Seq.empty).get
+    val wf = ns.workflow
+
+    val copy2call:WdlCall = wf.findCallByName("Copy2") match {
+      case None => throw new Exception(s"Call Add not found in WDL file")
+      case Some(call) => call
+    }
+
+    val e1 = copy2call.inputMappings("src")
+    val t1 = evalType(e1, copy2call)
+    t1 should equal(Success(WomFileType))
+
+    val e2 = copy2call.inputMappings("basename")
+    val t2 = evalType(e2, copy2call)
+    t2 should equal(Success(WomStringType))
+  }
+
+
+  val wdlCode3 =
+    """|
+       |task Inc {
+       |  Int i
+       |
+       |  command <<<
+       |    python -c "print(${i} + 1)"
+       |  >>>
+       |  output {
+       |    Int result = read_int(stdout())
+       |  }
+       |}
+       |
+       |task Mod7 {
+       |  Int i
+       |
+       |  command <<<
+       |    python -c "print(${i} % 7)"
+       |  >>>
+       |  output {
+       |    Int result = read_int(stdout())
+       |  }
+       |}
+       |
+       |workflow math {
+       |  Int n = 5
+       |
+       |  scatter (k in range(length(n))) {
+       |    call Mod7 {input: i=k}
+       |  }
+       |
+       |  scatter (k in Mod7.result) {
+       |    call Inc {input: i=k}
+       |  }
+       |
+       |  output {
+       |    Inc.result
+       |  }
+       |}
+       |""".stripMargin
+
+  it should "take context into account" in {
+    val ns = WdlNamespaceWithWorkflow.load(wdlCode3, Seq.empty).get
+    val wf = ns.workflow
+
+    val incCall:WdlCall = wf.findCallByName("Inc") match {
+      case None => throw new Exception(s"Call Add not found in WDL file")
+      case Some(call) => call
+    }
+
+    val e1 = incCall.inputMappings("i")
+    val t1 = evalType(e1, incCall)
+    t1 should equal(Success(WomIntegerType))
+
+    val output = wf.outputs.head
+    val e2 = output.requiredExpression
+    val t2 = evalType(e2, wf)
+    t2 should equal(Success(WomMaybeEmptyArrayType(WomIntegerType)))
+  }
+}

--- a/wdl/src/test/scala/wom/WdlSubworkflowWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlSubworkflowWomSpec.scala
@@ -19,7 +19,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
         |  Int x
         |  call import_me.inner as inner { input: i = x }
         |  output {
-        |    Array[String] out = inner.out
+        |    Array[String] out = [inner.out]
         |  }
         |}""".stripMargin
 
@@ -51,7 +51,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       workflowSource = outerWdl,
       resource = None,
       importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
-    
+
     val outerWorkflowGraph = namespace.workflow.womDefinition.map(_.graph)
 
     outerWorkflowGraph match {
@@ -165,7 +165,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(scatter)))
     }
   }
-  
+
   it should "support conversion of sub workflows with identical names" in {
     val outerWdl =
       """import "import_me.wdl" as import_me


### PR DESCRIPTION
This is a port of the original pull [request](https://github.com/broadinstitute/wdl4s/pull/256) to the Cromwell tree. I hope this was done correctly, while addressing the review comments. Thanks for pointing out how to use `Try` and `should equal` in the testing framework.

There are two outstanding comments, which I am answering here, since I am assuming you want to dismantle the old wdl4s git repository. 

1) TypeEvaluator.scala
*Q: Isn't the caller perhaps trying to ascertain if the expression actually can be coerced to the declared type?* 
A: That could be added as an assert. 

2) WdlSubworkflowWomSpec.scala
*Q: The magic conversion of a single Thing to an Array[Thing] was a feature someone explicitly asked for way back when. I never liked this feature but I'm sure there's WDL out there that expects this to work.*
A: I can see why a user might want that. A side effect is that Array[T] can automatically be coerced to Array[Array[T]]. I ran into a case where Array[String] was coerced into Array[Array[File]]. For example, the workflow below executes under Cromwell v0.29, involving the coercion of `Array[Int]` to `Array[Array[Int?]]`.
  
```
# Trying out file copy operations
task Num {
  Array[Array[Int?]] numbers
  command {
  }
  output {
    Array[Array[Int?]] result = numbers
  }
}


workflow w {
  Array[Int] primes = [2, 3, 5, 7, 11]
  call Num { input: numbers = primes }
  output {
    Num.result
  }
}
```

This raises two issues in my mind: 
1)  There are many ways to convert a single dimensional array into a two dimensional array. Which one does the WDL language specify? 
2) A user can mistakenly pass an incorrectly typed argument to a task without getting a compiler error. 