### PR TITLE
InitialWorkDirRequirement part 2: StringDirent entryname expressions

### DIFF
--- a/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement.inline_file_custom_entryname.test
+++ b/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement.inline_file_custom_entryname.test
@@ -1,0 +1,15 @@
+name: inline_file_custom_entryname
+testFormat: workflowsuccess
+workflowType: CWL
+workflowRoot: iwdr_inline_file
+workflowTypeVersion: v1.0
+
+files {
+  wdl: InitialWorkDirRequirement/inline_file_custom_entryname.cwl
+}
+
+metadata {
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "outputs.iwdr_inline_file.prime_list": "[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]"
+}

--- a/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/inline_file_custom_entryname.cwl
+++ b/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/inline_file_custom_entryname.cwl
@@ -1,0 +1,47 @@
+# Little tool that uses a prime sieve to generate primes up to 100
+
+cwlVersion: v1.0
+$graph:
+- id: iwdr_inline_file
+  class: CommandLineTool
+  baseCommand: ['python3']
+  requirements:
+      - class: DockerRequirement
+        dockerPull: "python:3.5.0"
+      - class: InitialWorkDirRequirement
+        listing:
+            - entryname: $(inputs.script_name)
+              entry: |
+                  import sys
+                  import math
+
+                  limit = int(sys.argv[1])
+                  sieve = [True for i in range(limit)]
+                  for i in range(2, math.floor(limit / 2)):
+                      if sieve[i]:
+                          for j in range(i * 2, limit, i):
+                              sieve[j] = False
+
+                  result = "["
+                  for i in range(2, limit):
+                      if sieve[i]:
+                          if result != "[":
+                              result += ", "
+                          result += str(i)
+                  result += "]"
+
+                  print(result)
+
+  stdout: "primes"
+  inputs:
+      - id: script_name
+        type: string
+        default: "astounding.py"
+  arguments: [ $(inputs.script_name), '100' ]
+  outputs:
+      - id: prime_list
+        type: string
+        outputBinding:
+          glob: primes
+          loadContents: true
+          outputEval: $(self[0].contents.trim())

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -9,6 +9,7 @@ import cwl.CommandLineTool._
 import cwl.CwlType.CwlType
 import cwl.CwlVersion._
 import cwl.command.ParentName
+import cwl.CwlAny.EnhancedCwlAny
 import cwl.requirement.RequirementToAttributeMap
 import eu.timepit.refined.W
 import shapeless.syntax.singleton._
@@ -74,7 +75,7 @@ case class CommandLineTool private(
       validRequirements ++ validHints
     }
   }
-  
+
   private def processRequirement(requirement: Requirement): Map[String, WomExpression] = {
     requirement.fold(RequirementToAttributeMap).apply(inputNames)
   }
@@ -131,7 +132,7 @@ case class CommandLineTool private(
         case CommandInputParameter(id, _, _, _, _, _, _, Some(default), Some(tpe)) =>
           val inputType = tpe.fold(MyriadInputTypeToWomType)
           val inputName = FullyQualifiedName(id).id
-          InputDefinitionWithDefault(inputName, inputType, ValueAsAnExpression(inputType.coerceRawValue(default.toString).get))
+          InputDefinitionWithDefault(inputName, inputType, ValueAsAnExpression(inputType.coerceRawValue(default.stringRepresentation).get))
         case CommandInputParameter(id, _, _, _, _, _, _, None, Some(tpe)) =>
           val inputType = tpe.fold(MyriadInputTypeToWomType)
           val inputName = FullyQualifiedName(id).id

--- a/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
+++ b/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
@@ -1,16 +1,16 @@
 package cwl
 
-import cwl.InitialWorkDirRequirement.{ExpressionOrString, IwdrListingArrayEntry, _}
+import cwl.InitialWorkDirRequirement._
 import eu.timepit.refined.W
 import shapeless.{:+:, CNil, _}
 
 final case class InitialWorkDirRequirement(
                                             `class`: W.`"InitialWorkDirRequirement"`.T,
-                                            listing: Array[IwdrListingArrayEntry] :+: ExpressionOrString :+: CNil
+                                            listing: IwdrListing
                                           ) {
   val listings: Array[IwdrListingArrayEntry] = listing match {
     case IwdrListingArray(array) => array
-    case ExpressionOrString(eos) => Array(Coproduct[IwdrListingArrayEntry](eos))
+    case StringOrExpression(soe) => Array(Coproduct[IwdrListingArrayEntry](soe))
   }
 
   override def toString: WorkflowStepInputId =
@@ -32,39 +32,34 @@ trait Dirent {
 
 final case class ExpressionDirent(
                                    entry: Expression,
-                                   entryname: Option[ExpressionOrString],
+                                   entryname: Option[StringOrExpression],
                                    writable: Option[Boolean]
                                  ) extends Dirent
 
 final case class StringDirent(
                                entry: String,
-                               entryname: ExpressionOrString,
+                               entryname: StringOrExpression,
                                writable: Option[Boolean]
                              ) extends Dirent
 
 object InitialWorkDirRequirement {
 
-  final type IwdrListingArrayEntry = File :+: Directory :+: StringDirent :+: ExpressionDirent :+: ExpressionOrString :+: CNil
+  final type IwdrListingArrayEntry = File :+: Directory :+: StringDirent :+: ExpressionDirent :+: StringOrExpression :+: CNil
+  final type IwdrListing = Array[IwdrListingArrayEntry] :+: StringOrExpression :+: CNil
 
   object IwdrListingArrayEntry {
     object StringDirent {
-      def unapply(e: IwdrListingArrayEntry): Option[(String, ExpressionOrString, Boolean)] =
+      def unapply(e: IwdrListingArrayEntry): Option[(String, StringOrExpression, Boolean)] =
         e.select[StringDirent].map(sd => (sd.entry, sd.entryname, sd.writableWithDefault))
+    }
+    object ExpressionDirent {
+      def unapply(e: IwdrListingArrayEntry): Option[(Expression, Option[StringOrExpression], Boolean)] =
+        e.select[ExpressionDirent].map(sd => (sd.entry, sd.entryname, sd.writableWithDefault))
     }
   }
 
   object IwdrListingArray {
-    def unapply(listing: Array[IwdrListingArrayEntry] :+: ExpressionOrString :+: CNil): Option[Array[IwdrListingArrayEntry]] =
+    def unapply(listing: IwdrListing): Option[Array[IwdrListingArrayEntry]] =
       listing.select[Array[IwdrListingArrayEntry]]
-  }
-  object Expression { def unapply(listing: Array[IwdrListingArrayEntry] :+: ExpressionOrString :+: CNil): Option[Array[IwdrListingArrayEntry]] = listing.select[Array[IwdrListingArrayEntry]] }
-
-
-
-  final type ExpressionOrString = Expression :+: String :+: CNil
-  object ExpressionOrString {
-    def unapply(listing: Array[IwdrListingArrayEntry] :+: ExpressionOrString :+: CNil): Option[ExpressionOrString] = listing.select[ExpressionOrString]
-    object Expression { def unapply(eos: ExpressionOrString): Option[Expression] = eos.select[Expression] }
-    object String { def unapply(eos: ExpressionOrString): Option[String] = eos.select[String] }
   }
 }

--- a/cwl/src/main/scala/cwl/TypeAliases.scala
+++ b/cwl/src/main/scala/cwl/TypeAliases.scala
@@ -99,6 +99,12 @@ trait TypeAliases {
   type ResourceRequirementType = Long :+: Expression :+: String :+: CNil
 }
 
+object CwlAny {
+  implicit class EnhancedCwlAny(val cwlAny: CwlAny) extends AnyVal {
+    def stringRepresentation: String = cwlAny.select[Json] map { json => json.asString.getOrElse(json.toString) } getOrElse "CwlAny (not Json)"
+  }
+}
+
 object MyriadInputType {
   object CwlType {
     def unapply(m: MyriadInputType): Option[CwlType] = {

--- a/cwl/src/main/scala/cwl/package.scala
+++ b/cwl/src/main/scala/cwl/package.scala
@@ -60,6 +60,8 @@ package object cwl extends TypeAliases {
   type Expression = ECMAScriptExpression :+: ECMAScriptFunction :+: CNil
 
   object StringOrExpression {
+    def unapply(listing: InitialWorkDirRequirement.IwdrListing): Option[StringOrExpression] = listing.select[StringOrExpression]
+
     object String {
       def unapply(soe: StringOrExpression): Option[String] = soe.select[String]
     }


### PR DESCRIPTION
Motivating case: [link](https://github.com/broadinstitute/cromwell/blob/cjl_initial_work_dir_requirement_2/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/inline_file_custom_entryname.cwl)

Allows the `entryname` to be an expression in `InitialWorkDirRequirement` `StringDirent` entries.


~~EDIT: Will rebase and target `develop` after merging https://github.com/broadinstitute/cromwell/pull/3078~~