### PR TITLE
DockerRequirement [PREGULL]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: deprecated-2017Q4
 services:
   - docker
   - mysql

--- a/centaur/src/main/resources/standardTestCases/three_step.test
+++ b/centaur/src/main/resources/standardTestCases/three_step.test
@@ -18,4 +18,7 @@ metadata {
   "calls.wc.executionStatus": Done
   "calls.ps.executionStatus": Done
   "calls.cgrep.executionStatus": Done
+  "calls.ps.runtimeAttributes.docker": "ubuntu:bionic"
+  "calls.wc.runtimeAttributes.docker": "ubuntu:latest"
+  "calls.cgrep.runtimeAttributes.docker": "ubuntu:latest"
 }

--- a/centaur/src/main/resources/standardTestCases/three_step/three_step.cwl
+++ b/centaur/src/main/resources/standardTestCases/three_step/three_step.cwl
@@ -2,13 +2,7 @@ cwlVersion: v1.0
 class: Workflow
 id: three_step
 hints:
-# hints can be anything (CwlAny)
-- fee: fi
-  fo: fum
-- eenie: meenie
-  minie: mo
-- 42
-- DockerRequirement:
+  DockerRequirement:
     dockerPull: "ubuntu:latest"
 inputs:
 - id: pattern
@@ -37,7 +31,7 @@ steps:
       # Check it: this DockerRequirement does not use the `class` formatting but should still parse
       # thanks to the magic of SALAD.
       DockerRequirement:
-        dockerPull: "debian:wheezy"
+        dockerPull: "ubuntu:bionic"
     baseCommand: ps
     stdout: ps-stdOut.txt
 - id: cgrep

--- a/cwl/src/main/scala-2.12/cwl/CwlExecutableValidation.scala
+++ b/cwl/src/main/scala-2.12/cwl/CwlExecutableValidation.scala
@@ -9,7 +9,8 @@ import io.circe.yaml
 import io.circe.literal._
 import common.Checked
 import common.validation.Checked._
-import wom.callable.ExecutableCallable
+import common.validation.ErrorOr.ErrorOr
+import wom.callable.{CallableTaskDefinition, ExecutableCallable, ExecutableTaskDefinition}
 import wom.executable.Executable
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
 
@@ -33,6 +34,14 @@ object CwlExecutableValidation {
     for {
       womDefinition <- callable
       executable <- Executable.withInputs(womDefinition, inputCoercionFunction, inputFile)
+    } yield executable
+  }
+
+  def buildWomExecutable(callableTaskDefinition: ErrorOr[CallableTaskDefinition], inputFile: Option[String]): Checked[Executable] = {
+    for {
+      taskDefinition <- callableTaskDefinition.toEither
+      executableTaskDefinition = ExecutableTaskDefinition.tryApply(taskDefinition).toEither
+      executable <- CwlExecutableValidation.buildWomExecutable(executableTaskDefinition, inputFile)
     } yield executable
   }
 }

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -67,7 +67,7 @@ case class InputParameterCommandPart(commandInputParameter: CommandInputParamete
         case cip: CommandInputParameter =>
           val localizedId = LocalName(FullyQualifiedName(cip.id).id)
           inputsMap.get(localizedId) match {
-            case Some(x) =>x
+            case Some(x) => valueMapper(x)
             case _ => throw new RuntimeException(s"could not find $localizedId in map $inputsMap")
           }
 

--- a/cwl/src/main/scala/cwl/CwlInputParsingPoly.scala
+++ b/cwl/src/main/scala/cwl/CwlInputParsingPoly.scala
@@ -9,21 +9,21 @@ import wom.types.{WomArrayType, WomFileType, WomType}
 import wom.values._
 
 private [cwl] object CwlInputCoercion extends Poly1 {
-  implicit def cwlFileToWdlValue: Case.Aux[MyriadInputValuePrimitives, DelayedCoercionFunction] = at[MyriadInputValuePrimitives] {
+  implicit def cwlFileToWomValue: Case.Aux[MyriadInputValuePrimitives, DelayedCoercionFunction] = at[MyriadInputValuePrimitives] {
     _.fold(CwlInputPrimitiveCoercion)
   }
   
-  implicit def inputArrayValueToWdlValue: Case.Aux[Array[MyriadInputValuePrimitives], DelayedCoercionFunction] =
+  implicit def inputArrayValueToWomValue: Case.Aux[Array[MyriadInputValuePrimitives], DelayedCoercionFunction] =
     at[Array[MyriadInputValuePrimitives]] { arrayValue =>
       womType: WomType => {
         import cats.instances.list._
         import cats.syntax.traverse._
 
         womType match {
-          case wdlArrayType: WomArrayType =>
+          case womArrayType: WomArrayType =>
             arrayValue.toList
-              .traverse[ErrorOr, WomValue](_.fold(CwlInputPrimitiveCoercion).apply(wdlArrayType.memberType))
-              .map { WomArray(wdlArrayType, _) }
+              .traverse[ErrorOr, WomValue](_.fold(CwlInputPrimitiveCoercion).apply(womArrayType.memberType))
+              .map { WomArray(womArrayType, _) }
 
           case other => s"Cannot convert an array input value into a non array type: $other".invalidNel
         }
@@ -32,46 +32,46 @@ private [cwl] object CwlInputCoercion extends Poly1 {
 }
 
 private [cwl] object CwlInputPrimitiveCoercion extends Poly1 {
-  implicit def cwlFileToWdlValue: Case.Aux[File, DelayedCoercionFunction] = at[File] { cwlFile =>
+  implicit def cwlFileToWomValue: Case.Aux[File, DelayedCoercionFunction] = at[File] { cwlFile =>
     womType: WomType => {
       womType match {
-        case WomFileType => cwlFile.asWdlValue
+        case WomFileType => cwlFile.asWomValue
         case otherType => s"Input value is a File but the targeted input is a $otherType".invalidNel
       }
     }
   }
 
-  implicit def stringToWdlValue: Case.Aux[String, DelayedCoercionFunction] = at[String] { stringValue =>
+  implicit def stringToWomValue: Case.Aux[String, DelayedCoercionFunction] = at[String] { stringValue =>
     womType: WomType => {
       womType.coerceRawValue(stringValue).toErrorOr
     }
   }
 
-  implicit def booleanToWdlValue: Case.Aux[Boolean, DelayedCoercionFunction] = at[Boolean] { booleanValue =>
+  implicit def booleanToWomValue: Case.Aux[Boolean, DelayedCoercionFunction] = at[Boolean] { booleanValue =>
     womType: WomType => {
       womType.coerceRawValue(booleanValue).toErrorOr
     }
   }
 
-  implicit def intToWdlValue: Case.Aux[Int, DelayedCoercionFunction] = at[Int] { intValue =>
+  implicit def intToWomValue: Case.Aux[Int, DelayedCoercionFunction] = at[Int] { intValue =>
     womType: WomType => {
       womType.coerceRawValue(intValue).toErrorOr
     }
   }
 
-  implicit def floatToWdlValue: Case.Aux[Float, DelayedCoercionFunction] = at[Float] { floatValue =>
+  implicit def floatToWomValue: Case.Aux[Float, DelayedCoercionFunction] = at[Float] { floatValue =>
     womType: WomType => {
       womType.coerceRawValue(floatValue).toErrorOr
     }
   }
 
-  implicit def doubleToWdlValue: Case.Aux[Double, DelayedCoercionFunction] = at[Double] { doubleValue =>
+  implicit def doubleToWomValue: Case.Aux[Double, DelayedCoercionFunction] = at[Double] { doubleValue =>
     womType: WomType => {
       womType.coerceRawValue(doubleValue).toErrorOr
     }
   }
 
-  implicit def longToWdlValue: Case.Aux[Long, DelayedCoercionFunction] = at[Long] { longValue =>
+  implicit def longToWomValue: Case.Aux[Long, DelayedCoercionFunction] = at[Long] { longValue =>
     womType: WomType => {
       womType.coerceRawValue(longValue).toErrorOr
     }

--- a/cwl/src/main/scala/cwl/CwlType.scala
+++ b/cwl/src/main/scala/cwl/CwlType.scala
@@ -35,8 +35,8 @@ case class File private(
   format: Option[String],
   contents: Option[String]) {
 
-  lazy val asWdlValue: ErrorOr[WomValue] = {
-    // TODO WOM: needs to handle basename and maybe other fields. We might need to augment WdlFile, or have a smarter WomFile
+  lazy val asWomValue: ErrorOr[WomValue] = {
+    // TODO WOM: needs to handle basename and maybe other fields.
     path.orElse(location) match {
       case Some(value) => WomSingleFile(value).validNel
       case None => "Cannot convert CWL File to WomValue without either a location or a path".invalidNel

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -54,8 +54,8 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
 
   /*
   TODO:
-   DB: It doesn't make sense to me that this function returns type WdlFile but accepts a type to which it coerces.
-   Wouldn't coerceTo always == WdlFileType, and if not then what?
+   DB: It doesn't make sense to me that this function returns type WomFile but accepts a type to which it coerces.
+   Wouldn't coerceTo always == WomFileType, and if not then what?
    */
   override def evaluateFiles(inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet, coerceTo: WomType): ErrorOr[Set[WomFile]] ={
 

--- a/cwl/src/main/scala/cwl/ExpressionTool.scala
+++ b/cwl/src/main/scala/cwl/ExpressionTool.scala
@@ -13,7 +13,7 @@ case class ExpressionTool(
                              CNil,
                            id: Option[String] = None,
                            requirements: Option[Array[Requirement]] = None,
-                           hints: Option[Array[CwlAny]] = None,
+                           hints: Option[Array[Hint]] = None,
                            label: Option[String] = None,
                            doc: Option[String] = None,
                            cwlVersion: Option[CwlVersion] = None) {

--- a/cwl/src/main/scala/cwl/ParameterContext.scala
+++ b/cwl/src/main/scala/cwl/ParameterContext.scala
@@ -12,11 +12,11 @@ case class ParameterContext(inputs: WomValue = WomOptionalValue(WomNothingType, 
                             self: WomValue = WomOptionalValue(WomNothingType, None),
                             runtime: WomValue = WomOptionalValue(WomNothingType, None)) {
   def withInputs(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ParameterContext = {
-    val wdlValueType = WomStringType
+    val womValueType = WomStringType
     copy(
       inputs = WomMap(
-        WomMapType(WomStringType, wdlValueType),
-        // TODO: WOM: convert inputValues (including WdlFile?) to inputs using the ioFunctionSet
+        WomMapType(WomStringType, womValueType),
+        // TODO: WOM: convert inputValues (including WomFile?) to inputs using the ioFunctionSet
         inputValues map {
           case (name, WomSingleFile(path)) => WomString(name) -> WomString(path)
           case (name, womValue) => WomString(name) -> womValue

--- a/cwl/src/main/scala/cwl/TypeAliases.scala
+++ b/cwl/src/main/scala/cwl/TypeAliases.scala
@@ -30,6 +30,11 @@ trait TypeAliases {
       StepInputExpressionRequirement :+:
       CNil
 
+  type Hint =
+    Requirement :+:
+      CwlAny :+:
+      CNil
+
   // TODO WOM: Record Schema as well as Directories are not included because they're not supported yet, although they should eventually be.
   // Removing them saves some compile time when building decoders for this type (in CwlInputParsing)
   type MyriadInputValuePrimitives = 

--- a/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
@@ -48,7 +48,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
     _.select[Workflow].get
   }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse! msg was $error"), identity)
 
-  lazy val graph = cwlWorkflow.womDefinition match {
+  lazy val graph = cwlWorkflow.womDefinition(AcceptAllRequirements) match {
     case Left(errors) => fail(s"Failed to build wom definition: ${errors.toList.mkString(", ")}")
     case Right(womDef) => womDef.graph
   }
@@ -63,7 +63,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
   lazy val w7OutputPort = graph.inputNodes.find(_.localName == "w7").getOrElse(fail("Failed to find an input node for w7")).singleOutputPort
   
   def validate(inputFile: String): Map[GraphNodePort.OutputPort, ResolvedExecutableInput] = {
-    cwlWorkflow.womExecutable(Option(inputFile)) match {
+    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile)) match {
       case Left(errors) => fail(s"Failed to build a wom executable: ${errors.toList.mkString(", ")}")
       case Right(executable) => executable.resolvedExecutableInputs
     }
@@ -105,7 +105,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
         w2: hello !
       """.stripMargin
 
-    cwlWorkflow.womExecutable(Option(inputFile)) match {
+    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile)) match {
       case Right(booh) => fail(s"Expected failed validation but got valid input map: $booh")
       case Left(errors) => errors.toList.toSet shouldBe Set(
         "Required workflow input 'w1' not specified",

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -408,10 +408,11 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
       case _ => Monad[Parse].unit
     }
 
+    import cwl.AcceptAllRequirements
     for {
       _ <- unzipDependencies
       cwl <- CwlDecoder.decodeAllCwl(cwlFile)
-      executable <-  fromEither[IO](cwl.womExecutable(Option(source.inputsJson)))
+      executable <-  fromEither[IO](cwl.womExecutable(AcceptAllRequirements, Option(source.inputsJson)))
       ioFunctions = new WdlFunctions(pathBuilders)
       validatedWomNamespace <- fromEither[IO](validateWomNamespace(executable, ioFunctions))
     } yield validatedWomNamespace

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val reactiveStreamsV = "1.0.1"
   val refinedV = "0.8.3"
   val scalaGraphV = "1.12.0"
-  val scalaLoggingV = "3.6.0"
+  val scalaLoggingV = "3.7.1"
   val scalaXmlV = "1.0.6"
   val scalacheckV = "1.13.4"
   val scalacticV = "3.0.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -106,7 +106,7 @@ object Settings {
       case Some((2, 11)) =>
         // Scala 2.11 takes a simplified set of options
         baseSettings
-      case wut => throw new NotImplementedError(s"Found unsupported Scala version $wut. wdl4s does not support versions of Scala other than 2.11 or 2.12.")
+      case wut => throw new NotImplementedError(s"Found unsupported Scala version $wut. WOM does not support versions of Scala other than 2.11 or 2.12.")
     }),
     // http://stackoverflow.com/questions/31488335/scaladoc-2-11-6-fails-on-throws-tag-with-unable-to-find-any-member-to-link#31497874
     scalacOptions in(Compile, doc) ++= baseSettings ++ List("-no-link-warnings"),
@@ -128,7 +128,7 @@ object Settings {
       case Some((2, 12)) => sys.env.get("ENABLE_COVERAGE").exists(_.toBoolean)
       case Some((2, 11)) => false
       case wut => throw new NotImplementedError(
-        s"Found unsupported Scala version $wut. wdl4s does not support versions of Scala other than 2.11 or 2.12.")
+        s"Found unsupported Scala version $wut. WOM does not support versions of Scala other than 2.11 or 2.12.")
     }),
     addCompilerPlugin("org.scalamacros" % "paradise" % paradiseV cross CrossVersion.full)
   )

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesJobCachingActorHelper.scala
@@ -28,8 +28,6 @@ trait JesJobCachingActorHelper extends StandardCachingActorHelper {
   lazy val callRootPath: Path = jesCallPaths.callExecutionRoot
   lazy val returnCodeFilename: String = jesCallPaths.returnCodeFilename
   lazy val returnCodeGcsPath: Path = jesCallPaths.returnCode
-  lazy val jesStdoutFile: Path = jesCallPaths.stdout
-  lazy val jesStderrFile: Path = jesCallPaths.stderr
   lazy val jesLogFilename: String = jesCallPaths.jesLogFilename
 
   lazy val maxPreemption: Int = runtimeAttributes.preemptible

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -76,7 +76,7 @@ object SharedFileSystem extends StrictLogging {
   }
 
   private def duplicate(description: String, source: Path, dest: Path, strategies: Stream[DuplicationStrategy]): Try[Unit] = {
-    val attempts: Stream[Try[Unit]] = strategies.map(_ (source.followSymbolicLinks, dest))
+    val attempts: Stream[Try[Unit]] = strategies.map(_.apply(source.followSymbolicLinks, dest))
     attempts.find(_.isSuccess) getOrElse {
       TryUtil.sequence(attempts, s"Could not $description $source -> $dest").void
     }
@@ -196,7 +196,7 @@ trait SharedFileSystem extends PathFactory {
     * @param toDestPath function specifying how to generate the destination path from the source path
     * @param strategies strategies to use for localization
     * @param womFile WomFile to localize
-    * @return localized wdl file
+    * @return localized WomFile
     */
   private def localizeWomFile(toDestPath: (String => Try[PairOfFiles]), strategies: Stream[DuplicationStrategy])
                              (womFile: WomFile): WomFile = {

--- a/wom/src/main/scala/wom/RuntimeAttributes.scala
+++ b/wom/src/main/scala/wom/RuntimeAttributes.scala
@@ -6,4 +6,6 @@ object RuntimeAttributes {
   def empty = new RuntimeAttributes(Map.empty)
 }
 
-case class RuntimeAttributes(attributes: Map[String, WomExpression])
+case class RuntimeAttributes(attributes: Map[String, WomExpression]) {
+  def withDockerImage(expression: WomExpression): RuntimeAttributes = RuntimeAttributes(this.attributes + ("docker" -> expression))
+}

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -60,7 +60,7 @@ object Executable {
 }
 
 /**
-  * Wraps an callable in an executable object. An executable 
+  * Wraps a callable in an executable object.
   * @param entryPoint callable that this executable wraps
   * @param resolvedExecutableInputs Resolved values for the ExternalGraphInputNodes of the entryPoint's graph
   */

--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -174,13 +174,14 @@ object WomGraph {
   }
 
   private def womExecutableFromCwl(filePath: String): Executable = {
+    import cwl.AcceptAllRequirements
     (for {
       clt <- CwlDecoder.decodeAllCwl(File(filePath)).
         value.
         unsafeRunSync
       inputs = clt.requiredInputs
       fakedInputs = JsObject(inputs map { i => i._1 -> fakeInput(i._2) })
-      wom <- clt.womExecutable(Option(fakedInputs.prettyPrint))
+      wom <- clt.womExecutable(AcceptAllRequirements, Option(fakedInputs.prettyPrint))
     } yield wom) match {
       case Right(womExecutable) => womExecutable
       case Left(e) => throw new Exception(s"Can't build WOM executable from CWL: ${e.toList.mkString("\n", "\n", "\n")}")


### PR DESCRIPTION
This does appear to work for 3 step but I'd like to add metadata assertions to the existing Centaur test assuming the PR doesn't get gulled out of existence.

TODO

- [x] Set parent workflow into subworkflows
- [x] Fix input path localization
- [x] Make "please turn on Docker" an explicit thing in `core`
- [x] Unbreak all the conformance tests that are broken on this branch
- [x] Centaur assertions that the expected Docker images are being used
- [ ] Turn on conformance tests in backends that require Docker
- [ ] Fix globs on JES
- [ ] Fix inputs on JES
- [ ] Return validation failures to the caller