### PR TITLE
qstat is the command to check aliveness

### DIFF
--- a/docs/tutorials/HPCIntro.md
+++ b/docs/tutorials/HPCIntro.md
@@ -197,7 +197,7 @@ Whenever Cromwell restarts it checks to see if a job has completed by searching 
 
 ```hocon
 backend.providers.SGE.config {
-  check-alive = "qdel ${job_id}"
+  check-alive = "qstat -j ${job_id}"
 }
 ```
 


### PR DESCRIPTION
The commented config in cromwell.examples.conf is correct so this just looks like a cut & paste issue in the docs.