### PR TITLE
Reuse ogins between if condition and the inner block

### DIFF
--- a/wdl/src/main/scala/wdl/Scatter.scala
+++ b/wdl/src/main/scala/wdl/Scatter.scala
@@ -40,17 +40,6 @@ object Scatter {
     * @param preserveIndexForOuterLookups When we're evaluating the scatter collection, should we preserve scatter index when we have to use the outerLookup?
     */
   def womScatterNode(scatter: Scatter, localLookup: Map[String, GraphNodePort.OutputPort], outerLookup: Map[String, OutputPort], preserveIndexForOuterLookups: Boolean): ErrorOr[ScatterNodeWithNewNodes] = {
-    // Convert the scatter collection WdlExpression to a WdlWomExpression 
-    val scatterCollectionExpression = WdlWomExpression(scatter.collection, scatter)
-    // Generate an ExpressionNode from the WdlWomExpression
-    val scatterCollectionExpressionNode =
-      WdlWomExpression.toAnonymousExpressionNode(WomIdentifier(scatter.item), scatterCollectionExpression, localLookup, outerLookup, preserveIndexForOuterLookups, scatter, PlainAnonymousExpressionNode.apply)
-    // Validate the collection evaluates to a traversable type
-    val scatterItemTypeValidation = scatterCollectionExpression.evaluateType((localLookup ++ outerLookup).map { case (k, v) => k -> v.womType }) flatMap {
-      case WomArrayType(itemType) => Valid(itemType) // Covers maps because this is a custom unapply (see WdlArrayType)
-      case other => s"Cannot scatter over a non-traversable type ${other.toDisplayString}".invalidNel
-    }
-
     /*
       * Why? Imagine that we're building three nested levels of a innerGraph.
       * - Say we're building the middle layer.
@@ -67,6 +56,17 @@ object Scatter {
       name -> OuterGraphInputNode(WomIdentifier(name), outerPort, preserveScatterIndex = false)
     }
     val possiblyNeededNestedOginPorts: Map[String, OutputPort] = possiblyNeededNestedOgins map { case (name: String, ogin: OuterGraphInputNode) => name -> ogin.singleOutputPort }
+
+    // Convert the scatter collection WdlExpression to a WdlWomExpression
+    val scatterCollectionExpression = WdlWomExpression(scatter.collection, scatter)
+    // Generate an ExpressionNode from the WdlWomExpression
+    val scatterCollectionExpressionNode =
+      WdlWomExpression.toAnonymousExpressionNode(WomIdentifier(scatter.item), scatterCollectionExpression, localLookup ++ possiblyNeededNestedOginPorts, Map.empty, preserveIndexForOuterLookups, scatter, PlainAnonymousExpressionNode.apply)
+    // Validate the collection evaluates to a traversable type
+    val scatterItemTypeValidation = scatterCollectionExpression.evaluateType((localLookup ++ outerLookup).map { case (k, v) => k -> v.womType }) flatMap {
+      case WomArrayType(itemType) => Valid(itemType) // Covers maps because this is a custom unapply (see WdlArrayType)
+      case other => s"Cannot scatter over a non-traversable type ${other.toDisplayString}".invalidNel
+    }
 
     for {
       itemType <- scatterItemTypeValidation

--- a/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
+++ b/wdl/src/test/scala/wom/WdlNestedConditionalWomSpec.scala
@@ -27,7 +27,8 @@ class WdlNestedConditionalWomSpec extends FlatSpec with Matchers {
     ("same lookups in multiple if expressions", sameLookupsInMultipleIfExpressions),
     ("same lookups in multiple scatter expressions", sameLookupsInMultipleScatterExpressions),
     ("same lookups in if and scatter expressions", sameLookupsInIfAndScatterExpressions),
-    ("same lookups in scatters and elsewhere", sameLookupsInScattersAndElsewhere)
+    ("same lookups in scatters and elsewhere", sameLookupsInScattersAndElsewhere),
+    ("same lookups in if condition, scatter collection, and task calls", sameLookupsInConditionsAndInnerTaskCalls)
   )
 
 
@@ -310,4 +311,38 @@ object WdlNestedConditionalWomSpec {
       |   }
       | }
     """.stripMargin
+
+  val sameLookupsInConditionsAndInnerTaskCalls =
+    """workflow Test {
+      |  String? testString
+      |  Array[String] testStrings = [""]
+      |
+      |  if(true) {
+      |    if (defined(testString)) {
+      |      call testTask as tt {
+      |        input:
+      |          testString = testString
+      |      }
+      |    }
+      |  }
+      |
+      |  if(true) {
+      |    scatter(ts in testStrings) {
+      |      call testTask as tt2 {
+      |        input:
+      |          testString = testStrings[0]
+      |      }
+      |    }
+      |  }
+      |}
+      |
+      |task testTask {
+      |    String? testString
+      |    command {
+      |      echo "Hello world"
+      |    }
+      |    runtime {
+      |      docker: "ubuntu"
+      |    }
+      |}""".stripMargin
 }

--- a/wom/src/main/scala/wom/graph/ConditionalNode.scala
+++ b/wom/src/main/scala/wom/graph/ConditionalNode.scala
@@ -27,7 +27,8 @@ object ConditionalNode  {
 
   final case class ConditionalNodeWithNewNodes(node: ConditionalNode) extends GeneratedNodeAndNewNodes {
     override val newInputs = node.innerGraph.externalInputNodes
-    override val usedOuterGraphInputNodes = (node.conditionExpression.upstream.filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode]) ++
+    override val usedOuterGraphInputNodes =
+      (node.conditionExpression.upstream.filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode]) ++
         (node.innerGraph.outerGraphInputNodes.map(_.linkToOuterGraphNode).filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode])
 
     override val newExpressions = Set(node.conditionExpression)

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -69,7 +69,8 @@ object ScatterNode {
   final case class ScatterNodeWithNewNodes(node: ScatterNode) extends GeneratedNodeAndNewNodes {
     override val newExpressions: Set[ExpressionNode] = node.scatterCollectionExpressionNodes.toSet
     override val newInputs: Set[ExternalGraphInputNode] = node.innerGraph.externalInputNodes
-    override val usedOuterGraphInputNodes: Set[OuterGraphInputNode] =(node.scatterCollectionExpressionNodes.flatMap(_.upstream).toSet.filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode]) ++
+    override val usedOuterGraphInputNodes: Set[OuterGraphInputNode] =
+      (node.scatterCollectionExpressionNodes.flatMap(_.upstream).toSet.filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode]) ++
       (node.innerGraph.outerGraphInputNodes.map(_.linkToOuterGraphNode).filterByType[OuterGraphInputNode]: Set[OuterGraphInputNode])
     def nodes: Set[GraphNode] = newExpressions ++ newInputs ++ usedOuterGraphInputNodes ++ Set(node)
   }


### PR DESCRIPTION
Make sure outer lookups for `if` conditions and `scatter` collections use the same set of ogins as the inner graph receives.

Most of this PR is moving code around