### PR TITLE
Throttle kv store an job store reads

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -191,7 +191,7 @@ object Operations {
           case _ =>
             // Re-add this to discover which test is running forever
             // But beware!! The stdout will break CWL conformance tests so you can't leave it in once the debugging is done:
-            //println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
+            println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
             pollDelay()
             doPerform()
         }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -191,7 +191,7 @@ object Operations {
           case _ =>
             // Re-add this to discover which test is running forever
             // But beware!! The stdout will break CWL conformance tests so you can't leave it in once the debugging is done:
-            println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
+//            println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
             pollDelay()
             doPerform()
         }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -191,7 +191,7 @@ object Operations {
           case _ =>
             // Re-add this to discover which test is running forever
             // But beware!! The stdout will break CWL conformance tests so you can't leave it in once the debugging is done:
-//            println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
+            // println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
             pollDelay()
             doPerform()
         }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -191,7 +191,7 @@ object Operations {
           case _ =>
             // Re-add this to discover which test is running forever
             // But beware!! The stdout will break CWL conformance tests so you can't leave it in once the debugging is done:
-            // println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
+            //println(s"Waiting for completion of test '${testDefinition.testName}' as ${workflow.id}")
             pollDelay()
             doPerform()
         }

--- a/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/StreamActorHelper.scala
@@ -73,14 +73,17 @@ trait StreamActorHelper[T <: StreamContext] { this: Actor with ActorLogging =>
   }
 
   private def streamReceive: Receive = {
-    case ShutdownCommand => stream.complete()
+    case ShutdownCommand => 
+      stream.complete()
     case EnqueueResponse(Enqueued, _: T @unchecked) => // Good !
 
     case EnqueueResponse(_, commandContext) => backpressure(commandContext)
     case FailedToEnqueue(_, commandContext) => backpressure(commandContext)
       
-    case StreamCompleted => context stop self
-    case StreamFailed(failure) => restart(failure)
+    case StreamCompleted => 
+      context stop self
+    case StreamFailed(failure) => 
+      restart(failure)
   }
 
   /** Throw the exception to force the actor to restart so it can be back in business

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -10,14 +10,18 @@ import scala.concurrent.duration.Duration
 
 /**
   * By removing the periodic flush and setting the batch size to 1,
-  * this transforms the BatchActor into throttler processing commands one at a time.
+  * this actor modifies the behavior of BatchActor so that it throttles processing commands one at a time.
   */
 abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
   override def weightFunction(command: C) = 1
   override final def process(data: NonEmptyVector[C]): Future[Int] = {
-    // This ShouldNotBePossible™ but in case it happens, instead of dropping elements process them all anyway
+    // This ShouldNotBePossible™ but in case it happens, instead of dropping elements process them all anyway.
+    // Explanation: batch size is 1 which means as soon as we receive 1 element, the process method should be called.
+    // Because the BatchActor calls the process method with vector of elements which total weight is batch size, and because
+    // each element's weight is 1, this method should always be called with a vector of size 1. If that is not the case it means
+    // there's a bug in the batch actor.
     if (data.tail.nonEmpty) {
-      log.error("{} is a read actor and is not supposed to process more than one element at a time !", self.path.name)
+      log.error("{} is throttled and is not supposed to process more than one element at a time !", self.path.name)
       data.toVector.traverse[Future, Any](processHead).map(_.length)
     } else processHead(data.head).map(_ => 1)
   }

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.Duration
 
 /**
   * By removing the periodic flush and setting the batch size to 1,
-  * This transforms the BatchActor into throttler processing commands one at a time.
+  * this transforms the BatchActor into throttler processing commands one at a time.
   */
 abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
   override def weightFunction(command: C) = 1

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -1,0 +1,25 @@
+package cromwell.core.actor
+
+import cats.data.NonEmptyVector
+
+import cats.syntax.traverse._
+import cats.instances.vector._
+import cats.instances.future._
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+/**
+  * By removing the periodic flush and setting the batch size to 1,
+  * This transforms the BatchActor into throttler processing commands one at a time.
+  */
+abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
+  override def weightFunction(command: C) = 1
+  override final def process(data: NonEmptyVector[C]): Future[Int] = {
+    // This ShouldNotBePossible™ but in case it happens, instead of dropping elements process them all anyway
+    if (data.tail.nonEmpty) {
+      log.error("{} is a read actor and is not supposed to process more than one element at a time !", self.path.name)
+      data.toVector.traverse[Future, Any](processHead).map(_.length)
+    } else processHead(data.head).map(_ => 1)
+  }
+  def processHead(head: C): Future[Any]
+}

--- a/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
@@ -1,11 +1,12 @@
 package cromwell.engine.instrumentation
 
+import akka.actor.Actor
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives.{extractRequest, mapResponse}
 import cats.data.NonEmptyList
 import cromwell.core.instrumentation.InstrumentationPrefixes._
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
 
 import scala.concurrent.duration._

--- a/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/HttpInstrumentation.scala
@@ -1,6 +1,5 @@
 package cromwell.engine.instrumentation
 
-import akka.actor.Actor
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.Directives.{extractRequest, mapResponse}

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -3,12 +3,12 @@ package cromwell.engine.instrumentation
 import akka.actor.Actor
 import cats.data.NonEmptyList
 import cromwell.core.instrumentation.InstrumentationKeys._
-import cromwell.core.io._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
+import cromwell.core.io._
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.filesystems.gcs.{GcsPath, GoogleUtil}
-import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 
 /**
   * Implicit methods to help convert Io objects to metric values

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -1,12 +1,13 @@
 package cromwell.engine.instrumentation
 
+import akka.actor.Actor
 import cats.data.NonEmptyList
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.io._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.filesystems.gcs.{GcsPath, GoogleUtil}
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
 
 /**
@@ -79,7 +80,7 @@ private object IoInstrumentationImplicits {
 /**
   * Helper methods for Io instrumentation
   */
-trait IoInstrumentation extends CromwellInstrumentation {
+trait IoInstrumentation extends CromwellInstrumentationActor { this: Actor =>
   import IoInstrumentationImplicits._
 
   /**

--- a/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
@@ -5,8 +5,8 @@ import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.instrumentation.JobInstrumentation._
-import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
@@ -1,10 +1,11 @@
 package cromwell.engine.instrumentation
 
+import akka.actor.Actor
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.instrumentation.JobInstrumentation._
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
 
 import scala.concurrent.duration.FiniteDuration
@@ -21,7 +22,7 @@ object JobInstrumentation {
 /**
   * Provides helper methods for Job instrumentation
   */
-trait JobInstrumentation extends CromwellInstrumentation {
+trait JobInstrumentation extends CromwellInstrumentationActor { this: Actor =>
 
   /**
     * Generic method to increment a workflow related counter metric value

--- a/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
@@ -1,11 +1,12 @@
 package cromwell.engine.instrumentation
 
+import akka.actor.Actor
 import cats.data.NonEmptyList
 import cromwell.core.WorkflowState
 import cromwell.database.sql.tables.WorkflowStoreEntry.WorkflowStoreState
 import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.engine.instrumentation.WorkflowInstrumentation._
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
 
 import scala.concurrent.duration.FiniteDuration
@@ -24,7 +25,7 @@ object WorkflowInstrumentation {
 /**
   * Provides helper methods for workflow instrumentation
   */
-trait WorkflowInstrumentation extends CromwellInstrumentation {
+trait WorkflowInstrumentation extends CromwellInstrumentationActor { this: Actor =>
   private def workflowStatePath(workflowState: WorkflowState): InstrumentationPath = WorkflowInstrumentation.WorkflowStatePaths(workflowState)
 
   /**

--- a/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
@@ -3,11 +3,11 @@ package cromwell.engine.instrumentation
 import akka.actor.Actor
 import cats.data.NonEmptyList
 import cromwell.core.WorkflowState
-import cromwell.database.sql.tables.WorkflowStoreEntry.WorkflowStoreState
 import cromwell.core.instrumentation.InstrumentationPrefixes._
+import cromwell.database.sql.tables.WorkflowStoreEntry.WorkflowStoreState
 import cromwell.engine.instrumentation.WorkflowInstrumentation._
-import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 
 import scala.concurrent.duration.FiniteDuration
 import scala.language.postfixOps

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{ActorRef, Props}
+import cats.data.NonEmptyVector
 import cats.instances.list._
 import cats.instances.tuple._
 import cats.syntax.foldable._
@@ -22,7 +23,7 @@ case class CallCacheWriteActor(callCache: CallCache) extends BatchActor[CommandA
 
   override protected def weightFunction(command: CommandAndReplyTo[SaveCallCacheHashes]) = 1
 
-  override protected def process(data: Vector[CommandAndReplyTo[SaveCallCacheHashes]]) = {
+  override protected def process(data: NonEmptyVector[CommandAndReplyTo[SaveCallCacheHashes]]) = {
     log.debug("Flushing {} call cache hashes sets to the DB", data.length)
 
     //     Collect all the bundles of hashes that should be written and all the senders which should be informed of
@@ -33,7 +34,7 @@ case class CallCacheWriteActor(callCache: CallCache) extends BatchActor[CommandA
       futureMessage map { message =>
         replyTos foreach { _ ! message }
       }
-      futureMessage.map(_ => data.size)
+      futureMessage.map(_ => data.length)
     } else Future.successful(0)
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -9,6 +9,7 @@ import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor._
 import cromwell.engine.workflow.tokens.TokenPool.TokenPoolPop
 import cromwell.services.instrumentation.CromwellInstrumentation._
 import cromwell.services.instrumentation.CromwellInstrumentationScheduler
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
 import scala.collection.immutable.Queue
 
@@ -26,6 +27,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
     case JobExecutionTokenRequest(tokenType) => sendTokenRequestResult(sender, tokenType)
     case JobExecutionTokenReturn(token) => unassign(sender, token)
     case Terminated(terminee) => onTerminate(terminee)
+    case ShutdownCommand => context stop self
   }
 
   private def sendTokenRequestResult(sndr: ActorRef, tokenType: JobExecutionTokenType): Unit = {

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreActor.scala
@@ -19,7 +19,7 @@ import scala.language.postfixOps
 class JobStoreActor(jobStore: JobStore, dbBatchSize: Int, dbFlushRate: FiniteDuration) extends Actor with ActorLogging with GracefulShutdownHelper {
   import JobStoreActor._
   val jobStoreWriterActor = context.actorOf(JobStoreWriterActor.props(jobStore, dbBatchSize, dbFlushRate), "JobStoreWriterActor")
-  val jobStoreReaderActor = context.actorOf(JobStoreReaderActor.props(jobStore), "JobStoreReaderActor")
+  val jobStoreReaderActor = context.actorOf(JobStoreReaderActor.props(jobStore), "JobStoreReaderActorRouter")
 
   override def receive: Receive = {
     case ShutdownCommand => waitForActorsAndShutdown(NonEmptyList.of(jobStoreWriterActor))

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -1,6 +1,7 @@
 package cromwell.jobstore
 
 import akka.actor.{ActorRef, Props}
+import cats.data.NonEmptyVector
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.actor.BatchActor._
 import cromwell.core.actor.BatchActor
@@ -22,7 +23,8 @@ case class JobStoreWriterActor(jsd: JobStore, override val batchSize: Int, overr
     case command: JobStoreWriterCommand => CommandAndReplyTo(command, snd)
   }
 
-  override protected def process(data: Vector[CommandAndReplyTo[JobStoreWriterCommand]]) = {
+  override protected def process(nonEmptyData: NonEmptyVector[CommandAndReplyTo[JobStoreWriterCommand]]) = {
+    val data = nonEmptyData.toVector
     log.debug("Flushing {} job store commands to the DB", data.length)
     val completions = data.collect({ case CommandAndReplyTo(c: JobStoreWriterCommand, _) => c.completion })
 

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -79,7 +79,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   lazy val throttlePer = systemConfig.as[Option[FiniteDuration]]("io.per").getOrElse(100 seconds)
   lazy val ioThrottle = Throttle(throttleElements, throttlePer, throttleElements)
   lazy val ioActor = context.actorOf(IoActor.props(1000, Option(ioThrottle), serviceRegistryActor), "IoActor")
-  lazy val ioActorProxy = context.actorOf(IoActorProxy.props(ioActor))
+  lazy val ioActorProxy = context.actorOf(IoActorProxy.props(ioActor), "IoProxy")
 
   lazy val workflowLogCopyRouter: ActorRef = context.actorOf(RoundRobinPool(numberOfWorkflowLogCopyWorkers)
     .withSupervisorStrategy(CopyWorkflowLogsActor.strategy)
@@ -119,7 +119,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   }
   lazy val backendSingletonCollection = BackendSingletonCollection(backendSingletons)
 
-  lazy val jobExecutionTokenDispenserActor = context.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistryActor))
+  lazy val jobExecutionTokenDispenserActor = context.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistryActor), "JobExecutionTokenDispenser")
 
   lazy val workflowManagerActor = context.actorOf(
     WorkflowManagerActor.props(
@@ -135,6 +135,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
       workflowManagerActor = workflowManagerActor,
       logCopyRouter = workflowLogCopyRouter,
       jobStoreActor = jobStoreActor,
+      jobTokenDispenser = jobExecutionTokenDispenserActor,
       workflowStoreActor = workflowStoreActor,
       subWorkflowStoreActor = subWorkflowStoreActor,
       callCacheWriteActor = callCacheWriteActor,

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 import cromwell.webservice.{CromwellApiService, SwaggerService}
 
 import scala.concurrent.Future
@@ -23,7 +24,7 @@ object CromwellServer {
 
 class CromwellServerActor(cromwellSystem: CromwellSystem, gracefulShutdown: Boolean, abortJobsOnTerminate: Boolean)(override implicit val materializer: ActorMaterializer)
   extends CromwellRootActor(gracefulShutdown, abortJobsOnTerminate)
-    with CromwellApiService
+    with CromwellApiService with CromwellInstrumentationActor
     with SwaggerService
     with ActorLogging {
   implicit val actorSystem = context.system

--- a/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
@@ -78,6 +78,7 @@ object CromwellShutdown extends GracefulStopSupport {
                              actorSystem: ActorSystem,
                              workflowManagerActor: ActorRef,
                              logCopyRouter: ActorRef,
+                             jobTokenDispenser: ActorRef,
                              jobStoreActor: ActorRef,
                              workflowStoreActor: ActorRef,
                              subWorkflowStoreActor: ActorRef,
@@ -189,7 +190,7 @@ object CromwellShutdown extends GracefulStopSupport {
       * - DockerHashActor
       * - IoActor
     */
-    List(subWorkflowStoreActor, jobStoreActor, callCacheWriteActor, serviceRegistryActor, dockerHashActor, ioActor) foreach {
+    List(jobTokenDispenser, subWorkflowStoreActor, jobStoreActor, callCacheWriteActor, serviceRegistryActor, dockerHashActor, ioActor) foreach {
       shutdownActor(_, PhaseStopIoActivity, ShutdownCommand)
     }
 

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -2,7 +2,7 @@ package cromwell.webservice
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorRefFactory}
+import akka.actor.{Actor, ActorRef, ActorRefFactory}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallable}
 import akka.http.scaladsl.model._

--- a/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
@@ -32,7 +32,13 @@ object CromwellInstrumentation {
   }
 }
 
-trait CromwellInstrumentation { this: Actor =>
+trait CromwellInstrumentationActor extends CromwellInstrumentation { this: Actor =>
+  override def instrumentationSender: ActorRef = self
+}
+
+trait CromwellInstrumentation {
+  protected def instrumentationSender: ActorRef = ActorRef.noSender
+
   def serviceRegistryActor: ActorRef
   
   /**
@@ -55,7 +61,7 @@ trait CromwellInstrumentation { this: Actor =>
     * Increment the counter for the given bucket
     */
   protected final def count(path: InstrumentationPath, count: Long, prefix: Option[String] = None): Unit = {
-    serviceRegistryActor ! countMessage(path, count, prefix)
+    serviceRegistryActor.tell(countMessage(path, count, prefix), instrumentationSender)
   }
   
   /**
@@ -69,7 +75,7 @@ trait CromwellInstrumentation { this: Actor =>
     * Increment the counter for the given bucket
     */
   protected final def increment(path: InstrumentationPath, prefix: Option[String] = None): Unit = {
-    serviceRegistryActor ! incrementMessage(path, prefix)
+    serviceRegistryActor.tell(incrementMessage(path, prefix), instrumentationSender)
   }
 
   /**
@@ -83,7 +89,7 @@ trait CromwellInstrumentation { this: Actor =>
     * Set the bucket to the gauge value
     */
   protected final def sendGauge(path: InstrumentationPath, value: Long, prefix: Option[String] = None): Unit = {
-    serviceRegistryActor ! gaugeMessage(path, value, prefix)
+    serviceRegistryActor.tell(gaugeMessage(path, value, prefix), instrumentationSender)
   }
 
   /**
@@ -97,7 +103,7 @@ trait CromwellInstrumentation { this: Actor =>
     * Add a timing information for the given bucket
     */
   protected final def sendTiming(path: InstrumentationPath, duration: FiniteDuration, prefix: Option[String] = None) = {
-    serviceRegistryActor ! timingMessage(path, duration, prefix)
+    serviceRegistryActor.tell(timingMessage(path, duration, prefix), instrumentationSender)
   }
 }
 

--- a/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
@@ -32,7 +32,7 @@ object CromwellInstrumentation {
   }
 }
 
-trait CromwellInstrumentation {
+trait CromwellInstrumentation { this: Actor =>
   def serviceRegistryActor: ActorRef
   
   /**

--- a/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
@@ -1,5 +1,6 @@
 package cromwell.services.instrumentation
 
+import cats.data.NonEmptyVector
 import cromwell.core.actor.BatchActor
 import cromwell.services.instrumentation.CromwellInstrumentation.InstrumentationPath
 import cromwell.services.instrumentation.InstrumentedBatchActor.{QueueSizeTimerAction, QueueSizeTimerKey}
@@ -33,8 +34,8 @@ abstract class InstrumentedBatchActor[C](flushRate: FiniteDuration,
   
   protected def processInner(data: Vector[C]): Future[Int]
   
-  override protected final def process(data: Vector[C]) = {
-    val action = processInner(data)
+  override protected final def process(data: NonEmptyVector[C]) = {
+    val action = processInner(data.toVector)
     action foreach { n =>
       count(writePath, n.toLong, instrumentationPrefix)
     }

--- a/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
@@ -20,7 +20,7 @@ abstract class InstrumentedBatchActor[C](flushRate: FiniteDuration,
                                          batchSize: Int,
                                          instrumentationPath: InstrumentationPath,
                                          instrumentationPrefix: Option[String]) extends BatchActor[C](flushRate, batchSize) 
-  with CromwellInstrumentation {
+  with CromwellInstrumentationActor {
   private val writePath = instrumentationPath.::("write")
   private val queueSizePath = instrumentationPath.::("queue")
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -5,7 +5,7 @@ import cromwell.core.Dispatcher.ServiceDispatcher
 import cromwell.core.Mailbox.PriorityMailbox
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.services.MetadataServicesStore
-import cromwell.services.instrumentation.{CromwellInstrumentation, InstrumentedBatchActor}
+import cromwell.services.instrumentation.{CromwellInstrumentationActor, InstrumentedBatchActor}
 import cromwell.services.metadata.MetadataEvent
 import cromwell.services.metadata.MetadataService._
 
@@ -18,7 +18,7 @@ class WriteMetadataActor(override val batchSize: Int,
                          override val serviceRegistryActor: ActorRef)
   extends InstrumentedBatchActor[MetadataWriteAction](flushRate, batchSize,
     MetadataServiceActor.MetadataInstrumentationPrefix, InstrumentationPrefixes.ServicesPrefix) with ActorLogging with
-    MetadataDatabaseAccess with MetadataServicesStore with CromwellInstrumentation {
+    MetadataDatabaseAccess with MetadataServicesStore with CromwellInstrumentationActor {
 
   def commandToData(snd: ActorRef): PartialFunction[Any, MetadataWriteAction] = {
     case command: MetadataWriteAction => command

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
@@ -8,20 +8,20 @@ import com.google.api.services.genomics.Genomics
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
 import cromwell.backend.impl.jes.statuspolling.JesPollingActor._
 import cromwell.core.Dispatcher.BackendDispatcher
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric._
 
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
-import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 
 /**
   * Sends batched requests to JES as a worker to the JesApiQueryManager
   */
 class JesPollingActor(val pollingManager: ActorRef, val qps: Int Refined Positive, override val serviceRegistryActor: ActorRef) extends Actor with ActorLogging
-  with StatusPolling with RunCreation with CromwellInstrumentation {
+  with StatusPolling with RunCreation with CromwellInstrumentationActor {
   // The interval to delay between submitting each batch
   lazy val batchInterval = determineBatchInterval(qps)
   log.debug("JES batch polling interval is {}", batchInterval)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
@@ -7,8 +7,8 @@ import cromwell.backend.impl.jes.statuspolling.PapiInstrumentation._
 import cromwell.backend.instrumentation.BackendInstrumentation._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.filesystems.gcs.GoogleUtil
-import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
+import cromwell.services.instrumentation.CromwellInstrumentationActor
 
 object PapiInstrumentation {
   private val PapiKey = NonEmptyList.of("papi")

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
@@ -1,12 +1,13 @@
 package cromwell.backend.impl.jes.statuspolling
 
+import akka.actor.Actor
 import cats.data.NonEmptyList
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryFailed, JesRunCreationQuery, JesStatusPollQuery}
 import cromwell.backend.impl.jes.statuspolling.PapiInstrumentation._
 import cromwell.backend.instrumentation.BackendInstrumentation._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.filesystems.gcs.GoogleUtil
-import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationActor}
 import cromwell.services.instrumentation.CromwellInstrumentation._
 
 object PapiInstrumentation {
@@ -26,7 +27,7 @@ object PapiInstrumentation {
   }
 }
 
-trait PapiInstrumentation extends CromwellInstrumentation {
+trait PapiInstrumentation extends CromwellInstrumentationActor { this: Actor =>
   def pollSuccess() = increment(PapiPollKey.concat(SuccessKey))
   def runSuccess() = increment(PapiRunKey.concat(SuccessKey))
 


### PR DESCRIPTION
Throttles the JobStore read queries and KV queries.
This imposes a hard limit that might be too low: not more than 1 query at a time. It might be too low in which case we can simply put it behind a router to increase the number of concurrent queries.
The important part is that we control how many of those requests are being done compared to "just send them to slick as fast as you possibly can".
Because it uses the same queue mechanism as batching it also makes it easy to turn the queue size into a metric that we can use to control the system's load.

TODO:

- [ ] Assess impact on scale