### PR TITLE
Improve parsing error messages

### DIFF
--- a/cwl/src/main/scala/cwl/AddEmbeddedCwl.scala
+++ b/cwl/src/main/scala/cwl/AddEmbeddedCwl.scala
@@ -4,15 +4,15 @@ import shapeless.{Path => _, _}
 import cats.syntax.traverse._
 import cats.instances.list._
 import cats.effect.IO
-import CwlDecoder.Parse
-import cats.Monad
+import CwlDecoder.{Parse, ParseValidated}
+import cats.{Applicative, Monad}
 import cats.data.EitherT._
 import cats.data.EitherT
 import common.validation.ErrorOr._
 
 object AddEmbeddedCwl extends Poly1 {
 
-  import CwlDecoder._
+  implicit val composedApplicative = Applicative[IO] compose Applicative[ErrorOr]
 
   implicit def workflow: Case.Aux[Workflow, Map[String, Cwl] => Parse[Cwl]] =
     at[Workflow] {

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -481,6 +481,8 @@ object CommandLineTool {
     import cats.instances.list._
     type DefaultToWomValueFunction = WomType => ErrorOr[WomValue]
 
+    type SecondaryFiles = StringOrExpression :+: Array[StringOrExpression] :+: CNil
+
     object DefaultToWomValuePoly extends Poly1 {
       implicit def caseFileOrDirectory: Case.Aux[FileOrDirectory, DefaultToWomValueFunction] = {
         at {

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -481,8 +481,6 @@ object CommandLineTool {
     import cats.instances.list._
     type DefaultToWomValueFunction = WomType => ErrorOr[WomValue]
 
-    type SecondaryFiles = StringOrExpression :+: Array[StringOrExpression] :+: CNil
-
     object DefaultToWomValuePoly extends Poly1 {
       implicit def caseFileOrDirectory: Case.Aux[FileOrDirectory, DefaultToWomValueFunction] = {
         at {


### PR DESCRIPTION

## What it does do
Gives you the field that does not parse.  (This is better than the previous `CanBuildFrom` brick wall.)

## What it does not do
* Tell you the offending value
* Distinguish between CWL's when multiple are submitted in one file.  This is because `id` field is optional and made random by SALAD preprocessing.


Example of 2 errors combined:
```
DecodingFailure at .inputs[1].inputBinding.position: Int
DecodingFailure at .stdout: DecodingFailure at .stdout: DecodingFailure at .stdout: String
```
So not amazing (don't know why `at .stdout` is repeated thrice) but better.