### PR TITLE
Don't log cwl preprocessing in womtool

### DIFF
--- a/cwl/src/main/scala/cwl/CwlDecoder.scala
+++ b/cwl/src/main/scala/cwl/CwlDecoder.scala
@@ -36,7 +36,7 @@ object CwlDecoder {
     fromEither[IO](cwlToolResult flatMap resultToEither)
   }
 
-  lazy val cwlPreProcessor = new CwlPreProcessor()
+  private lazy val cwlPreProcessor = new CwlPreProcessor()
 
   // TODO: WOM: During conformance testing the saladed-CWLs are referring to files in the temp directory.
   // Thus we can't delete the temp directory until after the workflow is complete, like the workflow logs.
@@ -54,9 +54,9 @@ object CwlDecoder {
     * Notice it gives you one instance of Cwl.  This has transformed all embedded files into scala object state
     */
   def decodeCwlFile(fileName: BFile,
-                    workflowRoot: Option[String] = None): Parse[Cwl] =
+                    workflowRoot: Option[String] = None)(implicit processor: CwlPreProcessor = cwlPreProcessor): Parse[Cwl] =
     for {
-      standaloneWorkflow <- cwlPreProcessor.preProcessCwlFile(fileName, workflowRoot)
+      standaloneWorkflow <- processor.preProcessCwlFile(fileName, workflowRoot)
       parsedCwl <- parseJson(standaloneWorkflow)
     } yield parsedCwl
 

--- a/cwl/src/main/scala/cwl/preprocessor/CwlPreProcessor.scala
+++ b/cwl/src/main/scala/cwl/preprocessor/CwlPreProcessor.scala
@@ -90,6 +90,8 @@ object CwlPreProcessor {
     def asReference: Option[CwlReference] = CwlReference.fromString(id)
     def stripFilePrefix = id.stripPrefix(LocalScheme)
   }
+  
+  def noLogging = new CwlPreProcessor(CwlDecoder.saladCwlFile)
 }
 
 /**

--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import better.files.File
 import cats.implicits._
 import cwl.CwlDecoder
+import cwl.preprocessor.CwlPreProcessor
 import spray.json.{JsArray, JsBoolean, JsNull, JsNumber, JsObject, JsString, JsValue}
 import wdl.{WdlNamespace, WdlNamespaceWithWorkflow}
 import wom.executable.Executable
@@ -144,6 +145,8 @@ class WomGraph(graphName: String, graph: Graph) {
 }
 
 object WomGraph {
+  
+  implicit val cwlPreProcessor = CwlPreProcessor.noLogging
 
   final case class WorkflowDigraph(workflowName: String, digraph: NodesAndLinks)
   final case class NodesAndLinks(nodes: Set[String], links: Set[String]) {


### PR DESCRIPTION
This allows to do write directly the output of `womtool womgraph` into a valid `.dot` file without the extra logging from cwl pre-processing