### PR TITLE
Support `runtime` in ECMAScript Expressions

### DIFF
--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -14,28 +14,31 @@ object RuntimeEnvironmentBuilder {
     * "For cores, ram, outdirSize and tmpdirSize, if an implementation can't provide the actual number of reserved cores
     * during the expression evaluation time, it should report back the minimal requested amount."
     */
-   def apply(runtimeAttributes: Map[String, WomValue], jobPaths: JobPaths): MinimumRuntimeEnvironment => RuntimeEnvironment = {
+   def apply(runtimeAttributes: Map[String, WomValue], jobPaths: JobPaths): MinimumRuntimeSettings => RuntimeEnvironment = {
      minimums =>
 
-       val outputPath = jobPaths.callRoot
+       val outputPath: String = jobPaths.callRoot.pathAsString
 
-       val tempPath = jobPaths.callRoot
+       val tempPath: String = jobPaths.callRoot.pathAsString
 
-        val cores: Int = CpuValidation.instance.validate(runtimeAttributes).getOrElse(minimums.cores)
+       val cores: Int = CpuValidation.instance.validate(runtimeAttributes).getOrElse(minimums.cores)
 
-        val memoryInMiB: Double =
-          MemoryValidation.instance().
-            validate(runtimeAttributes).
-            map(_.to(MemoryUnit.MiB).amount).
-            getOrElse(minimums.ram.amount)
+       val memoryInMiB: Double =
+         MemoryValidation.instance().
+           validate(runtimeAttributes).
+           map(_.to(MemoryUnit.MiB).amount).
+           getOrElse(minimums.ram.amount)
 
        //TODO: Read these from somewhere else
        val outputPathSize: Long = minimums.outputPathSize
 
        val tempPathSize: Long = minimums.outputPathSize
 
-       RuntimeEnvironment(outputPath.pathAsString, tempPath.pathAsString, cores, memoryInMiB, outputPathSize, tempPathSize)
+       RuntimeEnvironment(outputPath, tempPath, cores, memoryInMiB, outputPathSize, tempPathSize)
   }
 }
 
-case class MinimumRuntimeEnvironment(cores: Int = 1, ram: MemorySize = MemorySize(4, MemoryUnit.GiB), outputPathSize: Long = Long.MaxValue, tempPathSize: Long = Long.MaxValue)
+case class MinimumRuntimeSettings(cores: Int = 1,
+                                  ram: MemorySize = MemorySize(4, MemoryUnit.GiB),
+                                  outputPathSize: Long = Long.MaxValue,
+                                  tempPathSize: Long = Long.MaxValue)

--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -1,0 +1,50 @@
+package cromwell.backend
+
+import cromwell.backend.io.JobPaths
+import cromwell.backend.validation.{CpuValidation, MemoryValidation}
+import wdl4s.parser.MemoryUnit
+import wom.callable.RuntimeEnvironment
+import wom.values.WomValue
+
+/**
+  * from CWL Spec:
+  * runtime.outdir: an absolute path to the designated output directory
+  * runtime.tmpdir: an absolute path to the designated temporary directory
+  * runtime.cores: number of CPU cores reserved for the tool process
+  * runtime.ram: amount of RAM in mebibytes (2**20) reserved for the tool process
+  * runtime.outdirSize: reserved storage space available in the designated output directory
+  * runtime.tmpdirSize: reserved storage space available in the designated temporary directory
+  */
+object RuntimeEnvironmentBuilder {
+
+  /**
+    * Per the spec:
+    *
+    * "For cores, ram, outdirSize and tmpdirSize, if an implementation can't provide the actual number of reserved cores
+    * during the expression evaluation time, it should report back the minimal requested amount."
+    */
+   def apply(runtimeAttributes: Map[String, WomValue], jobPaths: JobPaths): MinimumRuntimeEnvironment => RuntimeEnvironment = {
+     minimums =>
+
+       val outputPath = jobPaths.callRoot
+
+       val tempPath = jobPaths.callRoot
+
+        val cores: Int = CpuValidation.instance.validate(runtimeAttributes).getOrElse(minimums.cores)
+
+        val memoryInMiB: Double =
+          MemoryValidation.instance().
+            validate(runtimeAttributes).
+            map(_.to(MemoryUnit.MiB).amount).
+            getOrElse(minimums.ram.amount)
+
+       //TODO: Read these from somewhere else
+       val outputPathSize: Long = minimums.outputPathSize
+
+       val tempPathSize: Long = minimums.outputPathSize
+
+       RuntimeEnvironment(outputPath.pathAsString, tempPath.pathAsString, cores, memoryInMiB, outputPathSize, tempPathSize)
+  }
+}
+
+case class MinimumRuntimeEnvironment(cores: Int = 1, ram: MemorySize = MemorySize(4, MemoryUnit.GiB), outputPathSize: Long = Long.MaxValue, tempPathSize: Long = Long.MaxValue)

--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -6,15 +6,6 @@ import wdl4s.parser.MemoryUnit
 import wom.callable.RuntimeEnvironment
 import wom.values.WomValue
 
-/**
-  * from CWL Spec:
-  * runtime.outdir: an absolute path to the designated output directory
-  * runtime.tmpdir: an absolute path to the designated temporary directory
-  * runtime.cores: number of CPU cores reserved for the tool process
-  * runtime.ram: amount of RAM in mebibytes (2**20) reserved for the tool process
-  * runtime.outdirSize: reserved storage space available in the designated output directory
-  * runtime.tmpdirSize: reserved storage space available in the designated temporary directory
-  */
 object RuntimeEnvironmentBuilder {
 
   /**

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -22,7 +22,6 @@ import common.exception.MessageAggregation
 import common.util.TryUtil
 import common.validation.ErrorOr.ErrorOr
 import net.ceedubs.ficus.Ficus._
-import wdl4s.parser.MemoryUnit
 import wom.values._
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -42,7 +42,8 @@ case class DefaultStandardAsyncExecutionActorParams
   override val configurationDescriptor: BackendConfigurationDescriptor,
   override val backendInitializationDataOption: Option[BackendInitializationData],
   override val backendSingletonActorOption: Option[ActorRef],
-  override val completionPromise: Promise[BackendJobExecutionResponse]
+  override val completionPromise: Promise[BackendJobExecutionResponse],
+  override val minimumRuntimeSettings: MinimumRuntimeSettings
 ) extends StandardAsyncExecutionActorParams
 
 /**
@@ -228,7 +229,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   lazy val instantiatedCommand: String =  {
 
     val todoMoveMeMinimums =
-      MinimumRuntimeEnvironment(
+      MinimumRuntimeSettings(
         cores = 1,
         ram = MemorySize.apply(4, MemoryUnit.GiB),
         outputPathSize = Long.MaxValue,

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -226,19 +226,9 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   }
 
   /** The instantiated command. */
-  lazy val instantiatedCommand: String =  {
-
-    val todoMoveMeMinimums =
-      MinimumRuntimeSettings(
-        cores = 1,
-        ram = MemorySize.apply(4, MemoryUnit.GiB),
-        outputPathSize = Long.MaxValue,
-        tempPathSize = Long.MaxValue
-      )
-
+  lazy val instantiatedCommand: String =
     Command.instantiate(
-      jobDescriptor, backendEngineFunctions, commandLinePreProcessor, commandLineValueMapper, RuntimeEnvironmentBuilder(jobDescriptor.runtimeAttributes, jobPaths)(todoMoveMeMinimums)).get
-  }
+      jobDescriptor, backendEngineFunctions, commandLinePreProcessor, commandLineValueMapper, RuntimeEnvironmentBuilder(jobDescriptor.runtimeAttributes, jobPaths)(standardParams.minimumRuntimeSettings)).get
 
   /**
     * Redirect the stdout and stderr to the appropriate files. While not necessary, mark the job as not receiving any

--- a/backend/src/main/scala/cromwell/backend/standard/StandardJobExecutionActorParams.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardJobExecutionActorParams.scala
@@ -28,6 +28,6 @@ trait StandardJobExecutionActorParams {
   /** The singleton actor. */
   def backendSingletonActorOption: Option[ActorRef]
 
-  /** The settings for runtime Environment passed to CWL expressions when not specified */
+  /** The default settings for runtime Environment passed to CWL expressions when not specified in the Resource Requirements */
   val minimumRuntimeSettings: MinimumRuntimeSettings
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardJobExecutionActorParams.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardJobExecutionActorParams.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.standard
 
 import akka.actor.ActorRef
-import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor}
+import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor, MinimumRuntimeSettings}
 
 /**
   * Base trait for params passed to both the sync and async backend actors.
@@ -9,7 +9,7 @@ import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationDa
 trait StandardJobExecutionActorParams {
   /** The service registry actor for key/value and metadata. */
   def serviceRegistryActor: ActorRef
-  
+
   /** Actor able to handle IO requests asynchronously */
   def ioActor: ActorRef
 
@@ -27,4 +27,7 @@ trait StandardJobExecutionActorParams {
 
   /** The singleton actor. */
   def backendSingletonActorOption: Option[ActorRef]
+
+  /** The settings for runtime Environment passed to CWL expressions when not specified */
+  val minimumRuntimeSettings: MinimumRuntimeSettings
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -102,7 +102,7 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
                               ioActor: ActorRef,
                               backendSingletonActorOption: Option[ActorRef]): StandardSyncExecutionActorParams = {
     DefaultStandardSyncExecutionActorParams(jobIdKey, serviceRegistryActor, ioActor, jobDescriptor, configurationDescriptor,
-      initializationDataOption, backendSingletonActorOption, asyncExecutionActorClass)
+      initializationDataOption, backendSingletonActorOption, asyncExecutionActorClass, MinimumRuntimeSettings())
   }
 
   override def fileHashingActorProps:

--- a/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
@@ -5,7 +5,7 @@ import akka.actor.{ActorRef, OneForOneStrategy, Props}
 import cromwell.backend.BackendJobExecutionActor.{AbortedResponse, BackendJobExecutionResponse}
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend.async.AsyncBackendJobExecutionActor.{Execute, Recover}
-import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor, BackendJobExecutionActor}
+import cromwell.backend._
 import cromwell.core.Dispatcher
 import cromwell.services.keyvalue.KeyValueServiceActor._
 
@@ -25,7 +25,8 @@ case class DefaultStandardSyncExecutionActorParams
   override val configurationDescriptor: BackendConfigurationDescriptor,
   override val backendInitializationDataOption: Option[BackendInitializationData],
   override val backendSingletonActorOption: Option[ActorRef],
-  override val asyncJobExecutionActorClass: Class[_ <: StandardAsyncExecutionActor]
+  override val asyncJobExecutionActorClass: Class[_ <: StandardAsyncExecutionActor],
+  override val minimumRuntimeSettings: MinimumRuntimeSettings
 ) extends StandardSyncExecutionActorParams
 
 /**
@@ -116,7 +117,8 @@ class StandardSyncExecutionActor(val standardParams: StandardSyncExecutionActorP
       standardParams.configurationDescriptor,
       standardParams.backendInitializationDataOption,
       standardParams.backendSingletonActorOption,
-      completionPromise
+      completionPromise,
+      standardParams.minimumRuntimeSettings
     )
   }
 

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
@@ -1,9 +1,15 @@
 package cromwell.backend.validation
 
+import wom.values.WomValue
+
 object RuntimeAttributesKeys {
   val DockerKey = "docker"
   val FailOnStderrKey = "failOnStderr"
   val ContinueOnReturnCodeKey = "continueOnReturnCode"
   val CpuKey = "cpu"
   val MemoryKey = "memory"
+}
+
+case class RuntimeKey[T](key: String) {
+  def apply(attributes: Map[String, WomValue]):
 }

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
@@ -1,7 +1,5 @@
 package cromwell.backend.validation
 
-import wom.values.WomValue
-
 object RuntimeAttributesKeys {
   val DockerKey = "docker"
   val FailOnStderrKey = "failOnStderr"
@@ -10,6 +8,3 @@ object RuntimeAttributesKeys {
   val MemoryKey = "memory"
 }
 
-case class RuntimeKey[T](key: String) {
-  def apply(attributes: Map[String, WomValue]):
-}

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesKeys.scala
@@ -7,4 +7,3 @@ object RuntimeAttributesKeys {
   val CpuKey = "cpu"
   val MemoryKey = "memory"
 }
-

--- a/backend/src/main/scala/cromwell/backend/wdl/Command.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/Command.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.wdl
 
 import cromwell.backend.BackendJobDescriptor
-import cromwell.core.path.Path
+import wom.callable.RuntimeEnvironment
 import wom.expression.IoFunctionSet
 import wom.values.{WomEvaluatedCallInputs, WomValue}
 
@@ -24,9 +24,9 @@ object Command {
                   callEngineFunction: IoFunctionSet,
                   inputsPreProcessor: WomEvaluatedCallInputs => Try[WomEvaluatedCallInputs] = (i: WomEvaluatedCallInputs) => Success(i),
                   valueMapper: WomValue => WomValue = identity,
-                  outputsDirectory: Path): Try[String] = {
+                  runtimeEnvironment: RuntimeEnvironment): Try[String] = {
     inputsPreProcessor(jobDescriptor.inputDeclarations) flatMap { mappedInputs =>
-      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper,  outputsDirectory.pathAsString)
+      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper,  runtimeEnvironment)
     }
   }
 }

--- a/backend/src/main/scala/cromwell/backend/wdl/Command.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/Command.scala
@@ -1,8 +1,9 @@
 package cromwell.backend.wdl
 
 import cromwell.backend.BackendJobDescriptor
+import cromwell.core.path.Path
 import wom.expression.IoFunctionSet
-import wom.values.{WomValue, WomEvaluatedCallInputs}
+import wom.values.{WomEvaluatedCallInputs, WomValue}
 
 import scala.util.{Success, Try}
 
@@ -22,9 +23,10 @@ object Command {
   def instantiate(jobDescriptor: BackendJobDescriptor,
                   callEngineFunction: IoFunctionSet,
                   inputsPreProcessor: WomEvaluatedCallInputs => Try[WomEvaluatedCallInputs] = (i: WomEvaluatedCallInputs) => Success(i),
-                  valueMapper: WomValue => WomValue = identity): Try[String] = {
+                  valueMapper: WomValue => WomValue = identity,
+                  outputsDirectory: Path): Try[String] = {
     inputsPreProcessor(jobDescriptor.inputDeclarations) flatMap { mappedInputs =>
-      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper)
+      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper,  outputsDirectory.pathAsString)
     }
   }
 }

--- a/backend/src/main/scala/cromwell/backend/wdl/Command.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/Command.scala
@@ -26,7 +26,7 @@ object Command {
                   valueMapper: WomValue => WomValue = identity,
                   runtimeEnvironment: RuntimeEnvironment): Try[String] = {
     inputsPreProcessor(jobDescriptor.inputDeclarations) flatMap { mappedInputs =>
-      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper,  runtimeEnvironment)
+      jobDescriptor.call.callable.instantiateCommand(mappedInputs, callEngineFunction, valueMapper, runtimeEnvironment)
     }
   }
 }

--- a/cwl/src/main/scala/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/cwl/CwlCodecs.scala
@@ -16,11 +16,7 @@ object CwlCodecs {
   implicit val wfD = implicitly[Decoder[Workflow]]
   implicit val cltD = implicitly[Decoder[CommandLineTool]]
 
-  def decodeCwl(in: String) = {
-    val x = decode[Workflow](in)
-    println(x)
-    decode[Cwl](in)
-  }
+  def decodeCwl(in: String) = decode[Cwl](in)
 
   def encodeCwlCommandLineTool(commandLineTool: CommandLineTool): Json = {
     import io.circe.syntax._

--- a/cwl/src/main/scala/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/cwl/CwlCodecs.scala
@@ -16,7 +16,11 @@ object CwlCodecs {
   implicit val wfD = implicitly[Decoder[Workflow]]
   implicit val cltD = implicitly[Decoder[CommandLineTool]]
 
-  def decodeCwl(in: String) = decode[Cwl](in)
+  def decodeCwl(in: String) = {
+    val x = decode[Workflow](in)
+    println(x)
+    decode[Cwl](in)
+  }
 
   def encodeCwlCommandLineTool(commandLineTool: CommandLineTool): Json = {
     import io.circe.syntax._

--- a/cwl/src/main/scala/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/cwl/CwlCodecs.scala
@@ -16,7 +16,7 @@ object CwlCodecs {
   implicit val wfD = implicitly[Decoder[Workflow]]
   implicit val cltD = implicitly[Decoder[CommandLineTool]]
 
-  def decodeCwl(in: String) = decode[Cwl](in)
+  def decodeCwl(in: String): Either[Error, Cwl] = decode[Cwl](in)
 
   def encodeCwlCommandLineTool(commandLineTool: CommandLineTool): Json = {
     import io.circe.syntax._

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -2,6 +2,7 @@ package cwl
 
 import cwl.CommandLineTool.CommandInputParameter
 import wom.CommandPart
+import wom.callable.RuntimeEnvironment
 import wom.expression.IoFunctionSet
 import wom.graph.LocalName
 import wom.values._
@@ -10,7 +11,8 @@ import wom.values._
 case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
-                           valueMapper: (WomValue) => WomValue): String = {
+                           valueMapper: (WomValue) => WomValue,
+                           runtimeEnvironment: RuntimeEnvironment ): String = {
 
     val pc = ParameterContext.Empty.withInputs(inputsMap.map({ case (LocalName(localName), value) => localName -> value }), functions)
 
@@ -24,7 +26,8 @@ case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
 case class CommandLineBindingCommandPart(argument: CommandLineBinding) extends CommandPart {
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
-                           valueMapper: (WomValue) => WomValue) = {
+                           valueMapper: (WomValue) => WomValue,
+                  runtimeEnvironment: RuntimeEnvironment) = {
 
     val pc = ParameterContext.Empty.withInputs(inputsMap.map({
       case (LocalName(localName), WomSingleFile(path)) => localName -> WomString(path)
@@ -48,7 +51,8 @@ case class InputParameterCommandPart(commandInputParameter: CommandInputParamete
 
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
-                           valueMapper: (WomValue) => WomValue) = {
+                           valueMapper: (WomValue) => WomValue,
+                  runtimeEnvironment: RuntimeEnvironment) = {
 
     val womValue: WomValue = commandInputParameter match {
 

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -18,8 +18,8 @@ case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
 
     val pc =
       ParameterContext(
-        runtime = runtimeEnvironment.cwlMap).
-        withInputs(stringKeyMap, functions)
+        runtime = runtimeEnvironment.cwlMap
+      ).withInputs(stringKeyMap, functions)
 
     val womValue: WomValue = expr.fold(EvaluateExpression).apply(pc)
 

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -14,7 +14,12 @@ case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
                            valueMapper: (WomValue) => WomValue,
                            runtimeEnvironment: RuntimeEnvironment ): String = {
 
-    val pc = ParameterContext(runtime = runtimeEnvironment.cwlMap).withInputs(inputsMap.map({ case (LocalName(localName), value) => localName -> value }), functions)
+    val stringKeyMap = inputsMap.map{ case (LocalName(localName), value) => localName -> value }
+
+    val pc =
+      ParameterContext(
+        runtime = runtimeEnvironment.cwlMap).
+        withInputs(stringKeyMap, functions)
 
     val womValue: WomValue = expr.fold(EvaluateExpression).apply(pc)
 
@@ -27,7 +32,7 @@ case class CommandLineBindingCommandPart(argument: CommandLineBinding) extends C
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
                            valueMapper: (WomValue) => WomValue,
-                  runtimeEnvironment: RuntimeEnvironment) = {
+                           runtimeEnvironment: RuntimeEnvironment) = {
 
     val pc = ParameterContext(runtime = runtimeEnvironment.cwlMap).withInputs(inputsMap.map({
       case (LocalName(localName), WomSingleFile(path)) => localName -> WomString(path)
@@ -52,12 +57,12 @@ case class InputParameterCommandPart(commandInputParameter: CommandInputParamete
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
                            valueMapper: (WomValue) => WomValue,
-                  runtimeEnvironment: RuntimeEnvironment) = {
+                           runtimeEnvironment: RuntimeEnvironment) = {
 
     val womValue: WomValue = commandInputParameter match {
 
       /*
-        In this case we are looking for the specific case where the only input binding option specified is the position.
+        Case where the only input binding option specified is the position.
 
         NB: We ignore the position as these have already been sorted prior to being submitted as command part
 

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -14,7 +14,7 @@ case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
                            valueMapper: (WomValue) => WomValue,
                            runtimeEnvironment: RuntimeEnvironment ): String = {
 
-    val pc = ParameterContext.Empty.withInputs(inputsMap.map({ case (LocalName(localName), value) => localName -> value }), functions)
+    val pc = ParameterContext(runtime = runtimeEnvironment.cwlMap).withInputs(inputsMap.map({ case (LocalName(localName), value) => localName -> value }), functions)
 
     val womValue: WomValue = expr.fold(EvaluateExpression).apply(pc)
 
@@ -29,7 +29,7 @@ case class CommandLineBindingCommandPart(argument: CommandLineBinding) extends C
                            valueMapper: (WomValue) => WomValue,
                   runtimeEnvironment: RuntimeEnvironment) = {
 
-    val pc = ParameterContext.Empty.withInputs(inputsMap.map({
+    val pc = ParameterContext(runtime = runtimeEnvironment.cwlMap).withInputs(inputsMap.map({
       case (LocalName(localName), WomSingleFile(path)) => localName -> WomString(path)
       case (LocalName(localName), value) => localName -> value
     }), functions)

--- a/cwl/src/main/scala/cwl/Decoder.scala
+++ b/cwl/src/main/scala/cwl/Decoder.scala
@@ -37,7 +37,14 @@ object CwlDecoder {
   }
 
   def parseJson(json: String): Parse[Cwl] =
-    EitherT{IO{CwlCodecs.decodeCwl(json).leftMap(_.getMessage).leftMap(NonEmptyList.one)} }
+    EitherT{IO{
+      CwlCodecs.decodeCwl(json).
+        leftMap{t =>
+          val s = json
+          println(s)
+          NonEmptyList.of(t.getMessage, t.getStackTrace.mkString("\n"))
+        }
+    }}
 
   /**
    * Notice it gives you one instance of Cwl.  This has transformed all embedded files into scala object state

--- a/cwl/src/main/scala/cwl/Decoder.scala
+++ b/cwl/src/main/scala/cwl/Decoder.scala
@@ -40,8 +40,6 @@ object CwlDecoder {
     EitherT{IO{
       CwlCodecs.decodeCwl(json).
         leftMap{t =>
-          val s = json
-          println(s)
           NonEmptyList.of(t.getMessage, t.getStackTrace.mkString("\n"))
         }
     }}

--- a/cwl/src/main/scala/cwl/ParameterContext.scala
+++ b/cwl/src/main/scala/cwl/ParameterContext.scala
@@ -5,14 +5,12 @@ import wom.types.{WomMapType, WomNothingType, WomStringType}
 import wom.values.{WomMap, WomOptionalValue, WomSingleFile, WomString, WomValue}
 
 object ParameterContext {
-  val Empty = ParameterContext(
-    inputs = WomOptionalValue(WomNothingType, None),
-    self = WomOptionalValue(WomNothingType, None),
-    runtime = WomOptionalValue(WomNothingType, None)
-  )
+  val Empty = ParameterContext()
 }
 
-case class ParameterContext(inputs: WomValue = WomOptionalValue(WomNothingType, None), self: WomValue = WomOptionalValue(WomNothingType, None), runtime: WomValue = WomOptionalValue(WomNothingType, None)) {
+case class ParameterContext(inputs: WomValue = WomOptionalValue(WomNothingType, None),
+                            self: WomValue = WomOptionalValue(WomNothingType, None),
+                            runtime: WomValue = WomOptionalValue(WomNothingType, None)) {
   def withInputs(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ParameterContext = {
     val wdlValueType = WomStringType
     copy(

--- a/cwl/src/main/scala/cwl/ParameterContext.scala
+++ b/cwl/src/main/scala/cwl/ParameterContext.scala
@@ -12,7 +12,7 @@ object ParameterContext {
   )
 }
 
-case class ParameterContext(inputs: WomValue, self: WomValue, runtime: WomValue) {
+case class ParameterContext(inputs: WomValue = WomOptionalValue(WomNothingType, None), self: WomValue = WomOptionalValue(WomNothingType, None), runtime: WomValue = WomOptionalValue(WomNothingType, None)) {
   def withInputs(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ParameterContext = {
     val wdlValueType = WomStringType
     copy(

--- a/cwl/src/main/scala/cwl/command/StringCommandPart.scala
+++ b/cwl/src/main/scala/cwl/command/StringCommandPart.scala
@@ -1,10 +1,14 @@
 package cwl.command
 
 import wom.CommandPart
+import wom.callable.RuntimeEnvironment
 import wom.expression.IoFunctionSet
 import wom.graph.LocalName
 import wom.values.WomValue
 
 case class StringCommandPart(literal: String) extends CommandPart {
-  override def instantiate(inputsMap: Map[LocalName, WomValue], functions: IoFunctionSet, valueMapper: (WomValue) => WomValue) = literal
+  override def instantiate(inputsMap: Map[LocalName, WomValue],
+                           functions: IoFunctionSet,
+                           valueMapper: (WomValue) => WomValue,
+                           runtimeEnvironment: RuntimeEnvironment) = literal
 }

--- a/cwl/src/test/scala/cwl/CwlExpressionCommandPartSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlExpressionCommandPartSpec.scala
@@ -5,6 +5,7 @@ import eu.timepit.refined._
 import eu.timepit.refined.string.MatchesRegex
 import ExpressionEvaluator._
 import shapeless.Coproduct
+import wom.callable.RuntimeEnvironment
 import wom.expression.PlaceholderIoFunctionSet
 import wom.graph.LocalName
 import wom.values.WomString
@@ -13,12 +14,14 @@ class CwlExpressionCommandPartSpec extends FlatSpec with Matchers {
 
   behavior of "CwlExpressionCommandPart"
 
+  val emptyEnvironment = RuntimeEnvironment("","",1,1,1,1)
+
   it should "instantiate" in {
     // NOTE: toFixed used to remove the fraction part of ECMAScript numbers
     // https://stackoverflow.com/questions/25989642/why-does-java-8-nashorn-javascript-modulo-returns-0-0-double-instead-of-0-i#answer-25991982
     // https://community.apigee.com/questions/33936/javascript-parseint-not-converting-to-int-value-ne.html
     val commandPart = CwlExpressionCommandPart(Coproduct[Expression](refineMV[MatchesRegex[ECMAScriptExpressionWitness.T]]("$(parseInt(inputs.myStringInt).toFixed())")))
-    val result = commandPart.instantiate(Map(LocalName("myStringInt") -> WomString("3")), PlaceholderIoFunctionSet, identity)
+    val result = commandPart.instantiate(Map(LocalName("myStringInt") -> WomString("3")), PlaceholderIoFunctionSet, identity, emptyEnvironment)
     result should be("3")
   }
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -116,7 +116,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
           configurationDescriptor = jesConfiguration.configurationDescriptor,
           backendInitializationDataOption = Option(buildInitializationData(jobDescriptor, jesConfiguration)),
           backendSingletonActorOption = Option(jesSingletonActor),
-          completionPromise = promise
+          completionPromise = promise,
+          minimumRuntimeSettings = MinimumRuntimeSettings()
         ),
         functions
       )

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesJobExecutionActorSpec.scala
@@ -2,7 +2,7 @@ package cromwell.backend.impl.jes
 
 import akka.actor.{Actor, ActorRef, Props}
 import akka.testkit._
-import cromwell.backend.BackendJobDescriptor
+import cromwell.backend.{BackendJobDescriptor, MinimumRuntimeSettings}
 import cromwell.backend.BackendJobExecutionActor.{ExecuteJobCommand, JobFailedNonRetryableResponse}
 import cromwell.backend.impl.jes.ControllableFailingJabjea.JabjeaExplode
 import cromwell.backend.standard.{DefaultStandardSyncExecutionActorParams, StandardSyncExecutionActor, StandardSyncExecutionActorParams}
@@ -36,7 +36,7 @@ class JesJobExecutionActorSpec extends TestKitSuite("JesJobExecutionActorSpec") 
     val deathwatch = TestProbe()
     val params = DefaultStandardSyncExecutionActorParams(JesAsyncBackendJobExecutionActor.JesOperationIdKey, serviceRegistryActor, ioActor,
       jobDescriptor, null, Option(initializationData), jesBackendSingletonActor,
-      classOf[JesAsyncBackendJobExecutionActor])
+      classOf[JesAsyncBackendJobExecutionActor], MinimumRuntimeSettings())
     val testJJEA = TestActorRef[TestJesJobExecutionActor](
       props = Props(new TestJesJobExecutionActor(params, Props(new ConstructorFailingJABJEA))),
       supervisor = parent.ref)
@@ -69,7 +69,8 @@ class JesJobExecutionActorSpec extends TestKitSuite("JesJobExecutionActorSpec") 
     val jabjeaConstructionPromise = Promise[ActorRef]()
     val params = DefaultStandardSyncExecutionActorParams(JesAsyncBackendJobExecutionActor.JesOperationIdKey, serviceRegistryActor, ioActor,
       jobDescriptor, null, Option(initializationData), jesBackendSingletonActor,
-      classOf[JesAsyncBackendJobExecutionActor])
+      classOf[JesAsyncBackendJobExecutionActor],
+      MinimumRuntimeSettings())
     val testJJEA = TestActorRef[TestJesJobExecutionActor](
       props = Props(new TestJesJobExecutionActor(params, Props(new ControllableFailingJabjea(jabjeaConstructionPromise)))),
       supervisor = parent.ref)

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/TestLocalAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/TestLocalAsyncJobExecutionActor.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestActorRef
 import cromwell.backend.io.WorkflowPathsWithDocker
 import cromwell.backend.standard._
 import cromwell.backend.validation.{DockerValidation, RuntimeAttributesValidation}
-import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor}
+import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, MinimumRuntimeSettings}
 import cromwell.core.SimpleIoActor
 import cromwell.services.keyvalue.InMemoryKvServiceActor
 
@@ -51,7 +51,8 @@ object TestLocalAsyncJobExecutionActor {
       configurationDescriptor = configurationDescriptor,
       backendInitializationDataOption = Option(initializationData),
       backendSingletonActorOption = None,
-      asyncJobExecutionActorClass = asyncClass)
+      asyncJobExecutionActorClass = asyncClass,
+      MinimumRuntimeSettings())
 
     TestActorRef(new StandardSyncExecutionActor(params))
   }

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -161,7 +161,7 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
         jobDescriptor,
         callEngineFunction,
         localizeInputs(jobPaths.callInputsRoot, docker = false),
-        runtimeEnvironment = RuntimeEnvironmentBuilder(jobDescriptor.runtimeAttributes, jobPaths)(MinimumRuntimeEnvironment())
+        runtimeEnvironment = RuntimeEnvironmentBuilder(jobDescriptor.runtimeAttributes, jobPaths)(MinimumRuntimeSettings())
       )
 
       log.debug("{} Creating bash script for executing command: {}", tag, command)

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -160,7 +160,8 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
       val command = Command.instantiate(
         jobDescriptor,
         callEngineFunction,
-        localizeInputs(jobPaths.callInputsRoot, docker = false)
+        localizeInputs(jobPaths.callInputsRoot, docker = false),
+        outputsDirectory = jobPaths.callRoot
       )
 
       log.debug("{} Creating bash script for executing command: {}", tag, command)

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -9,7 +9,7 @@ import cromwell.backend.io.JobPathsWithDocker
 import cromwell.backend.sfs.{SharedFileSystem, SharedFileSystemExpressionFunctions}
 import cromwell.backend.wdl.Command
 import cromwell.backend.wdl.OutputEvaluator.{InvalidJobOutputs, JobOutputsEvaluationException, ValidJobOutputs}
-import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor, BackendJobExecutionActor}
+import cromwell.backend._
 import cromwell.core.path.JavaWriterImplicits._
 import cromwell.core.path.Obsolete._
 import cromwell.core.path.{DefaultPathBuilder, TailedWriter, UntailedWriter}
@@ -161,7 +161,7 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
         jobDescriptor,
         callEngineFunction,
         localizeInputs(jobPaths.callInputsRoot, docker = false),
-        outputsDirectory = jobPaths.callRoot
+        runtimeEnvironment = RuntimeEnvironmentBuilder(jobDescriptor.runtimeAttributes, jobPaths)(MinimumRuntimeEnvironment())
       )
 
       log.debug("{} Creating bash script for executing command: {}", tag, command)

--- a/wdl/src/main/scala/wdl/command/WdlCommandPart.scala
+++ b/wdl/src/main/scala/wdl/command/WdlCommandPart.scala
@@ -17,7 +17,7 @@ trait WdlCommandPart extends CommandPart {
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
                            valueMapper: WomValue => WomValue,
-                  runtimeEnvironment: RuntimeEnvironment): String = {
+                           runtimeEnvironment: RuntimeEnvironment): String = {
     val wdlFunctions = WdlStandardLibraryFunctions.fromIoFunctionSet(functions)
     instantiate(Seq.empty, inputsMap.map({case (localName, value) => localName.value -> value}), wdlFunctions, valueMapper)
   }

--- a/wdl/src/main/scala/wdl/command/WdlCommandPart.scala
+++ b/wdl/src/main/scala/wdl/command/WdlCommandPart.scala
@@ -3,6 +3,7 @@ package wdl.command
 import wdl.expression.{WdlFunctions, WdlStandardLibraryFunctions}
 import wdl._
 import wom.CommandPart
+import wom.callable.RuntimeEnvironment
 import wom.graph.LocalName
 import wom.expression.IoFunctionSet
 import wom.values.WomValue
@@ -15,7 +16,8 @@ trait WdlCommandPart extends CommandPart {
 
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
-                           valueMapper: WomValue => WomValue): String = {
+                           valueMapper: WomValue => WomValue,
+                  runtimeEnvironment: RuntimeEnvironment): String = {
     val wdlFunctions = WdlStandardLibraryFunctions.fromIoFunctionSet(functions)
     instantiate(Seq.empty, inputsMap.map({case (localName, value) => localName.value -> value}), wdlFunctions, valueMapper)
   }

--- a/wom/src/main/scala/wom/CommandPart.scala
+++ b/wom/src/main/scala/wom/CommandPart.scala
@@ -1,5 +1,6 @@
 package wom
 
+import wom.callable.RuntimeEnvironment
 import wom.expression.IoFunctionSet
 import wom.graph.LocalName
 import wom.values.WomValue
@@ -7,5 +8,6 @@ import wom.values.WomValue
 trait CommandPart {
   def instantiate(inputsMap: Map[LocalName, WomValue],
                   functions: IoFunctionSet,
-                  valueMapper: WomValue => WomValue): String
+                  valueMapper: WomValue => WomValue,
+                  runtimeEnvironment: RuntimeEnvironment): String
 }

--- a/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
+++ b/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
@@ -1,9 +1,43 @@
 package wom.callable
 
+import wom.types.{WomMapType, WomStringType}
+import wom.values.{WomMap, WomString, WomValue}
+
+/**
+  * Parameter documentation quoted from CWL Spec.
+  *
+  * @param outputPath runtime.outdir: an absolute path to the designated output directory
+  * @param tempPath runtime.tmpdir: an absolute path to the designated temporary directory
+  * @param cores runtime.cores: number of CPU cores reserved for the tool process
+  * @param ram runtime.ram: amount of RAM in mebibytes (2**20) reserved for the tool process
+  * @param outputPathSize runtime.outdirSize: reserved storage space available in the designated output directory
+  * @param tempPathSize runtime.tmpdirSize: reserved storage space available in the designated temporary directory
+  */
 case class RuntimeEnvironment(outputPath: String,
                               tempPath: String,
                               cores: Int,
                               ram: Double,
                               outputPathSize: Long,
-                              tempPathSize: Long)
+                              tempPathSize: Long) {
+
+  def cwlMap: WomValue = {
+
+    val womMap: Map[WomValue, WomValue] = Map(
+      "outdir" -> outputPath,
+      "tmpdir" -> tempPath,
+      "cores" -> cores.toString,
+      "ram" -> ram.toString,
+      "outdirSize" -> outputPathSize.toString,
+      "tmpdirSize" -> tempPathSize.toString
+    ).map{
+      case (key, value) => WomString(key) -> WomString(value)
+    }
+
+    WomMap(
+      WomMapType(WomStringType, WomStringType),
+      womMap
+    )
+  }
+
+}
 

--- a/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
+++ b/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
@@ -33,11 +33,7 @@ case class RuntimeEnvironment(outputPath: String,
       case (key, value) => WomString(key) -> WomString(value)
     }
 
-    WomMap(
-      WomMapType(WomStringType, WomStringType),
-      womMap
-    )
+    WomMap(WomMapType(WomStringType, WomStringType), womMap)
   }
-
 }
 

--- a/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
+++ b/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
@@ -1,19 +1,9 @@
 package wom.callable
 
-/**
-  * from CWL Spec:
-  * runtime.outdir: an absolute path to the designated output directory
-  * runtime.tmpdir: an absolute path to the designated temporary directory
-  * runtime.cores: number of CPU cores reserved for the tool process
-  * runtime.ram: amount of RAM in mebibytes (2**20) reserved for the tool process
-  * runtime.outdirSize: reserved storage space available in the designated output directory
-  * runtime.tmpdirSize: reserved storage space available in the designated temporary directory
-  */
 case class RuntimeEnvironment(outputPath: String,
                               tempPath: String,
                               cores: Int,
-                              ram: Int,
-                              outputPathSize: Int,
-                              tempPathSize: Int
-                             )
+                              ram: Double,
+                              outputPathSize: Long,
+                              tempPathSize: Long)
 

--- a/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
+++ b/wom/src/main/scala/wom/callable/RuntimeEnvironment.scala
@@ -1,0 +1,19 @@
+package wom.callable
+
+/**
+  * from CWL Spec:
+  * runtime.outdir: an absolute path to the designated output directory
+  * runtime.tmpdir: an absolute path to the designated temporary directory
+  * runtime.cores: number of CPU cores reserved for the tool process
+  * runtime.ram: amount of RAM in mebibytes (2**20) reserved for the tool process
+  * runtime.outdirSize: reserved storage space available in the designated output directory
+  * runtime.tmpdirSize: reserved storage space available in the designated temporary directory
+  */
+case class RuntimeEnvironment(outputPath: String,
+                              tempPath: String,
+                              cores: Int,
+                              ram: Int,
+                              outputPathSize: Int,
+                              tempPathSize: Int
+                             )
+

--- a/wom/src/main/scala/wom/callable/TaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/TaskDefinition.scala
@@ -26,7 +26,9 @@ sealed trait TaskDefinition extends Callable {
   def instantiateCommand(taskInputs: WomEvaluatedCallInputs,
                          functions: IoFunctionSet,
                          valueMapper: WomValue => WomValue = identity[WomValue],
-                         separate: Boolean = false): Try[String] = {
+                        outputDirectory: String,
+                         separate: Boolean = false
+                         ): Try[String] = {
     val mappedInputs = taskInputs.map({case (k, v) => k.localName -> v})
     Try(StringUtil.normalize(commandTemplate.map(_.instantiate(mappedInputs, functions, valueMapper)).mkString(commandPartSeparator)))
   }

--- a/wom/src/main/scala/wom/callable/TaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/TaskDefinition.scala
@@ -26,11 +26,11 @@ sealed trait TaskDefinition extends Callable {
   def instantiateCommand(taskInputs: WomEvaluatedCallInputs,
                          functions: IoFunctionSet,
                          valueMapper: WomValue => WomValue = identity[WomValue],
-                        outputDirectory: String,
+                         runtimeEnvironment: RuntimeEnvironment,
                          separate: Boolean = false
                          ): Try[String] = {
     val mappedInputs = taskInputs.map({case (k, v) => k.localName -> v})
-    Try(StringUtil.normalize(commandTemplate.map(_.instantiate(mappedInputs, functions, valueMapper)).mkString(commandPartSeparator)))
+    Try(StringUtil.normalize(commandTemplate.map(_.instantiate(mappedInputs, functions, valueMapper, runtimeEnvironment)).mkString(commandPartSeparator)))
   }
 
   def commandTemplateString: String = StringUtil.normalize(commandTemplate.map(_.toString).mkString)

--- a/wom/src/main/scala/wom/util/JsUtil.scala
+++ b/wom/src/main/scala/wom/util/JsUtil.scala
@@ -31,6 +31,7 @@ object JsUtil {
     * @return The result of the expression.
     */
   def eval(expr: String, values: Map[String, WomValue] = Map.empty): WomValue = {
+    println(s"womvalues are\n${values.mkString("\n")}")
     val engine = ScriptEngineFactory.getScriptEngine(nashornStrictArgs, getNashornClassLoader, noJavaClassFilter)
 
     val bindings = engine.createBindings()

--- a/wom/src/main/scala/wom/util/JsUtil.scala
+++ b/wom/src/main/scala/wom/util/JsUtil.scala
@@ -31,7 +31,6 @@ object JsUtil {
     * @return The result of the expression.
     */
   def eval(expr: String, values: Map[String, WomValue] = Map.empty): WomValue = {
-    println(s"womvalues are\n${values.mkString("\n")}")
     val engine = ScriptEngineFactory.getScriptEngine(nashornStrictArgs, getNashornClassLoader, noJavaClassFilter)
 
     val bindings = engine.createBindings()


### PR DESCRIPTION
Introduces a `RuntimeEnvironment` type in order to provide CWL expressions the proper values for the `runtime` ECMAscript variable.  

See spec for explicit detail: http://www.commonwl.org/v1.0/CommandLineTool.html#Runtime_environment

Also introduce `MinimumRuntimeSettings` as the spec says 
> "if an implementation can't provide the actual number of reserved cores during the expression evaluation time, it should report back the minimal requested amount."

I've made a few tradeoffs which I intend to document as tickets unless there are objections.  To be clear the tradeoff is these compromises for speed, as I'm trying to "spike" on 1st-workflow and get it working :

* MinimumRuntimeSettings should come from the config.  I see a major dependency tree coming all the way down from `RootCromwellActor` and I'm trying to think of a better way.  In this PR I've taken the shortcut of instantiating MinimumRuntimeSettings with default values hardcoded.
* The values of `outdirSize` and `tmpdirSize` are specified in CWL but I haven't yet figured out how to provide those values accurately.  I will likely create an issue to do this effectively as I doubt this is regularly used.
* I think we could constrain the types of `RuntimeEnvironment` better than the `String` and `Int` we are using currently, e.g. using `Path` and `MemorySize`.  This requires moving these types up to the `wom` package.

