### PR TITLE
swap running jobs to aborting in the workflow store if abort-on-termi…

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -47,8 +47,8 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
   private val backoff = SimpleExponentialBackoff(1 second, 1 minute, 1.2)
 
   override lazy val workflowStore = new InMemoryWorkflowStore()
-  override lazy val jobStoreActor = context.actorOf(EmptyJobStoreActor.props)
-  override lazy val subWorkflowStoreActor = context.actorOf(EmptySubWorkflowStoreActor.props)
+  override lazy val jobStoreActor = context.actorOf(EmptyJobStoreActor.props, "JobStoreActor")
+  override lazy val subWorkflowStoreActor = context.actorOf(EmptySubWorkflowStoreActor.props, "SubWorkflowStoreActor")
 
   startWith(NotStarted, EmptySwraData)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -34,6 +34,14 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
       id.toString, WorkflowStoreState.Aborting.toString
     ).map(_ > 0)
   }
+  
+  override def abortAllRunning()(implicit ec: ExecutionContext): Future[Unit] = {
+    sqlDatabase.updateWorkflowsInState(
+      List(
+        WorkflowStoreState.Running.toString -> WorkflowStoreState.Aborting.toString
+      )
+    )
+  }
 
   override def stats(implicit ec: ExecutionContext): Future[Map[String, Int]] = sqlDatabase.stats
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -11,6 +11,8 @@ trait WorkflowStore {
   def initialize(implicit ec: ExecutionContext): Future[Unit]
   
   def aborting(id: WorkflowId)(implicit ec: ExecutionContext): Future[Boolean]
+
+  def abortAllRunning()(implicit ec: ExecutionContext): Future[Unit]
   
   def stats(implicit ec: ExecutionContext): Future[Map[String, Int]]
 

--- a/engine/src/main/scala/cromwell/jobstore/EmptyJobStoreActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/EmptyJobStoreActor.scala
@@ -3,11 +3,13 @@ package cromwell.jobstore
 import akka.actor.{Actor, Props}
 import cromwell.jobstore.JobStoreActor._
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
 class EmptyJobStoreActor extends Actor {
   override def receive: Receive = {
     case w: JobStoreWriterCommand => sender ! JobStoreWriteSuccess(w)
     case _: QueryJobCompletion => sender ! JobNotComplete
+    case ShutdownCommand => context stop self
   }
 }
 

--- a/engine/src/main/scala/cromwell/subworkflowstore/EmptySubWorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/subworkflowstore/EmptySubWorkflowStoreActor.scala
@@ -3,12 +3,14 @@ package cromwell.subworkflowstore
 import akka.actor.{Actor, ActorLogging, Props}
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
 class EmptySubWorkflowStoreActor extends Actor with ActorLogging {
   override def receive: Receive = {
     case register: RegisterSubWorkflow => sender() ! SubWorkflowStoreRegisterSuccess(register) 
     case query: QuerySubWorkflow => sender() ! SubWorkflowNotFound(query)
     case _: WorkflowComplete => // No-op!
+    case ShutdownCommand => context stop self
     case unknown => log.error(s"SubWorkflowStoreActor received unknown message: $unknown")
   }
 }

--- a/engine/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -48,14 +48,14 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
   "The WorkflowStoreActor" should {
     "return an ID for a submitted workflow" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
       storeActor ! SubmitWorkflow(helloWorldSourceFiles)
       expectMsgType[WorkflowSubmittedToStore](10 seconds)
     }
 
     "return 3 IDs for a batch submission of 3" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloWorldSourceFiles))
       expectMsgPF(10 seconds) {
         case WorkflowsBatchSubmittedToStore(ids) => ids.toList.size shouldBe 3
@@ -64,7 +64,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "fetch exactly N workflows" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloCwlWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
@@ -107,7 +107,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
 
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
       val readMetadataActor = system.actorOf(ReadMetadataActor.props())
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(optionedSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
@@ -150,7 +150,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "return only the remaining workflows if N is larger than size" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
@@ -170,7 +170,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "remain responsive if you ask to remove a workflow it doesn't have" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
 
       storeActor ! FetchRunnableWorkflows(100)
       expectMsgPF(10 seconds) {

--- a/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -56,7 +56,7 @@ object SingleWorkflowRunnerActorSpec {
 
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec with Mockito {
   private val workflowStore =
-    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor))
+    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false))
   private val serviceRegistry = TestProbe().ref
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
   private val ioActor = system.actorOf(SimpleIoActor.props)

--- a/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -32,7 +32,7 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
       val subWorkflowStoreService = system.actorOf(SubWorkflowStoreActor.props(subWorkflowStore))
 
       lazy val workflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
-      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref))
+      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false))
 
       val parentWorkflowId = WorkflowId.randomId()
       val subWorkflowId = WorkflowId.randomId()


### PR DESCRIPTION
…nate is true

It doesn't matter in run mode since it apparently uses an in-memory workflow store, but in the unlikely case in which someone sets `abort-on-terminate` to `true` in server mode, we want to set the status of all running jobs in the workflow store to `Aborting` so that when we restart the server we don't keep running those jobs.

It also fixes a bug which was preventing run mode to exit properly.