### PR TITLE
Rhino armor.

### DIFF
--- a/cwl/src/main/scala/cwl/internal/EnhancedRhinoSandbox.scala
+++ b/cwl/src/main/scala/cwl/internal/EnhancedRhinoSandbox.scala
@@ -1,0 +1,152 @@
+package cwl.internal
+
+import cwl.internal.EnhancedRhinoSandbox._
+import delight.rhinosandox.internal._
+import org.mozilla.javascript._
+
+import scala.collection.JavaConverters._
+import scala.reflect._
+
+/**
+  * Extends the RhinoSandboxImpl with some fixes and enhancements using java reflection.
+  *
+  * @param strict Should evaluation be strict.
+  * @param languageVersionOption The optional language version to set.
+  */
+class EnhancedRhinoSandbox(strict: Boolean = true, languageVersionOption: Option[Int] = None) extends RhinoSandboxImpl {
+
+  // Allows easier reflection access to private fields
+  private lazy val sandboxImpl: RhinoSandboxImpl = this
+
+  /**
+    * Similar to RhinoSandbox.eval but passes back the context and scope for mutating before evaluation.
+    *
+    * With the original RhinoSandbox.eval not sure how to:
+    * - Create (nested) arrays
+    * - Create (nested) maps
+    * - Set JS/ES version
+    *
+    * So this uses a copy-port of the original, using reflection to read some of RhinoSandbox's private variables.
+    *
+    * Instead of hiding the context and scope as in RhinoSandbox.eval, both are passed back through the block.
+    *
+    * TODO: Ask RhinoSandbox if hacks are even needed, and if so contrib back patches so that reflection isn't required.
+    * - Is there a way to pass nested maps/arrays via a `java.util.Map[String, Object]`, or must we use our `block`?
+    * - Additionally: can we skip passing `context` to a block as a thread may just call `Context.getCurrentContext()`?
+    *
+    * @see https://maxrohde.com/2015/08/06/sandboxing-javascript-in-java-app-link-collection/
+    * @see https://github.com/javadelight/delight-rhino-sandbox/blob/9f5a073/src/main/java/delight/rhinosandox/internal/RhinoSandboxImpl.java#L100-L123
+    * @see delight.rhinosandox.internal.RhinoSandboxImpl#assertContextFactory()
+    */
+  def eval(sourceName: String, js: String)(block: (Context, Scriptable) => Unit): AnyRef = {
+    assertContextFactory()
+    val sandboxImpl_contextFactory = PrivateField(sandboxImpl, "contextFactory").as[ContextFactory]
+    // RhinoSandbox diff: eval has enterContext inside the try, but Rhino docs say it belongs outside.
+    // https://www-archive.mozilla.org/rhino/apidocs/org/mozilla/javascript/ContextFactory.html#enterContext%28%29
+    val context = sandboxImpl_contextFactory.enterContext
+    try {
+      // RhinoSandbox diff: allow setting the language version
+      languageVersionOption foreach context.setLanguageVersion
+      assertSafeScope(context)
+      val sandboxImpl_globalScope = PrivateField(sandboxImpl, "globalScope").as[ScriptableObject]
+      val sandboxImpl_sealScope = PrivateField(sandboxImpl, "sealScope").as[Boolean]
+      if (sandboxImpl_sealScope) {
+        sandboxImpl_globalScope.sealObject()
+      }
+      val sandboxImpl_safeScope = PrivateField(sandboxImpl, "safeScope").as[ScriptableObject]
+      val instanceScope = context.newObject(sandboxImpl_safeScope)
+      instanceScope.setPrototype(sandboxImpl_safeScope)
+      instanceScope.setParentScope(null)
+
+      block(context, instanceScope)
+
+      // RhinoSandbox diff: allow strict JS/ES evaluation
+      // See note at top assertContextFactory as to why we have to put 'use strict'; here.
+      // All on one line to avoid off-by-one error for javascript error messages that report line numbers.
+      // Could also pass zero as the line number, but the RhinoSandbox passes hard codes line number one also.
+      val script = if (strict) s"'use strict';$js" else js
+      context.evaluateString(instanceScope, script, sourceName, 1, null)
+    } finally {
+      Context.exit()
+    }
+  }
+
+  /**
+    * Stricter context factory modified from RhinoSandboxImpl.assertContextFactory().
+    *
+    * The globalScope initialized via initSafeStandardObjects instead of initStandardObjects.
+    *
+    * The default implementation uses a SafeContext that allows non-strict JS/ES. We would ideally set
+    * FEATURE_STRICT_MODE to true but that only produces warnings and doesn't return an error. Unfortunately when
+    * FEATURE_WARNING_AS_ERROR is enabled then non-strict Rhino warnings like "missing ;" throw errors. Instead,
+    * "'use strict';" is injected before scripts.
+    */
+  override def assertContextFactory(): Unit = {
+    if (PrivateField(sandboxImpl, "contextFactory").as[ContextFactory] != null) {
+      return
+    }
+
+    val _safeContext = new SafeContext
+    PrivateField(sandboxImpl, "contextFactory") := _safeContext
+    val _hasExplicitGlobal = ContextFactory.hasExplicitGlobal
+    val _not = !_hasExplicitGlobal
+    val sandboxImpl_contextFactory = PrivateField(sandboxImpl, "contextFactory").as[SafeContext]
+    if (_not) ContextFactory.initGlobal(sandboxImpl_contextFactory)
+
+    val sandboxImpl_instructionLimit = PrivateField(sandboxImpl, "instructionLimit").as[Int]
+    PrivateField(sandboxImpl_contextFactory, "maxInstructions") := sandboxImpl_instructionLimit
+    val sandboxImpl_maxDuration = PrivateField(sandboxImpl, "maxDuration").as[Long]
+    PrivateField(sandboxImpl_contextFactory, "maxRuntimeInMs") := sandboxImpl_maxDuration
+    // RhinoSandbox diff: assertContextFactory has enterContext inside the try, but Rhino docs say it belongs outside.
+    // https://www-archive.mozilla.org/rhino/apidocs/org/mozilla/javascript/ContextFactory.html#enterContext%28%29
+    val context = sandboxImpl_contextFactory.enterContext
+    try {
+      // RhinoSandbox diff: Default globalScope is created via initStandardObjects instead of initSafeStandardObjects.
+      // initStandardObjects would add the various java packages into the global scope, including `java.io.File`, etc.
+      PrivateField(sandboxImpl, "globalScope") := context.initSafeStandardObjects(null, false)
+      val sandboxImpl_inScope = PrivateField(sandboxImpl, "inScope").as[java.util.Map[String, AnyRef]]
+      val _entrySet = sandboxImpl_inScope.entrySet
+      val sandboxImpl_globalScope = PrivateField(sandboxImpl, "globalScope").as[ScriptableObject]
+      for (entry <- _entrySet.asScala) {
+        sandboxImpl_globalScope.put(
+          entry.getKey,
+          sandboxImpl_globalScope,
+          Context.toObject(entry.getValue, sandboxImpl_globalScope))
+      }
+      val parameters = Array(classOf[String])
+      val dealMethod = classOf[RhinoEvalDummy].getMethod("eval", parameters: _*)
+      val _rhinoEval = new RhinoEval("eval", dealMethod, sandboxImpl_globalScope)
+      sandboxImpl_globalScope.defineProperty("eval", _rhinoEval, ScriptableObject.DONTENUM)
+    } finally {
+      Context.exit()
+    }
+  }
+
+}
+
+object EnhancedRhinoSandbox {
+
+  /**
+    * Get or sets a private field.
+    *
+    * @param obj  The instance to retrieve the field from.
+    * @param name The name of the field.
+    * @tparam A The class to retrieve the value from. The field MUST exist on this class, and not a superclass.
+    */
+  final case class PrivateField[A: ClassTag](obj: A, name: String) {
+    private[this] def field = {
+      val field = classTag[A].runtimeClass.getDeclaredField(name)
+      field.setAccessible(true)
+      field
+    }
+
+    def as[B]: B = {
+      field.get(obj).asInstanceOf[B]
+    }
+
+    def :=(value: Any): Unit = {
+      field.set(obj, value)
+    }
+  }
+
+}

--- a/cwl/src/test/scala/cwl/internal/EcmaScriptUtilSpec.scala
+++ b/cwl/src/test/scala/cwl/internal/EcmaScriptUtilSpec.scala
@@ -1,42 +1,91 @@
 package cwl.internal
 
 import common.validation.Validation._
+import delight.rhinosandox.exceptions.ScriptDurationException
+import org.mozilla.javascript.{EcmaError, EvaluatorException}
 import org.scalatest.{FlatSpec, Matchers}
 import wom.types._
 import wom.values._
 
 class EcmaScriptUtilSpec extends FlatSpec with Matchers {
 
-  behavior of "JsUtil"
+  behavior of "EcmaScriptUtil"
 
-  it should "eval" in {
+  it should "lookup a map entry with a string key" in {
     val values =
       "myName" -> WomMap(
         WomMapType(WomBooleanType, WomArrayType(WomStringType)),
         Map(WomBoolean(true) -> WomArray(WomArrayType(WomStringType), Seq(WomString("myValue"))))
       )
-
-    // NOTE: By using JsMap a JSObject, myName[true] doesn't work.
     val expr = """myName["true"][0] + 'Plus'"""
-
-    val result: WomValue = EcmaScriptUtil.evalStructish(expr,  values).toTry.get
-
+    val result: WomValue = EcmaScriptUtil.evalStructish(expr, values).toTry.get
     result should be(WomString("myValuePlus"))
   }
 
-   it should "JSON.stringify" in {
+  it should "lookup a map entry with a boolean key" in {
     val values =
       "myName" -> WomMap(
         WomMapType(WomBooleanType, WomArrayType(WomStringType)),
         Map(WomBoolean(true) -> WomArray(WomArrayType(WomStringType), Seq(WomString("myValue"))))
       )
+    val expr = "myName[true][0] + 'PlusPlus'"
+    val result = EcmaScriptUtil.evalStructish(expr, values).toTry.get
+    result should be(WomString("myValuePlusPlus"))
+  }
 
-
-
+  it should "JSON.stringify" in {
+    val values =
+      "myName" -> WomMap(
+        WomMapType(WomBooleanType, WomArrayType(WomStringType)),
+        Map(WomBoolean(true) -> WomArray(WomArrayType(WomStringType), Seq(WomString("myValue"))))
+      )
     val expr = "JSON.stringify(myName)"
-
     val result: WomValue = EcmaScriptUtil.evalStructish(expr, values).toTry.get
-
     result should be(WomString("""{"true":["myValue"]}"""))
+  }
+
+  it should "Array.prototype.sort" in {
+    val values = "myName" -> WomArray(List("hello", "world", "alpha", "zulu", "indigo").map(WomString))
+    val expr = "myName.sort()"
+    val expected = WomArray(List("alpha", "hello", "indigo", "world", "zulu").map(WomString))
+    val result = EcmaScriptUtil.evalStructish(expr, values).toTry.get
+    result should be(expected)
+  }
+
+  it should "run in strict mode" in {
+    the[EvaluatorException] thrownBy {
+      EcmaScriptUtil.evalRaw(
+        """|function sum(a, a, c) { // !!! syntax error
+           |  return a + a + c; // wrong if this code ran
+           |}
+           |""".stripMargin) { (_, _) => () }
+    } should have message
+      """Parameter "a" already declared in this function. (<ecmascript>#1)"""
+  }
+
+  it should "not run java code" in {
+    the[EcmaError] thrownBy {
+      EcmaScriptUtil.evalRaw(
+        """|var path = java.nio.file.Paths.get("/etc/passwd");
+           |java.nio.file.Files.exists(path);
+           |""".stripMargin) { (_, _) => () }
+    } should have message
+      """ReferenceError: "java" is not defined. (<ecmascript>#1)"""
+  }
+
+  it should "not run forever" in {
+    a[ScriptDurationException] should be thrownBy {
+      EcmaScriptUtil.evalRaw(
+        """|function sleep(milliseconds) {
+           |  var start = new Date().getTime();
+           |  while(true) {
+           |    if ((new Date().getTime() - start) > milliseconds){
+           |      break;
+           |    }
+           |  }
+           |}
+           |sleep(120 * 1000);
+           |""".stripMargin) { (_, _) => () }
+    }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Dependencies {
   val commonsLoggingV = "1.2"
   val commonsTextV = "1.1"
   val configsV = "0.4.4"
+  val delightRhinoSandboxV = "0.0.8"
   val errorProneAnnotationsV = "2.0.19"
   val ficusV = "1.4.1"
   val fs2V = "0.10.0-M7"
@@ -303,6 +304,7 @@ object Dependencies {
     "org.scalacheck" %% "scalacheck" % scalacheckV % Test,
     "io.circe" %% "circe-optics" % circeV,
     "org.mozilla" % "rhino" % rhinoV,
+    "org.javadelight" % "delight-rhino-sandbox" % delightRhinoSandboxV,
     "org.scalamock" %% "scalamock" % "4.0.0" % Test
   ) ++ circeDependencies ++ womDependencies ++ refinedTypeDependenciesList ++ betterFilesDependencies
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -9,7 +9,7 @@ object Merging {
       MergeStrategy.filterDistinctLines
     case PathList(ps@_*) if ps.last == "logback.xml" =>
       MergeStrategy.first
-    case x @ PathList("META-INF", path@_*) =>
+    case x@PathList("META-INF", path@_*) =>
       path map {
         _.toLowerCase
       } match {
@@ -19,6 +19,16 @@ object Merging {
           MergeStrategy.first
         case "maven" :: "com.google.guava" :: xs =>
           MergeStrategy.first
+        case _ =>
+          val oldStrategy = (assemblyMergeStrategy in assembly).value
+          oldStrategy(x)
+      }
+    case x@PathList("OSGI-INF", path@_*) =>
+      path map {
+        _.toLowerCase
+      } match {
+        case "l10n" :: "bundle.properties" :: Nil =>
+          MergeStrategy.concat
         case _ =>
           val oldStrategy = (assemblyMergeStrategy in assembly).value
           oldStrategy(x)


### PR DESCRIPTION
Using a reflection-modified RhinoSandbox to do stricter JS eval.
Fixed other IntelliJ warnings while disabling the one for multiple uses of shadow variables.
Concatenating an OSGI properties file that was causing assembly conflicts.