### PR TITLE
WDLOM expression elements

### DIFF
--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -60,6 +60,41 @@ object ExpressionElement {
   case object StderrCall extends FunctionCall
   // TODO: and the rest...
 
-
+  /**
+    * Represents a member access.
+    *
+    * But, why the split into firstIdentifier, secondIdentifierOrFirstMemberAccess and memberAccessTail? Take a look at some examples:
+    *
+    * ---
+    *
+    * Example 1: task output lookup expression:
+    * Pair[Pair[String, Int], Int] pair_of_pairs = my_task.pair_of_pairs
+    *
+    * The first identifier is 'my_task', the second identifier is 'pair_of_pairs' and the tail is [ ]
+    *
+    * ---
+    *
+    * Example 2:
+    * Int x = pair_of_pairs.left.right
+    *
+    * The first identifier is 'pair_of_pairs', the second is 'left' and the tail is [ 'right' ]
+    *
+    * ---
+    *
+    * Example 3:
+    * Int x = mytask.pair_of_pair_output.left.right
+    *
+    * The first identifier is mytask, the second is pair_of_pair_output, and the tail is ['left', 'right']
+    *
+    * ---
+    *
+    * Observations:
+    *  - We always get at least two identifiers.
+    *  - The firstIdentifier is *always* part of the identifier we'll need to look up in the value store.
+    *  - The tail will *always* be a chain of member accesses on a WomValue.
+    *  - But, the second element might be part of the identifier to look up (eg my_task.pair_of_pairs) OR it might
+    *      be part of a member access chain (eg pair_of_pairs.left.right). We won't know until we do the linking.
+    */
+  case class MemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String])
 
 }

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -7,6 +7,11 @@ sealed trait ExpressionElement
 object ExpressionElement {
   case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
 
+  case class ObjectLiteral(elements: Map[String, ExpressionElement])
+  case class ArrayLiteral(elements: Array[ExpressionElement])
+  case class MapLiteral(elements: Array[ExpressionElement])
+  case class TupleLiteral(elements: Array[ExpressionElement])
+
   /**
     * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
     */
@@ -54,5 +59,7 @@ object ExpressionElement {
   case object StdoutCall extends FunctionCall
   case object StderrCall extends FunctionCall
   // TODO: and the rest...
+
+
 
 }

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -4,4 +4,53 @@ import wom.values.WomPrimitive
 
 sealed trait ExpressionElement
 
-case class PrimitiveLiteralExpression(value: WomPrimitive) extends ExpressionElement
+case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
+
+/**
+  * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
+  */
+sealed trait UnaryOperation {
+  /**
+    * The expression which follows the unary operator. The argument to the operation.
+    */
+  def argument: ExpressionElement
+}
+
+case class LogicalNot(override val argument: ExpressionElement) extends UnaryOperation
+case class UnaryNegation(override val argument: ExpressionElement) extends UnaryOperation
+case class UnaryBooleanNot(override val argument: ExpressionElement) extends UnaryOperation
+
+/**
+  * A two-argument expression. Almost certainly comes from an infix operation in WDL (eg the '+' in  '7 + read_int(x)')
+  */
+sealed trait BinaryOperation {
+  /**
+    * The left-hand-side of the operation ('7' in the example above).
+    */
+  def left: ExpressionElement
+
+  /**
+    * The right-hand-side of the operation ('read_int(x)' in the example above).
+    */
+  def right: ExpressionElement
+}
+
+
+case class LogicalOr(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class LogicalAnd(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Equals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class NotEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class LessThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class LessThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class GreaterThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class GreaterThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Add(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Subtract(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Multiply(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Divide(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+case class Remainder(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+
+// TODO: and the rest...
+sealed trait FunctionCall
+case object StdoutCall extends FunctionCall
+case object StderrCall extends FunctionCall

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -5,26 +5,26 @@ import wom.values.WomPrimitive
 sealed trait ExpressionElement
 
 object ExpressionElement {
-  case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
+  final case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
 
-  case class ObjectLiteral(elements: Map[String, ExpressionElement]) extends ExpressionElement
-  case class ArrayLiteral(elements: Array[ExpressionElement]) extends ExpressionElement
-  case class MapLiteral(elements: Array[ExpressionElement]) extends ExpressionElement
-  case class PairLiteral(left: ExpressionElement, right: ExpressionElement) extends ExpressionElement
+  final case class ObjectLiteral(elements: Map[String, ExpressionElement]) extends ExpressionElement
+  final case class ArrayLiteral(elements: Array[ExpressionElement]) extends ExpressionElement
+  final case class MapLiteral(elements: Map[String, ExpressionElement]) extends ExpressionElement
+  final case class PairLiteral(left: ExpressionElement, right: ExpressionElement) extends ExpressionElement
 
   /**
     * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
     */
-  sealed trait UnaryOperation {
+  sealed trait UnaryOperation extends ExpressionElement {
     /**
       * The expression which follows the unary operator. The argument to the operation.
       */
     def argument: ExpressionElement
   }
 
-  case class LogicalNot(override val argument: ExpressionElement) extends UnaryOperation
-  case class UnaryNegation(override val argument: ExpressionElement) extends UnaryOperation
-  case class UnaryBooleanNot(override val argument: ExpressionElement) extends UnaryOperation
+  final case class LogicalNot(override val argument: ExpressionElement) extends UnaryOperation
+  final case class UnaryNegation(override val argument: ExpressionElement) extends UnaryOperation
+  final case class UnaryBooleanNot(override val argument: ExpressionElement) extends UnaryOperation
 
   /**
     * A two-argument expression. Almost certainly comes from an infix operation in WDL (eg the '+' in  '7 + read_int(x)')
@@ -41,29 +41,29 @@ object ExpressionElement {
     def right: ExpressionElement
   }
 
-  case class LogicalOr(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class LogicalAnd(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Equals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class NotEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class LessThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class LessThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class GreaterThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class GreaterThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Add(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Subtract(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Multiply(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Divide(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-  case class Remainder(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class LogicalOr(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class LogicalAnd(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Equals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class NotEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class LessThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class LessThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class GreaterThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class GreaterThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Add(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Subtract(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Multiply(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Divide(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  final case class Remainder(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
 
   sealed trait FunctionCall extends ExpressionElement
-  case object StdoutCall extends FunctionCall
-  case object StderrCall extends FunctionCall
+  final case object StdoutCall extends FunctionCall
+  final case object StderrCall extends FunctionCall
   // TODO: and other engine functions
 
   /**
     * A single identifier lookup expression, eg Int x = y
     */
-  case class IdentifierLookup(identifier: String)
+  final case class IdentifierLookup(identifier: String)
 
   /**
     * Represents a member access.
@@ -100,7 +100,7 @@ object ExpressionElement {
     *  - But, the second element might be part of the identifier to look up (eg my_task.pair_of_pairs) OR it might
     *      be part of a member access chain (eg pair_of_pairs.left.right). We won't know until we do the linking.
     */
-  case class IdentifierMemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String]) extends ExpressionElement
+  final case class IdentifierMemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String]) extends ExpressionElement
 
   /**
     * A member access which is based on an expression rather than an identifier.
@@ -108,5 +108,5 @@ object ExpressionElement {
     * eg:
     * (1, 2).left
     */
-  case class ExpressionMemberAccess(expression: ExpressionElement, memberAccessTail: Vector[String]) extends ExpressionElement
+  final case class ExpressionMemberAccess(expression: ExpressionElement, memberAccessTail: Vector[String]) extends ExpressionElement
 }

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -58,7 +58,7 @@ object ExpressionElement {
   sealed trait FunctionCall extends ExpressionElement
   case object StdoutCall extends FunctionCall
   case object StderrCall extends FunctionCall
-  // TODO: and the rest...
+  // TODO: and other engine functions
 
   /**
     * Represents a member access.
@@ -95,6 +95,13 @@ object ExpressionElement {
     *  - But, the second element might be part of the identifier to look up (eg my_task.pair_of_pairs) OR it might
     *      be part of a member access chain (eg pair_of_pairs.left.right). We won't know until we do the linking.
     */
-  case class MemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String])
+  case class IdentifierMemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String])
 
+  /**
+    * A member access which is based on an expression rather than an identifier.
+    *
+    * eg:
+    * (1, 2).left
+    */
+  case class ExpressionMemberAccess(expression: ExpressionElement, memberAccessTail: Vector[String])
 }

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -10,7 +10,7 @@ object ExpressionElement {
   case class ObjectLiteral(elements: Map[String, ExpressionElement])
   case class ArrayLiteral(elements: Array[ExpressionElement])
   case class MapLiteral(elements: Array[ExpressionElement])
-  case class TupleLiteral(elements: Array[ExpressionElement])
+  case class PairLiteral(left: ExpressionElement, right: ExpressionElement)
 
   /**
     * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -61,6 +61,11 @@ object ExpressionElement {
   // TODO: and other engine functions
 
   /**
+    * A single identifier lookup expression, eg Int x = y
+    */
+  case class IdentifierLookup(identifier: String)
+
+  /**
     * Represents a member access.
     *
     * But, why the split into firstIdentifier, secondIdentifierOrFirstMemberAccess and memberAccessTail? Take a look at some examples:

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -7,10 +7,10 @@ sealed trait ExpressionElement
 object ExpressionElement {
   case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
 
-  case class ObjectLiteral(elements: Map[String, ExpressionElement])
-  case class ArrayLiteral(elements: Array[ExpressionElement])
-  case class MapLiteral(elements: Array[ExpressionElement])
-  case class PairLiteral(left: ExpressionElement, right: ExpressionElement)
+  case class ObjectLiteral(elements: Map[String, ExpressionElement]) extends ExpressionElement
+  case class ArrayLiteral(elements: Array[ExpressionElement]) extends ExpressionElement
+  case class MapLiteral(elements: Array[ExpressionElement]) extends ExpressionElement
+  case class PairLiteral(left: ExpressionElement, right: ExpressionElement) extends ExpressionElement
 
   /**
     * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
@@ -95,7 +95,7 @@ object ExpressionElement {
     *  - But, the second element might be part of the identifier to look up (eg my_task.pair_of_pairs) OR it might
     *      be part of a member access chain (eg pair_of_pairs.left.right). We won't know until we do the linking.
     */
-  case class IdentifierMemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String])
+  case class IdentifierMemberAccess(firstIdentifier: String, secondIdentifierOrFirstMemberAccess: String, memberAccessTail: Vector[String]) extends ExpressionElement
 
   /**
     * A member access which is based on an expression rather than an identifier.
@@ -103,5 +103,5 @@ object ExpressionElement {
     * eg:
     * (1, 2).left
     */
-  case class ExpressionMemberAccess(expression: ExpressionElement, memberAccessTail: Vector[String])
+  case class ExpressionMemberAccess(expression: ExpressionElement, memberAccessTail: Vector[String]) extends ExpressionElement
 }

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -4,53 +4,55 @@ import wom.values.WomPrimitive
 
 sealed trait ExpressionElement
 
-case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
+object ExpressionElement {
+  case class PrimitiveLiteralExpressionElement(value: WomPrimitive) extends ExpressionElement
 
-/**
-  * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
-  */
-sealed trait UnaryOperation {
   /**
-    * The expression which follows the unary operator. The argument to the operation.
+    * Represents a unary operation (i.e. a operator symbol followed by a single argument expression)
     */
-  def argument: ExpressionElement
+  sealed trait UnaryOperation {
+    /**
+      * The expression which follows the unary operator. The argument to the operation.
+      */
+    def argument: ExpressionElement
+  }
+
+  case class LogicalNot(override val argument: ExpressionElement) extends UnaryOperation
+  case class UnaryNegation(override val argument: ExpressionElement) extends UnaryOperation
+  case class UnaryBooleanNot(override val argument: ExpressionElement) extends UnaryOperation
+
+  /**
+    * A two-argument expression. Almost certainly comes from an infix operation in WDL (eg the '+' in  '7 + read_int(x)')
+    */
+  sealed trait BinaryOperation extends ExpressionElement {
+    /**
+      * The left-hand-side of the operation ('7' in the example above).
+      */
+    def left: ExpressionElement
+
+    /**
+      * The right-hand-side of the operation ('read_int(x)' in the example above).
+      */
+    def right: ExpressionElement
+  }
+
+  case class LogicalOr(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class LogicalAnd(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Equals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class NotEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class LessThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class LessThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class GreaterThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class GreaterThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Add(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Subtract(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Multiply(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Divide(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+  case class Remainder(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
+
+  sealed trait FunctionCall extends ExpressionElement
+  case object StdoutCall extends FunctionCall
+  case object StderrCall extends FunctionCall
+  // TODO: and the rest...
+
 }
-
-case class LogicalNot(override val argument: ExpressionElement) extends UnaryOperation
-case class UnaryNegation(override val argument: ExpressionElement) extends UnaryOperation
-case class UnaryBooleanNot(override val argument: ExpressionElement) extends UnaryOperation
-
-/**
-  * A two-argument expression. Almost certainly comes from an infix operation in WDL (eg the '+' in  '7 + read_int(x)')
-  */
-sealed trait BinaryOperation {
-  /**
-    * The left-hand-side of the operation ('7' in the example above).
-    */
-  def left: ExpressionElement
-
-  /**
-    * The right-hand-side of the operation ('read_int(x)' in the example above).
-    */
-  def right: ExpressionElement
-}
-
-
-case class LogicalOr(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class LogicalAnd(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Equals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class NotEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class LessThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class LessThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class GreaterThan(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class GreaterThanOrEquals(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Add(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Subtract(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Multiply(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Divide(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-case class Remainder(override val left: ExpressionElement, override val right: ExpressionElement) extends BinaryOperation
-
-// TODO: and the rest...
-sealed trait FunctionCall
-case object StdoutCall extends FunctionCall
-case object StderrCall extends FunctionCall

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -1,0 +1,7 @@
+package wdl.model.draft3.elements
+
+import wom.values.WomPrimitive
+
+sealed trait ExpressionElement
+
+case class PrimitiveLiteralExpression(value: WomPrimitive) extends ExpressionElement

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/InputsSectionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/InputsSectionElement.scala
@@ -1,3 +1,3 @@
 package wdl.model.draft3.elements
 
-case class InputsSectionElement(inputDefinitions: Seq[InputDeclarationElement]) extends LanguageElement
+case class InputsSectionElement(inputDeclarations: Seq[InputDeclarationElement]) extends LanguageElement

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
@@ -1,0 +1,26 @@
+package wdl.draft3.transforms.ast2wdlom
+
+import cats.syntax.validated._
+import common.validation.Validation._
+import common.validation.ErrorOr.ErrorOr
+import wdl.draft3.parser.WdlParser.{AstNode, Terminal}
+import wdl.model.draft3.elements._
+import wom.values._
+
+import scala.util.Try
+
+object AstNodeToExpressionElement {
+  def convert(astNode: AstNode): ErrorOr[ExpressionElement] = astNode match {
+
+    case t: Terminal if asPrimitive.isDefinedAt((t.getTerminalStr, t.getSourceString)) => asPrimitive((t.getTerminalStr, t.getSourceString)).map(PrimitiveLiteralExpression)
+    case t: Terminal => s"No rule available to create ExpressionElement from terminal: ${t.getTerminalStr} ${t.getSourceString}".invalidNel
+  }
+
+  private val asPrimitive: PartialFunction[(String, String), ErrorOr[WomPrimitive]] = {
+    case ("integer", i) => Try(WomInteger(i.toInt)).toErrorOr
+    case ("float", f) => Try(WomFloat(f.toDouble)).toErrorOr
+    case ("boolean", b) => Try(WomBoolean(b.toBoolean)).toErrorOr
+    case ("string", s) => WomString(s).validNel
+    case ("file", s) => WomString(s).validNel
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
@@ -1,10 +1,14 @@
 package wdl.draft3.transforms.ast2wdlom
 
+import cats.syntax.apply._
+import cats.syntax.either._
 import cats.syntax.validated._
 import common.validation.Validation._
 import common.validation.ErrorOr.ErrorOr
-import wdl.draft3.parser.WdlParser.{AstNode, Terminal}
+import wdl.draft3.parser.WdlParser.{Ast, AstNode, Terminal}
+import wdl.model.draft3.elements.ExpressionElement._
 import wdl.model.draft3.elements._
+import wdl.draft3.transforms.ast2wdlom.EnhancedDraft3Ast._
 import wom.values._
 
 import scala.util.Try
@@ -14,6 +18,15 @@ object AstNodeToExpressionElement {
 
     case t: Terminal if asPrimitive.isDefinedAt((t.getTerminalStr, t.getSourceString)) => asPrimitive((t.getTerminalStr, t.getSourceString)).map(PrimitiveLiteralExpressionElement)
     case t: Terminal => s"No rule available to create ExpressionElement from terminal: ${t.getTerminalStr} ${t.getSourceString}".invalidNel
+
+    case a: Ast if a.getName == "Add" => getLhsAndRhs(a, Add.apply)
+  }
+
+  private def getLhsAndRhs(a: Ast, combiner: (ExpressionElement, ExpressionElement) => ExpressionElement): ErrorOr[ExpressionElement] = {
+    val lhsValidation: ErrorOr[ExpressionElement] = a.getAttributeAs[ExpressionElement]("lhs").toValidated
+    val rhsValidation: ErrorOr[ExpressionElement] = a.getAttributeAs[ExpressionElement]("rhs").toValidated
+
+    (lhsValidation, rhsValidation) mapN { combiner }
   }
 
   private val asPrimitive: PartialFunction[(String, String), ErrorOr[WomPrimitive]] = {

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 object AstNodeToExpressionElement {
   def convert(astNode: AstNode): ErrorOr[ExpressionElement] = astNode match {
 
-    case t: Terminal if asPrimitive.isDefinedAt((t.getTerminalStr, t.getSourceString)) => asPrimitive((t.getTerminalStr, t.getSourceString)).map(PrimitiveLiteralExpression)
+    case t: Terminal if asPrimitive.isDefinedAt((t.getTerminalStr, t.getSourceString)) => asPrimitive((t.getTerminalStr, t.getSourceString)).map(PrimitiveLiteralExpressionElement)
     case t: Terminal => s"No rule available to create ExpressionElement from terminal: ${t.getTerminalStr} ${t.getSourceString}".invalidNel
   }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstToInputDeclarationElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstToInputDeclarationElement.scala
@@ -2,16 +2,21 @@ package wdl.draft3.transforms.ast2wdlom
 
 import cats.syntax.apply._
 import cats.syntax.either._
+import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
 import wdl.draft3.parser.WdlParser.Ast
-import wdl.model.draft3.elements.{InputDeclarationElement, TypeElement}
+import wdl.model.draft3.elements.{ExpressionElement, InputDeclarationElement, TypeElement}
 
 object AstToInputDeclarationElement {
   def convert(a: Ast): ErrorOr[InputDeclarationElement] = {
 
     val nameValidation: ErrorOr[String] = astNodeToString(a.getAttribute("name")).toValidated
     val inputTypeValidation: ErrorOr[TypeElement] = astNodeToTypeElement(a.getAttribute("type")).toValidated
+    val expressionValidation: ErrorOr[Option[ExpressionElement]] = Option(a.getAttribute("expression")) match {
+      case Some(e) => astNodeToExpressionElement(e).map(Some.apply).toValidated
+      case None => None.validNel
+    }
 
-    (nameValidation, inputTypeValidation) mapN { (name, inputType) => InputDeclarationElement(inputType, name, None) }
+    (nameValidation, inputTypeValidation, expressionValidation) mapN { (name, inputType, expression) => InputDeclarationElement(inputType, name, expression) }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/CheckedAstToWorkflowDefinitionElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/CheckedAstToWorkflowDefinitionElement.scala
@@ -25,7 +25,6 @@ object CheckedAstToWorkflowDefinitionElement {
 
     val outputsValidation: ErrorOr[Vector[OutputsSectionElement]] = (inputsAndOutputs map { _._2 }).toValidated
 
-
     (nameElementValidation, inputsValidation, outputsValidation) mapN { (name, inputs, outputs) => WorkflowDefinitionElement(name, inputs, outputs) }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
@@ -22,6 +22,7 @@ package object ast2wdlom {
   implicit val astNodeToInputsSectionElement: CheckedAtoB[AstNode, InputsSectionElement] = astNodeToAst andThen CheckedAtoB.fromCheck(AstToInputsSectionElement.convert)
   implicit val astNodeToInputDeclarationElement: CheckedAtoB[AstNode, InputDeclarationElement] = astNodeToAst andThen CheckedAtoB.fromErrorOr(AstToInputDeclarationElement.convert)
   implicit val astNodeToTypeElement: CheckedAtoB[AstNode, TypeElement] = CheckedAtoB.fromErrorOr(AstNodeToTypeElement.convert)
+  implicit val astNodeToExpressionElement: CheckedAtoB[AstNode, ExpressionElement] = CheckedAtoB.fromErrorOr(AstNodeToExpressionElement.convert)
   implicit val checkedAstNodeToOutputsSectionElement: CheckedAtoB[AstNode, OutputsSectionElement] = astNodeToAst andThen CheckedAtoB.fromErrorOr(CheckedAstToOutputsSectionElement.convert)
   implicit val checkedAstNodeToOutputElement: CheckedAtoB[AstNode, OutputElement] = astNodeToAst andThen CheckedAtoB.fromErrorOr(CheckedAstToOutputElement.convert)
 

--- a/wdl/transforms/draft3/src/test/cases/input_expressions.nowom.wdl
+++ b/wdl/transforms/draft3/src/test/cases/input_expressions.nowom.wdl
@@ -1,0 +1,7 @@
+version draft-3
+
+workflow input_expressions {
+  input {
+    Int i = [[0]][0][0]
+  }
+}

--- a/wdl/transforms/draft3/src/test/cases/input_expressions.nowom.wdl
+++ b/wdl/transforms/draft3/src/test/cases/input_expressions.nowom.wdl
@@ -2,6 +2,7 @@ version draft-3
 
 workflow input_expressions {
   input {
-    Int i = [[0]][0][0]
+    Int four = 2 + 2
+#    Int i = [[0]][0][0]
   }
 }

--- a/wdl/transforms/draft3/src/test/cases/input_values.nowom.wdl
+++ b/wdl/transforms/draft3/src/test/cases/input_values.nowom.wdl
@@ -1,0 +1,11 @@
+version draft-3
+
+workflow input_values {
+  input {
+    # All the primitive types:
+    Int i = 5
+    String s = "s"
+    Float f = 5.5
+    Boolean b = true
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -82,10 +82,10 @@ object WdlFileToWdlomSpec {
           name = "input_values",
           inputsSection = Some(InputsSectionElement(
             inputDeclarations = Vector(
-              InputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "i", Some(PrimitiveLiteralExpression(WomInteger(5)))),
-              InputDeclarationElement(PrimitiveTypeElement(WomStringType), "s", Some(PrimitiveLiteralExpression(WomString("s")))),
-              InputDeclarationElement(PrimitiveTypeElement(WomFloatType), "f", Some(PrimitiveLiteralExpression(WomFloat(5.5)))),
-              InputDeclarationElement(PrimitiveTypeElement(WomBooleanType), "b", Some(PrimitiveLiteralExpression(WomBoolean(true)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "i", Some(PrimitiveLiteralExpressionElement(WomInteger(5)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomStringType), "s", Some(PrimitiveLiteralExpressionElement(WomString("s")))),
+              InputDeclarationElement(PrimitiveTypeElement(WomFloatType), "f", Some(PrimitiveLiteralExpressionElement(WomFloat(5.5)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomBooleanType), "b", Some(PrimitiveLiteralExpressionElement(WomBoolean(true)))),
             )
           )),
           outputsSection = Vector.empty)

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -4,8 +4,9 @@ import better.files.File
 import org.scalatest.{FlatSpec, Matchers}
 import wdl.model.draft3.elements._
 import wdl.draft3.transforms.ast2wdlom.WdlFileToWdlomSpec._
+import wdl.model.draft3.elements.ExpressionElement._
 import wom.types._
-import wom.values.{WomBoolean, WomFloat, WomInteger, WomSingleFile, WomString}
+import wom.values.{WomBoolean, WomFloat, WomInteger, WomString}
 
 class WdlFileToWdlomSpec extends FlatSpec with Matchers {
 
@@ -85,7 +86,22 @@ object WdlFileToWdlomSpec {
               InputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "i", Some(PrimitiveLiteralExpressionElement(WomInteger(5)))),
               InputDeclarationElement(PrimitiveTypeElement(WomStringType), "s", Some(PrimitiveLiteralExpressionElement(WomString("s")))),
               InputDeclarationElement(PrimitiveTypeElement(WomFloatType), "f", Some(PrimitiveLiteralExpressionElement(WomFloat(5.5)))),
-              InputDeclarationElement(PrimitiveTypeElement(WomBooleanType), "b", Some(PrimitiveLiteralExpressionElement(WomBoolean(true)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomBooleanType), "b", Some(PrimitiveLiteralExpressionElement(WomBoolean(true))))
+            )
+          )),
+          outputsSection = Vector.empty)
+        ),
+        tasks = List.empty),
+    "input_expressions" ->
+      FileElement(
+        imports = Vector.empty,
+        workflows = Vector(WorkflowDefinitionElement(
+          name = "input_expressions",
+          inputsSection = Some(InputsSectionElement(
+            inputDeclarations = Vector(
+              InputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "four", Some(Add(
+                left = PrimitiveLiteralExpressionElement(WomInteger(2)),
+                right = PrimitiveLiteralExpressionElement(WomInteger(2)))))
             )
           )),
           outputsSection = Vector.empty)

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import wdl.model.draft3.elements._
 import wdl.draft3.transforms.ast2wdlom.WdlFileToWdlomSpec._
 import wom.types._
+import wom.values.{WomBoolean, WomFloat, WomInteger, WomSingleFile, WomString}
 
 class WdlFileToWdlomSpec extends FlatSpec with Matchers {
 
@@ -74,6 +75,22 @@ object WdlFileToWdlomSpec {
           ))), Vector.empty
         )),
         tasks = Vector.empty),
+    "input_values" ->
+      FileElement(
+        imports = Vector.empty,
+        workflows = Vector(WorkflowDefinitionElement(
+          name = "input_values",
+          inputsSection = Some(InputsSectionElement(
+            inputDeclarations = Vector(
+              InputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "i", Some(PrimitiveLiteralExpression(WomInteger(5)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomStringType), "s", Some(PrimitiveLiteralExpression(WomString("s")))),
+              InputDeclarationElement(PrimitiveTypeElement(WomFloatType), "f", Some(PrimitiveLiteralExpression(WomFloat(5.5)))),
+              InputDeclarationElement(PrimitiveTypeElement(WomBooleanType), "b", Some(PrimitiveLiteralExpression(WomBoolean(true)))),
+            )
+          )),
+          outputsSection = Vector.empty)
+        ),
+        tasks = List.empty),
     "passthrough_workflow" ->
       FileElement(
         imports = List.empty,


### PR DESCRIPTION
Mostly just a set of `Element` case classes.

A proof of concept `AstNodeToExpressionElement.convert` which only works for primitive literals and the `Add` function