### PR TITLE
Generate coverage for integration tests

### DIFF
--- a/centaur/run_tests_parallel.sh
+++ b/centaur/run_tests_parallel.sh
@@ -10,6 +10,6 @@ THREADS=${1:-3}
 
 echo "Running tests with ${THREADS}-way parallelism"
 
-sbt test:compile
-CP=$(sbt "export test:dependencyClasspath" --error)
-java -cp $CP org.scalatest.tools.Runner -R target/scala-2.12/test-classes -oD -PS${THREADS}
+sbt centaur/it:compile
+CP=$(sbt "export centaur/it:dependencyClasspath" --error)
+java -cp $CP org.scalatest.tools.Runner -R target/scala-2.12/it-classes -oD -PS${THREADS}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -82,7 +82,9 @@ object Settings {
   lazy val assemblySettings = Seq(
     assemblyJarName in assembly := name.value + "-" + version.value + ".jar",
     test in assembly := {},
-    assemblyMergeStrategy in assembly := customMergeStrategy.value
+    assemblyMergeStrategy in assembly := customMergeStrategy.value,
+    logLevel in assembly :=
+      sys.env.get("ASSEMBLY_LOG_LEVEL").flatMap(Level.apply).getOrElse((logLevel in assembly).value)
   )
 
   val ScalaVersion211 = "2.11.11"

--- a/src/bin/travis/testCentaurCwlConformance.sh
+++ b/src/bin/travis/testCentaurCwlConformance.sh
@@ -5,12 +5,11 @@ set -e
 sudo -H pip install --upgrade pip
 sudo -H pip install cwltest
 
-sbt assembly
+ENABLE_COVERAGE=true sbt assembly
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 CENTAUR_CWL_RUNNER="$(pwd)/centaurCwlRunner/src/bin/centaur-cwl-runner.bash"
 
-TEMP_DIR="$(mktemp -d /tmp/centaur.XXXXXX)"
-git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git "${TEMP_DIR}"/common-workflow-language
+git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git
 
 shutdownCromwell() {
     if [ -z "${CROMWELL_PID}" ]; then
@@ -25,6 +24,12 @@ CROMWELL_PID=$$
 
 sleep 5
 
-cd "${TEMP_DIR}"/common-workflow-language
-# For now, always exit with 0.
-./run_test.sh RUNNER="${CENTAUR_CWL_RUNNER}" || true
+(
+    cd common-workflow-language
+    # For now, always exit with 0.
+    ./run_test.sh RUNNER="${CENTAUR_CWL_RUNNER}" || true
+)
+
+sbt coverageReport --warn
+sbt coverageAggregate --warn
+bash <(curl -s https://codecov.io/bash) >/dev/null

--- a/src/bin/travis/testCentaurJes.sh
+++ b/src/bin/travis/testCentaurJes.sh
@@ -143,7 +143,7 @@ docker run --rm \
     -e OUT_PATH=/output \
     broadinstitute/dsde-toolbox render-templates.sh
 
-sbt assembly
+ASSEMBLY_LOG_LEVEL=error ENABLE_COVERAGE=true sbt assembly --error
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 JES_CONF="$(pwd)/jes_centaur.conf"
 JES_REFRESH_TOKEN="$(pwd)/jes_refresh_token.txt"
@@ -160,11 +160,17 @@ fi
 # because pulling the image during some of the tests would cause them to fail
 # (specifically output_redirection which expects a specific value in stderr)
 docker pull ubuntu:latest
+
 centaur/test_cromwell.sh \
   -j${CROMWELL_JAR} \
+  -g \
   -c${JES_CONF} \
   -t${JES_REFRESH_TOKEN} \
   -s${JES_SERVICE_ACCOUNT_JSON} \
   -elocaldockertest \
   -p100 \
   $INTEGRATION_TESTS
+
+sbt coverageReport --warn
+sbt coverageAggregate --warn
+bash <(curl -s https://codecov.io/bash) >/dev/null

--- a/src/bin/travis/testCentaurLocal.sh
+++ b/src/bin/travis/testCentaurLocal.sh
@@ -78,13 +78,17 @@ printTravisHeartbeat
 set -x
 set -e
 
-docker pull ubuntu:latest
-
-sbt assembly
+ASSEMBLY_LOG_LEVEL=error ENABLE_COVERAGE=true sbt assembly --error
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 LOCAL_CONF="$(pwd)/src/bin/travis/resources/local_centaur.conf"
+
 # All tests use ubuntu:latest - make sure it's there before starting the tests
 # because pulling the image during some of the tests would cause them to fail 
 # (specifically output_redirection which expects a specific value in stderr)
 docker pull ubuntu:latest
-centaur/test_cromwell.sh -j"${CROMWELL_JAR}" -c${LOCAL_CONF}
+
+centaur/test_cromwell.sh -j"${CROMWELL_JAR}" -g -c${LOCAL_CONF}
+
+sbt coverageReport --warn
+sbt coverageAggregate --warn
+bash <(curl -s https://codecov.io/bash) >/dev/null

--- a/src/bin/travis/testCheckPublish.sh
+++ b/src/bin/travis/testCheckPublish.sh
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-sbt clean assembly doc
+sbt +clean +package assembly +doc

--- a/src/bin/travis/testSbt.sh
+++ b/src/bin/travis/testSbt.sh
@@ -7,6 +7,7 @@ docker pull ubuntu:latest
 
 ENABLE_COVERAGE=true sbt \
   -Dbackend.providers.Local.config.filesystems.local.localization.0=copy \
-  +clean +nointegration:test coverageReport
-sbt coverageAggregate
-bash <(curl -s https://codecov.io/bash)
+  +clean +nointegration:test
+sbt coverageReport --warn
+sbt coverageAggregate --warn
+bash <(curl -s https://codecov.io/bash) >/dev/null


### PR DESCRIPTION
PR 3 of 3:
1. Remove cromwell-core dependency from cloud-support
2. Run jes centaur on travis
3. Generate coverage for integration tests

---

Publishing test validates executables and cross-versioned libraries/docs.
Updated run_tests_parallel.sh for centaur monorepo.
Quieted centaur runs of sbt assembly and coverage gen/upload.
Don't run problematic no_new_calls on TES.