### PR TITLE
Patches for problematic tests.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/no_new_calls/no_new_calls.wdl
+++ b/centaur/src/main/resources/standardTestCases/no_new_calls/no_new_calls.wdl
@@ -22,8 +22,27 @@ task shouldNotStart {
 
 task shouldSucceed {
   String str
+
+  # For this test to pass, currently `sleep` must be large as JES can take minutes to run a job. Otherwise, if
+  # shouldSuceed finishes before boundToFail, delayedTask2 may still attempt a restart.
+
+  # Example where delayedTask2 attempts restart by 17:13:43, while boundToFail doesn't return until 13 seconds later:
+
+  # boundToFail         submitted       17:08:14  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L3312
+  # shouldSucceed       submitted       17:08:26  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L3616
+  # boundToFail        initializing     17:08:27  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L3680
+  # shouldSucceed      initializing     17:08:38  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L3735
+  # shouldSucceed        running        17:09:13  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L3864
+  # <cromwell>           restart        17:10:59  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L4825
+  # boundToFail          restart        17:11:23  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L5170
+  # shouldSucceed        restart        17:11:24  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L5270
+  # boundToFail          running        17:11:34  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L5471
+  # shouldSucceed        finish         17:11:35  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L5490
+  # delayedTask2   >>    restart    <<  17:13:43  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L6212
+  # boundToFail          finish         17:13:56  https://travis-ci.org/broadinstitute/cromwell/jobs/310544199#L6259
+
     command {
-     sleep 100
+     sleep 300
      echo ${str}
     }
     runtime {

--- a/src/bin/travis/resources/local_centaur.conf
+++ b/src/bin/travis/resources/local_centaur.conf
@@ -22,6 +22,11 @@ call-caching {
 system.graceful-server-shutdown = true
 
 backend.providers {
+  Local {
+    config {
+      script-epilogue = "sleep 5 && sync"
+    }
+  }
   LocalNoDocker {
     actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
     config {
@@ -29,6 +34,7 @@ backend.providers {
       runtime-attributes = ""
       submit = "/bin/bash ${script}"
       root: "cromwell-executions"
+      script-epilogue = "sleep 5 && sync"
 
       filesystems {
         local {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -25,7 +25,7 @@ import scala.concurrent.duration._
 
 class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpec") with FlatSpecLike with Matchers
   with ImplicitSender with Mockito {
-  val Timeout: FiniteDuration = 5.second.dilated
+  val Timeout: FiniteDuration = 10.second.dilated
 
   import BackendSpec._
   import JesInitializationActorSpec._

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 class SharedFileSystemInitializationActorSpec extends TestKitSuite("SharedFileSystemInitializationActorSpec")
   with WordSpecLike with Matchers with ImplicitSender {
-  val Timeout: FiniteDuration = 5.second.dilated
+  val Timeout: FiniteDuration = 10.second.dilated
 
   val HelloWorld: String =
     s"""

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkInitializationActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkInitializationActorSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 class SparkInitializationActorSpec  extends  TestKitSuite("SparkInitializationActorSpec")
   with WordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
 
-  val Timeout = 5.second.dilated
+  val Timeout = 10.second.dilated
 
   val HelloWorld =
     """


### PR DESCRIPTION
JES/SFS/Spark initialization specs use same timeout as TES.
Sleep more on no_new_calls to help JES from restarting delayedTask2.
Sleep a bit on local before sync'ing to help avoid (reworded) NoSuchFileException's.