### PR TITLE
fix subworkflow declarations

### DIFF
--- a/backend/src/test/scala/cromwell/backend/BackendSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/BackendSpec.scala
@@ -52,7 +52,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
                                           runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition]): BackendJobDescriptor = {
     val call = workflowDescriptor.workflow.taskCalls.head
     val jobKey = BackendJobDescriptorKey(call, None, 1)
-    val inputDeclarations = call.evaluateTaskInputs(inputs, NoFunctions).get // .get is ok because this is a test
+    val inputDeclarations = call.evaluateCallDeclarations(inputs, NoFunctions).get // .get is ok because this is a test
     val evaluatedAttributes = RuntimeAttributeDefinition.evaluateRuntimeAttributes(call.task.runtimeAttributes, NoFunctions, inputDeclarations).get // .get is OK here because this is a test
     val runtimeAttributes = RuntimeAttributeDefinition.addDefaultsToAttributes(runtimeAttributeDefinitions, options)(evaluatedAttributes)
     BackendJobDescriptor(workflowDescriptor, jobKey, runtimeAttributes, inputDeclarations, NoDocker, Map.empty)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, LoggingFSM, Props}
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.syntax.foldable._
-import cromwell.core.WorkflowId
+import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallCacheDiffActorData, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
 import cromwell.services.metadata.CallMetadataKeys.CallCachingKeys
@@ -12,7 +12,6 @@ import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, Metad
 import cromwell.services.metadata._
 import cromwell.webservice.metadata.MetadataComponent._
 import cromwell.webservice.metadata._
-import cromwell.core.Dispatcher.EngineDispatcher
 import spray.json.JsObject
 
 import scala.language.postfixOps

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/CallPreparation.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/CallPreparation.scala
@@ -23,19 +23,20 @@ object CallPreparation {
   case class JobCallPreparationFailed(jobKey: JobKey, throwable: Throwable) extends CallPreparationActorResponse
   case class CallPreparationFailed(jobKey: JobKey, throwable: Throwable) extends CallPreparationActorResponse
 
-  def resolveAndEvaluateInputs(callKey: CallKey,
-                               workflowDescriptor: EngineWorkflowDescriptor,
-                               expressionLanguageFunctions: WdlStandardLibraryFunctions,
-                               outputStore: OutputStore): Try[Map[Declaration, WdlValue]] = {
+  def resolveAndEvaluateCallDeclarations(callKey: CallKey,
+                                         workflowDescriptor: EngineWorkflowDescriptor,
+                                         expressionLanguageFunctions: WdlStandardLibraryFunctions,
+                                         outputStore: OutputStore): Try[Map[Declaration, WdlValue]] = {
     val call = callKey.scope
     val scatterMap = callKey.index flatMap { i =>
       // Will need update for nested scatters
       call.ancestry collectFirst { case s: Scatter => Map(s -> i) }
     } getOrElse Map.empty[Scatter, Int]
 
-    call.evaluateTaskInputs(
+    call.evaluateCallDeclarations(
       workflowDescriptor.backendDescriptor.knownValues,
       expressionLanguageFunctions,
+      callKey.index,
       outputStore.fetchNodeOutputEntries,
       scatterMap
     ) recoverWith {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/preparation/JobPreparationActor.scala
@@ -96,7 +96,7 @@ class JobPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
 
   private [preparation] def evaluateInputsAndAttributes(outputStore: OutputStore) = {
     for {
-      evaluatedInputs <- resolveAndEvaluateInputs(jobKey, workflowDescriptor, expressionLanguageFunctions, outputStore)
+      evaluatedInputs <- resolveAndEvaluateCallDeclarations(jobKey, workflowDescriptor, expressionLanguageFunctions, outputStore)
       runtimeAttributes <- prepareRuntimeAttributes(evaluatedInputs)
     } yield (evaluatedInputs, runtimeAttributes)
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val lenthallV = "0.27"
-  lazy val wdl4sV = "0.15-814d203" // Warning: 814d203 refers to the wrong cats-core/mouse versions. It requires 1.0.x!
+  lazy val wdl4sV = "0.15-c149133"
 
   lazy val akkaV = "2.5.3"
   lazy val akkaHttpV = "10.0.9"


### PR DESCRIPTION
Subworkflows are not tasks. Don't evaluate declarations in subworkflows which may be expressions involving calls that haven't run yet.  Only evaluate uninitialized and overridden declarations. 