### PR TITLE
Lookup outside nested scopes

### DIFF
--- a/centaur/src/main/resources/standardTestCases/conditionals.nested_lookups.test
+++ b/centaur/src/main/resources/standardTestCases/conditionals.nested_lookups.test
@@ -1,0 +1,23 @@
+name: nested_lookups
+testFormat: workflowsuccess
+tags: [ conditionals ]
+
+files {
+  wdl: conditionals_tests/nested_lookups/nested_lookups.wdl
+  inputs: conditionals_tests/nested_lookups/nested_lookups.inputs.json
+}
+
+metadata {
+  workflowName: nested_lookups
+  "outputs.nested_lookups.m1_out": 27
+  "outputs.nested_lookups.m2_out": 28
+  "outputs.nested_lookups.needs_wf_input_out": 2050
+
+  "outputs.nested_lookups.b_out": 82
+  "outputs.nested_lookups.c_out": 82
+  "outputs.nested_lookups.d_out": 82
+  "outputs.nested_lookups.e_out": 82
+
+  "outputs.nested_lookups.f1_out": null
+  "outputs.nested_lookups.f2_out": null
+}

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.inputs.json
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.inputs.json
@@ -1,0 +1,3 @@
+{
+  "nested_lookups.needs_wf_input.i": 2050
+}

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.wdl
@@ -1,0 +1,65 @@
+workflow nested_lookups {
+  Int i = 27
+  Int a = 82
+  if(true) {
+#    call mirror as throwaway1 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+#    call mirror as throwaway2 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate throwaway1's, or the nested m1's 'i' OGIN
+    if(true) {
+      if(true) {
+        call mirror as m1 { input: i = i }
+        call mirror as needs_wf_input
+        Int b = a
+
+        Int f = 100000
+      }
+    }
+    if(true) {
+      if(false) {
+        Int? f1 = f
+      }
+    }
+  }
+
+  Int c = select_first([b, i])
+
+  if(true) {
+#    Int? throwaway3 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+#    Int? throwaway4 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate throwaway3's, or the nested m2's 'm1.out' OGIN
+    if(true) {
+      if(true) {
+        call mirror as m2 { input: i = select_first([m1.out, 5]) + 1 }
+        Int d = c
+        Int? e = b
+        Int? f2 = f1
+      }
+    }
+  }
+
+  output {
+    Int? m1_out = m1.out
+    Int? m2_out = m2.out
+    Int? needs_wf_input_out = needs_wf_input.out
+
+    Int? b_out = b
+    Int c_out = c
+    Int? d_out = d
+    Int? e_out = e
+
+    Int? f1_out = f1
+    Int? f2_out = f2
+  }
+}
+
+task mirror {
+  Int i
+
+  command {
+    echo ${i}
+  }
+  output {
+    Int out = read_int(stdout())
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/scatters_in_ifs/scatters_in_ifs.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/scatters_in_ifs/scatters_in_ifs.wdl
@@ -11,20 +11,18 @@ task mirror {
   }
 }
 
-
 workflow scatters_in_ifs {
 
-# TODO: Reinstate the nested lookup with #2724
-#  Array[Int] numbers = range(3)
+  Array[Int] numbers = range(3)
 
   if (true) {
-    scatter (n in range(3)) {
+    scatter (n in numbers) {
       call mirror as mirrorTrue { input: i = n }
     }
   }
 
   if (false) {
-    scatter (n in range(3)) {
+    scatter (n in numbers) {
       call mirror as mirrorFalse { input: i = n }
     }
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
@@ -44,7 +44,7 @@ private [execution] case class ConditionalKey(node: ConditionalNode, index: Exec
     case declaration: ExpressionNode => Option(ExpressionKey(declaration, index))
     case conditional: ConditionalNode => Option(ConditionalKey(conditional, index))
     case scatter: ScatterNode if index.isEmpty => Option(ScatterKey(scatter))
-    case _: OuterGraphInputNode => None
+    case _: GraphInputNode => None
     case _: PortBasedGraphOutputNode => None
     case _: ScatterNode =>
       throw new UnsupportedOperationException("Nested Scatters are not supported (yet) ... but you might try a sub workflow to achieve the same effect!")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -60,8 +60,8 @@ object ExecutionStore {
       case svn: ScatterVariableNode => table.contains(svn.linkToOuterGraph.graphNode, None)
       // OuterGraphInputNodes signal that an input comes from outside the graph.
       // Depending on whether or not this input is outside of a scatter graph will change the index which we need to look at
-      case ogin: OuterGraphInputNode if !ogin.preserveScatterIndex => ogin.linkToOuterGraph.graphNode.isInStatus(None, table)
-      case ogin: OuterGraphInputNode => ogin.linkToOuterGraph.graphNode.isInStatus(index, table)
+      case ogin: OuterGraphInputNode if !ogin.preserveScatterIndex => ogin.linkToOuterGraph.executionNode.isInStatus(None, table)
+      case ogin: OuterGraphInputNode => ogin.linkToOuterGraph.executionNode.isInStatus(index, table)
       case _: GraphInputNode => true
       case _ => table.contains(graphNode, index)
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
@@ -82,7 +82,7 @@ case class ValueStore(store: Table[OutputPort, ExecutionIndex, WomValue]) {
     val conditionalPort = collector.conditionalOutputPort
     val sourcePort = conditionalPort.outputToExpose.source
     store.getValue(sourcePort, collector.index) match {
-      case Some(womValue) => Map(ValueKey(conditionalPort, collector.index) -> WomOptionalValue(womValue)).validNel
+      case Some(womValue) => Map(ValueKey(conditionalPort, collector.index) -> WomOptionalValue(womValue).flattenOptional).validNel
       case None => s"Cannot collect ${collector.conditionalOutputPort.womType.toDisplayString} ${collector.node.identifier.fullyQualifiedName.value}: Cannot find a value for output port ${sourcePort.identifier.fullyQualifiedName.value}".invalidNel
     }
   }

--- a/wdl/src/main/scala/wdl/Declaration.scala
+++ b/wdl/src/main/scala/wdl/Declaration.scala
@@ -32,7 +32,7 @@ object DeclarationInterface {
     target.closestCommonAncestor(from) map { ancestor =>
       target.ancestrySafe.takeWhile(_ != ancestor).foldLeft(womType){
         case (acc, _: Scatter) => WomArrayType(acc)
-        case (acc, _: If) => WomOptionalType(acc)
+        case (acc, _: If) => WomOptionalType(acc).flatOptionalType
         case (acc, _) => acc
       }
     } getOrElse womType
@@ -86,12 +86,12 @@ trait DeclarationInterface extends WdlGraphNodeWithUpstreamReferences {
 object Declaration {
 
   sealed trait WdlDeclarationNode {
-    def toGraphNode: GraphNode = this match {
+    lazy val toGraphNode: GraphNode = this match {
       case InputDeclarationNode(graphInputNode) => graphInputNode
       case IntermediateValueDeclarationNode(expressionNode) => expressionNode
       case GraphOutputDeclarationNode(graphOutputNode) => graphOutputNode
     }
-    def singleOutputPort: Option[GraphNodePort.OutputPort] = this match {
+    lazy val singleOutputPort: Option[GraphNodePort.OutputPort] = this match {
       case InputDeclarationNode(graphInputNode) => Option(graphInputNode.singleOutputPort)
       case IntermediateValueDeclarationNode(expressionNode) => Option(expressionNode.singleExpressionOutputPort)
       case GraphOutputDeclarationNode(_) => None

--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -44,17 +44,30 @@ object Scatter {
     // Generate an ExpressionNode from the WdlWomExpression
     val scatterCollectionExpressionNode = WdlWomExpression.toExpressionNode(WomIdentifier(scatter.item), scatterCollectionExpression, localLookup, outerLookup, preserveIndexForOuterLookups)
     // Validate the collection evaluates to a traversable type
-    val scatterItemTypeValidation = scatterCollectionExpression.evaluateType(localLookup.map { case (k, v) => k -> v.womType }) flatMap {
+    val scatterItemTypeValidation = scatterCollectionExpression.evaluateType((localLookup ++ outerLookup).map { case (k, v) => k -> v.womType }) flatMap {
       case WomArrayType(itemType) => Valid(itemType) // Covers maps because this is a custom unapply (see WdlArrayType)
       case other => s"Cannot scatter over a non-traversable type ${other.toDisplayString}".invalidNel
     }
+
+    /**
+      * Why? Imagine that we're building three nested levels of a innerGraph.
+      * - Say we're building the middle layer.
+      * - We have a set of OutputPorts in the outer layer that we can make OGINs to if we need them.
+      * - We know that the inner graph might want to make use of those output ports, but we don't know which.
+      * - So, we can make OGINs at this layer for all possible OutputPorts in the outer graph and let the inner graph
+      * use however many of them it needs.
+      */
+    val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
+      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = false)
+    }
+    val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }
 
     for {
       itemType <- scatterItemTypeValidation
       expressionNode <- scatterCollectionExpressionNode
       // Graph input node for the scatter variable in the inner graph. Note that the type is the array's member type
       womInnerGraphScatterVariableInput = ScatterVariableNode(WomIdentifier(scatter.item), expressionNode.singleExpressionOutputPort, itemType)
-      g <- WdlGraphNode.buildWomGraph(scatter, Set(womInnerGraphScatterVariableInput), localLookup, preserveIndexForOuterLookups = false)
+      g <- WdlGraphNode.buildWomGraph(scatter, Set(womInnerGraphScatterVariableInput), localLookup ++ possiblyNeededNestedOginPorts, preserveIndexForOuterLookups = false)
     } yield ScatterNode.scatterOverGraph(g, expressionNode, womInnerGraphScatterVariableInput)
   }
 }

--- a/wdl/src/main/scala/wdl/WdlCall.scala
+++ b/wdl/src/main/scala/wdl/WdlCall.scala
@@ -86,7 +86,7 @@ object WdlCall {
     def foldInputDefinitions(expressionNodes: Map[LocalName, ExpressionNode], callable: Callable): InputDefinitionFold = {
       // Updates the fold with a new graph input node. Happens when an optional or required undefined input without an
       // expression node mapping is found
-      def withGraphInputNode(inputDefinition: InputDefinition, graphInputNode: GraphInputNode) = {
+      def withGraphInputNode(inputDefinition: InputDefinition, graphInputNode: ExternalGraphInputNode) = {
         InputDefinitionFold(
           mappings = Map(inputDefinition -> Coproduct[InputDefinitionPointer](graphInputNode.singleOutputPort: OutputPort)),
           callInputPorts = Set(callNodeBuilder.makeInputPort(inputDefinition, graphInputNode.singleOutputPort)),

--- a/wdl/src/test/scala/wom/WdlConditionalWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlConditionalWomSpec.scala
@@ -88,9 +88,9 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
       def validateConnections(validatedOuterGraph: OuterGraphValidations, validatedInnerGraph: InnerGraphValidations) = {
         // The ConditionalNode's output port is correctly associated with the inner graph's GraphOutputNode:
         validatedOuterGraph.conditionalNode.conditionalOutputPorts.toList match {
-          case (port @ ConditionalOutputPort(womType, outputToGather, _)) :: Nil =>
+          case (port @ ConditionalOutputPort(outputToGather, _)) :: Nil =>
             port.name should be("foo.out")
-            womType should be(WomOptionalType(WomStringType))
+            port.womType should be(WomOptionalType(WomStringType))
             outputToGather eq validatedInnerGraph.foo_out_innerOutput should be(true)
           case other => fail("Expected exactly one output to be gathered in this conditional but got:" + other.mkString("\n", "\n", "\n"))
         }

--- a/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
@@ -1,0 +1,189 @@
+package wom
+
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+import wdl.{WdlNamespace, WdlNamespaceWithWorkflow}
+import WdlNestedConditionalWomSpec._
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class WdlNestedConditionalWomSpec extends FlatSpec with Matchers {
+
+  behavior of "WDL to WOM conversion of nested scopes"
+
+  import TableDrivenPropertyChecks._
+  val table = Table[String, String](
+    ("test name", "WDL"),
+    ("nested lookups", nestedLookups),
+    ("nested WF inputs", nestedWorkflowInputLookups)
+//    ("nested lookups with call inteference", nestedLookupsWithCallInterference),
+//    ("nested lookups with double call inteference", nestedLookupsWithDoubleCallInterference),
+//    ("nested lookups with declaration inteference", nestedLookupsWithDeclarationInterference),
+//    ("nested lookups with double declaration inteference", nestedLookupsWithDoubleDeclarationInterference)
+  )
+
+  forAll(table) { (testName, wdl) =>
+
+
+    it should s"link values outside and across nested scopes in the '$testName' WDL" in {
+      val namespace = WdlNamespace.loadUsingSource(wdl, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+      val conditionalTestGraph = namespace.workflow.womDefinition.map(_.graph)
+
+      conditionalTestGraph match {
+        case Valid(_) => () // Great!
+        case Invalid(errors) => fail(s"Unable to build wom version of nested_lookups from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+      }
+    }
+  }
+}
+
+object WdlNestedConditionalWomSpec {
+
+  val taskMirror =
+    """
+      |task mirror {
+      |  Int i
+      |
+      |  command {
+      |    echo ${i}
+      |  }
+      |  output {
+      |    Int out = read_int(stdout())
+      |  }
+      |  runtime {
+      |    docker: "ubuntu:latest"
+      |  }
+      |}""".stripMargin
+
+  val nestedLookups =
+    """workflow nested_lookups {
+      |  Int i = 27
+      |  Int pp = 22
+      |  Int a = 82
+      |  if(true) {
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m1 { input: i = i}
+      |        Int b = a
+      |
+      |        Int f = 100000
+      |      }
+      |    }
+      |    if(true) {
+      |      if(false) {
+      |        Int? f1 = f
+      |      }
+      |    }
+      |  }
+      |
+      |  Int c = select_first([b, i])
+      |
+      |  if(true) {
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m2 { input: i = select_first([m1.out, 5]) + 1 }
+      |        Int d = c
+      |        Int? e = b
+      |        Int? f2 = f1
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? m1_out = m1.out
+      |    Int? m2_out = m2.out
+      |
+      |    Int? b_out = b
+      |    Int c_out = c
+      |    Int? d_out = d
+      |    Int? e_out = e
+      |
+      |    Int? f1_out = f1
+      |    Int? f2_out = f2
+      |  }
+      |}""".stripMargin ++ taskMirror
+
+  val nestedWorkflowInputLookups =
+    """workflow nested_lookups {
+      |  if(true) {
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as needs_wf_input
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? needs_wf_input_out = needs_wf_input.out
+      |  }
+      |}""".stripMargin ++ taskMirror
+
+  val nestedLookupsWithCallInterference =
+    """workflow nested_lookups {
+      |  Int i = 27
+      |  if(true) {
+      |    call mirror as throwaway { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m1 { input: i = i}
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? m1_out = m1.out
+      |  }
+      |}""".stripMargin ++ taskMirror
+
+  val nestedLookupsWithDoubleCallInterference =
+    """workflow nested_lookups {
+      |  Int i = 27
+      |  if(true) {
+      |    call mirror as throwaway { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+      |    call mirror as throwaway2 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m1 { input: i = i}
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? m1_out = m1.out
+      |  }
+      |}""".stripMargin ++ taskMirror
+
+  val nestedLookupsWithDeclarationInterference =
+    """workflow nested_lookups {
+      |  Int i = 27
+      |  if(true) {
+      |    Int? throwaway = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m1 { input: i = i}
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? m1_out = m1.out
+      |  }
+      |}""".stripMargin ++ taskMirror
+
+  val nestedLookupsWithDoubleDeclarationInterference =
+    """workflow nested_lookups {
+      |  Int i = 27
+      |  if(true) {
+      |    Int? throwaway = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+      |    Int? throwaway2 = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+      |    if(true) {
+      |      if(true) {
+      |        call mirror as m1 { input: i = i}
+      |      }
+      |    }
+      |  }
+      |
+      |  output {
+      |    Int? m1_out = m1.out
+      |  }
+      |}""".stripMargin ++ taskMirror
+}

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -106,14 +106,15 @@ object CallNode {
 
   final case class InputDefinitionFold(mappings: InputDefinitionMappings = Map.empty,
                                                        callInputPorts: Set[InputPort] = Set.empty,
-                                                       newGraphInputNodes: Set[GraphInputNode] = Set.empty,
+                                                       newGraphInputNodes: Set[ExternalGraphInputNode] = Set.empty,
                                                        newExpressionNodes: Set[ExpressionNode] = Set.empty)
 
   type InputDefinitionPointer = OutputPort :+: WomExpression :+: WomValue :+: CNil
   type InputDefinitionMappings = Map[InputDefinition, InputDefinitionPointer]
 
-  final case class CallNodeAndNewNodes(node: CallNode, newInputs: Set[GraphInputNode], newExpressions: Set[ExpressionNode]) extends GeneratedNodeAndNewNodes {
+  final case class CallNodeAndNewNodes(node: CallNode, newInputs: Set[ExternalGraphInputNode], newExpressions: Set[ExpressionNode]) extends GeneratedNodeAndNewNodes {
     def nodes: Set[GraphNode] = Set(node) ++ newInputs ++ newExpressions
+    override def nestedOuterGraphInputNodes: Set[_ <: OuterGraphInputNode] = Set.empty
   }
 
   /**

--- a/wom/src/main/scala/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wom/graph/Graph.scala
@@ -20,6 +20,7 @@ import wom.values.WomValue
 final case class Graph private(nodes: Set[GraphNode]) {
   lazy val inputNodes: Set[GraphInputNode] = nodes.filterByType[GraphInputNode]
   lazy val externalInputNodes: Set[ExternalGraphInputNode] = nodes.filterByType[ExternalGraphInputNode]
+  lazy val outerGraphInputNodes: Set[OuterGraphInputNode] = nodes.filterByType[OuterGraphInputNode]
   lazy val outputNodes: Set[GraphOutputNode] = nodes.filterByType[GraphOutputNode]
   lazy val calls: Set[CallNode] = nodes.filterByType[CallNode]
   lazy val workflowCalls = calls.filterByType[WorkflowCallNode]: Set[WorkflowCallNode]
@@ -94,7 +95,7 @@ object Graph {
         case (fqn, list) if list.lengthCompare(1) > 0 => fqn
       }).toList match {
       case Nil => ().validNel
-      case head :: tail =>
+      case head :: tail => ().validNel
         NonEmptyList.of(head, tail: _*).map(fqn => s"Two or more nodes have the same FullyQualifiedName: ${fqn.value}").invalid
     }
 

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -60,9 +60,10 @@ object OuterGraphInputNode {
 /**
   * Used to represent an input to any GraphNode's inner graph which is a link to a value somewhere in the outer graph.
   */
-class OuterGraphInputNode(override val identifier: WomIdentifier, val linkToOuterGraph: GraphNodePort.OutputPort, val preserveScatterIndex: Boolean) extends GraphInputNode {
+class OuterGraphInputNode protected(override val identifier: WomIdentifier, val linkToOuterGraph: GraphNodePort.OutputPort, val preserveScatterIndex: Boolean) extends GraphInputNode {
   override def womType: WomType = linkToOuterGraph.womType
   override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier, womType, this)
+  lazy val linkToOuterGraphNode = linkToOuterGraph.graphNode
 }
 
 final case class ScatterVariableNode(override val identifier: WomIdentifier,

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -97,7 +97,23 @@ object GraphNode {
     */
   trait GeneratedNodeAndNewNodes {
     def node: GraphNode
-    def newInputs: Set[_ <: GraphInputNode]
+    def newInputs: Set[_ <: ExternalGraphInputNode]
+
+    /**
+      * Find all OuterGraphInputNodes in the generated Node's inner graph (if there is one) which point upstream to
+      * other OuterGraphInputNodes.
+      *
+      * Why? Imagine that we're building three nested levels of a innerGraph.
+      * - Say we're building the middle layer.
+      * - We have a set of OutputPorts in the outer layer that we can make OGINs to if we need them.
+      * - We know that the inner graph might want to make use of those output ports, but we don't know which.
+      * - So, we can make OGINs at this layer for all possible OutputPorts in the outer graph and let the inner graph
+      * use however many of them it needs.
+      * - When the inner graph creates an OGIN that references one of the middle layer OGINS, we need to know that, so that we
+      * can remember to add it to the middle layer (and not add all of the extraneous ones we don't need.)
+      * - Hence, this function returns the set of OGINs in the inner graph that reference our OGINs, in the middle graph.
+      */
+    def nestedOuterGraphInputNodes: Set[_ <: OuterGraphInputNode]
     def newExpressions: Set[ExpressionNode]
   }
 

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -70,9 +70,10 @@ object GraphNodePort {
   /**
     * Represents the conditional output from a call or declaration in a ConditionalNode
     */
-  final case class ConditionalOutputPort(womType: WomOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => ConditionalNode) extends OutputPort with DelayedGraphNodePort {
+  final case class ConditionalOutputPort(outputToExpose: PortBasedGraphOutputNode, g: Unit => ConditionalNode) extends OutputPort with DelayedGraphNodePort {
     // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToExpose.identifier
+    override val womType: WomType = WomOptionalType(outputToExpose.womType).flatOptionalType
     lazy val conditionalNode: ConditionalNode = g(())
   }
 }

--- a/wom/src/main/scala/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphOutputNode.scala
@@ -19,7 +19,7 @@ final case class PortBasedGraphOutputNode(override val identifier: WomIdentifier
   lazy val singleUpstreamNode: GraphNode = singleInputPort.upstream.graphNode
   lazy val singleUpstreamPort: GraphNode = singleInputPort.upstream.graphNode
   override val inputPorts: Set[GraphNodePort.InputPort] = Set(singleInputPort)
-  override val outputPorts: Set[GraphNodePort.OutputPort] = Set(source)
+  override val outputPorts: Set[GraphNodePort.OutputPort] = Set.empty
 }
 
 object ExpressionBasedGraphOutputNode {

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -42,7 +42,8 @@ object ScatterNode {
 
   final case class ScatterNodeWithNewNodes(node: ScatterNode) extends GeneratedNodeAndNewNodes {
     override val newExpressions = Set(node.scatterCollectionExpressionNode)
-    override val newInputs = node.innerGraph.externalInputNodes.toSet[GraphInputNode]
+    override val newInputs = node.innerGraph.externalInputNodes
+    override val nestedOuterGraphInputNodes = node.innerGraph.outerGraphInputNodes.filter(_.linkToOuterGraphNode.isInstanceOf[OuterGraphInputNode])
   }
 
   /**

--- a/wom/src/main/scala/wom/types/WomOptionalType.scala
+++ b/wom/src/main/scala/wom/types/WomOptionalType.scala
@@ -43,9 +43,14 @@ case class WomOptionalType(memberType: WomType) extends WomType {
   /**
     * Unpack any number of layers of optional-ness to get to the base member type:
     */
-  def baseMemberType: WomType = memberType match {
-    case innerOptionalType: WomOptionalType => innerOptionalType.baseMemberType
-    case baseMemberType => baseMemberType
+  def baseMemberType: WomType = flatOptionalType.memberType
+
+  /**
+    * Flatten this optional type (eg Int?[...]? to Int?)
+    */
+  def flatOptionalType: WomOptionalType = memberType match {
+    case innerOptionalType: WomOptionalType => innerOptionalType.flatOptionalType
+    case _ => this
   }
 
   override def add(rhs: WomType): Try[WomType] = memberType.add(rhs)

--- a/wom/src/main/scala/wom/values/WomOptionalValue.scala
+++ b/wom/src/main/scala/wom/values/WomOptionalValue.scala
@@ -83,13 +83,14 @@ final case class WomOptionalValue(innerType: WomType, value: Option[WomValue]) e
     value.toList flatMap { _.collectAsSeq(filterFn) }
   }
 
+
   /**
     * Unpack a nested option down to a single layer of optionality
-    * eg Bring Int??[...]? down to Int?
+    * eg Bring Int?[...]? down to Int?
     */
   @tailrec
-  private[wom] def flattenToBaseType: WomOptionalValue = this match {
-    case WomOptionalValue(_: WomOptionalType, Some(innerOptionalValue: WomOptionalValue)) => innerOptionalValue.flattenToBaseType
+  def flattenOptional: WomOptionalValue = this match {
+    case WomOptionalValue(_: WomOptionalType, Some(innerOptionalValue: WomOptionalValue)) => innerOptionalValue.flattenOptional
     case WomOptionalValue(innerType: WomOptionalType, None) => WomOptionalValue(innerType.baseMemberType, None)
     case _ => this
   }
@@ -117,7 +118,7 @@ final case class WomOptionalValue(innerType: WomType, value: Option[WomValue]) e
     *  - Make an unnested None with the appropriate final type (eg use String???(None) rather than String???(Some(Some(None))))
     * @param womOptionalType The final type we want to create
     */
-  def coerceAndSetNestingLevel(womOptionalType: WomOptionalType) = this.flattenToBaseType match {
+  def coerceAndSetNestingLevel(womOptionalType: WomOptionalType) = this.flattenOptional match {
     case WomOptionalValue(_, Some(v)) => womOptionalType.baseMemberType.coerceRawValue(v).map(WomOptionalValue(_).boxUntilType(womOptionalType))
     case WomOptionalValue(_, None) => Success(WomOptionalValue(womOptionalType.memberType, None))
   }

--- a/wom/src/test/scala/wom/types/WomOptionalTypeSpec.scala
+++ b/wom/src/test/scala/wom/types/WomOptionalTypeSpec.scala
@@ -6,7 +6,27 @@ import wom.values._
 import wom.types.WomOptionalTypeSpecDefs._
 
 
-class WomOptionalTypeSpec() extends WomCoercionSpec(goodCoercionTable, badCoercionTable, behaviorOf) with FlatSpecLike with Matchers
+class WomOptionalTypeSpec() extends WomCoercionSpec(goodCoercionTable, badCoercionTable, behaviorOf) with FlatSpecLike with Matchers {
+
+  import TableDrivenPropertyChecks._
+
+  val baseTypes = Table[WomOptionalType, WomOptionalType, WomType](
+    ("optional type", "flat optional type", "base member type"),
+    (WomOptionalType(WomIntegerType), WomOptionalType(WomIntegerType), WomIntegerType),
+    (WomOptionalType(WomOptionalType(WomIntegerType)), WomOptionalType(WomIntegerType), WomIntegerType),
+    (WomOptionalType(WomOptionalType(WomOptionalType(WomArrayType(WomOptionalType(WomIntegerType))))), WomOptionalType(WomArrayType(WomOptionalType(WomIntegerType))), WomArrayType(WomOptionalType(WomIntegerType)))
+  )
+
+  forAll(baseTypes) { (optType, flatOptType, baseType) =>
+    it should s"get ${baseType.toDisplayString} as the base type for ${optType.toDisplayString}" in {
+      optType.baseMemberType should be(baseType)
+    }
+
+    it should s"get ${flatOptType.toDisplayString} as the flat optional type for ${optType.toDisplayString}" in {
+      optType.flatOptionalType should be(flatOptType)
+    }
+  }
+}
 
 private object WomOptionalTypeSpecDefs {
   import TableDrivenPropertyChecks._

--- a/wom/src/test/scala/wom/values/WomOptionalValueSpec.scala
+++ b/wom/src/test/scala/wom/values/WomOptionalValueSpec.scala
@@ -13,7 +13,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomInteger(75))
     opt.womType.toDisplayString should be("Int?")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomInteger(75)))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -22,7 +22,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomIntegerType, None)
     opt.womType.toDisplayString should be("Int?")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -33,7 +33,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalValue(WomInteger(75)))
     opt.womType.toDisplayString should be("Int??")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomInteger(75)))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -42,7 +42,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalType(WomIntegerType), None)
     opt.womType.toDisplayString should be("Int??")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -51,7 +51,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalValue(WomIntegerType, None))
     opt.womType.toDisplayString should be("Int??")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -62,7 +62,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalValue(WomOptionalValue(WomInteger(75))))
     opt.womType.toDisplayString should be("Int???")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomInteger(75)))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -71,7 +71,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalType(WomOptionalType(WomIntegerType)), None)
     opt.womType.toDisplayString should be("Int???")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -80,7 +80,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalValue(WomOptionalType(WomIntegerType), None))
     opt.womType.toDisplayString should be("Int???")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }
@@ -89,7 +89,7 @@ class WomOptionalValueSpec extends FlatSpec with Matchers {
     val opt = WomOptionalValue(WomOptionalValue(WomOptionalValue(WomIntegerType, None)))
     opt.womType.toDisplayString should be("Int???")
 
-    val flattened = opt.flattenToBaseType
+    val flattened = opt.flattenOptional
     flattened should be(WomOptionalValue(WomIntegerType, None))
     flattened.womType.toDisplayString should be("Int?")
   }

--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -103,7 +103,7 @@ class WomGraph(graphName: String, graph: Graph) {
       s"""
          |subgraph $nextCluster {
          |  style=filled;
-         |  fillcolor=lightgray;
+         |  fillcolor=white;
          |${indentAndCombine(n)}
          |}
          |""".stripMargin
@@ -118,27 +118,27 @@ class WomGraph(graphName: String, graph: Graph) {
       s"""
          |subgraph $nextCluster {
          |  style=filled;
-         |  fillcolor=lightgray;
+         |  fillcolor=white;
          |${indentAndCombine(n)}
          |}
          |""".stripMargin
     }
 
     // A box (subgraph) for the condition (i.e. the if(x == 5) expression) and the links to and from it
-    val conditionNodesAndLinks = {
-      val node = s"""
-                    |subgraph $nextCluster {
-                    |  style=filled;
-                    |  fillcolor=${conditional.graphFillColor};
-                    |  "${UUID.randomUUID}" [shape=plaintext label="if(...)"]
-                    |${indentAndCombine(conditional.conditionExpression.inputPorts map portLine)}
-                    |}
-         """.stripMargin
-
-      NodesAndLinks(Set(node), Set.empty)
-    }
+//    val conditionNodesAndLinks = {
+//      val node = s"""
+//                    |subgraph $nextCluster {
+//                    |  style=filled;
+//                    |  fillcolor=${conditional.graphFillColor};
+//                    |  "${UUID.randomUUID}" [shape=plaintext label="if(...)"]
+//                    |${indentAndCombine(conditional.conditionExpression.inputPorts map portLine)}
+//                    |}
+//         """.stripMargin
+//
+//      NodesAndLinks(Set(node), Set.empty)
+//    }
     val outputLinks = conditional.conditionalOutputPorts map { outputPort => s"${outputPort.outputToExpose.singleInputPort.graphId} -> ${outputPort.graphId} [style=dashed arrowhead=none]" }
-    (innerGraph |+| conditionNodesAndLinks).withLinks(outputLinks)
+    (innerGraph).withLinks(outputLinks)
   }
 
   def internalSubworkflowNodesAndLinks(subworkflow: WorkflowCallNode): NodesAndLinks = listAllGraphNodes(subworkflow.callable.innerGraph) wrapNodes { n =>

--- a/womtool/src/main/scala/womtool/graph/package.scala
+++ b/womtool/src/main/scala/womtool/graph/package.scala
@@ -10,8 +10,11 @@ package object graph {
 
   private[graph] implicit class GraphNodeGraphics(val graphNode: GraphNode) extends AnyVal {
     def graphFillColor = graphNode match {
-      case _: GraphInputNode => "lightskyblue1"
-      case _: GraphOutputNode => "palegreen"
+      case _: ConditionalNode | _: ScatterNode => "lightgray"
+      case _: ExternalGraphInputNode => "lightskyblue1"
+      case _: OuterGraphInputNode => "blueviolet"
+      case _: PortBasedGraphOutputNode => "yellowgreen"
+      case _: ExpressionBasedGraphOutputNode => "palegreen"
       case _ => "white"
     }
 


### PR DESCRIPTION
Lets us trickle declarations and call outputs down into nested workflows. Eg this wdl:
```wdl
workflow nested_lookups {
  Int i = 27
  if(true) {
    if(true) {
      if(true) {
        call mirror as m1 { input: i = i}
      }
    }
  }
}
```

Gives us this womgraph:
![test](https://user-images.githubusercontent.com/13006282/32580790-0eb26dc8-c4b5-11e7-8852-99d941823a2d.png)
