### PR TITLE
PAPI Updates

### DIFF
--- a/backend/src/main/scala/cromwell/backend/instrumentation/BackendInstrumentation.scala
+++ b/backend/src/main/scala/cromwell/backend/instrumentation/BackendInstrumentation.scala
@@ -1,5 +1,0 @@
-package cromwell.backend.instrumentation
-
-object BackendInstrumentation {
-  val BackendPrefix: Option[String] = Option("backend")
-}

--- a/core/src/main/scala/cromwell/core/instrumentation/InstrumentationPrefixes.scala
+++ b/core/src/main/scala/cromwell/core/instrumentation/InstrumentationPrefixes.scala
@@ -1,9 +1,10 @@
 package cromwell.core.instrumentation
 
 object InstrumentationPrefixes {
-  val ServicesPrefix: Option[String] = Option("services")
-  val WorkflowPrefix: Option[String] = Option("workflow")
+  val ApiPrefix: Option[String] = Option("rest-api")
+  val BackendPrefix: Option[String] = Option("backend")
   val JobPrefix: Option[String] = Option("job")
   val IoPrefix: Option[String] = Option("io")
-  val ApiPrefix: Option[String] = Option("rest-api")
+  val ServicesPrefix: Option[String] = Option("services")
+  val WorkflowPrefix: Option[String] = Option("workflow")
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -520,8 +520,8 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   private def writeFuturePreemptedAndUnexpectedRetryCounts(p: Int, ur: Int): Future[Unit] = {
     val updateRequests = Seq(
-      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.unexpectedRetryCountKey), ur.toString)),
-      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.preemptionCountKey), p.toString))
+      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.unexpectedRetryCountKey), Option(ur.toString))),
+      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.preemptionCountKey), Option(p.toString)))
     )
 
     makeKvRequest(updateRequests).map(_ => ())

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -18,7 +18,7 @@ import cromwell.backend.impl.jes.errors.FailedToDelocalizeFailure
 import cromwell.backend.impl.jes.io._
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.DoAbortRun
 import cromwell.backend.impl.jes.statuspolling.JesRunCreationClient.JobAbortedException
-import cromwell.backend.impl.jes.statuspolling.{JesRunCreationClient, JesStatusRequestClient}
+import cromwell.backend.impl.jes.statuspolling.{JesAbortClient, JesRunCreationClient, JesStatusRequestClient}
 import cromwell.backend.io.DirectoryFunctions
 import cromwell.backend.standard.{StandardAsyncExecutionActor, StandardAsyncExecutionActorParams, StandardAsyncJob}
 import cromwell.core._
@@ -83,7 +83,7 @@ object JesAsyncBackendJobExecutionActor {
 
 class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyncExecutionActorParams)
   extends BackendJobLifecycleActor with StandardAsyncExecutionActor with JesJobCachingActorHelper
-    with JesStatusRequestClient with JesRunCreationClient with KvClient {
+    with JesStatusRequestClient with JesRunCreationClient with JesAbortClient with KvClient {
 
   override lazy val ioCommandBuilder = GcsBatchCommandBuilder
 
@@ -134,7 +134,7 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   override def requestsAbortAndDiesImmediately: Boolean = false
 
-  override def receive: Receive = pollingActorClientReceive orElse runCreationClientReceive orElse kvClientReceive orElse super.receive
+  override def receive: Receive = pollingActorClientReceive orElse runCreationClientReceive orElse abortActorClientReceive orElse kvClientReceive orElse super.receive
 
   private def gcsAuthParameter: Option[JesInput] = {
     if (jesAttributes.auths.gcs.requiresAuthFile || dockerConfiguration.isDefined)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendSingletonActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendSingletonActor.scala
@@ -5,12 +5,13 @@ import cromwell.backend.BackendSingletonActorAbortWorkflow
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiQueryManagerRequest
 import cromwell.core.Dispatcher.BackendDispatcher
+import cromwell.core.Mailbox
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 
 final case class JesBackendSingletonActor(qps: Int Refined Positive, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
 
-  val jesApiQueryManager = context.actorOf(JesApiQueryManager.props(qps, serviceRegistryActor))
+  val jesApiQueryManager = context.actorOf(JesApiQueryManager.props(qps, serviceRegistryActor).withMailbox(Mailbox.PriorityMailbox), "PAPIQueryManager")
 
   override def receive = {
     case abort: BackendSingletonActorAbortWorkflow => jesApiQueryManager.forward(abort)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/Run.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.jes
 
+import com.google.api.client.http.HttpRequest
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model._
 import cromwell.backend.BackendJobDescriptor
@@ -75,9 +76,8 @@ final case class Run(job: StandardAsyncJob, genomicsInterface: Genomics) {
 
   def getOperationCommand = genomicsInterface.operations().get(job.jobId)
 
-  def abort(): Unit = {
+  def abortRequest(): HttpRequest = {
     val cancellationRequest: CancelOperationRequest = new CancelOperationRequest()
-    genomicsInterface.operations().cancel(job.jobId, cancellationRequest).execute
-    ()
+    genomicsInterface.operations().cancel(job.jobId, cancellationRequest).buildHttpRequest()
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
@@ -2,15 +2,18 @@ package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiAbortQueryFailed
-import cromwell.backend.impl.jes.statuspolling.RunAbort.JesAbortRequestSuccessful
+import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled}
 import cromwell.core.logging.JobLogging
 
 trait JesAbortClient { this: Actor with ActorLogging with JobLogging =>
   val pollingActor: ActorRef
 
   def abortActorClientReceive: Actor.Receive = {
-    case JesAbortRequestSuccessful(jobId) =>
+    case PAPIAbortRequestSuccessful(jobId) =>
       jobLogger.info(s"Successfully requested cancellation of $jobId")
+    // In this case we could immediately return an aborted handle and spare ourselves a d round of polling
+    case PAPIOperationAlreadyCancelled(jobId) =>
+      jobLogger.info(s"Operation $jobId was already cancelled")
     case JesApiAbortQueryFailed(jobId, e) =>
       jobLogger.error(s"Could not request cancellation of job $jobId", e)
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
@@ -1,0 +1,17 @@
+package cromwell.backend.impl.jes.statuspolling
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiAbortQueryFailed
+import cromwell.backend.impl.jes.statuspolling.RunAbort.JesAbortRequestSuccessful
+import cromwell.core.logging.JobLogging
+
+trait JesAbortClient { this: Actor with ActorLogging with JobLogging =>
+  val pollingActor: ActorRef
+
+  def abortActorClientReceive: Actor.Receive = {
+    case JesAbortRequestSuccessful(jobId) =>
+      jobLogger.info(s"Successfully requested cancellation of $jobId")
+    case JesApiAbortQueryFailed(jobId, e) =>
+      jobLogger.error(s"Could not request cancellation of job $jobId", e)
+  }
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
@@ -40,16 +40,16 @@ class JesPollingActor(val pollingManager: ActorRef, val qps: Int Refined Positiv
       scheduleCheckForWork()
   }
 
-  private def handleBatch(workBatch: NonEmptyList[JesApiQuery]): Future[List[Try[Unit]]] = {
+  private def handleBatch(workBatch: NonEmptyList[PAPIApiRequest]): Future[List[Try[Unit]]] = {
     // Assume that the auth for the first element is also good enough for everything else:
     val batch: BatchRequest = createBatch(workBatch.head.genomicsInterface)
 
     // Create the batch:
     // WARNING: These call change 'batch' as a side effect. Things might go awry if map runs items in parallel?
     val batchFutures = workBatch map {
-      case pollingRequest: JesStatusPollQuery => enqueueStatusPollInBatch(pollingRequest, batch)
-      case runCreationRequest: JesRunCreationQuery => enqueueRunCreationInBatch(runCreationRequest, batch)
-      case abortRequest: JesAbortQuery => enqueueAbortInBatch(abortRequest, batch)
+      case pollingRequest: PAPIStatusPollRequest => enqueueStatusPollInBatch(pollingRequest, batch)
+      case runCreationRequest: PAPIRunCreationRequest => enqueueRunCreationInBatch(runCreationRequest, batch)
+      case abortRequest: PAPIAbortRequest => enqueueAbortInBatch(abortRequest, batch)
 
       // We do the "successful Failure" thing so that the Future.sequence doesn't short-out immediately when the first one fails.
       case other => Future.successful(Failure(new RuntimeException(s"Cannot handle ${other.getClass.getSimpleName} requests")))

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActor.scala
@@ -21,10 +21,10 @@ import scala.util.{Failure, Success, Try}
   * Sends batched requests to JES as a worker to the JesApiQueryManager
   */
 class JesPollingActor(val pollingManager: ActorRef, val qps: Int Refined Positive, override val serviceRegistryActor: ActorRef) extends Actor with ActorLogging
-  with StatusPolling with RunCreation with CromwellInstrumentationActor {
+  with StatusPolling with RunCreation with RunAbort with CromwellInstrumentationActor {
   // The interval to delay between submitting each batch
   lazy val batchInterval = determineBatchInterval(qps)
-  log.debug("JES batch polling interval is {}", batchInterval)
+  log.info("JES batch polling interval is {}", batchInterval)
 
   self ! NoWorkToDo // Starts the check-for-work cycle when the actor is fully initialized.
 
@@ -49,6 +49,7 @@ class JesPollingActor(val pollingManager: ActorRef, val qps: Int Refined Positiv
     val batchFutures = workBatch map {
       case pollingRequest: JesStatusPollQuery => enqueueStatusPollInBatch(pollingRequest, batch)
       case runCreationRequest: JesRunCreationQuery => enqueueRunCreationInBatch(runCreationRequest, batch)
+      case abortRequest: JesAbortQuery => enqueueAbortInBatch(abortRequest, batch)
 
       // We do the "successful Failure" thing so that the Future.sequence doesn't short-out immediately when the first one fails.
       case other => Future.successful(Failure(new RuntimeException(s"Cannot handle ${other.getClass.getSimpleName} requests")))
@@ -107,13 +108,10 @@ object JesPollingActor {
     * Given the Genomics API queries per 100 seconds and given MaxBatchSize will determine a batch interval which
     * is at 90% of the quota. The (still crude) delta is to provide some room at the edges for things like new
     * calls, etc.
-    *
-    * Forcing the minimum value to be 1 second, for now it seems unlikely to matter and it makes testing a bit
-    * easier
     */
   def determineBatchInterval(qps: Int Refined Positive): FiniteDuration = {
-    val maxInterval = MaxBatchSize / qps.value
-    val interval = Math.max(maxInterval / 0.9, 1).toInt
-    interval.seconds
+    val maxInterval = MaxBatchSize.toDouble / qps.value.toDouble
+    val interval = ((maxInterval / 0.9) * 1000).toInt
+    interval.milliseconds
   }
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesRunCreationClient.scala
@@ -3,7 +3,7 @@ package cromwell.backend.impl.jes.statuspolling
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.RunPipelineRequest
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiException, JesApiRunCreationQueryFailed}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{PAPIApiException, JesApiRunCreationQueryFailed}
 import cromwell.backend.standard.StandardAsyncJob
 import cromwell.core.WorkflowId
 
@@ -16,7 +16,7 @@ object JesRunCreationClient {
     * Exception used to represent the fact that a job was aborted before a creation attempt was made.
     * Meaning it was in the queue when the abort request was made, so it was just removed from the queue.
     */
-  case object JobAbortedException extends JesApiException(new Exception("The job was removed from the queue before a PAPI creation request was made"))
+  case object JobAbortedException extends PAPIApiException(new Exception("The job was removed from the queue before a PAPI creation request was made"))
 }
 
 /**

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
@@ -2,10 +2,10 @@ package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.Actor
 import cats.data.NonEmptyList
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiQueryFailed, JesRunCreationQuery, JesStatusPollQuery}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesAbortQuery, JesApiQueryFailed, JesRunCreationQuery, JesStatusPollQuery}
 import cromwell.backend.impl.jes.statuspolling.PapiInstrumentation._
-import cromwell.backend.instrumentation.BackendInstrumentation._
 import cromwell.core.instrumentation.InstrumentationKeys._
+import cromwell.core.instrumentation.InstrumentationPrefixes._
 import cromwell.filesystems.gcs.GoogleUtil
 import cromwell.services.instrumentation.CromwellInstrumentation._
 import cromwell.services.instrumentation.CromwellInstrumentationActor
@@ -14,12 +14,15 @@ object PapiInstrumentation {
   private val PapiKey = NonEmptyList.of("papi")
   private val PapiPollKey = PapiKey.concat("poll")
   private val PapiRunKey = PapiKey.concat("run")
-  
+  private val PapiAbortKey = PapiKey.concat("run")
+
   private val PapiPollFailedKey = PapiPollKey.concat(FailureKey)
   private val PapiRunFailedKey = PapiRunKey.concat(FailureKey)
+  private val PapiAbortFailedKey = PapiAbortKey.concat(FailureKey)
   private val PapiPollRetriedKey = PapiPollKey.concat(RetryKey)
   private val PapiRunRetriedKey = PapiRunKey.concat(RetryKey)
-  
+  private val PapiAbortRetriedKey = PapiAbortKey.concat(RetryKey)
+
   implicit class StatsDPathGoogleEnhanced(val statsDPath: InstrumentationPath) extends AnyVal {
     def withGoogleThrowable(failure: Throwable) = {
       statsDPath.withThrowable(failure, GoogleUtil.extractStatusCode)
@@ -28,18 +31,21 @@ object PapiInstrumentation {
 }
 
 trait PapiInstrumentation extends CromwellInstrumentationActor { this: Actor =>
-  def pollSuccess() = increment(PapiPollKey.concat(SuccessKey))
-  def runSuccess() = increment(PapiRunKey.concat(SuccessKey))
+  def pollSuccess() = increment(PapiPollKey.concat(SuccessKey), BackendPrefix)
+  def runSuccess() = increment(PapiRunKey.concat(SuccessKey), BackendPrefix)
+  def abortSuccess() = increment(PapiAbortKey.concat(SuccessKey), BackendPrefix)
 
   def failedQuery(failedQuery: JesApiQueryFailed) = failedQuery.query match {
     case _: JesStatusPollQuery => increment(PapiPollFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
     case _: JesRunCreationQuery => increment(PapiRunFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: JesAbortQuery => increment(PapiAbortFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
   }
 
   def retriedQuery(failedQuery: JesApiQueryFailed) = failedQuery.query match {
     case _: JesStatusPollQuery => increment(PapiPollRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
     case _: JesRunCreationQuery => increment(PapiRunRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: JesAbortQuery => increment(PapiAbortRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
   }
-  
+
   def updateQueueSize(size: Int) = sendGauge(PapiKey.concat("queue_size"), size.toLong, BackendPrefix)
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
@@ -2,7 +2,7 @@ package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.Actor
 import cats.data.NonEmptyList
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesAbortQuery, JesApiQueryFailed, JesRunCreationQuery, JesStatusPollQuery}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{PAPIAbortRequest, PAPIApiRequestFailed, PAPIRunCreationRequest, PAPIStatusPollRequest}
 import cromwell.backend.impl.jes.statuspolling.PapiInstrumentation._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
@@ -35,16 +35,16 @@ trait PapiInstrumentation extends CromwellInstrumentationActor { this: Actor =>
   def runSuccess() = increment(PapiRunKey.concat(SuccessKey), BackendPrefix)
   def abortSuccess() = increment(PapiAbortKey.concat(SuccessKey), BackendPrefix)
 
-  def failedQuery(failedQuery: JesApiQueryFailed) = failedQuery.query match {
-    case _: JesStatusPollQuery => increment(PapiPollFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
-    case _: JesRunCreationQuery => increment(PapiRunFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
-    case _: JesAbortQuery => increment(PapiAbortFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+  def failedQuery(failedQuery: PAPIApiRequestFailed) = failedQuery.query match {
+    case _: PAPIStatusPollRequest => increment(PapiPollFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: PAPIRunCreationRequest => increment(PapiRunFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: PAPIAbortRequest => increment(PapiAbortFailedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
   }
 
-  def retriedQuery(failedQuery: JesApiQueryFailed) = failedQuery.query match {
-    case _: JesStatusPollQuery => increment(PapiPollRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
-    case _: JesRunCreationQuery => increment(PapiRunRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
-    case _: JesAbortQuery => increment(PapiAbortRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+  def retriedQuery(failedQuery: PAPIApiRequestFailed) = failedQuery.query match {
+    case _: PAPIStatusPollRequest => increment(PapiPollRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: PAPIRunCreationRequest => increment(PapiRunRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
+    case _: PAPIAbortRequest => increment(PapiAbortRetriedKey.withGoogleThrowable(failedQuery.cause.e), BackendPrefix)
   }
 
   def updateQueueSize(size: Int) = sendGauge(PapiKey.concat("queue_size"), size.toLong, BackendPrefix)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/PapiInstrumentation.scala
@@ -14,7 +14,7 @@ object PapiInstrumentation {
   private val PapiKey = NonEmptyList.of("papi")
   private val PapiPollKey = PapiKey.concat("poll")
   private val PapiRunKey = PapiKey.concat("run")
-  private val PapiAbortKey = PapiKey.concat("run")
+  private val PapiAbortKey = PapiKey.concat("abort")
 
   private val PapiPollFailedKey = PapiPollKey.concat(FailureKey)
   private val PapiRunFailedKey = PapiRunKey.concat(FailureKey)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
@@ -6,7 +6,7 @@ import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonErrorCo
 import com.google.api.client.http.{HttpHeaders, HttpRequest}
 import com.google.api.services.genomics.model.Operation
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
-import cromwell.backend.impl.jes.statuspolling.RunAbort.JesAbortRequestSuccessful
+import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -16,7 +16,7 @@ private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPol
   private def abortResultHandler(originalRequest: PAPIAbortRequest, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
     override def onSuccess(operation: Operation, responseHeaders: HttpHeaders): Unit = {
       abortSuccess()
-      originalRequest.requester ! getJob(operation)
+      originalRequest.requester ! PAPIAbortRequestSuccessful(operation.getName)
       completionPromise.trySuccess(Success(()))
       ()
     }
@@ -24,7 +24,7 @@ private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPol
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
       // No need to fail the request if the job was already cancelled, we're all good
       if (Option(e.getCode).contains(400) && Option(e.getMessage).contains("Operation has already been canceled")) {
-        originalRequest.requester ! JesAbortRequestSuccessful(originalRequest.run.job.jobId)
+        originalRequest.requester ! PAPIOperationAlreadyCancelled(originalRequest.run.job.jobId)
         completionPromise.trySuccess(Success(()))
       } else {
         pollingManager ! JesApiAbortQueryFailed(originalRequest, new PAPIApiException(GoogleJsonException(e, responseHeaders)))
@@ -50,10 +50,10 @@ private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPol
     batch.queue(request, classOf[Operation], classOf[GoogleJsonErrorContainer], resultHandler)
     ()
   }
-
-  private def getJob(operation: Operation) = JesAbortRequestSuccessful(operation.getName)
 }
 
 object RunAbort {
-  case class JesAbortRequestSuccessful(operationId: String)
+  sealed trait PAPIAbortRequestSuccess
+  case class PAPIAbortRequestSuccessful(operationId: String) extends PAPIAbortRequestSuccess
+  case class PAPIOperationAlreadyCancelled(operationId: String) extends PAPIAbortRequestSuccess
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
@@ -1,0 +1,48 @@
+package cromwell.backend.impl.jes.statuspolling
+
+import com.google.api.client.googleapis.batch.BatchRequest
+import com.google.api.client.googleapis.batch.json.JsonBatchCallback
+import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonErrorContainer}
+import com.google.api.client.http.{HttpHeaders, HttpRequest}
+import com.google.api.services.genomics.model.Operation
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
+import cromwell.backend.standard.StandardAsyncJob
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success, Try}
+
+private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPollingActor =>
+
+  private def abortResultHandler(originalRequest: JesApiQuery, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
+    override def onSuccess(operation: Operation, responseHeaders: HttpHeaders): Unit = {
+      abortSuccess()
+      originalRequest.requester ! getJob(operation)
+      completionPromise.trySuccess(Success(()))
+      ()
+    }
+
+    override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
+      pollingManager ! JesApiAbortQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
+      ()
+    }
+  }
+
+  def enqueueAbortInBatch(abortQuery: JesAbortQuery, batch: BatchRequest): Future[Try[Unit]] = {
+    val completionPromise = Promise[Try[Unit]]()
+    val resultHandler = abortResultHandler(abortQuery, completionPromise)
+    addAbortToBatch(abortQuery.httpRequest, batch, resultHandler)
+    completionPromise.future
+  }
+
+  private def addAbortToBatch(request: HttpRequest, batch: BatchRequest, resultHandler: JsonBatchCallback[Operation]): Unit = {
+    /*
+      * Manually enqueue the request instead of doing it through the RunPipelineRequest
+      * as it would unnecessarily rebuild the request (which we already have)
+     */
+    batch.queue(request, classOf[Operation], classOf[GoogleJsonErrorContainer], resultHandler)
+    ()
+  }
+
+  private def getJob(operation: Operation) = StandardAsyncJob(operation.getName)
+}

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunCreation.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 
 private[statuspolling] trait RunCreation extends PapiInstrumentation { this: JesPollingActor =>
 
-  private def runCreationResultHandler(originalRequest: JesApiQuery, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
+  private def runCreationResultHandler(originalRequest: PAPIApiRequest, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
     override def onSuccess(operation: Operation, responseHeaders: HttpHeaders): Unit = {
       runSuccess()
       originalRequest.requester ! getJob(operation)
@@ -22,13 +22,13 @@ private[statuspolling] trait RunCreation extends PapiInstrumentation { this: Jes
     }
 
     override def onFailure(e: GoogleJsonError, responseHeaders: HttpHeaders): Unit = {
-      pollingManager ! JesApiRunCreationQueryFailed(originalRequest, new JesApiException(GoogleJsonException(e, responseHeaders)))
+      pollingManager ! JesApiRunCreationQueryFailed(originalRequest, new PAPIApiException(GoogleJsonException(e, responseHeaders)))
       completionPromise.trySuccess(Failure(new Exception(mkErrorString(e))))
       ()
     }
   }
 
-  def enqueueRunCreationInBatch(runCreationQuery: JesRunCreationQuery, batch: BatchRequest): Future[Try[Unit]] = {
+  def enqueueRunCreationInBatch(runCreationQuery: PAPIRunCreationRequest, batch: BatchRequest): Future[Try[Unit]] = {
     val completionPromise = Promise[Try[Unit]]()
     val resultHandler = runCreationResultHandler(runCreationQuery, completionPromise)
     addRunCreationToBatch(runCreationQuery.httpRequest, batch, resultHandler)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -176,8 +176,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
         val key = BackendJobDescriptorKey(job, None, attempt)
         val runtimeAttributes = makeRuntimeAttributes(job)
         val prefetchedKvEntries = Map(
-          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), Some(previousPreemptions.toString)),
-          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), Some(previousUnexpectedRetries.toString)))
+          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), previousPreemptions.toString),
+          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), previousUnexpectedRetries.toString))
         BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(Inputs), NoDocker, prefetchedKvEntries)
       case Left(badtimes) => fail(badtimes.toList.mkString(", "))
     }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -176,8 +176,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
         val key = BackendJobDescriptorKey(job, None, attempt)
         val runtimeAttributes = makeRuntimeAttributes(job)
         val prefetchedKvEntries = Map(
-          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), previousPreemptions.toString),
-          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), previousUnexpectedRetries.toString))
+          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), Some(previousPreemptions.toString)),
+          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), Some(previousUnexpectedRetries.toString)))
         BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(Inputs), NoDocker, prefetchedKvEntries)
       case Left(badtimes) => fail(badtimes.toList.mkString(", "))
     }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
@@ -184,6 +184,13 @@ class TestJesApiQueryManager(qps: Int Refined Positive, createRequestSize: Long,
     testProbes = Queue(statusPollerProbes: _*)
     testPollerCreations = 0
   }
+  
+  override private[statuspolling] lazy val nbWorkers = 1
+  override private[statuspolling] def resetAllWorkers() = {
+    val pollers = Array.fill(1) { makeWorkerActor() }
+    pollers.foreach(context.watch)
+    pollers
+  }
 
   override private[statuspolling] def makeCreateQuery(workflowId: WorkflowId, replyTo: ActorRef, genomics: Genomics, rpr: RunPipelineRequest) = {
     new JesRunCreationQuery(workflowId, replyTo, genomics, rpr) {
@@ -213,7 +220,7 @@ class TestJesApiQueryManager(qps: Int Refined Positive, createRequestSize: Long,
   }
 
   def queueSize = workQueue.size
-  def statusPollerEquals(otherStatusPoller: ActorRef) = statusPoller == otherStatusPoller
+  def statusPollerEquals(otherStatusPoller: ActorRef) = statusPollers sameElements Array(otherStatusPoller)
 }
 
 object TestJesApiQueryManager {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.{TestActorRef, TestProbe, _}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.RunPipelineRequest
 import cromwell.backend.BackendSingletonActorAbortWorkflow
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiRunCreationQueryFailed, JesRunCreationQuery, JesStatusPollQuery}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiRunCreationQueryFailed, PAPIRunCreationRequest, PAPIStatusPollRequest}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManagerSpec._
 import cromwell.backend.impl.jes.{JesConfiguration, Run}
 import cromwell.backend.standard.StandardAsyncJob
@@ -60,7 +60,7 @@ class JesApiQueryManagerSpec extends TestKitSuite("JesApiQueryManagerSpec") with
           val zippedWithRequesters = workBatch.toList.zip(requesters)
           zippedWithRequesters foreach { case (pollQuery, (index, testProbe)) =>
             pollQuery.requester should be(testProbe.ref)
-            pollQuery.asInstanceOf[JesStatusPollQuery].run.job should be(StandardAsyncJob(index.toString))
+            pollQuery.asInstanceOf[PAPIStatusPollRequest].run.job should be(StandardAsyncJob(index.toString))
           }
         case other => fail(s"Unexpected message: $other")
       }
@@ -161,7 +161,7 @@ class JesApiQueryManagerSpec extends TestKitSuite("JesApiQueryManagerSpec") with
     // It should remove all and only run requests for workflow A 
     eventually {
       jaqmActor.underlyingActor.queueSize shouldBe 1
-      jaqmActor.underlyingActor.workQueue.head.asInstanceOf[JesApiQueryManager.JesRunCreationQuery].workflowId shouldBe workflowIdB
+      jaqmActor.underlyingActor.workQueue.head.asInstanceOf[JesApiQueryManager.PAPIRunCreationRequest].workflowId shouldBe workflowIdB
     }
   }
 }
@@ -193,13 +193,13 @@ class TestJesApiQueryManager(qps: Int Refined Positive, createRequestSize: Long,
   }
 
   override private[statuspolling] def makeCreateQuery(workflowId: WorkflowId, replyTo: ActorRef, genomics: Genomics, rpr: RunPipelineRequest) = {
-    new JesRunCreationQuery(workflowId, replyTo, genomics, rpr) {
+    new PAPIRunCreationRequest(workflowId, replyTo, genomics, rpr) {
       override def contentLength = createRequestSize
     }
   }
 
   override private[statuspolling] def makePollQuery(workflowId: WorkflowId, replyTo: ActorRef, run: Run) = {
-    new JesStatusPollQuery(workflowId, replyTo, run) {
+    new PAPIStatusPollRequest(workflowId, replyTo, run) {
       override def contentLength = 0
     }
   }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
@@ -187,7 +187,7 @@ class TestJesApiQueryManager(qps: Int Refined Positive, createRequestSize: Long,
   
   override private[statuspolling] lazy val nbWorkers = 1
   override private[statuspolling] def resetAllWorkers() = {
-    val pollers = Array.fill(1) { makeWorkerActor() }
+    val pollers = Vector.fill(1) { makeWorkerActor() }
     pollers.foreach(context.watch)
     pollers
   }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
@@ -41,8 +41,8 @@ class JesPollingActorSpec extends TestKitSuite("JesPollingActor") with FlatSpecL
 
   it should "correctly calculate batch intervals" in {
     import eu.timepit.refined.auto._
-    JesPollingActor.determineBatchInterval(10) should be(11.seconds)
-    JesPollingActor.determineBatchInterval(100000) shouldBe 1.seconds
+    JesPollingActor.determineBatchInterval(10) should be(11111.milliseconds)
+    JesPollingActor.determineBatchInterval(100000) shouldBe 1.millisecond
   }
 
   it should "query for work and wait for a reply" in {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
@@ -9,7 +9,7 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpRequest
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model.Operation
-import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{JesApiException, JesApiQueryFailed, JesStatusPollQuery, RequestJesPollingWork}
+import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.{PAPIApiException, PAPIApiRequestFailed, PAPIStatusPollRequest, RequestJesPollingWork}
 import cromwell.backend.impl.jes.statuspolling.TestJesPollingActor.{CallbackFailure, CallbackSuccess, JesBatchCallbackResponse}
 import cromwell.backend.impl.jes.{JesConfiguration, Run, RunStatus}
 import cromwell.core.{ExecutionEvent, TestKitSuite}
@@ -54,11 +54,11 @@ class JesPollingActorSpec extends TestKitSuite("JesPollingActor") with FlatSpecL
     managerProbe.expectMsgClass(max = TestExecutionTimeout, c = classOf[JesApiQueryManager.RequestJesPollingWork])
 
     val requester1 = TestProbe()
-    val query1 = JesStatusPollQuery(null, requester1.ref, Run(null, null))
+    val query1 = PAPIStatusPollRequest(null, requester1.ref, Run(null, null))
     val requester2 = TestProbe()
-    val query2 = JesStatusPollQuery(null, requester2.ref, Run(null, null))
+    val query2 = PAPIStatusPollRequest(null, requester2.ref, Run(null, null))
     val requester3 = TestProbe()
-    val query3 = JesStatusPollQuery(null, requester3.ref, Run(null, null))
+    val query3 = PAPIStatusPollRequest(null, requester3.ref, Run(null, null))
 
     // For two requests the callback succeeds (first with RunStatus.Success, then RunStatus.Failed). The third callback fails (simulating a network timeout, for example):
     jpActor.underlyingActor.callbackResponses :+= CallbackSuccess
@@ -86,8 +86,8 @@ class JesPollingActorSpec extends TestKitSuite("JesPollingActor") with FlatSpecL
 
     // Requester3 expected nothing... Instead, the manager expects an API failure notification and then a request for more work:
     managerProbe.expectMsgPF(TestExecutionTimeout) {
-      case failure: JesApiQueryFailed =>
-        if (!failure.cause.isInstanceOf[JesApiException]) fail("Unexpected failure cause class: " + failure.cause.getClass.getSimpleName)
+      case failure: PAPIApiRequestFailed =>
+        if (!failure.cause.isInstanceOf[PAPIApiException]) fail("Unexpected failure cause class: " + failure.cause.getClass.getSimpleName)
         if (failure.query != query2 && failure.query != query3) fail("Unexpected query caused failure: " + failure.query)
     }
     managerProbe.expectMsg(RequestJesPollingWork(JesPollingActor.MaxBatchSize))
@@ -127,7 +127,7 @@ class TestJesPollingActor(manager: ActorRef, qps: Int Refined Positive, registry
     }}
   }
 
-  override private [statuspolling] def enqueueStatusPollInBatch(pollingRequest: JesStatusPollQuery, batch: BatchRequest): Future[Try[Unit]] = {
+  override private [statuspolling] def enqueueStatusPollInBatch(pollingRequest: PAPIStatusPollRequest, batch: BatchRequest): Future[Try[Unit]] = {
     val completionPromise = Promise[Try[Unit]]()
     val resultHandler = statusPollResultHandler(pollingRequest, completionPromise)
     addStatusPollToBatch(null, batch, resultHandler)


### PR DESCRIPTION
- Send abort requests through the `JesAPIQueryManager`. This is wanted because currently each JABJEA aborts on its own which has undesired consequences, like flooding the backend thread pool with blocking requests.
- Lift the "1 second" maximum limit of the `JesPollingActor` by switching to milliseconds (new limit is 1 millisecond)
- Add a second `JesPollingActor` to help with throughput of PAPI requests