### PR TITLE
Add flatten type detection

### DIFF
--- a/centaur/src/main/resources/standardTestCases/flatten.test
+++ b/centaur/src/main/resources/standardTestCases/flatten.test
@@ -1,0 +1,30 @@
+name: flatten
+testFormat: workflowsuccess
+
+files {
+  wdl: flatten/flatten.wdl
+}
+
+metadata {
+  "outputs.flatten.flattened_identity.0": 1
+  "outputs.flatten.flattened_identity.1": 0
+  "outputs.flatten.flattened_identity.2": 0
+  "outputs.flatten.flattened_identity.3": 0
+  "outputs.flatten.flattened_identity.4": 1
+  "outputs.flatten.flattened_identity.5": 0
+  "outputs.flatten.flattened_identity.6": 0
+  "outputs.flatten.flattened_identity.7": 0
+  "outputs.flatten.flattened_identity.8": 1
+
+  "outputs.flatten.flattened_map.0.left": 1
+  "outputs.flatten.flattened_map.0.right": "one"
+
+  "outputs.flatten.flattened_map.1.left": 2
+  "outputs.flatten.flattened_map.1.right": "two"
+
+  "outputs.flatten.flattened_map.2.left": 11
+  "outputs.flatten.flattened_map.2.right": "eleven"
+
+  "outputs.flatten.flattened_map.3.left": 22
+  "outputs.flatten.flattened_map.3.right": "twenty-two"
+}

--- a/centaur/src/main/resources/standardTestCases/flatten/flatten.wdl
+++ b/centaur/src/main/resources/standardTestCases/flatten/flatten.wdl
@@ -1,0 +1,18 @@
+workflow flatten {
+
+  Array[Array[Int]] identity = [
+    [1, 0, 0],
+    [0, 1, 0],
+    [0, 0, 1]
+  ]
+
+  Array[Map[Int, String]] list_of_maps = [
+    { 1: "one", 2: "two" },
+    { 11: "eleven", 22: "twenty-two" }
+  ]
+
+  output {
+    Array[Int] flattened_identity = flatten(identity)
+    Array[Pair[Int, String]] flattened_map = flatten(list_of_maps)
+  }
+}


### PR DESCRIPTION
@orodeh it looks like the `WdlStandardLibraryFunctionsType#flatten` method was missing, which meant Cromwell wasn't able to validate workflows with `flatten`s in them.

I also added the coercion so that `flatten(_: Array[Map[_]])` works as expected.