### PR TITLE
InitialWorkDirRequirement Part 3: Allow String entry expressions for Dirents

### DIFF
--- a/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement.input_string.test
+++ b/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement.input_string.test
@@ -1,0 +1,15 @@
+name: iwdr_input_string
+testFormat: workflowsuccess
+workflowType: CWL
+workflowRoot: iwdr_input_string
+workflowTypeVersion: v1.0
+
+files {
+  wdl: InitialWorkDirRequirement/input_string.cwl
+}
+
+metadata {
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "outputs.iwdr_input_string.prime_list": "[2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97]"
+}

--- a/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/input_string.cwl
+++ b/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/input_string.cwl
@@ -1,0 +1,46 @@
+# Little tool that uses a prime sieve to generate primes up to 100
+
+cwlVersion: v1.0
+$graph:
+- id: iwdr_input_string
+  class: CommandLineTool
+  baseCommand: ['python3', 'prime_sieve.py', '100']
+  requirements:
+      - class: DockerRequirement
+        dockerPull: "python:3.5.0"
+      - class: InitialWorkDirRequirement
+        listing:
+            - entryname: 'prime_sieve.py'
+              entry: $(inputs.script)
+
+  stdout: "primes"
+  inputs:
+      - id: script
+        type: string
+        default: |
+          import sys
+          import math
+
+          limit = int(sys.argv[1])
+          sieve = [True for i in range(limit)]
+          for i in range(2, math.floor(limit / 2)):
+              if sieve[i]:
+                  for j in range(i * 2, limit, i):
+                      sieve[j] = False
+
+          result = "["
+          for i in range(2, limit):
+              if sieve[i]:
+                  if result != "[":
+                      result += ", "
+                  result += str(i)
+          result += "]"
+
+          print(result)
+  outputs:
+      - id: prime_list
+        type: string
+        outputBinding:
+          glob: primes
+          loadContents: true
+          outputEval: $(self[0].contents.trim())

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -4,6 +4,11 @@ import cats.syntax.option._
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
+import common.validation.ErrorOr.ShortCircuitingFlatMap
+import wom.types._
+import wom.values._
+import wom.expression.{IoFunctionSet, WomExpression}
+import cats.syntax.validated._
 import cwl.InitialWorkDirRequirement.IwdrListingArrayEntry
 import cwl.WorkflowStepInput.InputSource
 import cwl.command.ParentName
@@ -120,32 +125,46 @@ final case class InitialWorkDirFileGeneratorExpression(entry: IwdrListingArrayEn
   override def cwlExpressionType: WomType = WomSingleFileType
   override def sourceString: String = entry.toString
 
-  override def evaluateValue(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = entry match {
-    case IwdrListingArrayEntry.StringDirent(content, StringOrExpression.String(entryname), _) =>
-      Try(Await.result(ioFunctionSet.writeFile(entryname, content), Duration.Inf)).toErrorOr
-    case IwdrListingArrayEntry.StringDirent(content, StringOrExpression.ECMAScriptExpression(entrynameExpression), _) =>
-      def mustBeString(womValue: WomValue): ErrorOr[String] = womValue match {
-        case WomString(s) => s.validNel
-        case other => WomStringType.coerceRawValue(other).map(_.asInstanceOf[WomString].value).toErrorOr
-      }
+  override def evaluateValue(inputValues: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomFile] = {
+    def mustBeString(womValue: WomValue): ErrorOr[String] = womValue match {
+      case WomString(s) => s.validNel
+      case other => WomStringType.coerceRawValue(other).map(_.asInstanceOf[WomString].value).toErrorOr
+    }
+    entry match {
+      // The entry name and the entry are both constant:
+      case IwdrListingArrayEntry.StringDirent(content, StringOrExpression.String(entryname), _) =>
+        Try(Await.result(ioFunctionSet.writeFile(entryname, content), Duration.Inf)).toErrorOr
 
-      import common.validation.ErrorOr.ShortCircuitingFlatMap
-      for {
-        expressionEvaluated <- ExpressionEvaluator.evalExpression(entrynameExpression, ParameterContext().withInputs(inputValues, ioFunctionSet)).toErrorOr
-        entryNameValidated <- mustBeString(expressionEvaluated)
+      // The entry name is an expression but the entry is constant:
+      case IwdrListingArrayEntry.StringDirent(content, StringOrExpression.ECMAScriptExpression(entrynameExpression), _) => for {
+        entryNameExpressionEvaluated <- ExpressionEvaluator.evalExpression(entrynameExpression, ParameterContext().withInputs(inputValues, ioFunctionSet)).toErrorOr
+        entryNameValidated <- mustBeString(entryNameExpressionEvaluated)
         writtenFile <- Try(Await.result(ioFunctionSet.writeFile(entryNameValidated, content), Duration.Inf)).toErrorOr
       } yield writtenFile
 
+      // The entry name is constant but the entry is an expression:
+      case IwdrListingArrayEntry.ExpressionDirent(Expression.ECMAScriptExpression(contentExpression), Some(StringOrExpression.String(entryname)), _) =>
 
-    case _ => ??? // TODO WOM and the rest....
+        val entryEvaluation: ErrorOr[WomValue] = ExpressionEvaluator.evalExpression(contentExpression, ParameterContext().withInputs(inputValues, ioFunctionSet)).toErrorOr
+
+        entryEvaluation flatMap {
+          case f: WomFile => f.validNel
+          case other => for {
+            coerced <- WomStringType.coerceRawValue(other).toErrorOr
+            contentString = coerced.asInstanceOf[WomString].value
+            writtenFile <- Try(Await.result(ioFunctionSet.writeFile(entryname, contentString), Duration.Inf)).toErrorOr
+          }  yield writtenFile
+        }
+      case _ => ??? // TODO WOM and the rest....
+    }
   }
 
 
   override def evaluateFiles(inputTypes: Map[String, WomValue], ioFunctionSet: IoFunctionSet, coerceTo: WomType): ErrorOr[Set[WomFile]] =
     "Programmer error: Shouldn't use InitialWorkDirRequirement listing to find output files. You silly goose.".invalidNel
 
-  override def inputs: Set[String] = entry match {
-    case IwdrListingArrayEntry.StringDirent(_, _, _) => Set.empty
-    case _ => Set.empty // TODO WOM: For some cases this might need some...
-  }
+  /**
+    * We already get all of the task inputs when evaluating, and we don't need to highlight anything else
+    */
+  override def inputs: Set[String] = Set.empty
 }

--- a/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
+++ b/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
@@ -44,7 +44,7 @@ final case class StringDirent(
 
 object InitialWorkDirRequirement {
 
-  final type IwdrListingArrayEntry = File :+: Directory :+: StringDirent :+: ExpressionDirent :+: StringOrExpression :+: CNil
+  final type IwdrListingArrayEntry = File :+: Directory :+: ExpressionDirent :+: StringDirent :+: StringOrExpression :+: CNil
   final type IwdrListing = Array[IwdrListingArrayEntry] :+: StringOrExpression :+: CNil
 
   object IwdrListingArrayEntry {

--- a/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
+++ b/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
@@ -44,6 +44,8 @@ final case class StringDirent(
 
 object InitialWorkDirRequirement {
 
+  // "ExpressionDirent" has to come before StringDirent because expressions are matched by "String" first if we do it the
+  // other way round.
   final type IwdrListingArrayEntry = File :+: Directory :+: ExpressionDirent :+: StringDirent :+: StringOrExpression :+: CNil
   final type IwdrListing = Array[IwdrListingArrayEntry] :+: StringOrExpression :+: CNil
 


### PR DESCRIPTION
Motivating case: [link](https://github.com/broadinstitute/cromwell/blob/cjl_initial_work_dir_requirement_3/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/input_string.cwl)

The entry field of a Dirent can now be used to access inputs and evaluate ECMAScript expressions.

- [x] Rebase and target develop after merging https://github.com/broadinstitute/cromwell/pull/3087