### PR TITLE
Readable error message for invalid indexing

### DIFF
--- a/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
+++ b/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
@@ -111,9 +111,9 @@ case class TypeEvaluator(override val lookup: String => WomType, override val fu
       (evaluate(a.getAttribute("lhs")), evaluate(a.getAttribute("rhs"))) match {
         case (Success(a: WomArrayType), Success(WomIntegerType)) => Success(a.memberType)
         case (Success(m: WomMapType), Success(_: WomType)) => Success(m.valueType)
-        case (Failure(ex), _) => Failure(ex)
-        case (_, Failure(ex)) => Failure(ex)
-        case (_, _) => Failure(new WomExpressionException(s"Can't index ${a.toPrettyString}"))
+        case (Success(otherLhs), Success(_)) => Failure(new WomExpressionException(s"Invalid indexing target. You cannot index a value of type '${otherLhs.toDisplayString}'"))
+        case (f: Failure[_], _) => f
+        case (_, f: Failure[_]) => f
       }
     case a: Ast if a.isFunctionCall =>
       val name = a.getAttribute("name").sourceString


### PR DESCRIPTION
For the example in #3007 replaces this message:
```
Unable to build WOM node for If '$if_2': Unable to build WOM node for Scatter '$scatter_2': Unable to build WOM node for WdlTaskCall 't3': Can't index (ArrayOrMapLookup:
  lhs=(MemberAccess:
    lhs=<string:19:29 identifier "dDI=">,
    rhs=<string:19:32 identifier "b3V0">
  ),
  rhs=<string:19:36 identifier "aQ==">
)
```

With this one:
```
Unable to build WOM node for If '$if_2': Unable to build WOM node for Scatter '$scatter_2': Unable to build WOM node for WdlTaskCall 't3': 
Invalid indexing target. You cannot index a value of type 'Array[Int]?'
```