### PR TITLE
For subworkflows, no outputs means no outputs.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/sub_workflow_var_refs.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_var_refs.test
@@ -1,4 +1,3 @@
-name: sub_workflow_var_refs
 testFormat: workflowsuccess
 ignore: true # Depends on #2901
 

--- a/wdl/src/main/scala/wdl/WdlWorkflow.scala
+++ b/wdl/src/main/scala/wdl/WdlWorkflow.scala
@@ -158,12 +158,12 @@ case class WdlWorkflow(unqualifiedName: String,
   lazy val hasEmptyOutputSection = workflowOutputWildcards.isEmpty && children.collect({ case o: WorkflowOutput => o }).isEmpty
 
   /**
-   * All outputs for this workflow and their associated types
+   * All outputs for this workflow and their associated types. Only applies to top-level workflows.
    *
    * @return a Map[FullyQualifiedName, WomType] representing the union
    *         of all outputs from all `call`s within this workflow
    */
-  lazy val expandedWildcardOutputs: Seq[WorkflowOutput] = {
+  lazy val expandedWildcardOutputs: Seq[WorkflowOutput] = if(!ancestry.exists(_.isInstanceOf[WdlWorkflow])) Seq.empty else {
 
     def toWorkflowOutput(output: DeclarationInterface, womType: WomType) = {
       val locallyQualifiedName = output.parent map { parent => output.locallyQualifiedName(parent) } getOrElse {


### PR DESCRIPTION
Fixes the second half of #2901 (which turned out to not be caused by task outputs at all, but incorrectly added subworkflow outputs)