### PR TITLE
Modified womgraph to make anonymous expressions ghostly

### DIFF
--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -62,7 +62,7 @@ class WomGraph(graphName: String, graph: Graph) {
       s"""
         |${combine((s.inputPorts -- s.scatterCollectionExpressionNode.inputPorts) map portLine)}
         |subgraph $nextCluster {
-        |  style=filled;
+        |  style=${s.graphStyle};
         |  fillcolor=${s.graphFillColor}
         |  "${UUID.randomUUID}" [shape=plaintext label="gather ports"]
         |${indentAndCombine(s.outputPorts map portLine)}
@@ -82,7 +82,7 @@ class WomGraph(graphName: String, graph: Graph) {
     val singleNode =
       s"""
          |subgraph $clusterName {
-         |  style=filled;
+         |  style=${graphNode.graphStyle};
          |  fillcolor=${graphNode.graphFillColor};
          |  ${graphNode.graphId} [shape=plaintext label=${graphNode.graphName}]
          |${indent(portLines(graphNode))}
@@ -104,7 +104,7 @@ class WomGraph(graphName: String, graph: Graph) {
     val innerGraph = listAllGraphNodes(scatter.innerGraph) wrapNodes { n =>
       s"""
          |subgraph $nextCluster {
-         |  style=filled;
+         |  style="filled,solid";
          |  fillcolor=white;
          |${indentAndCombine(n)}
          |}

--- a/womtool/src/main/scala/womtool/graph/package.scala
+++ b/womtool/src/main/scala/womtool/graph/package.scala
@@ -2,7 +2,7 @@ package womtool
 
 import wom.graph.GraphNodePort.{InputPort, OutputPort}
 import wom.graph._
-import wom.graph.expression.ExpressionNode
+import wom.graph.expression.{AnonymousExpressionNode, ExpressionNode}
 
 package object graph {
 
@@ -16,6 +16,11 @@ package object graph {
       case _: PortBasedGraphOutputNode => "yellowgreen"
       case _: ExpressionBasedGraphOutputNode => "palegreen"
       case _ => "white"
+    }
+
+    def graphStyle = graphNode match {
+      case _: AnonymousExpressionNode => "\"filled,dashed\""
+      case _ => "\"filled,solid\""
     }
 
     def graphName: String = dotSafe(graphNode match {


### PR DESCRIPTION
Eg spot the difference between the exposed `err` declaration and the anonymous `b_prime.in_file` expression in:
```wdl
workflow stdout_stderr_passing {
  call a
  call b {input: in_file=a.out}
  File err = a.err
  call b as b_prime {input: in_file=err}
  output {
    b_prime.out
  }
}
```

![test](https://user-images.githubusercontent.com/13006282/33454657-7eba9d28-d5e7-11e7-9774-a17cbf3c63e8.png)

NB: the dashes on the output are accidental, and I believe to-be-removed in an upcoming @mcovarr PR