### PR TITLE
Improve Error messaging surrounding Cwl parsing

### DIFF
--- a/cwl/src/main/scala/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/cwl/CwlCodecs.scala
@@ -16,13 +16,12 @@ import cats.syntax.show._
 object CwlCodecs {
   import Implicits._
 
-  def decodeCwl(in: String): Either[NonEmptyList[String], Cwl] = {
+  def decodeCwl(cwlWorkflow: String): Either[NonEmptyList[String], Cwl] = {
     //try to parse both and combine errors if they fail
-    (decode[Workflow](in), decode[CommandLineTool](in)) match {
+    (decode[Workflow](cwlWorkflow), decode[CommandLineTool](cwlWorkflow)) match {
       case (Right(wf), _) => Coproduct[Cwl](wf).asRight
       case (_, Right(clt)) => Coproduct[Cwl](clt).asRight
       case (Left(wfError), Left(cltError)) =>
-        //This is not really suppressed but there is no other way to compose errors at the Exception level API AFAIK
         NonEmptyList.of(
           s"Workflow parsing error: ${wfError.show}",
           s"Command Line Tool parsing error: ${cltError.show}"

--- a/cwl/src/main/scala/cwl/Decoder.scala
+++ b/cwl/src/main/scala/cwl/Decoder.scala
@@ -9,7 +9,6 @@ import cats.Applicative
 import better.files.{File => BFile}
 import common.validation.ErrorOr._
 import common.legacy.TwoElevenSupport._
-import io.circe.{DecodingFailure, ParsingFailure}
 import EitherT._
 import better.files.File.newTemporaryFile
 
@@ -39,14 +38,7 @@ object CwlDecoder {
     fromEither[IO](cwlToolResult flatMap resultToEither)
   }
 
-  def parseJson(json: String): Parse[Cwl] =
-    fromEither[IO] {
-      CwlCodecs.decodeCwl(json).
-        leftMap{
-          case df@DecodingFailure(message, ops) => NonEmptyList.of(message, ops.mkString("\n"), df.getStackTrace.mkString("\n"))
-          case ParsingFailure(message, underlying) => NonEmptyList.of(message, underlying.getMessage, underlying.getStackTrace.mkString("\n"))
-        }
-    }
+  def parseJson(json: String): Parse[Cwl] = fromEither[IO](CwlCodecs.decodeCwl(json))
 
   /**
    * Notice it gives you one instance of Cwl.  This has transformed all embedded files into scala object state

--- a/cwl/src/test/scala/cwl/ParsingSpec.scala
+++ b/cwl/src/test/scala/cwl/ParsingSpec.scala
@@ -1,31 +1,30 @@
 package cwl
 
-import io.circe.parser._
-import CwlCodecs._
+import CwlDecoder._
 import org.scalatest.{FlatSpec, Matchers}
 
 class WorkflowParsingSpec extends FlatSpec with Matchers {
 
   behavior of "Workflow Json Parser"
 
-  def workflowJson(classValue: String) = s"""{"class":"$classValue", "id": "MyCwlWorkflow", "inputs":[], "outputs":[], "steps":[]}"""
+  def workflowJson(classValue: String) = s"""{"class":"$classValue", "cwlVersion": "v1.0", "id": "MyCwlWorkflow", "inputs":[], "outputs":[], "steps":[]}"""
 
   it should "accept the Workflow argument" in {
-     decode[Workflow](workflowJson("Workflow")) match {
+     decodeTopLevelCwl(workflowJson("Workflow")).value.unsafeRunSync() match {
        case Right(_) => // great!
-       case Left(e) => fail(s"Workflow rejected because: ${e.getMessage}")
+       case Left(e) => fail(s"Workflow rejected because: ${e.toList.mkString(", ")}")
      }
   }
 
   it should "not parse w/something other than Workflow as class" in {
-    decode[Workflow](workflowJson("wrong")) match {
+    decodeTopLevelCwl(workflowJson("wrong")).value.unsafeRunSync() match {
       case Left(_) => // great!
       case Right(wf) => fail(s"workflow unexpectedly accepted: $wf")
     }
   }
 
   it should "not parse when class argument is missing" in {
-    decode[Workflow]("""{"inputs":[], "outputs":[], "steps":[]}""") match {
+    decodeTopLevelCwl("""{"cwlVersion": "v1.0", "inputs":[], "outputs":[], "steps":[]}""").value.unsafeRunSync() match {
       case Left(_) => // great!
       case Right(wf) => fail(s"workflow unexpectedly accepted: $wf")
     }
@@ -36,24 +35,24 @@ class CommandLineToolParsingSpec extends FlatSpec with Matchers {
 
   behavior of "CommandLineTool Json Parser"
 
-  def commandLineToolJson(classValue: String) = s"""{"class":"$classValue", "id": "MyCwlTask", "inputs":[], "outputs":[]}"""
+  def commandLineToolJson(classValue: String) = s"""{"class":"$classValue", "cwlVersion":"v1.0", "id": "MyCwlTask", "inputs":[], "outputs":[]}"""
 
   it should "accept the CommandLineTool argument for class" in {
-    decode[CommandLineTool](commandLineToolJson("CommandLineTool")) match {
+    decodeTopLevelCwl(commandLineToolJson("CommandLineTool")).value.unsafeRunSync() match {
       case Right(_) => // great!
       case Left(e) => fail(s"CommandLineTool rejected because: $e")
     }
   }
 
   it should "not parse w/something other than CommandLineTool" in {
-    decode[CommandLineTool](commandLineToolJson("wrong")) match {
+    decodeTopLevelCwl(commandLineToolJson("wrong")).value.unsafeRunSync() match {
       case Left(_) => // great!
       case Right(clt) => fail(s"CommandLineTool unexpectedly accepted: $clt")
     }
   }
 
   it should "doesn't parse when class argument is missing" in {
-    decode[CommandLineTool]("""{"inputs":[], "outputs":[]}""") match {
+    decodeTopLevelCwl("""{"inputs":[], "outputs":[]}""").value.unsafeRunSync() match {
       case Left(_) => // great!
       case Right(clt) => fail(s"CommandLineTool unexpectedly accepted: $clt")
     }


### PR DESCRIPTION
this will spit out more informative errors when a user encounters a parsing error:

![image](https://user-images.githubusercontent.com/165320/33690130-25f3b10c-dab0-11e7-8221-275ea9abec20.png)

Unfortunately this has to be done by hand as the `Coproduct` parser in circe only returns the `CNil` by virtue of its automaticness.

As such we will continue to hit `CNil` in deeper parts of the code(as seen in this example!) unless we write `Decoder`s by hand for all of our coproducts or figure out a way to implement error accumulation in Coproduct decoder derivation and submit a patch to Circe. For reference the offending code is [here](https://github.com/circe/circe/blob/master/modules/shapes/src/main/scala/io/circe/shapes/CoproductInstances.scala#L18)