### PR TITLE
Unify terminology for submitting labels to cromwell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * **API**  
     + Cromwell now supports input files in the yaml format (json format is still supported).
+    + The `customLabels` form field for workflow submission has been renamed to `labels`.
 
 * **Database**  
 You have the option of storing the metadata in a separate SQL database than the database containing the internal engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## 30 Release Notes
 
+### Breaking Changes
+
+* The `customLabels` form field for workflow submission has been renamed to `labels`.
+
 ### Other changes
 
 * **API**  
     + Cromwell now supports input files in the yaml format (json format is still supported).
-    + The `customLabels` form field for workflow submission has been renamed to `labels`.
 
 * **Database**  
 You have the option of storing the metadata in a separate SQL database than the database containing the internal engine

--- a/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
@@ -27,7 +27,7 @@ final case class Workflow private(testName: String,
     workflowTypeVersion = data.workflowTypeVersion,
     inputsJson = data.inputs,
     options = CromwellClient.replaceJson(data.options, "refresh_token", refreshToken),
-    customLabels = Option(data.labels),
+    labels = Option(data.labels),
     zippedImports = data.zippedImports)
 }
 

--- a/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
@@ -70,7 +70,7 @@ class CromwellClient(val cromwellUrl: URL, val apiVersion: String, val credentia
       workflowTypeVersion = workflow.workflowTypeVersion,
       inputsJson = Option(inputs),
       options = workflow.options,
-      customLabels = workflow.customLabels,
+      labels = workflow.labels,
       zippedImports = workflow.zippedImports))
 
     makeRequest[List[CromwellStatus]](HttpRequest(HttpMethods.POST, batchSubmitEndpoint, List.empty[HttpHeader], requestEntity)) map { statuses =>
@@ -192,7 +192,7 @@ object CromwellClient {
       "workflowTypeVersion" -> workflowSubmission.workflowTypeVersion,
       "workflowInputs" -> workflowSubmission.inputsJson,
       "workflowOptions" -> workflowSubmission.options,
-      "customLabels" -> workflowSubmission.customLabels.map(_.toJson.toString)
+      "labels" -> workflowSubmission.labels.map(_.toJson.toString)
     ) collect {
       case (name, Some(source: String)) =>
         Multipart.FormData.BodyPart(name, HttpEntity(MediaTypes.`application/json`, ByteString(source)))

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/WorkflowSubmission.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/WorkflowSubmission.scala
@@ -8,7 +8,7 @@ sealed trait WorkflowSubmission {
   val workflowTypeVersion: Option[String]
   val inputsJson: Option[String]
   val options: Option[String]
-  val customLabels: Option[List[Label]]
+  val labels: Option[List[Label]]
   val zippedImports: Option[File]
 }
 
@@ -17,7 +17,7 @@ final case class WorkflowSingleSubmission(wdl: String,
                                           workflowTypeVersion: Option[String],
                                           inputsJson: Option[String],
                                           options: Option[String],
-                                          customLabels: Option[List[Label]],
+                                          labels: Option[List[Label]],
                                           zippedImports: Option[File]) extends WorkflowSubmission
 
 final case class WorkflowBatchSubmission(wdl: String,
@@ -25,7 +25,7 @@ final case class WorkflowBatchSubmission(wdl: String,
                                          workflowTypeVersion: Option[String],
                                          inputsBatch: List[String],
                                          options: Option[String],
-                                         customLabels: Option[List[Label]],
+                                         labels: Option[List[Label]],
                                          zippedImports: Option[File]) extends WorkflowSubmission {
 
   override val inputsJson: Option[String] = Option(inputsBatch.mkString(start = "[", sep = ",", end = "]"))

--- a/cromwellApiClient/src/test/scala/cromwell/api/CromwellClientSpec.scala
+++ b/cromwellApiClient/src/test/scala/cromwell/api/CromwellClientSpec.scala
@@ -87,7 +87,7 @@ class CromwellClientSpec extends AsyncFlatSpec with BeforeAndAfterAll with Match
         "workflowTypeVersion" -> "wfTypeVersion",
         "workflowInputs" -> "inputsJson",
         "workflowOptions" -> "optionsJson",
-        "customLabels" -> """{"labelKey":"labelValue"}"""
+        "labels" -> """{"labelKey":"labelValue"}"""
       ),
       Map("workflowDependencies" -> tempFile)
     ),
@@ -108,7 +108,7 @@ class CromwellClientSpec extends AsyncFlatSpec with BeforeAndAfterAll with Match
         "workflowTypeVersion" -> "wfTypeVersion",
         "workflowInputs" -> "[inputsJson1,inputsJson2]",
         "workflowOptions" -> "optionsJson",
-        "customLabels" -> """{"labelKey":"labelValue"}"""
+        "labels" -> """{"labelKey":"labelValue"}"""
       ),
       Map("workflowDependencies" -> tempFile)
     )

--- a/docs/Labels.md
+++ b/docs/Labels.md
@@ -14,7 +14,7 @@ In order to assign labels to a workflow, the first step is to create a JSON file
 When choosing key-value pairs, it's important to make sure you're adhering to Cromwell supported label syntax below.  
 
 There are two ways to add labels to a workflow:  
-1. Upon workflow submission set the `customLabels` parameter of the [Submit endpoint](api/RESTAPI#submit-a-workflow-for-execution), or  
+1. Upon workflow submission set the `labels` parameter of the [Submit endpoint](api/RESTAPI#submit-a-workflow-for-execution), or  
 2. Setting the `-l` argument when running in [Command Line](/CommandLine) mode.
 
 Labels can be added to existing workflows by using the [Labels patch endpoint](api/RESTAPI#update-labels-for-a-workflow).

--- a/docs/api/RESTAPI.md
+++ b/docs/api/RESTAPI.md
@@ -48,7 +48,7 @@ Submits a workflow to Cromwell. Note that this endpoint can accept an unlimited 
 |Type|Name|Description|Schema|Default|
 |---|---|---|---|---|
 |**Path**|**version**  <br>*required*|Cromwell API Version|string|`"v1"`|
-|**FormData**|**customLabels**  <br>*optional*|JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.|file||
+|**FormData**|**labels**  <br>*optional*|JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.|file||
 |**FormData**|**workflowDependencies**  <br>*optional*|ZIP file containing workflow source files that are used to resolve local imports. This zip bundle will be unpacked in a sandbox accessible to this workflow.|file||
 |**FormData**|**workflowInputs**  <br>*optional*|JSON or YAML file containing the inputs as an object. For WDL workflows a skeleton file can be generated from wdltool using the "inputs" subcommand. When multiple files are specified, in case of key conflicts between multiple input JSON files, higher values of x in workflowInputs_x override lower values. For example, an input specified in workflowInputs_3 will override an input with the same name in workflowInputs or workflowInputs_2. Similarly, an input key specified in workflowInputs_5 will override an identical input key in any other input file.|file||
 |**FormData**|**workflowInputs_2**  <br>*optional*|A second JSON or YAML file containing inputs.|file||
@@ -140,7 +140,7 @@ In instances where you want to run the same workflow multiple times with varying
 |Type|Name|Description|Schema|Default|
 |---|---|---|---|---|
 |**Path**|**version**  <br>*required*|Cromwell API Version|string|`"v1"`|
-|**FormData**|**customLabels**  <br>*optional*|JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.|file||
+|**FormData**|**labels**  <br>*optional*|JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.|file||
 |**FormData**|**workflowDependencies**  <br>*optional*|ZIP file containing workflow source files that are used to resolve local imports. This zip bundle will be unpacked in a sandbox accessible to these workflows.|file||
 |**FormData**|**workflowInputs**  <br>*required*|JSON file containing the inputs as an array of objects. Every element of the array will correspond to a single workflow. For WDL workflows a skeleton file can be generated from wdltool using the "inputs" subcommand. When multiple files are specified, in case of key conflicts between multiple input JSON files, higher values of x in workflowInputs_x override lower values. For example, an input specified in workflowInputs_3 will override an input with the same name in workflowInputs or workflowInputs_2. Similarly, an input key specified in workflowInputs_5 will override an identical input key in any other input file.|file||
 |**FormData**|**workflowOptions**  <br>*optional*|JSON file containing configuration options for the execution of this workflow.|file||

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -59,7 +59,7 @@ paths:
           type: string
           enum: [draft-2]
           in: formData
-        - name: customLabels
+        - name: labels
           description: JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.
           required: false
           type: file
@@ -113,7 +113,7 @@ paths:
           type: string
           enum: [draft-2]
           in: formData
-        - name: customLabels
+        - name: labels
           description: JSON file containing a set of collection of key/value pairs for labels to apply to this workflow.
           required: false
           type: file


### PR DESCRIPTION
Workflow submission has a form field `customLabels` whereas the label update endpoint has the form field `labels`. When one is trying to abstract logic involving labels to the akka http DSL this makes it yucky. There's no reason why these need to be different. Unify them to `labels` terminology

There are still internal references to customLabels, but not in a user visible way.

edit: Looks like the command line API also has `labels` as the terminology