### PR TITLE
Use the I/O Actor to execute IoFunctionSet methods

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -10,6 +10,8 @@ import net.ceedubs.ficus.Ficus._
 import wom.expression.IoFunctionSet
 import wom.graph.TaskCallNode
 
+import scala.concurrent.ExecutionContext
+
 trait BackendLifecycleActorFactory {
 
   /**
@@ -91,7 +93,9 @@ trait BackendLifecycleActorFactory {
 
   def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                   jobKey: BackendJobDescriptorKey,
-                                  initializationData: Option[BackendInitializationData]): IoFunctionSet = NoIoFunctionSet
+                                  initializationData: Option[BackendInitializationData],
+                                  ioActor: ActorRef,
+                                  ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
 
   def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config, initializationData: Option[BackendInitializationData]): Path = {
     new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).executionRoot

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -719,10 +719,10 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
       lazy val stderrAsOption: Option[Path] = Option(jobPaths.stderr)
 
       val stderrSizeAndReturnCode = for {
-        returnCodeAsString <- contentAsStringAsync(jobPaths.returnCode)
+        returnCodeAsString <- asyncIo.contentAsStringAsync(jobPaths.returnCode)
         // Only check stderr size if we need to, otherwise this results in a lot of unnecessary I/O that
         // may fail due to race conditions on quickly-executing jobs.
-        stderrSize <- if (failOnStdErr) sizeAsync(jobPaths.stderr) else Future.successful(0L)
+        stderrSize <- if (failOnStdErr) asyncIo.sizeAsync(jobPaths.stderr) else Future.successful(0L)
       } yield (stderrSize, returnCodeAsString)
 
       stderrSizeAndReturnCode flatMap {

--- a/backend/src/main/scala/cromwell/backend/standard/StandardExpressionFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardExpressionFunctions.scala
@@ -1,26 +1,41 @@
 package cromwell.backend.standard
 
+import akka.actor.ActorRef
 import cromwell.backend.io.GlobFunctions
 import cromwell.backend.wdl.{ReadLikeFunctions, WriteFunctions}
 import cromwell.core.CallContext
+import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder, IoCommandBuilder}
 import cromwell.core.path.{Path, PathBuilder}
 import wom.values.{WomSingleFile, WomValue}
 
+import scala.concurrent.ExecutionContext
 import scala.util.{Success, Try}
 
 trait StandardExpressionFunctionsParams {
   def pathBuilders: List[PathBuilder]
 
   def callContext: CallContext
+
+  def ioActorEndpoint: ActorRef
+  
+  def executionContext: ExecutionContext
 }
 
 case class DefaultStandardExpressionFunctionsParams(override val pathBuilders: List[PathBuilder],
-                                                    override val callContext: CallContext
+                                                    override val callContext: CallContext,
+                                                    override val ioActorEndpoint: ActorRef,
+                                                    override val executionContext: ExecutionContext
                                                    ) extends StandardExpressionFunctionsParams
 
 // TODO: Once we figure out premapping and postmapping, maybe we can standardize that behavior. Currently that's the most important feature that subclasses override.
 class StandardExpressionFunctions(val standardParams: StandardExpressionFunctionsParams)
   extends GlobFunctions with ReadLikeFunctions with WriteFunctions {
+
+  override lazy val ec = standardParams.executionContext
+  
+  protected lazy val ioCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
+
+  override lazy val asyncIo = new AsyncIo(standardParams.ioActorEndpoint, ioCommandBuilder)
 
   override val pathBuilders: List[PathBuilder] = standardParams.pathBuilders
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardExpressionFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardExpressionFunctions.scala
@@ -16,14 +16,14 @@ trait StandardExpressionFunctionsParams {
 
   def callContext: CallContext
 
-  def ioActorEndpoint: ActorRef
+  def ioActorProxy: ActorRef
   
   def executionContext: ExecutionContext
 }
 
 case class DefaultStandardExpressionFunctionsParams(override val pathBuilders: List[PathBuilder],
                                                     override val callContext: CallContext,
-                                                    override val ioActorEndpoint: ActorRef,
+                                                    override val ioActorProxy: ActorRef,
                                                     override val executionContext: ExecutionContext
                                                    ) extends StandardExpressionFunctionsParams
 
@@ -35,7 +35,7 @@ class StandardExpressionFunctions(val standardParams: StandardExpressionFunction
   
   protected lazy val ioCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
 
-  override lazy val asyncIo = new AsyncIo(standardParams.ioActorEndpoint, ioCommandBuilder)
+  override lazy val asyncIo = new AsyncIo(standardParams.ioActorProxy, ioCommandBuilder)
 
   override val pathBuilders: List[PathBuilder] = standardParams.pathBuilders
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
@@ -1,7 +1,10 @@
 package cromwell.backend.standard
 
+import akka.actor.ActorRef
 import cromwell.backend.BackendInitializationData
 import cromwell.backend.io.{JobPaths, WorkflowPaths}
+
+import scala.concurrent.ExecutionContext
 
 class StandardInitializationData
 (
@@ -14,10 +17,10 @@ class StandardInitializationData
   private lazy val standardExpressionFunctionsConstructor =
     standardExpressionFunctionsClass.getConstructor(classOf[StandardExpressionFunctionsParams])
 
-  def expressionFunctions(jobPaths: JobPaths): StandardExpressionFunctions = {
+  def expressionFunctions(jobPaths: JobPaths, ioActorEndpoint: ActorRef, ec: ExecutionContext): StandardExpressionFunctions = {
     val pathBuilders = jobPaths.workflowPaths.pathBuilders
     val callContext = jobPaths.callContext
-    val standardParams = DefaultStandardExpressionFunctionsParams(pathBuilders, callContext)
+    val standardParams = DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorEndpoint, ec)
     standardExpressionFunctionsConstructor.newInstance(standardParams)
   }
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardInitializationData.scala
@@ -17,10 +17,10 @@ class StandardInitializationData
   private lazy val standardExpressionFunctionsConstructor =
     standardExpressionFunctionsClass.getConstructor(classOf[StandardExpressionFunctionsParams])
 
-  def expressionFunctions(jobPaths: JobPaths, ioActorEndpoint: ActorRef, ec: ExecutionContext): StandardExpressionFunctions = {
+  def expressionFunctions(jobPaths: JobPaths, ioActorProxy: ActorRef, ec: ExecutionContext): StandardExpressionFunctions = {
     val pathBuilders = jobPaths.workflowPaths.pathBuilders
     val callContext = jobPaths.callContext
-    val standardParams = DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorEndpoint, ec)
+    val standardParams = DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorProxy, ec)
     standardExpressionFunctionsConstructor.newInstance(standardParams)
   }
 }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -4,11 +4,13 @@ import akka.actor.{ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.backend._
 import cromwell.backend.standard.callcaching._
-import cromwell.core.{CallOutputs, Dispatcher}
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.path.Path
+import cromwell.core.{CallOutputs, Dispatcher}
 import wom.expression.IoFunctionSet
 import wom.graph.TaskCallNode
+
+import scala.concurrent.ExecutionContext
 
 /**
   * May be extended for using the standard sync/async backend pattern.
@@ -172,11 +174,13 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
-                                           initializationDataOption: Option[BackendInitializationData]):
+                                           initializationDataOption: Option[BackendInitializationData],
+                                           ioActorEndpoint: ActorRef,
+                                           ec: ExecutionContext):
   IoFunctionSet = {
     val standardInitializationData = BackendInitializationData.as[StandardInitializationData](initializationDataOption)
     val jobPaths = standardInitializationData.workflowPaths.toJobPaths(jobKey, workflowDescriptor)
-    standardInitializationData.expressionFunctions(jobPaths)
+    standardInitializationData.expressionFunctions(jobPaths, ioActorEndpoint, ec)
   }
 
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -175,12 +175,12 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
                                            initializationDataOption: Option[BackendInitializationData],
-                                           ioActorEndpoint: ActorRef,
+                                           ioActorProxy: ActorRef,
                                            ec: ExecutionContext):
   IoFunctionSet = {
     val standardInitializationData = BackendInitializationData.as[StandardInitializationData](initializationDataOption)
     val jobPaths = standardInitializationData.workflowPaths.toJobPaths(jobKey, workflowDescriptor)
-    standardInitializationData.expressionFunctions(jobPaths, ioActorEndpoint, ec)
+    standardInitializationData.expressionFunctions(jobPaths, ioActorProxy, ec)
   }
 
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,

--- a/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
@@ -4,9 +4,8 @@ import akka.actor.SupervisorStrategy.{Decider, Stop}
 import akka.actor.{ActorRef, OneForOneStrategy, Props}
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobAbortedResponse, JobNotFoundException}
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
-import cromwell.backend._
 import cromwell.backend.async.AsyncBackendJobExecutionActor.{Execute, Reconnect, ReconnectToAbort, Recover}
-import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor, BackendJobExecutionActor}
+import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor, BackendJobExecutionActor, _}
 import cromwell.core.Dispatcher
 import cromwell.services.keyvalue.KeyValueServiceActor._
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
@@ -4,8 +4,8 @@ import akka.actor.SupervisorStrategy.{Decider, Stop}
 import akka.actor.{ActorRef, OneForOneStrategy, Props}
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobAbortedResponse, JobNotFoundException}
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
+import cromwell.backend._
 import cromwell.backend.async.AsyncBackendJobExecutionActor.{Execute, Reconnect, ReconnectToAbort, Recover}
-import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor, BackendJobExecutionActor, _}
 import cromwell.core.Dispatcher
 import cromwell.services.keyvalue.KeyValueServiceActor._
 

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -102,13 +102,13 @@ object StandardCacheHitCopyingActor {
   private[callcaching] case class NextSubSet(commands: Set[IoCommand[_]]) extends CommandSetState
 }
 
-class DefaultStandardCacheHitCopyingActor(standardParams: StandardCacheHitCopyingActorParams) extends StandardCacheHitCopyingActor(standardParams) with DefaultIoCommandBuilder
+class DefaultStandardCacheHitCopyingActor(standardParams: StandardCacheHitCopyingActorParams) extends StandardCacheHitCopyingActor(standardParams)
 
 /**
   * Standard implementation of a BackendCacheHitCopyingActor.
   */
 abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHitCopyingActorParams)
-  extends FSM[StandardCacheHitCopyingActorState, Option[StandardCacheHitCopyingActorData]] with JobLogging with StandardCachingActorHelper with IoClientHelper { this: IoCommandBuilder =>
+  extends FSM[StandardCacheHitCopyingActorState, Option[StandardCacheHitCopyingActorData]] with JobLogging with StandardCachingActorHelper with IoClientHelper {
 
   override lazy val jobDescriptor: BackendJobDescriptor = standardParams.jobDescriptor
   override lazy val backendInitializationDataOption: Option[BackendInitializationData] = standardParams.backendInitializationDataOption
@@ -258,7 +258,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val destinationSimpleton = WomValueSimpleton(key, WomSingleFile(destinationPath.pathAsString))
 
-        List(destinationSimpleton) -> Set(copyCommand(sourcePath, destinationPath, overwrite = true))
+        List(destinationSimpleton) -> Set(DefaultIoCommandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
       case nonFileSimpleton => (List(nonFileSimpleton), Set.empty[IoCommand[_]])
     })
 
@@ -289,7 +289,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val newDetrituses = detrituses + (detritus -> destinationPath)
 
-        (newDetrituses, commands + copyCommand(sourcePath, destinationPath, overwrite = true))
+        (newDetrituses, commands + DefaultIoCommandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
     })
 
     (destinationDetritus + (JobPaths.CallRootPathKey -> destinationCallRootPath), ioCommands)

--- a/backend/src/main/scala/cromwell/backend/wdl/ReadLikeFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/ReadLikeFunctions.scala
@@ -16,7 +16,6 @@ trait ReadLikeFunctions extends PathFactory with IoFunctionSet with AsyncIoFunct
   // TODO WOM: https://github.com/broadinstitute/cromwell/issues/2611
   val fileSizeLimitationConfig =  FileSizeLimitationConfig.fileSizeLimitationConfig
 
-  // TODO WOM: https://github.com/broadinstitute/cromwell/issues/2612
   override def readFile(path: String): Future[String] = asyncIo.contentAsStringAsync(buildPath(path))
 
   protected def size(file: WomValue): Future[Double] = asyncIo.sizeAsync(buildPath(file.valueString)).map(_.toDouble)

--- a/backend/src/main/scala/cromwell/backend/wdl/ReadLikeFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/ReadLikeFunctions.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.wdl
 
 import cromwell.backend.MemorySize
+import cromwell.core.io.AsyncIoFunctions
 import cromwell.core.path.PathFactory
 import wdl4s.parser.MemoryUnit
 import wom.expression.IoFunctionSet
@@ -8,27 +9,24 @@ import wom.types._
 import wom.values._
 
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
-trait ReadLikeFunctions extends PathFactory with IoFunctionSet {
-
+trait ReadLikeFunctions extends PathFactory with IoFunctionSet with AsyncIoFunctions {
+  
   // TODO WOM: https://github.com/broadinstitute/cromwell/issues/2611
   val fileSizeLimitationConfig =  FileSizeLimitationConfig.fileSizeLimitationConfig
 
-  def fileSize: WomValue=> Try[Long] =
-    w => Try(buildPath(w.valueString).size)
-
   // TODO WOM: https://github.com/broadinstitute/cromwell/issues/2612
-  override def readFile(path: String): Future[String] = Future.successful(buildPath(path).contentAsString)
+  override def readFile(path: String): Future[String] = asyncIo.contentAsStringAsync(buildPath(path))
 
-  protected def size(file: WomValue): Try[Double] = Try(buildPath(file.valueString).size.toDouble)
+  protected def size(file: WomValue): Future[Double] = asyncIo.sizeAsync(buildPath(file.valueString)).map(_.toDouble)
 
   /**
     * Gets the size of a file.
     *
     * @param params First parameter must be a File or File? or coerceable to one. The second is an optional string containing the size unit (eg "MB", "GiB")
     */
-  override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = {
+  override def size(params: Seq[Try[WomValue]]): Future[WomFloat] = {
     // Inner function: get the memory unit from the second (optional) parameter
     def toUnit(womValue: Try[WomValue]) = womValue flatMap { unit => Try(MemoryUnit.fromSuffix(unit.valueString)) }
 
@@ -40,18 +38,18 @@ trait ReadLikeFunctions extends PathFactory with IoFunctionSet {
     }
 
     // Inner function: Get the file size, allowing for unpacking of optionals
-    def optionalSafeFileSize(value: WomValue): Try[Double] = value match {
+    def optionalSafeFileSize(value: WomValue): Future[Double] = value match {
       case f if f.isInstanceOf[WomSingleFile] || WomSingleFileType.isCoerceableFrom(f.womType) => size(f)
       case WomOptionalValue(_, Some(o)) => optionalSafeFileSize(o)
-      case WomOptionalValue(f, None) if isOptionalOfFileType(f) => Success(0d)
-      case _ => Failure(new Exception(s"The 'size' method expects a 'File' or 'File?' argument but instead got ${value.womType.toDisplayString}."))
+      case WomOptionalValue(f, None) if isOptionalOfFileType(f) => Future.successful(0d)
+      case _ => Future.failed(new Exception(s"The 'size' method expects a 'File' or 'File?' argument but instead got ${value.womType.toDisplayString}."))
     }
 
     // Inner function: get the file size and convert into the requested memory unit
     def fileSize(womValue: Try[WomValue], convertTo: Try[MemoryUnit] = Success(MemoryUnit.Bytes)) = {
       for {
-        value <- womValue
-        unit <- convertTo
+        value <- Future.fromTry(womValue)
+        unit <- Future.fromTry(convertTo)
         fileSize <- optionalSafeFileSize(value)
       } yield MemorySize(fileSize, MemoryUnit.Bytes).to(unit).amount
     }
@@ -59,7 +57,7 @@ trait ReadLikeFunctions extends PathFactory with IoFunctionSet {
     params match {
       case _ if params.length == 1 => fileSize(params.head) map WomFloat.apply
       case _ if params.length == 2 => fileSize(params.head, toUnit(params.tail.head)) map WomFloat.apply
-      case _ => Failure(new UnsupportedOperationException(s"Expected one or two parameters but got ${params.length} instead."))
+      case _ => Future.failed(new UnsupportedOperationException(s"Expected one or two parameters but got ${params.length} instead."))
     }
   }
 }

--- a/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
@@ -1,6 +1,8 @@
 package cromwell.backend.wdl
 
 import better.files.File.OpenOptions
+import cats.instances.future._
+import cats.syntax.functor._
 import cromwell.core.io.AsyncIoFunctions
 import cromwell.core.path.Path
 import wom.expression.IoFunctionSet
@@ -20,7 +22,7 @@ trait WriteFunctions extends IoFunctionSet with AsyncIoFunctions {
   override def writeFile(path: String, content: String): Future[WomSingleFile] = {
     val file = _writeDirectory / path
     asyncIo.existsAsync(file) flatMap {
-      case false => asyncIo.writeAsync(file, content, OpenOptions.default) map { _ => WomSingleFile(file.pathAsString) }
+      case false => asyncIo.writeAsync(file, content, OpenOptions.default) as { WomSingleFile(file.pathAsString) }
       case true => Future.successful(WomSingleFile(file.pathAsString))
     }
   }

--- a/backend/src/test/scala/cromwell/backend/wdl/FileSizeSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/wdl/FileSizeSpec.scala
@@ -3,19 +3,19 @@ package cromwell.backend.wdl
 import java.nio.file.StandardOpenOption._
 import java.nio.file.{Path, Paths}
 
+import cats.effect.IO
 import com.google.common.io.Files
 import cromwell.backend.standard.{DefaultStandardExpressionFunctionsParams, StandardExpressionFunctions}
-import cromwell.core.CallContext
 import cromwell.core.Tags.PostWomTest
 import cromwell.core.path.DefaultPathBuilder
+import cromwell.core.{CallContext, TestKitSuite}
 import fs2.Stream
-import cats.effect.IO
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpecLike, Matchers}
 import wom.values._
 
 import scala.util.{Failure, Success, Try}
 
-class FileSizeSpec extends FlatSpec with Matchers {
+class FileSizeSpec extends TestKitSuite with FlatSpecLike with Matchers {
   val _readLinesLimit = 4
   val _readBoolLimit = 5
   val _readIntLimit = 6
@@ -29,7 +29,11 @@ class FileSizeSpec extends FlatSpec with Matchers {
   val rlf = {
     val path = DefaultPathBuilder.build("/tmp").get
 
-    val dp = DefaultStandardExpressionFunctionsParams(List(cromwell.core.path.DefaultPathBuilder), CallContext(path, "stdout", "stderr"))
+    val dp = DefaultStandardExpressionFunctionsParams(
+      List(cromwell.core.path.DefaultPathBuilder),
+      CallContext(path, "stdout", "stderr"),
+      simpleIoActor,
+      scala.concurrent.ExecutionContext.global)
 
     new StandardExpressionFunctions(dp) {
       override val fileSizeLimitationConfig =

--- a/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
@@ -1,42 +1,42 @@
 package cromwell.backend.wdl
 
 import cromwell.core.Tags.PostWomTest
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{AsyncFlatSpec, Matchers}
 import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values._
 
-import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success, Try}
 
-class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
+class ReadLikeFunctionsSpec extends AsyncFlatSpec with Matchers {
 
   behavior of "ReadLikeFunctions.size"
 
   it should "correctly report a 2048 byte file, in bytes by default" in {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomSingleFile("blah")))) should be(Success(WomFloat(2048d)))
+    readLike.size(Seq(Success(WomSingleFile("blah")))) map { res => assert(res == WomFloat(2048d)) }
   }
 
   it should "correctly report a 2048 byte file, in bytes" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("B")))) should be(Success(WomFloat(2048d)))
+    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("B")))) map { res => assert(res == WomFloat(2048d)) }
   }
 
   it should "correctly report a 2048 byte file, in KB" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("KB")))) should be(Success(WomFloat(2.048d)))
+    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("KB")))) map { res => assert(res == WomFloat(2.048d)) }
   }
 
   it should "correctly report a 2048 byte file, in KiB" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("Ki")))) should be(Success(WomFloat(2d)))
+    readLike.size(Seq(Success(WomSingleFile("blah")), Success(WomString("Ki")))) map { res => assert(res == WomFloat(2d)) }
   }
 
   it should "correctly report the size of a supplied, optional, 2048 byte file" in {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, Option(WomSingleFile("blah")))))) should
-      be(Success(WomFloat(2048d)))
+    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, Option(WomSingleFile("blah")))))) map { res => assert(res == WomFloat(2048d)) }
   }
 
   it should "correctly report the size of a supplied, optional optional, 2048 byte file" taggedAs PostWomTest ignore {
@@ -44,36 +44,34 @@ class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
     readLike.size(Seq(Success(WomOptionalValue(
       WomOptionalType(WomSingleFileType),
       Option(WomOptionalValue(WomSingleFileType, Option(WomSingleFile("blah"))))
-    )))) should be(Success(WomFloat(2048d)))
+    )))) map { res => assert(res == WomFloat(2048d)) }
   }
 
   it should "correctly report the size of a supplied, optional, 2048 byte file, in MB" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
     readLike.size(Seq(Success(WomOptionalValue(
       WomSingleFileType, Option(WomSingleFile("blah")))), Success(WomString("MB")
-    ))) should be(Success(WomFloat(0.002048d)))
+    ))) map { res => assert(res == WomFloat(0.002048d)) }
   }
 
   it should "correctly report that an unsupplied optional file is empty" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, None)))) should be(Success(WomFloat(0d)))
+    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, None)))) map { res => assert(res == WomFloat(0d)) }
   }
 
   it should "correctly report that an unsupplied File?? is empty" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomOptionalValue(WomOptionalType(WomSingleFileType), None)))) should
-      be(Success(WomFloat(0d)))
+    readLike.size(Seq(Success(WomOptionalValue(WomOptionalType(WomSingleFileType), None)))) map { res => assert(res == WomFloat(0d)) }
   }
 
   it should "correctly report that an unsupplied optional file is empty, even in MB" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Success(2048d))
-    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, None)), Success(WomString("MB")))) should
-      be(Success(WomFloat(0d)))
+    readLike.size(Seq(Success(WomOptionalValue(WomSingleFileType, None)), Success(WomString("MB")))) map { res => assert(res == WomFloat(0d)) }
   }
 
   it should "refuse to report file sizes for Ints" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Failure(new Exception("Bad result: WdlIntegers shouldn't even be tried for getting file size")))
-    val oops = readLike.size(Seq(Success(WomInteger(7))))
+    val oops = Try(Await.result(readLike.size(Seq(Success(WomInteger(7)))), Duration.Inf))
     oops match {
       case Success(x) => fail(s"Expected a string to not have a file length but instead got $x")
       case Failure(e) => e.getMessage should be("The 'size' method expects a 'File' or 'File?' argument but instead got Int.")
@@ -82,7 +80,7 @@ class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
 
   it should "refuse to report file sizes for Int?s" taggedAs PostWomTest ignore {
     val readLike = new TestReadLikeFunctions(Failure(new Exception("Bad result: WdlIntegers shouldn't even be tried for getting file size")))
-    val oops = readLike.size(Seq(Success(WomOptionalValue(WomIntegerType, None))))
+    val oops = Try(Await.result(readLike.size(Seq(Success(WomOptionalValue(WomIntegerType, None)))), Duration.Inf))
     oops match {
       case Success(x) => fail(s"Expected a string to not have a file length but instead got $x")
       case Failure(e) => e.getMessage should be("The 'size' method expects a 'File' or 'File?' argument but instead got Int?.")
@@ -91,7 +89,7 @@ class ReadLikeFunctionsSpec extends FlatSpec with Matchers {
 
   it should "pass on underlying size reading errors" in {
     val readLike = new TestReadLikeFunctions(Failure(new Exception("'size' inner exception, expect me to be passed on")))
-    val oops = readLike.size(Seq(Success(WomSingleFile("blah"))))
+    val oops = Try(Await.result(readLike.size(Seq(Success(WomSingleFile("blah")))), Duration.Inf))
     oops match {
       case Success(_) => fail(s"The 'size' engine function didn't return the error generated in the inner 'size' method")
       case Failure(e) => e.getMessage should be("'size' inner exception, expect me to be passed on")
@@ -109,7 +107,7 @@ class TestReadLikeFunctions(sizeResult: Try[Double]) extends IoFunctionSet {
 
   override def stderr(params: Seq[Try[WomValue]]): Try[WomSingleFile] = ???
 
-  override def glob(pattern: String): Seq[String] = ???
+  override def glob(pattern: String): Future[Seq[String]] = ???
 
-  override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = sizeResult.map(WomFloat.apply)
+  override def size(params: Seq[Try[WomValue]]): Future[WomFloat] = Future.fromTry(sizeResult.map(WomFloat.apply))
 }

--- a/centaur/src/main/resources/standardTestCases/missing_input_failure.test
+++ b/centaur/src/main/resources/standardTestCases/missing_input_failure.test
@@ -11,5 +11,5 @@ metadata {
     workflowName: missing_input_failure
     status: Failed
     "failures.0.message": "Workflow failed"
-    "failures.0.causedBy.0.message": "Evaluating read_string(wf_hello_input) failed: gs://nonexistingbucket/path/doesnt/exist"
+    "failures.0.causedBy.0.message": "Evaluating read_string(wf_hello_input) failed: java.nio.file.NoSuchFileException: gs://nonexistingbucket/path/doesnt/exist"
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -127,6 +127,15 @@ system {
 
     # Number of times an I/O operation should be attempted before giving up and failing it.
     number-of-attempts = 5
+    
+    # Amount of time after which an I/O operation will timeout if no response has been received.
+    # Note that a timeout may result in a workflow failure so be careful not to set a timeout too low.
+    # Unless you start experiencing timeouts under very heavy load there should be no reason to change the default values.
+    timeout {
+      default = 3 minutes
+      # Copy can be a time consuming operation and its timeout can be set separately.
+      copy = 1 hour
+    }
   }
 
   # Maximum number of input file bytes allowed in order to read each type. 

--- a/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
+++ b/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
@@ -15,7 +15,7 @@ case object NoIoFunctionSet extends IoFunctionSet {
 
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = Failure(new NotImplementedError("stderr is not available here"))
 
-  override def glob(pattern: String): Seq[String] = throw new NotImplementedError("glob is not available here")
+  override def glob(pattern: String): Future[Seq[String]] = throw new NotImplementedError("glob is not available here")
 
-  override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = Failure(new NotImplementedError("size is not available here"))
+  override def size(params: Seq[Try[WomValue]]): Future[WomFloat] = Future.failed(new NotImplementedError("size is not available here"))
 }

--- a/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
@@ -1,6 +1,6 @@
 package cromwell.core.actor
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable}
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Timers}
 import cromwell.core.actor.RobustClientHelper._
 import cromwell.core.actor.StreamIntegration._
 
@@ -13,7 +13,7 @@ object RobustClientHelper {
   val DefaultRequestLostTimeout = 5 minutes
 }
 
-trait RobustClientHelper { this: Actor with ActorLogging =>
+trait RobustClientHelper extends Timers { this: Actor with ActorLogging =>
   private [actor] implicit val robustActorHelperEc = context.dispatcher
 
   private final val random = new Random()

--- a/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
@@ -1,6 +1,6 @@
 package cromwell.core.actor
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Timers}
+import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable}
 import cromwell.core.actor.RobustClientHelper._
 import cromwell.core.actor.StreamIntegration._
 
@@ -13,7 +13,7 @@ object RobustClientHelper {
   val DefaultRequestLostTimeout = 5 minutes
 }
 
-trait RobustClientHelper extends Timers { this: Actor with ActorLogging =>
+trait RobustClientHelper { this: Actor with ActorLogging =>
   private [actor] implicit val robustActorHelperEc = context.dispatcher
 
   private final val random = new Random()

--- a/core/src/main/scala/cromwell/core/io/AsyncIo.scala
+++ b/core/src/main/scala/cromwell/core/io/AsyncIo.scala
@@ -1,27 +1,25 @@
 package cromwell.core.io
 
-import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.actor.ActorRef
+import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
 import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.Path
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{Future, Promise}
-import scala.language.postfixOps
 
+object AsyncIo {
+  val ioTimeout = 3.minutes
+}
 
-trait AsyncIo extends IoClientHelper { this: Actor with ActorLogging with IoCommandBuilder =>
-  
-  protected val ioTimeout = 3 minutes
-  
-  override private [core] def ioResponseReceive: Receive = {
-    case (promise: Promise[_], ack: IoAck[Any] @unchecked) =>
-      cancelTimeout(promise -> ack.command)
-      // This is not typesafe. 
-      // However the sendIoCommand method ensures that the command and the promise have the same generic type
-      // Which means as long as only the sendIoCommand method is used to send requests, and the ioActor honors his contract
-      // and send back the right context with the right response, the types are virtually guaranteed to match.
-      promise.asInstanceOf[Promise[Any]].complete(ack.toTry)
-      ()
+/**
+  * Provides Futurized methods for I/O actions processed through the IoActor
+  */
+class AsyncIo(ioEndpoint: ActorRef, ioCommandBuilder: IoCommandBuilder) {
+  private def asyncCommand[A](command: IoCommand[A], timeout: FiniteDuration = AsyncIo.ioTimeout) = {
+    val commandWithPromise = IoCommandWithPromise(command, timeout)
+    ioEndpoint ! commandWithPromise
+    commandWithPromise.promise.future
   }
   
   /**
@@ -29,56 +27,35 @@ trait AsyncIo extends IoClientHelper { this: Actor with ActorLogging with IoComm
     * Only use for small files !
     */
   def contentAsStringAsync(path: Path): Future[String] = {
-    val promise = Promise[String]
-    sendIoCommandWithPromise(contentAsStringCommand(path), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.contentAsStringCommand(path))
   }
-  
+
   def writeAsync(path: Path, content: String, options: OpenOptions): Future[Unit] = {
-    val promise = Promise[Unit]
-    sendIoCommandWithPromise(writeCommand(path, content, options), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.writeCommand(path, content, options))
   }
 
   def sizeAsync(path: Path): Future[Long] = {
-    val promise = Promise[Long]
-    sendIoCommandWithPromise(sizeCommand(path), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.sizeCommand(path))
   }
 
   def hashAsync(path: Path): Future[String] = {
-    val promise = Promise[String]
-    sendIoCommandWithPromise(hashCommand(path), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.hashCommand(path))
   }
 
   def deleteAsync(path: Path, swallowIoExceptions: Boolean = false): Future[Unit] = {
-    val promise = Promise[Unit]
-    sendIoCommandWithPromise(deleteCommand(path, swallowIoExceptions), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.deleteCommand(path, swallowIoExceptions))
   }
-  
+
   def existsAsync(path: Path): Future[Boolean] = {
-    val promise = Promise[Boolean]
-    sendIoCommandWithPromise(existsCommand(path), promise)
-    promise.future
+    asyncCommand(ioCommandBuilder.existsCommand(path))
+  }
+
+  def readLinesAsync(path: Path): Future[Traversable[String]] = {
+    asyncCommand(ioCommandBuilder.readLines(path))
   }
 
   def copyAsync(src: Path, dest: Path, overwrite: Boolean = true): Future[Unit] = {
-    val promise = Promise[Unit]
     // Allow for a much larger timeout for copies, as large files can take a while (even on gcs, if they are in different locations...)
-    sendIoCommandWithPromise(copyCommand(src, dest, overwrite), promise, 1 hour)
-    promise.future
-  }
-
-  private def sendIoCommandWithPromise[T](command: IoCommand[T], promise: Promise[T], timeout: FiniteDuration = ioTimeout) = {
-    sendIoCommandWithContext(command, promise, timeout)
-  }
-
-  override def onTimeout(message: Any, to: ActorRef): Unit = message match {
-    case (promise: Promise[_], ioAck: IoAck[_]) => 
-      promise.tryFailure(IoTimeout(ioAck.command))
-      ()
-    case _ =>
+    asyncCommand(ioCommandBuilder.copyCommand(src, dest, overwrite), 1.hour)
   }
 }

--- a/core/src/main/scala/cromwell/core/io/AsyncIoActorClient.scala
+++ b/core/src/main/scala/cromwell/core/io/AsyncIoActorClient.scala
@@ -1,0 +1,43 @@
+package cromwell.core.io
+
+import akka.actor.ActorRef
+import cromwell.core.path.BetterFileMethods.OpenOptions
+import cromwell.core.path.Path
+
+import scala.concurrent.Future
+
+/**
+  * Helper trait to used async Io method easily
+  */
+trait AsyncIoActorClient {
+  
+  def ioActor: ActorRef
+  def ioCommandBuilder: IoCommandBuilder
+  private val asyncIo = new AsyncIo(ioActor, ioCommandBuilder)
+  
+  /**
+    * IMPORTANT: This loads the entire content of the file into memory !
+    * Only use for small files !
+    */
+  def contentAsStringAsync(path: Path): Future[String] = {
+    asyncIo.contentAsStringAsync(path)
+  }
+  def writeAsync(path: Path, content: String, options: OpenOptions): Future[Unit] = {
+    asyncIo.writeAsync(path, content, options)
+  }
+  def sizeAsync(path: Path): Future[Long] = {
+    asyncIo.sizeAsync(path)
+  }
+  def hashAsync(path: Path): Future[String] = {
+    asyncIo.hashAsync(path)
+  }
+  def deleteAsync(path: Path, swallowIoExceptions: Boolean = false): Future[Unit] = {
+    asyncIo.deleteAsync(path, swallowIoExceptions)
+  }
+  def existsAsync(path: Path): Future[Boolean] = {
+    asyncIo.existsAsync(path)
+  }
+  def copyAsync(src: Path, dest: Path, overwrite: Boolean = true): Future[Unit] = {
+    asyncIo.copyAsync(src, dest, overwrite)
+  }
+}

--- a/core/src/main/scala/cromwell/core/io/AsyncIoActorClient.scala
+++ b/core/src/main/scala/cromwell/core/io/AsyncIoActorClient.scala
@@ -1,43 +1,13 @@
 package cromwell.core.io
 
 import akka.actor.ActorRef
-import cromwell.core.path.BetterFileMethods.OpenOptions
-import cromwell.core.path.Path
-
-import scala.concurrent.Future
 
 /**
   * Helper trait to used async Io method easily
   */
 trait AsyncIoActorClient {
-  
   def ioActor: ActorRef
   def ioCommandBuilder: IoCommandBuilder
-  private val asyncIo = new AsyncIo(ioActor, ioCommandBuilder)
-  
-  /**
-    * IMPORTANT: This loads the entire content of the file into memory !
-    * Only use for small files !
-    */
-  def contentAsStringAsync(path: Path): Future[String] = {
-    asyncIo.contentAsStringAsync(path)
-  }
-  def writeAsync(path: Path, content: String, options: OpenOptions): Future[Unit] = {
-    asyncIo.writeAsync(path, content, options)
-  }
-  def sizeAsync(path: Path): Future[Long] = {
-    asyncIo.sizeAsync(path)
-  }
-  def hashAsync(path: Path): Future[String] = {
-    asyncIo.hashAsync(path)
-  }
-  def deleteAsync(path: Path, swallowIoExceptions: Boolean = false): Future[Unit] = {
-    asyncIo.deleteAsync(path, swallowIoExceptions)
-  }
-  def existsAsync(path: Path): Future[Boolean] = {
-    asyncIo.existsAsync(path)
-  }
-  def copyAsync(src: Path, dest: Path, overwrite: Boolean = true): Future[Unit] = {
-    asyncIo.copyAsync(src, dest, overwrite)
-  }
+
+  val asyncIo = new AsyncIo(ioActor, ioCommandBuilder)
 }

--- a/core/src/main/scala/cromwell/core/io/AsyncIoFunctions.scala
+++ b/core/src/main/scala/cromwell/core/io/AsyncIoFunctions.scala
@@ -1,0 +1,17 @@
+package cromwell.core.io
+
+import wom.expression.IoFunctionSet
+
+import scala.concurrent.ExecutionContext
+
+trait AsyncIoFunctions { this: IoFunctionSet =>
+  /**
+    * Used to perform io functions asynchronously through the IoActorEndpoint
+    */
+  def asyncIo: AsyncIo
+
+  /**
+    * To map/flatMap over IO results
+    */
+  implicit def ec: ExecutionContext
+}

--- a/core/src/main/scala/cromwell/core/io/AsyncIoFunctions.scala
+++ b/core/src/main/scala/cromwell/core/io/AsyncIoFunctions.scala
@@ -6,7 +6,7 @@ import scala.concurrent.ExecutionContext
 
 trait AsyncIoFunctions { this: IoFunctionSet =>
   /**
-    * Used to perform io functions asynchronously through the IoActorEndpoint
+    * Used to perform io functions asynchronously through the ioActorProxy
     */
   def asyncIo: AsyncIo
 

--- a/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
@@ -23,4 +23,5 @@ object DefaultIoCommand {
   case class DefaultIoHashCommand(override val file: Path) extends IoHashCommand(file)
   case class DefaultIoTouchCommand(override val file: Path) extends IoTouchCommand(file)
   case class DefaultIoExistsCommand(override val file: Path) extends IoExistsCommand(file)
+  case class DefaultIoReadLinesCommand(override val file: Path) extends IoReadLinesCommand(file)
 }

--- a/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
@@ -3,14 +3,15 @@ package cromwell.core.io
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import cromwell.core.actor.RobustClientHelper
 
+import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 
-trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging with IoCommandBuilder =>
+trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging =>
   def ioActor: ActorRef
 
   lazy val defaultIoTimeout = RobustClientHelper.DefaultRequestLostTimeout
 
-  private [core] def ioResponseReceive: Receive = {
+  protected def ioResponseReceive: Receive = {
     case ack: IoAck[_] if hasTimeout(ack.command) =>
       cancelTimeout(ack.command)
       receive.apply(ack)
@@ -31,5 +32,12 @@ trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging 
 
   def sendIoCommandWithContext[T](ioCommand: IoCommand[_], context: T, timeout: FiniteDuration = defaultIoTimeout) = {
     robustSend(context -> ioCommand, ioActor, timeout)
+  }
+
+  override protected def onTimeout(message: Any, to: ActorRef): Unit = message match {
+    case (promise: Promise[_], ioAck: IoAck[_]) =>
+      promise.tryFailure(IoTimeout(ioAck.command))
+      ()
+    case _ =>
   }
 }

--- a/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
@@ -3,7 +3,6 @@ package cromwell.core.io
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import cromwell.core.actor.RobustClientHelper
 
-import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 
 trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging =>
@@ -34,10 +33,4 @@ trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging 
     robustSend(context -> ioCommand, ioActor, timeout)
   }
 
-  override protected def onTimeout(message: Any, to: ActorRef): Unit = message match {
-    case (promise: Promise[_], ioAck: IoAck[_]) =>
-      promise.tryFailure(IoTimeout(ioAck.command))
-      ()
-    case _ =>
-  }
 }

--- a/core/src/main/scala/cromwell/core/io/IoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommand.scala
@@ -109,3 +109,11 @@ abstract class IoExistsCommand(val file: Path) extends SingleFileIoCommand[Boole
   override def toString = s"check whether ${file.pathAsString} exists"
   override lazy val name = "exist"
 }
+
+/**
+  * Check whether a file exists
+  */
+abstract class IoReadLinesCommand(val file: Path) extends SingleFileIoCommand[Traversable[String]] {
+  override def toString = s"read lines of ${file.pathAsString}"
+  override lazy val name = "read lines"
+}

--- a/core/src/main/scala/cromwell/core/io/IoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommand.scala
@@ -111,7 +111,7 @@ abstract class IoExistsCommand(val file: Path) extends SingleFileIoCommand[Boole
 }
 
 /**
-  * Check whether a file exists
+  * Return the lines of a file in a collection
   */
 abstract class IoReadLinesCommand(val file: Path) extends SingleFileIoCommand[Traversable[String]] {
   override def toString = s"read lines of ${file.pathAsString}"

--- a/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
@@ -4,24 +4,98 @@ import cromwell.core.io.DefaultIoCommand._
 import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.Path
 
-trait IoCommandBuilder {
-  def contentAsStringCommand(path: Path): IoContentAsStringCommand
-  def writeCommand(path: Path, content: String, options: OpenOptions): IoWriteCommand
-  def sizeCommand(path: Path): IoSizeCommand
-  def deleteCommand(path: Path, swallowIoExceptions: Boolean): IoDeleteCommand
-  def copyCommand(src: Path, dest: Path, overwrite: Boolean): IoCopyCommand
-  def hashCommand(file: Path): IoHashCommand
-  def touchCommand(file: Path): IoTouchCommand
-  def existsCommand(path: Path): IoExistsCommand
+/**
+  * Can be used to customize IoCommands for the desired I/O operations
+  */
+abstract class PartialIoCommandBuilder {
+  def contentAsStringCommand: PartialFunction[Path, IoContentAsStringCommand] = PartialFunction.empty
+  def writeCommand: PartialFunction[(Path, String, OpenOptions), IoWriteCommand] = PartialFunction.empty
+  def sizeCommand: PartialFunction[Path, IoSizeCommand] = PartialFunction.empty
+  def deleteCommand: PartialFunction[(Path, Boolean), IoDeleteCommand] = PartialFunction.empty
+  def copyCommand: PartialFunction[(Path, Path, Boolean), IoCopyCommand] = PartialFunction.empty
+  def hashCommand: PartialFunction[Path, IoHashCommand] = PartialFunction.empty
+  def touchCommand: PartialFunction[Path, IoTouchCommand] = PartialFunction.empty
+  def existsCommand: PartialFunction[Path, IoExistsCommand] = PartialFunction.empty
+  def readLinesCommand: PartialFunction[Path, IoReadLinesCommand] = PartialFunction.empty
 }
 
-trait DefaultIoCommandBuilder extends IoCommandBuilder {
-  def contentAsStringCommand(path: Path): IoContentAsStringCommand = DefaultIoContentAsStringCommand(path)
-  def writeCommand(path: Path, content: String, options: OpenOptions): IoWriteCommand = DefaultIoWriteCommand(path, content, options)
-  def sizeCommand(path: Path): IoSizeCommand = DefaultIoSizeCommand(path)
-  def deleteCommand(path: Path, swallowIoExceptions: Boolean): IoDeleteCommand = DefaultIoDeleteCommand(path, swallowIoExceptions)
-  def copyCommand(src: Path, dest: Path, overwrite: Boolean): IoCopyCommand = DefaultIoCopyCommand(src, dest, overwrite)
-  def hashCommand(file: Path): IoHashCommand = DefaultIoHashCommand(file)
-  def touchCommand(file: Path): IoTouchCommand = DefaultIoTouchCommand(file)
-  def existsCommand(file: Path): IoExistsCommand = DefaultIoExistsCommand(file)
+object IoCommandBuilder {
+  def apply(partialBuilders: PartialIoCommandBuilder*): IoCommandBuilder = {
+    new IoCommandBuilder(partialBuilders.toList)
+  }
+
+  def apply: IoCommandBuilder = {
+    new IoCommandBuilder(List.empty)
+  }
 }
+
+/**
+  * A command builder is a way to build an IoCommand for a specific I/O action.
+  * The default IO command builder can execute all IoCommand and therefore can always be used.
+  * One might want to create different I/O commands to allow for optimizations when the commands are processed by the I/O actor.
+  * Currently the only other command builder is the GcsBatchCommandBuilder that overrides some of the operations
+  * to return GcsBatchCommands instead that will be optimized by the IoActor.
+  * 
+  * This always defaults to building a DefaultIoCommand.
+  * @param partialBuilders list of PartialIoCommandBuilder to try
+  */
+class IoCommandBuilder(partialBuilders: List[PartialIoCommandBuilder] = List.empty) {
+  def contentAsStringCommand(path: Path): IoContentAsStringCommand = {
+    partialBuilders.toStream.map(_.contentAsStringCommand.lift(path)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoContentAsStringCommand(path))
+  }
+  
+  def writeCommand(path: Path, content: String, options: OpenOptions): IoWriteCommand = {
+    partialBuilders.toStream.map(_.writeCommand.lift((path, content, options))).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoWriteCommand(path, content, options))
+  }
+  
+  def sizeCommand(path: Path): IoSizeCommand = {
+    partialBuilders.toStream.map(_.sizeCommand.lift(path)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoSizeCommand(path))
+  } 
+  
+  def deleteCommand(path: Path, swallowIoExceptions: Boolean = true): IoDeleteCommand = {
+    partialBuilders.toStream.map(_.deleteCommand.lift((path, swallowIoExceptions))).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoDeleteCommand(path, swallowIoExceptions))
+  }
+  
+  def copyCommand(src: Path, dest: Path, overwrite: Boolean): IoCopyCommand = {
+    partialBuilders.toStream.map(_.copyCommand.lift((src, dest, overwrite))).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoCopyCommand(src, dest, overwrite))
+  }
+  
+  def hashCommand(file: Path): IoHashCommand = {
+    partialBuilders.toStream.map(_.hashCommand.lift(file)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoHashCommand(file))
+  }
+  
+  def touchCommand(file: Path): IoTouchCommand = {
+    partialBuilders.toStream.map(_.touchCommand.lift(file)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoTouchCommand(file))
+  }
+
+  def existsCommand(file: Path): IoExistsCommand = {
+    partialBuilders.toStream.map(_.existsCommand.lift(file)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoExistsCommand(file))
+  }
+
+  def readLines(file: Path): IoReadLinesCommand = {
+    partialBuilders.toStream.map(_.readLinesCommand.lift(file)).collectFirst({
+      case Some(command) => command
+    }).getOrElse(DefaultIoReadLinesCommand(file))
+  }
+}
+
+/**
+  * Only builds DefaultIoCommands.
+  */
+case object DefaultIoCommandBuilder extends IoCommandBuilder(List.empty)

--- a/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
+++ b/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
@@ -38,4 +38,11 @@ class IoPromiseProxyActor(override val ioActor: ActorRef) extends Actor with Act
       promise.asInstanceOf[Promise[Any]].complete(ack.toTry)
       ()
   }
+
+  override def onTimeout(message: Any, to: ActorRef): Unit = message match {
+    case (promise: Promise[_], ioAck: IoAck[_]) =>
+      promise.tryFailure(IoTimeout(ioAck.command))
+      ()
+    case _ =>
+  }
 }

--- a/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
+++ b/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
@@ -31,10 +31,7 @@ class IoPromiseProxyActor(override val ioActor: ActorRef) extends Actor with Act
   override protected def ioResponseReceive: Receive = {
     case (promise: Promise[_], ack: IoAck[Any] @unchecked) =>
       cancelTimeout(promise -> ack.command)
-      // This is not typesafe. 
-      // However the sendIoCommand method ensures that the command and the promise have the same generic type
-      // Which means as long as only the sendIoCommand method is used to send requests, and the ioActor honors his contract
-      // and send back the right context with the right response, the types are virtually guaranteed to match.
+      // This is not typesafe and assumes the Promise context is of the same type as the IoAck response.
       promise.asInstanceOf[Promise[Any]].complete(ack.toTry)
       ()
   }

--- a/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
+++ b/core/src/main/scala/cromwell/core/io/IoPromiseProxyActor.scala
@@ -1,14 +1,14 @@
 package cromwell.core.io
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import cromwell.core.io.AsyncIo.ioTimeout
+import cromwell.core.io.AsyncIo.defaultTimeout
 import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
 
 import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
 
 object IoPromiseProxyActor {
-  case class IoCommandWithPromise[A](ioCommand: IoCommand[A], timeout: FiniteDuration = ioTimeout) {
+  case class IoCommandWithPromise[A](ioCommand: IoCommand[A], timeout: FiniteDuration = defaultTimeout) {
     val promise = Promise[A]
   }
   def props(ioActor: ActorRef) = Props(new IoPromiseProxyActor(ioActor))

--- a/core/src/test/scala/cromwell/core/MockIoActor.scala
+++ b/core/src/test/scala/cromwell/core/MockIoActor.scala
@@ -1,7 +1,10 @@
 package cromwell.core
 
 import akka.actor.{Actor, Props}
+import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
 import cromwell.core.io._
+
+import scala.concurrent.Promise
 
 object MockIoActor {
   def props(returnCode: String = "0", stderrSize: Long = 0L) = Props(new MockIoActor(returnCode, stderrSize))
@@ -21,5 +24,11 @@ class MockIoActor(returnCode: String, stderrSize: Long) extends Actor {
     case (requestContext: Any, command: IoDeleteCommand) => sender() ! (requestContext -> IoSuccess(command, ()))
     case (requestContext: Any, command: IoSizeCommand) => sender() ! (requestContext -> IoSuccess(command, stderrSize))
     case (requestContext: Any, command: IoContentAsStringCommand) => sender() ! (requestContext -> IoSuccess(command, returnCode))
+
+    case withPromise: IoCommandWithPromise[_] => self ! ((withPromise.promise, withPromise.ioCommand))
+
+    case (promise: Promise[_], ack: IoAck[Any] @unchecked) =>
+      promise.asInstanceOf[Promise[Any]].complete(ack.toTry)
+      ()
   }
 }

--- a/core/src/test/scala/cromwell/core/TestKitSuite.scala
+++ b/core/src/test/scala/cromwell/core/TestKitSuite.scala
@@ -23,6 +23,7 @@ abstract class TestKitSuite(actorSystemName: String = TestKitSuite.randomName,
 
   val emptyActor = system.actorOf(Props.empty)
   val mockIoActor = system.actorOf(MockIoActor.props())
+  val simpleIoActor = system.actorOf(SimpleIoActor.props)
   val failIoActor = system.actorOf(FailIoActor.props())
 }
 

--- a/core/src/test/scala/cromwell/core/io/AsyncIoSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/AsyncIoSpec.scala
@@ -21,7 +21,7 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
 
     val testPath = DefaultPathBuilder.createTempFile()
     
-    testActor.underlyingActor.writeAsync(testPath, "hello", Seq.empty) map { _ =>
+    testActor.underlyingActor.asyncIo.writeAsync(testPath, "hello", Seq.empty) map { _ =>
       assert(testPath.contentAsString == "hello")
     }
   }
@@ -32,7 +32,7 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
 
-    testActor.underlyingActor.contentAsStringAsync(testPath) map { result =>
+    testActor.underlyingActor.asyncIo.contentAsStringAsync(testPath) map { result =>
       assert(result == "hello")
     }
   }
@@ -43,7 +43,7 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
 
-    testActor.underlyingActor.sizeAsync(testPath) map { size =>
+    testActor.underlyingActor.asyncIo.sizeAsync(testPath) map { size =>
       assert(size == 5)
     }
   }
@@ -54,7 +54,7 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
 
-    testActor.underlyingActor.hashAsync(testPath) map { hash =>
+    testActor.underlyingActor.asyncIo.hashAsync(testPath) map { hash =>
       assert(hash == "5D41402ABC4B2A76B9719D911017C592")
     }
   }
@@ -65,20 +65,20 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     val testCopyPath = testPath.sibling(UUID.randomUUID().toString)
 
-    testActor.underlyingActor.copyAsync(testPath, testCopyPath) map { hash =>
+    testActor.underlyingActor.asyncIo.copyAsync(testPath, testCopyPath) map { hash =>
       assert(testCopyPath.exists)
     }
 
     testPath.write("new text")
     
     // Honor overwrite true
-    testActor.underlyingActor.copyAsync(testPath, testCopyPath, overwrite = true) map { hash =>
+    testActor.underlyingActor.asyncIo.copyAsync(testPath, testCopyPath, overwrite = true) map { hash =>
       assert(testCopyPath.exists)
       assert(testCopyPath.contentAsString == "new text")
     }
 
     // Honor overwrite false
-    recoverToSucceededIf[FileAlreadyExistsException] { testActor.underlyingActor.copyAsync(testPath, testCopyPath, overwrite = false) }
+    recoverToSucceededIf[FileAlreadyExistsException] { testActor.underlyingActor.asyncIo.copyAsync(testPath, testCopyPath, overwrite = false) }
   }
 
   it should "delete asynchronously" in {
@@ -86,17 +86,17 @@ class AsyncIoSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
 
     val testPath = DefaultPathBuilder.createTempFile()
 
-    testActor.underlyingActor.deleteAsync(testPath) map { _ =>
+    testActor.underlyingActor.asyncIo.deleteAsync(testPath) map { _ =>
       assert(!testPath.exists)
     }
 
     // Honor swallow exception true
-    testActor.underlyingActor.deleteAsync(testPath, swallowIoExceptions = true) map { _ =>
+    testActor.underlyingActor.asyncIo.deleteAsync(testPath, swallowIoExceptions = true) map { _ =>
       assert(!testPath.exists)
     }
 
     // Honor swallow exception false
-    recoverToSucceededIf[NoSuchFileException] { testActor.underlyingActor.deleteAsync(testPath, swallowIoExceptions = false) }
+    recoverToSucceededIf[NoSuchFileException] { testActor.underlyingActor.asyncIo.deleteAsync(testPath, swallowIoExceptions = false) }
   }
 
   private class AsyncIoTestActor(override val ioActor: ActorRef) extends Actor with ActorLogging with AsyncIoActorClient {

--- a/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
@@ -83,8 +83,10 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   private class IoClientHelperTestActor(override val ioActor: ActorRef,
                                 delegateTo: ActorRef,
                                 override val backpressureTimeout: FiniteDuration,
-                                noResponseTimeout: FiniteDuration) extends Actor with ActorLogging with IoClientHelper with DefaultIoCommandBuilder {
+                                noResponseTimeout: FiniteDuration) extends Actor with ActorLogging with IoClientHelper {
 
+    implicit val ioCommandBuilder = DefaultIoCommandBuilder
+    
     context.become(ioReceive orElse receive)
 
     override def receive: Receive = {

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -63,7 +63,7 @@ case class CommandOutputExpression(outputBinding: CommandOutputBinding,
 
         //In the case of a single file being expected, we must enforce that the glob only represents a single file
         case (WomString(glob), WomSingleFileType) =>
-          ioFunctionSet.glob(glob) match {
+          Await.result(ioFunctionSet.glob(glob), Duration.Inf) match {
             case head :: Nil => WomString(head)
             case list => throw new RuntimeException(s"expecting a single File glob but instead got $list")
           }

--- a/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
+++ b/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
@@ -25,7 +25,7 @@ class CommandOutputExpressionSpec extends FlatSpec with Matchers {
       override def writeFile(path: String, content: String) = throw new Exception("writeFile should not be used in this test")
       override def stdout(params: Seq[Try[WomValue]]) = throw new Exception("stdout should not be used in this test")
       override def stderr(params: Seq[Try[WomValue]]) = throw new Exception("stderr should not be used in this test")
-      override def glob(pattern: String): Seq[String] = throw new Exception("glob should not be used in this test")
+      override def glob(pattern: String): Future[Seq[String]] = throw new Exception("glob should not be used in this test")
       override def size(params: Seq[Try[WomValue]]) = throw new Exception("size should not be used in this test")
     }
 

--- a/engine/src/main/scala/cromwell/engine/EngineIoFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineIoFunctions.scala
@@ -1,18 +1,19 @@
 package cromwell.engine
 
 import cromwell.backend.wdl.ReadLikeFunctions
+import cromwell.core.io.AsyncIo
 import cromwell.core.path.PathBuilder
 import wom.values.{WomFile, WomValue}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Try}
 
-class WdlFunctions(val pathBuilders: List[PathBuilder]) extends ReadLikeFunctions {
+class EngineIoFunctions(val pathBuilders: List[PathBuilder], override val asyncIo: AsyncIo, override val ec: ExecutionContext) extends ReadLikeFunctions {
   private def fail(name: String) = Failure(new NotImplementedError(s"$name() not supported at the workflow level yet"))
 
   override def stdout(params: Seq[Try[WomValue]]): Try[WomFile] = fail("stdout")
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = fail("stderr")
-  override def glob(pattern: String): Seq[String] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
+  override def glob(pattern: String): Future[Seq[String]] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
 
   // Cromwell does not support writing files from the engine.
   override def writeFile(path: String, content: String): Future[WomFile] = Future.failed(new Exception("Can't write files"))

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -1,11 +1,11 @@
 package cromwell.engine.instrumentation
 
 import cats.data.NonEmptyList
+import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.io._
 import cromwell.engine.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.filesystems.gcs.{GcsPath, GoogleUtil}
-import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.instrumentation.CromwellInstrumentation._
 

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -31,8 +31,8 @@ import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
   * @param serviceRegistryActor actorRef for the serviceRegistryActor
   */
 final class IoActor(queueSize: Int,
-                            throttle: Option[Throttle],
-                            override val serviceRegistryActor: ActorRef)(implicit val materializer: ActorMaterializer) 
+                    throttle: Option[Throttle],
+                    override val serviceRegistryActor: ActorRef)(implicit val materializer: ActorMaterializer) 
   extends Actor with ActorLogging with StreamActorHelper[IoCommandContext[_]] with IoInstrumentation {
   
   implicit private val system = context.system

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -31,8 +31,8 @@ import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
   * @param serviceRegistryActor actorRef for the serviceRegistryActor
   */
 final class IoActor(queueSize: Int,
-                    throttle: Option[Throttle],
-                    override val serviceRegistryActor: ActorRef)(implicit val materializer: ActorMaterializer) 
+                            throttle: Option[Throttle],
+                            override val serviceRegistryActor: ActorRef)(implicit val materializer: ActorMaterializer) 
   extends Actor with ActorLogging with StreamActorHelper[IoCommandContext[_]] with IoInstrumentation {
   
   implicit private val system = context.system

--- a/engine/src/main/scala/cromwell/engine/io/IoActorEndpoint.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActorEndpoint.scala
@@ -1,0 +1,28 @@
+package cromwell.engine.io
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import cats.data.NonEmptyList
+import cromwell.core.io.{IoCommand, IoPromiseProxyActor}
+import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
+import cromwell.util.GracefulShutdownHelper
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
+
+object IoActorEndpoint {
+  def props(ioActor: ActorRef) = Props(new IoActorEndpoint(ioActor))
+}
+
+class IoActorEndpoint(ioActor: ActorRef) extends Actor with ActorLogging with GracefulShutdownHelper {
+  private val ioPromiseProxyActor: ActorRef = context.actorOf(IoPromiseProxyActor.props(ioActor), "IoPromiseProxyActor")
+
+  override def receive = {
+    // If it's an IoCommandWithPromise send it to the proxy actor
+    case ioPromise: IoCommandWithPromise[_] => ioPromiseProxyActor forward ioPromise
+    // otherwise to the IoActor directly
+    case ioCommand: IoCommand[_] => ioActor forward ioCommand
+    case withContext: (Any, IoCommand[_]) @unchecked => ioActor forward withContext
+
+    case ShutdownCommand => 
+      context stop ioPromiseProxyActor
+      waitForActorsAndShutdown(NonEmptyList.one(ioActor))
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/io/IoActorProxy.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActorProxy.scala
@@ -7,11 +7,11 @@ import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
-object IoActorEndpoint {
-  def props(ioActor: ActorRef) = Props(new IoActorEndpoint(ioActor))
+object IoActorProxy {
+  def props(ioActor: ActorRef) = Props(new IoActorProxy(ioActor))
 }
 
-class IoActorEndpoint(ioActor: ActorRef) extends Actor with ActorLogging with GracefulShutdownHelper {
+class IoActorProxy(ioActor: ActorRef) extends Actor with ActorLogging with GracefulShutdownHelper {
   private val ioPromiseProxyActor: ActorRef = context.actorOf(IoPromiseProxyActor.props(ioActor), "IoPromiseProxyActor")
 
   override def receive = {

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -231,7 +231,7 @@ class WorkflowActor(val workflowId: WorkflowId,
 
   when(WorkflowUnstartedState) {
     case Event(StartWorkflowCommand, _) =>
-      val actor = context.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryActor, workflowId, importLocalFilesystem = !serverMode),
+      val actor = context.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryActor, workflowId, importLocalFilesystem = !serverMode, ioActorEndpoint = ioActor),
         "MaterializeWorkflowDescriptorActor")
       pushWorkflowStart(workflowId)
       actor ! MaterializeWorkflowDescriptorCommand(workflowSourceFilesCollection, conf)

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -231,7 +231,7 @@ class WorkflowActor(val workflowId: WorkflowId,
 
   when(WorkflowUnstartedState) {
     case Event(StartWorkflowCommand, _) =>
-      val actor = context.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryActor, workflowId, importLocalFilesystem = !serverMode, ioActorEndpoint = ioActor),
+      val actor = context.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryActor, workflowId, importLocalFilesystem = !serverMode, ioActorProxy = ioActor),
         "MaterializeWorkflowDescriptorActor")
       pushWorkflowStart(workflowId)
       actor ! MaterializeWorkflowDescriptorCommand(workflowSourceFilesCollection, conf)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -16,7 +16,7 @@ import cromwell.engine.workflow.lifecycle.execution.job.preparation.SubWorkflowP
 import cromwell.engine.workflow.lifecycle.execution.keys.SubWorkflowKey
 import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore
 import cromwell.engine.workflow.workflowstore.StartableState
-import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
+import cromwell.engine.{EngineWorkflowDescriptor, EngineIoFunctions}
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
@@ -24,7 +24,7 @@ import wom.values.WomEvaluatedCallInputs
 
 class SubWorkflowExecutionActor(key: SubWorkflowKey,
                                 parentWorkflow: EngineWorkflowDescriptor,
-                                expressionLanguageFunctions: WdlFunctions,
+                                expressionLanguageFunctions: EngineIoFunctions,
                                 factories: Map[String, BackendLifecycleActorFactory],
                                 ioActor: ActorRef,
                                 override val serviceRegistryActor: ActorRef,
@@ -280,7 +280,7 @@ object SubWorkflowExecutionActor {
 
   def props(key: SubWorkflowKey,
             parentWorkflow: EngineWorkflowDescriptor,
-            expressionLanguageFunctions: WdlFunctions,
+            expressionLanguageFunctions: EngineIoFunctions,
             factories: Map[String, BackendLifecycleActorFactory],
             ioActor: ActorRef,
             serviceRegistryActor: ActorRef,

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -3,13 +3,16 @@ package cromwell.engine.workflow.lifecycle.execution
 import akka.actor.ActorRef
 import cromwell.backend._
 import cromwell.core.ExecutionStatus._
+import cromwell.core.io.AsyncIo
 import cromwell.core.{JobKey, _}
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData.DataStoreUpdate
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore.ValueKey
 import cromwell.engine.workflow.lifecycle.execution.stores.{ExecutionStore, ValueStore}
-import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
+import cromwell.engine.{EngineIoFunctions, EngineWorkflowDescriptor}
 import wom.values.WomValue
+
+import scala.concurrent.ExecutionContext
 
 object WorkflowExecutionDiff {
   def empty = WorkflowExecutionDiff(Map.empty)
@@ -24,11 +27,13 @@ final case class WorkflowExecutionDiff(executionStoreChanges: Map[JobKey, Execut
 }
 
 object WorkflowExecutionActorData {
-  def apply(workflowDescriptor: EngineWorkflowDescriptor): WorkflowExecutionActorData = {
+  def apply(workflowDescriptor: EngineWorkflowDescriptor, ec: ExecutionContext, asyncIo: AsyncIo): WorkflowExecutionActorData = {
     WorkflowExecutionActorData(
       workflowDescriptor,
       ExecutionStore(workflowDescriptor.callable),
-      ValueStore.initialize(workflowDescriptor.knownValues)
+      ValueStore.initialize(workflowDescriptor.knownValues),
+      asyncIo,
+      ec
     )
   }
 
@@ -38,11 +43,13 @@ object WorkflowExecutionActorData {
 case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescriptor,
                                       executionStore: ExecutionStore,
                                       valueStore: ValueStore,
+                                      asyncIo: AsyncIo,
+                                      ec: ExecutionContext,
                                       jobKeyActorMappings: Map[ActorRef, JobKey] = Map.empty,
                                       jobFailures: Map[JobKey, Throwable] = Map.empty,
                                       downstreamExecutionMap: JobExecutionMap = Map.empty) {
 
-  val expressionLanguageFunctions = new WdlFunctions(workflowDescriptor.pathBuilders)
+  val expressionLanguageFunctions = new EngineIoFunctions(workflowDescriptor.pathBuilders, asyncIo, ec)
 
   def sealExecutionStore: WorkflowExecutionActorData = this.copy(
     executionStore = executionStore.seal

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
@@ -7,6 +7,7 @@ import common.exception.MessageAggregation
 import common.validation.ErrorOr.ErrorOr
 import cromwell.backend._
 import cromwell.backend.validation.DockerValidation
+import cromwell.core.Dispatcher
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.callcaching._
 import cromwell.core.logging.WorkflowLogging
@@ -48,8 +49,9 @@ class JobPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
   override lazy val workflowIdForLogging = workflowDescriptor.id
 
   private[preparation] lazy val noResponseTimeout: FiniteDuration = 3 minutes
+  private[preparation] val ioEc = context.system.dispatchers.lookup(Dispatcher.IoDispatcher)
 
-  private[preparation] lazy val expressionLanguageFunctions = factory.expressionLanguageFunctions(workflowDescriptor.backendDescriptor, jobKey, initializationData)
+  private[preparation] lazy val expressionLanguageFunctions = factory.expressionLanguageFunctions(workflowDescriptor.backendDescriptor, jobKey, initializationData, ioActor, ioEc)
   private[preparation] lazy val dockerHashCredentials = factory.dockerHashCredentials(initializationData)
   private[preparation] lazy val runtimeAttributeDefinitions = factory.runtimeAttributeDefinitions(initializationData)
   private[preparation] lazy val hasDockerDefinition = runtimeAttributeDefinitions.exists(_.name == DockerValidation.instance.key)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/SubWorkflowPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/SubWorkflowPreparationActor.scala
@@ -10,7 +10,7 @@ import cromwell.core.logging.WorkflowLogging
 import cromwell.engine.workflow.lifecycle.execution.keys.SubWorkflowKey
 import cromwell.engine.workflow.lifecycle.execution.job.preparation.CallPreparation.{CallPreparationFailed, Start, _}
 import cromwell.engine.workflow.lifecycle.execution.job.preparation.SubWorkflowPreparationActor.SubWorkflowPreparationSucceeded
-import cromwell.engine.{EngineWorkflowDescriptor, WdlFunctions}
+import cromwell.engine.{EngineWorkflowDescriptor, EngineIoFunctions}
 import common.exception.MessageAggregation
 import common.validation.ErrorOr.ErrorOr
 import wom.graph.{GraphInputNode, GraphNode, OptionalGraphInputNode, OptionalGraphInputNodeWithDefault}
@@ -18,7 +18,7 @@ import wom.graph.GraphNodePort.OutputPort
 import wom.values.{WomEvaluatedCallInputs, WomValue}
 
 class SubWorkflowPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
-                                  expressionLanguageFunctions: WdlFunctions,
+                                  expressionLanguageFunctions: EngineIoFunctions,
                                   callKey: SubWorkflowKey,
                                   subWorkflowId: WorkflowId) extends Actor with WorkflowLogging {
 
@@ -85,7 +85,7 @@ object SubWorkflowPreparationActor {
   case class SubWorkflowPreparationSucceeded(workflowDescriptor: EngineWorkflowDescriptor, inputs: WomEvaluatedCallInputs) extends CallPreparationActorResponse
 
   def props(workflowDescriptor: EngineWorkflowDescriptor,
-            expressionLanguageFunctions: WdlFunctions,
+            expressionLanguageFunctions: EngineIoFunctions,
             key: SubWorkflowKey,
             subWorkflowId: WorkflowId) = {
     // Note that JobPreparationActor doesn't run on the engine dispatcher as it mostly executes backend-side code

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -8,7 +8,7 @@ import cromwell.backend.{AllBackendInitializationData, BackendConfigurationDescr
 import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core.WorkflowOptions._
 import cromwell.core._
-import cromwell.core.io.AsyncIo
+import cromwell.core.io.AsyncIoActorClient
 import cromwell.core.path.{Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
@@ -27,12 +27,12 @@ object CopyWorkflowOutputsActor {
 
 class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: ActorRef, val workflowDescriptor: EngineWorkflowDescriptor, workflowOutputs: CallOutputs,
                                initializationData: AllBackendInitializationData)
-  extends Actor with ActorLogging with PathFactory with AsyncIo with GcsBatchCommandBuilder {
-
+  extends Actor with ActorLogging with PathFactory with AsyncIoActorClient {
+  override lazy val ioCommandBuilder = GcsBatchCommandBuilder
   implicit val ec = context.dispatcher
   override val pathBuilders = workflowDescriptor.pathBuilders
 
-  override def receive = ioReceive orElse LoggingReceive {
+  override def receive = LoggingReceive {
     case Finalize => performActionThenRespond(afterAll()(context.dispatcher), FinalizationFailed)(context.dispatcher)
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -54,7 +54,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
     val copies = outputFilePaths map {
       case (srcPath, dstPath) => 
         dstPath.createDirectories()
-        copyAsync(srcPath, dstPath)
+        asyncIo.copyAsync(srcPath, dstPath)
     }
     
     Future.sequence(copies)

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -19,7 +19,7 @@ import cromwell.docker.registryv2.flows.dockerhub.DockerHubFlow
 import cromwell.docker.registryv2.flows.gcr.GoogleFlow
 import cromwell.docker.registryv2.flows.quay.QuayFlow
 import cromwell.engine.backend.{BackendSingletonCollection, CromwellBackends}
-import cromwell.engine.io.{IoActor, IoActorEndpoint}
+import cromwell.engine.io.{IoActor, IoActorProxy}
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.engine.workflow.WorkflowManagerActor.AbortAllWorkflowsCommand
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCache, CallCacheReadActor, CallCacheWriteActor}
@@ -79,7 +79,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   lazy val throttlePer = systemConfig.as[Option[FiniteDuration]]("io.per").getOrElse(100 seconds)
   lazy val ioThrottle = Throttle(throttleElements, throttlePer, throttleElements)
   lazy val ioActor = context.actorOf(IoActor.props(1000, Option(ioThrottle), serviceRegistryActor), "IoActor")
-  lazy val ioActorEndpoint = context.actorOf(IoActorEndpoint.props(ioActor))
+  lazy val ioActorProxy = context.actorOf(IoActorProxy.props(ioActor))
 
   lazy val workflowLogCopyRouter: ActorRef = context.actorOf(RoundRobinPool(numberOfWorkflowLogCopyWorkers)
     .withSupervisorStrategy(CopyWorkflowLogsActor.strategy)
@@ -123,7 +123,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
 
   lazy val workflowManagerActor = context.actorOf(
     WorkflowManagerActor.props(
-      workflowStoreActor, ioActorEndpoint, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, subWorkflowStoreActor, callCacheReadActor, callCacheWriteActor,
+      workflowStoreActor, ioActorProxy, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, subWorkflowStoreActor, callCacheReadActor, callCacheWriteActor,
       dockerHashActor, jobExecutionTokenDispenserActor, backendSingletonCollection, serverMode),
     "WorkflowManagerActor")
 
@@ -138,7 +138,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
       workflowStoreActor = workflowStoreActor,
       subWorkflowStoreActor = subWorkflowStoreActor,
       callCacheWriteActor = callCacheWriteActor,
-      ioActor = ioActorEndpoint,
+      ioActor = ioActorProxy,
       dockerHashActor = dockerHashActor,
       serviceRegistryActor = serviceRegistryActor,
       materializer = materializer

--- a/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/engine/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -275,7 +275,6 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
   implicit val defaultPatience = PatienceConfig(timeout = Span(200, Seconds), interval = Span(1000, Millis))
   implicit val ec = system.dispatcher
   implicit val materializer = twms.materializer
-
   val dummyServiceRegistryActor = system.actorOf(Props.empty)
   val dummyLogCopyRouter = system.actorOf(Props.empty)
 

--- a/engine/src/test/scala/cromwell/EngineIoFunctionsAtWorkflowLevelSpec.scala
+++ b/engine/src/test/scala/cromwell/EngineIoFunctionsAtWorkflowLevelSpec.scala
@@ -6,7 +6,7 @@ import wom.types.{WomMapType, WomStringType}
 import wom.values.{WomMap, WomString}
 
 
-class WdlFunctionsAtWorkflowLevelSpec extends CromwellTestKitWordSpec {
+class EngineIoFunctionsAtWorkflowLevelSpec extends CromwellTestKitWordSpec {
   val outputMap = WomMap(WomMapType(WomStringType, WomStringType), Map(
     WomString("k1") -> WomString("v1"),
     WomString("k2") -> WomString("v2"),

--- a/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
@@ -7,7 +7,7 @@ import cromwell.core.{CallOutputs, NoIoFunctionSet}
 import wom.expression.IoFunctionSet
 import wom.graph.TaskCallNode
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object DefaultBackendJobExecutionActor {
   def props(jobDescriptor: BackendJobDescriptor, configurationDescriptor: BackendConfigurationDescriptor) = Props(DefaultBackendJobExecutionActor(jobDescriptor, configurationDescriptor))
@@ -41,6 +41,8 @@ class DefaultBackendLifecycleActorFactory(val name: String, val configurationDes
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
-                                           initializationData: Option[BackendInitializationData]): IoFunctionSet = NoIoFunctionSet
+                                           initializationData: Option[BackendInitializationData],
+                                           ioActorEndpoint: ActorRef,
+                                           ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
 }
 

--- a/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/DefaultBackendJobExecutionActor.scala
@@ -42,7 +42,7 @@ class DefaultBackendLifecycleActorFactory(val name: String, val configurationDes
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
                                            initializationData: Option[BackendInitializationData],
-                                           ioActorEndpoint: ActorRef,
+                                           ioActorProxy: ActorRef,
                                            ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
 }
 

--- a/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
@@ -6,6 +6,8 @@ import cromwell.core.NoIoFunctionSet
 import wom.expression.IoFunctionSet
 import wom.graph.TaskCallNode
 
+import scala.concurrent.ExecutionContext
+
 class RetryableBackendLifecycleActorFactory(val name: String,
                                             val configurationDescriptor: BackendConfigurationDescriptor)
   extends BackendLifecycleActorFactory {
@@ -25,5 +27,7 @@ class RetryableBackendLifecycleActorFactory(val name: String,
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
-                                           initializationData: Option[BackendInitializationData]): IoFunctionSet = NoIoFunctionSet
+                                           initializationData: Option[BackendInitializationData],
+                                           ioActorEndpoint: ActorRef,
+                                           ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
 }

--- a/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
+++ b/engine/src/test/scala/cromwell/engine/backend/mock/RetryableBackendLifecycleActorFactory.scala
@@ -28,6 +28,6 @@ class RetryableBackendLifecycleActorFactory(val name: String,
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                            jobKey: BackendJobDescriptorKey,
                                            initializationData: Option[BackendInitializationData],
-                                           ioActorEndpoint: ActorRef,
+                                           ioActorProxy: ActorRef,
                                            ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
 }

--- a/engine/src/test/scala/cromwell/engine/io/IoActorEndpointGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorEndpointGcsBatchSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class IoActorGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
+class IoActorEndpointGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
   behavior of "IoActor [GCS Batch]"
 
   implicit val actorSystem = system

--- a/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class IoActorEndpointGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
+class IoActorProxyGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
   behavior of "IoActor [GCS Batch]"
 
   implicit val actorSystem = system

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -11,13 +11,14 @@ import cromwell.core.io._
 import cromwell.core.path.DefaultPathBuilder
 import cromwell.core.{CromwellFatalException, TestKitSuite}
 import cromwell.engine.io.IoActor.DefaultCommandContext
+import cromwell.core.io.DefaultIoCommandBuilder._
 import cromwell.engine.io.IoCommandContext
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{AsyncFlatSpecLike, Matchers}
 
 import scala.concurrent.Future
 
-class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with MockitoSugar with DefaultIoCommandBuilder {
+class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with MockitoSugar {
 
   behavior of "NioFlowSpec"
 

--- a/engine/src/test/scala/cromwell/engine/workflow/WorkflowDescriptorBuilder.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/WorkflowDescriptorBuilder.scala
@@ -22,7 +22,7 @@ trait WorkflowDescriptorBuilder {
     implicit val ec = actorSystem.dispatcher
 
     val serviceRegistryIgnorer = actorSystem.actorOf(Props.empty)
-    val actor = actorSystem.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryIgnorer, id, importLocalFilesystem = false, ioActorEndpoint = ioActor), "MaterializeWorkflowDescriptorActor-" + id.id)
+    val actor = actorSystem.actorOf(MaterializeWorkflowDescriptorActor.props(serviceRegistryIgnorer, id, importLocalFilesystem = false, ioActorProxy = ioActor), "MaterializeWorkflowDescriptorActor-" + id.id)
     val workflowDescriptorFuture = actor.ask(
       MaterializeWorkflowDescriptorCommand(workflowSources, ConfigFactory.load)
     ).mapTo[WorkflowDescriptorMaterializationResult]

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/MaterializeWorkflowDescriptorActorSpec.scala
@@ -61,7 +61,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
 
   "MaterializeWorkflowDescriptorActor" should {
     "accept valid WDL, inputs and options files" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
         workflowRoot = None,
@@ -121,7 +121,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
       val cromwellBackends = CromwellBackends(fauxBackendEntries)
 
       // Run the test:
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, cromwellBackends, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, cromwellBackends, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = wdl,
         workflowRoot = None,
@@ -164,7 +164,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
           |}
         """.stripMargin
 
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = wdl,
         workflowRoot = None,
@@ -191,7 +191,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject an invalid WDL source" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = unstructuredFile,
         workflowRoot = None,
@@ -223,7 +223,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
           |
           |# no workflow foo { ... } block!!
         """.stripMargin
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = noWorkflowWdl,
         workflowRoot = None,
@@ -249,7 +249,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject an invalid options file" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
         workflowRoot = None,
@@ -275,7 +275,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject an unstructured labels file" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
         workflowRoot = None,
@@ -303,7 +303,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject invalid labels" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
         workflowRoot = None,
@@ -335,7 +335,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject an invalid workflow inputs file" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
         workflowRoot = None,
@@ -361,7 +361,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
     }
 
     "reject requests if any required inputs are missing" in {
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val noInputsJson = "{}"
       val badOptionsSources = WorkflowSourceFilesWithoutImports(
         workflowSource = workflowSourceNoDocker,
@@ -396,7 +396,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
           |  call bar
           |}
         """.stripMargin
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = wdl,
         workflowRoot = None,
@@ -439,7 +439,7 @@ class MaterializeWorkflowDescriptorActorSpec extends CromwellTestKitWordSpec wit
         "foo.bad_two" -> "\"gs://another/bad/gcs/path.txt",
         "foo.bad_three" -> ""
       ).toJson.toString
-      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorEndpoint = ioActor))
+      val materializeWfActor = system.actorOf(MaterializeWorkflowDescriptorActor.props(NoBehaviorActor, workflowId, importLocalFilesystem = false, ioActorProxy = ioActor))
       val sources = WorkflowSourceFilesWithoutImports(
         workflowSource = wdl,
         workflowRoot = None,

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
@@ -7,6 +7,7 @@ import akka.testkit.{TestFSMRef, TestProbe}
 import cromwell.backend.{AllBackendInitializationData, BackendWorkflowDescriptor, JobExecutionMap}
 import cromwell.core._
 import cromwell.core.callcaching.CallCachingOff
+import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
 import cromwell.database.sql.tables.SubWorkflowStoreEntry
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.lifecycle.execution.SubWorkflowExecutionActor._
@@ -17,7 +18,7 @@ import cromwell.engine.workflow.lifecycle.execution.job.preparation.SubWorkflowP
 import cromwell.engine.workflow.lifecycle.execution.keys.SubWorkflowKey
 import cromwell.engine.workflow.lifecycle.execution.stores.ValueStore
 import cromwell.engine.workflow.workflowstore.{RestartableRunning, StartableState, Submitted}
-import cromwell.engine.{ContinueWhilePossible, EngineWorkflowDescriptor, WdlFunctions}
+import cromwell.engine.{ContinueWhilePossible, EngineIoFunctions, EngineWorkflowDescriptor}
 import cromwell.subworkflowstore.SubWorkflowStoreActor.{QuerySubWorkflow, SubWorkflowFound, SubWorkflowNotFound}
 import cromwell.util.WomMocks
 import org.scalatest.concurrent.Eventually
@@ -66,7 +67,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with FlatSpecLike with 
       new SubWorkflowExecutionActor(
         subKey,
         parentWorkflowDescriptor,
-        new WdlFunctions(List.empty),
+        new EngineIoFunctions(List.empty, new AsyncIo(simpleIoActor, DefaultIoCommandBuilder), system.dispatcher),
         Map.empty,
         ioActorProbe.ref,
         serviceRegistryProbe.ref,

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -26,6 +26,7 @@ import wom.expression.IoFunctionSet
 import wom.graph.{TaskCallNode, WomIdentifier}
 import wom.types.{WomIntegerType, WomStringType}
 
+import scala.concurrent.ExecutionContext
 import scala.util.Success
 
 
@@ -92,7 +93,11 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
 
     override def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef) => Props] = Option((_, _, _, _) => callCacheHitCopyingProbe.props)
 
-    override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor, jobKey: BackendJobDescriptorKey, initializationData: Option[BackendInitializationData]): IoFunctionSet = {
+    override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
+                                             jobKey: BackendJobDescriptorKey,
+                                             initializationData: Option[BackendInitializationData],
+                                             ioActorEndpoint: ActorRef,
+                                             ec: ExecutionContext): IoFunctionSet = {
       NoIoFunctionSet
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -96,7 +96,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
     override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                              jobKey: BackendJobDescriptorKey,
                                              initializationData: Option[BackendInitializationData],
-                                             ioActorEndpoint: ActorRef,
+                                             ioActorProxy: ActorRef,
                                              ec: ExecutionContext): IoFunctionSet = {
       NoIoFunctionSet
     }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
@@ -1,37 +1,32 @@
 package cromwell.filesystems.gcs.batch
 
 import cromwell.core.io._
-import cromwell.core.path.Path
 import cromwell.filesystems.gcs.GcsPath
 
-trait GcsBatchCommandBuilder extends DefaultIoCommandBuilder {
-  override def sizeCommand(path: Path) = path match {
+private case object PartialGcsBatchCommandBuilder extends PartialIoCommandBuilder {
+  override def sizeCommand = {
     case gcsPath: GcsPath => GcsBatchSizeCommand(gcsPath)
-    case _ => super.sizeCommand(path)
   }
   
-  override def deleteCommand(path: Path, swallowIoExceptions: Boolean = false) = path match {
-    case gcsPath: GcsPath => GcsBatchDeleteCommand(gcsPath, swallowIoExceptions)
-    case _ => super.deleteCommand(path, swallowIoExceptions)
+  override def deleteCommand = {
+    case (gcsPath: GcsPath, swallowIoExceptions) => GcsBatchDeleteCommand(gcsPath, swallowIoExceptions)
   }
   
-  override def copyCommand(src: Path, dest: Path, overwrite: Boolean = true) =  (src, dest) match {
-    case (gcsSrc: GcsPath, gcsDest: GcsPath) => GcsBatchCopyCommand(gcsSrc, gcsDest, overwrite)
-    case _ => super.copyCommand(src, dest, overwrite)
+  override def copyCommand = {
+    case (gcsSrc: GcsPath, gcsDest: GcsPath, overwrite) => GcsBatchCopyCommand(gcsSrc, gcsDest, overwrite)
   }
   
-  override def hashCommand(path: Path) =  path match {
+  override def hashCommand = {
     case gcsPath: GcsPath => GcsBatchCrc32Command(gcsPath)
-    case _ => super.hashCommand(path)
   }
 
-  override def touchCommand(path: Path) =  path match {
+  override def touchCommand = {
     case gcsPath: GcsPath => GcsBatchTouchCommand(gcsPath)
-    case _ => super.touchCommand(path)
   }
 
-  override def existsCommand(path: Path) =  path match {
+  override def existsCommand = {
     case gcsPath: GcsPath => GcsBatchExistsCommand(gcsPath)
-    case _ => super.existsCommand(path)
   }
 }
+
+case object GcsBatchCommandBuilder extends IoCommandBuilder(List(PartialGcsBatchCommandBuilder))

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -364,7 +364,7 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
     def uploadScriptFile = commandScriptContents.fold(
       errors => Future.failed(new RuntimeException(errors.toList.mkString(", "))),
-      writeAsync(jobPaths.script, _, Seq(CloudStorageOptions.withMimeType("text/plain"))))
+      asyncIo.writeAsync(jobPaths.script, _, Seq(CloudStorageOptions.withMimeType("text/plain"))))
 
     def makeRpr(jesParameters: Seq[JesParameter]) = Future.fromTry(Try {
       createJesRunPipelineRequest(jesParameters)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesExpressionFunctions.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesExpressionFunctions.scala
@@ -1,11 +1,14 @@
 package cromwell.backend.impl.jes
 
 import cromwell.backend.standard.{StandardExpressionFunctions, StandardExpressionFunctionsParams}
+import cromwell.core.io.IoCommandBuilder
 import cromwell.filesystems.gcs.GcsPathBuilder
 import cromwell.filesystems.gcs.GcsPathBuilder.{InvalidGcsPath, PossiblyValidRelativeGcsPath, ValidFullGcsPath}
+import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 
 class JesExpressionFunctions(standardParams: StandardExpressionFunctionsParams)
   extends StandardExpressionFunctions(standardParams) {
+  override lazy val ioCommandBuilder: IoCommandBuilder = GcsBatchCommandBuilder
 
   override def preMapping(str: String) = {
     GcsPathBuilder.validateGcsPath(str) match {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import cromwell.backend._
 import cromwell.backend.standard.{StandardFinalizationActor, StandardFinalizationActorParams}
 import cromwell.core.CallOutputs
-import cromwell.core.io.AsyncIo
+import cromwell.core.io.AsyncIoActorClient
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import wom.graph.TaskCallNode
 
@@ -24,11 +24,11 @@ case class JesFinalizationActorParams
 }
 
 class JesFinalizationActor(val jesParams: JesFinalizationActorParams)
-  extends StandardFinalizationActor(jesParams) with AsyncIo with GcsBatchCommandBuilder {
+  extends StandardFinalizationActor(jesParams) with AsyncIoActorClient {
 
   lazy val jesConfiguration: JesConfiguration = jesParams.jesConfiguration
-  
-  override def receive = ioReceive orElse super.receive
+
+  override lazy val ioCommandBuilder = GcsBatchCommandBuilder
 
   override def afterAll(): Future[Unit] = {
     for {

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -40,7 +40,7 @@ class JesFinalizationActor(val jesParams: JesFinalizationActorParams)
 
   private def deleteAuthenticationFile(): Future[Unit] = {
     (jesConfiguration.needAuthFileUpload, workflowPaths) match {
-      case (true, Some(paths: JesWorkflowPaths)) => deleteAsync(paths.gcsAuthFilePath)
+      case (true, Some(paths: JesWorkflowPaths)) => asyncIo.deleteAsync(paths.gcsAuthFilePath)
       case _ => Future.successful(())
     }
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -11,7 +11,7 @@ import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject, J
 import cromwell.backend.standard.{StandardInitializationActor, StandardInitializationActorParams, StandardValidatedRuntimeAttributesBuilder}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.auth.{ClientSecrets, GoogleAuthMode}
-import cromwell.core.io.AsyncIo
+import cromwell.core.io.AsyncIoActorClient
 import cromwell.core.path.Path
 import cromwell.filesystems.gcs.GoogleUtil._
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
@@ -38,14 +38,12 @@ object JesInitializationActor {
 }
 
 class JesInitializationActor(jesParams: JesInitializationActorParams)
-  extends StandardInitializationActor(jesParams) with AsyncIo with GcsBatchCommandBuilder {
+  extends StandardInitializationActor(jesParams) with AsyncIoActorClient {
 
   override lazy val ioActor = jesParams.ioActor
   private val jesConfiguration = jesParams.jesConfiguration
   private val workflowOptions = workflowDescriptor.workflowOptions
   implicit private val system = context.system
-
-  context.become(ioReceive orElse receive)
 
   override lazy val runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder =
     JesRuntimeAttributes.runtimeAttributesBuilder(jesConfiguration)
@@ -133,4 +131,6 @@ class JesInitializationActor(jesParams: JesInitializationActorParams)
     if (jsonMap.nonEmpty) Option(JsObject(jsonMap).prettyPrint)
     else None
   }
+
+  override lazy val ioCommandBuilder = GcsBatchCommandBuilder
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -82,7 +82,7 @@ class JesInitializationActor(jesParams: JesInitializationActorParams)
   } yield JesBackendInitializationData(jesWorkflowPaths, runtimeAttributesBuilder, jesConfiguration, gcsCreds, genomicsFactory)
 
   override def beforeAll(): Future[Option[BackendInitializationData]] = {
-    def fileUpload(paths: JesWorkflowPaths) = existsAsync(paths.gcsAuthFilePath) flatMap {
+    def fileUpload(paths: JesWorkflowPaths) = asyncIo.existsAsync(paths.gcsAuthFilePath) flatMap {
       // if we aren't restarting then something is definitely wrong
       case true if !jesParams.restarting =>
         Future.failed(AuthFileAlreadyExistsException(paths.gcsAuthFilePath))
@@ -113,7 +113,7 @@ class JesInitializationActor(jesParams: JesInitializationActorParams)
       val path = workflowPath.gcsAuthFilePath
       workflowLogger.info(s"Creating authentication file for workflow ${workflowDescriptor.id} at \n $path")
       val openOptions = List(CloudStorageOptions.withMimeType("application/json"))
-      writeAsync(path, content, openOptions)
+      asyncIo.writeAsync(path, content, openOptions)
     } getOrElse Future.successful(())
   }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendFileHashingActor.scala
@@ -3,4 +3,6 @@ package cromwell.backend.impl.jes.callcaching
 import cromwell.backend.standard.callcaching.{StandardFileHashingActor, StandardFileHashingActorParams}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 
-class JesBackendFileHashingActor(standardParams: StandardFileHashingActorParams) extends StandardFileHashingActor(standardParams) with GcsBatchCommandBuilder
+class JesBackendFileHashingActor(standardParams: StandardFileHashingActorParams) extends StandardFileHashingActor(standardParams) {
+  override val ioCommandBuilder = GcsBatchCommandBuilder
+}

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -46,7 +46,6 @@ import scala.util.Success
 
 class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackendJobExecutionActorSpec")
   with FlatSpecLike with Matchers with ImplicitSender with Mockito with BackendSpec with BeforeAndAfter with DefaultJsonProtocol {
-  
   val mockPathBuilder: GcsPathBuilder = GcsPathBuilder.fromCredentials(NoCredentials.getInstance(),
     "test-cromwell", RetrySettings.newBuilder().build(), GcsStorage.DefaultCloudStorageConfiguration, WorkflowOptions.empty)
   
@@ -86,6 +85,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
   lazy val TestableStandardExpressionFunctionsParams = new StandardExpressionFunctionsParams {
     override lazy val pathBuilders: List[PathBuilder] = List(mockPathBuilder)
     override lazy val callContext: CallContext = TestableCallContext
+    override val ioActorEndpoint: ActorRef = simpleIoActor
+    override val executionContext = system.dispatcher
   }
 
   lazy val TestableJesExpressionFunctions: JesExpressionFunctions = {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -85,7 +85,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
   lazy val TestableStandardExpressionFunctionsParams = new StandardExpressionFunctionsParams {
     override lazy val pathBuilders: List[PathBuilder] = List(mockPathBuilder)
     override lazy val callContext: CallContext = TestableCallContext
-    override val ioActorEndpoint: ActorRef = simpleIoActor
+    override val ioActorProxy: ActorRef = simpleIoActor
     override val executionContext = system.dispatcher
   }
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesJobExecutionActorSpec.scala
@@ -2,10 +2,10 @@ package cromwell.backend.impl.jes
 
 import akka.actor.{Actor, ActorRef, Props}
 import akka.testkit._
-import cromwell.backend.{BackendJobDescriptor, MinimumRuntimeSettings}
 import cromwell.backend.BackendJobExecutionActor.{ExecuteJobCommand, JobFailedNonRetryableResponse}
 import cromwell.backend.impl.jes.ControllableFailingJabjea.JabjeaExplode
 import cromwell.backend.standard.{DefaultStandardSyncExecutionActorParams, StandardSyncExecutionActor, StandardSyncExecutionActorParams}
+import cromwell.backend.{BackendJobDescriptor, MinimumRuntimeSettings}
 import cromwell.core.TestKitSuite
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendFileHashingActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigBackendFileHashingActor.scala
@@ -13,8 +13,10 @@ object ConfigBackendFileHashingActor {
   def props(standardParams: StandardFileHashingActorParams) = Props(new ConfigBackendFileHashingActor(standardParams))
 }
 
-class ConfigBackendFileHashingActor(standardParams: StandardFileHashingActorParams) extends StandardFileHashingActor(standardParams) with GcsBatchCommandBuilder {
+class ConfigBackendFileHashingActor(standardParams: StandardFileHashingActorParams) extends StandardFileHashingActor(standardParams) {
 
+  override val ioCommandBuilder = GcsBatchCommandBuilder
+  
   lazy val hashingStrategy: ConfigHashingStrategy = {
     configurationDescriptor.backendConfig.as[Option[Config]]("filesystems.local.caching") map ConfigHashingStrategy.apply getOrElse ConfigHashingStrategy.defaultStrategy
   }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemCacheHitCopyingActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemCacheHitCopyingActor.scala
@@ -1,16 +1,16 @@
 package cromwell.backend.sfs
 
-import cromwell.backend.standard.callcaching.StandardCacheHitCopyingActor.PathPair
-import cromwell.backend.standard.callcaching.{StandardCacheHitCopyingActor, StandardCacheHitCopyingActorParams}
-import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
-import common.util.TryUtil
 import cats.instances.try_._
 import cats.syntax.functor._
+import common.util.TryUtil
+import cromwell.backend.standard.callcaching.StandardCacheHitCopyingActor.PathPair
+import cromwell.backend.standard.callcaching.{StandardCacheHitCopyingActor, StandardCacheHitCopyingActorParams}
 
 import scala.util.{Failure, Try}
 
 class SharedFileSystemCacheHitCopyingActor(standardParams: StandardCacheHitCopyingActorParams)
-  extends StandardCacheHitCopyingActor(standardParams) with SharedFileSystemJobCachingActorHelper with GcsBatchCommandBuilder {
+  extends StandardCacheHitCopyingActor(standardParams) with SharedFileSystemJobCachingActorHelper {
+
   override protected def duplicate(copyPairs: Set[PathPair]): Option[Try[Unit]] = Option {
     val copies = copyPairs map {
       case (source, destination) => 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
@@ -1,21 +1,30 @@
 package cromwell.backend.sfs
 
+import akka.actor.ActorRef
 import cromwell.backend.io._
 import cromwell.backend.standard.{DefaultStandardExpressionFunctionsParams, StandardExpressionFunctions, StandardExpressionFunctionsParams}
 import cromwell.core.CallContext
 import cromwell.core.path.{DefaultPath, Path, PathBuilder}
 
+import scala.concurrent.ExecutionContext
+
 object SharedFileSystemExpressionFunctions {
-  def apply(jobPaths: JobPaths, pathBuilders: List[PathBuilder]): SharedFileSystemExpressionFunctions = {
-    new SharedFileSystemExpressionFunctions(pathBuilders, jobPaths.callContext)
+  def apply(jobPaths: JobPaths,
+            pathBuilders: List[PathBuilder],
+            ioActorEndpoint: ActorRef,
+            ec: ExecutionContext): SharedFileSystemExpressionFunctions = {
+    new SharedFileSystemExpressionFunctions(pathBuilders, jobPaths.callContext, ioActorEndpoint, ec)
   }
 }
 
 class SharedFileSystemExpressionFunctions(standardParams: StandardExpressionFunctionsParams)
   extends StandardExpressionFunctions(standardParams) {
 
-  def this(pathBuilders: List[PathBuilder], callContext: CallContext) = {
-    this(DefaultStandardExpressionFunctionsParams(pathBuilders, callContext))
+  def this(pathBuilders: List[PathBuilder],
+           callContext: CallContext,
+           ioActorEndpoint: ActorRef,
+           ec: ExecutionContext) = {
+    this(DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorEndpoint, ec))
   }
 
   override def postMapping(path: Path) = {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemExpressionFunctions.scala
@@ -11,9 +11,9 @@ import scala.concurrent.ExecutionContext
 object SharedFileSystemExpressionFunctions {
   def apply(jobPaths: JobPaths,
             pathBuilders: List[PathBuilder],
-            ioActorEndpoint: ActorRef,
+            ioActorProxy: ActorRef,
             ec: ExecutionContext): SharedFileSystemExpressionFunctions = {
-    new SharedFileSystemExpressionFunctions(pathBuilders, jobPaths.callContext, ioActorEndpoint, ec)
+    new SharedFileSystemExpressionFunctions(pathBuilders, jobPaths.callContext, ioActorProxy, ec)
   }
 }
 
@@ -22,9 +22,9 @@ class SharedFileSystemExpressionFunctions(standardParams: StandardExpressionFunc
 
   def this(pathBuilders: List[PathBuilder],
            callContext: CallContext,
-           ioActorEndpoint: ActorRef,
+           ioActorProxy: ActorRef,
            ec: ExecutionContext) = {
-    this(DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorEndpoint, ec))
+    this(DefaultStandardExpressionFunctionsParams(pathBuilders, callContext, ioActorProxy, ec))
   }
 
   override def postMapping(path: Path) = {

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -26,7 +26,7 @@ case class SparkBackendFactory(name: String, configurationDescriptor: BackendCon
 
   override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor, jobKey: BackendJobDescriptorKey,
                                            initializationData: Option[BackendInitializationData],
-                                           ioActorEndpoint: ActorRef,
+                                           ioActorProxy: ActorRef,
                                            ec: ExecutionContext): IoFunctionSet = {
     val jobPaths = JobPathsWithDocker(jobKey, workflowDescriptor, configurationDescriptor.backendConfig)
     val callContext = CallContext(
@@ -35,6 +35,6 @@ case class SparkBackendFactory(name: String, configurationDescriptor: BackendCon
       jobPaths.stderr.toAbsolutePath.toString
     )
 
-    new SharedFileSystemExpressionFunctions(SparkJobExecutionActor.DefaultPathBuilders, callContext, ioActorEndpoint, ec)
+    new SharedFileSystemExpressionFunctions(SparkJobExecutionActor.DefaultPathBuilders, callContext, ioActorProxy, ec)
   }
 }

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkJobExecutionActor.scala
@@ -25,13 +25,13 @@ object SparkJobExecutionActor {
 
   def props(jobDescriptor: BackendJobDescriptor,
             configurationDescriptor: BackendConfigurationDescriptor,
-            ioActorEndpoint: ActorRef): Props =
-    Props(new SparkJobExecutionActor(jobDescriptor, configurationDescriptor, ioActorEndpoint))
+            ioActorProxy: ActorRef): Props =
+    Props(new SparkJobExecutionActor(jobDescriptor, configurationDescriptor, ioActorProxy))
 }
 
 class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
                              override val configurationDescriptor: BackendConfigurationDescriptor,
-                             ioActorEndpoint: ActorRef) extends BackendJobExecutionActor with SharedFileSystem {
+                             ioActorProxy: ActorRef) extends BackendJobExecutionActor with SharedFileSystem {
 
   import SparkJobExecutionActor._
 
@@ -62,7 +62,7 @@ class SparkJobExecutionActor(override val jobDescriptor: BackendJobDescriptor,
   private lazy val SubmitJobJson = "%s.json"
   private lazy val isClusterMode = isSparkClusterMode(sparkDeployMode, sparkMaster)
 
-  private val callEngineFunction = SharedFileSystemExpressionFunctions(jobPaths, DefaultPathBuilders, ioActorEndpoint, context.dispatcher)
+  private val callEngineFunction = SharedFileSystemExpressionFunctions(jobPaths, DefaultPathBuilders, ioActorProxy, context.dispatcher)
 
   private val executionResponse = Promise[BackendJobExecutionResponse]()
 

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkJobExecutionActorSpec.scala
@@ -156,7 +156,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       val stderr = ""
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -186,7 +186,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       val stderr = ""
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -217,7 +217,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       val stderr = ""
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -249,7 +249,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       File(jobPaths.stderr) < "failed"
       File(jobPaths.callExecutionRoot.resolve("cluster.json")) < sampleSubmissionResponse
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -277,7 +277,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubUntailed = new UntailedWriter(jobPaths.stdout) with MockPathWriter
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       val stderrResult = ""
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -303,7 +303,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val stubUntailed = new UntailedWriter(jobPaths.stdout) with MockPathWriter
       val stubTailed = new TailedWriter(jobPaths.stderr, 100) with MockPathWriter
       val stderrResult = ""
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val clusterExtProcess = sparkClusterProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -339,7 +339,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       when(sparkProcess.untailedWriter(any[Path])).thenReturn(stubUntailed)
       when(sparkProcess.processStderr).thenReturn(stderrResult)
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val extProcess = sparkProcess
         override lazy val cmds = sparkCommands
       }).underlyingActor
@@ -358,7 +358,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val jobDescriptor = prepareJob()
       val (job, jobPaths, backendConfigDesc) = (jobDescriptor.jobDescriptor, jobDescriptor.jobPaths, jobDescriptor.backendConfigurationDescriptor)
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val cmds = sparkCommands
         override lazy val extProcess = sparkProcess
       }).underlyingActor
@@ -385,7 +385,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val jobDescriptor = prepareJob(runtimeString = failedOnStderr)
       val (job, jobPaths, backendConfigDesc) = (jobDescriptor.jobDescriptor, jobDescriptor.jobPaths, jobDescriptor.backendConfigurationDescriptor)
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val cmds = sparkCommands
         override lazy val extProcess = sparkProcess
       }).underlyingActor
@@ -411,7 +411,7 @@ class SparkJobExecutionActorSpec extends TestKitSuite("SparkJobExecutionActor")
       val jobDescriptor = prepareJob()
       val (job, jobPaths, backendConfigDesc) = (jobDescriptor.jobDescriptor, jobDescriptor.jobPaths, jobDescriptor.backendConfigurationDescriptor)
 
-      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc) {
+      val backend = TestActorRef(new SparkJobExecutionActor(job, backendConfigDesc, simpleIoActor) {
         override lazy val cmds = sparkCommands
         override lazy val extProcess = sparkProcess
       }).underlyingActor

--- a/wdl/src/main/scala/wdl/WdlExpression.scala
+++ b/wdl/src/main/scala/wdl/WdlExpression.scala
@@ -228,9 +228,9 @@ final case class WdlWomExpression(wdlExpression: WdlExpression, from: Scope) ext
 
       override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = ioFunctionSet.stderr(params)
 
-      override def globHelper(pattern: String): Seq[String] = ioFunctionSet.glob(pattern)
+      override def globHelper(pattern: String): Seq[String] = Await.result(ioFunctionSet.glob(pattern), Duration.Inf)
 
-      override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = ioFunctionSet.size(params)
+      override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = Try(Await.result(ioFunctionSet.size(params), Duration.Inf))
     }
     wdlExpression.evaluateFiles(inputTypes.apply, wdlFunctions, coerceTo).toErrorOr.map(_.toSet[WomFile])
   }

--- a/wdl/src/main/scala/wdl/expression/WdlStandardLibraryFunctions.scala
+++ b/wdl/src/main/scala/wdl/expression/WdlStandardLibraryFunctions.scala
@@ -327,9 +327,9 @@ object WdlStandardLibraryFunctions {
 
     override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = ioFunctionSet.stderr(params)
 
-    override def globHelper(pattern: String): Seq[String] = ioFunctionSet.glob(pattern)
+    override def globHelper(pattern: String): Seq[String] = Await.result(ioFunctionSet.glob(pattern), Duration.Inf)
 
-    override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = ioFunctionSet.size(params)
+    override def size(params: Seq[Try[WomValue]]): Try[WomFloat] = Try(Await.result(ioFunctionSet.size(params), Duration.Inf))
   }
 
   def crossProduct[A, B](as: Seq[A], bs: Seq[B]): Seq[(A, B)] = for {

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -34,8 +34,8 @@ trait IoFunctionSet {
   def writeFile(path: String, content: String): Future[WomFile]
   def stdout(params: Seq[Try[WomValue]]): Try[WomFile]
   def stderr(params: Seq[Try[WomValue]]): Try[WomFile]
-  def glob(pattern: String): Seq[String]
-  def size(params: Seq[Try[WomValue]]): Try[WomFloat]
+  def glob(pattern: String): Future[Seq[String]]
+  def size(params: Seq[Try[WomValue]]): Future[WomFloat]
 }
 
 /**

--- a/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
+++ b/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
@@ -24,6 +24,6 @@ case object PlaceholderIoFunctionSet extends IoFunctionSet {
   override def writeFile(path: String, content: String): Future[WomFile] = ???
   override def stdout(params: Seq[Try[WomValue]]) = ???
   override def stderr(params: Seq[Try[WomValue]]) = ???
-  override def glob(pattern: String): Seq[String] = ???
+  override def glob(pattern: String): Future[Seq[String]] = ???
   override def size(params: Seq[Try[WomValue]]) = ???
 }


### PR DESCRIPTION
The gist is:

The `ioActor` that is already wired through from the CromwellRoot into the system has been swapped for an `IoActorEndpoint`. This endpoint just forwards existing requests to the IoActor so nothing changes on that side. The only difference is it forwards `IoCommandWithPromise` requests to a proxy actor that will communicate with the IoActor and complete the promise when the answer comes back, thus providing a globally accessible (even outside of an actor) `Future`-like interface that performs operations through the I/O actor.
This is then used in the IoFunctionSet to add retries, throttling and GCS optimizations to it.