### PR TITLE
Handle globs in cwl output expressions

### DIFF
--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -17,7 +17,6 @@ object RuntimeEnvironmentBuilder {
    def apply(runtimeAttributes: Map[String, WomValue], jobPaths: JobPaths): MinimumRuntimeSettings => RuntimeEnvironment = {
      minimums =>
 
-       //val outputPath: String = jobPaths.callRoot.pathAsString
        val outputPath: String = jobPaths.callExecutionRoot.pathAsString
 
        val tempPath: String = jobPaths.callRoot.pathAsString

--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -17,7 +17,8 @@ object RuntimeEnvironmentBuilder {
    def apply(runtimeAttributes: Map[String, WomValue], jobPaths: JobPaths): MinimumRuntimeSettings => RuntimeEnvironment = {
      minimums =>
 
-       val outputPath: String = jobPaths.callRoot.pathAsString
+       //val outputPath: String = jobPaths.callRoot.pathAsString
+       val outputPath: String = jobPaths.callExecutionRoot.pathAsString
 
        val tempPath: String = jobPaths.callRoot.pathAsString
 

--- a/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
@@ -40,11 +40,10 @@ trait GlobFunctions extends IoFunctionSet {
     *
     * The paths are currently read from a list file based on the pattern, and the path parameter is not used.
     *
-    * @param path    The path string returned by globPath. This isn't currently used.
     * @param pattern The pattern of the glob. This is the same "glob" passed to globPath().
     * @return The paths that match the pattern.
     */
-  override def glob(path: String, pattern: String): Seq[String] = {
+  override def glob(pattern: String): Seq[String] = {
     val globPatternName = globName(pattern)
     val listFilePath = callContext.root.resolve(s"${globName(pattern)}.list")
     // This "lines" is technically a read file and hence should use the readFile IO method

--- a/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
@@ -22,9 +22,7 @@ trait GlobFunctions extends IoFunctionSet {
       }
     }
 
-  def globDirectory(glob: String): String = globName(glob) + "/"
-  def globName(glob: String) = s"glob-${glob.md5Sum}"
-
+  def globDirectory(glob: String): String = GlobFunctions.globName(glob) + "/"
   /**
     * Returns a path to the glob.
     *
@@ -44,6 +42,7 @@ trait GlobFunctions extends IoFunctionSet {
     * @return The paths that match the pattern.
     */
   override def glob(pattern: String): Seq[String] = {
+    import GlobFunctions._
     val globPatternName = globName(pattern)
     val listFilePath = callContext.root.resolve(s"${globName(pattern)}.list")
     // This "lines" is technically a read file and hence should use the readFile IO method
@@ -51,4 +50,8 @@ trait GlobFunctions extends IoFunctionSet {
       (callContext.root /  globPatternName  / fileName).pathAsString
     }
   }
+}
+
+object GlobFunctions {
+  def globName(glob: String) = s"glob-${glob.md5Sum}"
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -13,7 +13,7 @@ import cromwell.backend.async.AsyncBackendJobExecutionActor._
 import cromwell.backend.async.{AbortedExecutionHandle, AsyncBackendJobExecutionActor, ExecutionHandle, FailedNonRetryableExecutionHandle, FailedRetryableExecutionHandle, PendingExecutionHandle, ReturnCodeIsNotAnInt, StderrNonEmpty, SuccessfulExecutionHandle, WrongReturnCode}
 import cromwell.backend.validation._
 import cromwell.backend.wdl.OutputEvaluator._
-import cromwell.backend.wdl.{Command, OutputEvaluator, WdlFileMapper}
+import cromwell.backend.wdl.{Command, OutputEvaluator, WomFileMapper}
 import cromwell.backend._
 import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
 import cromwell.core.path.Path
@@ -116,9 +116,11 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
 
   /** @see [[Command.instantiate]] */
   final lazy val commandLinePreProcessor: WomEvaluatedCallInputs => Try[WomEvaluatedCallInputs] = {
-    inputs => TryUtil.sequenceMap(inputs mapValues WdlFileMapper.mapWdlFiles(preProcessWdlFile)) recoverWith {
-      case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)
-    }
+    inputs =>
+      TryUtil.sequenceMap(inputs mapValues WomFileMapper.mapWomFiles(preProcessWdlFile)).
+        recoverWith {
+          case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)
+        }
   }
 
   /**
@@ -132,7 +134,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
 
   /** @see [[Command.instantiate]] */
   final lazy val commandLineValueMapper: WomValue => WomValue = {
-    womValue => WdlFileMapper.mapWdlFiles(mapCommandLineWdlFile)(womValue).get
+    womValue => WomFileMapper.mapWomFiles(mapCommandLineWdlFile)(womValue).get
   }
 
   /**
@@ -437,7 +439,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @return The Try wrapped and mapped wdl value.
     */
   final def outputValueMapper(womValue: WomValue): Try[WomValue] = {
-    WdlFileMapper.mapWdlFiles(mapOutputWdlFile)(womValue)
+    WomFileMapper.mapWomFiles(mapOutputWdlFile)(womValue)
   }
 
   /**

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -156,7 +156,8 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param globFiles The globs.
     * @return The shell scripting.
     */
-  def globManipulations(globFiles: Traversable[WomGlobFile]): String = globFiles map globManipulation mkString "\n"
+  def globManipulations(globFiles: Traversable[WomGlobFile]): String =
+    globFiles map globManipulation mkString "\n"
 
   /**
     * Returns the shell scripting for hard linking a glob results using ln.
@@ -187,7 +188,8 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     val rcPath = cwd./(jobPaths.returnCodeFilename)
     val rcTmpPath = rcPath.plusExt("tmp")
 
-    val globFiles: ErrorOr[List[WomGlobFile]] = backendEngineFunctions.findGlobOutputs(call, jobDescriptor)
+    val globFiles: ErrorOr[List[WomGlobFile]] =
+      backendEngineFunctions.findGlobOutputs(call, jobDescriptor)
 
     globFiles.map(globFiles =>
     s"""|#!/bin/bash

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -21,6 +21,10 @@ import cromwell.core.{CromwellAggregatedException, CromwellFatalExceptionMarker,
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.keyvalue.KvClient
 import cromwell.services.metadata.CallMetadataKeys
+import common.exception.MessageAggregation
+import common.util.TryUtil
+import common.validation.ErrorOr.ErrorOr
+import cromwell.backend.io.GlobFunctions
 import net.ceedubs.ficus.Ficus._
 import wom.values._
 
@@ -169,7 +173,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     */
   def globManipulation(globFile: WomGlobFile): String = {
     val parentDirectory = globParentDirectory(globFile)
-    val globDir = backendEngineFunctions.globName(globFile.value)
+    val globDir = GlobFunctions.globName(globFile.value)
     val globDirectory = parentDirectory./(globDir)
     val globList = parentDirectory./(s"$globDir.list")
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -13,7 +13,7 @@ import cromwell.backend.async.AsyncBackendJobExecutionActor._
 import cromwell.backend.async.{AbortedExecutionHandle, AsyncBackendJobExecutionActor, ExecutionHandle, FailedNonRetryableExecutionHandle, FailedRetryableExecutionHandle, PendingExecutionHandle, ReturnCodeIsNotAnInt, StderrNonEmpty, SuccessfulExecutionHandle, WrongReturnCode}
 import cromwell.backend.validation._
 import cromwell.backend.wdl.OutputEvaluator._
-import cromwell.backend.wdl.{Command, OutputEvaluator, WomFileMapper}
+import cromwell.backend.wdl.{Command, OutputEvaluator}
 import cromwell.backend._
 import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
 import cromwell.core.path.Path
@@ -26,6 +26,7 @@ import common.util.TryUtil
 import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.io.GlobFunctions
 import net.ceedubs.ficus.Ficus._
+import wom.WomFileMapper
 import wom.values._
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future, Promise}
@@ -183,7 +184,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |# symlink all the files into the glob directory
         |( ln -L ${globFile.value} $globDirectory 2> /dev/null ) || ( ln ${globFile.value} $globDirectory )
         |
-        |# list all the files that match teh glob into a file called glob-[md5 of glob].list
+        |# list all the files that match the glob into a file called glob-[md5 of glob].list
         |ls -1 $globDirectory > $globList
         |""".stripMargin
   }

--- a/backend/src/main/scala/cromwell/backend/wdl/OutputEvaluator.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/OutputEvaluator.scala
@@ -12,8 +12,6 @@ import common.validation.Checked._
 import common.validation.ErrorOr.ErrorOr
 import cromwell.core.CallOutputs
 import cromwell.backend.io.GlobFunctions
-import wom.JobOutput
-import wom.callable.Callable.OutputDefinition
 import wom.expression.IoFunctionSet
 import wom.graph.GraphNodePort.{ExpressionBasedOutputPort, OutputPort}
 import wom.types.WomType

--- a/backend/src/main/scala/cromwell/backend/wdl/WomFileMapper.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/WomFileMapper.scala
@@ -5,29 +5,29 @@ import wom.values._
 
 import scala.util.{Success, Try}
 
-object WdlFileMapper {
-  def mapWdlFiles(mapper: (WomFile => WomFile))(womValue: WomValue): Try[WomValue] = {
+object WomFileMapper {
+  def mapWomFiles(mapper: (WomFile => WomFile))(womValue: WomValue): Try[WomValue] = {
     womValue match {
       case file: WomFile => Try(mapper(file))
       case array: WomArray =>
-        val mappedArray = array.value map mapWdlFiles(mapper)
+        val mappedArray = array.value map mapWomFiles(mapper)
         TryUtil.sequence(mappedArray) map {
           WomArray(array.womType, _)
         }
       case map: WomMap =>
         val mappedMap = map.value map {
-          case (key, value) => mapWdlFiles(mapper)(key) -> mapWdlFiles(mapper)(value)
+          case (key, value) => mapWomFiles(mapper)(key) -> mapWomFiles(mapper)(value)
         }
         TryUtil.sequenceKeyValues(mappedMap) map {
           WomMap(map.womType, _)
         }
       case pair: WomPair =>
-        val mappedPair: (Try[WomValue], Try[WomValue]) = (mapWdlFiles(mapper)(pair.left), mapWdlFiles(mapper)(pair.right))
+        val mappedPair: (Try[WomValue], Try[WomValue]) = (mapWomFiles(mapper)(pair.left), mapWomFiles(mapper)(pair.right))
         TryUtil.sequenceTuple(mappedPair) map {
           (WomPair.apply _).tupled
         }
       case optionalValue: WomOptionalValue =>
-        val mappedOptional: Option[Try[WomValue]] = optionalValue.value.map(mapWdlFiles(mapper))
+        val mappedOptional: Option[Try[WomValue]] = optionalValue.value.map(mapWomFiles(mapper))
         TryUtil.sequenceOption(mappedOptional) map {
           WomOptionalValue(optionalValue.innerType, _)
         }

--- a/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
@@ -101,7 +101,7 @@ class TestReadLikeFunctions(sizeResult: Try[Double]) extends IoFunctionSet {
 
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = ???
 
-  override def glob(path: String, pattern: String): Seq[String] = ???
+  override def glob(pattern: String): Seq[String] = ???
 
   override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = sizeResult.map(WomFloat.apply)
 }

--- a/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
+++ b/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
@@ -15,7 +15,7 @@ case object NoIoFunctionSet extends IoFunctionSet {
 
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = Failure(new NotImplementedError("stderr is not available here"))
 
-  override def glob(path: String, pattern: String): Seq[String] = throw new NotImplementedError("glob is not available here")
+  override def glob(pattern: String): Seq[String] = throw new NotImplementedError("glob is not available here")
 
   override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = Failure(new NotImplementedError("size is not available here"))
 }

--- a/cwl/src/main/scala/cwl/CommandOutputBinding.scala
+++ b/cwl/src/main/scala/cwl/CommandOutputBinding.scala
@@ -25,7 +25,7 @@ case class CommandOutputBinding(
 
   http://www.commonwl.org/v1.0/CommandLineTool.html#CommandOutputBinding
    */
-  def commandOutputBindingToWdlValue(parameterContext: ParameterContext,
+  def commandOutputBindingToWomValue(parameterContext: ParameterContext,
                                      ioFunctionSet: IoFunctionSet): WomValue = {
 
     val paths: Seq[String] = glob map { globValue =>

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -26,25 +26,30 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
   override def evaluateValue(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
     val parameterContext = ParameterContext.Empty.withInputs(inputValues, ioFunctionSet)
 
-    val wdlValue: WomValue = outputBinding.
-      commandOutputBindingToWdlValue(parameterContext, ioFunctionSet)
-    val extractFile: WomValue =
-      wdlValue match {
+    //To facilitate ECMAScript evaluation, filenames are stored in a map under the key "location"
+    val womValue = outputBinding.
+      commandOutputBindingToWomValue(parameterContext, ioFunctionSet) match {
         case WomArray(_, Seq(WomMap(WomMapType(WomStringType, WomStringType), map))) => map(WomString("location"))
         case other => other
       }
 
-    val globIfFile =
-      (extractFile, cwlExpressionType) match {
+    //If the value is a string but the output is expecting a file, we consider that string a POSIX "glob" and apply
+    //it accordingly to retrieve the file list to which it expands.
+    val globbedIfFile =
+      (womValue, cwlExpressionType) match {
+
+        //In the case of a single file being expected, we must enforce that the glob only represents a single file
         case (WomString(glob), WomFileType) =>
           ioFunctionSet.glob(glob) match {
             case head :: Nil => WomString(head)
             case list => throw new RuntimeException(s"expecting a single File glob but instead got $list")
           }
-        case _  => extractFile
+
+        case _  => womValue
       }
 
-    cwlExpressionType.coerceRawValue(globIfFile).toErrorOr
+    //CWL tells us the type this output is expected to be.  Attempt to coerce the actual output into this type.
+    cwlExpressionType.coerceRawValue(globbedIfFile).toErrorOr
   }
 
   /*

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -1,7 +1,5 @@
 package cwl
 
-import java.security.MessageDigest
-
 import cats.syntax.option._
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
@@ -36,15 +34,7 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
         case other => other
       }
 
-    extractFile match {
-      case WomString(string) if string.contains("*") =>
-        val md5: String = MessageDigest.getInstance("MD5").digest(string.getBytes).map("%02X".format(_)).mkString
-        cwlExpressionType.coerceRawValue(
-          WomString(s"glob-$md5.list")).
-          toErrorOr
-      case _ => cwlExpressionType.coerceRawValue(extractFile).toErrorOr
-    }
-
+   cwlExpressionType.coerceRawValue(extractFile).toErrorOr
   }
 
   /*

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -41,7 +41,7 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
             case head :: Nil => WomString(head)
             case list => throw new RuntimeException(s"expecting a single File glob but instead got $list")
           }
-        case other => other
+        case _  => extractFile
       }
 
     cwlExpressionType.coerceRawValue(globIfFile).toErrorOr

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -34,7 +34,17 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
         case other => other
       }
 
-    cwlExpressionType.coerceRawValue(extractFile).toErrorOr
+    val globIfFile =
+      (extractFile, cwlExpressionType) match {
+        case (WomString(glob), WomFileType) =>
+          ioFunctionSet.glob(glob) match {
+            case head :: Nil => WomString(head)
+            case list => throw new RuntimeException(s"expecting a single File glob but instead got $list")
+          }
+        case other => other
+      }
+
+    cwlExpressionType.coerceRawValue(globIfFile).toErrorOr
   }
 
   /*

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -34,7 +34,7 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
         case other => other
       }
 
-   cwlExpressionType.coerceRawValue(extractFile).toErrorOr
+    cwlExpressionType.coerceRawValue(extractFile).toErrorOr
   }
 
   /*

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -22,15 +22,18 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
 
   // TODO WOM: outputBinding.toString is probably not be the best representation of the outputBinding
   override def sourceString = outputBinding.toString
+
   override def evaluateValue(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
     val parameterContext = ParameterContext.Empty.withInputs(inputValues, ioFunctionSet)
 
-    val wdlValue: WomValue = outputBinding.commandOutputBindingToWdlValue(parameterContext, ioFunctionSet)
+    val wdlValue: WomValue = outputBinding.
+      commandOutputBindingToWdlValue(parameterContext, ioFunctionSet)
     val extractFile: WomValue =
       wdlValue match {
         case WomArray(_, Seq(WomMap(WomMapType(WomStringType, WomStringType), map))) => map(WomString("location"))
         case other => other
       }
+
     cwlExpressionType.coerceRawValue(extractFile).toErrorOr
   }
 
@@ -41,7 +44,7 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
    */
   override def evaluateFiles(inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet, coerceTo: WomType): ErrorOr[Set[WomFile]] ={
 
-    val pc = ParameterContext.Empty.withInputs(inputs, ioFunctionSet)
+    val pc = ParameterContext().withInputs(inputs, ioFunctionSet)
 
     val files = for {
       globValue <- outputBinding.glob.toList

--- a/cwl/src/main/scala/cwl/GlobEvaluator.scala
+++ b/cwl/src/main/scala/cwl/GlobEvaluator.scala
@@ -4,7 +4,6 @@ import shapeless._
 import wom.expression.IoFunctionSet
 import wom.types.{WomArrayType, WomStringType}
 
-import scala.Function._
 import wom.values._
 
 /*
@@ -18,14 +17,14 @@ http://www.commonwl.org/v1.0/CommandLineTool.html#CommandOutputBinding
  */
 object GlobEvaluator {
 
-  private type GlobHandler = ParameterContext => Seq[String]
+  private type GlobHandler = (ParameterContext, IoFunctionSet) => Seq[String]
 
   type Glob[A] = String
 
   def globPaths(glob: CommandOutputBinding.Glob,
                 parameterContext: ParameterContext,
                 ioFunctionSet: IoFunctionSet): Seq[String] = {
-    val globs: Seq[String] = glob.fold(GlobToPaths).apply(parameterContext)
+    val globs: Seq[String] = glob.fold(GlobToPaths).apply(parameterContext, ioFunctionSet)
     getPaths(globs, ioFunctionSet)
   }
 
@@ -45,7 +44,7 @@ object GlobEvaluator {
   object GlobToPaths extends Poly1 {
     implicit def caseECMAScript: Case.Aux[Expression, GlobHandler] = {
       at[Expression] { ecmaScript =>
-        (parameterContext: ParameterContext) => {
+        (parameterContext: ParameterContext, ioFunctions: IoFunctionSet) => {
           ecmaScript.fold(EvaluateExpression).apply(parameterContext) match {
             case WomArray(_, values) if values.isEmpty => Vector.empty
             case WomString(value) => Vector(value)
@@ -59,11 +58,17 @@ object GlobEvaluator {
     }
 
     implicit def caseArrayString: Case.Aux[Array[String], GlobHandler] = {
-      at[Array[String]] { const(_) }
+      at[Array[String]] { _ =>
+        throw new NotImplementedError("The Array[String] case of Glob evaluator has not yet been implemented")
+      }
     }
 
     implicit def caseString: Case.Aux[String, GlobHandler] = {
-      at[String] { string => const(Vector(string)) }
+      at[String] { glob =>
+        (parameterContext: ParameterContext, ioFunctions: IoFunctionSet) => {
+          ioFunctions.glob(glob)
+        }
+      }
     }
   }
 

--- a/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
+++ b/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
@@ -25,7 +25,7 @@ class CommandOutputExpressionSpec extends FlatSpec with Matchers {
       override def writeFile(path: String, content: String) = throw new Exception("writeFile should not be used in this test")
       override def stdout(params: Seq[Try[WomValue]]) = throw new Exception("stdout should not be used in this test")
       override def stderr(params: Seq[Try[WomValue]]) = throw new Exception("stderr should not be used in this test")
-      override def glob(path: String, pattern: String) = throw new Exception("glob should not be used in this test")
+      override def glob(pattern: String): Seq[String] = throw new Exception("glob should not be used in this test")
       override def size(params: Seq[Try[WomValue]]) = throw new Exception("size should not be used in this test")
     }
 

--- a/engine/src/main/scala/cromwell/engine/WdlFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/WdlFunctions.scala
@@ -12,7 +12,7 @@ class WdlFunctions(val pathBuilders: List[PathBuilder]) extends ReadLikeFunction
 
   override def stdout(params: Seq[Try[WomValue]]): Try[WomFile] = fail("stdout")
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = fail("stderr")
-  override def glob(path: String, pattern: String): Seq[String] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
+  override def glob(pattern: String): Seq[String] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
 
   // TODO WOM: fix this
   override def writeFile(path: String, content: String): Future[WomFile] = Future.failed(new Exception("Can't write files"))

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -25,6 +25,7 @@ import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.keyvalue.KvClient
 import common.validation.ErrorOr.ErrorOr
+import cromwell.backend.io.GlobFunctions
 import org.slf4j.LoggerFactory
 import wom.callable.Callable.OutputDefinition
 import wom.core.FullyQualifiedName
@@ -234,7 +235,7 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
   }
 
   private def generateJesGlobFileOutputs(wdlFile: WomGlobFile): List[JesFileOutput] = {
-    val globName = backendEngineFunctions.globName(wdlFile.value)
+    val globName = GlobFunctions.globName(wdlFile.value)
     val globDirectory = globName + "/"
     val globListFile = globName + ".list"
     val gcsGlobDirectoryDestinationPath = callRootPath.resolve(globDirectory).pathAsString

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -16,7 +16,7 @@ import cromwell.backend.impl.jes.RunStatus.UnsuccessfulRunStatus
 import cromwell.backend.impl.jes.io.{DiskType, JesWorkingDisk}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.DoPoll
 import cromwell.backend.standard.{DefaultStandardAsyncExecutionActorParams, StandardAsyncExecutionActorParams, StandardAsyncJob, StandardExpressionFunctionsParams}
-import cromwell.backend.wdl.WdlFileMapper
+import cromwell.backend.wdl.WomFileMapper
 import cromwell.cloudsupport.gcp.gcs.GcsStorage
 import cromwell.core.Tags.PostWomTest
 import cromwell.core._
@@ -381,7 +381,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
 
 
         def gcsPathToLocal(womValue: WomValue): WomValue = {
-          WdlFileMapper.mapWdlFiles(testActorRef.underlyingActor.mapCommandLineWdlFile)(womValue).get
+          WomFileMapper.mapWomFiles(testActorRef.underlyingActor.mapCommandLineWdlFile)(womValue).get
         }
 
         val mappedInputs = jobDescriptor.localInputs mapValues gcsPathToLocal
@@ -652,7 +652,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       props, s"TestableJesJobExecutionActor-${jobDescriptor.workflowDescriptor.id}")
 
     def wdlValueToGcsPath(jesOutputs: Set[JesFileOutput])(womValue: WomValue): WomValue = {
-      WdlFileMapper.mapWdlFiles(testActorRef.underlyingActor.wdlFileToGcsPath(jesOutputs))(womValue).get
+      WomFileMapper.mapWomFiles(testActorRef.underlyingActor.wdlFileToGcsPath(jesOutputs))(womValue).get
     }
 
     val result = outputValues map wdlValueToGcsPath(jesOutputs)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -16,7 +16,6 @@ import cromwell.backend.impl.jes.RunStatus.UnsuccessfulRunStatus
 import cromwell.backend.impl.jes.io.{DiskType, JesWorkingDisk}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.DoPoll
 import cromwell.backend.standard.{DefaultStandardAsyncExecutionActorParams, StandardAsyncExecutionActorParams, StandardAsyncJob, StandardExpressionFunctionsParams}
-import cromwell.backend.wdl.WomFileMapper
 import cromwell.cloudsupport.gcp.gcs.GcsStorage
 import cromwell.core.Tags.PostWomTest
 import cromwell.core._
@@ -34,6 +33,7 @@ import org.scalatest.prop.Tables.Table
 import org.slf4j.Logger
 import org.specs2.mock.Mockito
 import spray.json._
+import wom.WomFileMapper
 import wom.graph.TaskCallNode
 import wom.types._
 import wom.values._

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -7,10 +7,10 @@ import cats.syntax.functor._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend.io.JobPaths
-import cromwell.backend.wdl.WomFileMapper
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.path.{DefaultPath, DefaultPathBuilder, Path, PathFactory}
 import common.util.TryUtil
+import wom.WomFileMapper
 import wom.values._
 
 import scala.collection.JavaConverters._

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -7,7 +7,7 @@ import cats.syntax.functor._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend.io.JobPaths
-import cromwell.backend.wdl.WdlFileMapper
+import cromwell.backend.wdl.WomFileMapper
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.path.{DefaultPath, DefaultPathBuilder, Path, PathFactory}
 import common.util.TryUtil
@@ -133,7 +133,7 @@ trait SharedFileSystem extends PathFactory {
   }
 
   def outputMapper(job: JobPaths)(womValue: WomValue): Try[WomValue] = {
-    WdlFileMapper.mapWdlFiles(mapJobWdlFile(job))(womValue)
+    WomFileMapper.mapWomFiles(mapJobWdlFile(job))(womValue)
   }
 
   def mapJobWdlFile(job: JobPaths)(wdlFile: WomFile): WomFile = {
@@ -155,7 +155,7 @@ trait SharedFileSystem extends PathFactory {
    */
   def localizeInputs(inputsRoot: Path, docker: Boolean)(inputs: WomEvaluatedCallInputs): Try[WomEvaluatedCallInputs] = {
     TryUtil.sequenceMap(
-      inputs mapValues WdlFileMapper.mapWdlFiles(localizeWdlFile(inputsRoot, docker)),
+      inputs mapValues WomFileMapper.mapWomFiles(localizeWdlFile(inputsRoot, docker)),
       "Failures during localization"
     ) recoverWith {
       case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -140,7 +140,7 @@ trait SharedFileSystemAsyncJobExecutionActor
   def writeScriptContents(): Either[ExecutionHandle, Unit] =
     commandScriptContents.fold(
       errors => Left(FailedNonRetryableExecutionHandle(new RuntimeException("Unable to start job due to: " + errors.toList.mkString(", ")))),
-      {script => println(s"script was \n$script"); jobPaths.script.write(script); Right(())} )
+      {script => jobPaths.script.write(script); Right(())} )
 
   /**
     * Creates a script to submit the script for asynchronous processing. The default implementation assumes the

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -140,7 +140,7 @@ trait SharedFileSystemAsyncJobExecutionActor
   def writeScriptContents(): Either[ExecutionHandle, Unit] =
     commandScriptContents.fold(
       errors => Left(FailedNonRetryableExecutionHandle(new RuntimeException("Unable to start job due to: " + errors.toList.mkString(", ")))),
-      {script => jobPaths.script.write(script); Right(())} )
+      {script => println(s"script was \n$script"); jobPaths.script.write(script); Right(())} )
 
   /**
     * Creates a script to submit the script for asynchronous processing. The default implementation assumes the

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.tes
 
+import cromwell.backend.io.GlobFunctions
 import cromwell.backend.standard.StandardExpressionFunctions
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor}
 import cromwell.core.NoIoFunctionSet
@@ -140,7 +141,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
           )
         )
       case (g: WomGlobFile, index) =>
-        val globName = backendEngineFunctions.globName(g.value)
+        val globName = GlobFunctions.globName(g.value)
         val globDirName = "globDir." + index
         val globDirectory = globName + "/"
         val globListName =  "globList." + index

--- a/wdl/src/main/scala/wdl/WdlExpression.scala
+++ b/wdl/src/main/scala/wdl/WdlExpression.scala
@@ -227,7 +227,7 @@ final case class WdlWomExpression(wdlExpression: WdlExpression, from: Option[Sco
 
       override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = ioFunctionSet.stderr(params)
 
-      override def glob(path: String, pattern: String): Seq[String] = ioFunctionSet.glob(path, pattern)
+      override def glob(path: String, pattern: String): Seq[String] = ioFunctionSet.glob(pattern)
 
       override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = ioFunctionSet.size(params)
     }

--- a/wdl/src/main/scala/wdl/expression/FileEvaluator.scala
+++ b/wdl/src/main/scala/wdl/expression/FileEvaluator.scala
@@ -34,9 +34,8 @@ class FileEvaluatorWdlFunctions
  * evaluate("b.txt") would return Seq().
  */
 case class FileEvaluator(valueEvaluator: ValueEvaluator, coerceTo: WomType = WomAnyType) {
-  type T = Seq[WomFile]
-  def lookup = (s:String) => Seq.empty[WomFile]
 
+  def lookup = (s:String) => Seq.empty[WomFile]
 
   private def evalValue(ast: AstNode): Try[WomValue] = valueEvaluator.evaluate(ast)
 

--- a/wdl/src/main/scala/wdl/expression/WdlStandardLibraryFunctions.scala
+++ b/wdl/src/main/scala/wdl/expression/WdlStandardLibraryFunctions.scala
@@ -309,7 +309,7 @@ object WdlStandardLibraryFunctions {
 
     override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = ioFunctionSet.stderr(params)
 
-    override def glob(path: String, pattern: String): Seq[String] = ioFunctionSet.glob(path, pattern)
+    override def glob(path: String, pattern: String): Seq[String] = ioFunctionSet.glob(pattern)
 
     override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = ioFunctionSet.size(params)
   }

--- a/wom/src/main/scala/wom/WomFileMapper.scala
+++ b/wom/src/main/scala/wom/WomFileMapper.scala
@@ -1,4 +1,4 @@
-package cromwell.backend.wdl
+package wom
 
 import common.util.TryUtil
 import wom.values._

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -33,6 +33,6 @@ trait IoFunctionSet {
   def writeFile(path: String, content: String): Future[WomFile]
   def stdout(params: Seq[Try[WomValue]]): Try[WomFile]
   def stderr(params: Seq[Try[WomValue]]): Try[WomFile]
-  def glob(path: String, pattern: String): Seq[String]
+  def glob(pattern: String): Seq[String]
   def size(params: Seq[Try[WomValue]]): Try[WomFloat]
 }

--- a/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
+++ b/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
@@ -24,6 +24,6 @@ case object PlaceholderIoFunctionSet extends IoFunctionSet {
   override def writeFile(path: String, content: String): Future[WomFile] = ???
   override def stdout(params: Seq[Try[WomValue]]) = ???
   override def stderr(params: Seq[Try[WomValue]]) = ???
-  override def glob(path: String, pattern: String) = ???
+  override def glob(pattern: String): Seq[String] = ???
   override def size(params: Seq[Try[WomValue]]) = ???
 }


### PR DESCRIPTION
CWL was treating output glob strings as if they were filenames, and thus was not returning the filename that Cromwell expects, namely `glob-${md5(fileName)}.list`.

The implementation boils down to `OutputEvaluator` trying to detect whether the output of the expression is a glob.  If it is _is_ a glob, it changes the output to be the filename as listed above.