### PR TITLE
Prevent OGIN interference from nested calls and declarations

### DIFF
--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/nested_lookups/nested_lookups.wdl
@@ -2,8 +2,8 @@ workflow nested_lookups {
   Int i = 27
   Int a = 82
   if(true) {
-#    call mirror as throwaway1 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
-#    call mirror as throwaway2 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate throwaway1's, or the nested m1's 'i' OGIN
+    call mirror as throwaway1 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+    call mirror as throwaway2 { input: i = i } # Make sure this 'i' OGIN doesn't duplicate throwaway1's, or the nested m1's 'i' OGIN
     if(true) {
       if(true) {
         call mirror as m1 { input: i = i }
@@ -23,8 +23,11 @@ workflow nested_lookups {
   Int c = select_first([b, i])
 
   if(true) {
-#    Int? throwaway3 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
-#    Int? throwaway4 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate throwaway3's, or the nested m2's 'm1.out' OGIN
+    Int? throwaway3 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+    Int? throwaway4 = m1.out # Make sure this 'm1.out' OGIN doesn't duplicate throwaway3's, or the nested m2's 'm1.out' OGIN
+    Int? throwaway5 = b # Make sure this 'b' OGIN doesn't duplicate the nested e's 'b' OGIN
+    Int? throwaway6 = b # Make sure this 'b' OGIN doesn't duplicate throwaway5's, or the nested e's 'b' OGIN
+
     if(true) {
       if(true) {
         call mirror as m2 { input: i = select_first([m1.out, 5]) + 1 }

--- a/wdl/src/main/scala/wdl/Declaration.scala
+++ b/wdl/src/main/scala/wdl/Declaration.scala
@@ -91,11 +91,6 @@ object Declaration {
       case IntermediateValueDeclarationNode(expressionNode) => expressionNode
       case GraphOutputDeclarationNode(graphOutputNode) => graphOutputNode
     }
-    lazy val singleOutputPort: Option[GraphNodePort.OutputPort] = this match {
-      case InputDeclarationNode(graphInputNode) => Option(graphInputNode.singleOutputPort)
-      case IntermediateValueDeclarationNode(expressionNode) => Option(expressionNode.singleExpressionOutputPort)
-      case GraphOutputDeclarationNode(_) => None
-    }
   }
   final case class InputDeclarationNode(graphInputNode: GraphInputNode) extends WdlDeclarationNode
   final case class IntermediateValueDeclarationNode(expressionNode: ExpressionNode) extends WdlDeclarationNode
@@ -114,7 +109,7 @@ object Declaration {
     )
   }
 
-  def buildWomNode(decl: DeclarationInterface, localLookup: Map[String, GraphNodePort.OutputPort], outerLookup: Map[String, GraphNodePort.OutputPort], preserveIndexForOuterLookups: Boolean): ErrorOr[WdlDeclarationNode] = {
+  def buildWdlDeclarationNode(decl: DeclarationInterface, localLookup: Map[String, GraphNodePort.OutputPort], outerLookup: Map[String, GraphNodePort.OutputPort], preserveIndexForOuterLookups: Boolean): ErrorOr[WdlDeclarationNode] = {
 
     def declarationAsExpressionNode(wdlExpression: WdlExpression) = {
       val womExpression = WdlWomExpression(wdlExpression, None)

--- a/wdl/src/main/scala/wdl/If.scala
+++ b/wdl/src/main/scala/wdl/If.scala
@@ -53,7 +53,7 @@ object If {
       * - So, we can make OGINs at this layer for all possible OutputPorts in the outer graph and let the inner graph
       * use however many of them it needs.
       */
-    val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot{ case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
+    val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
       name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = true)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }

--- a/wdl/src/main/scala/wdl/WdlCall.scala
+++ b/wdl/src/main/scala/wdl/WdlCall.scala
@@ -126,7 +126,12 @@ object WdlCall {
 
     (expressionNodeMappings, wdlCall.callable.womDefinition) mapN {
       case (mappings, callable) =>
-        callNodeBuilder.build(wdlCall.womIdentifier, callable, foldInputDefinitions(mappings, callable))
+        val usedOgins: Set[OuterGraphInputNode] = for {
+          expressionNode <- mappings.values.toSet[ExpressionNode]
+          ogin <- expressionNode.upstreamOuterGraphInputNodes
+        } yield ogin
+
+        callNodeBuilder.build(wdlCall.womIdentifier, callable, foldInputDefinitions(mappings, callable).copy(usedOuterGraphInputNodes = usedOgins))
     }
   }
 }

--- a/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
@@ -14,17 +14,16 @@ class WdlNestedConditionalWomSpec extends FlatSpec with Matchers {
   val table = Table[String, String](
     ("test name", "WDL"),
     ("nested lookups", nestedLookups),
-    ("nested WF inputs", nestedWorkflowInputLookups)
-//    ("nested lookups with call inteference", nestedLookupsWithCallInterference),
-//    ("nested lookups with double call inteference", nestedLookupsWithDoubleCallInterference),
-//    ("nested lookups with declaration inteference", nestedLookupsWithDeclarationInterference),
-//    ("nested lookups with double declaration inteference", nestedLookupsWithDoubleDeclarationInterference)
+    ("nested WF inputs", nestedWorkflowInputLookups),
+    ("nested lookups with call interference", nestedLookupsWithCallInterference),
+    ("nested lookups with double call interference", nestedLookupsWithDoubleCallInterference),
+    ("nested lookups with declaration interference", nestedLookupsWithDeclarationInterference),
+    ("nested lookups with double declaration interference", nestedLookupsWithDoubleDeclarationInterference)
   )
 
   forAll(table) { (testName, wdl) =>
-
-
     it should s"link values outside and across nested scopes in the '$testName' WDL" in {
+
       val namespace = WdlNamespace.loadUsingSource(wdl, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
       val conditionalTestGraph = namespace.workflow.womDefinition.map(_.graph)
 
@@ -156,10 +155,10 @@ object WdlNestedConditionalWomSpec {
     """workflow nested_lookups {
       |  Int i = 27
       |  if(true) {
-      |    Int? throwaway = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+      |    Int? throwaway = i # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
       |    if(true) {
       |      if(true) {
-      |        call mirror as m1 { input: i = i}
+      |        call mirror as m1 { input: i = i }
       |      }
       |    }
       |  }
@@ -173,8 +172,8 @@ object WdlNestedConditionalWomSpec {
     """workflow nested_lookups {
       |  Int i = 27
       |  if(true) {
-      |    Int? throwaway = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
-      |    Int? throwaway2 = i # Make sure this 'm1.out' OGIN doesn't duplicate the nested m2's 'm1.out' OGIN
+      |    Int? throwaway = i # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
+      |    Int? throwaway2 = i # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
       |    if(true) {
       |      if(true) {
       |        call mirror as m1 { input: i = i}

--- a/wdl/src/test/scala/wom/WdlWomExpressionsAsInputsSpec.scala
+++ b/wdl/src/test/scala/wom/WdlWomExpressionsAsInputsSpec.scala
@@ -16,29 +16,13 @@ object WdlWomExpressionsAsInputsSpec {
     // Using calls as inputs since declaration inputs are currently not supported.
     """
       |workflow foo {
-      |    call a
-      |    call b
+      |    call x as a
+      |    call x as b
       |
-      |    call c { input: int_in = a.int_out + b.int_out }
+      |    call x as c { input: int_in = a.int_out + b.int_out }
       |}
       |
-      |task a {
-      |    Int int_in
-      |    command {}
-      |    output {
-      |        Int int_out = int_in
-      |    }
-      |}
-      |
-      |task b {
-      |    Int int_in
-      |    command {}
-      |    output {
-      |        Int int_out = int_in
-      |    }
-      |}
-      |
-      |task c {
+      |task x {
       |    Int int_in
       |    command {}
       |    output {

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -99,22 +99,23 @@ object CallNode {
         mappings = x.mappings ++ y.mappings,
         callInputPorts = x.callInputPorts ++ y.callInputPorts,
         newGraphInputNodes = x.newGraphInputNodes ++ y.newGraphInputNodes,
-        newExpressionNodes = x.newExpressionNodes ++ y.newExpressionNodes
+        newExpressionNodes = x.newExpressionNodes ++ y.newExpressionNodes,
+        usedOuterGraphInputNodes = x.usedOuterGraphInputNodes ++ y.usedOuterGraphInputNodes
       )
     }
   }
 
   final case class InputDefinitionFold(mappings: InputDefinitionMappings = Map.empty,
-                                                       callInputPorts: Set[InputPort] = Set.empty,
-                                                       newGraphInputNodes: Set[ExternalGraphInputNode] = Set.empty,
-                                                       newExpressionNodes: Set[ExpressionNode] = Set.empty)
+                                       callInputPorts: Set[InputPort] = Set.empty,
+                                       newGraphInputNodes: Set[ExternalGraphInputNode] = Set.empty,
+                                       newExpressionNodes: Set[ExpressionNode] = Set.empty,
+                                       usedOuterGraphInputNodes: Set[OuterGraphInputNode] = Set.empty)
 
   type InputDefinitionPointer = OutputPort :+: WomExpression :+: WomValue :+: CNil
   type InputDefinitionMappings = Map[InputDefinition, InputDefinitionPointer]
 
-  final case class CallNodeAndNewNodes(node: CallNode, newInputs: Set[ExternalGraphInputNode], newExpressions: Set[ExpressionNode]) extends GeneratedNodeAndNewNodes {
-    def nodes: Set[GraphNode] = Set(node) ++ newInputs ++ newExpressions
-    override def nestedOuterGraphInputNodes: Set[_ <: OuterGraphInputNode] = Set.empty
+  final case class CallNodeAndNewNodes(node: CallNode, newInputs: Set[ExternalGraphInputNode], newExpressions: Set[ExpressionNode], override val usedOuterGraphInputNodes: Set[OuterGraphInputNode]) extends GeneratedNodeAndNewNodes {
+    def nodes: Set[GraphNode] = Set(node) ++ newInputs ++ newExpressions ++ usedOuterGraphInputNodes
   }
 
   /**
@@ -148,7 +149,7 @@ object CallNode {
               inputDefinitionFold: InputDefinitionFold): CallNodeAndNewNodes = {
       val callNode = CallNode(nodeIdentifier, callable, inputDefinitionFold.callInputPorts, inputDefinitionFold.mappings)
       graphNodeSetter._graphNode = callNode
-      CallNodeAndNewNodes(callNode, inputDefinitionFold.newGraphInputNodes, inputDefinitionFold.newExpressionNodes)
+      CallNodeAndNewNodes(callNode, inputDefinitionFold.newGraphInputNodes, inputDefinitionFold.newExpressionNodes, inputDefinitionFold.usedOuterGraphInputNodes)
     }
   }
 }

--- a/wom/src/main/scala/wom/graph/ConditionalNode.scala
+++ b/wom/src/main/scala/wom/graph/ConditionalNode.scala
@@ -4,6 +4,7 @@ import wom.graph.GraphNode.{GeneratedNodeAndNewNodes, GraphNodeWithInnerGraph}
 import wom.graph.GraphNodePort.{ConditionalOutputPort, ConnectedInputPort, InputPort, OutputPort}
 import wom.graph.expression.ExpressionNode
 import wom.types.WomBooleanType
+import common.collections.EnhancedCollections._
 
 /**
   * Currently only WDL has the concept of conditional executions:
@@ -26,7 +27,7 @@ object ConditionalNode  {
 
   final case class ConditionalNodeWithNewNodes(node: ConditionalNode) extends GeneratedNodeAndNewNodes {
     override val newInputs = node.innerGraph.externalInputNodes
-    override val nestedOuterGraphInputNodes = node.innerGraph.outerGraphInputNodes.filter(_.linkToOuterGraphNode.isInstanceOf[OuterGraphInputNode])
+    override val usedOuterGraphInputNodes = node.innerGraph.outerGraphInputNodes.map(_.linkToOuterGraphNode).filterByType[OuterGraphInputNode]
     override val newExpressions = Set(node.conditionExpression)
   }
 

--- a/wom/src/main/scala/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wom/graph/Graph.scala
@@ -95,7 +95,7 @@ object Graph {
         case (fqn, list) if list.lengthCompare(1) > 0 => fqn
       }).toList match {
       case Nil => ().validNel
-      case head :: tail => ().validNel
+      case head :: tail =>
         NonEmptyList.of(head, tail: _*).map(fqn => s"Two or more nodes have the same FullyQualifiedName: ${fqn.value}").invalid
     }
 

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -64,6 +64,8 @@ class OuterGraphInputNode protected(override val identifier: WomIdentifier, val 
   override def womType: WomType = linkToOuterGraph.womType
   override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier, womType, this)
   lazy val linkToOuterGraphNode = linkToOuterGraph.graphNode
+
+  lazy val nameToPortMapping: (String, GraphNodeOutputPort) = localName -> singleOutputPort
 }
 
 final case class ScatterVariableNode(override val identifier: WomIdentifier,

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -4,6 +4,7 @@ import wom.graph.GraphNode.{GeneratedNodeAndNewNodes, GraphNodeWithInnerGraph}
 import wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort, ScatterGathererPort}
 import wom.graph.expression.ExpressionNode
 import wom.types.WomArrayType
+import common.collections.EnhancedCollections._
 
 /**
   *
@@ -41,9 +42,9 @@ object ScatterNode {
   case class ScatterVariableMapping(scatterCollectionExpressionNode: ExpressionNode, graphInputNode: GraphInputNode)
 
   final case class ScatterNodeWithNewNodes(node: ScatterNode) extends GeneratedNodeAndNewNodes {
-    override val newExpressions = Set(node.scatterCollectionExpressionNode)
-    override val newInputs = node.innerGraph.externalInputNodes
-    override val nestedOuterGraphInputNodes = node.innerGraph.outerGraphInputNodes.filter(_.linkToOuterGraphNode.isInstanceOf[OuterGraphInputNode])
+    override val newExpressions: Set[ExpressionNode] = Set(node.scatterCollectionExpressionNode)
+    override val newInputs: Set[ExternalGraphInputNode] = node.innerGraph.externalInputNodes
+    override val usedOuterGraphInputNodes: Set[OuterGraphInputNode] = node.innerGraph.outerGraphInputNodes.map(_.linkToOuterGraphNode).filterByType[OuterGraphInputNode]
   }
 
   /**

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -52,7 +52,7 @@ class GraphSpec extends FlatSpec with Matchers {
     
     val psNodeBuilder = new CallNodeBuilder()
     
-    val CallNodeAndNewNodes(psCall, psGraphInputs, _) = psNodeBuilder.build(WomIdentifier("ps"), taskDefinition_ps, InputDefinitionFold())
+    val CallNodeAndNewNodes(psCall, psGraphInputs, _, _) = psNodeBuilder.build(WomIdentifier("ps"), taskDefinition_ps, InputDefinitionFold())
     val ps_procsOutputPort = psCall.outputByName("procs").getOrElse(fail("Unexpectedly unable to find 'ps.procs' output"))
     
     val cgrepNodeBuilder = new CallNodeBuilder()
@@ -67,7 +67,7 @@ class GraphSpec extends FlatSpec with Matchers {
       ),
       Set(workflowInputNode)
     )
-    val CallNodeAndNewNodes(cgrepCall, cgrepGraphInputs, _) = cgrepNodeBuilder.build(WomIdentifier("cgrep"), taskDefinition_cgrep, cgrepInputDefinitionFold)
+    val CallNodeAndNewNodes(cgrepCall, cgrepGraphInputs, _, _) = cgrepNodeBuilder.build(WomIdentifier("cgrep"), taskDefinition_cgrep, cgrepInputDefinitionFold)
     val cgrep_countOutputPort = cgrepCall.outputByName("count").getOrElse(fail("Unexpectedly unable to find 'cgrep.count' output"))
 
     val wcNodeBuilder = new CallNodeBuilder()
@@ -81,7 +81,7 @@ class GraphSpec extends FlatSpec with Matchers {
       Set.empty
     )
     
-    val CallNodeAndNewNodes(wcCall, wcGraphInputs, _) = wcNodeBuilder.build(WomIdentifier("wc"), taskDefinition_wc, wcInputDefinitionFold)
+    val CallNodeAndNewNodes(wcCall, wcGraphInputs, _, _) = wcNodeBuilder.build(WomIdentifier("wc"), taskDefinition_wc, wcInputDefinitionFold)
     val wc_countOutputPort = wcCall.outputByName("count").getOrElse(fail("Unexpectedly unable to find 'wc.count' output"))
 
     val psProcsOutputNode = PortBasedGraphOutputNode(WomIdentifier("ps.procs"), WomFileType, ps_procsOutputPort)
@@ -120,7 +120,7 @@ class GraphSpec extends FlatSpec with Matchers {
       Set.empty,
       Set(workflowInputNode)
     )
-    val CallNodeAndNewNodes(threeStepCall, threeStepInputs, _) = threeStepNodeBuilder.build(WomIdentifier("three_step"), threeStepWorkflow, inputDefinitionFold)
+    val CallNodeAndNewNodes(threeStepCall, threeStepInputs, _, _) = threeStepNodeBuilder.build(WomIdentifier("three_step"), threeStepWorkflow, inputDefinitionFold)
 
     // This is painful manually, but it's not up to WOM to decide which subworkflow outputs are forwarded through:
     val psProcsOutputNode = PortBasedGraphOutputNode(WomIdentifier("three_step.ps.procs"), WomFileType, threeStepCall.outputByName("ps.procs").getOrElse(fail("Subworkflow didn't expose the ps.procs output")))

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -66,7 +66,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
       ),
       newGraphInputNodes = Set.empty
     )
-    val CallNodeAndNewNodes(foo_callNode, _, _) = fooNodeBuilder.build(WomIdentifier("foo"), task_foo, fooInputFold)
+    val CallNodeAndNewNodes(foo_callNode, _, _, _) = fooNodeBuilder.build(WomIdentifier("foo"), task_foo, fooInputFold)
     val foo_call_outNode = PortBasedGraphOutputNode(WomIdentifier("foo.out"), WomStringType, foo_callNode.outputByName("out").getOrElse(fail("foo CallNode didn't contain the expected 'out' output")))
     val scatterGraph = Graph.validateAndConstruct(Set(foo_callNode, x_inputNode, foo_call_outNode)) match {
       case Valid(sg) => sg


### PR DESCRIPTION
See below for motivating use case WDL (now a test). The throwaways need OGINs to reference the `i`, but we weren't recording the OGINs that they were making. The upshot was that multiple usages of the same variable in a nested scope was producing multiple OGINs for the same value, and that was causing the "duplicate FQN" errors to trigger.


```
workflow nested_lookups {
  Int i = 27
  if(true) {
    Int? throwaway = i # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
    Int? throwaway2 = i # Make sure this 'i' OGIN doesn't duplicate the nested m1's 'i' OGIN
    if(true) {
      if(true) {
        call mirror as m1 { input: i = i}
      }
    }
  }
```