### PR TITLE
IWDR: Allow Array[File] expressions as listings

### DIFF
--- a/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/wdl/WriteFunctions.scala
@@ -26,4 +26,11 @@ trait WriteFunctions extends IoFunctionSet with AsyncIoFunctions {
       case true => Future.successful(WomSingleFile(file.pathAsString))
     }
   }
+
+  override def copyFile(pathFrom: String, targetName: String): Future[WomSingleFile] = {
+    val source = _writeDirectory.root / pathFrom
+    val destination = _writeDirectory / targetName
+
+    asyncIo.copyAsync(source, destination).as(WomSingleFile(destination.pathAsString))
+  }
 }

--- a/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/wdl/ReadLikeFunctionsSpec.scala
@@ -110,4 +110,6 @@ class TestReadLikeFunctions(sizeResult: Try[Double]) extends IoFunctionSet {
   override def glob(pattern: String): Future[Seq[String]] = ???
 
   override def size(params: Seq[Try[WomValue]]): Future[WomFloat] = Future.fromTry(sizeResult.map(WomFloat.apply))
+
+  override def copyFile(pathFrom: String, targetName: String): Future[WomFile] = ???
 }

--- a/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/file_array_listing.cwl
+++ b/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/file_array_listing.cwl
@@ -1,0 +1,26 @@
+cwlVersion: v1.0
+$graph:
+- id: iwdr_array_listing
+  class: CommandLineTool
+  baseCommand: ['ls']
+  requirements:
+      - class: DockerRequirement
+        dockerPull: "python:3.5.0"
+      - class: InitialWorkDirRequirement
+        listing: $(inputs.files)
+
+  stdout: file_list
+  inputs:
+      - id: files
+        type:
+          type: array
+          items: File
+        default: [ "/Users/chrisl/Downloads/cwl/allRequirements.txt" ]
+  arguments: [ "*.txt" ]
+  outputs:
+      - id: file_list
+        type: string
+        outputBinding:
+          glob: file_list
+          loadContents: true
+          outputEval: $(self[0].contents.trim())

--- a/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
+++ b/core/src/main/scala/cromwell/core/NoIoFunctionSet.scala
@@ -11,6 +11,8 @@ case object NoIoFunctionSet extends IoFunctionSet {
 
   override def writeFile(path: String, content: String): Future[WomFile] = Future.failed(new NotImplementedError("writeFile is not available here"))
 
+  override def copyFile(pathFrom: String, targetName: String): Future[WomFile] = throw new Exception("copyFile is not available here")
+
   override def stdout(params: Seq[Try[WomValue]]): Try[WomFile] = Failure(new NotImplementedError("stdout is not available here"))
 
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = Failure(new NotImplementedError("stderr is not available here"))

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -9,7 +9,7 @@ import cwl.CommandLineTool._
 import cwl.CwlType.CwlType
 import cwl.CwlVersion._
 import cwl.command.ParentName
-import cwl.CwlAny.EnhancedCwlAny
+import cwl.CwlAny.EnhancedJson
 import cwl.requirement.RequirementToAttributeMap
 import eu.timepit.refined.W
 import shapeless.syntax.singleton._
@@ -137,7 +137,11 @@ case class CommandLineTool private(
         case CommandInputParameter(id, _, _, _, _, _, _, Some(default), Some(tpe)) =>
           val inputType = tpe.fold(MyriadInputTypeToWomType)
           val inputName = FullyQualifiedName(id).id
-          InputDefinitionWithDefault(inputName, inputType, ValueAsAnExpression(inputType.coerceRawValue(default.stringRepresentation).get))
+          val defaultValue = default match {
+            case CwlAny.Json(jsonDefault) => ValueAsAnExpression(inputType.coerceRawValue(jsonDefault.sprayJsonRepresentation).get)
+            case CwlAny.File(fileDefault) => ValueAsAnExpression(inputType.coerceRawValue(fileDefault.path.get).get)
+          }
+          InputDefinitionWithDefault(inputName, inputType, defaultValue)
         case CommandInputParameter(id, _, _, _, _, _, _, None, Some(tpe)) =>
           val inputType = tpe.fold(MyriadInputTypeToWomType)
           val inputName = FullyQualifiedName(id).id

--- a/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
+++ b/cwl/src/main/scala/cwl/InitialWorkDirRequirement.scala
@@ -1,5 +1,6 @@
 package cwl
 
+import cwl.ExpressionEvaluator.ECMAScriptExpression
 import cwl.InitialWorkDirRequirement._
 import eu.timepit.refined.W
 import shapeless.{:+:, CNil, _}
@@ -57,6 +58,21 @@ object InitialWorkDirRequirement {
     object ExpressionDirent {
       def unapply(e: IwdrListingArrayEntry): Option[(Expression, Option[StringOrExpression], Boolean)] =
         e.select[ExpressionDirent].map(sd => (sd.entry, sd.entryname, sd.writableWithDefault))
+    }
+    object FilePath {
+      def unapply(e: IwdrListingArrayEntry): Option[String] = e.select[File].flatMap(file => file.location)
+    }
+    object String {
+      def unapply(e: IwdrListingArrayEntry): Option[String] = e.select[StringOrExpression].flatMap(_.select[String])
+    }
+    object ECMAScriptExpression {
+      def unapply(e: IwdrListingArrayEntry): Option[ECMAScriptExpression] = for {
+        soe <- e.select[StringOrExpression]
+        expr <- soe.select[Expression]
+        ecmaScriptExpression <- expr.select[ECMAScriptExpression]
+      } yield ecmaScriptExpression
+
+
     }
   }
 

--- a/cwl/src/main/scala/cwl/JsUtil.scala
+++ b/cwl/src/main/scala/cwl/JsUtil.scala
@@ -84,7 +84,11 @@ object JsUtil {
         WomMap(womMapType, keys.map(key =>
           WomString(key) -> fromJavascript(scriptObjectMirror.get(key))
         ).toMap)
-      case _ => throw new IllegalArgumentException(s"Unexpected value: $value")
+      case array: Array[Object] =>
+        val values = array map fromJavascript
+        WomArray(values)
+
+      case _ => throw new IllegalArgumentException(s"Unexpected ${value.getClass.getSimpleName} value: $value")
     }
   }
 }

--- a/cwl/src/main/scala/cwl/TypeAliases.scala
+++ b/cwl/src/main/scala/cwl/TypeAliases.scala
@@ -4,7 +4,9 @@ import cwl.CommandLineTool._
 import shapeless.{:+:, CNil}
 import cwl.CwlType.CwlType
 import io.circe.Json
+import spray.json.JsValue
 import wom.types.WomType
+import spray.json._
 
 trait TypeAliases {
 
@@ -100,9 +102,14 @@ trait TypeAliases {
 }
 
 object CwlAny {
-  implicit class EnhancedCwlAny(val cwlAny: CwlAny) extends AnyVal {
-    def stringRepresentation: String = cwlAny.select[Json] map { json => json.asString.getOrElse(json.toString) } getOrElse "CwlAny (not Json)"
+
+  implicit class EnhancedJson(val json: Json) extends AnyVal {
+    // Yes, urgh! This is disgusting but until we rewrite the entire JS coercion set for circe...
+    def sprayJsonRepresentation: JsValue = json.noSpaces.parseJson
   }
+
+  object Json { def unapply(cwlAny: CwlAny): Option[Json] = cwlAny.select[Json] }
+  object File { def unapply(cwlAny: CwlAny): Option[File] = cwlAny.select[File] }
 }
 
 object MyriadInputType {

--- a/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
+++ b/cwl/src/test/scala/cwl/CommandOutputExpressionSpec.scala
@@ -23,6 +23,7 @@ class CommandOutputExpressionSpec extends FlatSpec with Matchers {
     new IoFunctionSet {
       override def readFile(path: String) = Future.successful(data)
       override def writeFile(path: String, content: String) = throw new Exception("writeFile should not be used in this test")
+      override def copyFile(pathFrom: String, pathTo: String): Future[WomFile] = throw new Exception("copyFile should not be used in this test")
       override def stdout(params: Seq[Try[WomValue]]) = throw new Exception("stdout should not be used in this test")
       override def stderr(params: Seq[Try[WomValue]]) = throw new Exception("stderr should not be used in this test")
       override def glob(pattern: String): Future[Seq[String]] = throw new Exception("glob should not be used in this test")

--- a/engine/src/main/scala/cromwell/engine/EngineIoFunctions.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineIoFunctions.scala
@@ -15,6 +15,8 @@ class EngineIoFunctions(val pathBuilders: List[PathBuilder], override val asyncI
   override def stderr(params: Seq[Try[WomValue]]): Try[WomFile] = fail("stderr")
   override def glob(pattern: String): Future[Seq[String]] = throw new NotImplementedError(s"glob(path, pattern) not implemented yet")
 
-  // Cromwell does not support writing files from the engine.
-  override def writeFile(path: String, content: String): Future[WomFile] = Future.failed(new Exception("Can't write files"))
+  override def writeFile(path: String, content: String): Future[WomFile] =
+    Future.failed(new Exception("Cromwell does not support writing files from a workflow context"))
+  override def copyFile(pathFrom: String, targetName: String): Future[WomFile] =
+    Future.failed(new Exception("Cromwell does not support copying files from a workflow context"))
 }

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -32,6 +32,7 @@ final case class ValueAsAnExpression(value: WomValue) extends WomExpression {
 trait IoFunctionSet {
   def readFile(path: String): Future[String]
   def writeFile(path: String, content: String): Future[WomFile]
+  def copyFile(pathFrom: String, targetName: String): Future[WomFile]
   def stdout(params: Seq[Try[WomValue]]): Try[WomFile]
   def stderr(params: Seq[Try[WomValue]]): Try[WomFile]
   def glob(pattern: String): Future[Seq[String]]

--- a/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
+++ b/wom/src/test/scala/wom/expression/PlaceholderWomExpression.scala
@@ -22,6 +22,7 @@ final case class PlaceholderWomExpression(inputs: Set[String], fixedWomType: Wom
 case object PlaceholderIoFunctionSet extends IoFunctionSet {
   override def readFile(path: String): Future[String] = ???
   override def writeFile(path: String, content: String): Future[WomFile] = ???
+  override def copyFile(pathFrom: String, targetName: String): Future[WomFile] = ???
   override def stdout(params: Seq[Try[WomValue]]) = ???
   override def stderr(params: Seq[Try[WomValue]]) = ???
   override def glob(pattern: String): Future[Seq[String]] = ???


### PR DESCRIPTION
See [here](https://github.com/broadinstitute/cromwell/blob/cjl_initial_work_dir_requirement_6/centaur/src/main/resources/standardTestCases/InitialWorkDirRequirement/file_array_listing.cwl#L10) for the motivating use case. 

This needs improving as a centaur tests because we need to generate the file so that it can be passed in (which needs a WF rather than a simple CLT).