### PR TITLE
Ability for services to communicate with each other + a few fixes here and there

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -114,6 +114,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   override lazy val backendInitializationDataOption: Option[BackendInitializationData] = standardParams.backendInitializationDataOption
   override lazy val serviceRegistryActor: ActorRef = standardParams.serviceRegistryActor
   override lazy val configurationDescriptor: BackendConfigurationDescriptor = standardParams.configurationDescriptor
+  protected val commandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
 
   lazy val destinationCallRootPath: Path = jobPaths.callRoot
   lazy val destinationJobDetritusPaths: Map[String, Path] = jobPaths.detritusPaths
@@ -258,7 +259,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val destinationSimpleton = WomValueSimpleton(key, WomSingleFile(destinationPath.pathAsString))
 
-        List(destinationSimpleton) -> Set(DefaultIoCommandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
+        List(destinationSimpleton) -> Set(commandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
       case nonFileSimpleton => (List(nonFileSimpleton), Set.empty[IoCommand[_]])
     })
 
@@ -289,7 +290,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val newDetrituses = detrituses + (detritus -> destinationPath)
 
-        (newDetrituses, commands + DefaultIoCommandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
+        (newDetrituses, commands + commandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
     })
 
     (destinationDetritus + (JobPaths.CallRootPathKey -> destinationCallRootPath), ioCommands)

--- a/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
@@ -37,6 +37,8 @@ trait StreamActorHelper[T <: StreamContext] { this: Actor with ActorLogging =>
   protected def streamSource: Source[(Any, T), SourceQueueWithComplete[T]]
 
   override def receive = streamReceive.orElse(actorReceive)
+  
+  protected def onBackpressure(): Unit = {}
 
   private [actor] lazy val stream = {
     streamSource
@@ -67,6 +69,7 @@ trait StreamActorHelper[T <: StreamContext] { this: Actor with ActorLogging =>
   private def backpressure(commandContext: StreamContext) = {
     val originalRequest = commandContext.clientContext map { _ -> commandContext.request } getOrElse commandContext.request
     commandContext.replyTo ! BackPressure(originalRequest)
+    onBackpressure()
   }
 
   private def streamReceive: Receive = {

--- a/core/src/main/scala/cromwell/core/instrumentation/InstrumentationPrefixes.scala
+++ b/core/src/main/scala/cromwell/core/instrumentation/InstrumentationPrefixes.scala
@@ -1,4 +1,4 @@
-package cromwell.engine.instrumentation
+package cromwell.core.instrumentation
 
 object InstrumentationPrefixes {
   val ServicesPrefix: Option[String] = Option("services")

--- a/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives.{extractRequest, mapResponse}
 import cats.data.NonEmptyList
-import cromwell.engine.instrumentation.InstrumentationPrefixes._
+import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.instrumentation.CromwellInstrumentation._
 

--- a/engine/src/main/scala/cromwell/engine/instrumentation/InstrumentationPrefixes.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/InstrumentationPrefixes.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.instrumentation
 
 object InstrumentationPrefixes {
+  val ServicesPrefix: Option[String] = Option("services")
   val WorkflowPrefix: Option[String] = Option("workflow")
   val JobPrefix: Option[String] = Option("job")
   val IoPrefix: Option[String] = Option("io")

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -3,7 +3,7 @@ package cromwell.engine.instrumentation
 import cats.data.NonEmptyList
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.io._
-import cromwell.engine.instrumentation.InstrumentationPrefixes._
+import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.filesystems.gcs.{GcsPath, GoogleUtil}
 import cromwell.services.instrumentation.CromwellInstrumentation

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -16,6 +16,8 @@ private object IoInstrumentationImplicits {
   val LocalPath = NonEmptyList.of("local")
   val GcsPath = NonEmptyList.of("gcs")
   val UnknownFileSystemPath = NonEmptyList.of("unknown")
+  
+  val backpressure = NonEmptyList.of("backpressure")
 
   /**
     * Augments IoResult to provide instrumentation conversion methods
@@ -89,6 +91,8 @@ trait IoInstrumentation extends CromwellInstrumentation {
     * Increment an IoResult to the proper bucket depending on the request type and the result (success or failure).
     */
   final def incrementIoResult(ioResult: IoResult): Unit = incrementIo(ioResult.toPath)
+  
+  final def incrementBackpressure(): Unit = incrementIo(backpressure)
 
   /**
     * Increment an IoCommand to the proper bucket depending on the request type.

--- a/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
@@ -2,7 +2,7 @@ package cromwell.engine.instrumentation
 
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.instrumentation.InstrumentationKeys._
-import cromwell.engine.instrumentation.InstrumentationPrefixes._
+import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.instrumentation.JobInstrumentation._
 import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.instrumentation.CromwellInstrumentation._

--- a/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
@@ -3,7 +3,7 @@ package cromwell.engine.instrumentation
 import cats.data.NonEmptyList
 import cromwell.core.WorkflowState
 import cromwell.database.sql.tables.WorkflowStoreEntry.WorkflowStoreState
-import cromwell.engine.instrumentation.InstrumentationPrefixes._
+import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.instrumentation.WorkflowInstrumentation._
 import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.instrumentation.CromwellInstrumentation._

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -96,6 +96,10 @@ final class IoActor(queueSize: Int,
     .via(throttledFlow)
     .alsoTo(instrumentationSink)  
     .withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
+
+  override def onBackpressure() = {
+    incrementBackpressure()
+  }
   
   override def actorReceive: Receive = {
     /* GCS Batch command with context */

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -427,7 +427,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
           else s"$tag ($shardCount shards)"
       })
     val mode = if (restarting) "Restarting" else "Starting"
-    if (runnableCalls.nonEmpty) workflowLogger.info(s"$mode " + runnableCalls.mkString(", "))
+    if (runnableCalls.nonEmpty) workflowLogger.info(s"$mode calls: " + runnableCalls.mkString(", "))
 
     val diffValidation = runnableKeys.traverse[ErrorOr, WorkflowExecutionDiff]({
       case key: BackendJobDescriptorKey => processRunnableJob(key, data)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -416,11 +416,18 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
     import keys._
 
     val DataStoreUpdate(runnableKeys, updatedData) = data.executionStoreUpdate
-    val runnableCalls = runnableKeys.view collect { case k if k.node.isInstanceOf[CallNode] => k } sortBy { k =>
-      (k.node.fullyQualifiedName, k.index.getOrElse(-1)) } map { _.tag }
-
+    val runnableCalls = runnableKeys.view
+      .collect({ case k: BackendJobDescriptorKey => k })
+      .groupBy(_.node)
+      .map({
+        case (node, keys) => 
+          val tag = node.fullyQualifiedName
+          val shardCount = keys.map(_.index).distinct.size
+          if (shardCount == 1) tag
+          else s"$tag ($shardCount shards)"
+      })
     val mode = if (restarting) "Restarting" else "Starting"
-    if (runnableCalls.nonEmpty) workflowLogger.info(s"$mode calls: " + runnableCalls.mkString(", "))
+    if (runnableCalls.nonEmpty) workflowLogger.info(s"$mode " + runnableCalls.mkString(", "))
 
     val diffValidation = runnableKeys.traverse[ErrorOr, WorkflowExecutionDiff]({
       case key: BackendJobDescriptorKey => processRunnableJob(key, data)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -1,5 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.job
 
+import java.util.concurrent.TimeoutException
+
 import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor.{ActorInitializationException, ActorRef, LoggingFSM, OneForOneStrategy, Props}
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
@@ -347,6 +349,10 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       }
     case Event(EngineLifecycleActorAbortCommand, _) =>
       forwardAndStop(JobAbortedResponse(jobDescriptorKey))
+      // We can get extra I/O timeout messages from previous cache copy attempt. This is due to the fact that if one file fails to copy,
+      // we immediately cache miss and try the next potential hit, but don't cancel previous copy requests.
+    case Event(JobFailedNonRetryableResponse(_, _: TimeoutException, _), _) =>
+      stay()
     case Event(msg, _) =>
       log.error("Bad message from {} to EngineJobExecutionActor in state {}(with data {}): {}", sender, stateName, stateData, msg)
       stay

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/noop/NoopHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/noop/NoopHealthMonitorServiceActor.scala
@@ -1,5 +1,6 @@
 package cromwell.services.healthmonitor.impl.noop
 
+import akka.actor.ActorRef
 import com.typesafe.config.Config
 import cromwell.services.healthmonitor.HealthMonitorServiceActor
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.MonitoredSubsystem
@@ -7,7 +8,7 @@ import cromwell.services.healthmonitor.HealthMonitorServiceActor.MonitoredSubsys
 /**
   * A health monitor which performs no checks
   */
-class NoopHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
+class NoopHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends HealthMonitorServiceActor {
   override val subsystems: Set[MonitoredSubsystem] = Set.empty[MonitoredSubsystem]
 }

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/standard/StandardHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/standard/StandardHealthMonitorServiceActor.scala
@@ -1,5 +1,6 @@
 package cromwell.services.healthmonitor.impl.standard
 
+import akka.actor.ActorRef
 import com.typesafe.config.Config
 import cromwell.services.healthmonitor.HealthMonitorServiceActor
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.MonitoredSubsystem
@@ -8,7 +9,7 @@ import cromwell.services.healthmonitor.impl.common.{DockerHubMonitor, EngineData
 /**
   * A health monitor implementation which only monitors things available to out of the box Cromwell installations
   */
-class StandardHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
+class StandardHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends HealthMonitorServiceActor
     with DockerHubMonitor
     with EngineDatabaseMonitor {

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -2,6 +2,7 @@ package cromwell.services.healthmonitor.impl.workbench
 
 import java.net.URL
 
+import akka.actor.ActorRef
 import cats.data.Validated.{Invalid, Valid}
 import cats.instances.future._
 import cats.syntax.functor._
@@ -22,7 +23,7 @@ import scala.concurrent.Future
   * as GCS and PAPI. This implementation makes some assumptions of Cromwell's configuration which will be true
   * in a Workbench scenario but YMMV otherwise. Caveat emptor and all of that fun stuff.
   */
-class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config)
+class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends HealthMonitorServiceActor
     with DockerHubMonitor
     with EngineDatabaseMonitor {

--- a/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
@@ -41,7 +41,21 @@ trait CromwellInstrumentation {
     * cromwell.[prefix].path
     */
   final private def makeBucket(path: InstrumentationPath, prefix: Option[String]): CromwellBucket = {
-    CromwellBucket(List("cromwell") ++ prefix, path)
+    CromwellBucket(prefix.toList, path)
+  }
+
+  /**
+    * Creates an increment message for the given bucket
+    */
+  private final def countMessage(path: InstrumentationPath, count: Long, prefix: Option[String]): InstrumentationServiceMessage = {
+    InstrumentationServiceMessage(CromwellCount(makeBucket(path, prefix), count))
+  }
+
+  /**
+    * Increment the counter for the given bucket
+    */
+  protected final def count(path: InstrumentationPath, count: Long, prefix: Option[String] = None): Unit = {
+    serviceRegistryActor ! countMessage(path, count, prefix)
   }
   
   /**

--- a/services/src/main/scala/cromwell/services/instrumentation/impl/noop/NoopInstrumentationServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/impl/noop/NoopInstrumentationServiceActor.scala
@@ -1,18 +1,18 @@
 package cromwell.services.instrumentation.impl.noop
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
 object NoopInstrumentationServiceActor {
-  def props(serviceConfig: Config, globalConfig: Config) = Props(new NoopInstrumentationServiceActor(serviceConfig, globalConfig))
+  def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(new NoopInstrumentationServiceActor(serviceConfig, globalConfig, serviceRegistryActor))
 }
 
 /**
   * Actor that ignores every InstrumentationServiceMessage - This is the default implementation of this service
   */
-class NoopInstrumentationServiceActor(serviceConfig: Config, globalConfig: Config) extends Actor {
+class NoopInstrumentationServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) extends Actor {
   override def receive = {
     case InstrumentationServiceMessage(_) => // Drop all messages
     case ShutdownCommand => context stop self

--- a/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
@@ -2,7 +2,7 @@ package cromwell.services.instrumentation.impl.statsd
 
 import java.util.concurrent.TimeUnit
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import com.readytalk.metrics.{CromwellStatsD, StatsDReporter}
 import com.typesafe.config.Config
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
@@ -15,7 +15,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 object StatsDInstrumentationServiceActor {
-  def props(serviceConfig: Config, globalConfig: Config) = Props(new StatsDInstrumentationServiceActor(serviceConfig, globalConfig))
+  def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(new StatsDInstrumentationServiceActor(serviceConfig, globalConfig, serviceRegistryActor))
 
   /* Values inserted between a CromwellBucket prefix and its path when building a StatsD path to make up for the fact
    * that everything is sent as a gauge which makes differentiating the meaning of the metrics harder.
@@ -47,7 +47,7 @@ object StatsDInstrumentationServiceActor {
   * If performance or statistics accuracy becomes a problem one might implement a more efficient solution
   * by making use of downsampling and / or multi metrics packets: https://github.com/etsy/statsd/blob/master/docs/metric_types.md
   */
-class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Config) extends Actor with DefaultInstrumented {
+class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) extends Actor with DefaultInstrumented {
   val statsDConfig = StatsDConfig(serviceConfig)
 
   override lazy val metricBaseName = MetricName("cromwell")

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
@@ -1,6 +1,6 @@
 package cromwell.services.keyvalue.impl
 
-import akka.actor.Props
+import akka.actor.{ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.core.Dispatcher.ServiceDispatcher
 import cromwell.services.keyvalue.KeyValueServiceActor
@@ -9,10 +9,10 @@ import cromwell.services.keyvalue.KeyValueServiceActor._
 import scala.concurrent.Future
 
 object SqlKeyValueServiceActor {
-  def props(serviceConfig: Config, globalConfig: Config) = Props(SqlKeyValueServiceActor(serviceConfig, globalConfig)).withDispatcher(ServiceDispatcher)
+  def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(SqlKeyValueServiceActor(serviceConfig, globalConfig, serviceRegistryActor)).withDispatcher(ServiceDispatcher)
 }
 
-final case class SqlKeyValueServiceActor(serviceConfig: Config, globalConfig: Config)
+final case class SqlKeyValueServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends KeyValueServiceActor with BackendKeyValueDatabaseAccess {
   override implicit val ec = context.dispatcher
   private implicit val system = context.system

--- a/services/src/main/scala/cromwell/services/metadata/impl/hybridpubsub/HybridPubSubMetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/hybridpubsub/HybridPubSubMetadataServiceActor.scala
@@ -19,9 +19,9 @@ import cromwell.services.metadata.impl.pubsub.PubSubMetadataServiceActor
   * It is expected that the user will supply any desired config fields for both MetadataServiceActor and
   * PubSubMetadataServiceActor as the serviceConfig block will be passed along to both of them.
   */
-class HybridPubSubMetadataServiceActor(serviceConfig: Config, globalConfig: Config) extends Actor with ActorLogging {
-  val standardMetadataActor: ActorRef = context.actorOf(MetadataServiceActor.props(serviceConfig, globalConfig))
-  val pubSubMetadataActor: ActorRef = context.actorOf(PubSubMetadataServiceActor.props(serviceConfig, globalConfig))
+class HybridPubSubMetadataServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+  val standardMetadataActor: ActorRef = context.actorOf(MetadataServiceActor.props(serviceConfig, globalConfig, serviceRegistryActor))
+  val pubSubMetadataActor: ActorRef = context.actorOf(PubSubMetadataServiceActor.props(serviceConfig, globalConfig, serviceRegistryActor))
 
   override def receive = {
     case action: PutMetadataAction =>

--- a/services/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
@@ -21,7 +21,7 @@ abstract class EmptyActor extends Actor {
   override def receive: Receive = Actor.emptyBehavior
 }
 
-class FooServiceActor(config: Config, configp: Config) extends EmptyActor
+class FooServiceActor(config: Config, configp: Config, registryActor: ActorRef) extends EmptyActor
 
 class NoAppropriateConstructorServiceActor extends EmptyActor
 
@@ -33,7 +33,7 @@ object BarServiceActor {
   case object ArbitraryBarMessage extends BarServiceMessage
 }
 
-class BarServiceActor(config: Config, configp: Config) extends Actor {
+class BarServiceActor(config: Config, configp: Config, registryActor: ActorRef) extends Actor {
   var probe: TestProbe = _
   override def receive: Receive = {
     case SetProbe(p) => probe = p

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -26,6 +26,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
     """.stripMargin
   )
 
+  val registryProbe = TestProbe().ref
   val udpProbe = TestProbe()
   val patience = 1.second
   val testBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "metric", "bucket"))
@@ -73,7 +74,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
   ) foreach {
     case StatsDTestBit(description, metric, expectedPackets) =>
       it should description in {
-        val instrumentationActor = TestActorRef(new StatsDInstrumentationServiceActor(config, ConfigFactory.load()))
+        val instrumentationActor = TestActorRef(new StatsDInstrumentationServiceActor(config, ConfigFactory.load(), registryProbe))
         instrumentationActor ! InstrumentationServiceMessage(metric)
         val received = udpProbe.receiveWhile(patience) {
           case Udp.Received(data, _) => data.utf8String

--- a/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueServiceActorSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.services.keyvalue.impl
 
 import akka.pattern._
+import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import cromwell.core.WorkflowId
 import cromwell.services.ServicesSpec
@@ -21,7 +22,7 @@ class KeyValueServiceActorSpec extends ServicesSpec("KeyValue") {
   )
 
   val emptyConfig = ConfigFactory.empty()
-  val sqlKvServiceActor = system.actorOf(SqlKeyValueServiceActor.props(emptyConfig, emptyConfig))
+  val sqlKvServiceActor = system.actorOf(SqlKeyValueServiceActor.props(emptyConfig, emptyConfig, TestProbe().ref))
   val wfID = WorkflowId.randomId()
 
   val jobKey1 = KvJobKey("some_FQN", Option(-1), 1)

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -3,6 +3,7 @@ package cromwell.services.metadata.impl
 import java.time.OffsetDateTime
 
 import akka.pattern._
+import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import cromwell.core._
 import cromwell.services.ServicesSpec
@@ -16,7 +17,7 @@ import scala.concurrent.duration._
 class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
   import MetadataServiceActorSpec.Config
   val config = ConfigFactory.parseString(Config)
-  val actor = system.actorOf(MetadataServiceActor.props(config, config))
+  val actor = system.actorOf(MetadataServiceActor.props(config, config, TestProbe().ref))
 
     val workflowId = WorkflowId.randomId()
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendCacheHitCopyingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/callcaching/JesBackendCacheHitCopyingActor.scala
@@ -17,6 +17,7 @@ import scala.language.postfixOps
 import scala.util.Try
 
 class JesBackendCacheHitCopyingActor(standardParams: StandardCacheHitCopyingActorParams) extends StandardCacheHitCopyingActor(standardParams) {
+  override protected val commandBuilder = GcsBatchCommandBuilder
   private val cachingStrategy = BackendInitializationData
     .as[JesBackendInitializationData](standardParams.backendInitializationDataOption)
     .jesConfiguration.jesAttributes.duplicationStrategy


### PR DESCRIPTION
Turns out the batch size for write metadata was ignored (we were looking at the wrong config path)
Also turns out it doesn't matter that much when load is very high.
That is mostly because when we flush the event queue, we flush all of it, not just `dbBatchSize` of it.
This added to the fact that the flushes are controlled by messages we sent to `self` that can get lost in an ocean of metadata event messages, we can end up flushing queues of several million events at once, in one transaction, which can take quite some time for slick to do. The more time it takes, the more events we accumulate before the next flush, so the next flush takes even more time etc... 
I'll have a follow up PR to re-factor this a bit, with stats to be able to compare.

TODO:
- [x] Add some tests