### PR TITLE
Load Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 31 Release Notes
 
+* **Robustness**
+    + The rate at which jobs are being started can now be controlled using the `system.job-rate-control` configuration stanza.  
+    + A load controller service has been added to allow Cromwell to self-monitor and adjust its load accordingly.
+The load controller is currently a simple on/off switch controlling the job start rate. It gathers metrics from different parts of the system
+to inform its decision to stop the creation of jobs.
+You can find the relevant configuration in the `services.LoadController` section of the `cromwell.examples.conf` file.
+The load level of the monitored sub-systems are instrumented and can be found under the `cromwell.load` statsD path.
+    + The statsD metrics have been re-shuffled a bit. If you had a dashboard you might find that you need to update it.
+Changes include: 
+        + Removed artificially inserted "count" and "timing" the path
+        + Added a `load` section
+        + Metrics were prefixed twice with `cromwell` (`cromwell.cromwell.my_metric`), now they're only prefixed once
+        + Added `processed` and `queue` metrics under various metrics monitoring the throughput and amount of queued work respectively
+        + Added a memory metric representing an estimation of the free memory Cromwell thinks it has left
+
 * Added a configuration option under `docker.hash-lookup.enabled` to disable docker hash lookup.
  Disabling it will also disable call caching for jobs with floating docker tags.
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     + A load controller service has been added to allow Cromwell to self-monitor and adjust its load accordingly.
 The load controller is currently a simple on/off switch controlling the job start rate. It gathers metrics from different parts of the system
 to inform its decision to stop the creation of jobs.
-You can find the relevant configuration in the `services.LoadController` section of the `cromwell.examples.conf` file.
+You can find relevant configuration in the `services.LoadController` section of the `cromwell.examples.conf` file,
+as well as in the `load-control` section in `reference.conf`.
 The load level of the monitored sub-systems are instrumented and can be found under the `cromwell.load` statsD path.
     + The statsD metrics have been re-shuffled a bit. If you had a dashboard you might find that you need to update it.
 Changes include: 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -902,7 +902,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     val kvJobKey =
       KvJobKey(jobDescriptor.key.call.fullyQualifiedName, jobDescriptor.key.index, jobDescriptor.key.attempt)
     val scopedKey = ScopedKey(jobDescriptor.workflowDescriptor.id, kvJobKey, jobIdKey)
-    val kvValue = Option(runningJob.jobId)
+    val kvValue = runningJob.jobId
     val kvPair = KvPair(scopedKey, kvValue)
     val kvPut = KvPut(kvPair)
     makeKvRequest(Seq(kvPut)).map(_.head)

--- a/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardSyncExecutionActor.scala
@@ -79,7 +79,7 @@ class StandardSyncExecutionActor(val standardParams: StandardSyncExecutionActorP
   }
   
   private def recovering(executor: ActorRef): Receive = running(executor).orElse {
-    case KvPair(key, Some(jobId)) if key.key == jobIdKey =>
+    case KvPair(key, jobId) if key.key == jobIdKey =>
       // Successful operation ID lookup.
       executor ! Recover(StandardAsyncJob(jobId))
     case KvKeyLookupFailed(_) =>
@@ -88,7 +88,7 @@ class StandardSyncExecutionActor(val standardParams: StandardSyncExecutionActorP
   }
 
   private def reconnectingToAbort(executor: ActorRef): Receive = running(executor).orElse {
-    case KvPair(key, Some(jobId)) if key.key == jobIdKey =>
+    case KvPair(key, jobId) if key.key == jobIdKey =>
       // Successful operation ID lookup.
       executor ! ReconnectToAbort(StandardAsyncJob(jobId))
     case KvKeyLookupFailed(_) =>
@@ -98,7 +98,7 @@ class StandardSyncExecutionActor(val standardParams: StandardSyncExecutionActorP
   }
 
   private def reconnecting(executor: ActorRef): Receive = running(executor).orElse {
-    case KvPair(key, Some(jobId)) if key.key == jobIdKey =>
+    case KvPair(key, jobId) if key.key == jobIdKey =>
       // Successful operation ID lookup.
       executor ! Reconnect(StandardAsyncJob(jobId))
     case KvKeyLookupFailed(_) =>

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardFileHashingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardFileHashingActor.scala
@@ -2,10 +2,10 @@ package cromwell.backend.standard.callcaching
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.actor.{Actor, ActorLogging, ActorRef, Timers}
 import akka.event.LoggingAdapter
 import cromwell.backend.standard.StandardCachingActorHelper
-import cromwell.backend.standard.callcaching.StandardFileHashingActor.{FileHashResponse, SingleFileHashRequest}
+import cromwell.backend.standard.callcaching.StandardFileHashingActor._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor}
 import cromwell.core.JobKey
 import cromwell.core.callcaching._
@@ -56,17 +56,23 @@ object StandardFileHashingActor {
   case class FileHashResponse(hashResult: HashResult) extends BackendSpecificHasherResponse { override def hashes = Set(hashResult) }
 }
 
-abstract class StandardFileHashingActor(standardParams: StandardFileHashingActorParams) extends Actor with ActorLogging with JobLogging with IoClientHelper with StandardCachingActorHelper {
+abstract class StandardFileHashingActor(standardParams: StandardFileHashingActorParams)
+  extends Actor
+    with ActorLogging
+    with JobLogging
+    with IoClientHelper
+    with StandardCachingActorHelper
+    with Timers {
   override lazy val ioActor = standardParams.ioActor
   override lazy val jobDescriptor: BackendJobDescriptor = standardParams.jobDescriptor
   override lazy val backendInitializationDataOption: Option[BackendInitializationData] = standardParams.backendInitializationDataOption
   override lazy val serviceRegistryActor: ActorRef = standardParams.serviceRegistryActor
   override lazy val configurationDescriptor: BackendConfigurationDescriptor = standardParams.configurationDescriptor
-  
-  protected def ioCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
-  
-  def customHashStrategy(fileRequest: SingleFileHashRequest): Option[Try[String]] = None
 
+  protected def ioCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
+
+  def customHashStrategy(fileRequest: SingleFileHashRequest): Option[Try[String]] = None
+  
   def fileHashingReceive: Receive = {
     // Hash Request
     case fileRequest: SingleFileHashRequest =>
@@ -101,7 +107,7 @@ abstract class StandardFileHashingActor(standardParams: StandardFileHashingActor
     }
   }
 
-  override def receive: Receive = ioReceive orElse fileHashingReceive
+  override def receive: Receive = ioReceive orElse fileHashingReceive 
 
   override protected def onTimeout(message: Any, to: ActorRef): Unit = {
     message match {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -446,5 +446,10 @@ load-control {
   # How often each actor should update its perceived load
   monitoring-frequency = 5 seconds
   # Memory is monitored by looking at the amount of free memory left
-  memory-threshold-in-mb = 500
+  memory-threshold-in-mb = 1024
+  # Because memory measurements are not precise, the last memory-measurement-window measurements are recorded
+  # and changes on load are only triggered if all measurements are below or above the threshold
+  # The default value 6 combined with a monitoring frequencey of 5 seconds means that load alerts are triggered
+  # If the memory is below the threshold for at least 30 consecutive seconds
+  memory-measurement-window = 6
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -355,6 +355,11 @@ backend {
 services {
   KeyValue {
     class = "cromwell.services.keyvalue.impl.SqlKeyValueServiceActor"
+    config {
+      # Similar to metadata service config, see cromwell.examples.conf
+      # db-batch-size = 200
+      # db-flush-rate = 5 seconds
+    }
   }
   MetadataService {
     class = "cromwell.services.metadata.impl.MetadataServiceActor"
@@ -403,4 +408,43 @@ database {
     # of control we monitor its size and execute/commit when it reaches or exceeds writeBatchSize.
     write-batch-size = 100000
   }
+}
+
+# Configuration for load-control related values 
+load-control {
+  ## Queue Size Thresholds ##
+  # Cromwell centralizes some operations through singleton actors (possibly acting as routers).
+  # This allows for a more efficient control, throttling, and potentially batching of those operations which overall improves throughput.
+  # In order to do that, those operations are queued until they can be performed.
+  # Those queues are for the most part unbounded in size, which can become a problem under heavy load.
+  # Each actor can however let the load controller service know when it considers its work load to be abnormally high.
+  # In the case of those queuing actors, this means that their queue size is over a certain threshold.
+  # This section allows to configure those threshold values.
+  # They should be kept at a reasonable number where reasonable will depend on your system and how much load Cromwell is submitted to.
+  # If they're too high they could end up using a lot of memory, if they're too small any small spike will be considered a high load and the system will automatically slow itself down.
+  # Benchmarking is recommended to find the values that suit your use case best.
+  # If you use the statsD instrumentation service, the queue size and throughput of these actors are instrumented and looking at their value over time can also help you find the right configuration.
+  
+  job-store-read = 10000
+  job-store-write = 10000
+  # call cache read actors are routed (several actors are performing cache read operations
+  # this threshold applies to each routee individually, so set it to a lower value to account for that
+  # to change the number of routees, see the services.number-of-cache-read-workers config value
+  call-cache-read = 1000
+  call-cache-write = 10000
+  key-value-read = 10000
+  key-value-write = 10000
+  io = 10000
+  # metadata is an order of magnitude higher because its normal load is much higher than other actors
+  metadata-write = 100000
+  
+  ## Backend specific ##
+  # Google requests to the Pipelines API are also queued and batched
+  papi-requests = 10000
+  
+  ## Misc. ##
+  # How often each actor should update its perceived load
+  monitoring-frequency = 5 seconds
+  # Memory is monitored by looking at the amount of free memory left
+  memory-threshold-in-mb = 500
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -169,7 +169,7 @@ system {
   instrumentation-rate = 5 seconds
   
   job-rate-control {
-    jobs = 100
+    jobs = 50
     per = 1 second
   }
 }
@@ -371,6 +371,12 @@ services {
     class = "cromwell.services.healthmonitor.impl.standard.StandardHealthMonitorServiceActor"
     # Override the standard dispatcher. In particular this one has a low throughput so as to be lower in priority
     dispatcher = "akka.dispatchers.health-monitor-dispatcher"
+  }
+  LoadController {
+    class = "cromwell.services.loadcontroller.impl.LoadControllerServiceActor"
+    config {
+      # See cromwell.examples.conf for details on settings one can use here
+    }
   }
 }
 

--- a/core/src/main/scala/cromwell/core/LoadConfig.scala
+++ b/core/src/main/scala/cromwell/core/LoadConfig.scala
@@ -1,0 +1,21 @@
+package cromwell.core
+
+import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.duration.FiniteDuration
+
+object LoadConfig {
+  private val conf = ConfigFactory.load().getConfig("load-control")
+  val JobStoreReadThreshold = conf.as[Int]("job-store-read")
+  val JobStoreWriteThreshold = conf.as[Int]("job-store-write")
+  val CallCacheReadThreshold = conf.as[Int]("call-cache-read")
+  val CallCacheWriteThreshold = conf.as[Int]("call-cache-write")
+  val KeyValueReadThreshold = conf.as[Int]("key-value-read")
+  val KeyValueWriteThreshold = conf.as[Int]("key-value-write")
+  val IoThreshold = conf.as[Int]("io")
+  val MetadataWriteThreshold = conf.as[Int]("metadata-write")
+  val MonitoringFrequency = conf.as[FiniteDuration]("monitoring-frequency")
+  val MemoryThresholdInMB = conf.as[Int]("memory-threshold-in-mb")
+  val PAPIThreshold = conf.as[Int]("papi-requests")
+}

--- a/core/src/main/scala/cromwell/core/LoadConfig.scala
+++ b/core/src/main/scala/cromwell/core/LoadConfig.scala
@@ -17,5 +17,6 @@ object LoadConfig {
   val MetadataWriteThreshold = conf.as[Int]("metadata-write")
   val MonitoringFrequency = conf.as[FiniteDuration]("monitoring-frequency")
   val MemoryThresholdInMB = conf.as[Int]("memory-threshold-in-mb")
+  val MemoryMeasurementWindow = conf.as[Int]("memory-measurement-window")
   val PAPIThreshold = conf.as[Int]("papi-requests")
 }

--- a/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
@@ -17,15 +17,15 @@ trait RobustClientHelper { this: Actor with ActorLogging =>
   private [actor] implicit val robustActorHelperEc = context.dispatcher
 
   private final val random = new Random()
-  
+
   // package private for testing
   private [core] var timeouts = Map.empty[Any, (Cancellable, FiniteDuration)]
-  
+
   protected def backpressureTimeout: FiniteDuration = 10 seconds
   protected def backpressureRandomizerFactor: Double = 0.5D
-  
- def robustReceive: Receive = {
-    case BackPressure(request) => 
+
+  def robustReceive: Receive = {
+    case BackPressure(request) =>
       val snd = sender()
       newTimer(request, snd, generateBackpressureTime)
       resetTimeout(request, snd)
@@ -36,12 +36,12 @@ trait RobustClientHelper { this: Actor with ActorLogging =>
   private final def newTimer(msg: Any, to: ActorRef, in: FiniteDuration) = {
     context.system.scheduler.scheduleOnce(in, to, msg)(robustActorHelperEc, self)
   }
-  
+
   def robustSend(msg: Any, to: ActorRef, timeout: FiniteDuration = DefaultRequestLostTimeout): Unit = {
     to ! msg
     addTimeout(msg, to, timeout)
   }
-  
+
   private final def addTimeout(command: Any, to: ActorRef, timeout: FiniteDuration) = {
     val cancellable = newTimer(RequestTimeout(command, to), self, timeout)
     timeouts = timeouts + (command -> (cancellable -> timeout))
@@ -59,16 +59,16 @@ trait RobustClientHelper { this: Actor with ActorLogging =>
     cancelTimeout(command)
     timeout foreach { addTimeout(command, to, _) }
   }
-  
+
   private [actor] final def generateBackpressureTime = {
     val backpressureTimeoutInMillis = backpressureTimeout.toMillis
-    
+
     val delta = backpressureRandomizerFactor * backpressureTimeoutInMillis
     val minInterval = backpressureTimeoutInMillis - delta
     val maxInterval = backpressureTimeoutInMillis + delta
     val randomValue = (minInterval + (random.nextDouble() * (maxInterval - minInterval + 1))).toInt
     randomValue.milliseconds
   }
-  
+
   protected def onTimeout(message: Any, to: ActorRef): Unit
 }

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -6,16 +6,18 @@ import cats.syntax.traverse._
 import cats.instances.vector._
 import cats.instances.future._
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 
 /**
   * By removing the periodic flush and setting the batch size to 1,
   * this actor modifies the behavior of BatchActor so that it throttles processing commands one at a time.
+  * Having 
   */
 abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
+  override protected def logOnStartUp = false
   override def weightFunction(command: C) = 1
   override final def process(data: NonEmptyVector[C]): Future[Int] = {
-    // This ShouldNotBePossible™ but in case it happens, instead of dropping elements process them all anyway.
+    // This ShouldNotBePossible™ but in case it happens, instead of dropping elements process them all anyway
     // Explanation: batch size is 1 which means as soon as we receive 1 element, the process method should be called.
     // Because the BatchActor calls the process method with vector of elements which total weight is batch size, and because
     // each element's weight is 1, this method should always be called with a vector of size 1. If that is not the case it means
@@ -25,5 +27,5 @@ abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
       data.toVector.traverse[Future, Any](processHead).map(_.length)
     } else processHead(data.head).map(_ => 1)
   }
-  def processHead(head: C): Future[Any]
+  def processHead(head: C): Future[Int]
 }

--- a/core/src/test/scala/cromwell/core/LoadConfigSpec.scala
+++ b/core/src/test/scala/cromwell/core/LoadConfigSpec.scala
@@ -16,7 +16,8 @@ class LoadConfigSpec extends FlatSpec with Matchers {
     LoadConfig.MetadataWriteThreshold shouldBe 100000
     LoadConfig.IoThreshold shouldBe 10000
     LoadConfig.MonitoringFrequency shouldBe 5.seconds
-    LoadConfig.MemoryThresholdInMB shouldBe 500
+    LoadConfig.MemoryThresholdInMB shouldBe 1024
     LoadConfig.PAPIThreshold shouldBe 10000
+    LoadConfig.MemoryMeasurementWindow shouldBe 6
   }
 }

--- a/core/src/test/scala/cromwell/core/LoadConfigSpec.scala
+++ b/core/src/test/scala/cromwell/core/LoadConfigSpec.scala
@@ -1,0 +1,22 @@
+package cromwell.core
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
+
+class LoadConfigSpec extends FlatSpec with Matchers {
+  behavior of "LoadConfig"
+  
+  it should "parse load config" in {
+    LoadConfig.JobStoreReadThreshold shouldBe 10000
+    LoadConfig.JobStoreWriteThreshold shouldBe 10000
+    LoadConfig.CallCacheReadThreshold shouldBe 1000
+    LoadConfig.CallCacheWriteThreshold shouldBe 10000
+    LoadConfig.KeyValueReadThreshold shouldBe 10000
+    LoadConfig.KeyValueWriteThreshold shouldBe 10000
+    LoadConfig.MetadataWriteThreshold shouldBe 100000
+    LoadConfig.IoThreshold shouldBe 10000
+    LoadConfig.MonitoringFrequency shouldBe 5.seconds
+    LoadConfig.MemoryThresholdInMB shouldBe 500
+    LoadConfig.PAPIThreshold shouldBe 10000
+  }
+}

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -696,6 +696,19 @@ services {
       # gcs-bucket-to-check = some-bucket-name
     }
   }
+  LoadController {
+    config {
+      # The load controller service will periodically look at the status of various metrics its collecting and make an
+      # assessment of the system's load. If the necessary an alert will be sent to the rest of the system.
+      # This option sets how frequently this should happen
+      # control-frequency = 5 seconds
+
+      # Memory is monitored and this service will start sending alert if the amount of available memory falls under a certain threshold
+      # memory-threshold-in-mb = 500
+      # How often memory should be checked
+      # memory-check-rate = 30 seconds
+    }
+  }
 }
 
 database {

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -556,6 +556,9 @@ backend {
     #      # token = ""
     #    }
     #
+    #    # Number of workers to assaign to PAPI requests
+    #    request-workers = 3
+    #
     #    genomics {
     #      # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
     #      # Pipelines and manipulate auth JSONs.
@@ -699,14 +702,9 @@ services {
   LoadController {
     config {
       # The load controller service will periodically look at the status of various metrics its collecting and make an
-      # assessment of the system's load. If the necessary an alert will be sent to the rest of the system.
+      # assessment of the system's load. If necessary an alert will be sent to the rest of the system.
       # This option sets how frequently this should happen
       # control-frequency = 5 seconds
-
-      # Memory is monitored and this service will start sending alert if the amount of available memory falls under a certain threshold
-      # memory-threshold-in-mb = 500
-      # How often memory should be checked
-      # memory-check-rate = 30 seconds
     }
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -103,7 +103,7 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
     * Adapted from https://github.com/slick/slick/issues/1781
    */
   protected[this] def createBatchUpsert[T](description: String,
-                                           compiled: MySQLProfile.JdbcCompiledInsert,
+                                           compiled: dataAccess.driver.JdbcCompiledInsert,
                                            values: Iterable[T]
                                           )(implicit ec: ExecutionContext): DBIO[Unit] = {
     SimpleDBIO { context =>

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -1,6 +1,6 @@
 package cromwell.database.slick
 
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement, Statement}
 
 import com.typesafe.config.Config
 import cromwell.database.slick.tables.DataAccessComponent
@@ -8,10 +8,10 @@ import cromwell.database.sql.SqlDatabase
 import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
-import slick.jdbc.{JdbcCapabilities, JdbcProfile}
+import slick.jdbc.{JdbcCapabilities, JdbcProfile, MySQLProfile}
 
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 object SlickDatabase {
   /**
@@ -95,5 +95,36 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
 
   protected[this] def runTransaction[R](action: DBIO[R]): Future[R] = {
     database.run(action.transactionally)
+  }
+
+  /*
+    * Upsert the provided values in batch.
+    * Fails the query if one or more upsert failed.
+    * Adapted from https://github.com/slick/slick/issues/1781
+   */
+  protected[this] def createBatchUpsert[T](description: String,
+                                           compiled: MySQLProfile.JdbcCompiledInsert,
+                                           values: Iterable[T]
+                                          )(implicit ec: ExecutionContext): DBIO[Unit] = {
+    SimpleDBIO { context =>
+      context.session.withPreparedStatement[Array[Int]](compiled.upsert.sql) { (st: PreparedStatement) =>
+        values.foreach { update =>
+          st.clearParameters()
+          compiled.upsert.converter.set(update, st)
+          st.addBatch()
+        }
+        st.executeBatch()
+      }
+    } flatMap { upsertCounts =>
+      val failures = upsertCounts.filter(_ == Statement.EXECUTE_FAILED)
+      if (failures.isEmpty) DBIO.successful(())
+      else {
+        val valueList = values.toList
+        val failedRequests = failures.map(valueList(_))
+        DBIO.failed(new RuntimeException(
+          s"$description failed to upsert the following rows: ${failedRequests.mkString(", ")}"
+        ))
+      }
+    }
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
@@ -1,6 +1,7 @@
 package cromwell.database.slick.tables
 
 import cromwell.database.sql.tables.JobKeyValueEntry
+import slick.jdbc.MySQLProfile
 
 trait JobKeyValueEntryComponent {
 
@@ -31,6 +32,7 @@ trait JobKeyValueEntryComponent {
   }
 
   protected val jobKeyValueEntries = TableQuery[JobKeyValueEntries]
+  lazy val jobKeyValueTableQueryCompiled = MySQLProfile.compileInsert(jobKeyValueEntries.toNode)
 
   val jobKeyValueEntryIdsAutoInc = jobKeyValueEntries returning jobKeyValueEntries.map(_.jobKeyValueEntryId)
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
@@ -1,7 +1,6 @@
 package cromwell.database.slick.tables
 
 import cromwell.database.sql.tables.JobKeyValueEntry
-import slick.jdbc.MySQLProfile
 
 trait JobKeyValueEntryComponent {
 
@@ -32,7 +31,7 @@ trait JobKeyValueEntryComponent {
   }
 
   protected val jobKeyValueEntries = TableQuery[JobKeyValueEntries]
-  lazy val jobKeyValueTableQueryCompiled = MySQLProfile.compileInsert(jobKeyValueEntries.toNode)
+  lazy val jobKeyValueTableQueryCompiled = driver.compileInsert(jobKeyValueEntries.toNode)
 
   val jobKeyValueEntryIdsAutoInc = jobKeyValueEntries returning jobKeyValueEntries.map(_.jobKeyValueEntryId)
 

--- a/database/sql/src/main/scala/cromwell/database/sql/JobKeyValueSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/JobKeyValueSqlDatabase.scala
@@ -10,6 +10,9 @@ trait JobKeyValueSqlDatabase {
   def addJobKeyValueEntry(jobKeyValueEntry: JobKeyValueEntry)
                          (implicit ec: ExecutionContext): Future[Unit]
 
+  def addJobKeyValueEntries(jobKeyValueEntries: Iterable[JobKeyValueEntry])
+                           (implicit ec: ExecutionContext): Future[Unit]
+
   def queryStoreValue(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int,
                       jobRetryAttempt: Int, storeKey: String)
                      (implicit ec: ExecutionContext): Future[Option[String]]

--- a/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/IoInstrumentation.scala
@@ -17,7 +17,7 @@ private object IoInstrumentationImplicits {
   val LocalPath = NonEmptyList.of("local")
   val GcsPath = NonEmptyList.of("gcs")
   val UnknownFileSystemPath = NonEmptyList.of("unknown")
-  
+
   val backpressure = NonEmptyList.of("backpressure")
 
   /**
@@ -92,7 +92,7 @@ trait IoInstrumentation extends CromwellInstrumentationActor { this: Actor =>
     * Increment an IoResult to the proper bucket depending on the request type and the result (success or failure).
     */
   final def incrementIoResult(ioResult: IoResult): Unit = incrementIo(ioResult.toPath)
-  
+
   final def incrementBackpressure(): Unit = incrementIo(backpressure)
 
   /**

--- a/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/JobInstrumentation.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.instrumentation
 
 import akka.actor.Actor
+import cats.data.NonEmptyList
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.instrumentation.InstrumentationKeys._
 import cromwell.core.instrumentation.InstrumentationPrefixes._
@@ -11,11 +12,13 @@ import cromwell.services.instrumentation.CromwellInstrumentationActor
 import scala.concurrent.duration.FiniteDuration
 
 object JobInstrumentation {
+  private val jobTimingKey = NonEmptyList.one("timing")
+
   private def backendJobExecutionResponsePaths(response: BackendJobExecutionResponse) = response match {
-    case _: JobSucceededResponse => SuccessKey
-    case _: JobAbortedResponse => AbortedKey
-    case _: JobFailedNonRetryableResponse => FailureKey
-    case _: JobFailedRetryableResponse => RetryKey
+    case _: JobSucceededResponse => jobTimingKey.concat(SuccessKey)
+    case _: JobAbortedResponse => jobTimingKey.concat(AbortedKey)
+    case _: JobFailedNonRetryableResponse => jobTimingKey.concat(FailureKey)
+    case _: JobFailedRetryableResponse => jobTimingKey.concat(RetryKey)
   }
 }
 

--- a/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
+++ b/engine/src/main/scala/cromwell/engine/instrumentation/WorkflowInstrumentation.scala
@@ -16,7 +16,7 @@ object WorkflowInstrumentation {
   private val WorkflowStatePaths: Map[WorkflowState, InstrumentationPath] = WorkflowState.WorkflowStateValues map { state =>
     state -> NonEmptyList.of(state.toString)
   } toMap
-  
+
   // Use "Queued" instead of "Submitted" as it seems to reflect better the actual state
   private val SubmittedPath = NonEmptyList.of("Queued")
   private val RunningPath = NonEmptyList.of(WorkflowStoreState.Running.toString)

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -5,6 +5,7 @@ import javax.net.ssl.SSLException
 
 import akka.NotUsed
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Timers}
+import akka.dispatch.ControlMessage
 import akka.stream._
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink, Source}
 import com.google.cloud.storage.StorageException
@@ -166,7 +167,7 @@ object IoActor {
   case class DefaultCommandContext[T](request: IoCommand[T], replyTo: ActorRef, override val clientContext: Option[Any] = None) extends IoCommandContext[T]
   
   case object BackPressureTimerResetKey
-  case object BackPressureTimerResetAction
+  case object BackPressureTimerResetAction extends ControlMessage
 
   /**
     * ATTENTION: Transient failures are retried *forever* 

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -4,7 +4,7 @@ import java.net.{SocketException, SocketTimeoutException}
 import javax.net.ssl.SSLException
 
 import akka.NotUsed
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Timers}
 import akka.stream._
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink, Source}
 import com.google.cloud.storage.StorageException
@@ -20,6 +20,9 @@ import cromwell.engine.io.gcs.GcsBatchFlow.BatchFailedException
 import cromwell.engine.io.gcs.{GcsBatchCommandContext, ParallelGcsBatchFlow}
 import cromwell.engine.io.nio.NioFlow
 import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
+
+import scala.concurrent.duration._
 
 /**
   * Actor that performs IO operations asynchronously using akka streams
@@ -33,7 +36,7 @@ import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
 final class IoActor(queueSize: Int,
                     throttle: Option[Throttle],
                     override val serviceRegistryActor: ActorRef)(implicit val materializer: ActorMaterializer) 
-  extends Actor with ActorLogging with StreamActorHelper[IoCommandContext[_]] with IoInstrumentation {
+  extends Actor with ActorLogging with StreamActorHelper[IoCommandContext[_]] with IoInstrumentation with Timers {
   
   implicit private val system = context.system
   implicit val ec = context.dispatcher
@@ -46,7 +49,13 @@ final class IoActor(queueSize: Int,
     incrementIoRetry(commandContext.request, throwable)
   }
   
-  private [io] lazy val defaultFlow = new NioFlow(parallelism = 100, context.system.scheduler, onRetry).flow.withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
+  override def preStart() = {
+    // On start up, let the controller know that the load is normal
+    serviceRegistryActor ! LoadMetric("IO", NormalLoad)
+    super.preStart()
+  }
+  
+  private [io] lazy val defaultFlow = new NioFlow(parallelism = 10, context.system.scheduler, onRetry).flow.withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
   private [io] lazy val gcsBatchFlow = new ParallelGcsBatchFlow(parallelism = 10, batchSize = 100, context.system.scheduler, onRetry).flow.withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
   
   protected val source = Source.queue[IoCommandContext[_]](queueSize, OverflowStrategy.dropNew)
@@ -99,6 +108,10 @@ final class IoActor(queueSize: Int,
 
   override def onBackpressure() = {
     incrementBackpressure()
+    serviceRegistryActor ! LoadMetric("IO", HighLoad)
+    // Because this method will be called every time we backpressure, the timer will be overridden every
+    // time until we're not backpressuring anymore
+    timers.startSingleTimer(BackPressureTimerResetKey, BackPressureTimerResetAction, 10.seconds)
   }
   
   override def actorReceive: Receive = {
@@ -125,6 +138,7 @@ final class IoActor(queueSize: Int,
       val replyTo = sender()
       val commandContext= DefaultCommandContext(command, replyTo)
       sendToStream(commandContext)
+    case BackPressureTimerResetAction => serviceRegistryActor ! LoadMetric("IO", NormalLoad)
   }
 }
 
@@ -150,6 +164,9 @@ object IoActor {
   val MaxAttemptsNumber = ioConfig.getOrElse[Int]("number-of-attempts", 5)
 
   case class DefaultCommandContext[T](request: IoCommand[T], replyTo: ActorRef, override val clientContext: Option[Any] = None) extends IoCommandContext[T]
+  
+  case object BackPressureTimerResetKey
+  case object BackPressureTimerResetAction
 
   /**
     * ATTENTION: Transient failures are retried *forever* 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -1,42 +1,32 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
-import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
-import akka.pattern.pipe
+import akka.actor.{ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.WorkflowId
+import cromwell.core.actor.BatchActor.CommandAndReplyTo
 import cromwell.core.callcaching.HashResult
+import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
+import cromwell.services.EnhancedThrottlerActor
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 /**
   * Queues up work sent to it because its receive is non-blocking.
   *
   * Would be nice if instead there was a pull- rather than push-based mailbox but I can't find one...
   */
-class CallCacheReadActor(cache: CallCache) extends Actor with ActorLogging {
-
-  private implicit val ec: ExecutionContext = context.dispatcher
-
-  private var requestQueue: List[RequestTuple] = List.empty
-  private var currentRequester: Option[ActorRef] = None
-
-  override def receive: Receive = {
-    case request: CallCacheReadActorRequest => receiveNewRequest(request)
-    case response: CallCacheReadActorResponse =>
-      currentRequester foreach { _ ! response }
-      cycleRequestQueue()
-    case Status.Failure(f) =>
-      currentRequester foreach { _ ! CacheResultLookupFailure(new Exception(s"Call Cache query failure: ${f.getMessage}")) }
-      cycleRequestQueue()
-    case other =>
-      log.error("Unexpected message type to CallCacheReadActor: " + other.getClass.getSimpleName)
-  }
-
-  private def runRequest(request: CallCacheReadActorRequest): Unit = {
-    val response = request match {
+class CallCacheReadActor(cache: CallCache,
+                         override val serviceRegistryActor: ActorRef,
+                         override val threshold: Int)
+  extends EnhancedThrottlerActor[CommandAndReplyTo[CallCacheReadActorRequest]]
+    with ActorLogging {
+  override def routed = true
+  override def processHead(request: CommandAndReplyTo[CallCacheReadActorRequest]): Future[Int] = instrumentedProcess {
+    val response = request.command match {
       case HasMatchingInitialHashLookup(initialHash) =>
         cache.hasBaseAggregatedHashMatch(initialHash) map {
           case true => HasMatchingEntries
@@ -60,33 +50,29 @@ class CallCacheReadActor(cache: CallCache) extends Actor with ActorLogging {
         }
     }
 
-    val recovered = response recover {
-      case t => CacheResultLookupFailure(t)
+    response onComplete {
+      case Success(success) => request.replyTo ! success
+      case Failure(f) => request.replyTo ! CacheResultLookupFailure(f)
     }
 
-    recovered.pipeTo(self)
-    ()
+    response.map(_ => 1)
   }
 
-  private def cycleRequestQueue() = requestQueue match {
-    case RequestTuple(replyTo, request) :: tail =>
-      currentRequester = Option(replyTo)
-      requestQueue = tail
-      runRequest(request)
-    case Nil =>
-      currentRequester = None
-  }
-
-  private def receiveNewRequest(request: CallCacheReadActorRequest): Unit = currentRequester match {
-    case Some(_) => requestQueue :+= RequestTuple(sender, request)
-    case None =>
-      currentRequester = Option(sender)
-      runRequest(request)
+  // EnhancedBatchActor overrides
+  override def receive: Receive = enhancedReceive.orElse(super.receive)
+  override protected def instrumentationPath = NonEmptyList.of("callcaching", "read")
+  override protected def instrumentationPrefix = InstrumentationPrefixes.JobPrefix
+  override def commandToData(snd: ActorRef) = {
+    case request: CallCacheReadActorRequest => CommandAndReplyTo(request, snd)
   }
 }
 
 object CallCacheReadActor {
-  def props(callCache: CallCache): Props = Props(new CallCacheReadActor(callCache)).withDispatcher(EngineDispatcher)
+  // Call cache read actor is routed amongst several actors, so set a smaller queue threshold
+  val QueueThreshold = 10 * 1000
+  def props(callCache: CallCache, serviceRegistryActor: ActorRef): Props = {
+    Props(new CallCacheReadActor(callCache, serviceRegistryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+  }
 
   private[CallCacheReadActor] case class RequestTuple(requester: ActorRef, request: CallCacheReadActorRequest)
 
@@ -111,10 +97,10 @@ object CallCacheReadActor {
   // Responses when asking for the next cache hit
   final case class CacheLookupNextHit(hit: CallCachingEntryId) extends CallCacheReadActorResponse
   case object CacheLookupNoHit extends CallCacheReadActorResponse
-  
+
   final case class HasCallCacheEntry(call: CallCacheEntryForCall) extends CallCacheReadActorResponse
   final case class NoCallCacheEntry(call: CallCacheEntryForCall) extends CallCacheReadActorResponse
-  
+
   // Failure Response
   case class CacheResultLookupFailure(reason: Throwable) extends CallCacheReadActorResponse
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.Dispatcher.EngineDispatcher
-import cromwell.core.WorkflowId
+import cromwell.core.{LoadConfig, WorkflowId}
 import cromwell.core.actor.BatchActor.CommandAndReplyTo
 import cromwell.core.callcaching.HashResult
 import cromwell.core.instrumentation.InstrumentationPrefixes
@@ -68,10 +68,8 @@ class CallCacheReadActor(cache: CallCache,
 }
 
 object CallCacheReadActor {
-  // Call cache read actor is routed amongst several actors, so set a smaller queue threshold
-  val QueueThreshold = 10 * 1000
   def props(callCache: CallCache, serviceRegistryActor: ActorRef): Props = {
-    Props(new CallCacheReadActor(callCache, serviceRegistryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+    Props(new CallCacheReadActor(callCache, serviceRegistryActor, LoadConfig.CallCacheReadThreshold)).withDispatcher(EngineDispatcher)
   }
 
   private[CallCacheReadActor] case class RequestTuple(requester: ActorRef, request: CallCacheReadActorRequest)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -1,29 +1,27 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{ActorRef, Props}
-import cats.data.NonEmptyVector
+import cats.data.{NonEmptyList, NonEmptyVector}
 import cats.instances.list._
 import cats.instances.tuple._
 import cats.syntax.foldable._
 import cromwell.core.Dispatcher.EngineDispatcher
-import cromwell.core.actor.BatchActor
 import cromwell.core.actor.BatchActor._
+import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCacheHashBundle
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheWriteActor.SaveCallCacheHashes
+import cromwell.services.EnhancedBatchActor
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-case class CallCacheWriteActor(callCache: CallCache) extends BatchActor[CommandAndReplyTo[SaveCallCacheHashes]](CallCacheWriteActor.dbFlushRate, CallCacheWriteActor.dbBatchSize) {
+case class CallCacheWriteActor(callCache: CallCache, serviceRegistryActor: ActorRef, threshold: Int)
+  extends EnhancedBatchActor[CommandAndReplyTo[SaveCallCacheHashes]](
+    CallCacheWriteActor.dbFlushRate,
+    CallCacheWriteActor.dbBatchSize) {
 
-  def commandToData(snd: ActorRef): PartialFunction[Any, CommandAndReplyTo[SaveCallCacheHashes]] = {
-    case command: SaveCallCacheHashes => CommandAndReplyTo(command, snd)
-  }
-
-  override protected def weightFunction(command: CommandAndReplyTo[SaveCallCacheHashes]) = 1
-
-  override protected def process(data: NonEmptyVector[CommandAndReplyTo[SaveCallCacheHashes]]) = {
+  override protected def process(data: NonEmptyVector[CommandAndReplyTo[SaveCallCacheHashes]]) = instrumentedProcess {
     log.debug("Flushing {} call cache hashes sets to the DB", data.length)
 
     //     Collect all the bundles of hashes that should be written and all the senders which should be informed of
@@ -37,10 +35,23 @@ case class CallCacheWriteActor(callCache: CallCache) extends BatchActor[CommandA
       futureMessage.map(_ => data.length)
     } else Future.successful(0)
   }
+
+  // EnhancedBatchActor overrides
+  override def receive = enhancedReceive.orElse(super.receive)
+  override protected def weightFunction(command: CommandAndReplyTo[SaveCallCacheHashes]) = 1
+  override protected def instrumentationPath = NonEmptyList.of("callcaching", "write")
+  override protected def instrumentationPrefix = InstrumentationPrefixes.JobPrefix
+  def commandToData(snd: ActorRef): PartialFunction[Any, CommandAndReplyTo[SaveCallCacheHashes]] = {
+    case command: SaveCallCacheHashes => CommandAndReplyTo(command, snd)
+  }
 }
 
 object CallCacheWriteActor {
-  def props(callCache: CallCache): Props = Props(CallCacheWriteActor(callCache)).withDispatcher(EngineDispatcher)
+  def props(callCache: CallCache, registryActor: ActorRef): Props = {
+    Props(CallCacheWriteActor(callCache, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+  }
+
+  val QueueThreshold = 10 * 1000
 
   case class SaveCallCacheHashes(bundle: CallCacheHashBundle)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheWriteActor.scala
@@ -6,6 +6,7 @@ import cats.instances.list._
 import cats.instances.tuple._
 import cats.syntax.foldable._
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.core.LoadConfig
 import cromwell.core.actor.BatchActor._
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCacheHashBundle
@@ -48,10 +49,8 @@ case class CallCacheWriteActor(callCache: CallCache, serviceRegistryActor: Actor
 
 object CallCacheWriteActor {
   def props(callCache: CallCache, registryActor: ActorRef): Props = {
-    Props(CallCacheWriteActor(callCache, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+    Props(CallCacheWriteActor(callCache, registryActor, LoadConfig.CallCacheWriteThreshold)).withDispatcher(EngineDispatcher)
   }
-
-  val QueueThreshold = 10 * 1000
 
   case class SaveCallCacheHashes(bundle: CallCacheHashBundle)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -446,7 +446,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     jobTokenDispenserActor ! JobExecutionTokenRequest(factory.jobExecutionTokenType)
   }
 
-  private def returnExecutionToken(): Unit = {
+  // Return the execution token (if we have one)
+  private def returnExecutionToken(): Unit = if (stateName != Pending && stateName != RequestingExecutionToken) {
     jobTokenDispenserActor ! JobExecutionTokenReturn
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -4,7 +4,7 @@ import common.collections.Table
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import cromwell.core.ExecutionStatus._
-import cromwell.core.{ExecutionIndex, JobKey}
+import cromwell.core.{CallKey, ExecutionIndex, ExecutionStatus, JobKey}
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{apply => _}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStore._
@@ -104,8 +104,8 @@ final case class ActiveExecutionStore private[stores](private val statusStore: M
     this.copy(statusStore = statusStore ++ values, needsUpdate = needsUpdate)
   }
   override def seal: SealedExecutionStore = SealedExecutionStore(statusStore.filterNot(_._2 == NotStarted), needsUpdate)
-  override def withNeedsUpdateFalse: ExecutionStore = this.copy(needsUpdate = false)
-  override def withNeedsUpdateTrue: ExecutionStore = this.copy(needsUpdate = true)
+  override def withNeedsUpdateFalse: ExecutionStore = if (!needsUpdate) this else this.copy(needsUpdate = false)
+  override def withNeedsUpdateTrue: ExecutionStore = if (needsUpdate) this else this.copy(needsUpdate = true)
 }
 
 /**
@@ -139,6 +139,11 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
   def keyForNode(node: GraphNode): Option[JobKey] = {
     statusStore.keys collectFirst { case k if k.node eq node => k }
   }
+
+  /**
+    * Number of queued jobs
+    */
+  lazy val queuedJobs = store.get(ExecutionStatus.QueuedInCromwell).map(_.length).getOrElse(0)
 
   /**
     * Update key statuses and needsUpdate
@@ -227,19 +232,25 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
   def update: ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     var unstartables = Map.empty[JobKey, ExecutionStatus]
-
-    // filter the keys that are runnable. In the process remember the ones that are unreachable
-    val readyToStart = keysWithStatus(NotStarted).toStream.filter(key => {
+    val runCallNodes = queuedJobs < 500
+    
+    def filterFunction(key: JobKey) = {
       // A key is runnable if all its dependencies are Done
       val runnable = key.allDependenciesAreIn(doneStatus)
-      
+
       // If the key is not runnable, but all its dependencies are in a terminal status, then it's unreachable
       if (!runnable && key.allDependenciesAreIn(terminalStatus)) {
         unstartables = unstartables ++ key.nonStartableOutputKeys.map(_ -> Unstartable) + (key -> Unstartable)
       }
-      
+
       // returns the runnable value for the filter
       runnable
+    }
+
+    // filter the keys that are runnable. In the process remember the ones that are unreachable
+    val readyToStart = keysWithStatus(NotStarted).toStream.filter({
+      case _: CallKey if !runCallNodes => false
+      case key => filterFunction(key)
     })
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
@@ -252,7 +263,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     val updated = if (unstartables.nonEmpty) {
       updateKeys(unstartables, needsUpdate = true)
     // If the list was truncated, set needsUpdate to true because we'll need to do this again to get the truncated keys
-    } else if (truncated) {
+    } else if (truncated || !runCallNodes) {
       withNeedsUpdateTrue
     // Otherwise we can reset it, nothing else will be runnable / unstartable until some new keys become terminal
     } else withNeedsUpdateFalse

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/DynamicRateLimiter.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/DynamicRateLimiter.scala
@@ -1,0 +1,63 @@
+package cromwell.engine.workflow.tokens
+
+import akka.actor.{Actor, ActorLogging, Timers}
+import akka.dispatch.ControlMessage
+import cromwell.engine.workflow.tokens.DynamicRateLimiter._
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, NormalLoad}
+
+import scala.concurrent.duration._
+
+/**
+  * Simply listen to load alerts and freeze the token distribution if the load is high, restore it when load is back to normal.
+  */
+trait DynamicRateLimiter { this: Actor with Timers with ActorLogging =>
+  protected def distributionRate: Rate
+
+  protected def ratePreStart(): Unit = {
+    startDistributionTimer()
+    log.info("{} - Distribution rate: {}.", self.path.name, distributionRate)
+  }
+
+  protected def rateReceive: Receive = {
+    case ResetAction if distributionRate.n != 0 => releaseTokens()
+    case HighLoad => highLoad()
+    case NormalLoad => backToNormal()
+  }
+
+  private def startDistributionTimer() = if (!distributionRate.isZero && !timers.isTimerActive(ResetKey)) {
+    timers.startPeriodicTimer(ResetKey, ResetAction, distributionRate.per)
+  }
+
+  private def releaseTokens() = {
+    self ! TokensAvailable(distributionRate.n)
+  }
+
+  // When load is high, freeze token distribution
+  private def highLoad(doLogging: Boolean = true) = {
+    // This guarantees that even if the ResetAction message has already been sent and is in the message queue it will be removed in time
+    timers.cancel(ResetKey)
+    log.warning("{} - High load alert. Freeze token distribution.", self.path.name)
+  }
+
+  // When back to normal, restart the token distribution timer if needed
+  private def backToNormal() = {
+    startDistributionTimer()
+    log.info("{} - Load back to normal", self.path.name)
+  }
+}
+
+object DynamicRateLimiter {
+  private case object ResetKey
+  private case object ResetAction extends ControlMessage
+
+  case class TokensAvailable(n: Int) extends ControlMessage
+
+  implicit class RateEnhancer(val n: Int) extends AnyVal {
+    def per(duration: FiniteDuration) = Rate(n, duration)
+  }
+
+  case class Rate(n: Int, per: FiniteDuration) {
+    def isZero = n == 0 || per == Duration.Zero
+    override def toString = s"$n per ${per.toSeconds} seconds"
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -99,6 +99,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         self.tell(msg = JobExecutionTokenReturn, sender = terminee)
       case None =>
         log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
+        // This is a very inefficient way to remove the actor from the queue and can lead to very poor performance for a large queue and a large number of actors to remove
         tokenQueues = tokenQueues map {
           case (tokenType, tokenQueue @ TokenQueue(queue, _)) => tokenType -> tokenQueue.copy(queue = queue.filterNot(_ == terminee))
         }

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -5,16 +5,17 @@ import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.JobExecutionToken._
 import cromwell.core.{ExecutionStatus, JobExecutionToken}
 import cromwell.engine.instrumentation.JobInstrumentation
+import cromwell.engine.workflow.tokens.DynamicRateLimiter.TokensAvailable
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor._
 import cromwell.engine.workflow.tokens.TokenQueue.LeasedActor
 import cromwell.services.instrumentation.CromwellInstrumentation._
 import cromwell.services.instrumentation.CromwellInstrumentationScheduler
+import cromwell.services.loadcontroller.LoadControllerService.ListenToLoadController
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import io.github.andrebeat.pool.Lease
-import scala.concurrent.duration._
 
-class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRef, rate: Rate) extends Actor with ActorLogging 
-  with JobInstrumentation with CromwellInstrumentationScheduler with Timers {
+class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRef, override val distributionRate: DynamicRateLimiter.Rate) extends Actor with ActorLogging
+  with JobInstrumentation with CromwellInstrumentationScheduler with Timers with DynamicRateLimiter {
 
   /**
     * Lazily created token queue. We only create a queue for a token type when we need it
@@ -22,18 +23,20 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
   var tokenQueues: Map[JobExecutionTokenType, TokenQueue] = Map.empty
   var tokenAssignments: Map[ActorRef, Lease[JobExecutionToken]] = Map.empty
 
-  scheduleInstrumentation { 
+  scheduleInstrumentation {
     sendGaugeJob(ExecutionStatus.Running.toString, tokenAssignments.size.toLong)
     sendGaugeJob(ExecutionStatus.QueuedInCromwell.toString, tokenQueues.values.map(_.size).sum.toLong)
   }
 
   override def preStart() = {
-    // Fixed for now, but soon to be modifiable 
-    timers.startPeriodicTimer(TokensTimerKey, TokensAvailable(rate.n), rate.per)
+    ratePreStart()
+    serviceRegistryActor ! ListenToLoadController
     super.preStart()
   }
 
-  override def receive: Actor.Receive = {
+  override def receive: Actor.Receive = tokenDistributionReceive.orElse(rateReceive)
+
+  private def tokenDistributionReceive: Receive = {
     case JobExecutionTokenRequest(tokenType) => enqueue(sender, tokenType)
     case JobExecutionTokenReturn => release(sender)
     case TokensAvailable(n) => distribute(n)
@@ -65,7 +68,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
     val iterator = RoundRobinQueueIterator(tokenQueues.values.toList)
 
     val nextTokens = iterator.take(n)
-    
+
     nextTokens.foreach({
       case LeasedActor(actor, lease) if !tokenAssignments.contains(actor) =>
         tokenAssignments = tokenAssignments + (actor -> lease)
@@ -74,7 +77,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
       // Only one token per actor, if you've already got one, you don't get this token !
       case LeasedActor(_, lease) => lease.release()
     })
-    
+
     tokenQueues = iterator.updatedQueues.map(queue => queue.tokenType -> queue).toMap
   }
 
@@ -106,11 +109,9 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
 }
 
 object JobExecutionTokenDispenserActor {
-  case class Rate(n: Int, per: FiniteDuration)
   case object TokensTimerKey
-  case class TokensAvailable(n: Int)
 
-  def props(serviceRegistryActor: ActorRef, rate: Rate) = Props(new JobExecutionTokenDispenserActor(serviceRegistryActor, rate)).withDispatcher(EngineDispatcher)
+  def props(serviceRegistryActor: ActorRef, rate: DynamicRateLimiter.Rate) = Props(new JobExecutionTokenDispenserActor(serviceRegistryActor, rate)).withDispatcher(EngineDispatcher)
 
   case class JobExecutionTokenRequest(jobExecutionTokenType: JobExecutionTokenType)
 

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreReaderActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreReaderActor.scala
@@ -3,6 +3,7 @@ package cromwell.jobstore
 import akka.actor.{ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.core.LoadConfig
 import cromwell.core.actor.BatchActor.CommandAndReplyTo
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.jobstore.JobStoreActor.{JobComplete, JobNotComplete, JobStoreReadFailure, QueryJobCompletion}
@@ -11,8 +12,7 @@ import cromwell.services.EnhancedThrottlerActor
 import scala.util.{Failure, Success}
 
 object JobStoreReaderActor {
-  val QueueThreshold = 10 * 1000
-  def props(database: JobStore, registryActor: ActorRef) = Props(new JobStoreReaderActor(database, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+  def props(database: JobStore, registryActor: ActorRef) = Props(new JobStoreReaderActor(database, registryActor, LoadConfig.JobStoreReadThreshold)).withDispatcher(EngineDispatcher)
 }
 
 class JobStoreReaderActor(database: JobStore, override val serviceRegistryActor: ActorRef, override val threshold: Int)

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreReaderActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreReaderActor.scala
@@ -1,20 +1,26 @@
 package cromwell.jobstore
 
 import akka.actor.{ActorLogging, ActorRef, Props}
+import cats.data.NonEmptyList
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.actor.BatchActor.CommandAndReplyTo
-import cromwell.core.actor.ThrottlerActor
+import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.jobstore.JobStoreActor.{JobComplete, JobNotComplete, JobStoreReadFailure, QueryJobCompletion}
+import cromwell.services.EnhancedThrottlerActor
 
 import scala.util.{Failure, Success}
 
 object JobStoreReaderActor {
-  def props(database: JobStore) = Props(new JobStoreReaderActor(database)).withDispatcher(EngineDispatcher)
+  val QueueThreshold = 10 * 1000
+  def props(database: JobStore, registryActor: ActorRef) = Props(new JobStoreReaderActor(database, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
 }
 
-class JobStoreReaderActor(database: JobStore) extends ThrottlerActor[CommandAndReplyTo[QueryJobCompletion]] with ActorLogging {
-  override def processHead(head: CommandAndReplyTo[QueryJobCompletion]) = {
-    val action = database.readJobResult(head.command.jobKey, head.command.taskOutputs) 
+class JobStoreReaderActor(database: JobStore, override val serviceRegistryActor: ActorRef, override val threshold: Int)
+  extends EnhancedThrottlerActor[CommandAndReplyTo[QueryJobCompletion]]
+    with ActorLogging {
+
+  override def processHead(head: CommandAndReplyTo[QueryJobCompletion]) = instrumentedProcess {
+    val action = database.readJobResult(head.command.jobKey, head.command.taskOutputs)
     action onComplete {
       case Success(Some(result)) => head.replyTo ! JobComplete(result)
       case Success(None) => head.replyTo ! JobNotComplete
@@ -22,9 +28,13 @@ class JobStoreReaderActor(database: JobStore) extends ThrottlerActor[CommandAndR
         log.error(t, "JobStoreReadFailure")
         head.replyTo ! JobStoreReadFailure(t)
     }
-    action
+    action.map(_ => 1)
   }
 
+  // EnhancedBatchActorOverrides
+  override def receive = enhancedReceive.orElse(super.receive)
+  override protected def instrumentationPath = NonEmptyList.of("store", "read")
+  override protected def instrumentationPrefix = InstrumentationPrefixes.JobPrefix
   override def commandToData(snd: ActorRef) = {
     case query: QueryJobCompletion => CommandAndReplyTo(query, sender())
   }

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -1,12 +1,13 @@
 package cromwell.jobstore
 
 import akka.actor.{ActorRef, Props}
-import cats.data.NonEmptyVector
+import cats.data.{NonEmptyList, NonEmptyVector}
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.actor.BatchActor._
-import cromwell.core.actor.BatchActor
+import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.jobstore.JobStore.{JobCompletion, WorkflowCompletion}
 import cromwell.jobstore.JobStoreActor._
+import cromwell.services.EnhancedBatchActor
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -14,16 +15,15 @@ import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 
-case class JobStoreWriterActor(jsd: JobStore, override val batchSize: Int, override val flushRate: FiniteDuration) extends 
-  BatchActor[CommandAndReplyTo[JobStoreWriterCommand]](flushRate, batchSize) {
+case class JobStoreWriterActor(jsd: JobStore,
+                               override val batchSize: Int,
+                               override val flushRate: FiniteDuration,
+                               serviceRegistryActor: ActorRef,
+                               threshold: Int
+                              )
+  extends EnhancedBatchActor[CommandAndReplyTo[JobStoreWriterCommand]](flushRate, batchSize) {
 
-  override protected def weightFunction(command: CommandAndReplyTo[JobStoreWriterCommand]) = 1
-
-  def commandToData(snd: ActorRef): PartialFunction[Any, CommandAndReplyTo[JobStoreWriterCommand]] = {
-    case command: JobStoreWriterCommand => CommandAndReplyTo(command, snd)
-  }
-
-  override protected def process(nonEmptyData: NonEmptyVector[CommandAndReplyTo[JobStoreWriterCommand]]) = {
+  override protected def process(nonEmptyData: NonEmptyVector[CommandAndReplyTo[JobStoreWriterCommand]]) = instrumentedProcess {
     val data = nonEmptyData.toVector
     log.debug("Flushing {} job store commands to the DB", data.length)
     val completions = data.collect({ case CommandAndReplyTo(c: JobStoreWriterCommand, _) => c.completion })
@@ -47,9 +47,23 @@ case class JobStoreWriterActor(jsd: JobStore, override val batchSize: Int, overr
       databaseAction.map(_ => 1)
     } else Future.successful(0)
   }
+
+  // EnhancedBatchActor overrides
+  override def receive = enhancedReceive.orElse(super.receive)
+  override protected def weightFunction(command: CommandAndReplyTo[JobStoreWriterCommand]) = 1
+  override protected def instrumentationPath = NonEmptyList.of("store", "write")
+  override protected def instrumentationPrefix = InstrumentationPrefixes.JobPrefix
+  override def commandToData(snd: ActorRef): PartialFunction[Any, CommandAndReplyTo[JobStoreWriterCommand]] = {
+    case command: JobStoreWriterCommand => CommandAndReplyTo(command, snd)
+  }
 }
 
 object JobStoreWriterActor {
-
-  def props(jobStoreDatabase: JobStore, dbBatchSize: Int, dbFlushRate: FiniteDuration): Props = Props(new JobStoreWriterActor(jobStoreDatabase, dbBatchSize, dbFlushRate)).withDispatcher(EngineDispatcher)
+  def props(jobStoreDatabase: JobStore,
+            dbBatchSize: Int,
+            dbFlushRate: FiniteDuration,
+            registryActor: ActorRef): Props = {
+    Props(new JobStoreWriterActor(jobStoreDatabase, dbBatchSize, dbFlushRate, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+  }
+  val QueueThreshold = 10 * 1000
 }

--- a/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
+++ b/engine/src/main/scala/cromwell/jobstore/JobStoreWriterActor.scala
@@ -3,6 +3,7 @@ package cromwell.jobstore
 import akka.actor.{ActorRef, Props}
 import cats.data.{NonEmptyList, NonEmptyVector}
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.core.LoadConfig
 import cromwell.core.actor.BatchActor._
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.jobstore.JobStore.{JobCompletion, WorkflowCompletion}
@@ -63,7 +64,6 @@ object JobStoreWriterActor {
             dbBatchSize: Int,
             dbFlushRate: FiniteDuration,
             registryActor: ActorRef): Props = {
-    Props(new JobStoreWriterActor(jobStoreDatabase, dbBatchSize, dbFlushRate, registryActor, QueueThreshold)).withDispatcher(EngineDispatcher)
+    Props(new JobStoreWriterActor(jobStoreDatabase, dbBatchSize, dbFlushRate, registryActor, LoadConfig.JobStoreWriteThreshold)).withDispatcher(EngineDispatcher)
   }
-  val QueueThreshold = 10 * 1000
 }

--- a/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
@@ -154,9 +154,13 @@ object CromwellShutdown extends GracefulStopSupport {
       *   Use the ShutdownCommand because a PoisonPill could stop the routees in the middle of "transaction"
       *   with the IoActor. The routees handle the ShutdownCommand properly and shutdown only when they have
       *   no outstanding requests to the IoActor. When all routees are dead the router automatically stops itself.
+      *   
+      *  - Stop the job token dispenser: stop it before stopping WMA and its EJEA descendants because
+      *  the dispenser is watching all EJEAs and would be flooded by Terminated messages otherwise  
     */
     shutdownActor(workflowStoreActor, CoordinatedShutdown.PhaseServiceRequestsDone, ShutdownCommand)
     shutdownActor(logCopyRouter, CoordinatedShutdown.PhaseServiceRequestsDone, Broadcast(ShutdownCommand))
+    shutdownActor(jobTokenDispenser, CoordinatedShutdown.PhaseServiceRequestsDone, ShutdownCommand)
     
     /*
       * Aborting is only a special case of shutdown. Instead of sending a PoisonPill, send a AbortAllWorkflowsCommand
@@ -192,7 +196,7 @@ object CromwellShutdown extends GracefulStopSupport {
       * - DockerHashActor
       * - IoActor
     */
-    List(jobTokenDispenser, subWorkflowStoreActor, jobStoreActor, callCacheWriteActor, serviceRegistryActor, dockerHashActor, ioActor) foreach {
+    List(subWorkflowStoreActor, jobStoreActor, callCacheWriteActor, serviceRegistryActor, dockerHashActor, ioActor) foreach {
       shutdownActor(_, PhaseStopIoActivity, ShutdownCommand)
     }
 

--- a/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellShutdown.scala
@@ -96,8 +96,10 @@ object CromwellShutdown extends GracefulStopSupport {
                       message: AnyRef,
                       customTimeout: Option[FiniteDuration] = None)(implicit executionContext: ExecutionContext) = {
       coordinatedShutdown.addTask(phase, s"stop${actor.path.name.capitalize}") { () =>
-        val action = gracefulStop(actor, customTimeout.getOrElse(coordinatedShutdown.timeout(phase)), message)
+        val timeout = coordinatedShutdown.timeout(phase)
+        logger.info(s"Shutting down ${actor.path.name} - Timeout = $timeout")
 
+        val action = gracefulStop(actor, customTimeout.getOrElse(coordinatedShutdown.timeout(phase)), message)
         action onComplete {
           case Success(_) => logger.info(s"${actor.path.name} stopped")
           case Failure(_: AskTimeoutException) => 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
@@ -78,7 +78,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     val hashResult = DockerHashResult("sha256", "71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950")
     val inputsAndAttributes = (inputs, attributes).validNel
     val prefetchedKey1 = "hello"
-    val prefetchedVal1 = KvPair(helper.scopedKeyMaker(prefetchedKey1), Some("world"))
+    val prefetchedVal1 = KvPair(helper.scopedKeyMaker(prefetchedKey1), "world")
     val prefetchedKey2 = "bonjour"
     val prefetchedVal2 = KvKeyLookupFailed(KvGet(helper.scopedKeyMaker(prefetchedKey2)))
     val prefetchedValues = Map(prefetchedKey1 -> prefetchedVal1, prefetchedKey2 -> prefetchedVal2)

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -3,6 +3,7 @@ package cromwell.engine.workflow.tokens
 import akka.actor.{ActorSystem, PoisonPill}
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
+import cromwell.engine.workflow.tokens.DynamicRateLimiter.{Rate, TokensAvailable}
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor._
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActorSpec._
 import cromwell.util.AkkaTestUtil

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -12,7 +12,7 @@ import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.WorkflowActor
 import cromwell.engine.workflow.WorkflowActor._
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
-import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.Rate
+import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
 import cromwell.engine.workflow.workflowstore.Submitted
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.HelloWorld.Addressee

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -16,7 +16,7 @@ import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
-import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.Rate
+import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
@@ -10,7 +10,7 @@ import cromwell.engine.backend.{BackendConfigurationEntry, BackendSingletonColle
 import cromwell.engine.workflow.WorkflowDescriptorBuilder
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{ExecuteWorkflowCommand, WorkflowExecutionFailedResponse}
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
-import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.Rate
+import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
 import cromwell.engine.workflow.workflowstore.Submitted
 import cromwell.services.ServiceRegistryActor
 import cromwell.services.metadata.MetadataService

--- a/server/src/test/scala/cromwell/jobstore/JobStoreServiceSpec.scala
+++ b/server/src/test/scala/cromwell/jobstore/JobStoreServiceSpec.scala
@@ -28,7 +28,7 @@ class JobStoreServiceSpec extends CromwellTestKitWordSpec with Matchers with Moc
   "JobStoreService" should {
     "work" in {
       lazy val jobStore: JobStore = new SqlJobStore(EngineServicesStore.engineDatabaseInterface)
-      val jobStoreService = system.actorOf(JobStoreActor.props(jobStore))
+      val jobStoreService = system.actorOf(JobStoreActor.props(jobStore, dummyServiceRegistryActor))
 
       val workflowId = WorkflowId.randomId()
       val mockTask = WomMocks.mockTaskDefinition("bar")

--- a/server/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
+++ b/server/src/test/scala/cromwell/jobstore/JobStoreWriterSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.jobstore
 
-import akka.testkit.TestFSMRef
+import akka.testkit.{TestFSMRef, TestProbe}
 import common.collections.WeightedQueue
 import cromwell.CromwellTestKitWordSpec
 import cromwell.core.actor.BatchActor.{BatchActorState, CommandAndReplyTo, Processing}
@@ -25,7 +25,7 @@ class JobStoreWriterSpec extends CromwellTestKitWordSpec with Matchers with Befo
 
   before {
     database = WriteCountingJobStore.makeNew
-    jobStoreWriter = TestFSMRef(new JobStoreWriterActor(database, 5, flushFrequency))
+    jobStoreWriter = TestFSMRef(new JobStoreWriterActor(database, 5, flushFrequency, TestProbe().ref, 1000))
     workflowId = WorkflowId.randomId()
   }
 

--- a/services/src/main/scala/cromwell/services/EnhancedBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/EnhancedBatchActor.scala
@@ -1,0 +1,18 @@
+package cromwell.services
+
+import cromwell.core.actor.BatchActor
+import cromwell.services.instrumentation.{CromwellInstrumentationActor, InstrumentedBatchActor}
+import cromwell.services.loadcontroller.LoadControlledBatchActor
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * A BatchActor with instrumentation and load control traits mixed in to remove some boilerplate
+  */
+abstract class EnhancedBatchActor[C](flushRate: FiniteDuration, batchSize: Int)
+  extends BatchActor[C](flushRate, batchSize)
+    with InstrumentedBatchActor[C]
+    with CromwellInstrumentationActor
+    with LoadControlledBatchActor[C] {
+  protected def enhancedReceive: Receive = loadControlReceive.orElse(instrumentationReceive).orElse(super.receive)
+}

--- a/services/src/main/scala/cromwell/services/EnhancedThrottlerActor.scala
+++ b/services/src/main/scala/cromwell/services/EnhancedThrottlerActor.scala
@@ -1,0 +1,16 @@
+package cromwell.services
+
+import cromwell.core.actor.ThrottlerActor
+import cromwell.services.instrumentation.{CromwellInstrumentationActor, InstrumentedBatchActor}
+import cromwell.services.loadcontroller.LoadControlledBatchActor
+
+/**
+  * A ThrottlerActor with instrumentation and load control traits mixed in to remove some boilerplate
+  */
+abstract class EnhancedThrottlerActor[C]
+  extends ThrottlerActor[C]
+  with InstrumentedBatchActor[C] 
+  with CromwellInstrumentationActor
+  with LoadControlledBatchActor[C] {
+  protected def enhancedReceive: Receive = loadControlReceive.orElse(instrumentationReceive).orElse(super.receive)
+}

--- a/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
@@ -1,44 +1,53 @@
 package cromwell.services.instrumentation
 
-import cats.data.NonEmptyVector
+import cats.data.NonEmptyList
 import cromwell.core.actor.BatchActor
-import cromwell.services.instrumentation.CromwellInstrumentation.InstrumentationPath
 import cromwell.services.instrumentation.InstrumentedBatchActor.{QueueSizeTimerAction, QueueSizeTimerKey}
 
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 object InstrumentedBatchActor {
-  case object QueueSizeTimerKey  
-  case object QueueSizeTimerAction  
+  case object QueueSizeTimerKey
+  case object QueueSizeTimerAction
 }
 
 /**
-  * Layer over batch actor that instruments the throughput and queue size
+  * Can be mixed in a BatchActor to provide helper methods to instrument queue size and throughput
   */
-abstract class InstrumentedBatchActor[C](flushRate: FiniteDuration,
-                                         batchSize: Int,
-                                         instrumentationPath: InstrumentationPath,
-                                         instrumentationPrefix: Option[String]) extends BatchActor[C](flushRate, batchSize) 
-  with CromwellInstrumentationActor {
-  private val writePath = instrumentationPath.::("write")
-  private val queueSizePath = instrumentationPath.::("queue")
+trait InstrumentedBatchActor[C] { this: BatchActor[C] with CromwellInstrumentation =>
+
+  protected def instrumentationPath: NonEmptyList[String]
+  protected def instrumentationPrefix: Option[String]
+
+  // If this actor is behind a router, add its name to the instrumentation path so that all routees don't override each other's values
+  private def makePath(name: String) = if (routed)
+    instrumentationPath.concat(NonEmptyList.of(self.path.name, name))
+  else
+    instrumentationPath.concat(NonEmptyList.one(name))
+
+  private val processedPath = makePath("processed")
+  private val queueSizePath = makePath("queue")
 
   timers.startPeriodicTimer(QueueSizeTimerKey, QueueSizeTimerAction, CromwellInstrumentation.InstrumentationRate)
-  
-  whenUnhandled {
-    case Event(QueueSizeTimerAction, data) =>
-      sendGauge(queueSizePath, data.weight.toLong, instrumentationPrefix)
-      stay()
+
+  /**
+    * Don't forget to chain this into your receive method to instrument the queue size:
+    * override def receive = instrumentationReceive.orElse(super.receive)
+    */
+  protected def instrumentationReceive: Receive = {
+    case QueueSizeTimerAction => sendGauge(queueSizePath, stateData.weight.toLong, instrumentationPrefix)
   }
-  
-  protected def processInner(data: Vector[C]): Future[Int]
-  
-  override protected final def process(data: NonEmptyVector[C]) = {
-    val action = processInner(data.toVector)
-    action foreach { n =>
-      count(writePath, n.toLong, instrumentationPrefix)
-    }
+
+  /**
+    * Don't forget to wrap your `process` or `processHead` method with this function if you want
+    * to instrument your processing rate:
+    * instrumentedProcess {
+    *   do work
+    * }
+    */
+  protected def instrumentedProcess(f: => Future[Int]) = {
+    val action = f
+    action foreach { n => count(processedPath, n.toLong, instrumentationPrefix) }
     action
   }
 }

--- a/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
@@ -16,13 +16,6 @@ import scala.concurrent.duration._
 
 object StatsDInstrumentationServiceActor {
   def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(new StatsDInstrumentationServiceActor(serviceConfig, globalConfig, serviceRegistryActor))
-
-  /* Values inserted between a CromwellBucket prefix and its path when building a StatsD path to make up for the fact
-   * that everything is sent as a gauge which makes differentiating the meaning of the metrics harder.
-  */
-  private val TimingInsert = Option("timing")
-  private val CountInsert = Option("count")
-  
   
   implicit class CromwellBucketEnhanced(val cromwellBucket: CromwellBucket) extends AnyVal {
     /**
@@ -76,7 +69,7 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
     */
   private def meterFor(bucket: CromwellBucket): Meter = {
     // Because everything is a gauge, for clarity prepend "count" for counters so it counts events instead of giving a current value
-    val name = bucket.toStatsDString(CountInsert)
+    val name = bucket.toStatsDString()
     val counterName = metricBaseName.append(name).name
     metricRegistry.getMeters.asScala.get(counterName) match {
         // Make a new one if none is found
@@ -113,6 +106,6 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
     * Adds a new timing value for this bucket
     */
   private def updateTiming(bucket: CromwellBucket, value: FiniteDuration) = {
-    metrics.timer(bucket.toStatsDString(TimingInsert)).update(value)
+    metrics.timer(bucket.toStatsDString()).update(value)
   }
 }

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueReadActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueReadActor.scala
@@ -20,6 +20,8 @@ abstract class KeyValueReadActor(override val threshold: Int, override val servi
       case Success(response) => head.replyTo ! response
       case Failure(f) => head.replyTo ! KvFailure(head.command, f)
     }
+    // This method should return how many "operations" have been performed to enable instrumentation of throughput
+    // In this case it's 1 because we processed 1 KvGet
     processed.map(_ => 1)
   }
   

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueReadActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueReadActor.scala
@@ -1,0 +1,33 @@
+package cromwell.services.keyvalue
+
+import akka.actor.ActorRef
+import cats.data.NonEmptyList
+import cromwell.core.actor.BatchActor.CommandAndReplyTo
+import cromwell.core.instrumentation.InstrumentationPrefixes
+import cromwell.services.EnhancedThrottlerActor
+import cromwell.services.keyvalue.KeyValueServiceActor.{KvFailure, KvGet, KvResponse}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+abstract class KeyValueReadActor(override val threshold: Int, override val serviceRegistryActor: ActorRef)
+  extends EnhancedThrottlerActor[CommandAndReplyTo[KvGet]] {
+  override def receive = enhancedReceive.orElse(super.receive)
+  
+  override def processHead(head: CommandAndReplyTo[KvGet]) = instrumentedProcess {
+    val processed = processGet(head.command)
+    processed onComplete {
+      case Success(response) => head.replyTo ! response
+      case Failure(f) => head.replyTo ! KvFailure(head.command, f)
+    }
+    processed.map(_ => 1)
+  }
+  
+  def processGet(get: KvGet): Future[KvResponse]
+
+  override protected lazy val instrumentationPath = KeyValueServiceActor.InstrumentationPath.concat(NonEmptyList.one("read"))
+  override protected lazy val instrumentationPrefix = InstrumentationPrefixes.ServicesPrefix
+  override def commandToData(snd: ActorRef) = {
+    case get: KvGet => CommandAndReplyTo(get, snd)
+  }
+}

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueServiceActor.scala
@@ -1,14 +1,12 @@
 package cromwell.services.keyvalue
 
-import akka.actor.ActorRef
-import cromwell.core.actor.BatchActor.CommandAndReplyTo
-import cromwell.core.actor.ThrottlerActor
+import akka.actor.{Actor, ActorLogging, Props}
+import cats.data.NonEmptyList
 import cromwell.core.{JobKey, WorkflowId}
 import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
 import cromwell.services.keyvalue.KeyValueServiceActor._
-
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
+import cromwell.util.GracefulShutdownHelper
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
 object KeyValueServiceActor {
   final case class KvJobKey(callFqn: String, callIndex: Option[Int], callAttempt: Int)
@@ -33,30 +31,25 @@ object KeyValueServiceActor {
 
   sealed trait KvResponse extends KvMessage
 
-  final case class KvPair(key: ScopedKey, value: Option[String]) extends KvResponse
+  final case class KvPair(key: ScopedKey, value: String) extends KvResponse
   final case class KvFailure(action: KvAction, failure: Throwable) extends KvResponse with KvMessageWithAction
   final case class KvKeyLookupFailed(action: KvGet) extends KvResponse with KvMessageWithAction
   final case class KvPutSuccess(action: KvPut) extends KvResponse with KvMessageWithAction
+
+  val QueueThreshold = 10 * 1000
+  val InstrumentationPath = NonEmptyList.of("keyvalue")
 }
 
-trait KeyValueServiceActor extends ThrottlerActor[CommandAndReplyTo[KvAction]] {
-  override def commandToData(snd: ActorRef): PartialFunction[Any, CommandAndReplyTo[KvAction]] = {
-    case c: KvAction => CommandAndReplyTo(c, snd)
-  }
-
-  override def processHead(action: CommandAndReplyTo[KvAction]) = action.command match {
-    case get: KvGet => respond(action.replyTo, get, doGet(get))
-    case put: KvPut => respond(action.replyTo, put, doPut(put))
-  }
-
-  def doPut(put: KvPut): Future[KvResponse]
-  def doGet(get: KvGet): Future[KvResponse]
-
-  private def respond(replyTo: ActorRef, action: KvAction, response: Future[KvResponse]): Future[KvResponse] = {
-    response.onComplete {
-      case Success(x) => replyTo ! x
-      case Failure(ex) => replyTo ! KvFailure(action, ex)
-    }
-    response
+trait KeyValueServiceActor extends Actor with GracefulShutdownHelper with ActorLogging {
+  protected def kvReadActorProps: Props
+  protected def kvWriteActorProps: Props
+  
+  private val kvReadActor = context.actorOf(kvReadActorProps, "KvReadActor")
+  private val kvWriteActor = context.actorOf(kvWriteActorProps, "KvWriteActor")
+  
+  override def receive = {
+    case get: KvGet => kvReadActor forward get
+    case put: KvPut => kvWriteActor forward put
+    case ShutdownCommand => waitForActorsAndShutdown(NonEmptyList.one(kvWriteActor))
   }
 }

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueServiceActor.scala
@@ -36,7 +36,6 @@ object KeyValueServiceActor {
   final case class KvKeyLookupFailed(action: KvGet) extends KvResponse with KvMessageWithAction
   final case class KvPutSuccess(action: KvPut) extends KvResponse with KvMessageWithAction
 
-  val QueueThreshold = 10 * 1000
   val InstrumentationPath = NonEmptyList.of("keyvalue")
 }
 

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueWriteActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueWriteActor.scala
@@ -1,0 +1,41 @@
+package cromwell.services.keyvalue
+
+import akka.actor.ActorRef
+import cats.data.{NonEmptyList, NonEmptyVector}
+import cromwell.core.actor.BatchActor.CommandAndReplyTo
+import cromwell.core.instrumentation.InstrumentationPrefixes
+import cromwell.services.EnhancedBatchActor
+import cromwell.services.keyvalue.KeyValueServiceActor.{KvFailure, KvPut, KvPutSuccess}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success}
+
+abstract class KeyValueWriteActor(override val serviceRegistryActor: ActorRef, flushRate: FiniteDuration, batchSize: Int)
+  extends EnhancedBatchActor[CommandAndReplyTo[KvPut]](flushRate, batchSize) {
+
+  
+  override protected def process(data: NonEmptyVector[CommandAndReplyTo[KvPut]]) = instrumentedProcess {
+    val processed = processPut(data.map(_.command).toVector)
+    processed onComplete {
+      case Success(_) => data.toVector.foreach({
+        case CommandAndReplyTo(command, replyTo) => replyTo ! KvPutSuccess(command)
+      })
+      case Failure(f) => data.toVector.foreach({
+        case CommandAndReplyTo(command, replyTo) => replyTo ! KvFailure(command, f)
+      })
+    }
+    processed.map(_ => data.length)
+  }
+
+  def processPut(put: Vector[KvPut]): Future[Unit]
+  
+  // EnhancedBatchActor overrides
+  override def receive = enhancedReceive.orElse(super.receive)
+  override protected def weightFunction(command: CommandAndReplyTo[KvPut]) = 1
+  override protected def instrumentationPath = KeyValueServiceActor.InstrumentationPath.concat(NonEmptyList.one("write"))
+  override protected def instrumentationPrefix = InstrumentationPrefixes.ServicesPrefix
+  override def commandToData(snd: ActorRef) = {
+    case put: KvPut => CommandAndReplyTo(put, snd)
+  }
+}

--- a/services/src/main/scala/cromwell/services/keyvalue/KeyValueWriteActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/KeyValueWriteActor.scala
@@ -25,6 +25,8 @@ abstract class KeyValueWriteActor(override val serviceRegistryActor: ActorRef, f
         case CommandAndReplyTo(command, replyTo) => replyTo ! KvFailure(command, f)
       })
     }
+    // This method should return how many "operations" have been performed to enable instrumentation of throughput
+    // Here we've processed all the KvPuts in "data"
     processed.map(_ => data.length)
   }
 

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueReadActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueReadActor.scala
@@ -1,0 +1,27 @@
+package cromwell.services.keyvalue.impl
+
+import akka.actor.{ActorRef, Props}
+import cromwell.services.keyvalue.KeyValueServiceActor.{KvKeyLookupFailed, KvPair}
+import cromwell.services.keyvalue.{KeyValueReadActor, KeyValueServiceActor}
+
+object SqlKeyValueReadActor {
+  def props(threshold: Int, serviceRegistryActor: ActorRef) = {
+    Props(new SqlKeyValueReadActor(threshold, serviceRegistryActor))
+  }
+}
+
+class SqlKeyValueReadActor(threshold: Int, serviceRegistryActor: ActorRef)
+  extends KeyValueReadActor(threshold, serviceRegistryActor) with BackendKeyValueDatabaseAccess {
+  override def processGet(get: KeyValueServiceActor.KvGet) = {
+    val backendValue = getBackendValueByKey(
+      get.key.workflowId,
+      get.key.jobKey,
+      get.key.key
+    )
+
+    backendValue map {
+      case Some(maybeValue) => KvPair(get.key, maybeValue)
+      case None => KvKeyLookupFailed(get)
+    }
+  }
+}

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
@@ -3,31 +3,34 @@ package cromwell.services.keyvalue.impl
 import akka.actor.{ActorRef, Props}
 import com.typesafe.config.Config
 import cromwell.core.Dispatcher.ServiceDispatcher
+import cromwell.core.LoadConfig
 import cromwell.services.keyvalue.KeyValueServiceActor
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
 object SqlKeyValueServiceActor {
   def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(SqlKeyValueServiceActor(serviceConfig, globalConfig, serviceRegistryActor)).withDispatcher(ServiceDispatcher)
-  val WriteQueueThreshold = 10 * 1000
-  val ReadQueueThreshold = 10 * 1000
 }
 
 final case class SqlKeyValueServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends KeyValueServiceActor {
 
+  private val dbFlushRate = serviceConfig.as[Option[FiniteDuration]]("db-flush-rate").getOrElse(5.seconds)
+  private val dbBatchSize = serviceConfig.as[Option[Int]]("db-batch-size").getOrElse(200)
+
   override protected def kvReadActorProps = {
     SqlKeyValueReadActor.props(
-      SqlKeyValueServiceActor.WriteQueueThreshold,
+      LoadConfig.KeyValueReadThreshold,
       serviceRegistryActor
     )
   }
 
   override protected def kvWriteActorProps = {
     SqlKeyValueWriteActor.props(
-      SqlKeyValueServiceActor.WriteQueueThreshold,
+      LoadConfig.KeyValueWriteThreshold,
       serviceRegistryActor,
-      5.seconds,
-      1000
+      dbFlushRate,
+      dbBatchSize
     )
   }
 }

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueServiceActor.scala
@@ -15,8 +15,8 @@ object SqlKeyValueServiceActor {
 final case class SqlKeyValueServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends KeyValueServiceActor {
 
-  private val dbFlushRate = serviceConfig.as[Option[FiniteDuration]]("db-flush-rate").getOrElse(5.seconds)
-  private val dbBatchSize = serviceConfig.as[Option[Int]]("db-batch-size").getOrElse(200)
+  private lazy val dbFlushRate = serviceConfig.as[Option[FiniteDuration]]("db-flush-rate").getOrElse(5.seconds)
+  private lazy val dbBatchSize = serviceConfig.as[Option[Int]]("db-batch-size").getOrElse(200)
 
   override protected def kvReadActorProps = {
     SqlKeyValueReadActor.props(

--- a/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueWriteActor.scala
+++ b/services/src/main/scala/cromwell/services/keyvalue/impl/SqlKeyValueWriteActor.scala
@@ -1,0 +1,27 @@
+package cromwell.services.keyvalue.impl
+
+import akka.actor.{ActorRef, Props}
+import cromwell.services.keyvalue.{KeyValueServiceActor, KeyValueWriteActor}
+
+import scala.concurrent.duration.FiniteDuration
+
+object SqlKeyValueWriteActor {
+  def props(threshold: Int, serviceRegistryActor: ActorRef, flushRate: FiniteDuration, batchSize: Int) = {
+    Props(new SqlKeyValueWriteActor(threshold, serviceRegistryActor, flushRate, batchSize))
+  }
+}
+
+class SqlKeyValueWriteActor(override val threshold: Int, serviceRegistryActor: ActorRef, flushRate: FiniteDuration, batchSize: Int)
+  extends KeyValueWriteActor(serviceRegistryActor, flushRate, batchSize) with BackendKeyValueDatabaseAccess {
+  private implicit val system = context.system
+
+  override def processPut(puts: Vector[KeyValueServiceActor.KvPut]) = {
+    val pairs = puts.map({put =>
+      (put.pair.key.workflowId,
+        put.pair.key.jobKey,
+        put.pair.key.key,
+        put.pair.value)
+    })
+    updateBackendKeyValuePairs(pairs)
+  }
+}

--- a/services/src/main/scala/cromwell/services/loadcontroller/LoadControlledBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/LoadControlledBatchActor.scala
@@ -1,0 +1,34 @@
+package cromwell.services.loadcontroller
+
+import akka.actor.ActorRef
+import cats.data.NonEmptyList
+import cromwell.core.actor.BatchActor
+import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.loadcontroller.LoadControlledBatchActor._
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
+
+object LoadControlledBatchActor {
+  case object LoadControlledBatchActorTimerKey
+  case object LoadControlledBatchActorTimerAction
+}
+
+/**
+  * Can be mixed in a BatchActor to provide automated monitoring of the queue size based on a threshold value
+  */
+trait LoadControlledBatchActor[C] { this: BatchActor[C] =>
+  def threshold: Int
+  def serviceRegistryActor: ActorRef
+  private val path = if (routed) NonEmptyList.of(context.parent.path.name, self.path.name) else NonEmptyList.one(self.path.name)
+
+  timers.startSingleTimer(LoadControlledBatchActorTimerKey, LoadControlledBatchActorTimerAction, CromwellInstrumentation.InstrumentationRate)
+
+  private def weightToLoad(weight: Int) = if (weight > threshold) HighLoad else NormalLoad
+
+  /**
+    * Don't forget to chain this into your receive method to monitor the queue size:
+    * override def receive = loadControlReceive.orElse(super.receive)
+    */
+  protected def loadControlReceive: Receive = {
+    case LoadControlledBatchActorTimerAction => serviceRegistryActor ! LoadMetric(path, weightToLoad(stateData.weight))
+  }
+}

--- a/services/src/main/scala/cromwell/services/loadcontroller/LoadControlledBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/LoadControlledBatchActor.scala
@@ -2,8 +2,8 @@ package cromwell.services.loadcontroller
 
 import akka.actor.ActorRef
 import cats.data.NonEmptyList
+import cromwell.core.LoadConfig
 import cromwell.core.actor.BatchActor
-import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.loadcontroller.LoadControlledBatchActor._
 import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
 
@@ -20,7 +20,7 @@ trait LoadControlledBatchActor[C] { this: BatchActor[C] =>
   def serviceRegistryActor: ActorRef
   private val path = if (routed) NonEmptyList.of(context.parent.path.name, self.path.name) else NonEmptyList.one(self.path.name)
 
-  timers.startSingleTimer(LoadControlledBatchActorTimerKey, LoadControlledBatchActorTimerAction, CromwellInstrumentation.InstrumentationRate)
+  timers.startSingleTimer(LoadControlledBatchActorTimerKey, LoadControlledBatchActorTimerAction, LoadConfig.MonitoringFrequency)
 
   private def weightToLoad(weight: Int) = if (weight > threshold) HighLoad else NormalLoad
 

--- a/services/src/main/scala/cromwell/services/loadcontroller/LoadControllerService.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/LoadControllerService.scala
@@ -1,0 +1,23 @@
+package cromwell.services.loadcontroller
+
+import cats.data.NonEmptyList
+import cromwell.services.ServiceRegistryActor.{ListenToMessage, ServiceRegistryMessage}
+import cromwell.services.loadcontroller.impl.LoadControllerServiceActor.LoadControllerServiceName
+
+object LoadControllerService {
+  sealed trait LoadControllerMessage extends ServiceRegistryMessage {
+    def serviceName = LoadControllerServiceName
+  }
+  object LoadMetric {
+    def apply(name: String, loadLevel: LoadLevel) = new LoadMetric(NonEmptyList.one(name), loadLevel)
+  }
+  case class LoadMetric(name: NonEmptyList[String], loadLevel: LoadLevel) extends LoadControllerMessage
+
+  sealed trait LoadLevel { def level: Int }
+  case object NormalLoad extends LoadLevel { val level = 0 }
+  // Start with a single abnormal load level for now and we can add more if we want to be more granular
+  case object HighLoad extends LoadLevel { val level = 1 }
+
+  implicit val loadLevelOrdering: Ordering[LoadLevel] = Ordering.by[LoadLevel, Int](_.level)
+  case object ListenToLoadController extends LoadControllerMessage with ListenToMessage
+}

--- a/services/src/main/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActor.scala
@@ -31,8 +31,6 @@ class LoadControllerServiceActor(serviceConfig: Config,
                                 ) extends Actor
   with ActorLogging with Listeners with Timers with CromwellInstrumentation {
   private val controlFrequency = serviceConfig.as[Option[FiniteDuration]]("control-frequency").getOrElse(5.seconds)
-  private val memoryThreshold = serviceConfig.as[Option[Long]]("memory-threshold-in-mb").getOrElse(500L)
-  private val memoryCheckRate = serviceConfig.as[Option[FiniteDuration]]("memory-check-rate").getOrElse(30.seconds)
 
   private [impl] var loadLevel: LoadLevel = NormalLoad
   private [impl] var monitoredActors: Set[ActorRef] = Set.empty
@@ -42,7 +40,7 @@ class LoadControllerServiceActor(serviceConfig: Config,
 
   override def preStart() = {
     timers.startPeriodicTimer(LoadControlTimerKey, LoadControlTimerAction, controlFrequency)
-    context.actorOf(MemoryLoadControllerActor.props(memoryThreshold, memoryCheckRate, serviceRegistryActor))
+    context.actorOf(MemoryLoadControllerActor.props(serviceRegistryActor))
     super.preStart()
   }
 

--- a/services/src/main/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActor.scala
@@ -1,0 +1,85 @@
+package cromwell.services.loadcontroller.impl
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Terminated, Timers}
+import akka.routing.Listeners
+import cats.data.NonEmptyList
+import com.typesafe.config.Config
+import cromwell.services.instrumentation.CromwellInstrumentation
+import cromwell.services.loadcontroller.LoadControllerService._
+import cromwell.services.loadcontroller.impl.LoadControllerServiceActor._
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
+import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.duration._
+
+object LoadControllerServiceActor {
+  val LoadControllerServiceName = "LoadController"
+  val LoadInstrumentationPrefix = Option("load")
+  case object LoadControlTimerKey
+  case object LoadControlTimerAction
+  case class ActorAndMetric(actorRef: ActorRef, metricPath: NonEmptyList[String])
+}
+
+/**
+  * Actor that monitors load and sends alert to the rest of the system when load is determined abnormal.
+  * Send a LoadMetric message to the serviceRegistryActor to let this actor know about your current load.
+  * Send a ListenToLoadController message to the serviceRegistryActor to listen to load updates.
+  */
+class LoadControllerServiceActor(serviceConfig: Config,
+                                 globalConfig: Config,
+                                 override val serviceRegistryActor: ActorRef
+                                ) extends Actor
+  with ActorLogging with Listeners with Timers with CromwellInstrumentation {
+  private val controlFrequency = serviceConfig.as[Option[FiniteDuration]]("control-frequency").getOrElse(5.seconds)
+  private val memoryThreshold = serviceConfig.as[Option[Long]]("memory-threshold-in-mb").getOrElse(500L)
+  private val memoryCheckRate = serviceConfig.as[Option[FiniteDuration]]("memory-check-rate").getOrElse(30.seconds)
+
+  private [impl] var loadLevel: LoadLevel = NormalLoad
+  private [impl] var monitoredActors: Set[ActorRef] = Set.empty
+  private [impl] var loadMetrics: Map[ActorAndMetric, LoadLevel] = Map.empty
+  
+  override def receive = listenerManagement.orElse(controlReceive)
+
+  override def preStart() = {
+    timers.startPeriodicTimer(LoadControlTimerKey, LoadControlTimerAction, controlFrequency)
+    context.actorOf(MemoryLoadControllerActor.props(memoryThreshold, memoryCheckRate, serviceRegistryActor))
+    super.preStart()
+  }
+
+  private val controlReceive: Receive = {
+    case metric: LoadMetric => updateMetric(metric)
+    case LoadControlTimerAction => checkLoad()
+    case Terminated(terminee) => handleTerminated(terminee)
+    case ShutdownCommand => context stop self
+  }
+
+  private def updateMetric(metric: LoadMetric): Unit = {
+    val snd = sender()
+    loadMetrics = loadMetrics + (ActorAndMetric(snd, metric.name) -> metric.loadLevel)
+    if (!monitoredActors.contains(snd)) {
+      context.watch(snd)
+      monitoredActors = monitoredActors + snd
+    }
+    sendGauge(metric.name, metric.loadLevel.level.toLong, LoadInstrumentationPrefix)
+  }
+
+  private def checkLoad(): Unit = {
+    // Simply take the max level of all load metrics for now
+    val newLoadLevel = if (loadMetrics.nonEmpty) loadMetrics.values.max else NormalLoad
+    // The load level escalates if the new load is higher than the previous load
+    val escalates = loadLevelOrdering.gt(newLoadLevel, loadLevel)
+    // Back to normal if we were not normal before but now are
+    val backToNormal = loadLevel != NormalLoad && newLoadLevel == NormalLoad
+    // If there's something to say, let it out !
+    if (escalates || backToNormal) gossip(newLoadLevel)
+    loadLevel = newLoadLevel
+    sendGauge(NonEmptyList.one("global"), loadLevel.level.toLong, LoadInstrumentationPrefix)
+  }
+  
+  private def handleTerminated(terminee: ActorRef) = {
+    monitoredActors = monitoredActors - terminee
+    loadMetrics = loadMetrics.filterKeys({
+      case ActorAndMetric(actor, _) => actor != terminee
+    })
+  }
+}

--- a/services/src/main/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerActor.scala
@@ -1,0 +1,55 @@
+package cromwell.services.loadcontroller.impl
+
+import akka.actor.{Actor, ActorRef, Props, Timers}
+
+import scala.concurrent.duration._
+import MemoryLoadControllerActor._
+import cats.data.NonEmptyList
+import cromwell.services.instrumentation.CromwellInstrumentationActor
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadLevel, LoadMetric, NormalLoad}
+object MemoryLoadControllerActor {
+  case object MemoryLoadControlTimerKey
+  case object MemoryLoadControlTimerAction
+  private val runtime = Runtime.getRuntime
+  private val FreeMemoryInstrumentationPath = NonEmptyList.one("freeMemoryInMB")
+  private val MB = 1024L * 1024L
+  private def freeMemoryInMB = (runtime.maxMemory() - (runtime.totalMemory() - runtime.freeMemory())) / MB
+  def props(threshold: Long, frequency: FiniteDuration, serviceActor: ActorRef) = {
+    Props(new MemoryLoadControllerActor(threshold, frequency, serviceActor))
+  }
+}
+
+class MemoryLoadControllerActor(thresholdInMB: Long,
+                                frequency: FiniteDuration,
+                                override val serviceRegistryActor: ActorRef) extends Actor with Timers with CromwellInstrumentationActor {
+  private val nbRecordings = 10
+  private var index: Int = 0
+  private val loadRecordings = Array.fill[LoadLevel](nbRecordings) { NormalLoad }
+
+  override def preStart() = {
+    timers.startSingleTimer(MemoryLoadControlTimerKey, MemoryLoadControlTimerAction, frequency)
+    super.preStart()
+  }
+  
+  override def receive = {
+    case MemoryLoadControlTimerAction => updateAndCheckMemory()
+  }
+  
+  private [impl] def getFreeMemory = freeMemoryInMB
+  
+  private def updateAndCheckMemory() = {
+    val currentFreeMemory = getFreeMemory
+    val currentLoad = if (currentFreeMemory < thresholdInMB) HighLoad else NormalLoad
+    // Update
+    loadRecordings.update(index, currentLoad)
+    index = (index + 1) % nbRecordings
+    
+    // Check
+    val amortizedLoad = if (loadRecordings.forall(_ == HighLoad)) HighLoad
+    else NormalLoad
+
+    serviceRegistryActor ! LoadMetric("Memory", amortizedLoad)
+    sendGauge(FreeMemoryInstrumentationPath, currentFreeMemory)
+    timers.startSingleTimer(MemoryLoadControlTimerKey, MemoryLoadControlTimerAction, frequency)
+  }
+}

--- a/services/src/main/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerActor.scala
+++ b/services/src/main/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerActor.scala
@@ -22,6 +22,7 @@ object MemoryLoadControllerActor {
 class MemoryLoadControllerActor(thresholdInMB: Long,
                                 frequency: FiniteDuration,
                                 override val serviceRegistryActor: ActorRef) extends Actor with Timers with CromwellInstrumentationActor {
+  private var amortizedLoad: LoadLevel = NormalLoad
   private val nbRecordings = 10
   private var index: Int = 0
   private val loadRecordings = Array.fill[LoadLevel](nbRecordings) { NormalLoad }
@@ -30,23 +31,26 @@ class MemoryLoadControllerActor(thresholdInMB: Long,
     timers.startSingleTimer(MemoryLoadControlTimerKey, MemoryLoadControlTimerAction, frequency)
     super.preStart()
   }
-  
+
   override def receive = {
     case MemoryLoadControlTimerAction => updateAndCheckMemory()
   }
-  
+
   private [impl] def getFreeMemory = freeMemoryInMB
-  
+
   private def updateAndCheckMemory() = {
     val currentFreeMemory = getFreeMemory
     val currentLoad = if (currentFreeMemory < thresholdInMB) HighLoad else NormalLoad
     // Update
     loadRecordings.update(index, currentLoad)
     index = (index + 1) % nbRecordings
-    
-    // Check
-    val amortizedLoad = if (loadRecordings.forall(_ == HighLoad)) HighLoad
-    else NormalLoad
+
+    // Check if the load has been homogeneous for the past 10 checks
+    loadRecordings.toSet.size match {
+      // If yes and it's different from the current amortized load, update it
+      case 1 if loadRecordings.head != amortizedLoad => amortizedLoad = loadRecordings.head
+      case _ =>
+    }
 
     serviceRegistryActor ! LoadMetric("Memory", amortizedLoad)
     sendGauge(FreeMemoryInstrumentationPath, currentFreeMemory)

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime
 import akka.actor.ActorRef
 import cats.data.NonEmptyList
 import cromwell.core._
-import cromwell.services.ServiceRegistryActor.ServiceRegistryMessage
+import cromwell.services.ServiceRegistryActor.{ListenToMessage, ServiceRegistryMessage}
 import common.exception.{MessageAggregation, ThrowableAggregation}
 import wom.core._
 import wom.values._
@@ -69,7 +69,7 @@ object MetadataService {
   final case class PutMetadataAction(events: Iterable[MetadataEvent]) extends MetadataWriteAction 
   final case class PutMetadataActionAndRespond(events: Iterable[MetadataEvent], replyTo: ActorRef) extends MetadataWriteAction
 
-  final case object ListenToMetadataWriteActor extends MetadataServiceAction
+  final case object ListenToMetadataWriteActor extends MetadataServiceAction with ListenToMessage
 
   final case class GetSingleWorkflowMetadataAction(workflowId: WorkflowId, includeKeysOption: Option[NonEmptyList[String]],
                                              excludeKeysOption: Option[NonEmptyList[String]],
@@ -214,7 +214,7 @@ object MetadataService {
         }
         message ++ indexedCauseEvents
 
-      case other @ _ =>
+      case _ =>
         val message = List(MetadataEvent(metadataKey.copy(key = s"$metadataKeyAndFailureIndex:message"), MetadataValue(t.getMessage)))
         val causeKey = metadataKey.copy(key = s"$metadataKeyAndFailureIndex:causedBy")
         val cause = Option(t.getCause) map { cause => throwableToMetadataEvents(causeKey, cause, 0) } getOrElse emptyCauseList

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -7,7 +7,7 @@ import akka.routing.Listen
 import cats.data.NonEmptyList
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.Dispatcher.ServiceDispatcher
-import cromwell.core.WorkflowId
+import cromwell.core.{LoadConfig, WorkflowId}
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.impl.MetadataServiceActor._
@@ -52,8 +52,7 @@ final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Confi
 
   val dbFlushRate = serviceConfig.as[Option[FiniteDuration]]("db-flush-rate").getOrElse(5 seconds)
   val dbBatchSize = serviceConfig.as[Option[Int]]("db-batch-size").getOrElse(200)
-  val queueThreshold = 100 * 1000
-  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate, serviceRegistryActor, queueThreshold), "WriteMetadataActor")
+  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate, serviceRegistryActor, LoadConfig.MetadataWriteThreshold), "WriteMetadataActor")
   implicit val ec = context.dispatcher
   private var summaryRefreshCancellable: Option[Cancellable] = None
 

--- a/services/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServiceRegistryActorSpec.scala
@@ -5,11 +5,12 @@ import java.util.UUID
 
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{Actor, ActorInitializationException, ActorRef, OneForOneStrategy, Props}
+import akka.routing.Listen
 import akka.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}
 import cromwell.core.TestKitSuite
-import cromwell.services.BarServiceActor.{ArbitraryBarMessage, SetProbe}
-import cromwell.services.ServiceRegistryActor.{ServiceRegistryFailure, ServiceRegistryMessage}
+import cromwell.services.BarServiceActor.{ArbitraryBarMessage, ListenToBarMessage, SetProbe}
+import cromwell.services.ServiceRegistryActor.{ListenToMessage, ServiceRegistryFailure, ServiceRegistryMessage}
 import cromwell.services.ServiceRegistryActorSpec._
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
@@ -31,6 +32,7 @@ object BarServiceActor {
   }
   final case class SetProbe(probe: TestProbe) extends BarServiceMessage
   case object ArbitraryBarMessage extends BarServiceMessage
+  case object ListenToBarMessage extends BarServiceMessage with ListenToMessage
 }
 
 class BarServiceActor(config: Config, configp: Config, registryActor: ActorRef) extends Actor {
@@ -191,6 +193,21 @@ class ServiceRegistryActorSpec extends TestKitSuite("service-registry-actor-spec
 
     barProbe.expectMsgPF(AwaitTimeout) {
       case ArbitraryBarMessage =>
+      case x => fail("unexpected message: " + x)
+    }
+  }
+  
+  it should "unpack ListenTo messages" in {
+    val snd = TestProbe().ref
+    val configString = buildConfig(classOf[BarServiceActor])
+    val service = buildServiceRegistry(ConfigFactory.parseString(configString))
+
+    val barProbe = TestProbe()
+    service ! SetProbe(barProbe)
+    service.tell(ListenToBarMessage, snd)
+
+    barProbe.expectMsgPF(AwaitTimeout) {
+      case Listen(l) => l shouldBe snd
       case x => fail("unexpected message: " + x)
     }
   }

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -51,24 +51,24 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
   // Note: The current StatsD implementation sends everything as StatsD gauges so we expect all packets to be "...|g"
   List(
     StatsDTestBit("increment counters", CromwellIncrement(testBucket),
-      Set("prefix_value.cromwell.test_prefix.count.test.metric.bucket.samples:1|g",
-        "prefix_value.cromwell.test_prefix.count.test.metric.bucket.m1_rate:0.00|g"
+      Set("prefix_value.cromwell.test_prefix.test.metric.bucket.samples:1|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.m1_rate:0.00|g"
       )
     ),
     StatsDTestBit("add count", CromwellCount(testBucket, 80),
-      Set("prefix_value.cromwell.test_prefix.count.test.metric.bucket.samples:81|g",
-        "prefix_value.cromwell.test_prefix.count.test.metric.bucket.m1_rate:0.00|g"
+      Set("prefix_value.cromwell.test_prefix.test.metric.bucket.samples:81|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.m1_rate:0.00|g"
       )
     ),
     StatsDTestBit("set gauges", CromwellGauge(testBucket, 89),
       Set("prefix_value.cromwell.test_prefix.test.metric.bucket:89|g")
     ),
-    StatsDTestBit("set timings", CromwellTiming(testBucket, 5.seconds),
-      Set("prefix_value.cromwell.test_prefix.timing.test.metric.bucket.stddev:0.00|g",
-        "prefix_value.cromwell.test_prefix.timing.test.metric.bucket.samples:1|g",
-        "prefix_value.cromwell.test_prefix.timing.test.metric.bucket.p95:5000.00|g",
-        "prefix_value.cromwell.test_prefix.timing.test.metric.bucket.mean:5000.00|g",
-        "prefix_value.cromwell.test_prefix.timing.test.metric.bucket.m1_rate:0.00|g"
+    StatsDTestBit("set timings", CromwellTiming(testBucket.expand("timing"), 5.seconds),
+      Set("prefix_value.cromwell.test_prefix.test.metric.bucket.timing.stddev:0.00|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.timing.samples:1|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.timing.p95:5000.00|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.timing.mean:5000.00|g",
+        "prefix_value.cromwell.test_prefix.test.metric.bucket.timing.m1_rate:0.00|g"
       )
     )
   ) foreach {

--- a/services/src/test/scala/cromwell/services/keyvalue/InMemoryKvServiceActor.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/InMemoryKvServiceActor.scala
@@ -1,21 +1,39 @@
 package cromwell.services.keyvalue
 
+import akka.actor.{ActorRef, Props}
 import cromwell.services.keyvalue.KeyValueServiceActor._
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 final class InMemoryKvServiceActor extends KeyValueServiceActor {
-  override implicit val ec: ExecutionContextExecutor = context.dispatcher
+  implicit val ec: ExecutionContext = context.dispatcher
 
-  var kvStore = Map.empty[ScopedKey, Option[String]]
+  var kvStore = Map.empty[ScopedKey, String]
 
-  override def doGet(get: KvGet): Future[KvResponse] = kvStore.get(get.key).map(KvPair(get.key, _)) match {
-    case Some(kvPair) => Future.successful(kvPair)
+  override def receive = {
+    case get: KvGet => respond(sender, get, doGet(get))
+    case put: KvPut => respond(sender, put, doPut(put))
+  }
+
+  def doGet(get: KvGet): Future[KvResponse] = kvStore.get(get.key) match {
+    case Some(value) => Future.successful(KvPair(get.key, value))
     case None => Future.successful(KvKeyLookupFailed(get))
   }
 
-  override def doPut(put: KvPut): Future[KvResponse] = {
+  def doPut(put: KvPut): Future[KvResponse] = {
     kvStore += (put.key -> put.pair.value)
     Future.successful(KvPutSuccess(put))
+  }
+
+  override protected def kvReadActorProps = Props.empty
+
+  override protected def kvWriteActorProps = Props.empty
+
+  private def respond(replyTo: ActorRef, action: KvAction, response: Future[KvResponse]): Unit = {
+    response.onComplete {
+      case Success(x) => replyTo ! x
+      case Failure(ex) => replyTo ! KvFailure(action, ex)
+    }
   }
 }

--- a/services/src/test/scala/cromwell/services/keyvalue/KvClientSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/KvClientSpec.scala
@@ -23,10 +23,10 @@ class KvClientSpec extends TestKit(ActorSystem("KvClientSpec")) with FlatSpecLik
 
     val scopedKey1 = ScopedKey(null, null, "key1")
     val scopedKey2 = ScopedKey(null, null, "key2")
-    val putRequest = KvPut(KvPair(scopedKey1, Some("value1")))
+    val putRequest = KvPut(KvPair(scopedKey1, "value1"))
     val getRequest = KvGet(scopedKey2)
     val putResponse = KvFailure(putRequest, new IOException())
-    val getResponse = KvPair(scopedKey2, Some("value2"))
+    val getResponse = KvPair(scopedKey2, "value2")
 
     val requests = Seq(putRequest, getRequest)
     val futureResult = kvTestClient.underlyingActor.makeKvRequest(requests)

--- a/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
@@ -1,0 +1,78 @@
+package cromwell.services.keyvalue.impl
+
+import com.typesafe.config.ConfigFactory
+import cromwell.core.Tags.DbmsTest
+import cromwell.core.WorkflowId
+import cromwell.database.slick.EngineSlickDatabase
+import cromwell.database.sql.tables.JobKeyValueEntry
+import cromwell.services.EngineServicesStore
+import cromwell.services.ServicesStore.EnhancedSqlDatabase
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.specs2.mock.Mockito
+
+import scala.concurrent.ExecutionContext
+
+class KeyValueDatabaseSpec extends FlatSpec with Matchers with ScalaFutures with BeforeAndAfterAll with Mockito {
+
+  implicit val ec = ExecutionContext.global
+  implicit val defaultPatience = PatienceConfig(scaled(Span(5, Seconds)), scaled(Span(100, Millis)))
+
+  "SlickDatabase (hsqldb)" should behave like testWith("database")
+
+  "SlickDatabase (mysql)" should behave like testWith("database-test-mysql")
+
+  def testWith(configPath: String): Unit = {
+    lazy val databaseConfig = ConfigFactory.load.getConfig(configPath)
+    lazy val dataAccess = new EngineSlickDatabase(databaseConfig)
+      .initialized(EngineServicesStore.EngineLiquibaseSettings)
+    val workflowId = WorkflowId.randomId().toString
+    val callFqn = "AwesomeWorkflow.GoodJob"
+
+    val keyValueEntryA = JobKeyValueEntry(
+      workflowExecutionUuid = workflowId,
+      callFullyQualifiedName = callFqn,
+      jobIndex = 0,
+      jobAttempt = 1,
+      storeKey = "myKeyA",
+      storeValue = "myValueA"
+    )
+
+    val keyValueEntryA2= JobKeyValueEntry(
+      workflowExecutionUuid = workflowId,
+      callFullyQualifiedName = callFqn,
+      jobIndex = 0,
+      jobAttempt = 1,
+      storeKey = "myKeyA",
+      storeValue = "myValueA2"
+    )
+
+    val keyValueEntryB = JobKeyValueEntry(
+      workflowExecutionUuid = workflowId,
+      callFullyQualifiedName = callFqn,
+      jobIndex = 0,
+      jobAttempt = 1,
+      storeKey = "myKeyB",
+      storeValue = "myValueB"
+    )
+
+    it should "upsert and retrieve kv pairs correctly" taggedAs DbmsTest in {
+      (for {
+        // Just add A
+        _ <- dataAccess.addJobKeyValueEntries(Seq(keyValueEntryA))
+        valueA <- dataAccess.queryStoreValue(workflowId.toString, callFqn, 0, 1, "myKeyA")
+        // Check that it's there
+        _ = valueA shouldBe Some("myValueA")
+        // Update A and add B in the same transaction
+        _ <- dataAccess.addJobKeyValueEntries(Seq(keyValueEntryA2, keyValueEntryB))
+        // A should have a new value
+        valueA2 <- dataAccess.queryStoreValue(workflowId.toString, callFqn, 0, 1, "myKeyA")
+        _ = valueA2 shouldBe Some("myValueA2")
+        // B should also be there
+        valueB <- dataAccess.queryStoreValue(workflowId.toString, callFqn, 0, 1, "myKeyB")
+        _ = valueB shouldBe Some("myValueB")
+      } yield ()).futureValue
+    }
+  }
+}

--- a/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueServiceActorSpec.scala
@@ -28,13 +28,13 @@ class KeyValueServiceActorSpec extends ServicesSpec("KeyValue") {
   val jobKey1 = KvJobKey("some_FQN", Option(-1), 1)
   val jobKey2 = KvJobKey("some_FQN", Option(-1), 2)
 
-  val kvPair1 = KvPair(ScopedKey(wfID, jobKey1, "k1"), Option("v1"))
-  val kvPair2 = KvPair(ScopedKey(wfID, jobKey1, "k2"), Option("v2"))
-  val kvPair3 = KvPair(ScopedKey(wfID, jobKey2, "k1"), Option("v1"))
+  val kvPair1 = KvPair(ScopedKey(wfID, jobKey1, "k1"), "v1")
+  val kvPair2 = KvPair(ScopedKey(wfID, jobKey1, "k2"), "v2")
+  val kvPair3 = KvPair(ScopedKey(wfID, jobKey2, "k1"), "v1")
 
   "KeyValueServiceActor" should {
     "insert a key/value" in {
-      val kvPut1 = KvPut(KvPair(ScopedKey(wfID, jobKey1, "k1"), Option("v1")))
+      val kvPut1 = KvPut(KvPair(ScopedKey(wfID, jobKey1, "k1"), "v1"))
 
           (for {
             putResult <- (sqlKvServiceActor ? kvPut1).mapTo[KvResponse]
@@ -56,7 +56,7 @@ class KeyValueServiceActorSpec extends ServicesSpec("KeyValue") {
     }
 
     "be able to overwrite values" in {
-      val kvPairOverride = KvPair(ScopedKey(wfID, jobKey1, "k1"), Option("v3"))
+      val kvPairOverride = KvPair(ScopedKey(wfID, jobKey1, "k1"), "v3")
 
       (for {
         putResult <- (sqlKvServiceActor ? KvPut(kvPair2)).mapTo[KvResponse]

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
@@ -15,11 +15,7 @@ import org.scalatest.{FlatSpecLike, Matchers}
 import scala.concurrent.duration._
 
 object LoadControllerServiceActorSpec {
-  val Config = ConfigFactory.parseString(
-    """
-      |control-frequency = 1 second
-    """.stripMargin
-  )
+  val Config = ConfigFactory.parseString("control-frequency = 1 second")
 }
 
 class LoadControllerServiceActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Eventually with ImplicitSender {

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
@@ -1,0 +1,94 @@
+package cromwell.services.loadcontroller.impl
+
+import akka.actor.Kill
+import akka.routing.Listen
+import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
+import cats.data.NonEmptyList
+import com.typesafe.config.ConfigFactory
+import cromwell.core.TestKitSuite
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
+import cromwell.services.loadcontroller.impl.LoadControllerServiceActor.ActorAndMetric
+import cromwell.services.loadcontroller.impl.LoadControllerServiceActorSpec._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+
+object LoadControllerServiceActorSpec {
+  val Config = ConfigFactory.parseString(
+    """
+      |control-frequency = 1 second
+    """.stripMargin
+  )
+}
+
+class LoadControllerServiceActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Eventually with ImplicitSender {
+  behavior of "LoadControllerServiceActor"
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(2.seconds))
+
+  it should "record metrics" in {
+    val loadActor = TestActorRef(new LoadControllerServiceActor(Config, Config, TestProbe().ref))
+    loadActor ! LoadMetric("itsme", NormalLoad)
+    loadActor ! LoadMetric("itsotherme", HighLoad)
+    loadActor.underlyingActor.loadMetrics(ActorAndMetric(self, NonEmptyList.one("itsme"))) shouldBe NormalLoad
+    loadActor.underlyingActor.loadMetrics(ActorAndMetric(self, NonEmptyList.one("itsotherme"))) shouldBe HighLoad
+  }
+
+  it should "update global load level periodically" in {
+    val loadActor = TestActorRef(new LoadControllerServiceActor(Config, Config, TestProbe().ref))
+    loadActor.underlyingActor.loadLevel shouldBe NormalLoad
+    loadActor ! LoadMetric("itsme", NormalLoad)
+    loadActor ! LoadMetric("itsotherme", HighLoad)
+    eventually {
+      loadActor.underlyingActor.loadLevel shouldBe HighLoad
+    }
+    loadActor ! LoadMetric("itsotherme", NormalLoad)
+    eventually {
+      loadActor.underlyingActor.loadLevel shouldBe NormalLoad
+    }
+  }
+
+  it should "evict monitored actors from the metric store if they die" in {
+    val snd = TestProbe().ref
+    val loadActor = TestActorRef(new LoadControllerServiceActor(Config, Config, TestProbe().ref))
+    // Send 2 metrics from the same actor
+    loadActor.tell(LoadMetric("itsme", NormalLoad), snd)
+    loadActor.tell(LoadMetric("itsmeagain", HighLoad), snd)
+
+    // Check that we've got them
+    loadActor.underlyingActor.loadMetrics(ActorAndMetric(snd, NonEmptyList.one("itsme"))) shouldBe NormalLoad
+    loadActor.underlyingActor.loadMetrics(ActorAndMetric(snd, NonEmptyList.one("itsmeagain"))) shouldBe HighLoad
+
+    // Check that we're monitoring this actor
+    loadActor.underlyingActor.monitoredActors shouldBe Set(snd)
+
+    // Kill the sender
+    snd ! Kill
+
+    // Check that it's gone
+    eventually {
+      loadActor.underlyingActor.loadMetrics shouldBe empty
+      loadActor.underlyingActor.monitoredActors shouldBe empty
+    }
+  }
+
+  it should "send updates to listeners when necessary" in {
+    val loadActor = TestActorRef(new LoadControllerServiceActor(Config, Config, TestProbe().ref))
+    loadActor ! Listen(self)
+
+    // Raise the load level
+    loadActor ! LoadMetric("itsme", HighLoad)
+
+    // We should get an alert
+    expectMsg(max = 2.seconds, HighLoad)
+
+    // And only one
+    expectNoMsg(2.seconds)
+
+    // Set the load level back to normal
+    loadActor ! LoadMetric("itsme", NormalLoad)
+
+    // We should get an alert that the load is back to normal
+    expectMsg(max = 2.seconds, NormalLoad)
+  }
+}

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
@@ -14,7 +14,7 @@ class MemoryLoadControllerSpec extends TestKitSuite with FlatSpecLike with Match
   
   it should "send memory load metrics" in {
     val registry = TestProbe()
-    TestActorRef(new MemoryLoadControllerActorTest(5L, 1.second, registry.ref))
+    TestActorRef(new MemoryLoadControllerActorTest(5, 1.second, registry.ref))
     registry.expectMsgPF(2.seconds){
       case metric: LoadMetric => 
         metric.name.head shouldBe "Memory"
@@ -24,7 +24,7 @@ class MemoryLoadControllerSpec extends TestKitSuite with FlatSpecLike with Match
 
   it should "send high memory load metrics iff all load recordings are high" in {
     val registry = TestProbe()
-    TestActorRef(new MemoryLoadControllerActorTest(20L, 200.milliseconds, registry.ref))
+    TestActorRef(new MemoryLoadControllerActorTest(20, 200.milliseconds, registry.ref))
     var metrics: List[LoadMetric] = List.empty
     registry.receiveWhile(3.seconds) {
       case metric: LoadMetric => metrics = metrics :+ metric 
@@ -37,7 +37,9 @@ class MemoryLoadControllerSpec extends TestKitSuite with FlatSpecLike with Match
     metrics.drop(9).forall(_.loadLevel == HighLoad) shouldBe true 
   }
   
-  class MemoryLoadControllerActorTest(threshold: Long, frequency: FiniteDuration, registry: ActorRef) extends MemoryLoadControllerActor(threshold, frequency, registry) {
+  class MemoryLoadControllerActorTest(threshold: Int, frequency: FiniteDuration, registry: ActorRef) extends MemoryLoadControllerActor(registry) {
     override def getFreeMemory = 10L
+    override private[impl] val memoryThreshold = threshold
+    override private[impl] val monitoringFrequency = frequency
   }
 }

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
@@ -1,0 +1,43 @@
+package cromwell.services.loadcontroller.impl
+
+import akka.actor.ActorRef
+import akka.testkit.{TestActorRef, TestProbe}
+import cromwell.core.TestKitSuite
+import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+
+class MemoryLoadControllerSpec extends TestKitSuite with FlatSpecLike with Matchers {
+  behavior of "MemoryLoadController"
+  
+  it should "send memory load metrics" in {
+    val registry = TestProbe()
+    TestActorRef(new MemoryLoadControllerActorTest(5L, 1.second, registry.ref))
+    registry.expectMsgPF(2.seconds){
+      case metric: LoadMetric => 
+        metric.name.head shouldBe "Memory"
+        metric.loadLevel shouldBe NormalLoad
+    }
+  }
+
+  it should "send high memory load metrics iff all load recordings are high" in {
+    val registry = TestProbe()
+    TestActorRef(new MemoryLoadControllerActorTest(20L, 200.milliseconds, registry.ref))
+    var metrics: List[LoadMetric] = List.empty
+    registry.receiveWhile(3.seconds) {
+      case metric: LoadMetric => metrics = metrics :+ metric 
+      case _: InstrumentationServiceMessage =>
+    }
+
+    // The first 9 should be normal
+    metrics.take(9).forall(_.loadLevel == NormalLoad) shouldBe true
+    // The rest should be high
+    metrics.drop(9).forall(_.loadLevel == HighLoad) shouldBe true 
+  }
+  
+  class MemoryLoadControllerActorTest(threshold: Long, frequency: FiniteDuration, registry: ActorRef) extends MemoryLoadControllerActor(threshold, frequency, registry) {
+    override def getFreeMemory = 10L
+  }
+}

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/MemoryLoadControllerSpec.scala
@@ -41,5 +41,6 @@ class MemoryLoadControllerSpec extends TestKitSuite with FlatSpecLike with Match
     override def getFreeMemory = 10L
     override private[impl] val memoryThreshold = threshold
     override private[impl] val monitoringFrequency = frequency
+    override private[impl] val nbRecordings = 10
   }
 }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorBenchmark.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorBenchmark.scala
@@ -34,7 +34,7 @@ class WriteMetadataActorBenchmark extends TestKitSuite with FlatSpecLike with Ev
   }
 
   it should "provide good throughput" taggedAs IntegrationTest in {
-    val writeActor = TestFSMRef(new WriteMetadataActor(1000, 5.seconds, registry) {
+    val writeActor = TestFSMRef(new WriteMetadataActor(1000, 5.seconds, registry, Int.MaxValue) {
       override val metadataDatabaseInterface = {
         val databaseConfig = ConfigFactory.load.getConfig("database-test-mysql")
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActor.scala
@@ -521,8 +521,8 @@ class JesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
 
   private def writeFuturePreemptedAndUnexpectedRetryCounts(p: Int, ur: Int): Future[Unit] = {
     val updateRequests = Seq(
-      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.unexpectedRetryCountKey), Option(ur.toString))),
-      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.preemptionCountKey), Option(p.toString)))
+      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.unexpectedRetryCountKey), ur.toString)),
+      KvPut(KvPair(ScopedKey(workflowId, futureKvJobKey, JesBackendLifecycleActorFactory.preemptionCountKey), p.toString))
     )
 
     makeKvRequest(updateRequests).map(_ => ())

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendLifecycleActorFactory.scala
@@ -47,7 +47,9 @@ case class JesBackendLifecycleActorFactory(name: String, configurationDescriptor
     Option(classOf[JesBackendCacheHitCopyingActor])
   }
 
-  override def backendSingletonActorProps(serviceRegistryActor: ActorRef) = Option(JesBackendSingletonActor.props(jesConfiguration.qps, serviceRegistryActor))
+  override def backendSingletonActorProps(serviceRegistryActor: ActorRef) = {
+    Option(JesBackendSingletonActor.props(jesConfiguration.qps, jesConfiguration.papiRequestWorkers, serviceRegistryActor))
+  }
 
   override lazy val fileHashingActorClassOption: Option[Class[_ <: StandardFileHashingActor]] = Option(classOf[JesBackendFileHashingActor])
   

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendSingletonActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesBackendSingletonActor.scala
@@ -9,9 +9,9 @@ import cromwell.core.Mailbox
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 
-final case class JesBackendSingletonActor(qps: Int Refined Positive, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+final case class JesBackendSingletonActor(qps: Int Refined Positive, requestWorkers: Int Refined Positive, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
 
-  val jesApiQueryManager = context.actorOf(JesApiQueryManager.props(qps, serviceRegistryActor).withMailbox(Mailbox.PriorityMailbox), "PAPIQueryManager")
+  val jesApiQueryManager = context.actorOf(JesApiQueryManager.props(qps, requestWorkers, serviceRegistryActor).withMailbox(Mailbox.PriorityMailbox), "PAPIQueryManager")
 
   override def receive = {
     case abort: BackendSingletonActorAbortWorkflow => jesApiQueryManager.forward(abort)
@@ -22,5 +22,5 @@ final case class JesBackendSingletonActor(qps: Int Refined Positive, serviceRegi
 }
 
 object JesBackendSingletonActor {
-  def props(qps: Int Refined Positive, serviceRegistryActor: ActorRef): Props = Props(JesBackendSingletonActor(qps, serviceRegistryActor)).withDispatcher(BackendDispatcher)
+  def props(qps: Int Refined Positive, requestWorkers: Int Refined Positive, serviceRegistryActor: ActorRef): Props = Props(JesBackendSingletonActor(qps, requestWorkers, serviceRegistryActor)).withDispatcher(BackendDispatcher)
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
@@ -21,4 +21,5 @@ class JesConfiguration(val configurationDescriptor: BackendConfigurationDescript
   val dockerCredentials = BackendDockerConfiguration.build(configurationDescriptor.backendConfig).dockerCredentials map JesDockerCredentials.apply
   val needAuthFileUpload = jesAuths.gcs.requiresAuthFile || dockerCredentials.isDefined || jesAttributes.restrictMetadataAccess
   val qps = jesAttributes.qps
+  val papiRequestWorkers = jesAttributes.requestWorkers
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/PreviousRetryReasons.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/PreviousRetryReasons.scala
@@ -28,14 +28,13 @@ object PreviousRetryReasons {
   }
 
   private def validatedKvResponse(r: Option[KvResponse], fromKey: String): ErrorOr[Int] = r match {
-    case Some(KvPair(_, v)) => validatedIntOption(v, fromKey)
+    case Some(KvPair(_, v)) => validatedInt(v, fromKey)
     case Some(_: KvKeyLookupFailed) => 0.validNel
     case Some(KvFailure(_, failure)) => s"Failed to get key $fromKey: ${failure.getMessage}".invalidNel
     case Some(_: KvPutSuccess) => s"Programmer Error: Got a KvPutSuccess from a Get request...".invalidNel
     case None => s"Programmer Error: Engine made no effort to prefetch $fromKey".invalidNel
   }
 
-  private def validatedIntOption(s: Option[String], fromKey: String): ErrorOr[Int] = validatedInt(s.getOrElse(""), fromKey)
   private def validatedInt(s: String, fromKey: String): ErrorOr[Int] = {
     Try(s.toInt) match {
       case Success(i) => i.validNel

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesAbortClient.scala
@@ -2,7 +2,7 @@ package cromwell.backend.impl.jes.statuspolling
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager.JesApiAbortQueryFailed
-import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled}
+import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled, PAPIOperationHasAlreadyFinished}
 import cromwell.core.logging.JobLogging
 
 trait JesAbortClient { this: Actor with ActorLogging with JobLogging =>
@@ -14,6 +14,9 @@ trait JesAbortClient { this: Actor with ActorLogging with JobLogging =>
     // In this case we could immediately return an aborted handle and spare ourselves a d round of polling
     case PAPIOperationAlreadyCancelled(jobId) =>
       jobLogger.info(s"Operation $jobId was already cancelled")
+    // In this case we could immediately return an aborted handle and spare ourselves a d round of polling
+    case PAPIOperationHasAlreadyFinished(jobId) =>
+      jobLogger.info(s"Operation $jobId has already finished")
     case JesApiAbortQueryFailed(jobId, e) =>
       jobLogger.error(s"Could not request cancellation of job $jobId", e)
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -72,7 +72,8 @@ class JesApiQueryManager(val qps: Int Refined Positive, override val serviceRegi
 
   private[statuspolling] lazy val nbWorkers = 2
 
-  private lazy val workerBatchInterval = determineBatchInterval(qps) / nbWorkers.toLong
+  // 
+  private lazy val workerBatchInterval = determineBatchInterval(qps) * nbWorkers.toLong
 
   scheduleInstrumentation { updateQueueSize(workQueue.size) }
 

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManager.scala
@@ -18,6 +18,7 @@ import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
 import cromwell.core.{CromwellFatalExceptionMarker, WorkflowId}
 import cromwell.services.instrumentation.CromwellInstrumentationScheduler
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
 import cromwell.util.StopAndLogSupervisor
 import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
@@ -96,7 +97,19 @@ class JesApiQueryManager(val qps: Int Refined Positive, override val serviceRegi
     super.preStart()
   }
 
+  def monitorQueueSize() = {
+    val load = if (workQueue.size > JesApiQueryManager.QueueThreshold) HighLoad else NormalLoad
+    serviceRegistryActor ! LoadMetric("PAPIQueryManager", load)
+    timers.startSingleTimer(QueueMonitoringTimerKey, QueueMonitoringTimerAction, 10.seconds)
+  }
+
+  override def preStart() = {
+    timers.startSingleTimer(QueueMonitoringTimerKey, QueueMonitoringTimerAction, 10.seconds)
+    super.preStart()
+  }
+
   override def receive = {
+    case QueueMonitoringTimerAction => monitorQueueSize()
     case BackendSingletonActorAbortWorkflow(id) => abort(id)
     case DoPoll(workflowId, run) => workQueue :+= makePollQuery(workflowId, sender, run)
     case DoCreateRun(workflowId, genomics, rpr) =>

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
@@ -6,7 +6,7 @@ import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonErrorCo
 import com.google.api.client.http.{HttpHeaders, HttpRequest}
 import com.google.api.services.genomics.model.Operation
 import cromwell.backend.impl.jes.statuspolling.JesApiQueryManager._
-import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled}
+import cromwell.backend.impl.jes.statuspolling.RunAbort.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled, PAPIOperationHasAlreadyFinished}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -25,6 +25,9 @@ private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPol
       // No need to fail the request if the job was already cancelled, we're all good
       if (Option(e.getCode).contains(400) && Option(e.getMessage).contains("Operation has already been canceled")) {
         originalRequest.requester ! PAPIOperationAlreadyCancelled(originalRequest.run.job.jobId)
+        completionPromise.trySuccess(Success(()))
+      } else if (Option(e.getCode).contains(400) && Option(e.getMessage).contains("Operation has already finished")) {
+        originalRequest.requester ! PAPIOperationHasAlreadyFinished(originalRequest.run.job.jobId)
         completionPromise.trySuccess(Success(()))
       } else {
         pollingManager ! JesApiAbortQueryFailed(originalRequest, new PAPIApiException(GoogleJsonException(e, responseHeaders)))
@@ -56,4 +59,5 @@ object RunAbort {
   sealed trait PAPIAbortRequestSuccess
   case class PAPIAbortRequestSuccessful(operationId: String) extends PAPIAbortRequestSuccess
   case class PAPIOperationAlreadyCancelled(operationId: String) extends PAPIAbortRequestSuccess
+  case class PAPIOperationHasAlreadyFinished(operationId: String) extends PAPIAbortRequestSuccess
 }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/statuspolling/RunAbort.scala
@@ -16,7 +16,7 @@ private[statuspolling] trait RunAbort extends PapiInstrumentation { this: JesPol
   private def abortResultHandler(originalRequest: PAPIAbortRequest, completionPromise: Promise[Try[Unit]]) = new JsonBatchCallback[Operation] {
     override def onSuccess(operation: Operation, responseHeaders: HttpHeaders): Unit = {
       abortSuccess()
-      originalRequest.requester ! PAPIAbortRequestSuccessful(operation.getName)
+      originalRequest.requester ! PAPIAbortRequestSuccessful(originalRequest.run.job.jobId)
       completionPromise.trySuccess(Success(()))
       ()
     }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -176,8 +176,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
         val key = BackendJobDescriptorKey(job, None, attempt)
         val runtimeAttributes = makeRuntimeAttributes(job)
         val prefetchedKvEntries = Map(
-          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), Some(previousPreemptions.toString)),
-          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), Some(previousUnexpectedRetries.toString)))
+          JesBackendLifecycleActorFactory.preemptionCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.preemptionCountKey), previousPreemptions.toString),
+          JesBackendLifecycleActorFactory.unexpectedRetryCountKey -> KvPair(ScopedKey(workflowDescriptor.id, KvJobKey(key), JesBackendLifecycleActorFactory.unexpectedRetryCountKey), previousUnexpectedRetries.toString))
         BackendJobDescriptor(workflowDescriptor, key, runtimeAttributes, fqnWdlMapToDeclarationMap(Inputs), NoDocker, prefetchedKvEntries)
       case Left(badtimes) => fail(badtimes.toList.mkString(", "))
     }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
@@ -21,6 +21,8 @@ object JesTestConfig {
       |  }
       |}
       |
+      |request-workers = 1
+      |
       |default-runtime-attributes {
       |    cpu: 1
       |    failOnStderr: false

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesApiQueryManagerSpec.scala
@@ -176,7 +176,7 @@ object JesApiQueryManagerSpec {
 /**
   * This test class allows us to hook into the JesApiQueryManager's makeStatusPoller and provide our own TestProbes instead
   */
-class TestJesApiQueryManager(qps: Int Refined Positive, createRequestSize: Long, registry: ActorRef, statusPollerProbes: ActorRef*) extends JesApiQueryManager(qps, registry) {
+class TestJesApiQueryManager(qps: Int Refined Positive, requestWorkers: Int Refined Positive, createRequestSize: Long, registry: ActorRef, statusPollerProbes: ActorRef*) extends JesApiQueryManager(qps, requestWorkers, registry) {
   var testProbes: Queue[ActorRef] = _
   var testPollerCreations: Int = _
 
@@ -227,5 +227,5 @@ object TestJesApiQueryManager {
   import cromwell.backend.impl.jes.JesTestConfig.JesBackendConfigurationDescriptor
   val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-  def props(createRequestSize: Long, registryProbe: ActorRef, statusPollers: ActorRef*): Props = Props(new TestJesApiQueryManager(jesConfiguration.qps, createRequestSize, registryProbe, statusPollers: _*))
+  def props(createRequestSize: Long, registryProbe: ActorRef, statusPollers: ActorRef*): Props = Props(new TestJesApiQueryManager(jesConfiguration.qps, jesConfiguration.papiRequestWorkers, createRequestSize, registryProbe, statusPollers: _*))
 }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/statuspolling/JesPollingActorSpec.scala
@@ -41,8 +41,8 @@ class JesPollingActorSpec extends TestKitSuite("JesPollingActor") with FlatSpecL
 
   it should "correctly calculate batch intervals" in {
     import eu.timepit.refined.auto._
-    JesPollingActor.determineBatchInterval(10) should be(11111.milliseconds)
-    JesPollingActor.determineBatchInterval(100000) shouldBe 1.millisecond
+    JesApiQueryManager.determineBatchInterval(10) should be(11111.milliseconds)
+    JesApiQueryManager.determineBatchInterval(100000) shouldBe 1.millisecond
   }
 
   it should "query for work and wait for a reply" in {
@@ -106,9 +106,7 @@ class JesPollingActorSpec extends TestKitSuite("JesPollingActor") with FlatSpecL
   * - Mocks out the methods which actually call out to JES, and allows the callbacks to be triggered in a testable way
   * - Also waits a **lot** less time before polls!
   */
-class TestJesPollingActor(manager: ActorRef, qps: Int Refined Positive, registryProbe: ActorRef) extends JesPollingActor(manager, qps, registryProbe) with Mockito {
-
-  override lazy val batchInterval = 10.milliseconds
+class TestJesPollingActor(manager: ActorRef, qps: Int Refined Positive, registryProbe: ActorRef) extends JesPollingActor(manager, 10.milliseconds, registryProbe) with Mockito {
 
   var operationStatusResponses: Queue[RunStatus] = Queue.empty
   var resultHandlers: Queue[JsonBatchCallback[Operation]] = Queue.empty

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -203,7 +203,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
     val kvJobKey =
       KvJobKey(jobDescriptor.key.call.fullyQualifiedName, jobDescriptor.key.index, jobDescriptor.key.attempt)
     val scopedKey = ScopedKey(workflowDescriptor.id, kvJobKey, SharedFileSystemAsyncJobExecutionActor.JobIdKey)
-    val kvPair = KvPair(scopedKey, Option(pid))
+    val kvPair = KvPair(scopedKey, pid)
 
     val previousKvPutter = TestProbe()
     val kvPutReq = KvPut(kvPair)


### PR DESCRIPTION
This sets up a mechanism to:
1) Collect information about "load" from various part of the system
2) Summarize this information and calculate a global load
3) Notify parts of the system of changes in the global load

Current implementation is simple:
Only 2 load levels: `NormalLoad` and `HighLoad`
Actors reporting their load are:
- WriteMetadataActor
- JobStoreReadActor
- JobStoreWriteActor
- CallCacheWriteActor
- CallCacheReadActor
- KeyValueReadActor
- KeyValueWriteActor
- IoActor
- JesAPIQueryManagerActor

Additionally free memory is also being monitored and will go to `HighLoad` if going below a certain threshold

Global load == max(all load levels). So if one actor or more say their load is high, the global load will be high, otherwise normal.
The only actor listening to changes on the global load is the job token dispenser. It will stop dispensing tokens when load is high and start again when load is back to normal.

At the exception of the IoActor, all the above mentioned actors have a queue in which they store work to be done. Their load is determined by comparing the size of this queue to a threshold.
The IoActor's queue is not easily accessible because hidden in the stream implementation and its size cannot easily be known. However we know when its full because we can't add to it anymore (this is when backpressure messages are sent). When that happens the IO actor reports its load to be `High`. When it hasn't had to backpressure for 10 seconds, the load returns to normal.

There are many ways this could be made smarter but it already yields improvements in terms of stability and robustness.

TODO: 

- [x] Add Changelog
- [x]  Configuration ? Lots of thresholds and values in this PR that could be configurable, how much and how do we want to configure ?