### PR TITLE
fix expensive metadata sorting by not sorting

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -109,9 +109,12 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataTimestamp)
   )
 
+  // This is only used for metadata summary which should not require metadata sorting if rows are committed
+  // with monotonically increasing IDs. The metadata summary logic records the maximum ID it last saw and uses
+  // that last ID + 1 as the minimum ID for the next query iteration.
   val metadataEntriesForIdGreaterThanOrEqual = Compiled(
     (metadataEntryId: Rep[Long], startMetadataKey: Rep[String], endMetadataKey: Rep[String], nameMetadataKey: Rep[String],
-     statusMetadataKey: Rep[String], likeLabelMetadataKey: Rep[String]) => (for {
+     statusMetadataKey: Rep[String], likeLabelMetadataKey: Rep[String]) => for {
       metadataEntry <- metadataEntries
       if metadataEntry.metadataEntryId >= metadataEntryId
       if (metadataEntry.metadataKey === startMetadataKey || metadataEntry.metadataKey === endMetadataKey ||
@@ -119,7 +122,7 @@ trait MetadataEntryComponent {
         metadataEntry.metadataKey.like(likeLabelMetadataKey)) &&
         (metadataEntry.callFullyQualifiedName.isEmpty && metadataEntry.jobIndex.isEmpty &&
           metadataEntry.jobAttempt.isEmpty)
-    } yield metadataEntry).sortBy(_.metadataTimestamp)
+    } yield metadataEntry
   )
 
   /**


### PR DESCRIPTION
ftfy the metadata sort by deleting it. Batching the summary updates didn't work out since the metadata summary "last updated id" scheme assumes rows are processed in batches where each batch has IDs greater than those of the preceding batch. AFAICT that wouldn't be possible without sorting all rows with IDs greater than the last processed row. Instead this just takes all committed rows with IDs greater than the last processed row and assumes that rows are being committed with monotonically increasing IDs.