### PR TITLE
Set CWL repo git hash to stabilize conformance tests

### DIFF
--- a/src/bin/travis/testCentaurCwlConformanceLocal.sh
+++ b/src/bin/travis/testCentaurCwlConformanceLocal.sh
@@ -9,7 +9,7 @@ ENABLE_COVERAGE=true sbt assembly
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 CENTAUR_CWL_RUNNER="$(pwd)/centaurCwlRunner/src/bin/centaur-cwl-runner.bash"
 
-git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git
+git clone https://github.com/common-workflow-language/common-workflow-language.git
 cd common-workflow-language
 # checkout a known git hash to prevent the tests from changing out from under us
 git checkout af9e073634dc6aec4092c55e1c081f335affa54a

--- a/src/bin/travis/testCentaurCwlConformanceLocal.sh
+++ b/src/bin/travis/testCentaurCwlConformanceLocal.sh
@@ -10,6 +10,11 @@ CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 CENTAUR_CWL_RUNNER="$(pwd)/centaurCwlRunner/src/bin/centaur-cwl-runner.bash"
 
 git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git
+cd common-workflow-language
+# checkout a known git hash to prevent the tests from changing out from under us
+git checkout af9e073634dc6aec4092c55e1c081f335affa54a
+cd ..
+
 CWL_TEST_DIR=$(pwd)/common-workflow-language/v1.0/v1.0
 CONFORMANCE_EXPECTED_FAILURES=$(pwd)/src/bin/travis/resources/local_conformance_expected_failures.txt
 

--- a/src/bin/travis/testCentaurCwlConformancePAPI.sh
+++ b/src/bin/travis/testCentaurCwlConformancePAPI.sh
@@ -52,7 +52,7 @@ sed -i '/^call-caching\s*/{N;s/enabled.*/  enabled: false/;}' ${JES_CONF}
 
 ENABLE_COVERAGE=true sbt assembly
 
-git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git
+git clone https://github.com/common-workflow-language/common-workflow-language.git
 cd common-workflow-language
 # checkout a known git hash to prevent the tests from changing out from under us
 git checkout af9e073634dc6aec4092c55e1c081f335affa54a

--- a/src/bin/travis/testCentaurCwlConformancePAPI.sh
+++ b/src/bin/travis/testCentaurCwlConformancePAPI.sh
@@ -53,6 +53,10 @@ sed -i '/^call-caching\s*/{N;s/enabled.*/  enabled: false/;}' ${JES_CONF}
 ENABLE_COVERAGE=true sbt assembly
 
 git clone --depth 1 https://github.com/common-workflow-language/common-workflow-language.git
+cd common-workflow-language
+# checkout a known git hash to prevent the tests from changing out from under us
+git checkout af9e073634dc6aec4092c55e1c081f335affa54a
+cd ..
 
 CROMWELL_JAR=$(find "$(pwd)/target/scala-2.12" -name "cromwell-*.jar")
 CENTAUR_CWL_RUNNER="$(pwd)/centaurCwlRunner/src/bin/centaur-cwl-runner.bash"


### PR DESCRIPTION
This is to keep the rug from moving out from under us as far as CWL conformance tests is concerned.