### PR TITLE
Fix variable resolution to call outputs. Fixes #3176

### DIFF
--- a/wdl/src/main/scala/wdl/MemberAccess.scala
+++ b/wdl/src/main/scala/wdl/MemberAccess.scala
@@ -25,8 +25,10 @@ import wdl.AstTools.EnhancedAstNode
  *  }
  *}
  */
-case class MemberAccess(lhs: String, rhs: String, ast: Ast) {
-  def memberAccessString = s"$lhs.$rhs"
+case class MemberAccess(lhsString: String, rhsString: String, ast: Ast) {
+  def memberAccessString = s"$lhsString.$rhsString"
+
+  def lhsAst = ast.getAttribute("lhs")
 }
 
 object MemberAccess {

--- a/wdl/src/main/scala/wdl/Scope.scala
+++ b/wdl/src/main/scala/wdl/Scope.scala
@@ -197,7 +197,7 @@ trait Scope {
     val localLookup = (siblingScopes ++ siblingCallOutputs) collect {
       case d: Declaration if d.unqualifiedName == name => d
       case c: WdlTaskCall if c.unqualifiedName == name => c
-      case co: CallOutput if co.call.unqualifiedName + "." + co.unqualifiedName == name => co
+      case co: CallOutput if co.unqualifiedName == name => co
       case o: TaskOutput if o.unqualifiedName == name => o
     }
 

--- a/wdl/src/main/scala/wdl/WdlExpression.scala
+++ b/wdl/src/main/scala/wdl/WdlExpression.scala
@@ -193,7 +193,7 @@ case class WdlExpression(ast: AstNode) extends WomValue {
   override def toWomString: String = toString(NullSyntaxHighlighter)
 
   def prerequisiteCallNames: Set[FullyQualifiedName] = {
-    this.topLevelMemberAccesses map { _.lhs }
+    this.topLevelMemberAccesses map { _.lhsString }
   }
   def topLevelMemberAccesses: Set[MemberAccess] = AstTools.findTopLevelMemberAccesses(ast) map { MemberAccess(_) } toSet
   def variableReferences(from: Scope): Iterable[VariableReference] = AstTools.findVariableReferences(ast, from)

--- a/wdl/src/main/scala/wdl/WdlSyntaxErrorFormatter.scala
+++ b/wdl/src/main/scala/wdl/WdlSyntaxErrorFormatter.scala
@@ -206,7 +206,7 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   def noTargetForMemberAccess(memberAccess: MemberAccess): String = {
     val rhsAst = memberAccess.ast.getAttribute("rhs").asInstanceOf[Terminal]
 
-    s"""ERROR: Cannot find reference to '${memberAccess.lhs}' for member access '${memberAccess.memberAccessString}' (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
+    s"""ERROR: Cannot find reference to '${memberAccess.lhsString}' for member access '${memberAccess.memberAccessString}' (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
      |
      |${pointToSource(rhsAst)}
      """.stripMargin
@@ -215,7 +215,7 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   def badTargetTypeForMemberAccess(memberAccess: MemberAccess, unexpectedType: WomType): String = {
     val rhsAst = memberAccess.ast.getAttribute("rhs").asInstanceOf[Terminal]
 
-    s"""ERROR: Bad target for member access '${memberAccess.memberAccessString}': '${memberAccess.lhs}' was a ${unexpectedType.toDisplayString} (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
+    s"""ERROR: Bad target for member access '${memberAccess.memberAccessString}': '${memberAccess.lhsString}' was a ${unexpectedType.toDisplayString} (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
        |
      |${pointToSource(rhsAst)}
      """.stripMargin
@@ -224,7 +224,7 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   def badTargetScopeForMemberAccess(memberAccess: MemberAccess, unexpectedScope: Scope): String = {
     val rhsAst = memberAccess.ast.getAttribute("rhs").asInstanceOf[Terminal]
 
-    s"""ERROR: Bad target for member access '${memberAccess.memberAccessString}': '${memberAccess.lhs}' was a ${unexpectedScope.getClass.getSimpleName} (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
+    s"""ERROR: Bad target for member access '${memberAccess.memberAccessString}': '${memberAccess.lhsString}' was a ${unexpectedScope.getClass.getSimpleName} (line ${rhsAst.getLine}, col ${rhsAst.getColumn}):
        |
      |${pointToSource(rhsAst)}
      """.stripMargin
@@ -236,12 +236,12 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
     val taskName = call.unqualifiedName
     val goodOutputs = s" (current outputs of '$taskName': " + call.outputs.map("'" + _.unqualifiedName + "'").mkString(", ") + ")"
 
-    s"""ERROR: Call output not found: Call '${memberAccess.lhs}' doesn't have an output '${memberAccess.rhs}' (line ${rhsAst.getLine}, col ${rhsAst.getColumn}).
+    s"""ERROR: Call output not found: Call '${memberAccess.lhsString}' doesn't have an output '${memberAccess.rhsString}' (line ${rhsAst.getLine}, col ${rhsAst.getColumn}).
      |
      |${pointToSource(rhsAst)}
      |
      |Options:
-     | - Add the output '${memberAccess.rhs}' to '$taskName'.
+     | - Add the output '${memberAccess.rhsString}' to '$taskName'.
      | - Modify the member access (on line ${rhsAst.getLine}) to use an existing output$goodOutputs.
      """.stripMargin
   }

--- a/womtool/src/test/scala/womtool/graph/OutputNameCollisionSpec.scala
+++ b/womtool/src/test/scala/womtool/graph/OutputNameCollisionSpec.scala
@@ -25,7 +25,7 @@ class OutputNameCollisionSpec extends WomDotGraphTest {
       |}
     """.stripMargin
 
-  val expressionNodeGraph = {
+  val outputCollisionWdlGraph = {
     val namespace = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
     namespace.womExecutable() match {
       case Right(executable) => executable.graph
@@ -33,8 +33,8 @@ class OutputNameCollisionSpec extends WomDotGraphTest {
     }
   }
 
-  val expressionNodeDot =
-    """digraph "ExpressionNodes"
+  val outputCollisionWdlDot =
+    """digraph "non_colliding_output_names"
       |{
       |  compound=true;
       |  "PORT0" -> "PORT1"
@@ -56,7 +56,7 @@ class OutputNameCollisionSpec extends WomDotGraphTest {
       |}
       |""".stripMargin
 
-  override val cases = List(WomDotGraphTestCase("ExpressionNodes", expressionNodeGraph, expressionNodeDot))
+  override val cases = List(WomDotGraphTestCase("non_colliding_output_names", outputCollisionWdlGraph, outputCollisionWdlDot))
 
   tests()
 }

--- a/womtool/src/test/scala/womtool/graph/OutputNameCollisionSpec.scala
+++ b/womtool/src/test/scala/womtool/graph/OutputNameCollisionSpec.scala
@@ -1,0 +1,62 @@
+package womtool.graph
+
+import wdl.WdlNamespaceWithWorkflow
+
+class OutputNameCollisionSpec extends WomDotGraphTest {
+
+  val wdl =
+    """
+      |workflow wf {
+      |  # This call has an output with a reference to 'out'. That **must not** be resolved to the wf.out!
+      |  call tsk
+      |  output {
+      |    Array[File] out = tsk.out[0]
+      |  }
+      |}
+      |
+      |task tsk {
+      |  command {
+      |    # ...
+      |  }
+      |  output {
+      |    Array[Array[File]] out = [["out.txt"]]
+      |    Array[File] reads_1 = out[0]
+      |  }
+      |}
+    """.stripMargin
+
+  val expressionNodeGraph = {
+    val namespace = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
+    namespace.womExecutable() match {
+      case Right(executable) => executable.graph
+      case Left(errors) => throw new Exception(errors.toList.mkString(", "))
+    }
+  }
+
+  val expressionNodeDot =
+    """digraph "ExpressionNodes"
+      |{
+      |  compound=true;
+      |  "PORT0" -> "PORT1"
+      |
+      |  subgraph cluster_0 {
+      |    style="filled,solid";
+      |    fillcolor=white;
+      |    "NODE2" [shape=plaintext label="call tsk"]
+      |    "PORT0" [shape=hexagon label="Array[Array[File]] out"];
+      |    "PORT3" [shape=hexagon label="Array[File] reads_1"];
+      |  }
+      |  subgraph cluster_1 {
+      |    style="filled,solid";
+      |    fillcolor=palegreen;
+      |    "NODE4" [shape=plaintext label="Array[File] out"]
+      |    "PORT5" [shape=hexagon label="Array[File] out"];
+      |    "PORT1" [shape=oval label="Array[Array[File]] tsk.out"];
+      |  }
+      |}
+      |""".stripMargin
+
+  override val cases = List(WomDotGraphTestCase("ExpressionNodes", expressionNodeGraph, expressionNodeDot))
+
+  tests()
+}


### PR DESCRIPTION
Fixes #3176.

The `case co: CallOutput` looks so deliberately different but I can't work out why. Maybe there's a test case that will now fail to show why it was like that originally.

I almost made this PR just not look up dependencies for CallOutputs because... they're never used for anything and can cause breakages. Yet another case of "why on earth is this a `GraphNode`"... 🤷‍♂️ 