### PR TITLE
Start is not required on query results

### DIFF
--- a/docs/api/RESTAPI.md
+++ b/docs/api/RESTAPI.md
@@ -864,7 +864,7 @@ Result for an individual workflow returned by a workflow query
 |**end**  <br>*optional*|Workflow end datetime|string (date-time)|
 |**id**  <br>*required*|Workflow ID|string|
 |**name**  <br>*required*|Workflow name|string|
-|**start**  <br>*required*|Workflow start datetime|string (date-time)|
+|**start**  <br>*optional*|Workflow start datetime|string (date-time)|
 |**status**  <br>*required*|Workflow status|string|
 
 

--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -819,7 +819,6 @@ definitions:
       - id
       - name
       - status
-      - start
     properties:
       id:
         type: string


### PR DESCRIPTION
Unless queryWorkflows **only** returns jobs that have already started, I think it cannot be true that this field is required.