### PR TITLE
Reinstante invalid_runtime_attributes test.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/invalid_runtime_attributes.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_runtime_attributes.test
@@ -1,7 +1,5 @@
-ignore: true # Depends on 2904
 name: invalid_runtime_attributes
 testFormat: workflowfailure
-
 
 files {
   wdl: invalid_runtime_attributes/invalid_runtime_attributes.wdl
@@ -10,5 +8,6 @@ files {
 metadata {
     "workflowName": "invalid_runtime_attributes_wf"
     "failures.0.message": "Workflow failed"
-    "failures.0.causedBy.0.causedBy.0.message": "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]"
+    "failures.0.causedBy.0.causedBy.0.causedBy.0.message":
+      "Expecting continueOnReturnCode runtime attribute to be either a Boolean, a String 'true' or 'false', or an Array[Int]"
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -113,7 +113,7 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   override lazy val dockerImageUsed: Option[String] = Option(jobDockerImage)
 
-  override val preemptible: Boolean = previousRetryReasons match {
+  override lazy val preemptible: Boolean = previousRetryReasons match {
     case Valid(PreviousRetryReasons(p, _)) => p < maxPreemption
     case _ => false
   }


### PR DESCRIPTION
A val instead of lazy-val was throwing an exception "too early".
The additional ActorInitializationException then affected the depth of the expected causeBy messages.