### PR TITLE
Use preserveScatterIndex for inner graph OGINs

### DIFF
--- a/centaur/src/main/resources/standardTestCases/conditionals.ifs_in_scatters.test
+++ b/centaur/src/main/resources/standardTestCases/conditionals.ifs_in_scatters.test
@@ -9,8 +9,8 @@ files {
 metadata {
   workflowName: ifs_in_scatters
   "outputs.ifs_in_scatters.mirrors.0": null
-  "outputs.ifs_in_scatters.mirrors.1": "3"
+  "outputs.ifs_in_scatters.mirrors.1": "5"
   "outputs.ifs_in_scatters.mirrors.2": null
-  "outputs.ifs_in_scatters.mirrors.3": "5"
+  "outputs.ifs_in_scatters.mirrors.3": "7"
   "outputs.ifs_in_scatters.mirrors.4": null
 }

--- a/centaur/src/main/resources/standardTestCases/conditionals.ifs_in_scatters.test
+++ b/centaur/src/main/resources/standardTestCases/conditionals.ifs_in_scatters.test
@@ -9,8 +9,8 @@ files {
 metadata {
   workflowName: ifs_in_scatters
   "outputs.ifs_in_scatters.mirrors.0": null
-  "outputs.ifs_in_scatters.mirrors.1": "2"
+  "outputs.ifs_in_scatters.mirrors.1": "3"
   "outputs.ifs_in_scatters.mirrors.2": null
-  "outputs.ifs_in_scatters.mirrors.3": "4"
+  "outputs.ifs_in_scatters.mirrors.3": "5"
   "outputs.ifs_in_scatters.mirrors.4": null
 }

--- a/centaur/src/main/resources/standardTestCases/conditionals.lots_of_nesting.test
+++ b/centaur/src/main/resources/standardTestCases/conditionals.lots_of_nesting.test
@@ -12,32 +12,32 @@ files {
 metadata {
   workflowName: lots_of_nesting
   "outputs.lots_of_nesting.a.0": null
-  "outputs.lots_of_nesting.a.1": "2"
+  "outputs.lots_of_nesting.a.1": "5"
   "outputs.lots_of_nesting.a.2": null
-  "outputs.lots_of_nesting.a.3": "4"
+  "outputs.lots_of_nesting.a.3": "7"
   "outputs.lots_of_nesting.a.4": null
-  "outputs.lots_of_nesting.b.0": "2"
-  "outputs.lots_of_nesting.b.1": "4"
-  "outputs.lots_of_nesting.c.0.left": "2"
-  "outputs.lots_of_nesting.c.0.right": "2"
-  "outputs.lots_of_nesting.c.1.left": "2"
-  "outputs.lots_of_nesting.c.1.right": "4"
-  "outputs.lots_of_nesting.c.2.left": "4"
-  "outputs.lots_of_nesting.c.2.right": "2"
-  "outputs.lots_of_nesting.c.3.left": "4"
-  "outputs.lots_of_nesting.c.3.right": "4"
-  "outputs.lots_of_nesting.d.0.left": "2"
+  "outputs.lots_of_nesting.b.0": "5"
+  "outputs.lots_of_nesting.b.1": "7"
+  "outputs.lots_of_nesting.c.0.left": "5"
+  "outputs.lots_of_nesting.c.0.right": "5"
+  "outputs.lots_of_nesting.c.1.left": "5"
+  "outputs.lots_of_nesting.c.1.right": "7"
+  "outputs.lots_of_nesting.c.2.left": "7"
+  "outputs.lots_of_nesting.c.2.right": "5"
+  "outputs.lots_of_nesting.c.3.left": "7"
+  "outputs.lots_of_nesting.c.3.right": "7"
+  "outputs.lots_of_nesting.d.0.left": "5"
   "outputs.lots_of_nesting.d.0.right": null
-  "outputs.lots_of_nesting.d.1.left": "2"
-  "outputs.lots_of_nesting.d.1.right": "4"
-  "outputs.lots_of_nesting.d.2.left": "4"
-  "outputs.lots_of_nesting.d.2.right": "2"
-  "outputs.lots_of_nesting.d.3.left": "4"
+  "outputs.lots_of_nesting.d.1.left": "5"
+  "outputs.lots_of_nesting.d.1.right": "7"
+  "outputs.lots_of_nesting.d.2.left": "7"
+  "outputs.lots_of_nesting.d.2.right": "5"
+  "outputs.lots_of_nesting.d.3.left": "7"
   "outputs.lots_of_nesting.d.3.right": null
   "outputs.lots_of_nesting.e.0": null
-  "outputs.lots_of_nesting.e.1.left": "2"
-  "outputs.lots_of_nesting.e.1.right": "4"
-  "outputs.lots_of_nesting.e.2.left": "4"
-  "outputs.lots_of_nesting.e.2.right": "2"
+  "outputs.lots_of_nesting.e.1.left": "5"
+  "outputs.lots_of_nesting.e.1.right": "7"
+  "outputs.lots_of_nesting.e.2.left": "7"
+  "outputs.lots_of_nesting.e.2.right": "5"
   "outputs.lots_of_nesting.e.3": null
 }

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/ifs_in_scatters/ifs_in_scatters.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/ifs_in_scatters/ifs_in_scatters.wdl
@@ -27,13 +27,16 @@ task mirror {
 workflow ifs_in_scatters {
   Array[Int] numbers = range(5)
   call mirror as init { input: i = 1 }
+  Int mirrorPlusOne = 1 + init.out
 
   scatter (n in numbers) {
 
     call validate_int { input: i = n }
     if (validate_int.validation) {
       Int incremented = n + 1
-      call mirror { input: i = incremented + init.out }
+      if (incremented != 0) {
+        call mirror { input: i = incremented + init.out + mirrorPlusOne }
+      }
     }
   }
 

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/ifs_in_scatters/ifs_in_scatters.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/ifs_in_scatters/ifs_in_scatters.wdl
@@ -26,13 +26,14 @@ task mirror {
 
 workflow ifs_in_scatters {
   Array[Int] numbers = range(5)
+  call mirror as init { input: i = 1 }
 
   scatter (n in numbers) {
 
     call validate_int { input: i = n }
     if (validate_int.validation) {
       Int incremented = n + 1
-      call mirror { input: i = incremented }
+      call mirror { input: i = incremented + init.out }
     }
   }
 

--- a/centaur/src/main/resources/standardTestCases/conditionals_tests/lots_of_nesting/lots_of_nesting.wdl
+++ b/centaur/src/main/resources/standardTestCases/conditionals_tests/lots_of_nesting/lots_of_nesting.wdl
@@ -12,7 +12,7 @@ workflow lots_of_nesting {
 
     scatter (m in mxm) {
       Int lhs = m.left
-      if (lhs * m.right == 8) {
+      if (lhs * m.right == 35) {
         Int rhs = m.right
         Pair[Int, Int] hooroo = ( lhs, rhs )
       }

--- a/wdl/src/main/scala/wdl/If.scala
+++ b/wdl/src/main/scala/wdl/If.scala
@@ -56,6 +56,15 @@ object If {
       * use however many of them it needs.
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
+      /*
+        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup should be considered "siblings" of the conditional in term of scatter index
+        * preserveIndexForOuterLookups = false means the outerLookup nodes are outside a scatter containing this conditional node
+        * preserveIndexForOuterLookups = true means the above predicate does not hold
+        * 
+        * When creating OGINs from those outer lookup nodes for the inner graph we want to make sure we set their preserveScatterIndex to preserveIndexForOuterLookups
+        * because they effectively represent the outer lookup nodes inside the conditional. So whether the index must be preserved depends on whether this
+        * conditional node has been asked to "preserveIndexForOuterLookups".
+       */
       name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = preserveIndexForOuterLookups)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }

--- a/wdl/src/main/scala/wdl/If.scala
+++ b/wdl/src/main/scala/wdl/If.scala
@@ -56,7 +56,7 @@ object If {
       * use however many of them it needs.
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
-      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = true)
+      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = preserveIndexForOuterLookups)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }
 

--- a/wdl/src/main/scala/wdl/If.scala
+++ b/wdl/src/main/scala/wdl/If.scala
@@ -57,7 +57,7 @@ object If {
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
       /*
-        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup should be considered "siblings" of the conditional in term of scatter index
+        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup are in the same scatter inn graph as this node
         * preserveIndexForOuterLookups = false means the outerLookup nodes are outside a scatter containing this conditional node
         * preserveIndexForOuterLookups = true means the above predicate does not hold
         * 

--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -60,7 +60,7 @@ object Scatter {
       * use however many of them it needs.
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
-      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = false)
+      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = preserveIndexForOuterLookups)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }
 

--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -60,6 +60,19 @@ object Scatter {
       * use however many of them it needs.
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
+      /*
+        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup should be considered "siblings" of the scatter in term of scatter index
+        * preserveIndexForOuterLookups = false means the outerLookup nodes are outside a scatter containing this scatter node
+        * preserveIndexForOuterLookups = true means the above predicate does not hold
+        * 
+        * When creating OGINs from those outer lookup nodes for the inner graph we want to make sure we set their preserveScatterIndex to preserveIndexForOuterLookups
+        * because they effectively represent the outer lookup nodes inside the scatter. So whether the index must be preserved depends on whether this
+        * scatter node has been asked to "preserveIndexForOuterLookups".
+        * 
+        * Note that preserveIndexForOuterLookups will always be true here as long as scatters can't be nested. Indeed the only reason for a node to be
+        * asked to NOT preserve the index is if its outerLookup is referencing nodes outside a scatter.
+        * In this case preserveIndexForOuterLookups = false would mean this scatter node is part of the inner graph of another scatter node.
+       */
       name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = preserveIndexForOuterLookups)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }

--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -61,7 +61,7 @@ object Scatter {
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
       /*
-        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup should be considered "siblings" of the scatter in term of scatter index
+        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup are in the same scatter inn graph as this node
         * preserveIndexForOuterLookups = false means the outerLookup nodes are outside a scatter containing this scatter node
         * preserveIndexForOuterLookups = true means the above predicate does not hold
         * 

--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -61,19 +61,10 @@ object Scatter {
       */
     val possiblyNeededNestedOgins: Map[String, OuterGraphInputNode] = outerLookup filterNot { case (name, _) => localLookup.contains(name) } map { case (name, outerPort) =>
       /*
-        * preserveIndexForOuterLookups indicates us whether or not nodes in the outerLookup are in the same scatter inn graph as this node
-        * preserveIndexForOuterLookups = false means the outerLookup nodes are outside a scatter containing this scatter node
-        * preserveIndexForOuterLookups = true means the above predicate does not hold
-        * 
-        * When creating OGINs from those outer lookup nodes for the inner graph we want to make sure we set their preserveScatterIndex to preserveIndexForOuterLookups
-        * because they effectively represent the outer lookup nodes inside the scatter. So whether the index must be preserved depends on whether this
-        * scatter node has been asked to "preserveIndexForOuterLookups".
-        * 
-        * Note that preserveIndexForOuterLookups will always be true here as long as scatters can't be nested. Indeed the only reason for a node to be
-        * asked to NOT preserve the index is if its outerLookup is referencing nodes outside a scatter.
-        * In this case preserveIndexForOuterLookups = false would mean this scatter node is part of the inner graph of another scatter node.
+        * preserveScatterIndex = false because in the absence of support of nested scatters,
+        * the index should never be preserved when for nodes coming from outside the scatter.
        */
-      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = preserveIndexForOuterLookups)
+      name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = false)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }
 


### PR DESCRIPTION
In a configuration like

```wdl
workflow ifs_in_scatters {
  call hello

  scatter (n in range(5)) {
    if (true) {
      call goodbye { input: i = hello.out }
    }
  }
}
```
When the conditional graph is created, all nodes outside of the scatter get "wrapped" in an `OuterGraphInputNode` that gets passed into the inner conditional graph so that nodes in the inner graph can reference nodes outside of the scatter.
The issue is that those OGINs are created with `preserveScatterIndex  = true` even though the node they're pointing to is outside of the scatter. This was preventing the `ExecutionStore` from detecting the `i = hello.out` expression as being runnable because it was looking for a `hello.out` node in `Done` state at index `n`, which doesn't exist since `call hello` is outside the scatter.
This PR changes that to use the `preserveIndexForOuterLookups ` value of the conditional / scatter instead, which in this case will be `false`, because the scatter node does set `preserveScatterIndex = false` to build its inner graph (in this case the if).