### PR TITLE
Reinstates workflow outputs (et al)

### DIFF
--- a/backend/src/test/scala/cromwell/backend/BackendSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/BackendSpec.scala
@@ -77,20 +77,20 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
     val jobKey = BackendJobDescriptorKey(call, None, 1)
     
     val inputDeclarations: Map[InputDefinition, WomValue] = call.inputDefinitionMappings.map {
-      case (inputDef, resolved) => inputDef -> 
+      case (inputDef, resolved) => inputDef ->
         resolved.select[WomValue].orElse(
           resolved.select[WomExpression]
             .map(
               _.evaluateValue(inputs, NoIoFunctionSet).getOrElse(fail("Can't evaluate input"))
             )
         ).orElse(
-        workflowDescriptor.knownValues
-          .get(resolved.select[OutputPort].get)
+          workflowDescriptor.knownValues
+            .get(resolved.select[OutputPort].get)
         )
-        .getOrElse {
-          inputs(inputDef.name) 
-        }
-    }
+          .getOrElse {
+            inputs(inputDef.name)
+          }
+    }.toMap
     val evaluatedAttributes = RuntimeAttributeDefinition.evaluateRuntimeAttributes(call.callable.runtimeAttributes, NoIoFunctionSet, Map.empty).getOrElse(fail("Failed to evaluate runtime attributes")) // .get is OK here because this is a test
     val runtimeAttributes = RuntimeAttributeDefinition.addDefaultsToAttributes(runtimeAttributeDefinitions, options)(evaluatedAttributes)
     BackendJobDescriptor(workflowDescriptor, jobKey, runtimeAttributes, inputDeclarations, NoDocker, Map.empty)

--- a/centaur/src/main/resources/standardTestCases/if_then_else_expressions.test
+++ b/centaur/src/main/resources/standardTestCases/if_then_else_expressions.test
@@ -1,4 +1,3 @@
-ignore: true # Depends on #2860
 name: if_then_else_expressions
 testFormat: workflowsuccess
 

--- a/centaur/src/main/resources/standardTestCases/missing_input_failure.test
+++ b/centaur/src/main/resources/standardTestCases/missing_input_failure.test
@@ -11,5 +11,5 @@ metadata {
     workflowName: missing_input_failure
     status: Failed
     "failures.0.message": "Workflow failed"
-    "failures.0.causedBy.0.message": "gs://nonexistingbucket/path/doesnt/exist"
+    "failures.0.causedBy.0.message": "Evaluating read_string(wf_hello_input) failed: gs://nonexistingbucket/path/doesnt/exist"
 }

--- a/centaur/src/main/resources/standardTestCases/optional_parameter.test
+++ b/centaur/src/main/resources/standardTestCases/optional_parameter.test
@@ -1,5 +1,5 @@
-ignore: true # Reinstate with #2860
-# Tests interactions with an optional parameter. Supplying no value at all, using a default value and supplying a value
+# Tests interactions with an optional parameter.
+# Supplying no value at all, using a default value and supplying a value, depending on optional inputs in other inputs
 
 name: optional_parameter
 testFormat: workflowsuccess

--- a/centaur/src/main/resources/standardTestCases/optional_parameter/optional_parameter.wdl
+++ b/centaur/src/main/resources/standardTestCases/optional_parameter/optional_parameter.wdl
@@ -2,6 +2,7 @@ task select_first_with_optionals {
 	String? supplied
 	String? wfSupplied
 	String? unsupplied
+	# Tests that we can use an optional input in a subsequent input expression:
 	String suppliedWithDefault = select_first([supplied, "HAPPY_BIRTHDAY_RUCHI"])
 	String wfSuppliedWithDefault = select_first([wfSupplied, "HAPPY_BIRTHDAY_RUCHI"])
 	String unsuppliedWithDefault = select_first([unsupplied, "HAPPY_BIRTHDAY_RUCHI"])

--- a/centaur/src/main/resources/standardTestCases/select_functions.test
+++ b/centaur/src/main/resources/standardTestCases/select_functions.test
@@ -1,4 +1,3 @@
-ignore: true # depends on #2860
 # Tests that the select_all and select_first functions work in a variety of situations.
 
 name: select_functions

--- a/centaur/src/main/resources/standardTestCases/workflow_output_declarations.test
+++ b/centaur/src/main/resources/standardTestCases/workflow_output_declarations.test
@@ -1,4 +1,3 @@
-ignore: true # depends on #2860
 name: workflow_output_declarations
 testFormat: workflowsuccess
 

--- a/core/src/test/scala/cromwell/util/WomMocks.scala
+++ b/core/src/test/scala/cromwell/util/WomMocks.scala
@@ -16,11 +16,11 @@ object WomMocks {
   val EmptyWorkflowDefinition = mockWorkflowDefinition("emptyWorkflow")
 
   def mockTaskCall(identifier: WomIdentifier, definition: TaskDefinition = EmptyTaskDefinition) = {
-    TaskCallNode(identifier, definition, Set.empty, Map.empty)
+    TaskCallNode(identifier, definition, Set.empty, List.empty)
   }
   
   def mockWorkflowCall(identifier: WomIdentifier, definition: WorkflowDefinition = EmptyWorkflowDefinition) = {
-    WorkflowCallNode(identifier, definition, Set.empty, Map.empty)
+    WorkflowCallNode(identifier, definition, Set.empty, List.empty)
   }
 
   def mockWorkflowDefinition(name: String) = {

--- a/cwl/src/main/scala/cwl/WorkflowStep.scala
+++ b/cwl/src/main/scala/cwl/WorkflowStep.scala
@@ -8,8 +8,6 @@ import cats.syntax.either._
 import cats.syntax.foldable._
 import cats.syntax.monoid._
 import cats.syntax.validated._
-import cwl.ScatterMethod._
-import cwl.WorkflowStep._
 import common.Checked
 import common.validation.Checked._
 import common.validation.ErrorOr.ErrorOr
@@ -172,7 +170,7 @@ case class WorkflowStep(
           case _ if expressionNodes.contains(inputDefinition.name) =>
             val expressionNode = expressionNodes(inputDefinition.name)
             InputDefinitionFold(
-              mappings = Map(inputDefinition -> expressionNode.inputDefinitionPointer),
+              mappings = List(inputDefinition -> expressionNode.inputDefinitionPointer),
               callInputPorts = Set(callNodeBuilder.makeInputPort(inputDefinition, expressionNode.singleExpressionOutputPort)),
               newExpressionNodes = Set(expressionNode)
             ).validNel
@@ -180,7 +178,7 @@ case class WorkflowStep(
           // No expression node mapping, use the default
           case withDefault @ InputDefinitionWithDefault(_, _, expression) =>
             InputDefinitionFold(
-              mappings = Map(withDefault -> Coproduct[InputDefinitionPointer](expression))
+              mappings = List(withDefault -> Coproduct[InputDefinitionPointer](expression))
             ).validNel
 
           // Required input without default value and without mapping, this is a validation error
@@ -190,7 +188,7 @@ case class WorkflowStep(
           // Optional input without mapping, defaults to empty value
           case optional: OptionalInputDefinition =>
             InputDefinitionFold(
-              mappings = Map(optional -> Coproduct[InputDefinitionPointer](optional.womType.none: WomValue))
+              mappings = List(optional -> Coproduct[InputDefinitionPointer](optional.womType.none: WomValue))
             ).validNel
         }
       }

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -196,11 +196,12 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
     ps.inputDefinitionMappings shouldBe empty
     cgrep.inputDefinitionMappings should have size 2
 
+    val cgrepInputs = cgrep.inputDefinitionMappings.toMap
     val cgrepFileInputDef = cgrep.callable.inputs.find(_.name == "file").get
-    cgrep.inputDefinitionMappings(cgrepFileInputDef).select[OutputPort].get should be theSameInstanceAs cgrepFileExpression.singleExpressionOutputPort
+    cgrepInputs(cgrepFileInputDef).select[OutputPort].get should be theSameInstanceAs cgrepFileExpression.singleExpressionOutputPort
 
     val cgrepPatternInputDef = cgrep.callable.inputs.find(_.name == "pattern").get
-    cgrep.inputDefinitionMappings(cgrepPatternInputDef).select[OutputPort].get should be theSameInstanceAs cgrepPatternExpression.singleExpressionOutputPort
+    cgrepInputs(cgrepPatternInputDef).select[OutputPort].get should be theSameInstanceAs cgrepPatternExpression.singleExpressionOutputPort
   }
 
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/CallPreparation.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/CallPreparation.scala
@@ -36,7 +36,7 @@ object CallPreparation {
         })
         
         val coercedValue = pointer.fold(InputPointerToWdlValue).apply(
-          callKey.node, validInputsAccumulated, expressionLanguageFunctions, valueStore, callKey.index
+          validInputsAccumulated, expressionLanguageFunctions, valueStore, callKey.index, inputDefinition
         ) flatMap(inputDefinition.womType.coerceRawValue(_).toErrorOr)
 
         accumulatedInputsSoFar + (inputDefinition -> coercedValue)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/InputPointerToWdlValue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/InputPointerToWdlValue.scala
@@ -1,31 +1,41 @@
 package cromwell.engine.workflow.lifecycle.execution.job.preparation
 
+import cats.data.Validated.Valid
 import cats.syntax.validated._
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import common.validation.ErrorOr.ErrorOr
 import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore
 import shapeless.Poly1
+import wom.callable.Callable.{InputDefinition, InputDefinitionWithDefault, OptionalInputDefinition}
 import wom.expression.{IoFunctionSet, WomExpression}
-import wom.graph.GraphNode
 import wom.graph.GraphNodePort.OutputPort
 import wom.values.WomValue
 
 object InputPointerToWdlValue extends Poly1 {
   // Function that can transform any of the coproduct types to an ErrorOr[WomValue]
-  type ToWdlValueFn = (GraphNode, Map[String, WomValue], IoFunctionSet, ValueStore, ExecutionIndex) => ErrorOr[WomValue]
+  type ToWdlValueFn = (Map[String, WomValue], IoFunctionSet, ValueStore, ExecutionIndex, InputDefinition) => ErrorOr[WomValue]
 
-  implicit def fromWdlValue: Case.Aux[WomValue, ToWdlValueFn] = at[WomValue] {
-    WomValue => (_: GraphNode, _: Map[String, WomValue], _: IoFunctionSet, _: ValueStore, _: ExecutionIndex) =>
-      WomValue.validNel: ErrorOr[WomValue]
+  implicit def fromWomValue: Case.Aux[WomValue, ToWdlValueFn] = at[WomValue] {
+    womValue => (_: Map[String, WomValue], _: IoFunctionSet, _: ValueStore, _: ExecutionIndex, _: InputDefinition) =>
+      womValue.validNel: ErrorOr[WomValue]
   }
 
   implicit def fromOutputPort: Case.Aux[OutputPort, ToWdlValueFn] = at[OutputPort] {
-    port => (_: GraphNode, _: Map[String, WomValue], _: IoFunctionSet, valueStore: ValueStore, index : ExecutionIndex) =>
-      valueStore.resolve(index)(port)
+    port => (knownValues: Map[String, WomValue], ioFunctions: IoFunctionSet, valueStore: ValueStore, index: ExecutionIndex, inputDefinition: InputDefinition) =>
+      (valueStore.resolve(index)(port), inputDefinition) match {
+        case (v: Valid[WomValue], _) => v
+        case (_, InputDefinitionWithDefault(_, _, defaultExpression)) =>
+          evaluate(defaultExpression, knownValues, ioFunctions)
+        case (_, OptionalInputDefinition(_, optionalType)) => optionalType.none.validNel
+        case _ => s"Failed to lookup input value for required input ${port.name} at index $index in value store $valueStore".invalidNel
+      }
   }
 
   implicit def fromWomExpression: Case.Aux[WomExpression, ToWdlValueFn] = at[WomExpression] { 
-    womExpression => (_: GraphNode, knownValues: Map[String, WomValue], ioFunctions: IoFunctionSet, _: ValueStore, _ : ExecutionIndex) =>
+    womExpression => (knownValues: Map[String, WomValue], ioFunctions: IoFunctionSet, _: ValueStore, _ : ExecutionIndex, _: InputDefinition) =>
       womExpression.evaluateValue(knownValues, ioFunctions): ErrorOr[WomValue]
   }
+
+  def evaluate(womExpression: WomExpression, knownValues: Map[String, WomValue], ioFunctions: IoFunctionSet): ErrorOr[WomValue] =
+    womExpression.evaluateValue(knownValues, ioFunctions)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
@@ -60,7 +60,7 @@ class JobPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
       evaluateInputsAndAttributes(valueStore) match {
         case Valid((inputs, attributes)) => fetchDockerHashesIfNecessary(inputs, attributes)
         case Invalid(failure) => sendFailureAndStop(new MessageAggregation {
-          override def exceptionContext: String = "Call input and runtime attributes evaluation failed"
+          override def exceptionContext: String = s"Call input and runtime attributes evaluation failed for ${jobKey.call.localName}"
           override def errorMessages: Traversable[String] = failure.toList
         })
       }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ConditionalKey.scala
@@ -9,7 +9,7 @@ import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore.ValueKey
 import cromwell.engine.workflow.lifecycle.execution.{WorkflowExecutionActorData, WorkflowExecutionDiff}
 import wom.graph._
 import wom.graph.expression.ExpressionNode
-import wom.values.{WomBoolean, WomOptionalValue, WomValue}
+import wom.values.{WomBoolean, WomValue}
 
 /**
   * Represents a conditional node in the execution store.
@@ -60,7 +60,7 @@ private [execution] case class ConditionalKey(node: ConditionalNode, index: Exec
         val conditionalStatus = if (b.value) ExecutionStatus.Done else ExecutionStatus.Bypassed
 
         val valueStoreAdditions: Map[ValueKey, WomValue] = if (!b.value) {
-          node.outputPorts.map(op => ValueKey(op, index) -> WomOptionalValue(op.womType, None)).toMap
+          node.conditionalOutputPorts.map(op => ValueKey(op, index) -> op.womType.none).toMap
         } else Map.empty
 
         WorkflowExecutionDiff(

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
@@ -37,7 +37,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val actor = TestActorRef(helper.buildTestJobPreparationActor(null, null, null, error.invalidNel, List.empty), self)
     actor ! Start(ValueStore.empty)
     expectMsgPF(1.second) {
-      case CallPreparationFailed(_, ex) => ex.getMessage shouldBe "Call input and runtime attributes evaluation failed:\nFailed to prepare inputs/attributes - part of test flow"
+      case CallPreparationFailed(_, ex) => ex.getMessage shouldBe "Call input and runtime attributes evaluation failed for JobPreparationSpec_call:\nFailed to prepare inputs/attributes - part of test flow"
     }
     helper.workflowDockerLookupActor.expectNoMsg(100 millis)
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationTestHelper.scala
@@ -11,6 +11,7 @@ import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore
 import cromwell.services.keyvalue.KeyValueServiceActor.{KvJobKey, ScopedKey}
 import common.validation.ErrorOr.ErrorOr
 import org.specs2.mock.Mockito
+import wom.graph.{TaskCallNode, WomIdentifier}
 import wom.values.{WomEvaluatedCallInputs, WomValue}
 
 import scala.concurrent.duration.FiniteDuration
@@ -23,6 +24,8 @@ class JobPreparationTestHelper(implicit val system: ActorSystem) extends Mockito
   workflowDescriptor.id returns WorkflowId.randomId()
   executionData.workflowDescriptor returns workflowDescriptor
   val jobKey = mock[BackendJobDescriptorKey]
+  val call = TaskCallNode(WomIdentifier("JobPreparationSpec_call"), null, null, null)
+  jobKey.call returns call
   val serviceRegistryProbe = TestProbe()
   val ioActor = TestProbe()
   val workflowDockerLookupActor = TestProbe()

--- a/wdl/src/main/scala/wdl/Declaration.scala
+++ b/wdl/src/main/scala/wdl/Declaration.scala
@@ -102,6 +102,12 @@ object Declaration {
       case IntermediateValueDeclarationNode(expressionNode) => expressionNode
       case GraphOutputDeclarationNode(graphOutputNode) => graphOutputNode
     }
+    lazy val singleOutputPort = this match {
+      case InputDeclarationNode(graphInputNode) => graphInputNode.singleOutputPort
+      case IntermediateValueDeclarationNode(expressionNode) => expressionNode.singleExpressionOutputPort
+      case GraphOutputDeclarationNode(outputNode) => outputNode.graphOutputPort
+    }
+    lazy val localName = toGraphNode.localName
   }
   final case class InputDeclarationNode(graphInputNode: GraphInputNode) extends WdlDeclarationNode
   final case class IntermediateValueDeclarationNode(expressionNode: ExpressionNode) extends WdlDeclarationNode

--- a/wdl/src/main/scala/wdl/WdlCall.scala
+++ b/wdl/src/main/scala/wdl/WdlCall.scala
@@ -87,7 +87,7 @@ object WdlCall {
       // expression node mapping is found
       def withGraphInputNode(inputDefinition: InputDefinition, graphInputNode: ExternalGraphInputNode) = {
         InputDefinitionFold(
-          mappings = Map(inputDefinition -> Coproduct[InputDefinitionPointer](graphInputNode.singleOutputPort: OutputPort)),
+          mappings = List(inputDefinition -> Coproduct[InputDefinitionPointer](graphInputNode.singleOutputPort: OutputPort)),
           callInputPorts = Set(callNodeBuilder.makeInputPort(inputDefinition, graphInputNode.singleOutputPort)),
           newGraphInputNodes = Set(graphInputNode)
         )
@@ -98,7 +98,7 @@ object WdlCall {
         case inputDefinition if expressionNodes.contains(inputDefinition.localName) =>
           val expressionNode = expressionNodes(inputDefinition.localName)
           InputDefinitionFold(
-            mappings = Map(inputDefinition -> expressionNode.inputDefinitionPointer),
+            mappings = List(inputDefinition -> expressionNode.inputDefinitionPointer),
             callInputPorts = Set(callNodeBuilder.makeInputPort(inputDefinition, expressionNode.singleExpressionOutputPort)),
             newExpressionNodes = Set(expressionNode)
           )
@@ -106,7 +106,7 @@ object WdlCall {
         // No input mapping, use the default expression
         case withDefault @ InputDefinitionWithDefault(_, _, expression) =>
           InputDefinitionFold(
-            mappings = Map(withDefault -> Coproduct[InputDefinitionPointer](expression))
+            mappings = List(withDefault -> Coproduct[InputDefinitionPointer](expression))
           )
 
         // No input mapping, required and we don't have a default value, create a new RequiredGraphInputNode

--- a/wdl/src/main/scala/wdl/WdlExpression.scala
+++ b/wdl/src/main/scala/wdl/WdlExpression.scala
@@ -242,7 +242,11 @@ object WdlWomExpression {
     *
     * If the input is found in an outer scope, we also make a new input node in the inner graph to represent it.
     */
-  def findInputsforExpression(expression: WdlWomExpression, innerLookup: Map[String, GraphNodePort.OutputPort], outerLookup: Map[String, GraphNodePort.OutputPort], preserveIndexForOuterLookups: Boolean, owningScope: Scope): ErrorOr[Map[String, GraphNodePort.OutputPort]] = {
+  def findInputsforExpression(expression: WdlWomExpression,
+                              innerLookup: Map[String, GraphNodePort.OutputPort],
+                              outerLookup: Map[String, GraphNodePort.OutputPort],
+                              preserveIndexForOuterLookups: Boolean,
+                              owningScope: Scope): ErrorOr[Map[String, GraphNodePort.OutputPort]] = {
 
     def resolveVariable(v: AstTools.VariableReference): ErrorOr[(String, GraphNodePort.OutputPort)] = {
       val name = v.referencedVariableName

--- a/wdl/src/test/scala/wom/WdlNamespaceWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlNamespaceWomSpec.scala
@@ -94,7 +94,8 @@ class WdlNamespaceWomSpec extends FlatSpec with Matchers {
     cgrep.inputDefinitionMappings should have size 2
 
     val cgrepFileInputDef = cgrep.callable.inputs.find(_.name == "in_file").get
-    val inFileMapping = cgrep.inputDefinitionMappings(cgrepFileInputDef)
+    val cgrepInputs = cgrep.inputDefinitionMappings.toMap
+    val inFileMapping = cgrepInputs(cgrepFileInputDef)
     inFileMapping.select[OutputPort].isDefined shouldBe true
     // This should be less ugly when we can access a string value from a womexpression
     inFileMapping.select[OutputPort].get
@@ -103,7 +104,7 @@ class WdlNamespaceWomSpec extends FlatSpec with Matchers {
       .wdlExpression.valueString shouldBe "ps.procs"
 
     val cgrepPatternInputDef = cgrep.callable.inputs.find(_.name == "pattern").get
-    cgrep.inputDefinitionMappings(cgrepPatternInputDef).select[OutputPort].get eq patternInputNode.singleOutputPort shouldBe true
+    cgrepInputs(cgrepPatternInputDef).select[OutputPort].get eq patternInputNode.singleOutputPort shouldBe true
   }
 
 }

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -73,7 +73,7 @@ object GraphNodePort {
   final case class ConditionalOutputPort(outputToExpose: PortBasedGraphOutputNode, g: Unit => ConditionalNode) extends OutputPort with DelayedGraphNodePort {
     // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToExpose.identifier
-    override val womType: WomType = WomOptionalType(outputToExpose.womType).flatOptionalType
+    override val womType: WomOptionalType = WomOptionalType(outputToExpose.womType).flatOptionalType
     lazy val conditionalNode: ConditionalNode = g(())
   }
 

--- a/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
+++ b/wom/src/main/scala/wom/graph/expression/ExpressionNode.scala
@@ -38,7 +38,7 @@ abstract class ExpressionNode(override val identifier: WomIdentifier,
   def evaluateAndCoerce(inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): Checked[WomValue] = (for {
     evaluated <- womExpression.evaluateValue(inputs, ioFunctionSet)
     coerced <- womType.coerceRawValue(evaluated).toErrorOr
-  } yield coerced).toEither
+  } yield coerced).leftMap(_.map(e => s"Evaluating ${womExpression.sourceString} failed: $e")).toEither
 }
 
 object ExpressionNode {

--- a/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
@@ -43,7 +43,7 @@ class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
     val inputDefinition = TaskDefinitionSpec.oneInputTask.inputs.head
     
     val inputDefinitionFold = InputDefinitionFold(
-      mappings = Map(inputDefinition -> expressionNode.inputDefinitionPointer),
+      mappings = List(inputDefinition -> expressionNode.inputDefinitionPointer),
       callInputPorts = Set(callNodeBuilder.makeInputPort(inputDefinition, expressionNode.singleExpressionOutputPort)),
       newExpressionNodes = Set(expressionNode)
     )

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -57,7 +57,7 @@ class GraphSpec extends FlatSpec with Matchers {
     
     val cgrepNodeBuilder = new CallNodeBuilder()
     val cgrepInputDefinitionFold = InputDefinitionFold(
-      mappings = Map(
+      mappings = List(
         cgrepPattern -> Coproduct[InputDefinitionPointer](workflowInputNode.singleOutputPort: OutputPort),
         cgrepInFile -> Coproduct[InputDefinitionPointer](psCall.outputPorts.head: OutputPort)
       ),
@@ -72,7 +72,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
     val wcNodeBuilder = new CallNodeBuilder()
     val wcInputDefinitionFold = InputDefinitionFold(
-      mappings = Map(
+      mappings = List(
         wcInFile -> Coproduct[InputDefinitionPointer](psCall.outputPorts.head)
       ),
       Set(
@@ -116,7 +116,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val workflowInputNode = RequiredGraphInputNode(WomIdentifier("three_step.cgrep.pattern"), WomStringType)
     
     val inputDefinitionFold = InputDefinitionFold(
-      mappings = Map.empty,
+      mappings = List.empty,
       Set.empty,
       Set(workflowInputNode)
     )

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -58,7 +58,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     val x_inputNode = ScatterVariableNode(WomIdentifier("x"), xsExpressionAsInput.singleExpressionOutputPort, WomArrayType(WomIntegerType))
     val fooNodeBuilder = new CallNodeBuilder()
     val fooInputFold = InputDefinitionFold(
-      mappings = Map(
+      mappings = List(
         fooInputDef -> Coproduct[InputDefinitionPointer](x_inputNode.singleOutputPort: OutputPort)
       ),
       callInputPorts = Set(

--- a/womtool/src/main/scala/womtool/graph/package.scala
+++ b/womtool/src/main/scala/womtool/graph/package.scala
@@ -41,7 +41,7 @@ package object graph {
       case _: OutputPort => "hexagon"
     }
 
-    def graphName: String = dotSafe(graphNodePort.name)
+    def graphName: String = dotSafe(graphNodePort.womType.toDisplayString + " " + graphNodePort.name)
     def graphId: String = dotSafe("PORT" + graphObjectUniqueId(graphNodePort))
   }
 


### PR DESCRIPTION
As well as allowing workflow outputs to refer to other outputs (commit 1), to make the four tests in this ticket work involved:
- Making the result from not-run conditionals be of type `X?`, not the incorrect `X??` (commit 2)
- Making task input evaluation honor optionals and defaults, and be evaluated in the right order (commit 3)