### PR TITLE
 Type evaluators

### DIFF
--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/BinaryOperatorEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/BinaryOperatorEvaluators.scala
@@ -1,0 +1,36 @@
+package wdl.draft3.transforms.linking.expression.types
+
+import common.validation.ErrorOr.ErrorOr
+import common.validation.ErrorOr._
+
+import common.validation.Validation._
+import wdl.model.draft3.elements.ExpressionElement._
+import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
+import wdl.model.draft3.graph.expression.TypeEvaluator
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
+import wom.types.WomType
+
+import scala.util.Try
+
+object BinaryOperatorEvaluators {
+  implicit val logicalOrEvaluator: TypeEvaluator[LogicalOr] = forOperation(_.or(_))
+  implicit val logicalAndEvaluator: TypeEvaluator[LogicalAnd] = forOperation(_.and(_))
+  implicit val equalsEvaluator: TypeEvaluator[Equals] = forOperation(_.equalsType(_))
+  implicit val notEqualsEvaluator: TypeEvaluator[NotEquals] = forOperation(_.notEquals(_))
+  implicit val lessThanEvaluator: TypeEvaluator[LessThan] = forOperation(_.lessThan(_))
+  implicit val lessThanOrEqualEvaluator: TypeEvaluator[LessThanOrEquals] = forOperation(_.lessThanOrEqual(_))
+  implicit val greaterThanEvaluator: TypeEvaluator[GreaterThan] = forOperation(_.greaterThan(_))
+  implicit val greaterThanOrEqualEvaluator: TypeEvaluator[GreaterThanOrEquals] = forOperation(_.greaterThanOrEqual(_))
+  implicit val addEvaluator: TypeEvaluator[Add] = forOperation(_.add(_))
+  implicit val subtractEvaluator: TypeEvaluator[Subtract] = forOperation(_.subtract(_))
+  implicit val multiplyEvaluator: TypeEvaluator[Multiply] = forOperation(_.multiply(_))
+  implicit val divideEvaluator: TypeEvaluator[Divide] = forOperation(_.divide(_))
+  implicit val remainderEvaluator: TypeEvaluator[Remainder] = forOperation(_.mod(_))
+
+  private def forOperation[A <: BinaryOperation](op: (WomType, WomType) => Try[WomType]) = new TypeEvaluator[A] {
+    override def evaluateType(a: A, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      (a.left.evaluateType(linkedValues),
+        a.right.evaluateType(linkedValues)) flatMapN { (left, right) => op(left, right).toErrorOr }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LiteralEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LiteralEvaluators.scala
@@ -1,0 +1,64 @@
+package wdl.draft3.transforms.linking.expression.types
+
+import cats.syntax.apply._
+import cats.syntax.validated._
+import cats.syntax.traverse._
+import cats.instances.list._
+import common.validation.ErrorOr.ErrorOr
+import wdl.model.draft3.elements.ExpressionElement
+import wdl.model.draft3.elements.ExpressionElement._
+import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
+import wdl.model.draft3.graph.expression.TypeEvaluator
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
+import wom.types._
+
+object LiteralEvaluators {
+  implicit val primitiveTypeEvaluator: TypeEvaluator[PrimitiveLiteralExpressionElement] = new TypeEvaluator[PrimitiveLiteralExpressionElement] {
+    override def evaluateType(a: PrimitiveLiteralExpressionElement, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = a.value.womType.validNel
+  }
+
+  implicit val objectLiteralTypeEvaluator: TypeEvaluator[ObjectLiteral] = new TypeEvaluator[ObjectLiteral] {
+    override def evaluateType(a: ObjectLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = WomObjectType.validNel
+  }
+
+  implicit val stringLiteralTypeEvaluator: TypeEvaluator[StringLiteral] = new TypeEvaluator[StringLiteral] {
+    override def evaluateType(a: StringLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = WomStringType.validNel
+  }
+
+  implicit val stringExpressionTypeEvaluator: TypeEvaluator[StringExpression] = new TypeEvaluator[StringExpression] {
+    override def evaluateType(a: StringExpression, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = WomStringType.validNel
+  }
+
+  implicit val mapLiteralTypeEvaluator: TypeEvaluator[MapLiteral] = new TypeEvaluator[MapLiteral] {
+    override def evaluateType(a: MapLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+
+      val keyTypes = a.elements.keySet.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val commonKeyType: ErrorOr[WomType] = keyTypes.map(WomType.homogeneousTypeFromTypes)
+
+      val valueTypes = a.elements.keySet.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val commonValueType: ErrorOr[WomType] = valueTypes.map(WomType.homogeneousTypeFromTypes)
+
+      (commonKeyType, commonValueType) mapN { (k, v) => WomMapType(k, v) }
+    }
+  }
+
+  implicit val arrayLiteralTypeEvaluator: TypeEvaluator[ArrayLiteral] = new TypeEvaluator[ArrayLiteral] {
+    override def evaluateType(a: ArrayLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+
+      val types = a.elements.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val commonType: ErrorOr[WomType] = types.map(WomType.homogeneousTypeFromTypes)
+
+      commonType.map(WomArrayType.apply(_, guaranteedNonEmpty = a.elements.nonEmpty))
+    }
+  }
+
+  implicit val pairLiteralTypeEvaluator: TypeEvaluator[PairLiteral] = new TypeEvaluator[PairLiteral] {
+    override def evaluateType(a: PairLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+
+      val leftType = a.left.evaluateType(linkedValues)
+      val rightType = a.right.evaluateType(linkedValues)
+
+      (leftType, rightType) mapN { (l, r) => WomPairType(l, r) }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LookupEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LookupEvaluators.scala
@@ -64,6 +64,7 @@ object LookupEvaluators {
       case WomObjectType => WomAnyType.validNel
       case WomPairType(left, _) if key == "left" => left.validNel
       case WomPairType(_, right) if key == "right" => right.validNel
+      case WomAnyType => WomAnyType.validNel
       case _ => s"No such field '$key' on type ${womType.toDisplayString}. Report this bug! Static validation failed.".invalidNel
     }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/TernaryIfEvaluator.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/TernaryIfEvaluator.scala
@@ -1,0 +1,24 @@
+package wdl.draft3.transforms.linking.expression.types
+
+import cats.syntax.apply._
+import cats.syntax.validated._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.ErrorOr._
+import wdl.model.draft3.elements.ExpressionElement._
+import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
+import wdl.model.draft3.graph.expression.TypeEvaluator
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
+import wom.types.{WomBooleanType, WomType}
+
+object TernaryIfEvaluator {
+  implicit val ternaryIfEvaluator: TypeEvaluator[TernaryIf] = new TypeEvaluator[TernaryIf] {
+    override def evaluateType(a: TernaryIf, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.condition.evaluateType(linkedValues) flatMap {
+        case WomBooleanType =>
+          (a.ifTrue.evaluateType(linkedValues): ErrorOr[WomType],
+            a.ifFalse.evaluateType(linkedValues): ErrorOr[WomType]) mapN { (tType, fType) => WomType.homogeneousTypeFromTypes(Seq(tType, fType)) }
+        case other => s"Condition should have evaluated to a Boolean but instead got ${other.toDisplayString}".invalidNel
+      }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/UnaryOperatorEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/UnaryOperatorEvaluators.scala
@@ -1,0 +1,25 @@
+package wdl.draft3.transforms.linking.expression.types
+
+import common.validation.ErrorOr._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import wdl.model.draft3.elements.ExpressionElement._
+import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
+import wdl.model.draft3.graph.expression.TypeEvaluator
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
+import wom.types.WomType
+
+import scala.util.Try
+
+object UnaryOperatorEvaluators {
+
+  implicit val unaryPlusEvaluator: TypeEvaluator[UnaryPlus] = forOperation(_.unaryPlus)
+  implicit val unaryNegationEvaluator: TypeEvaluator[UnaryNegation] = forOperation(_.unaryMinus)
+  implicit val logicalNotEvaluator: TypeEvaluator[LogicalNot] = forOperation(_.not)
+
+  private def forOperation[A <: UnaryOperation](op: WomType => Try[WomType]) = new TypeEvaluator[A] {
+    override def evaluateType(a: A, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.argument.evaluateType(linkedValues) flatMap { op(_).toErrorOr }
+    }
+  }
+}

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
@@ -8,28 +8,23 @@ import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
 import wdl.model.draft3.graph.expression.TypeEvaluator
 import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
 import wdl.draft3.transforms.linking.expression.types.LookupEvaluators._
-import wom.types.{WomObjectType, WomType}
+import wdl.draft3.transforms.linking.expression.types.LiteralEvaluators._
+import wdl.draft3.transforms.linking.expression.types.UnaryOperatorEvaluators._
+import wdl.draft3.transforms.linking.expression.types.BinaryOperatorEvaluators._
+import wom.types.WomType
 
 package object types {
-  implicit val primitiveTypeEvaluator: TypeEvaluator[PrimitiveLiteralExpressionElement] = new TypeEvaluator[PrimitiveLiteralExpressionElement] {
-    override def evaluateType(a: PrimitiveLiteralExpressionElement, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = a.value.womType.validNel
-  }
-
-  implicit val objectLiteralTypeEvaluator: TypeEvaluator[ObjectLiteral] = new TypeEvaluator[ObjectLiteral] {
-    override def evaluateType(a: ObjectLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = WomObjectType.validNel
-  }
-
   implicit val expressionTypeEvaluator: TypeEvaluator[ExpressionElement] = new TypeEvaluator[ExpressionElement] {
     override def evaluateType(a: ExpressionElement, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
 
       a match {
         // Literals:
         case a: PrimitiveLiteralExpressionElement => a.evaluateType(linkedValues)
-//        case a: StringLiteral => a.evaluateType(linkedValues)
+        case a: StringLiteral => a.evaluateType(linkedValues)
         case a: ObjectLiteral => a.evaluateType(linkedValues)
-//        case a: MapLiteral => a.evaluateType(linkedValues)
-//        case a: ArrayLiteral => a.evaluateType(linkedValues)
-//        case a: PairLiteral => a.evaluateType(linkedValues)
+        case a: MapLiteral => a.evaluateType(linkedValues)
+        case a: ArrayLiteral => a.evaluateType(linkedValues)
+        case a: PairLiteral => a.evaluateType(linkedValues)
 
         // Lookups and member accesses:
         case a: IdentifierLookup => a.evaluateType(linkedValues)
@@ -37,24 +32,24 @@ package object types {
         case a: IdentifierMemberAccess => a.evaluateType(linkedValues)
 
         // Unary operators:
-//        case a: UnaryNegation => a.evaluateType(linkedValues)
-//        case a: UnaryPlus => a.evaluateType(linkedValues)
-//        case a: LogicalNot => a.evaluateType(linkedValues)
+        case a: UnaryNegation => a.evaluateType(linkedValues)
+        case a: UnaryPlus => a.evaluateType(linkedValues)
+        case a: LogicalNot => a.evaluateType(linkedValues)
 
         // Binary operators (at some point we might want to split these into separate cases):
-//        case a: LogicalOr => a.evaluateType(linkedValues)
-//        case a: LogicalAnd => a.evaluateType(linkedValues)
-//        case a: Equals => a.evaluateType(linkedValues)
-//        case a: NotEquals => a.evaluateType(linkedValues)
-//        case a: LessThan => a.evaluateType(linkedValues)
-//        case a: LessThanOrEquals => a.evaluateType(linkedValues)
-//        case a: GreaterThan => a.evaluateType(linkedValues)
-//        case a: GreaterThanOrEquals => a.evaluateType(linkedValues)
-//        case a: Add => a.evaluateType(linkedValues)
-//        case a: Subtract => a.evaluateType(linkedValues)
-//        case a: Multiply => a.evaluateType(linkedValues)
-//        case a: Divide => a.evaluateType(linkedValues)
-//        case a: Remainder => a.evaluateType(linkedValues)
+        case a: LogicalOr => a.evaluateType(linkedValues)
+        case a: LogicalAnd => a.evaluateType(linkedValues)
+        case a: Equals => a.evaluateType(linkedValues)
+        case a: NotEquals => a.evaluateType(linkedValues)
+        case a: LessThan => a.evaluateType(linkedValues)
+        case a: LessThanOrEquals => a.evaluateType(linkedValues)
+        case a: GreaterThan => a.evaluateType(linkedValues)
+        case a: GreaterThanOrEquals => a.evaluateType(linkedValues)
+        case a: Add => a.evaluateType(linkedValues)
+        case a: Subtract => a.evaluateType(linkedValues)
+        case a: Multiply => a.evaluateType(linkedValues)
+        case a: Divide => a.evaluateType(linkedValues)
+        case a: Remainder => a.evaluateType(linkedValues)
 
 //        case a: TernaryIf => a.evaluateType(linkedValues)
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
@@ -11,6 +11,7 @@ import wdl.draft3.transforms.linking.expression.types.LookupEvaluators._
 import wdl.draft3.transforms.linking.expression.types.LiteralEvaluators._
 import wdl.draft3.transforms.linking.expression.types.UnaryOperatorEvaluators._
 import wdl.draft3.transforms.linking.expression.types.BinaryOperatorEvaluators._
+import wdl.draft3.transforms.linking.expression.types.TernaryIfEvaluator._
 import wom.types.WomType
 
 package object types {
@@ -51,9 +52,7 @@ package object types {
         case a: Divide => a.evaluateType(linkedValues)
         case a: Remainder => a.evaluateType(linkedValues)
 
-//        case a: TernaryIf => a.evaluateType(linkedValues)
-
-
+        case a: TernaryIf => a.evaluateType(linkedValues)
 
         case other => s"Unable to process ${other.getClass.getSimpleName}: No evaluateValue exists for that type.".invalidNel
       }

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/expression/MemberAccessTypeEvaluatorSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/expression/MemberAccessTypeEvaluatorSpec.scala
@@ -1,0 +1,92 @@
+package wdl.draft3.transforms.expression
+
+import cats.data.NonEmptyList
+import common.assertion.ErrorOrAssertions._
+import org.scalatest.{FlatSpec, Matchers}
+import wdl.draft3.transforms.linking.expression.types.expressionTypeEvaluator
+import wdl.model.draft3.elements.ExpressionElement
+import wdl.model.draft3.elements.ExpressionElement._
+import wdl.model.draft3.graph._
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
+import wom.types._
+import wom.values.WomInteger
+
+class MemberAccessTypeEvaluatorSpec extends FlatSpec with Matchers{
+
+  behavior of "member access type evaluator"
+
+  val fiveLiteral = PrimitiveLiteralExpressionElement(WomInteger(5))
+  val sixLiteral = PrimitiveLiteralExpressionElement(WomInteger(6))
+
+  it should "find the left and right hand sides of a pair expression" in {
+    val pair = PairLiteral(fiveLiteral, sixLiteral)
+    val leftExpression: ExpressionElement = ExpressionMemberAccess(pair, NonEmptyList("left", List.empty))
+    leftExpression.evaluateType(Map.empty) shouldBeValid WomIntegerType
+
+    val rightExpression: ExpressionElement = ExpressionMemberAccess(pair, NonEmptyList("right", List.empty))
+    rightExpression.evaluateType(Map.empty) shouldBeValid WomIntegerType
+  }
+
+  it should "find the appropriate value in a deeply nested Pair" in {
+    val nestedPairLookup: ExpressionElement = ExpressionMemberAccess(
+      expression = PairLiteral(
+        left = PairLiteral(
+          left = fiveLiteral,
+          right = PairLiteral(
+            left = fiveLiteral,
+            right = PairLiteral(
+              left = PairLiteral(fiveLiteral, sixLiteral), // This pair is the value we should be selecting
+              right = fiveLiteral
+            )
+          )
+        ),
+        right = fiveLiteral
+      ),
+      memberAccessTail = NonEmptyList("left", List("right", "right", "left"))
+    )
+     nestedPairLookup.evaluateType(Map.empty) shouldBeValid WomPairType(WomIntegerType, WomIntegerType)
+  }
+
+  it should "evaluate a nested member access on a call output" in {
+    val callOutputLookup: ExpressionElement = IdentifierMemberAccess("t", "out", List("left", "right"))
+    val linkedValues = Map[UnlinkedConsumedValueHook, GeneratedValueHandle](
+      UnlinkedCallOutputOrIdentifierAndMemberAccessHook("t", "out") -> GeneratedCallOutputValueHandle("t", "out", WomPairType(WomPairType(WomIntegerType, WomPairType(WomIntegerType, WomIntegerType)), WomStringType))
+    )
+
+    callOutputLookup.evaluateType(linkedValues) shouldBeValid WomPairType(WomIntegerType, WomIntegerType)
+  }
+
+  it should "evaluate a nested member access on a struct" in {
+    val objectLookup: ExpressionElement = IdentifierMemberAccess("t", "out", List("left", "right"))
+    val linkedValues = Map[UnlinkedConsumedValueHook, GeneratedValueHandle](
+      UnlinkedCallOutputOrIdentifierAndMemberAccessHook("t", "out") -> GeneratedIdentifierValueHandle(
+        linkableName = "t",
+        womType = WomCompositeType(Map("out" -> WomPairType(WomPairType(WomIntegerType, WomPairType(WomIntegerType, WomIntegerType)), WomIntegerType)))
+      )
+    )
+
+    objectLookup.evaluateType(linkedValues) shouldBeValid WomPairType(WomIntegerType, WomIntegerType)
+  }
+
+  it should "evaluate a nested member access type on an object" in {
+    val objectLookup: ExpressionElement = IdentifierMemberAccess("t", "out", List("left", "right"))
+    val linkedValues = Map[UnlinkedConsumedValueHook, GeneratedValueHandle](
+      UnlinkedCallOutputOrIdentifierAndMemberAccessHook("t", "out") -> GeneratedIdentifierValueHandle(
+        linkableName = "t",
+        womType = WomObjectType
+      )
+    )
+
+    objectLookup.evaluateType(linkedValues) shouldBeValid WomAnyType
+  }
+
+  it should "evaluate an identifier lookup" in {
+    val identifierLookup: ExpressionElement = IdentifierLookup("foo")
+    val linkedValues = Map[UnlinkedConsumedValueHook, GeneratedValueHandle](
+      UnlinkedIdentifierHook("foo") -> GeneratedIdentifierValueHandle(linkableName = "foo", womType = WomPairType(WomStringType, WomStringType))
+    )
+
+    identifierLookup.evaluateType(linkedValues) shouldBeValid WomPairType(WomStringType, WomStringType)
+  }
+
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/expression/UnaryAndBinaryOperatorsEvaluatorSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/expression/UnaryAndBinaryOperatorsEvaluatorSpec.scala
@@ -3,10 +3,13 @@ package wdl.draft3.transforms.expression
 import common.assertion.ErrorOrAssertions._
 import org.scalatest.{FlatSpec, Matchers}
 import wdl.draft3.transforms.linking.expression.values.expressionEvaluator
+import wdl.draft3.transforms.linking.expression.types.expressionTypeEvaluator
 import wdl.model.draft3.elements.ExpressionElement
 import wdl.model.draft3.elements.ExpressionElement._
 import wdl.model.draft3.graph.expression.ValueEvaluator.ops._
+import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
 import wom.expression.NoIoFunctionSet
+import wom.types.{WomBooleanType, WomIntegerType, WomType}
 import wom.values.{WomBoolean, WomInteger, WomValue}
 
 /**
@@ -26,40 +29,44 @@ class UnaryAndBinaryOperatorsEvaluatorSpec extends FlatSpec with Matchers{
   val womSix = WomInteger(6)
 
   // Format:
-  // Test name, input expression, output value.
-  val expressionTests: List[(String, ExpressionElement, WomValue)] = List(
-    ("+5", UnaryPlus(fiveLiteral), womFive),
-    ("-5", UnaryNegation(fiveLiteral), WomInteger(-5)),
-    ("-(-5)", UnaryNegation(UnaryNegation(fiveLiteral)), womFive),
-    ("-(+(-5))", UnaryNegation(UnaryPlus(UnaryNegation(fiveLiteral))), WomInteger(-5)),
-    ("!true", LogicalNot(trueLiteral), WomBoolean(false)),
-    ("!(!true)", LogicalNot(LogicalNot(trueLiteral)), WomBoolean(true)),
+  // Test name, input expression, output value, output type.
+  val expressionTests: List[(String, ExpressionElement, WomValue, WomType)] = List(
+    ("+5", UnaryPlus(fiveLiteral), womFive, WomIntegerType),
+    ("-5", UnaryNegation(fiveLiteral), WomInteger(-5), WomIntegerType),
+    ("-(-5)", UnaryNegation(UnaryNegation(fiveLiteral)), womFive, WomIntegerType),
+    ("-(+(-5))", UnaryNegation(UnaryPlus(UnaryNegation(fiveLiteral))), WomInteger(-5), WomIntegerType),
+    ("!true", LogicalNot(trueLiteral), WomBoolean(false), WomBooleanType),
+    ("!(!true)", LogicalNot(LogicalNot(trueLiteral)), WomBoolean(true), WomBooleanType),
 
-    ("true || false", LogicalOr(trueLiteral, falseLiteral), WomBoolean(true)),
-    ("true && false", LogicalAnd(trueLiteral, falseLiteral), WomBoolean(false)),
-    ("true == false", Equals(trueLiteral, falseLiteral), WomBoolean(false)),
-    ("true != false", NotEquals(trueLiteral, falseLiteral), WomBoolean(true)),
+    ("true || false", LogicalOr(trueLiteral, falseLiteral), WomBoolean(true), WomBooleanType),
+    ("true && false", LogicalAnd(trueLiteral, falseLiteral), WomBoolean(false), WomBooleanType),
+    ("true == false", Equals(trueLiteral, falseLiteral), WomBoolean(false), WomBooleanType),
+    ("true != false", NotEquals(trueLiteral, falseLiteral), WomBoolean(true), WomBooleanType),
 
-    ("5 < 6", LessThan(fiveLiteral, sixLiteral), WomBoolean(true)),
-    ("5 < 5", LessThan(fiveLiteral, fiveLiteral), WomBoolean(false)),
-    ("5 <= 6", LessThanOrEquals(fiveLiteral, sixLiteral), WomBoolean(true)),
-    ("5 <= 5", LessThanOrEquals(fiveLiteral, fiveLiteral), WomBoolean(true)),
+    ("5 < 6", LessThan(fiveLiteral, sixLiteral), WomBoolean(true), WomBooleanType),
+    ("5 < 5", LessThan(fiveLiteral, fiveLiteral), WomBoolean(false), WomBooleanType),
+    ("5 <= 6", LessThanOrEquals(fiveLiteral, sixLiteral), WomBoolean(true), WomBooleanType),
+    ("5 <= 5", LessThanOrEquals(fiveLiteral, fiveLiteral), WomBoolean(true), WomBooleanType),
 
-    ("6 > 5", GreaterThan(sixLiteral, fiveLiteral), WomBoolean(true)),
-    ("5 > 5", GreaterThan(fiveLiteral, fiveLiteral), WomBoolean(false)),
-    ("6 >= 6", GreaterThanOrEquals(sixLiteral, fiveLiteral), WomBoolean(true)),
-    ("5 >= 5", GreaterThanOrEquals(fiveLiteral, fiveLiteral), WomBoolean(true)),
+    ("6 > 5", GreaterThan(sixLiteral, fiveLiteral), WomBoolean(true), WomBooleanType),
+    ("5 > 5", GreaterThan(fiveLiteral, fiveLiteral), WomBoolean(false), WomBooleanType),
+    ("6 >= 6", GreaterThanOrEquals(sixLiteral, fiveLiteral), WomBoolean(true), WomBooleanType),
+    ("5 >= 5", GreaterThanOrEquals(fiveLiteral, fiveLiteral), WomBoolean(true), WomBooleanType),
 
-    ("5 + 5", Add(fiveLiteral, fiveLiteral), WomInteger(10)),
-    ("5 - 5", Subtract(fiveLiteral, fiveLiteral), WomInteger(0)),
-    ("5 * 5", Multiply(fiveLiteral, fiveLiteral), WomInteger(25)),
-    ("25 * 5", Divide(PrimitiveLiteralExpressionElement(WomInteger(25)), fiveLiteral), WomInteger(5)),
-    ("27 % 5", Remainder(PrimitiveLiteralExpressionElement(WomInteger(27)), fiveLiteral), WomInteger(2))
+    ("5 + 5", Add(fiveLiteral, fiveLiteral), WomInteger(10), WomIntegerType),
+    ("5 - 5", Subtract(fiveLiteral, fiveLiteral), WomInteger(0), WomIntegerType),
+    ("5 * 5", Multiply(fiveLiteral, fiveLiteral), WomInteger(25), WomIntegerType),
+    ("25 * 5", Divide(PrimitiveLiteralExpressionElement(WomInteger(25)), fiveLiteral), WomInteger(5), WomIntegerType),
+    ("27 % 5", Remainder(PrimitiveLiteralExpressionElement(WomInteger(27)), fiveLiteral), WomInteger(2), WomIntegerType)
   )
 
-  expressionTests foreach { case (name, expression, expected) =>
+  expressionTests foreach { case (name, expression, expectedValue, expectedType) =>
     it should s"evaluate the expression '$name'" in {
-      expression.evaluateValue(Map.empty, NoIoFunctionSet) shouldBeValid expected
+      expression.evaluateValue(Map.empty, NoIoFunctionSet) shouldBeValid expectedValue
+    }
+
+    it should s"evaluate the type of the expression '$name'" in {
+      expression.evaluateType(Map.empty) shouldBeValid expectedType
     }
   }
 }


### PR DESCRIPTION
- [x] Rebase onto develop after merging #3358 

Fills out a lot more type evaluators, a prerequisite for conversion of WDLOM expression elements into full WOM expressions