### PR TITLE
Array flatten library function

### DIFF
--- a/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
+++ b/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
@@ -38,7 +38,7 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
 
   behavior of "flatten"
 
-  it should "get the right answers" in {
+  it should "concatenate arrays of arrays of integers" in {
     val ar1 = WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2)))
     val ar2 = WomArray(WomArrayType(WomIntegerType), List(WomInteger(3), WomInteger(4), WomInteger(5)))
     val ar3 = WomArray(WomArrayType(WomIntegerType), List.empty)
@@ -48,7 +48,9 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
                                                               WomInteger(3), WomInteger(4),
                                                               WomInteger(5), WomInteger(6)))
     PureStandardLibraryFunctions.flatten(Seq(Success(aar))) should be(Success(flat_ar))
+  }
 
+  it should "concatenate arrays of arrays of strings" in {
     val sar1 = WomArray(WomArrayType(WomStringType), List(WomString("chatting"), WomString("is")))
     val sar2 = WomArray(WomArrayType(WomStringType), List(WomString("great"), WomString("for"), WomString("you")))
     val saar = WomArray(WomArrayType(WomArrayType(WomStringType)), List(sar1, sar2))
@@ -56,7 +58,9 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
                                                               WomString("great"), WomString("for"),
                                                               WomString("you")))
     PureStandardLibraryFunctions.flatten(Seq(Success(saar))) should be(Success(flat_sar))
+  }
 
+  it should "return errors for arguments which are not two dimensional arrays" in {
     val err1 = WomArray(WomArrayType(WomFileType), List.empty)
     PureStandardLibraryFunctions.flatten(Seq(Success(err1))) should be(a[Failure[_]])
 

--- a/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
+++ b/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import wom.types._
 import wom.values._
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
 
@@ -35,6 +35,35 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
     val empty = WomArray(WomArrayType(WomIntegerType), List.empty)
     PureStandardLibraryFunctions.length(Seq(Success(empty))) should be(Success(WomInteger(0)))
   }
+
+  behavior of "flatten"
+
+  it should "get the right answers" in {
+    val ar1 = WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2)))
+    val ar2 = WomArray(WomArrayType(WomIntegerType), List(WomInteger(3), WomInteger(4), WomInteger(5)))
+    val ar3 = WomArray(WomArrayType(WomIntegerType), List.empty)
+    val ar4 = WomArray(WomArrayType(WomIntegerType), List(WomInteger(6)))
+    val aar = WomArray(WomArrayType(WomArrayType(WomIntegerType)), List(ar1, ar2, ar3, ar4))
+    val flat_ar = WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2),
+                                                              WomInteger(3), WomInteger(4),
+                                                              WomInteger(5), WomInteger(6)))
+    PureStandardLibraryFunctions.flatten(Seq(Success(aar))) should be(Success(flat_ar))
+
+    val sar1 = WomArray(WomArrayType(WomStringType), List(WomString("chatting"), WomString("is")))
+    val sar2 = WomArray(WomArrayType(WomStringType), List(WomString("great"), WomString("for"), WomString("you")))
+    val saar = WomArray(WomArrayType(WomArrayType(WomStringType)), List(sar1, sar2))
+    val flat_sar = WomArray(WomArrayType(WomStringType), List(WomString("chatting"), WomString("is"),
+                                                              WomString("great"), WomString("for"),
+                                                              WomString("you")))
+    PureStandardLibraryFunctions.flatten(Seq(Success(saar))) should be(Success(flat_sar))
+
+    val err1 = WomArray(WomArrayType(WomFileType), List.empty)
+    PureStandardLibraryFunctions.flatten(Seq(Success(err1))) should be(a[Failure[_]])
+
+    val err2 = WomArray(WomArrayType(WomFloatType), List(WomFloat(1.0), WomFloat(3.2)))
+    PureStandardLibraryFunctions.flatten(Seq(Success(err2))) should be(a[Failure[_]])
+  }
+
 
   behavior of "prefix"
 

--- a/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
+++ b/wdl/src/test/scala/wdl/expression/PureStandardLibraryFunctionsSpec.scala
@@ -60,7 +60,7 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
     PureStandardLibraryFunctions.flatten(Seq(Success(saar))) should be(Success(flat_sar))
   }
 
-  it should "return errors for arguments which are not two dimensional arrays" in {
+  it should "return errors for arguments which are arrays with fewer than two dimensions" in {
     val err1 = WomArray(WomArrayType(WomFileType), List.empty)
     PureStandardLibraryFunctions.flatten(Seq(Success(err1))) should be(a[Failure[_]])
 
@@ -68,6 +68,14 @@ class PureStandardLibraryFunctionsSpec extends FlatSpec with Matchers {
     PureStandardLibraryFunctions.flatten(Seq(Success(err2))) should be(a[Failure[_]])
   }
 
+  it should "return errors for arguments which are not arrays" in {
+    val nonArrays: List[WomValue] = List(WomInteger(17),
+                                         WomString("banana"),
+                                         WomFile("/tmp/bubbles"))
+    nonArrays.foreach{ elem =>
+      PureStandardLibraryFunctions.flatten(Seq(Success(elem))) should be(a[Failure[_]])
+    }
+  }
 
   behavior of "prefix"
 


### PR DESCRIPTION
Currently, there is no library function to flatten an array of array of files (`Array[Array[File]]`). A scatter, where each task call produces an array of files, is a natural way of ending up with such a structure. In order to flatten this array, you can write a task that takes the it as an argument, and manipulate it with python code. However, this task will also download all the files, taking significant time and disk space. To work around this, you can coerce the files into strings (their paths), and manipulate the paths. 

You can see an example [here](https://github.com/HumanCellAtlas/skylab/blob/master/10x/count/count.wdl#L195). The `chunk_reads_join` task flattens the `fastq_chunks` file array, which is coerced into an `Array[Array[String]]`.

In order to avoid this circuitous implementation, this pull requests implements a generic flatten operation for ragged array types.