### PR TITLE
Partial wiring for Sam whitelist checking.

### DIFF
--- a/CromIAM/src/main/resources/application.conf
+++ b/CromIAM/src/main/resources/application.conf
@@ -1,6 +1,11 @@
 cromiam {
   interface = "0.0.0.0"
   port = 8001
+
+  whitelist {
+    # Specifies the google auth to use for whitelisting users
+    #auth = "application-default"
+  }
 }
 
 sam {
@@ -20,3 +25,13 @@ swagger_oauth {
   realm = "realm"
   app_name = "app_name"
 }
+
+#google {
+#  application-name = "cromiam"
+#  auths = [
+#    {
+#      name = "application-default"
+#      scheme = "application_default"
+#    }
+#  ]
+#}

--- a/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
@@ -53,7 +53,13 @@ trait CromIamApiService extends RequestSupport
     configuration.cromwellConfig.port,
     log)
 
-  lazy val samClient = new SamClient(configuration.samConfig.scheme, configuration.samConfig.interface, configuration.samConfig.port, log)
+  lazy val samClient = new SamClient(
+    configuration.samConfig.scheme,
+    configuration.samConfig.interface,
+    configuration.samConfig.port,
+    configuration.whitelistAuthModeOption,
+    log
+  )
 
   val statusService: StatusService
 

--- a/CromIAM/src/main/scala/cromiam/webservice/QuerySupport.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/QuerySupport.scala
@@ -9,7 +9,6 @@ import cats.data.NonEmptyList
 import cromiam.auth.Collection.CollectionLabelName
 import cromiam.auth.{Collection, User}
 import cromiam.cromwell.CromwellClient
-import cromiam.sam.SamClient
 import cromiam.webservice.QuerySupport._
 
 import scala.concurrent.ExecutionContextExecutor
@@ -17,7 +16,6 @@ import scala.util.{Failure, Success, Try}
 
 trait QuerySupport extends RequestSupport {
   val cromwellClient: CromwellClient
-  val samClient: SamClient
 
   val log: LoggingAdapter
 
@@ -39,7 +37,7 @@ trait QuerySupport extends RequestSupport {
 
   def queryPostRoute: Route = path("api" / "workflows" / Segment / "query") { _ =>
     post {
-      preprocessQuery("GET") { (user, collections, request) =>
+      preprocessQuery("POST") { (user, collections, request) =>
         processLabelsForPostQuery(user, collections) { entity =>
           complete { cromwellClient.forwardToCromwell(request.withEntity(entity)) }
         }

--- a/CromIAM/src/test/scala/cromiam/webservice/MockClients.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/MockClients.scala
@@ -23,7 +23,7 @@ final class MockCromwellClient()(implicit system: ActorSystem,
 class MockSamClient()(implicit system: ActorSystem,
                       ece: ExecutionContextExecutor,
                       materializer: ActorMaterializer)
-  extends SamClient("http", "bar", 1, NoLogging)(system, ece, materializer) {
+  extends SamClient("http", "bar", 1, None, NoLogging)(system, ece, materializer) {
   override def collectionsForUser(user: User): Future[List[Collection]] = {
     Future.successful(List(Collection("col1"), Collection("col2")))
   }

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val databaseMigration = (project in file("database/migration"))
 
 lazy val dockerHashing = project
   .withLibrarySettings("cromwell-docker-hashing")
+  .dependsOn(cloudSupport)
   .dependsOn(core)
   .dependsOn(core % "test->test")
 
@@ -177,7 +178,7 @@ lazy val womtool = project
 
 lazy val cromiam = (project in file("CromIAM")) // TODO: git mv CromIAM to a canonical lowercased name
   .withExecutableSettings("cromiam", cromiamDependencies, cromiamSettings)
-  .dependsOn(common)
+  .dependsOn(cloudSupport)
   .dependsOn(cromwellApiClient)
 
 lazy val languageFactoryRoot = Path("languageFactories")

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/GoogleConfigurationSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/GoogleConfigurationSpec.scala
@@ -85,7 +85,6 @@ class GoogleConfigurationSpec extends FlatSpec with Matchers {
     val user = (auths collectFirst { case a: UserMode => a }).get
     user.name shouldBe "name-user"
     user.secretsPath shouldBe pemMockFile.pathAsString
-    user.datastoreDir shouldBe "/where/the/data/at"
 
     val servicePem = (auths collectFirst { case a: ServiceAccountMode if a.name == "name-pem-service" => a }).get
     servicePem.name shouldBe "name-pem-service"

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/RefreshTokenModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/RefreshTokenModeSpec.scala
@@ -1,6 +1,5 @@
 package cromwell.cloudsupport.gcp.auth
 
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class RefreshTokenModeSpec extends FlatSpec with Matchers {
@@ -11,8 +10,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
     val exception = intercept[RuntimeException](refreshTokenMode.credential(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
@@ -22,8 +20,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
     refreshTokenMode.credentialValidation = _ => throw new IllegalArgumentException("no worries! this is expected")
     val exception = intercept[RuntimeException](refreshTokenMode.credential(workflowOptions))
@@ -34,8 +31,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     refreshTokenMode.credentialValidation = _ => ()
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
     val credentials = refreshTokenMode.credential(workflowOptions)
@@ -46,8 +42,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
     refreshTokenMode.validate(workflowOptions)
   }
@@ -56,8 +51,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[OptionLookupException](refreshTokenMode.validate(workflowOptions))
     exception.getMessage should be("refresh_token")
@@ -67,8 +61,7 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret")
     refreshTokenMode.requiresAuthFile should be(true)
   }
 

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ServiceAccountModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ServiceAccountModeSpec.scala
@@ -17,7 +17,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[RuntimeException](serviceAccountMode.credential(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
@@ -31,7 +31,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[RuntimeException](serviceAccountMode.credential(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
@@ -44,7 +44,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       ServiceAccountMode(
         "service-account",
         ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-        GoogleConfiguration.GoogleScopes)
+        GoogleConfiguration.PipelinesApiScopes)
     }
     exception.getMessage should fullyMatch regex "File .*/service-account..*.json does not exist or is not readable"
   }
@@ -55,7 +55,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       ServiceAccountMode(
         "service-account",
         ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-        GoogleConfiguration.GoogleScopes)
+        GoogleConfiguration.PipelinesApiScopes)
     }
     exception.getMessage should fullyMatch regex "File .*/service-account..*.pem does not exist or is not readable"
   }
@@ -67,7 +67,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     serviceAccountMode.credentialValidation = _ => ()
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val credentials = serviceAccountMode.credential(workflowOptions)
@@ -82,7 +82,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     serviceAccountMode.credentialValidation = _ => ()
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val credentials = serviceAccountMode.credential(workflowOptions)
@@ -97,7 +97,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     serviceAccountMode.validate(workflowOptions)
     jsonMockFile.delete(true)
@@ -110,7 +110,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     serviceAccountMode.validate(workflowOptions)
     pemMockFile.delete(true)
@@ -123,7 +123,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     serviceAccountMode.requiresAuthFile should be(false)
     jsonMockFile.delete(true)
   }
@@ -135,7 +135,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     serviceAccountMode.requiresAuthFile should be(false)
     pemMockFile.delete(true)
   }

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserModeSpec.scala
@@ -3,7 +3,6 @@ package cromwell.cloudsupport.gcp.auth
 import java.io.FileNotFoundException
 
 import better.files.File
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class UserModeSpec extends FlatSpec with Matchers {
@@ -12,84 +11,64 @@ class UserModeSpec extends FlatSpec with Matchers {
 
   it should "fail to generate a bad credential" in {
     val secretsMockFile = File.newTemporaryFile("secrets.", ".json").write(GoogleAuthModeSpec.userCredentialsContents)
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
     val userMode = UserMode(
       "user",
       "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      secretsMockFile.pathAsString
     )
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[RuntimeException](userMode.credential(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
     secretsMockFile.delete(true)
-    dataStoreMockDir.delete(true)
   }
 
   it should "fail to generate a bad credential from a secrets json" in {
     val secretsMockFile = File.newTemporaryFile("secrets.", ".json").delete()
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
     val userMode = UserMode(
       "user",
       "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      secretsMockFile.pathAsString
     )
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[FileNotFoundException](userMode.credential(workflowOptions))
     exception.getMessage should fullyMatch regex "File .*/secrets..*.json does not exist or is not readable"
-    dataStoreMockDir.delete(true)
   }
 
   it should "generate a non-validated credential" in {
     val secretsMockFile = File.newTemporaryFile("secrets.", ".json").write(GoogleAuthModeSpec.userCredentialsContents)
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
     val userMode = UserMode(
       "user",
       "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      secretsMockFile.pathAsString
     )
     userMode.credentialValidation = _ => ()
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val credentials = userMode.credential(workflowOptions)
     credentials.getAuthenticationType should be("OAuth2")
     secretsMockFile.delete(true)
-    dataStoreMockDir.delete(true)
   }
 
   it should "validate" in {
     val secretsMockFile = File.newTemporaryFile("secrets.", ".json").write(GoogleAuthModeSpec.userCredentialsContents)
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
     val userMode = UserMode(
       "user",
       "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      secretsMockFile.pathAsString
     )
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     userMode.validate(workflowOptions)
     secretsMockFile.delete(true)
-    dataStoreMockDir.delete(true)
   }
 
   it should "requiresAuthFile" in {
     val secretsMockFile = File.newTemporaryFile("secrets.", ".json").write(GoogleAuthModeSpec.userCredentialsContents)
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
     val userMode = UserMode(
       "user",
       "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      secretsMockFile.pathAsString
     )
     userMode.requiresAuthFile should be(false)
     secretsMockFile.delete(true)
-    dataStoreMockDir.delete(true)
   }
 
 }

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserServiceAccountModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserServiceAccountModeSpec.scala
@@ -10,7 +10,7 @@ class UserServiceAccountModeSpec extends FlatSpec with Matchers {
   it should "generate a credential" in {
     val userServiceAccountMode = UserServiceAccountMode(
       "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.userServiceAccountOptions
     val credentials = userServiceAccountMode.credential(workflowOptions)
     credentials.getAuthenticationType should be("OAuth2")
@@ -19,7 +19,7 @@ class UserServiceAccountModeSpec extends FlatSpec with Matchers {
   it should "validate with a user_service_account_json workflow option" in {
     val userServiceAccountMode = UserServiceAccountMode(
       "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.userServiceAccountOptions
     userServiceAccountMode.validate(workflowOptions)
   }
@@ -27,7 +27,7 @@ class UserServiceAccountModeSpec extends FlatSpec with Matchers {
   it should "fail validate without a user_service_account_json workflow option" in {
     val userServiceAccountMode = UserServiceAccountMode(
       "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     val workflowOptions = GoogleAuthModeSpec.emptyOptions
     val exception = intercept[OptionLookupException](userServiceAccountMode.validate(workflowOptions))
     exception.getMessage should be("user_service_account_json")
@@ -36,7 +36,7 @@ class UserServiceAccountModeSpec extends FlatSpec with Matchers {
   it should "requiresAuthFile" in {
     val userServiceAccountMode = UserServiceAccountMode(
       "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+      GoogleConfiguration.PipelinesApiScopes)
     userServiceAccountMode.requiresAuthFile should be(false)
   }
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -9,12 +9,11 @@ import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed
 import cromwell.backend.async.RuntimeAttributeValidationFailures
 import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendSpec, BackendWorkflowDescriptor}
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.auth.{GoogleAuthModeSpec, RefreshTokenMode, SimpleClientSecrets}
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.Tags.{IntegrationTest, PostWomTest}
-import cromwell.core.{TestKitSuite, WorkflowOptions}
 import cromwell.core.logging.LoggingTest._
+import cromwell.core.{TestKitSuite, WorkflowOptions}
 import cromwell.util.{EncryptionSpec, SampleWdl}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -23,6 +22,7 @@ import wom.graph.CommandCallNode
 
 import scala.concurrent.duration._
 
+//noinspection NameBooleanParameters
 class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpec") with FlatSpecLike with Matchers
   with ImplicitSender with Mockito {
   val Timeout: FiniteDuration = 10.second.dilated
@@ -246,7 +246,8 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
 
     val TestingBits(actorRef, _) = buildJesInitializationTestingBits(refreshTokenConfig)
     val actor = actorRef.underlyingActor
-    actor.refreshTokenAuth should be(Some(GcsLocalizing(RefreshTokenMode("user-via-refresh", "secret_id", "secret_secret", GoogleConfiguration.GoogleScopes),  "mytoken")))
+    actor.refreshTokenAuth should be(
+      Some(GcsLocalizing(RefreshTokenMode("user-via-refresh", "secret_id", "secret_secret"),  "mytoken")))
   }
 
   it should "generate the correct json content for no docker token and no refresh token" in {


### PR DESCRIPTION
Made GoogleAuthMode scopes optional via a param/conf, still defaulting to the pipelines api scopes.
Removed unused scopes and data-dirs from google auth modes that do not uses them.
Moved access token TTL refresher from GcrAbstractFlow to GoogleAuthMode.
Fixed queryPostRoute logging method as "GET" instead of "POST".