### PR TITLE
Customizable input identifier

### DIFF
--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -65,11 +65,11 @@ case class Workflow private(
 
         // TODO: Eurgh! But until we have something better ...
         val womValue = womType.coerceRawValue(inputParameter.default.get).get
-        OptionalGraphInputNodeWithDefault(WomIdentifier(parsedInputId), womType, ValueAsAnExpression(womValue))
+        OptionalGraphInputNodeWithDefault(WomIdentifier(parsedInputId, inputParameter.id), womType, ValueAsAnExpression(womValue), parsedInputId)
       case input =>
         val parsedInputId = FileAndId(input.id).id
 
-        RequiredGraphInputNode(WomIdentifier(parsedInputId), wdlTypeForInputParameter(input).get)
+        RequiredGraphInputNode(WomIdentifier(parsedInputId, input.id), wdlTypeForInputParameter(input).get, parsedInputId)
     }.toSet
 
     val workflowInputs: Map[String, GraphNodeOutputPort] =

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -81,7 +81,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
             case exprNode: ExpressionNode if exprNode.localName == s"file://$rootPath/1st-workflow.cwl#untar/tarfile" =>
               exprNode.inputPorts.map(_.upstream.graphNode).count {
                 case rgin: RequiredGraphInputNode =>
-                  rgin.identifier == WomIdentifier("inp") &&
+                  rgin.identifier.localName == LocalName("inp") &&
                     rgin.womType == WomFileType
               }  shouldBe 1
           }).getOrElse(fail("Can't find expression node for inp"))

--- a/wdl/src/main/scala/wdl/Declaration.scala
+++ b/wdl/src/main/scala/wdl/Declaration.scala
@@ -145,9 +145,9 @@ object Declaration {
     }
 
     def asWorkflowInput(inputDefinition: InputDefinition): GraphInputNode = inputDefinition match {
-      case RequiredInputDefinition(_, womType) => RequiredGraphInputNode(decl.womIdentifier, womType)
-      case OptionalInputDefinition(_, optionalType) => OptionalGraphInputNode(decl.womIdentifier, optionalType)
-      case InputDefinitionWithDefault(_, womType, default) => OptionalGraphInputNodeWithDefault(decl.womIdentifier, womType, default)
+      case RequiredInputDefinition(_, womType) => RequiredGraphInputNode(decl.womIdentifier, womType, decl.womIdentifier.fullyQualifiedName.value)
+      case OptionalInputDefinition(_, optionalType) => OptionalGraphInputNode(decl.womIdentifier, optionalType, decl.womIdentifier.fullyQualifiedName.value)
+      case InputDefinitionWithDefault(_, womType, default) => OptionalGraphInputNodeWithDefault(decl.womIdentifier, womType, default, decl.womIdentifier.fullyQualifiedName.value)
     }
 
     (decl.asWorkflowInput, decl) match {

--- a/wdl/src/main/scala/wdl/WdlCall.scala
+++ b/wdl/src/main/scala/wdl/WdlCall.scala
@@ -140,13 +140,13 @@ object WdlCall {
         // so that it can be satisfied via workflow inputs
         case required@RequiredInputDefinition(n, womType) =>
           val identifier = wdlCall.womIdentifier.combine(n)
-          withGraphInputNode(required, RequiredGraphInputNode(identifier, womType))
+          withGraphInputNode(required, RequiredGraphInputNode(identifier, womType, identifier.fullyQualifiedName.value))
 
         // No input mapping, no default value but optional, create a OptionalGraphInputNode
         // so that it can be satisfied via workflow inputs
         case optional@OptionalInputDefinition(n, womType) =>
           val identifier = wdlCall.womIdentifier.combine(n)
-          withGraphInputNode(optional, OptionalGraphInputNode(identifier, womType))
+          withGraphInputNode(optional, OptionalGraphInputNode(identifier, womType, identifier.fullyQualifiedName.value))
       }
     }
 

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -47,7 +47,7 @@ object Executable {
     }
 
     def fallBack(gin: ExternalGraphInputNode): ErrorOr[ResolvedExecutableInput] = gin match {
-      case required: RequiredGraphInputNode => s"Required workflow input '${required.identifier.fullyQualifiedName.value}' not specified".invalidNel
+      case required: RequiredGraphInputNode => s"Required workflow input '${required.nameInInputSet}' not specified".invalidNel
       case optionalWithDefault: OptionalGraphInputNodeWithDefault => Coproduct[ResolvedExecutableInput](optionalWithDefault.default).validNel
       case optional: OptionalGraphInputNode => Coproduct[ResolvedExecutableInput](optional.womType.none: WomValue).validNel
     }

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -27,7 +27,6 @@ object Executable {
   type InputParsingFunction = String => Checked[ParsedInputMap]
   type ParsedInputMap = Map[String, DelayedCoercionFunction]
   type DelayedCoercionFunction = WomType => ErrorOr[WomValue]
-  type EGINInputIdentifier = ExternalGraphInputNode => String
   
   /*
     * Maps output ports from graph input nodes to ResolvedExecutableInput

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -27,6 +27,7 @@ object Executable {
   type InputParsingFunction = String => Checked[ParsedInputMap]
   type ParsedInputMap = Map[String, DelayedCoercionFunction]
   type DelayedCoercionFunction = WomType => ErrorOr[WomValue]
+  type EGINInputIdentifier = ExternalGraphInputNode => String
   
   /*
     * Maps output ports from graph input nodes to ResolvedExecutableInput
@@ -42,7 +43,7 @@ object Executable {
     */
   private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction]): ErrorOr[ResolvedExecutableInputs] = {
     def fromInputMapping(gin: ExternalGraphInputNode): Option[ErrorOr[ResolvedExecutableInput]] = {
-      inputCoercionMap.get(gin.identifier.fullyQualifiedName.value).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
+      inputCoercionMap.get(gin.nameInInputSet).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
     }
 
     def fallBack(gin: ExternalGraphInputNode): ErrorOr[ResolvedExecutableInput] = gin match {

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -51,6 +51,7 @@ object TaskCall {
     
     // Creates an identifier for an input or an output
     // The localName is the name of the input or output
+    
     // The FQN combines the name of the task to the name of the input or output
     def identifier(name: LocalName) = WomIdentifier(name, taskDefinitionLocalName.combineToFullyQualifiedName(name))
 
@@ -64,9 +65,9 @@ object TaskCall {
     val inputDefinitionFold = taskDefinition.inputs.foldMap({ inputDef =>
     {
       val newNode = inputDef match {
-        case RequiredInputDefinition(name, womType) => RequiredGraphInputNode(identifier(name), womType)
-        case InputDefinitionWithDefault(name, womType, default) => OptionalGraphInputNodeWithDefault(identifier(name), womType, default)
-        case OptionalInputDefinition(name, womType) => OptionalGraphInputNode(identifier(name), womType)
+        case RequiredInputDefinition(name, womType) => RequiredGraphInputNode(identifier(name), womType, name.value)
+        case InputDefinitionWithDefault(name, womType, default) => OptionalGraphInputNodeWithDefault(identifier(name), womType, default, name.value)
+        case OptionalInputDefinition(name, womType) => OptionalGraphInputNode(identifier(name), womType, name.value)
       }
 
       InputDefinitionFold(

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -49,8 +49,9 @@ object TaskCall {
   def graphFromDefinition(taskDefinition: TaskDefinition): ErrorOr[Graph] = {
     val taskDefinitionLocalName = LocalName(taskDefinition.name)
     
-    // Creates an identifier for an input or an output
-    // The localName is the name of the input or output
+    /* Creates an identifier for an input or an output
+     * The localName is the name of the input or output
+     */
     
     // The FQN combines the name of the task to the name of the input or output
     def identifier(name: LocalName) = WomIdentifier(name, taskDefinitionLocalName.combineToFullyQualifiedName(name))
@@ -92,8 +93,9 @@ object TaskCall {
 }
 
 object CallNode {
-  // A monoid can't be derived automatically for this class because it contains a Map[InputDefinition, InputDefinitionPointer],
-  // and there's no monoid defined over InputDefinitionPointer
+  /* A monoid can't be derived automatically for this class because it contains a Map[InputDefinition, InputDefinitionPointer],
+   * and there's no monoid defined over InputDefinitionPointer
+   */
   implicit val inputDefinitionFoldMonoid = new Monoid[InputDefinitionFold] {
     override def empty: InputDefinitionFold = InputDefinitionFold()
     override def combine(x: InputDefinitionFold, y: InputDefinitionFold): InputDefinitionFold = {

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -38,18 +38,26 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
     */
   
   override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier, womType, this)
+
+  /**
+    * Key that should be looked for in the input set to satisfy this GIN
+    */
+  def nameInInputSet: String
 }
 
 final case class RequiredGraphInputNode(override val identifier: WomIdentifier,
-                                        womType: WomType) extends ExternalGraphInputNode
+                                        womType: WomType,
+                                        nameInInputSet: String) extends ExternalGraphInputNode
 
 final case class OptionalGraphInputNode(override val identifier: WomIdentifier,
-                                        womType: WomOptionalType) extends ExternalGraphInputNode
+                                        womType: WomOptionalType,
+                                        nameInInputSet: String) extends ExternalGraphInputNode
 
 // If we want to allow defaults to be "complex" expressions with dependencies we may need to make it an InstantiatedExpression here instead
 final case class OptionalGraphInputNodeWithDefault(override val identifier: WomIdentifier,
                                                    womType: WomType,
-                                                   default: WomExpression) extends ExternalGraphInputNode
+                                                   default: WomExpression,
+                                                   nameInInputSet: String) extends ExternalGraphInputNode
 
 object OuterGraphInputNode {
   def apply(forIdentifier: WomIdentifier, linkToOuterGraph: GraphNodePort.OutputPort, preserveScatterIndex: Boolean): OuterGraphInputNode = {

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -40,7 +40,7 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
   override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier, womType, this)
 
   /**
-    * Key that should be looked for in the input set to satisfy this GIN
+    * Key that should be looked for in the input set to satisfy this EGIN
     */
   def nameInInputSet: String
 }

--- a/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
@@ -28,8 +28,8 @@ class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
     */
   it should "create and wire in InstantiatedExpressions where appropriate" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType)
-    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType, "i")
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType, "j")
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WomIntegerType)

--- a/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
@@ -26,8 +26,8 @@ class ExpressionNodeSpec extends FlatSpec with Matchers {
     */
   it should "construct an ExpressionNode if inputs are available" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType)
-    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType, "i")
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType, "j")
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WomIntegerType)

--- a/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
@@ -11,8 +11,8 @@ class GraphOutputNodeSpec extends FlatSpec with Matchers {
 
   it should "construct an ExpressionBasedGraphOutputNode node if inputs are available" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType)
-    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType, "i")
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType, "j")
 
     // Declare a port output from i:
     val jOutput = PortBasedGraphOutputNode(WomIdentifier("j_out"), WomIntegerType, jInputNode.singleOutputPort)

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -48,7 +48,7 @@ class GraphSpec extends FlatSpec with Matchers {
       inputs = List(wcInFile)
     )
     
-    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("cgrep.pattern"), WomStringType)
+    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("cgrep.pattern"), WomStringType, "cgrep.pattern")
     
     val psNodeBuilder = new CallNodeBuilder()
     
@@ -113,7 +113,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val threeStepWorkflow = WorkflowDefinition("three_step", threeStepGraph, Map.empty, Map.empty, List.empty)
     val threeStepNodeBuilder = new CallNodeBuilder()
 
-    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("three_step.cgrep.pattern"), WomStringType)
+    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("three_step.cgrep.pattern"), WomStringType, "three_step.cgrep.pattern")
     
     val inputDefinitionFold = InputDefinitionFold(
       mappings = List.empty,
@@ -138,10 +138,10 @@ class GraphSpec extends FlatSpec with Matchers {
   }
   
   it should "fail to validate a Graph with duplicate identifiers" in {
-    val nodeA = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WomStringType)
-    val nodeB = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WomIntegerType)
-    val nodeC = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WomStringType)
-    val nodeD = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WomIntegerType)
+    val nodeA = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WomStringType, "foo.bar")
+    val nodeB = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WomIntegerType, "foo.bar")
+    val nodeC = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WomStringType, "foo.baz")
+    val nodeD = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WomIntegerType, "foo.baz")
     
     Graph.validateAndConstruct(Set(nodeA, nodeB, nodeC, nodeD)) match {
       case Valid(_) => fail("Graph should not validate")

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -48,7 +48,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     *
     */
   it should "be able to wrap a single task call" in {
-    val xs_inputNode = RequiredGraphInputNode(WomIdentifier("xs"), WomArrayType(WomIntegerType))
+    val xs_inputNode = RequiredGraphInputNode(WomIdentifier("xs"), WomArrayType(WomIntegerType), "xs")
 
     val xsExpression = PlaceholderWomExpression(Set("xs"), WomArrayType(WomIntegerType))
     val xsExpressionAsInput = AnonymousExpressionNode

--- a/womtool/src/test/scala/womtool/graph/ExpressionBasedGraphOutputNodeSpec.scala
+++ b/womtool/src/test/scala/womtool/graph/ExpressionBasedGraphOutputNodeSpec.scala
@@ -9,8 +9,8 @@ class ExpressionBasedGraphOutputNodeSpec extends WomDotGraphTest {
 
   val expressionOutputGraph = {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType)
-    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType, "i")
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType, "j")
 
     // Declare a port output from i:
     val jOutput = PortBasedGraphOutputNode(WomIdentifier("j_out"), WomIntegerType, jInputNode.singleOutputPort)

--- a/womtool/src/test/scala/womtool/graph/ExpressionNodeSpec.scala
+++ b/womtool/src/test/scala/womtool/graph/ExpressionNodeSpec.scala
@@ -10,8 +10,8 @@ class ExpressionNodeSpec extends WomDotGraphTest {
 
   val expressionNodeGraph = {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType)
-    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WomIntegerType, "i")
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WomIntegerType, "j")
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WomIntegerType)


### PR DESCRIPTION
A bunch of CWL tests fail at materialization time because CWL expects the keys in the input file to be the "local name" of the input whereas WDL expects the "fully qualified name" 
e.g

cwl:
```
{
  "my_input": "hello"
}
``` 

wdl:
```
{
  "my_workflow.my_input": "hello"
}
```

This allows each language to define how an `ExternalGraphInputNode` should be mapped to a `String` to look for in the input file.