### PR TITLE
Include additional keys in workflow query response

### DIFF
--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -356,6 +356,16 @@ paths:
             returns workflows with all of the specified label keys. Specify the label key
             and label value pair as separated with
             "label-key:label-value"
+        - name: additionalKeys
+          required: false
+          in: query
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          description: >
+            Includes the specified keys in the metadata for the returned workflows.
       tags:
         - Workflows
       responses:

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -356,7 +356,7 @@ paths:
             returns workflows with all of the specified label keys. Specify the label key
             and label value pair as separated with
             "label-key:label-value"
-        - name: additionalKeys
+        - name: additionalQueryResultFields
           required: false
           in: query
           type: array

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -363,7 +363,6 @@ paths:
           items:
             type: string
           collectionFormat: multi
-          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
           description: >
             Includes the specified keys in the metadata for the returned workflows.
       tags:

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -50,6 +50,6 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
     }
   }
 
-  implicit val workflowQueryResult = jsonFormat5(WorkflowQueryResult)
+  implicit val workflowQueryResult = jsonFormat7(WorkflowQueryResult)
   implicit val workflowQueryResponse = jsonFormat1(WorkflowQueryResponse)
 }

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -503,8 +503,8 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
     }
 
     behavior of "REST API /query GET endpoint"
-    it should "return labels if specified in query additionalKeys param" in {
-      Get(s"/workflows/$version/query?additionalKeys=labels&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
+    it should "return labels if specified in additionalQueryResultFields param" in {
+      Get(s"/workflows/$version/query?additionalQueryResultFields=labels&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
         akkaHttpService.workflowRoutes ~>
         check {
           status should be(StatusCodes.OK)
@@ -517,8 +517,8 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
     }
 
     behavior of "REST API /query GET endpoint"
-    it should "return parentWorkflowId if specified in query additionalKeys param" in {
-      Get(s"/workflows/$version/query?additionalKeys=parentWorkflowId&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
+    it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
+      Get(s"/workflows/$version/query?additionalQueryResultFields=parentWorkflowId&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
         akkaHttpService.workflowRoutes ~>
         check {
           status should be(StatusCodes.OK)
@@ -530,8 +530,8 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
     }
 
     behavior of "REST API /query POST endpoint"
-    it should "return labels if specified in query additionalKeys param" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalKeys":"labels"}]""")) ~>
+    it should "return labels if specified in additionalQueryResultFields param" in {
+      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"labels"}]""")) ~>
         akkaHttpService.workflowRoutes ~>
         check {
           assertResult(StatusCodes.OK) {
@@ -544,8 +544,8 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
     }
 
     behavior of "REST API /query POST endpoint"
-    it should "return parentWorkflowId if specified in query additionalKeys param" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalKeys":"parentWorkflowId"}]""")) ~>
+    it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
+      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"parentWorkflowId"}]""")) ~>
         akkaHttpService.workflowRoutes ~>
         check {
           assertResult(StatusCodes.OK) {
@@ -645,14 +645,14 @@ object CromwellApiServiceSpec {
     override def receive = {
       case WorkflowQuery(parameters) =>
         val labels: Option[Map[String, String]] = {
-          if (parameters.contains(("additionalKeys", "labels"))) {
+          if (parameters.contains(("additionalQueryResultFields", "labels"))) {
             Some(Map("key1" -> "label1", "key2" -> "label2"))
           } else {
             None
           }
         }
         val parentWorkflowId: Option[String] =  {
-          if (parameters.contains(("additionalKeys", "parentWorkflowId"))) {
+          if (parameters.contains(("additionalQueryResultFields", "parentWorkflowId"))) {
             Some("pid")
           } else {
             None

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -590,7 +590,7 @@ object CromwellApiServiceSpec {
     override def receive = {
       case WorkflowQuery(_) =>
         val response = WorkflowQuerySuccess(WorkflowQueryResponse(List(WorkflowQueryResult(ExistingWorkflowId.toString,
-          None, Some(WorkflowSucceeded.toString), None, None))), None)
+          None, Some(WorkflowSucceeded.toString), None, None, None, None))), None)
         sender ! response
       case ValidateWorkflowId(id) =>
         if (RecognizedWorkflowIds.contains(id)) sender ! MetadataService.RecognizedWorkflowId

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -17,7 +17,7 @@ object MetadataService {
 
   final val MetadataServiceName = "MetadataService"
 
-  final case class WorkflowQueryResult(id: String, name: Option[String], status: Option[String], start: Option[OffsetDateTime], end: Option[OffsetDateTime])
+  final case class WorkflowQueryResult(id: String, name: Option[String], status: Option[String], start: Option[OffsetDateTime], end: Option[OffsetDateTime], labels: Option[String], parentWorkflowId: Option[String])
 
   final case class WorkflowQueryResponse(results: Seq[WorkflowQueryResult])
 

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -17,7 +17,7 @@ object MetadataService {
 
   final val MetadataServiceName = "MetadataService"
 
-  final case class WorkflowQueryResult(id: String, name: Option[String], status: Option[String], start: Option[OffsetDateTime], end: Option[OffsetDateTime], labels: Option[String], parentWorkflowId: Option[String])
+  final case class WorkflowQueryResult(id: String, name: Option[String], status: Option[String], start: Option[OffsetDateTime], end: Option[OffsetDateTime], labels: Option[Map[String, String]], parentWorkflowId: Option[String])
 
   final case class WorkflowQueryResponse(results: Seq[WorkflowQueryResult])
 

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -92,7 +92,7 @@ object WorkflowQueryKey {
   }
 
   case object AdditionalQueryResultFields extends SeqWorkflowQueryKey[String] {
-    override val name = "AdditionalQueryResultFields"
+    override val name = "Additionalqueryresultfields"
 
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -14,7 +14,7 @@ import cats.instances.list._
 import scala.util.{Success, Try}
 
 object WorkflowQueryKey {
-  val ValidKeys = Set(StartDate, EndDate, Name, Id, Status, LabelKeyValue, Page, PageSize) map { _.name }
+  val ValidKeys = Set(StartDate, EndDate, Name, Id, Status, LabelKeyValue, Page, PageSize, AdditionalKeys) map { _.name }
 
   case object StartDate extends DateTimeWorkflowQueryKey {
     override val name = "Start"
@@ -87,6 +87,18 @@ object WorkflowQueryKey {
         if (Try(WorkflowState.withName(v.toLowerCase.capitalize)).isSuccess) v.validNel[String] else v.invalidNel[String]
       }
       sequenceListOfValidatedNels("Unrecognized status values", nels)
+    }
+  }
+
+  case object AdditionalKeys extends SeqWorkflowQueryKey[String] {
+    override val name = "Additionalkeys"
+
+    override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
+      val values = valuesFromMap(grouped).toList
+      val nels = values map { v =>
+        v.validNel[String]
+      }
+      sequenceListOfValidatedNels("Unrecognized values", nels)
     }
   }
 }

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -14,7 +14,7 @@ import cats.instances.list._
 import scala.util.{Success, Try}
 
 object WorkflowQueryKey {
-  val ValidKeys = Set(StartDate, EndDate, Name, Id, Status, LabelKeyValue, Page, PageSize, AdditionalKeys) map { _.name }
+  val ValidKeys = Set(StartDate, EndDate, Name, Id, Status, LabelKeyValue, Page, PageSize, AdditionalQueryResultFields) map { _.name }
 
   case object StartDate extends DateTimeWorkflowQueryKey {
     override val name = "Start"
@@ -90,8 +90,8 @@ object WorkflowQueryKey {
     }
   }
 
-  case object AdditionalKeys extends SeqWorkflowQueryKey[String] {
-    override val name = "Additionalkeys"
+  case object AdditionalQueryResultFields extends SeqWorkflowQueryKey[String] {
+    override val name = "AdditionalQueryResultFields"
 
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -6,7 +6,7 @@ import cats.data
 import cats.syntax.traverse._
 import cats.syntax.validated._
 import cromwell.core.labels.Label
-import cromwell.core.{WorkflowId, WorkflowState}
+import cromwell.core.{WorkflowId, WorkflowMetadataKeys, WorkflowState}
 import common.validation.ErrorOr._
 import cats.data.Validated._
 import cats.instances.list._
@@ -95,8 +95,10 @@ object WorkflowQueryKey {
 
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList
-      val nels = values map { v =>
-        v.validNel[String]
+      val allowedValues = Seq(WorkflowMetadataKeys.Labels, WorkflowMetadataKeys.ParentWorkflowId)
+      val nels:List[data.ValidatedNel[String,String]] = values map { v => {
+        if (allowedValues.contains(v)) v.validNel[String] else v.invalidNel[String]
+      }
       }
       sequenceListOfValidatedNels("Unrecognized values", nels)
     }

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -10,6 +10,7 @@ import cromwell.core.{WorkflowId, WorkflowMetadataKeys, WorkflowState}
 import common.validation.ErrorOr._
 import cats.data.Validated._
 import cats.instances.list._
+import mouse.boolean._
 
 import scala.util.{Success, Try}
 
@@ -96,10 +97,9 @@ object WorkflowQueryKey {
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList
       val allowedValues = Seq(WorkflowMetadataKeys.Labels, WorkflowMetadataKeys.ParentWorkflowId)
-      val nels:List[data.ValidatedNel[String,String]] = values map { v => {
-        if (allowedValues.contains(v)) v.validNel[String] else v.invalidNel[String]
-      }
-      }
+      val nels: List[ErrorOr[String]] = values map { v => {
+        allowedValues.contains(v).fold(v.validNel[String], v.invalidNel[String])
+      }}
       sequenceListOfValidatedNels("Unrecognized values", nels)
     }
   }

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
@@ -18,7 +18,7 @@ case class WorkflowQueryParameters private(statuses: Set[String],
                                            endDate: Option[OffsetDateTime],
                                            page: Option[Int],
                                            pageSize: Option[Int],
-                                           additionalKeys: Set[String])
+                                           additionalQueryResultFields: Set[String])
 
 object WorkflowQueryParameters {
 
@@ -69,7 +69,7 @@ object WorkflowQueryParameters {
     val labelsValidation: ErrorOr[Set[Label]] = WorkflowQueryKey.LabelKeyValue.validate(valuesByCanonicalCapitalization).map(_.toSet)
     val pageValidation = Page.validate(valuesByCanonicalCapitalization)
     val pageSizeValidation = PageSize.validate(valuesByCanonicalCapitalization)
-    val additionalKeysValidation: ErrorOr[Set[String]] = AdditionalKeys.validate(valuesByCanonicalCapitalization).map(_.toSet)
+    val additionalQueryResultFieldsValidation: ErrorOr[Set[String]] = AdditionalQueryResultFields.validate(valuesByCanonicalCapitalization).map(_.toSet)
 
     // Only validate start before end if both of the individual date parsing validations have already succeeded.
     val startBeforeEndValidation: ErrorOr[Unit] = (startDateValidation, endDateValidation) match {
@@ -87,7 +87,7 @@ object WorkflowQueryParameters {
       endDateValidation,
       pageValidation,
       pageSizeValidation,
-      additionalKeysValidation) mapN { (_, _, statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalKeys) => WorkflowQueryParameters(statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalKeys) }
+      additionalQueryResultFieldsValidation) mapN { (_, _, statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalQueryResultFields) => WorkflowQueryParameters(statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalQueryResultFields) }
   }
 
   def apply(rawParameters: Seq[(String, String)]): WorkflowQueryParameters = {

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
@@ -17,7 +17,8 @@ case class WorkflowQueryParameters private(statuses: Set[String],
                                            startDate: Option[OffsetDateTime],
                                            endDate: Option[OffsetDateTime],
                                            page: Option[Int],
-                                           pageSize: Option[Int])
+                                           pageSize: Option[Int],
+                                           additionalKeys: Set[String])
 
 object WorkflowQueryParameters {
 
@@ -68,6 +69,7 @@ object WorkflowQueryParameters {
     val labelsValidation: ErrorOr[Set[Label]] = WorkflowQueryKey.LabelKeyValue.validate(valuesByCanonicalCapitalization).map(_.toSet)
     val pageValidation = Page.validate(valuesByCanonicalCapitalization)
     val pageSizeValidation = PageSize.validate(valuesByCanonicalCapitalization)
+    val additionalKeysValidation: ErrorOr[Set[String]] = AdditionalKeys.validate(valuesByCanonicalCapitalization).map(_.toSet)
 
     // Only validate start before end if both of the individual date parsing validations have already succeeded.
     val startBeforeEndValidation: ErrorOr[Unit] = (startDateValidation, endDateValidation) match {
@@ -84,7 +86,8 @@ object WorkflowQueryParameters {
       startDateValidation,
       endDateValidation,
       pageValidation,
-      pageSizeValidation) mapN { (_, _, statuses, names, ids, labels, startDate, endDate, page, pageSize) => WorkflowQueryParameters(statuses, names, ids, labels, startDate, endDate, page, pageSize) }
+      pageSizeValidation,
+      additionalKeysValidation) mapN { (_, _, statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalKeys) => WorkflowQueryParameters(statuses, names, ids, labels, startDate, endDate, page, pageSize, additionalKeys) }
   }
 
   def apply(rawParameters: Seq[(String, String)]): WorkflowQueryParameters = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -202,6 +202,17 @@ trait MetadataDatabaseAccess {
         )
       }
 
+      def metadataEntriesToValue(entries: Seq[MetadataEntry]): Option[String] = {
+        entries.headOption.flatMap(_.metadataValue.toRawStringOption)
+      }
+
+      def keyToMetadataValue(key: String): Future[Option[String]] = {
+        val metadataEntries: Future[Seq[MetadataEntry]] = metadataDatabaseInterface.queryMetadataEntries(workflow.workflowExecutionUuid, key)
+        metadataEntries map { entries =>
+          metadataEntriesToValue(entries)
+        }
+      }
+
       def getWorkflowLabels: Future[Map[String, String]] = {
         if (queryParameters.additionalKeys.contains(WorkflowMetadataKeys.Labels)) {
           metadataDatabaseInterface.getWorkflowLabels(workflow.workflowExecutionUuid)
@@ -216,17 +227,6 @@ trait MetadataDatabaseAccess {
         } else {
           Future.successful(None)
         }
-      }
-
-      def keyToMetadataValue(key: String): Future[Option[String]] = {
-        val metadataEntries: Future[Seq[MetadataEntry]] = metadataDatabaseInterface.queryMetadataEntries(workflow.workflowExecutionUuid, key)
-        metadataEntries map { entries =>
-          metadataEntriesToValue(entries)
-        }
-      }
-
-      def metadataEntriesToValue(entries: Seq[MetadataEntry]): Option[String] = {
-        entries.headOption.flatMap(_.metadataValue.toRawStringOption)
       }
 
       val result: Future[MetadataService.WorkflowQueryResult] = for {

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -214,7 +214,7 @@ trait MetadataDatabaseAccess {
       }
 
       def getWorkflowLabels: Future[Map[String, String]] = {
-        if (queryParameters.additionalKeys.contains(WorkflowMetadataKeys.Labels)) {
+        if (queryParameters.additionalQueryResultFields.contains(WorkflowMetadataKeys.Labels)) {
           metadataDatabaseInterface.getWorkflowLabels(workflow.workflowExecutionUuid)
         } else {
           Future.successful(Map.empty)
@@ -222,7 +222,7 @@ trait MetadataDatabaseAccess {
       }
 
       val getParentWorkflowId: Future[Option[String]] = {
-        if (queryParameters.additionalKeys.contains(WorkflowMetadataKeys.ParentWorkflowId)) {
+        if (queryParameters.additionalQueryResultFields.contains(WorkflowMetadataKeys.ParentWorkflowId)) {
           keyToMetadataValue(WorkflowMetadataKeys.ParentWorkflowId)
         } else {
           Future.successful(None)


### PR DESCRIPTION
Update the `query` endpoint to take in an `additionalKeys` parameter, which will include the specified keys in the returned workflow metadata. This currently just supports "labels" and "parentWorkflowId" but can be expanded later if necessary.

E.g. A GET request to `http://localhost:8000/api/workflows/v1/query?additionalKeys=parentWorkflowId` would return: 

```
{
  "results": [
    {
      "name": "test",
      "id": "4e1bf4b5-caea-4e8a-9cd3-f48ac8d11393",
      "status": "Failed",
      "parentWorkflowId": "21b58d24-7f14-4e45-a45a-5e8678fd83cb",
      "end": "2017-12-01T19:00:23.778-05:00",
      "start": "2017-12-01T19:00:16.738-05:00"
    }
  ]
}
```

A GET request to `http://localhost:8000/api/workflows/v1/query?additionalKeys=labels` would return: 

```
{
  "results": [
    {
      "name": "use_sub_wfs",
      "id": "21b58d24-7f14-4e45-a45a-5e8678fd83cb",
      "labels": {
        "project": "test",
        "version": "2",
        "cromwell-workflow-id": "cromwell-21b58d24-7f14-4e45-a45a-5e8678fd83cb"
      },
      "status": "Failed",
      "end": "2017-12-01T19:00:24.627-05:00",
      "start": "2017-12-01T19:00:14.210-05:00"
    }
  ]
}
```