### PR TITLE
Fix requirement nesting

### DIFF
--- a/centaur/src/main/resources/standardTestCases/three_step.test
+++ b/centaur/src/main/resources/standardTestCases/three_step.test
@@ -16,5 +16,5 @@ metadata {
   "calls.cgrep.executionStatus": Done
   "calls.ps.runtimeAttributes.docker": "ubuntu:bionic"
   "calls.wc.runtimeAttributes.docker": "ubuntu:latest"
-  "calls.cgrep.runtimeAttributes.docker": "ubuntu:latest"
+  "calls.cgrep.runtimeAttributes.docker": "debian:jessie"
 }

--- a/centaur/src/main/resources/standardTestCases/three_step/three_step.cwl
+++ b/centaur/src/main/resources/standardTestCases/three_step/three_step.cwl
@@ -1,6 +1,7 @@
 cwlVersion: v1.0
 class: Workflow
 id: three_step
+# Workflow-level DockerRequirement
 hints:
   DockerRequirement:
     dockerPull: "ubuntu:latest"
@@ -28,6 +29,7 @@ steps:
       type: File
     class: CommandLineTool
     requirements:
+      # Command line tool-level DockerRequirement
       # Check it: this DockerRequirement does not use the `class` formatting but should still parse
       # thanks to the magic of SALAD.
       DockerRequirement:
@@ -42,6 +44,10 @@ steps:
     source: "#ps/ps-stdOut"
   out:
   - id: cgrep-count
+  # Workflow step-level DockerRequirement
+  requirements:
+    DockerRequirement:
+      dockerPull: "debian:jessie"
   run:
     inputs:
     - id: pattern

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -36,7 +36,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
               map(_.select[CommandLineTool].get).
               value.
               unsafeRunSync
-      taskDef <- clt.buildTaskDefinition(None, _.validNel).toEither
+      taskDef <- clt.buildTaskDefinition(_.validNel).toEither
     } yield validateWom(taskDef)).leftMap(e => throw new RuntimeException(s"error! $e"))
   }
 


### PR DESCRIPTION
Whilst working on env vars I noticed the Run / WorkflowStep / Workflow relationship wasn't modeled correctly wrt Requirements. That's something the env var conformance tests in particular will check, but it's generally useful to have this be correct so here it is in its own wee PR.