### PR TITLE
Add valid hostname to DockerHubFlow

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cacheBetweenWF/cacheBetweenWF.wdl
+++ b/centaur/src/main/resources/standardTestCases/cacheBetweenWF/cacheBetweenWF.wdl
@@ -8,7 +8,7 @@ task getAverage {
         Float average = read_float(stdout())
     }
     runtime {
-       docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+       docker: "docker.io/ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
@@ -10,10 +10,10 @@ task dockerhub {
 
 workflow docker_hash_dockerhub {
 
-    Array[String] hostnames = ["", "docker.io/", "index.docker.io/"]
+    call dockerhub as dockerWithoutHost { input: hostname = "" }
 
-    scatter (hostname in hostnames) {
-        call dockerhub { input: hostname = hostname }
-    }
+    call dockerhub as implicitRegistryHost { input: hostname = "docker.io/" }
+
+    call dockerhub as defaultRegistryHost { input: hostname = "index.docker.io/" }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
@@ -1,12 +1,19 @@
 task dockerhub {
+    String hostname
     command {
         echo "hello"
     }
     runtime {
-        docker: "docker.io/ubuntu:precise-20161209"
+        docker: hostname + "ubuntu:precise-20161209"
     }
 }
 
 workflow docker_hash_dockerhub {
-    call dockerhub
+
+    Array[String] hostnames = ["", "docker.io/", "index.docker.io/"]
+
+    scatter (hostname in hostnames) {
+        call dockerhub { input: hostname = hostname }
+    }
 }
+

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_dockerhub.wdl
@@ -3,7 +3,7 @@ task dockerhub {
         echo "hello"
     }
     runtime {
-        docker: "ubuntu:precise-20161209"
+        docker: "docker.io/ubuntu:precise-20161209"
     }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
@@ -9,7 +9,7 @@ metadata {
   "calls.docker_hash_dockerhub.dockerhub.0.runtimeAttributes.docker": "ubuntu:precise-20161209",
   "calls.docker_hash_dockerhub.dockerhub.0.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
   "calls.docker_hash_dockerhub.dockerhub.1.runtimeAttributes.docker": "docker.io/ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.1.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
+  "calls.docker_hash_dockerhub.dockerhub.1.dockerImageUsed": "docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
   "calls.docker_hash_dockerhub.dockerhub.2.runtimeAttributes.docker": "index.docker.io/ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.2.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
+  "calls.docker_hash_dockerhub.dockerhub.2.dockerImageUsed": "index.docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
@@ -6,10 +6,10 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_dockerhub.dockerhub.0.runtimeAttributes.docker": "ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.0.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
-  "calls.docker_hash_dockerhub.dockerhub.1.runtimeAttributes.docker": "docker.io/ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.1.dockerImageUsed": "docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
-  "calls.docker_hash_dockerhub.dockerhub.2.runtimeAttributes.docker": "index.docker.io/ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.2.dockerImageUsed": "index.docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
+  "calls.docker_hash_dockerhub.dockerWithoutHost.runtimeAttributes.docker": "ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.dockerWithoutHost.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
+  "calls.docker_hash_dockerhub.implicitRegistryHost.runtimeAttributes.docker": "docker.io/ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.implicitRegistryHost.dockerImageUsed": "docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
+  "calls.docker_hash_dockerhub.defaultRegistryHost.runtimeAttributes.docker": "index.docker.io/ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.defaultRegistryHost.dockerImageUsed": "index.docker.io/ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub.test
@@ -6,6 +6,10 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_dockerhub.dockerhub.runtimeAttributes.docker": "ubuntu:precise-20161209",
-  "calls.docker_hash_dockerhub.dockerhub.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
+  "calls.docker_hash_dockerhub.dockerhub.0.runtimeAttributes.docker": "ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.dockerhub.0.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
+  "calls.docker_hash_dockerhub.dockerhub.1.runtimeAttributes.docker": "docker.io/ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.dockerhub.1.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7",
+  "calls.docker_hash_dockerhub.dockerhub.2.runtimeAttributes.docker": "index.docker.io/ubuntu:precise-20161209",
+  "calls.docker_hash_dockerhub.dockerhub.2.dockerImageUsed": "ubuntu@sha256:abdc090336ba4503bd72d0961a4f3d45134900d9a793d3f0c06a64d2555fbab7"
 }

--- a/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
@@ -18,6 +18,7 @@ object DockerHubFlow {
   private val AuthorizationServerHostName = "auth.docker.io"
   private val DockerHubImplicitRegistryHostName = "docker.io"
   private val ServiceName = Option("registry.docker.io")
+  private val validDockerHubHosts = Array(DockerHubDefaultRegistry, RegistryHostName, DockerHubImplicitRegistryHostName)
 }
 
 class DockerHubFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContext, materializer: ActorMaterializer, scheduler: Scheduler) 
@@ -41,7 +42,7 @@ class DockerHubFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContex
     dockerImageIdentifierWithoutHash.host match {
         // If no host is provided, assume dockerhub
       case None => true
-      case Some(host) if host == registryHostName || host == DockerHubDefaultRegistry || host == DockerHubImplicitRegistryHostName => true
+      case Some(host) if validDockerHubHosts.contains(host) => true
       case _ => false
     }
   }

--- a/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/dockerhub/DockerHubFlow.scala
@@ -16,6 +16,7 @@ object DockerHubFlow {
   private val DockerHubDefaultRegistry = "index.docker.io"
   private val RegistryHostName = "registry-1.docker.io"
   private val AuthorizationServerHostName = "auth.docker.io"
+  private val DockerHubImplicitRegistryHostName = "docker.io"
   private val ServiceName = Option("registry.docker.io")
 }
 
@@ -40,7 +41,7 @@ class DockerHubFlow(httpClientFlow: HttpDockerFlow)(implicit ec: ExecutionContex
     dockerImageIdentifierWithoutHash.host match {
         // If no host is provided, assume dockerhub
       case None => true
-      case Some(host) if host == registryHostName || host == DockerHubDefaultRegistry => true
+      case Some(host) if host == registryHostName || host == DockerHubDefaultRegistry || host == DockerHubImplicitRegistryHostName => true
       case _ => false
     }
   }


### PR DESCRIPTION
Previously, if a docker image was named "docker.io/<repo>/<imageName>:<tag>", there was an issue such that Cromwell failed to pull the docker hash. The job was allowed to run but the results were never saved and so one could never call-cache to jobs with that kind of docker syntax. 

This change is meant to make "docker.io" an accept hostname for the DockerHubFlow.