### PR TITLE
[PREGULL] (De)Simpletonize WomFiles

### DIFF
--- a/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
+++ b/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
@@ -106,8 +106,8 @@ object WomValueBuilder {
       else {
         // Otherwise make a map of the components and detect the type of file from the marker
         val groupedListing = components.asMap
-        if (groupedListing.get("<<directory>>").isDefined) toWomValue(WomMaybeListedDirectoryType, components)
-        else if (groupedListing.get("<<populated>>").isDefined) toWomValue(WomMaybePopulatedFileType, components)
+        if (groupedListing.get(WomValueSimpleton.DirectoryMarker).isDefined) toWomValue(WomMaybeListedDirectoryType, components)
+        else if (groupedListing.get(WomValueSimpleton.PopulatedMarker).isDefined) toWomValue(WomMaybePopulatedFileType, components)
         else throw new IllegalArgumentException(s"Cannot build a WomFile from simpletons: ${groupedListing.toList.mkString(", ")}")
       }
     }
@@ -134,7 +134,7 @@ object WomValueBuilder {
         val map: Map[String, WomValue] = components.asMap map { case (k, ss) => k -> toWomValue(WomAnyType, ss) }
         WomObject(map)
       case WomMaybeListedDirectoryType =>
-        val directoryValues = components.asMap("<<directory>>").asMap
+        val directoryValues = components.asMap(WomValueSimpleton.DirectoryMarker).asMap
 
         val value = directoryValues.get("value").map(_.asString)
         val listing = directoryValues.get("listing")
@@ -142,7 +142,7 @@ object WomValueBuilder {
 
         WomMaybeListedDirectory(value, listing)
       case WomMaybePopulatedFileType =>
-        val populatedValues = components.asMap("<<populated>>").asMap
+        val populatedValues = components.asMap(WomValueSimpleton.PopulatedMarker).asMap
 
         val value = populatedValues.get("value").map(_.asString)
         val checksum = populatedValues.get("checksum").map(_.asString)

--- a/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
+++ b/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
@@ -55,23 +55,37 @@ object WomValueBuilder {
   // Within the noncapturing `?:` group, this looks for an escaped metacharacter OR a non-metacharacter.
   private val MapElementPattern = raw"^:((?:\\[]\[:]|[^]\[:])+)(.*)".r
 
+  // Group tuples by key using a Map with key type `K`.
+  private def group[K](tuples: Traversable[(K, SimpletonComponent)]): Map[K, Traversable[SimpletonComponent]] = {
+    tuples groupBy { case (i, _) => i } mapValues { _ map { case (_, s) => s} }
+  }
+
+  // Returns a tuple of the index into the outermost array and a `SimpletonComponent` whose path reflects the "descent"
+  // into the array.  e.g. for a component
+  // SimpletonComponent("[0][1]", v) this would return (0 -> SimpletonComponent("[1]", v)).
+  private def descendIntoArray(component: SimpletonComponent): (Int, SimpletonComponent) = {
+    component.path match { case ArrayElementPattern(index, more) => index.toInt -> component.copy(path = more)}
+  }
+
+  // Returns a tuple of the key into the outermost map and a `SimpletonComponent` whose path reflects the "descent"
+  // into the map.  e.g. for a component
+  // SimpletonComponent(":bar:baz", v) this would return ("bar" -> SimpletonComponent(":baz", v)).
+  // Map keys are treated as Strings by this method, the caller must ultimately do the appropriate coercion to the
+  // actual map key type.
+  private def descendIntoMap(component: SimpletonComponent): (String, SimpletonComponent) = {
+    component.path match { case MapElementPattern(key, more) => key.unescapeMeta -> component.copy(path = more)}
+  }
+
+  private implicit class EnhancedSimpletonComponents(val components: Traversable[SimpletonComponent]) extends AnyVal {
+    def asArray: List[Traversable[SimpletonComponent]] = group(components map descendIntoArray).toList.sortBy(_._1).map(_._2)
+    def asMap: Map[String, Traversable[SimpletonComponent]] = group(components map descendIntoMap)
+    def asPrimitive: WomValue = components.head.value
+    def asString: String = asPrimitive.valueString
+  }
+
   private def toWomValue(outputType: WomType, components: Traversable[SimpletonComponent]): WomValue = {
 
-    // Returns a tuple of the index into the outermost array and a `SimpletonComponent` whose path reflects the "descent"
-    // into the array.  e.g. for a component
-    // SimpletonComponent("[0][1]", v) this would return (0 -> SimpletonComponent("[1]", v)).
-    def descendIntoArray(component: SimpletonComponent): (Int, SimpletonComponent) = {
-      component.path match { case ArrayElementPattern(index, more) => index.toInt -> component.copy(path = more)}
-    }
 
-    // Returns a tuple of the key into the outermost map and a `SimpletonComponent` whose path reflects the "descent"
-    // into the map.  e.g. for a component
-    // SimpletonComponent(":bar:baz", v) this would return ("bar" -> SimpletonComponent(":baz", v)).
-    // Map keys are treated as Strings by this method, the caller must ultimately do the appropriate coercion to the
-    // actual map key type.
-    def descendIntoMap(component: SimpletonComponent): (String, SimpletonComponent) = {
-      component.path match { case MapElementPattern(key, more) => key.unescapeMeta -> component.copy(path = more)}
-    }
 
     // Returns a tuple of the key into the pair (i.e. left or right) and a `SimpletonComponent` whose path reflects the "descent"
     // into the pair.  e.g. for a component
@@ -85,15 +99,22 @@ object WomValueBuilder {
         case MapElementPattern("right", more) => PairRight -> component.copy(path = more)
       }
     }
-
-    // Group tuples by key using a Map with key type `K`.
-    def group[K](tuples: Traversable[(K, SimpletonComponent)]): Map[K, Traversable[SimpletonComponent]] = {
-      tuples groupBy { case (i, _) => i } mapValues { _ map { case (_, s) => s} }
+    
+    def toWomFile(components: Traversable[SimpletonComponent]) = {
+      // If there's just one simpleton, it's a single file
+      if (components.size == 1) toWomValue(WomSingleFileType, components)
+      else {
+        // Otherwise make a map of the components and detect the type of file from the marker
+        val groupedListing = components.asMap
+        if (groupedListing.get("<<directory>>").isDefined) toWomValue(WomMaybeListedDirectoryType, components)
+        else if (groupedListing.get("<<populated>>").isDefined) toWomValue(WomMaybePopulatedFileType, components)
+        else throw new IllegalArgumentException(s"Cannot build a WomFile from simpletons: ${groupedListing.toList.mkString(", ")}")
+      }
     }
-
+    
     outputType match {
       case _: WomPrimitiveType =>
-        components collectFirst { case SimpletonComponent(_, v) => v } get
+        components.asPrimitive
       case opt: WomOptionalType =>
         if (components.isEmpty) {
           WomOptionalValue(opt.memberType, None)
@@ -101,20 +122,45 @@ object WomValueBuilder {
           WomOptionalValue(toWomValue(opt.memberType, components))
         }
       case arrayType: WomArrayType =>
-        val groupedByArrayIndex: Map[Int, Traversable[SimpletonComponent]] = group(components map descendIntoArray)
-        WomArray(arrayType, groupedByArrayIndex.toList.sortBy(_._1) map { case (_, s) => toWomValue(arrayType.memberType, s) })
+        WomArray(arrayType, components.asArray map { toWomValue(arrayType.memberType, _) })
       case mapType: WomMapType =>
-        val groupedByMapKey: Map[String, Traversable[SimpletonComponent]] = group(components map descendIntoMap)
         // map keys are guaranteed by the WDL spec to be primitives, so the "coerceRawValue(..).get" is safe.
-        WomMap(mapType, groupedByMapKey map { case (k, ss) => mapType.keyType.coerceRawValue(k).get -> toWomValue(mapType.valueType, ss) })
+        WomMap(mapType, components.asMap map { case (k, ss) => mapType.keyType.coerceRawValue(k).get -> toWomValue(mapType.valueType, ss) })
       case pairType: WomPairType =>
         val groupedByLeftOrRight: Map[PairLeftOrRight, Traversable[SimpletonComponent]] = group(components map descendIntoPair)
         WomPair(toWomValue(pairType.leftType, groupedByLeftOrRight(PairLeft)), toWomValue(pairType.rightType, groupedByLeftOrRight(PairRight)))
       case WomObjectType =>
-        val groupedByMapKey: Map[String, Traversable[SimpletonComponent]] = group(components map descendIntoMap)
         // map keys are guaranteed by the WDL spec to be primitives, so the "coerceRawValue(..).get" is safe.
-        val map: Map[String, WomValue] = groupedByMapKey map { case (k, ss) => k -> toWomValue(WomAnyType, ss) }
+        val map: Map[String, WomValue] = components.asMap map { case (k, ss) => k -> toWomValue(WomAnyType, ss) }
         WomObject(map)
+      case WomMaybeListedDirectoryType =>
+        val directoryValues = components.asMap("<<directory>>").asMap
+
+        val value = directoryValues.get("value").map(_.asString)
+        val listing = directoryValues.get("listing")
+          .map({ _.asArray.map(toWomFile).collect({ case womFile: WomFile => womFile }) })
+
+        WomMaybeListedDirectory(value, listing)
+      case WomMaybePopulatedFileType =>
+        val populatedValues = components.asMap("<<populated>>").asMap
+
+        val value = populatedValues.get("value").map(_.asString)
+        val checksum = populatedValues.get("checksum").map(_.asString)
+        val size = populatedValues.get("size").map(_.asString.toLong)
+        val format = populatedValues.get("format").map(_.asString)
+        val contents = populatedValues.get("contents").map(_.asString)
+        val secondaryFiles = populatedValues.get("secondaryFiles").toList.flatMap({ 
+          _.asArray.map(toWomFile).collect({ case womFile: WomFile => womFile })
+        })
+
+        WomMaybePopulatedFile(
+          valueOption = value,
+          checksumOption = checksum,
+          sizeOption = size,
+          formatOption = format,
+          contentsOption = contents,
+          secondaryFiles = secondaryFiles
+        )
       case WomAnyType =>
         // Ok, we're going to have to guess, but the keys should give us some clues:
         if (components forall { component => MapElementPattern.findFirstMatchIn(component.path).isDefined }) {

--- a/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
+++ b/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
@@ -182,8 +182,7 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
     it should s"decompose WdlValues into simpletons ($name)" in {
 
       val map = Map(WomMocks.mockOutputPort(name) -> womValue)
-      val simplified = map.simplify
-      assertSimpletonsEqual(expectedSimpletons, simplified)
+      assertSimpletonsEqual(expectedSimpletons, map.simplify)
     }
 
     it should s"build simpletons back into WdlValues ($name)" in {

--- a/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
+++ b/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.specs2.mock.Mockito
 import wom.callable.Callable.OutputDefinition
 import wom.expression.PlaceholderWomExpression
-import wom.types.{WomArrayType, WomMapType, WomStringType}
+import wom.types.{WomArrayType, WomIntegerType, WomMapType, WomStringType}
 import wom.values._
 
 import scala.util.Success
@@ -21,122 +21,122 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
 
   case class SimpletonConversion(name: String, womValue: WomValue, simpletons: Seq[WomValueSimpleton])
   val simpletonConversions = List(
-//    SimpletonConversion("foo", WomString("none"), List(WomValueSimpleton("foo", WomString("none")))),
-//    SimpletonConversion("bar", WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))), List(WomValueSimpleton("bar[0]", WomInteger(1)), WomValueSimpleton("bar[1]", WomInteger(2)))),
-//    SimpletonConversion("empty_array", WomArray(WomArrayType(WomIntegerType), List.empty), List()),
-//    SimpletonConversion(
-//      "baz",
-//      WomArray(WomArrayType(WomArrayType(WomIntegerType)), List(
-//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
-//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
-//      List(WomValueSimpleton("baz[0][0]", WomInteger(0)), WomValueSimpleton("baz[0][1]", WomInteger(1)), WomValueSimpleton("baz[1][0]", WomInteger(2)), WomValueSimpleton("baz[1][1]", WomInteger(3)))
-//    ),
-//    SimpletonConversion(
-//      "map",
-//      WomMap(WomMapType(WomStringType, WomStringType), Map(
-//        WomString("foo") -> WomString("foo"),
-//        WomString("bar") -> WomString("bar"))),
-//      List(WomValueSimpleton("map:foo", WomString("foo")), WomValueSimpleton("map:bar", WomString("bar")))
-//    ),
-//    SimpletonConversion(
-//      "mapOfMaps",
-//      WomMap(WomMapType(WomStringType, WomMapType(WomStringType, WomStringType)), Map(
-//        WomString("foo") -> WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("foo2") -> WomString("foo"))),
-//        WomString("bar") ->WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("bar2") -> WomString("bar"))))),
-//      List(WomValueSimpleton("mapOfMaps:foo:foo2", WomString("foo")), WomValueSimpleton("mapOfMaps:bar:bar2", WomString("bar")))
-//    ),
-//    SimpletonConversion(
-//      "simplePair1",
-//      WomPair(WomInteger(1), WomString("hello")),
-//      List(WomValueSimpleton("simplePair1:left", WomInteger(1)), WomValueSimpleton("simplePair1:right", WomString("hello")))
-//    ),
-//    SimpletonConversion(
-//      "simplePair2",
-//      WomPair(WomString("left"), WomInteger(5)),
-//      List(WomValueSimpleton("simplePair2:left", WomString("left")), WomValueSimpleton("simplePair2:right", WomInteger(5)))
-//    ),
-//    SimpletonConversion(
-//      "pairOfPairs",
-//      WomPair(
-//        WomPair(WomInteger(1), WomString("one")),
-//        WomPair(WomString("two"), WomInteger(2))),
-//      List(
-//        WomValueSimpleton("pairOfPairs:left:left", WomInteger(1)),
-//        WomValueSimpleton("pairOfPairs:left:right", WomString("one")),
-//        WomValueSimpleton("pairOfPairs:right:left", WomString("two")),
-//        WomValueSimpleton("pairOfPairs:right:right", WomInteger(2)))
-//    ),
-//    SimpletonConversion(
-//      "pairOfArrayAndMap",
-//      WomPair(
-//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))),
-//        WomMap(WomMapType(WomStringType, WomIntegerType), Map(WomString("left") -> WomInteger(100), WomString("right") -> WomInteger(200)))),
-//      List(
-//        WomValueSimpleton("pairOfArrayAndMap:left[0]", WomInteger(1)),
-//        WomValueSimpleton("pairOfArrayAndMap:left[1]", WomInteger(2)),
-//        WomValueSimpleton("pairOfArrayAndMap:right:left", WomInteger(100)),
-//        WomValueSimpleton("pairOfArrayAndMap:right:right", WomInteger(200)))
-//    ),
-//    SimpletonConversion(
-//      "mapOfArrays",
-//      WomMap(WomMapType(WomStringType, WomArrayType(WomIntegerType)), Map(
-//        WomString("foo") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
-//        WomString("bar") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
-//      List(WomValueSimpleton("mapOfArrays:foo[0]", WomInteger(0)), WomValueSimpleton("mapOfArrays:foo[1]", WomInteger(1)),
-//        WomValueSimpleton("mapOfArrays:bar[0]", WomInteger(2)), WomValueSimpleton("mapOfArrays:bar[1]", WomInteger(3)))
-//    ),
-//    SimpletonConversion(
-//      "escapology",
-//      WomMap(WomMapType(WomStringType, WomStringType), Map(
-//        WomString("foo[1]") -> WomString("foo"),
-//        WomString("bar[[") -> WomString("bar"),
-//        WomString("baz:qux") -> WomString("baz:qux"))),
-//      List(WomValueSimpleton("escapology:foo\\[1\\]", WomString("foo")),
-//        WomValueSimpleton("escapology:bar\\[\\[", WomString("bar")),
-//        WomValueSimpleton("escapology:baz\\:qux", WomString("baz:qux")))
-//    ),
-//    SimpletonConversion(
-//      "flat_object",
-//      WomObject(Map(
-//        "a" -> WomString("aardvark"),
-//        "b" -> WomInteger(25),
-//        "c" -> WomBoolean(false)
-//      )),
-//      List(WomValueSimpleton("flat_object:a", WomString("aardvark")),
-//        WomValueSimpleton("flat_object:b", WomInteger(25)),
-//        WomValueSimpleton("flat_object:c", WomBoolean(false)))
-//    ),
-//    SimpletonConversion(
-//      "object_with_array",
-//      WomObject(Map(
-//        "a" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("beetle")))
-//      )),
-//      List(WomValueSimpleton("object_with_array:a[0]", WomString("aardvark")),
-//        WomValueSimpleton("object_with_array:a[1]", WomString("beetle")))
-//    ),
-//    SimpletonConversion(
-//      "object_with_object",
-//      WomObject(Map(
-//        "a" -> WomObject(Map(
-//          "aa" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("aaron"))),
-//          "ab" -> WomArray(WomArrayType(WomStringType), Seq(WomString("abacus"), WomString("a bee")))
-//        )),
-//        "b" -> WomObject(Map(
-//          "ba" -> WomArray(WomArrayType(WomStringType), Seq(WomString("baa"), WomString("battle"))),
-//          "bb" -> WomArray(WomArrayType(WomStringType), Seq(WomString("bbrrrr"), WomString("bb gun")))
-//        ))
-//      )),
-//      List(
-//        WomValueSimpleton("object_with_object:a:aa[0]", WomString("aardvark")),
-//        WomValueSimpleton("object_with_object:a:aa[1]", WomString("aaron")),
-//        WomValueSimpleton("object_with_object:a:ab[0]", WomString("abacus")),
-//        WomValueSimpleton("object_with_object:a:ab[1]", WomString("a bee")),
-//        WomValueSimpleton("object_with_object:b:ba[0]", WomString("baa")),
-//        WomValueSimpleton("object_with_object:b:ba[1]", WomString("battle")),
-//        WomValueSimpleton("object_with_object:b:bb[0]", WomString("bbrrrr")),
-//        WomValueSimpleton("object_with_object:b:bb[1]", WomString("bb gun")),
-//      )
-//    ),
+    SimpletonConversion("foo", WomString("none"), List(WomValueSimpleton("foo", WomString("none")))),
+    SimpletonConversion("bar", WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))), List(WomValueSimpleton("bar[0]", WomInteger(1)), WomValueSimpleton("bar[1]", WomInteger(2)))),
+    SimpletonConversion("empty_array", WomArray(WomArrayType(WomIntegerType), List.empty), List()),
+    SimpletonConversion(
+      "baz",
+      WomArray(WomArrayType(WomArrayType(WomIntegerType)), List(
+        WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
+        WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
+      List(WomValueSimpleton("baz[0][0]", WomInteger(0)), WomValueSimpleton("baz[0][1]", WomInteger(1)), WomValueSimpleton("baz[1][0]", WomInteger(2)), WomValueSimpleton("baz[1][1]", WomInteger(3)))
+    ),
+    SimpletonConversion(
+      "map",
+      WomMap(WomMapType(WomStringType, WomStringType), Map(
+        WomString("foo") -> WomString("foo"),
+        WomString("bar") -> WomString("bar"))),
+      List(WomValueSimpleton("map:foo", WomString("foo")), WomValueSimpleton("map:bar", WomString("bar")))
+    ),
+    SimpletonConversion(
+      "mapOfMaps",
+      WomMap(WomMapType(WomStringType, WomMapType(WomStringType, WomStringType)), Map(
+        WomString("foo") -> WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("foo2") -> WomString("foo"))),
+        WomString("bar") ->WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("bar2") -> WomString("bar"))))),
+      List(WomValueSimpleton("mapOfMaps:foo:foo2", WomString("foo")), WomValueSimpleton("mapOfMaps:bar:bar2", WomString("bar")))
+    ),
+    SimpletonConversion(
+      "simplePair1",
+      WomPair(WomInteger(1), WomString("hello")),
+      List(WomValueSimpleton("simplePair1:left", WomInteger(1)), WomValueSimpleton("simplePair1:right", WomString("hello")))
+    ),
+    SimpletonConversion(
+      "simplePair2",
+      WomPair(WomString("left"), WomInteger(5)),
+      List(WomValueSimpleton("simplePair2:left", WomString("left")), WomValueSimpleton("simplePair2:right", WomInteger(5)))
+    ),
+    SimpletonConversion(
+      "pairOfPairs",
+      WomPair(
+        WomPair(WomInteger(1), WomString("one")),
+        WomPair(WomString("two"), WomInteger(2))),
+      List(
+        WomValueSimpleton("pairOfPairs:left:left", WomInteger(1)),
+        WomValueSimpleton("pairOfPairs:left:right", WomString("one")),
+        WomValueSimpleton("pairOfPairs:right:left", WomString("two")),
+        WomValueSimpleton("pairOfPairs:right:right", WomInteger(2)))
+    ),
+    SimpletonConversion(
+      "pairOfArrayAndMap",
+      WomPair(
+        WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))),
+        WomMap(WomMapType(WomStringType, WomIntegerType), Map(WomString("left") -> WomInteger(100), WomString("right") -> WomInteger(200)))),
+      List(
+        WomValueSimpleton("pairOfArrayAndMap:left[0]", WomInteger(1)),
+        WomValueSimpleton("pairOfArrayAndMap:left[1]", WomInteger(2)),
+        WomValueSimpleton("pairOfArrayAndMap:right:left", WomInteger(100)),
+        WomValueSimpleton("pairOfArrayAndMap:right:right", WomInteger(200)))
+    ),
+    SimpletonConversion(
+      "mapOfArrays",
+      WomMap(WomMapType(WomStringType, WomArrayType(WomIntegerType)), Map(
+        WomString("foo") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
+        WomString("bar") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
+      List(WomValueSimpleton("mapOfArrays:foo[0]", WomInteger(0)), WomValueSimpleton("mapOfArrays:foo[1]", WomInteger(1)),
+        WomValueSimpleton("mapOfArrays:bar[0]", WomInteger(2)), WomValueSimpleton("mapOfArrays:bar[1]", WomInteger(3)))
+    ),
+    SimpletonConversion(
+      "escapology",
+      WomMap(WomMapType(WomStringType, WomStringType), Map(
+        WomString("foo[1]") -> WomString("foo"),
+        WomString("bar[[") -> WomString("bar"),
+        WomString("baz:qux") -> WomString("baz:qux"))),
+      List(WomValueSimpleton("escapology:foo\\[1\\]", WomString("foo")),
+        WomValueSimpleton("escapology:bar\\[\\[", WomString("bar")),
+        WomValueSimpleton("escapology:baz\\:qux", WomString("baz:qux")))
+    ),
+    SimpletonConversion(
+      "flat_object",
+      WomObject(Map(
+        "a" -> WomString("aardvark"),
+        "b" -> WomInteger(25),
+        "c" -> WomBoolean(false)
+      )),
+      List(WomValueSimpleton("flat_object:a", WomString("aardvark")),
+        WomValueSimpleton("flat_object:b", WomInteger(25)),
+        WomValueSimpleton("flat_object:c", WomBoolean(false)))
+    ),
+    SimpletonConversion(
+      "object_with_array",
+      WomObject(Map(
+        "a" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("beetle")))
+      )),
+      List(WomValueSimpleton("object_with_array:a[0]", WomString("aardvark")),
+        WomValueSimpleton("object_with_array:a[1]", WomString("beetle")))
+    ),
+    SimpletonConversion(
+      "object_with_object",
+      WomObject(Map(
+        "a" -> WomObject(Map(
+          "aa" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("aaron"))),
+          "ab" -> WomArray(WomArrayType(WomStringType), Seq(WomString("abacus"), WomString("a bee")))
+        )),
+        "b" -> WomObject(Map(
+          "ba" -> WomArray(WomArrayType(WomStringType), Seq(WomString("baa"), WomString("battle"))),
+          "bb" -> WomArray(WomArrayType(WomStringType), Seq(WomString("bbrrrr"), WomString("bb gun")))
+        ))
+      )),
+      List(
+        WomValueSimpleton("object_with_object:a:aa[0]", WomString("aardvark")),
+        WomValueSimpleton("object_with_object:a:aa[1]", WomString("aaron")),
+        WomValueSimpleton("object_with_object:a:ab[0]", WomString("abacus")),
+        WomValueSimpleton("object_with_object:a:ab[1]", WomString("a bee")),
+        WomValueSimpleton("object_with_object:b:ba[0]", WomString("baa")),
+        WomValueSimpleton("object_with_object:b:ba[1]", WomString("battle")),
+        WomValueSimpleton("object_with_object:b:bb[0]", WomString("bbrrrr")),
+        WomValueSimpleton("object_with_object:b:bb[1]", WomString("bb gun")),
+      )
+    ),
     SimpletonConversion(
       "directory",
       WomMaybeListedDirectory(

--- a/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
+++ b/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
@@ -1,14 +1,14 @@
 package cromwell.core.simpleton
 
 import cromwell.core.simpleton.WomValueBuilderSpec._
+import cromwell.core.simpleton.WomValueSimpleton._
 import cromwell.util.WomMocks
 import org.scalatest.{FlatSpec, Matchers}
 import org.specs2.mock.Mockito
 import wom.callable.Callable.OutputDefinition
 import wom.expression.PlaceholderWomExpression
-import wom.types.{WomArrayType, WomIntegerType, WomMapType, WomStringType}
+import wom.types.{WomArrayType, WomMapType, WomStringType}
 import wom.values._
-import WomValueSimpleton._
 
 import scala.util.Success
 
@@ -21,120 +21,157 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
 
   case class SimpletonConversion(name: String, womValue: WomValue, simpletons: Seq[WomValueSimpleton])
   val simpletonConversions = List(
-    SimpletonConversion("foo", WomString("none"), List(WomValueSimpleton("foo", WomString("none")))),
-    SimpletonConversion("bar", WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))), List(WomValueSimpleton("bar[0]", WomInteger(1)), WomValueSimpleton("bar[1]", WomInteger(2)))),
-    SimpletonConversion("empty_array", WomArray(WomArrayType(WomIntegerType), List.empty), List()),
+//    SimpletonConversion("foo", WomString("none"), List(WomValueSimpleton("foo", WomString("none")))),
+//    SimpletonConversion("bar", WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))), List(WomValueSimpleton("bar[0]", WomInteger(1)), WomValueSimpleton("bar[1]", WomInteger(2)))),
+//    SimpletonConversion("empty_array", WomArray(WomArrayType(WomIntegerType), List.empty), List()),
+//    SimpletonConversion(
+//      "baz",
+//      WomArray(WomArrayType(WomArrayType(WomIntegerType)), List(
+//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
+//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
+//      List(WomValueSimpleton("baz[0][0]", WomInteger(0)), WomValueSimpleton("baz[0][1]", WomInteger(1)), WomValueSimpleton("baz[1][0]", WomInteger(2)), WomValueSimpleton("baz[1][1]", WomInteger(3)))
+//    ),
+//    SimpletonConversion(
+//      "map",
+//      WomMap(WomMapType(WomStringType, WomStringType), Map(
+//        WomString("foo") -> WomString("foo"),
+//        WomString("bar") -> WomString("bar"))),
+//      List(WomValueSimpleton("map:foo", WomString("foo")), WomValueSimpleton("map:bar", WomString("bar")))
+//    ),
+//    SimpletonConversion(
+//      "mapOfMaps",
+//      WomMap(WomMapType(WomStringType, WomMapType(WomStringType, WomStringType)), Map(
+//        WomString("foo") -> WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("foo2") -> WomString("foo"))),
+//        WomString("bar") ->WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("bar2") -> WomString("bar"))))),
+//      List(WomValueSimpleton("mapOfMaps:foo:foo2", WomString("foo")), WomValueSimpleton("mapOfMaps:bar:bar2", WomString("bar")))
+//    ),
+//    SimpletonConversion(
+//      "simplePair1",
+//      WomPair(WomInteger(1), WomString("hello")),
+//      List(WomValueSimpleton("simplePair1:left", WomInteger(1)), WomValueSimpleton("simplePair1:right", WomString("hello")))
+//    ),
+//    SimpletonConversion(
+//      "simplePair2",
+//      WomPair(WomString("left"), WomInteger(5)),
+//      List(WomValueSimpleton("simplePair2:left", WomString("left")), WomValueSimpleton("simplePair2:right", WomInteger(5)))
+//    ),
+//    SimpletonConversion(
+//      "pairOfPairs",
+//      WomPair(
+//        WomPair(WomInteger(1), WomString("one")),
+//        WomPair(WomString("two"), WomInteger(2))),
+//      List(
+//        WomValueSimpleton("pairOfPairs:left:left", WomInteger(1)),
+//        WomValueSimpleton("pairOfPairs:left:right", WomString("one")),
+//        WomValueSimpleton("pairOfPairs:right:left", WomString("two")),
+//        WomValueSimpleton("pairOfPairs:right:right", WomInteger(2)))
+//    ),
+//    SimpletonConversion(
+//      "pairOfArrayAndMap",
+//      WomPair(
+//        WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))),
+//        WomMap(WomMapType(WomStringType, WomIntegerType), Map(WomString("left") -> WomInteger(100), WomString("right") -> WomInteger(200)))),
+//      List(
+//        WomValueSimpleton("pairOfArrayAndMap:left[0]", WomInteger(1)),
+//        WomValueSimpleton("pairOfArrayAndMap:left[1]", WomInteger(2)),
+//        WomValueSimpleton("pairOfArrayAndMap:right:left", WomInteger(100)),
+//        WomValueSimpleton("pairOfArrayAndMap:right:right", WomInteger(200)))
+//    ),
+//    SimpletonConversion(
+//      "mapOfArrays",
+//      WomMap(WomMapType(WomStringType, WomArrayType(WomIntegerType)), Map(
+//        WomString("foo") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
+//        WomString("bar") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
+//      List(WomValueSimpleton("mapOfArrays:foo[0]", WomInteger(0)), WomValueSimpleton("mapOfArrays:foo[1]", WomInteger(1)),
+//        WomValueSimpleton("mapOfArrays:bar[0]", WomInteger(2)), WomValueSimpleton("mapOfArrays:bar[1]", WomInteger(3)))
+//    ),
+//    SimpletonConversion(
+//      "escapology",
+//      WomMap(WomMapType(WomStringType, WomStringType), Map(
+//        WomString("foo[1]") -> WomString("foo"),
+//        WomString("bar[[") -> WomString("bar"),
+//        WomString("baz:qux") -> WomString("baz:qux"))),
+//      List(WomValueSimpleton("escapology:foo\\[1\\]", WomString("foo")),
+//        WomValueSimpleton("escapology:bar\\[\\[", WomString("bar")),
+//        WomValueSimpleton("escapology:baz\\:qux", WomString("baz:qux")))
+//    ),
+//    SimpletonConversion(
+//      "flat_object",
+//      WomObject(Map(
+//        "a" -> WomString("aardvark"),
+//        "b" -> WomInteger(25),
+//        "c" -> WomBoolean(false)
+//      )),
+//      List(WomValueSimpleton("flat_object:a", WomString("aardvark")),
+//        WomValueSimpleton("flat_object:b", WomInteger(25)),
+//        WomValueSimpleton("flat_object:c", WomBoolean(false)))
+//    ),
+//    SimpletonConversion(
+//      "object_with_array",
+//      WomObject(Map(
+//        "a" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("beetle")))
+//      )),
+//      List(WomValueSimpleton("object_with_array:a[0]", WomString("aardvark")),
+//        WomValueSimpleton("object_with_array:a[1]", WomString("beetle")))
+//    ),
+//    SimpletonConversion(
+//      "object_with_object",
+//      WomObject(Map(
+//        "a" -> WomObject(Map(
+//          "aa" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("aaron"))),
+//          "ab" -> WomArray(WomArrayType(WomStringType), Seq(WomString("abacus"), WomString("a bee")))
+//        )),
+//        "b" -> WomObject(Map(
+//          "ba" -> WomArray(WomArrayType(WomStringType), Seq(WomString("baa"), WomString("battle"))),
+//          "bb" -> WomArray(WomArrayType(WomStringType), Seq(WomString("bbrrrr"), WomString("bb gun")))
+//        ))
+//      )),
+//      List(
+//        WomValueSimpleton("object_with_object:a:aa[0]", WomString("aardvark")),
+//        WomValueSimpleton("object_with_object:a:aa[1]", WomString("aaron")),
+//        WomValueSimpleton("object_with_object:a:ab[0]", WomString("abacus")),
+//        WomValueSimpleton("object_with_object:a:ab[1]", WomString("a bee")),
+//        WomValueSimpleton("object_with_object:b:ba[0]", WomString("baa")),
+//        WomValueSimpleton("object_with_object:b:ba[1]", WomString("battle")),
+//        WomValueSimpleton("object_with_object:b:bb[0]", WomString("bbrrrr")),
+//        WomValueSimpleton("object_with_object:b:bb[1]", WomString("bb gun")),
+//      )
+//    ),
     SimpletonConversion(
-      "baz",
-      WomArray(WomArrayType(WomArrayType(WomIntegerType)), List(
-        WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
-        WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
-      List(WomValueSimpleton("baz[0][0]", WomInteger(0)), WomValueSimpleton("baz[0][1]", WomInteger(1)), WomValueSimpleton("baz[1][0]", WomInteger(2)), WomValueSimpleton("baz[1][1]", WomInteger(3)))
-    ),
-    SimpletonConversion(
-      "map",
-      WomMap(WomMapType(WomStringType, WomStringType), Map(
-        WomString("foo") -> WomString("foo"),
-        WomString("bar") -> WomString("bar"))),
-      List(WomValueSimpleton("map:foo", WomString("foo")), WomValueSimpleton("map:bar", WomString("bar")))
-    ),
-    SimpletonConversion(
-      "mapOfMaps",
-      WomMap(WomMapType(WomStringType, WomMapType(WomStringType, WomStringType)), Map(
-        WomString("foo") -> WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("foo2") -> WomString("foo"))),
-        WomString("bar") ->WomMap(WomMapType(WomStringType, WomStringType), Map(WomString("bar2") -> WomString("bar"))))),
-      List(WomValueSimpleton("mapOfMaps:foo:foo2", WomString("foo")), WomValueSimpleton("mapOfMaps:bar:bar2", WomString("bar")))
-    ),
-    SimpletonConversion(
-      "simplePair1",
-      WomPair(WomInteger(1), WomString("hello")),
-      List(WomValueSimpleton("simplePair1:left", WomInteger(1)), WomValueSimpleton("simplePair1:right", WomString("hello")))
-    ),
-    SimpletonConversion(
-      "simplePair2",
-      WomPair(WomString("left"), WomInteger(5)),
-      List(WomValueSimpleton("simplePair2:left", WomString("left")), WomValueSimpleton("simplePair2:right", WomInteger(5)))
-    ),
-    SimpletonConversion(
-      "pairOfPairs",
-      WomPair(
-        WomPair(WomInteger(1), WomString("one")),
-        WomPair(WomString("two"), WomInteger(2))),
+      "directory",
+      WomMaybeListedDirectory(
+        Option("outerValueName"), 
+        Option(List(
+          WomSingleFile("outerSingleFile"),
+          WomMaybeListedDirectory(Option("innerValueName"), Option(List(WomSingleFile("innerSingleFile")))),
+          WomMaybePopulatedFile(
+            Option("populatedInnerValueName"),
+            Option("innerChecksum"),
+            Option(10L),
+            Option("innerFormat"),
+            Option("innerContents"),
+            List(
+              WomSingleFile("populatedInnerSingleFile"),
+              WomMaybeListedDirectory(Option("innerDirectoryValueName"), Option(List(WomSingleFile("innerDirectorySingleFile"))))
+            )
+          )
+      ))),
       List(
-        WomValueSimpleton("pairOfPairs:left:left", WomInteger(1)),
-        WomValueSimpleton("pairOfPairs:left:right", WomString("one")),
-        WomValueSimpleton("pairOfPairs:right:left", WomString("two")),
-        WomValueSimpleton("pairOfPairs:right:right", WomInteger(2)))
-    ),
-    SimpletonConversion(
-      "pairOfArrayAndMap",
-      WomPair(
-        WomArray(WomArrayType(WomIntegerType), List(WomInteger(1), WomInteger(2))),
-        WomMap(WomMapType(WomStringType, WomIntegerType), Map(WomString("left") -> WomInteger(100), WomString("right") -> WomInteger(200)))),
-      List(
-        WomValueSimpleton("pairOfArrayAndMap:left[0]", WomInteger(1)),
-        WomValueSimpleton("pairOfArrayAndMap:left[1]", WomInteger(2)),
-        WomValueSimpleton("pairOfArrayAndMap:right:left", WomInteger(100)),
-        WomValueSimpleton("pairOfArrayAndMap:right:right", WomInteger(200)))
-    ),
-    SimpletonConversion(
-      "mapOfArrays",
-      WomMap(WomMapType(WomStringType, WomArrayType(WomIntegerType)), Map(
-        WomString("foo") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(0), WomInteger(1))),
-        WomString("bar") -> WomArray(WomArrayType(WomIntegerType), List(WomInteger(2), WomInteger(3))))),
-      List(WomValueSimpleton("mapOfArrays:foo[0]", WomInteger(0)), WomValueSimpleton("mapOfArrays:foo[1]", WomInteger(1)),
-        WomValueSimpleton("mapOfArrays:bar[0]", WomInteger(2)), WomValueSimpleton("mapOfArrays:bar[1]", WomInteger(3)))
-    ),
-    SimpletonConversion(
-      "escapology",
-      WomMap(WomMapType(WomStringType, WomStringType), Map(
-        WomString("foo[1]") -> WomString("foo"),
-        WomString("bar[[") -> WomString("bar"),
-        WomString("baz:qux") -> WomString("baz:qux"))),
-      List(WomValueSimpleton("escapology:foo\\[1\\]", WomString("foo")),
-        WomValueSimpleton("escapology:bar\\[\\[", WomString("bar")),
-        WomValueSimpleton("escapology:baz\\:qux", WomString("baz:qux")))
-    ),
-    SimpletonConversion(
-      "flat_object",
-      WomObject(Map(
-        "a" -> WomString("aardvark"),
-        "b" -> WomInteger(25),
-        "c" -> WomBoolean(false)
-      )),
-      List(WomValueSimpleton("flat_object:a", WomString("aardvark")),
-        WomValueSimpleton("flat_object:b", WomInteger(25)),
-        WomValueSimpleton("flat_object:c", WomBoolean(false)))
-    ),
-    SimpletonConversion(
-      "object_with_array",
-      WomObject(Map(
-        "a" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("beetle")))
-      )),
-      List(WomValueSimpleton("object_with_array:a[0]", WomString("aardvark")),
-        WomValueSimpleton("object_with_array:a[1]", WomString("beetle")))
-    ),
-    SimpletonConversion(
-      "object_with_object",
-      WomObject(Map(
-        "a" -> WomObject(Map(
-          "aa" -> WomArray(WomArrayType(WomStringType), Seq(WomString("aardvark"), WomString("aaron"))),
-          "ab" -> WomArray(WomArrayType(WomStringType), Seq(WomString("abacus"), WomString("a bee")))
-        )),
-        "b" -> WomObject(Map(
-          "ba" -> WomArray(WomArrayType(WomStringType), Seq(WomString("baa"), WomString("battle"))),
-          "bb" -> WomArray(WomArrayType(WomStringType), Seq(WomString("bbrrrr"), WomString("bb gun")))
-        ))
-      )),
-      List(
-        WomValueSimpleton("object_with_object:a:aa[0]", WomString("aardvark")),
-        WomValueSimpleton("object_with_object:a:aa[1]", WomString("aaron")),
-        WomValueSimpleton("object_with_object:a:ab[0]", WomString("abacus")),
-        WomValueSimpleton("object_with_object:a:ab[1]", WomString("a bee")),
-        WomValueSimpleton("object_with_object:b:ba[0]", WomString("baa")),
-        WomValueSimpleton("object_with_object:b:ba[1]", WomString("battle")),
-        WomValueSimpleton("object_with_object:b:bb[0]", WomString("bbrrrr")),
-        WomValueSimpleton("object_with_object:b:bb[1]", WomString("bb gun")),
+        WomValueSimpleton("directory:<<directory>>:value", WomString("outerValueName")),
+        
+        WomValueSimpleton("directory:<<directory>>:listing[0]", WomSingleFile("outerSingleFile")),
+        
+        WomValueSimpleton("directory:<<directory>>:listing[1]:<<directory>>:value", WomString("innerValueName")),
+        WomValueSimpleton("directory:<<directory>>:listing[1]:<<directory>>:listing[0]", WomSingleFile("innerSingleFile")),
+        
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:value", WomString("populatedInnerValueName")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:checksum", WomString("innerChecksum")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:size", WomInteger(10)),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:format", WomString("innerFormat")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:contents", WomString("innerContents")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:secondaryFiles[0]", WomSingleFile("populatedInnerSingleFile")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:secondaryFiles[1]:<<directory>>:value", WomString("innerDirectoryValueName")),
+        WomValueSimpleton("directory:<<directory>>:listing[2]:<<populated>>:secondaryFiles[1]:<<directory>>:listing[0]", WomSingleFile("innerDirectorySingleFile")),
       )
     )
   )
@@ -145,7 +182,8 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
     it should s"decompose WdlValues into simpletons ($name)" in {
 
       val map = Map(WomMocks.mockOutputPort(name) -> womValue)
-      assertSimpletonsEqual(expectedSimpletons, map.simplify)
+      val simplified = map.simplify
+      assertSimpletonsEqual(expectedSimpletons, simplified)
     }
 
     it should s"build simpletons back into WdlValues ($name)" in {


### PR DESCRIPTION
This might be controversial hence the PREGULL.
The problem is `WomFile` can now take different forms.
`WomSingleFile` is just a file path (for now)
`WomMaybePopulatedFile` can have a whole bunch of attributes, including a `List[WomFile]`
Same for `WomMaybeListedDirectory`.
`WomFile` => Simpletons is not the problem since we can just simpletonize a "complex file" as an object.
Simpletons => `WomFile` is harder because we don't necessarily know which kind of `WomFile` it is that we're trying to build.
The solution in this PR is to leave a "marker" in the simpleton key to give us a hint that what's following is a `WomMaybeListedDirectory` or a `WomMaybePopulatedFile` and re-build it appropriately.