### PR TITLE
Limit number of queued jobs per workflow

### DIFF
--- a/core/src/main/scala/cromwell/core/ExecutionStatus.scala
+++ b/core/src/main/scala/cromwell/core/ExecutionStatus.scala
@@ -2,7 +2,7 @@ package cromwell.core
 
 object ExecutionStatus extends Enumeration {
   type ExecutionStatus = Value
-  val NotStarted, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
+  val NotStarted, WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
   val TerminalStatuses = Set(Failed, Done, Aborted, Bypassed, Unstartable)
   val TerminalOrRetryableStatuses = TerminalStatuses + RetryableFailure
   val NonTerminalStatuses = values.diff(TerminalOrRetryableStatuses)
@@ -10,16 +10,17 @@ object ExecutionStatus extends Enumeration {
   implicit val ExecutionStatusOrdering = Ordering.by { status: ExecutionStatus =>
     status match {
       case NotStarted => 0
-      case QueuedInCromwell => 1
-      case Starting => 2
-      case Running => 3
-      case Aborting => 4
-      case Unstartable => 5
-      case Aborted => 6
-      case Bypassed => 7
-      case RetryableFailure => 8
-      case Failed => 9
-      case Done => 10
+      case WaitingForQueueSpace => 1
+      case QueuedInCromwell => 2
+      case Starting => 3
+      case Running => 4
+      case Aborting => 5
+      case Unstartable => 6
+      case Aborted => 7
+      case Bypassed => 8
+      case RetryableFailure => 9
+      case Failed => 10
+      case Done => 11
     }
   }
   

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -59,6 +59,11 @@ trait CallMetadataHelper {
 
     serviceRegistryActor ! PutMetadataAction(events)
   }
+  
+  def pushWaitingForQueueSpaceCallMetadata(jobKey: JobKey) = {
+    val event = MetadataEvent(metadataKeyForCall(jobKey, CallMetadataKeys.ExecutionStatus), MetadataValue(WaitingForQueueSpace))
+    serviceRegistryActor ! PutMetadataAction(event)
+  }
 
   def pushSuccessfulCallMetadata(jobKey: JobKey, returnCode: Option[Int], outputs: CallOutputs) = {
     val completionEvents = completedCallMetadataEvents(jobKey, ExecutionStatus.Done, returnCode)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -38,7 +38,7 @@ object WorkflowExecutionActorData {
     )
   }
 
-  final case class DataStoreUpdate(runnableKeys: List[JobKey], newData: WorkflowExecutionActorData)
+  final case class DataStoreUpdate(runnableKeys: List[JobKey], statusChanges: Map[JobKey, ExecutionStatus], newData: WorkflowExecutionActorData)
 }
 
 case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescriptor,
@@ -119,7 +119,7 @@ case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescript
   
   def executionStoreUpdate: DataStoreUpdate = {
     val update = executionStore.update
-    DataStoreUpdate(update.runnableKeys, this.copy(executionStore = update.updatedStore))
+    DataStoreUpdate(update.runnableKeys, update.statusChanges, this.copy(executionStore = update.updatedStore))
   }
 
   def done: Boolean = executionStore.isDone

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -248,6 +248,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
       key match {
         // Even if the key is runnable, if it's a call key and there's already too many queued jobs,
         // don't start it and mark it as WaitingForQueueSpace
+        // TODO maybe also limit the number of expression keys to run somehow ?
         case callKey: CallKey if runnable && queuedJobsAboveThreshold =>
           internalUpdates = internalUpdates + (callKey -> WaitingForQueueSpace)
           false
@@ -258,7 +259,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     // If the queued jobs are not above the threshold, use the nodes that are already waiting for queue space
     val runnableWaitingForQueueSpace = if (!queuedJobsAboveThreshold) keysWithStatus(WaitingForQueueSpace).toStream else Stream.empty[JobKey]
     
-    // Start with keys that are waiting for queue space as we now they're runnable already. Then filter the not started ones
+    // Start with keys that are waiting for queue space as we know they're runnable already. Then filter the not started ones
     val readyToStart = runnableWaitingForQueueSpace ++ keysWithStatus(NotStarted).toStream.filter(filterFunction)
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -41,14 +41,14 @@ object ExecutionStore {
         case _ => key.node.upstreamPorts forall { p => p.executionNode.isInStatus(chooseIndex(p), statusTable) }
       }
     }
-    
+
     def nonStartableOutputKeys: Set[JobKey] = key match {
       case scatterKey: ScatterKey => scatterKey.makeCollectors(0, scatterKey.node.scatterCollectionFunctionBuilder(List.empty)).toSet[JobKey]
       case conditionalKey: ConditionalKey => conditionalKey.collectors.toSet[JobKey]
       case _ => Set.empty[JobKey]
     }
   }
-  
+
   implicit class EnhancedOutputPort(val outputPort: OutputPort) extends AnyVal {
     /**
       * Node that should be considered to determine upstream dependencies
@@ -74,7 +74,7 @@ object ExecutionStore {
   }
 
   case class ExecutionStoreUpdate(runnableKeys: List[JobKey], updatedStore: ExecutionStore, statusChanges: Map[JobKey, ExecutionStatus])
-  
+
   def empty = ActiveExecutionStore(Map.empty[JobKey, ExecutionStatus], needsUpdate = false)
 
   def apply(callable: ExecutableCallable) = {
@@ -128,7 +128,7 @@ final case class SealedExecutionStore private[stores](private val statusStore: M
   * @param statusStore status of job keys
   * @param needsUpdate This is a boolean meant to tell the WEA whether or not it should call "update".
   *                    The idea is to avoid unnecessary calls to "update" which is an expansive method.
-  *                    
+  *
   *                    when true, something happened since the last update that could yield new runnable keys, so update should be called
   *                    when false, nothing happened between the last update and now that will yield different results so no need to call the update method
   */
@@ -150,7 +150,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     * Update key statuses and needsUpdate
     */
   protected def updateKeys(values: Map[JobKey, ExecutionStatus], needsUpdate: Boolean): ExecutionStore
-  
+
   /**
     * Update key statuses
     */
@@ -172,7 +172,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     * Resets the needsUpdate Boolean to false.
     */
   protected def withNeedsUpdateFalse: ExecutionStore
-  
+
   /*
     * Create 2 Tables, one for keys in done status and one for keys in terminal status.
     * A Table is nothing more than a Map[R, Map[C, V]], see Table trait for more details
@@ -225,17 +225,18 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     * Only computes the first MaxJobsToStartPerTick runnable keys.
     * In the process, identifies and updates the status of keys that are unstartable.
     * Returns an ExecutionStoreUpdate which is the list of runnable keys and an updated execution store.
-    * 
+    *
     * If needsUpdate, returns an empty list of runnable keys and this instance of the store.
-    * 
+    *
     * This method can expansive to run for very large workflows if needsUpdate is true.
     */
   def update: ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     // Also keep track of jobs that need to be updated to WaitingForQueueSpace
     var internalUpdates = Map.empty[JobKey, ExecutionStatus]
-    
-    def filterFunction(key: JobKey) = {
+
+    // Returns true if a key should be run now. Update its status if necessary
+    def filterFunction(key: JobKey): Boolean = {
       // A key is runnable if all its dependencies are Done
       val runnable = key.allDependenciesAreIn(doneStatus)
 
@@ -244,34 +245,35 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
         internalUpdates = internalUpdates ++ key.nonStartableOutputKeys.map(_ -> Unstartable) + (key -> Unstartable)
       }
 
-      // returns the runnable value for the filter
-      runnable
+      key match {
+        // Even if the key is runnable, if it's a call key and there's already too many queued jobs,
+        // don't start it and mark it as  WaitingForQueueSpace
+        case callKey: CallKey if runnable && queuedJobsAboveThreshold =>
+          internalUpdates = internalUpdates + (callKey -> WaitingForQueueSpace)
+          false
+        case _ => runnable
+      }
     }
 
-    // filter the keys that are runnable. In the process remember the ones that are unreachable
-    val readyToStart = (keysWithStatus(WaitingForQueueSpace).toStream ++ keysWithStatus(NotStarted).toStream).filter({
-      case callKey: CallKey if queuedJobsAboveThreshold =>
-        internalUpdates = internalUpdates + (callKey -> WaitingForQueueSpace)
-        false
-      case key => filterFunction(key)
-    })
+    // Start with keys that are waiting for queue space as we now they're runnable already. Then filter the not started ones
+    val readyToStart = keysWithStatus(WaitingForQueueSpace).toStream ++ keysWithStatus(NotStarted).toStream.filter(filterFunction)
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
     val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList
-    
+
     // Will be true if the result is truncated, in which case we'll need to do another pass later
     val truncated = keysToStartPlusOne.size > MaxJobsToStartPerTick
 
     // If we found unstartable keys, update their status, and set needsUpdate to true (it might unblock other keys)
     val updated = if (internalUpdates.nonEmpty) {
       updateKeys(internalUpdates, needsUpdate = true)
-    // If the list was truncated, set needsUpdate to true because we'll need to do this again to get the truncated keys
+      // If the list was truncated, set needsUpdate to true because we'll need to do this again to get the truncated keys
     } else if (truncated) {
       withNeedsUpdateTrue
-    // Otherwise we can reset it, nothing else will be runnable / unstartable until some new keys become terminal
+      // Otherwise we can reset it, nothing else will be runnable / unstartable until some new keys become terminal
     } else withNeedsUpdateFalse
-    
+
     // Only take the first ExecutionStore.MaxJobsToStartPerTick from the above list.
     ExecutionStoreUpdate(keysToStartPlusOne.take(MaxJobsToStartPerTick), updated, internalUpdates)
-  } else ExecutionStoreUpdate(List.empty, this)
+  } else ExecutionStoreUpdate(List.empty, this, Map.empty)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -4,7 +4,7 @@ import common.collections.Table
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import cromwell.core.ExecutionStatus._
-import cromwell.core.{ExecutionIndex, JobKey}
+import cromwell.core.{CallKey, ExecutionIndex, ExecutionStatus, JobKey}
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{apply => _}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStore._
@@ -104,8 +104,8 @@ final case class ActiveExecutionStore private[stores](private val statusStore: M
     this.copy(statusStore = statusStore ++ values, needsUpdate = needsUpdate)
   }
   override def seal: SealedExecutionStore = SealedExecutionStore(statusStore.filterNot(_._2 == NotStarted), needsUpdate)
-  override def withNeedsUpdateFalse: ExecutionStore = this.copy(needsUpdate = false)
-  override def withNeedsUpdateTrue: ExecutionStore = this.copy(needsUpdate = true)
+  override def withNeedsUpdateFalse: ExecutionStore = if (!needsUpdate) this else this.copy(needsUpdate = false)
+  override def withNeedsUpdateTrue: ExecutionStore = if (needsUpdate) this else this.copy(needsUpdate = true)
 }
 
 /**
@@ -139,6 +139,11 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
   def keyForNode(node: GraphNode): Option[JobKey] = {
     statusStore.keys collectFirst { case k if k.node eq node => k }
   }
+
+  /**
+    * Number of queued jobs
+    */
+  lazy val queuedJobs = store.get(ExecutionStatus.QueuedInCromwell).map(_.length).getOrElse(0)
 
   /**
     * Update key statuses and needsUpdate
@@ -227,19 +232,25 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
   def update: ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     var unstartables = Map.empty[JobKey, ExecutionStatus]
-
-    // filter the keys that are runnable. In the process remember the ones that are unreachable
-    val readyToStart = keysWithStatus(NotStarted).toStream.filter(key => {
+    val runCallNodes = queuedJobs < MaxJobsToStartPerTick
+    
+    def filterFunction(key: JobKey) = {
       // A key is runnable if all its dependencies are Done
       val runnable = key.allDependenciesAreIn(doneStatus)
-      
+
       // If the key is not runnable, but all its dependencies are in a terminal status, then it's unreachable
       if (!runnable && key.allDependenciesAreIn(terminalStatus)) {
         unstartables = unstartables ++ key.nonStartableOutputKeys.map(_ -> Unstartable) + (key -> Unstartable)
       }
-      
+
       // returns the runnable value for the filter
       runnable
+    }
+
+    // filter the keys that are runnable. In the process remember the ones that are unreachable
+    val readyToStart = keysWithStatus(NotStarted).toStream.filter({
+      case _: CallKey if !runCallNodes => false
+      case key => filterFunction(key)
     })
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
@@ -252,7 +263,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     val updated = if (unstartables.nonEmpty) {
       updateKeys(unstartables, needsUpdate = true)
     // If the list was truncated, set needsUpdate to true because we'll need to do this again to get the truncated keys
-    } else if (truncated) {
+    } else if (truncated || !runCallNodes) {
       withNeedsUpdateTrue
     // Otherwise we can reset it, nothing else will be runnable / unstartable until some new keys become terminal
     } else withNeedsUpdateFalse


### PR DESCRIPTION
This might be a bit controversial so feel free to seagull.

_What it does_: When looking for new nodes to run in a workflow, if there are more than 1000 call nodes in "Queued" state, don't start new call nodes (still execute other ones like ExpressionNodes etc...).
_Pro_: Reduce load by not starting too many jobs that won't be able to run for the moment anyway since there's already 1000+ queued (waiting for a token)
_Con_: Jobs stay in `NotStarted` state longer (this status is sent to metadata and is visible by users), even if they could technically be started as far as dependencies are concerned.