### PR TITLE
WDL: Object literals, read_json and write_json. Closes #1825

### DIFF
--- a/centaur/src/main/resources/standardTestCases/read_write_json.test
+++ b/centaur/src/main/resources/standardTestCases/read_write_json.test
@@ -1,0 +1,12 @@
+name: read_write_json
+testFormat: workflowsuccess
+
+files {
+  wdl: read_write_json/read_write_json.wdl
+}
+
+metadata {
+  workflowName: read_write_json
+  status: Succeeded
+  "outputs.read_write_json.result" = "27.5 was equal to 27.5"
+}

--- a/centaur/src/main/resources/standardTestCases/read_write_json/read_write_json.wdl
+++ b/centaur/src/main/resources/standardTestCases/read_write_json/read_write_json.wdl
@@ -1,0 +1,63 @@
+workflow read_write_json {
+  Object json_object = object {
+    str: "hi",
+    int: 57,
+    float: 27.5,
+    pair: (5, "hello"),
+    array: ["a", "b", "c"]
+  }
+
+  call make_some_json
+  call round_trip { input: to_jsonify = json_object }
+
+  if (round_trip.round_tripped.float == make_some_json.output_json.float) {
+    call success { input: actual = round_trip.round_tripped.float, expected = make_some_json.output_json.float }
+  }
+
+  output {
+    String? result = success.result
+  }
+}
+
+task round_trip {
+  Object to_jsonify
+  File jsonified = write_json(to_jsonify)
+  command {
+    cp ${jsonified} output.json
+  }
+  output {
+    Object round_tripped = read_json("output.json")
+  }
+}
+
+task make_some_json {
+  command <<<
+    echo '{'
+    echo '  "str": "hi",'
+    echo '  "int": 57,'
+    echo '  "float": 27.5,'
+    echo '  "pair": {'
+    echo '    "left": 5,'
+    echo '    "right": "hello"'
+    echo '  },'
+    echo '  "array": ["a", "b", "c"]'
+    echo '}'
+  >>>
+  output {
+    Object output_json = read_json(stdout())
+  }
+}
+
+task success {
+  Float actual
+  Float expected
+  command {
+    echo "${actual} was equal to ${expected}"
+  }
+  output {
+    String result = read_string(stdout())
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
+++ b/wdl/src/main/scala/wdl/expression/TypeEvaluator.scala
@@ -62,6 +62,7 @@ case class TypeEvaluator(override val lookup: String => WomType, override val fu
         elements <- TryUtil.sequence(evaluatedElements)
         subtype = WomType.homogeneousTypeFromTypes(elements)
       } yield WomArrayType(subtype)
+    case o: Ast if o.isObjectLiteral => Success(WomObjectType)
     case a: Ast if a.isTupleLiteral => tupleAstToWdlType(a)
     case a: Ast if a.isMapLiteral =>
       val evaluatedMap = a.getAttribute("map").astListAsVector map { kv =>

--- a/wom/src/main/scala/wom/types/WomAnyType.scala
+++ b/wom/src/main/scala/wom/types/WomAnyType.scala
@@ -2,6 +2,8 @@ package wom.types
 
 import wom.values.WomValue
 
+import scala.util.{Success, Try}
+
 case object WomAnyType extends WomType {
   val toDisplayString: String = s"Any"
 
@@ -49,4 +51,5 @@ case object WomAnyType extends WomType {
   }
 
   override final def isCoerceableFrom(otherType: WomType): Boolean = true
+  override def equals(rhs: WomType): Try[WomType] = Success(WomBooleanType)
 }

--- a/wom/src/main/scala/wom/types/WomIntegerType.scala
+++ b/wom/src/main/scala/wom/types/WomIntegerType.scala
@@ -10,7 +10,7 @@ case object WomIntegerType extends WomPrimitiveType {
 
   override protected def coercion = {
     case i: Integer => WomInteger(i)
-    case n: JsNumber => WomInteger(n.value.intValue())
+    case n: JsNumber if n.value.isValidInt => WomInteger(n.value.intValue())
     case i: WomInteger => i
     case s: WomString => WomInteger(s.value.toInt)
     case s: String => WomInteger(s.toInt)

--- a/wom/src/main/scala/wom/types/WomObjectType.scala
+++ b/wom/src/main/scala/wom/types/WomObjectType.scala
@@ -2,6 +2,7 @@ package wom.types
 
 import cats.instances.list._
 import cats.syntax.traverse._
+import common.util.TryUtil
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
 import spray.json.JsObject
@@ -46,12 +47,15 @@ case object WomObjectType extends WomObjectTypeLike {
 
       WomObject(coercedMap)
     case js: JsObject =>
-      val coercedMap = WomMap.coerceMap(js.fields, WomMapType(WomStringType, WomAnyType)).value map {
-        // get is safe because coerceMap above would have failed already if k was not coerceable to WomString
-        case (k, v) => toWomString(k).get.value -> v
-      }
 
-      WomObject(coercedMap)
+      val mapToTry = js.fields map { case (key, value) => key -> WomAnyType.coerceRawValue(value) }
+      val mapOfTry = mapToTry map { kvp => kvp._2 map { kvp._1 -> _ } }
+      // The TryUtil exception is ignored, we only use it to tell whether it worked or not. We use handleCoercionFailures
+      // to compose the errors.
+      TryUtil.sequence(mapOfTry.toList) match {
+        case Success(map) => WomObject(map.toMap)
+        case Failure(_) => handleCoercionFailures(mapOfTry.toSeq: _*)
+      }
   }
 
   private def toWomString(v: WomValue) = WomStringType.coerceRawValue(v).map(_.asInstanceOf[WomString])

--- a/wom/src/main/scala/wom/types/WomType.scala
+++ b/wom/src/main/scala/wom/types/WomType.scala
@@ -71,7 +71,7 @@ trait WomType {
 object WomType {
   /* This is in the order of coercion from non-wom types */
   val womTypeCoercionOrder: Seq[WomType] = Seq(
-    WomStringType, WomIntegerType, WomFloatType, WomMapType(WomAnyType, WomAnyType),
+    WomStringType, WomIntegerType, WomFloatType, WomPairType(WomAnyType, WomAnyType), WomMapType(WomAnyType, WomAnyType),
     WomArrayType(WomAnyType), WomBooleanType, WomObjectType
   )
 

--- a/womtool/src/main/scala/womtool/Main.scala
+++ b/womtool/src/main/scala/womtool/Main.scala
@@ -104,6 +104,7 @@ object Main extends App {
   private[this] def loadWdl(path: String)(f: WdlNamespace => Termination): Termination = {
     WdlNamespace.loadUsingPath(Paths.get(path), None, None) match {
       case Success(namespace) => f(namespace)
+      case Failure(r: RuntimeException) => throw new RuntimeException("Unexpected failure mode", r)
       case Failure(t) => UnsuccessfulTermination(t.getMessage)
     }
   }


### PR DESCRIPTION
A big ask at BOSC:

Allows Cromwell to read `object { ... }` literals in WDL, to call `read_json(file)`, and to call `write_json(object)`.

Even if the `Object` type fades away after the structs PR, these building blocks are still going to be needed.