### PR TITLE
Power through non-findable terminals in error messages

### DIFF
--- a/wdl/src/main/scala/wdl/WdlSyntaxErrorFormatter.scala
+++ b/wdl/src/main/scala/wdl/WdlSyntaxErrorFormatter.scala
@@ -10,10 +10,12 @@ import scala.collection.JavaConverters._
 case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) extends SyntaxErrorFormatter {
 
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
-  private def line(t:Terminal): String = t match {
-    case interpolated: InterpolatedTerminal => terminalMap(interpolated.rootTerminal).split("\n")(interpolated.getLine - 1)
-    case classicTerminal => terminalMap(classicTerminal).split("\n")(classicTerminal.getLine - 1)
+  private def getTerminal(t: Terminal) = t match {
+    case interpolated: InterpolatedTerminal => terminalMap.get(interpolated.rootTerminal)
+    case classicTerminal => terminalMap.get(classicTerminal)
   }
+
+  private def line(t:Terminal): String = getTerminal(t).map(_.split("\n")(t.getLine - 1)).getOrElse(s"Cannot highlight line. It was probably in an imported file.")
 
   def unexpectedEof(method: String, expected: java.util.List[TerminalIdentifier], nt_rules: java.util.List[String]): String = "ERROR: Unexpected end of file"
 


### PR DESCRIPTION
Fixes #3039 

As far as I can tell, expressions that lookup subworkflow outputs sometimes cause an error message to be written which is subsequently ignored.

Something in Cromwell 30 caused building that error message to fail because it can no longer find the sub-workflow line to point to in the error message. This hotfix PR lets us build a partial error message with no "pointing to the error" line. I think this is ok since we're ignoring the resulting message anyway for subworkflows.