### PR TITLE
Initial conversions and tests from WDLOM to WOM

### DIFF
--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
@@ -3,6 +3,7 @@ package wdl.draft3.transforms
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
 import wdl.draft3.parser.WdlParser.{AstNode, Terminal}
+import wdl.draft3.transforms.parsing.FileParser
 
 package object ast2wdlom {
 
@@ -11,6 +12,8 @@ package object ast2wdlom {
   implicit val draft3ImportElementFromAstNode = FromAtoB.viaX(AstFromAstNode, Draft3ImportElementFromAst)
   implicit val draft3TaskDefinitionElementFromAstNode = FromAtoB.viaX(AstFromAstNode, Draft3TaskDefinitionElementFromAst)
   implicit val draft3WorkflowDefinitionElementFromAstNode = FromAtoB.viaX(AstFromAstNode, Draft3WorkflowDefinitionElementFromAst)
+
+  implicit val draft3FileElementFromFile = FromAtoB.viaX(FileParser, Draft3FileElementFromAst)
 
   implicit val StringFromAstNode: FromAtoB[AstNode, String] = new FromAtoB[AstNode, String] {
     override def convert(a: AstNode): ErrorOr[String] = a match {

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/parsing/Draft3Parser.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/parsing/Draft3Parser.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 object StringParser extends FromAtoB[FileParserInput, Ast] {
   override def convert(a: FileParserInput): ErrorOr[Ast] = Try {
     val parser = new WdlParser()
-    val tokens = parser.lex(a. workflowSource, a.resource)
+    val tokens = parser.lex(a.workflowSource, a.resource)
     val terminalMap = (tokens.asScala.toVector map {(_, a.workflowSource)}).toMap
     val syntaxErrorFormatter = WdlDraft3SyntaxErrorFormatter(terminalMap)
     parser.parse(tokens, syntaxErrorFormatter).toAst.asInstanceOf[Ast]

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/parsing/Draft3Parser.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/parsing/Draft3Parser.scala
@@ -1,0 +1,32 @@
+package wdl.draft3.transforms.parsing
+
+import better.files.File
+import scala.collection.JavaConverters._
+
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation.TryValidation
+import wdl.draft3.parser.WdlParser
+import wdl.draft3.parser.WdlParser.Ast
+import wdl.draft3.transforms.ast2wdlom.FromAtoB
+import wom.core.WorkflowSource
+
+import scala.util.Try
+
+object StringParser extends FromAtoB[FileParserInput, Ast] {
+  override def convert(a: FileParserInput): ErrorOr[Ast] = Try {
+    val parser = new WdlParser()
+    val tokens = parser.lex(a. workflowSource, a.resource)
+    val terminalMap = (tokens.asScala.toVector map {(_, a.workflowSource)}).toMap
+    val syntaxErrorFormatter = WdlDraft3SyntaxErrorFormatter(terminalMap)
+    parser.parse(tokens, syntaxErrorFormatter).toAst.asInstanceOf[Ast]
+  }.toErrorOr
+}
+
+final case class FileParserInput(workflowSource: WorkflowSource, resource: String)
+
+object FileParser extends FromAtoB[File, Ast] {
+  override def convert(a: File): ErrorOr[Ast] = {
+    val parserInput = FileParserInput(a.contentAsString, a.name)
+    StringParser.convert(parserInput)
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomExecutable.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomExecutable.scala
@@ -1,0 +1,28 @@
+package wdl.draft3.transforms.wdlom2wom
+
+import cats.syntax.validated._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.ErrorOr._
+import wdl.draft3.transforms.ast2wdlom.FromAtoB
+import wdl.model.draft3.elements.{FileElement, ImportElement, TaskDefinitionElement, WorkflowDefinitionElement}
+import wom.callable.WorkflowDefinition
+import wom.executable.Executable
+
+case class FileElementToWomExecutable(inputs: Option[String]) extends FromAtoB[FileElement, Executable] {
+  override def convert(a: FileElement): ErrorOr[Executable] = {
+
+    val importsValidation: ErrorOr[Vector[ImportElement]] = if (a.imports.isEmpty) Vector.empty.valid else "FileElement to WOM conversion of imports not yet implemented.".invalidNel
+    val tasksValidation: ErrorOr[Vector[TaskDefinitionElement]] = if (a.imports.isEmpty) Vector.empty.valid else "FileElement to WOM conversion of tasks not yet implemented.".invalidNel
+
+
+    (importsValidation, tasksValidation) flatMapN { (_, _) =>
+      implicit val workflowConverter: FromAtoB[WorkflowDefinitionElement, WorkflowDefinition] = WorkflowDefinitionElementToWomWorkflowDefinition(inputs)
+      val workflowsValidation: ErrorOr[Vector[WorkflowDefinition]] = FromAtoB.forVectors[WorkflowDefinitionElement, WorkflowDefinition].convert(a.workflows.toVector)
+
+      workflowsValidation flatMap {
+        case one if one.size == 1 => Executable(one.head, Map.empty).valid
+        case notOne => s"Cannot turn a ${notOne.size}-workflow WDL FileElement into a WomExecutable (must be exactly 1)".invalidNel
+      }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinition.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinition.scala
@@ -1,0 +1,19 @@
+package wdl.draft3.transforms.wdlom2wom
+
+import common.validation.ErrorOr.ErrorOr
+import wdl.draft3.transforms.ast2wdlom.FromAtoB
+import wdl.model.draft3.elements.WorkflowDefinitionElement
+import wom.callable.WorkflowDefinition
+import wom.graph.Graph
+
+case class WorkflowDefinitionElementToWomWorkflowDefinition(inputs: Option[String]) extends FromAtoB[WorkflowDefinitionElement, WorkflowDefinition] {
+  override def convert(a: WorkflowDefinitionElement): ErrorOr[WorkflowDefinition] = {
+
+    val g: ErrorOr[Graph] = Graph.validateAndConstruct(Set.empty)
+
+    g map { graph =>
+      WorkflowDefinition(a.identifier, graph, Map.empty, Map.empty, List.empty)
+    }
+
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/package.scala
@@ -1,0 +1,11 @@
+package wdl.draft3.transforms
+
+import better.files.File
+import wdl.draft3.transforms.ast2wdlom._
+import wom.executable.Executable
+
+package object wdlom2wom {
+  implicit val fromWorkflowDefinitionElementToWorkflowDefinition = WorkflowDefinitionElementToWomWorkflowDefinition
+
+  def womFromDraft3FileConverter(inputs: Option[String]): FromAtoB[File, Executable] = FromAtoB.viaX(draft3FileElementFromFile, FileElementToWomExecutable(inputs))
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomExecutableSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomExecutableSpec.scala
@@ -1,0 +1,5 @@
+package wdl.draft3.transforms.wdlom2wom
+
+class FileElementToWomExecutableSpec {
+
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
@@ -1,0 +1,38 @@
+package wdl.draft3.transforms.wdlom2wom
+
+import better.files.File
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+
+class WdlFileToWomSpec extends FlatSpec with Matchers {
+  behavior of "WDL File to WOM"
+
+  val testCases = File("wdl/transforms/draft3/src/test/cases")
+
+  it should "be set up for testing" in {
+    testCases.exists shouldBe true
+    testCases.list.nonEmpty shouldBe true
+  }
+
+  testCases.list.filter(x => x.isRegularFile && x.extension.contains(".wdl")) foreach { testCase =>
+
+    val fileName = testCase.name
+
+    val itShouldString = s"create a valid WOM object for $fileName"
+    val testOrIgnore: (=>Any) => Unit = if (testCase.name.endsWith(".ignored.wdl") || testCase.name.endsWith(".nowom.wdl")) {
+      (it should itShouldString).ignore _
+    } else {
+      (it should itShouldString).in _
+    }
+
+    testOrIgnore {
+
+      womFromDraft3FileConverter(None).convert(testCase) match {
+        case Valid(_) => // Great!
+        case Invalid(errors) =>
+          val formattedErrors = errors.toList.mkString(System.lineSeparator(), System.lineSeparator(), System.lineSeparator())
+          fail(s"Failed to create WOM: $formattedErrors")
+      }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinitionSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinitionSpec.scala
@@ -1,0 +1,24 @@
+package wdl.draft3.transforms.wdlom2wom
+
+import cats.data.Validated.Valid
+import org.scalatest.{FlatSpec, Matchers}
+import wdl.model.draft3.elements.WorkflowDefinitionElement
+
+class WorkflowDefinitionElementToWomWorkflowDefinitionSpec extends FlatSpec with Matchers {
+
+  val cases = List(
+    ("empty workflow definition", WorkflowDefinitionElement("empty_workflow"), None)
+  )
+
+
+  cases foreach { case (testName, workflowDefinitionElement, inputs) =>
+    it should s"convert the '$testName' into WOM" in {
+
+      val convertor = WorkflowDefinitionElementToWomWorkflowDefinition(inputs)
+      convertor.convert(workflowDefinitionElement) match {
+        case Valid(_) => // Great!
+        case errors => fail(s"Failed to produce WOM for '$testName': ${errors.toList.mkString(System.lineSeparator, System.lineSeparator, System.lineSeparator)}")
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Demonstrates a simple (empty workflow) being processed by `FromAtoB[File, Executable]` (i.e passing all the way through from file system to WOM)
- Next up, enough wiring to let us submit the `empty_workflow.wdl` to the rest API and get the void result from it

- [x] **Note: needs rebase onto develop after merge of #3265** 