### PR TITLE
reference slick docs in our db config

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -358,6 +358,9 @@ services {
 database {
   # hsql default
   profile = "slick.jdbc.HsqldbProfile$"
+
+  # see all possible parameters and default values here:
+  # http://slick.lightbend.com/doc/3.2.0/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver):Database
   db {
     driver = "org.hsqldb.jdbcDriver"
     url = "jdbc:hsqldb:mem:${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -681,6 +681,9 @@ services {
 database {
   # mysql example
   #driver = "slick.driver.MySQLDriver$"
+
+  # see all possible parameters and default values here:
+  # http://slick.lightbend.com/doc/3.2.0/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver):Database
   #db {
   #  driver = "com.mysql.jdbc.Driver"
   #  url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -173,6 +173,8 @@ database {
 }
 ```
 
+To see the full list of possible parameters and values for the `db` stanza see [the slick documentation](http://slick.lightbend.com/doc/3.2.0/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver):Database).
+
 **Cromwell server on MySQL Database**
 
 You can use [docker-compose](https://github.com/broadinstitute/cromwell/tree/develop/scripts) to link together a Cromwell docker image (built locally with `sbt docker` or available on [Dockerhub](https://hub.docker.com/r/broadinstitute/cromwell/)) with a MySQL docker image.


### PR DESCRIPTION
We see questions on these often and it would be nice for users to know where to look to find answers.