### PR TITLE
Remove unused 'declarations' field from WorkflowDefinition

### DIFF
--- a/core/src/test/scala/cromwell/util/WomMocks.scala
+++ b/core/src/test/scala/cromwell/util/WomMocks.scala
@@ -25,7 +25,7 @@ object WomMocks {
   }
 
   def mockWorkflowDefinition(name: String) = {
-    WorkflowDefinition(name, Graph(Set.empty), Map.empty, Map.empty, List.empty)
+    WorkflowDefinition(name, Graph(Set.empty), Map.empty, Map.empty)
   }
 
   def mockTaskDefinition(name: String) = {

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -158,15 +158,13 @@ case class Workflow private(
     val name: String = Paths.get(id).getFileName.toString
     val meta: Map[String, String] = Map.empty
     val paramMeta: Map[String, String] = Map.empty
-    val declarations: List[(String, WomExpression)] = List.empty
 
     womGraph(name, validator, expressionLib).map(graph =>
       WorkflowDefinition(
         name,
         graph,
         meta,
-        paramMeta,
-        declarations
+        paramMeta
       )
     )
   }

--- a/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomWorkflowDefinitionMaker.scala
+++ b/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomWorkflowDefinitionMaker.scala
@@ -16,8 +16,7 @@ object WdlDraft2WomWorkflowDefinitionMaker extends WomWorkflowDefinitionMaker[Wd
         wdlWorkflow.unqualifiedName,
         wg,
         wdlWorkflow.meta,
-        wdlWorkflow.parameterMeta,
-        List.empty)
+        wdlWorkflow.parameterMeta)
     }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinition.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WorkflowDefinitionElementToWomWorkflowDefinition.scala
@@ -12,7 +12,7 @@ object WorkflowDefinitionElementToWomWorkflowDefinition {
     val g: ErrorOr[Graph] = Graph.validateAndConstruct(Set.empty)
 
     g map { graph =>
-      WorkflowDefinition(a.name, graph, Map.empty, Map.empty, List.empty)
+      WorkflowDefinition(a.name, graph, Map.empty, Map.empty)
     }
 
   }

--- a/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
+++ b/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
@@ -1,15 +1,12 @@
 package wom.callable
 
-import common.validation.ErrorOr.ErrorOr
-import wom.expression.WomExpression
 import wom.graph.GraphNode._
 import wom.graph.{CommandCallNode, Graph}
 
 final case class WorkflowDefinition(name: String,
                                     innerGraph: Graph,
                                     meta: Map[String, String],
-                                    parameterMeta: Map[String, String],
-                                    declarations: List[(String, WomExpression)]) extends ExecutableCallable {
+                                    parameterMeta: Map[String, String]) extends ExecutableCallable {
 
   override lazy val toString = s"[Workflow $name]"
   override val graph: Graph = innerGraph

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -116,7 +116,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
   it should "be able to represent calls to sub-workflows" in {
     val threeStepGraph = makeThreeStep
-    val threeStepWorkflow = WorkflowDefinition("three_step", threeStepGraph, Map.empty, Map.empty, List.empty)
+    val threeStepWorkflow = WorkflowDefinition("three_step", threeStepGraph, Map.empty, Map.empty)
     val threeStepNodeBuilder = new CallNodeBuilder()
 
     val workflowInputNode = RequiredGraphInputNode(WomIdentifier("three_step.cgrep.pattern"), WomStringType, "three_step.cgrep.pattern")


### PR DESCRIPTION
I'm not sure what this was originally intended for?

It was always set to `List.empty` and never read from, so I think it's safe to remove it.