### PR TITLE
Nested scatters and OGIN lookups

### DIFF
--- a/centaur/src/main/resources/standardTestCases/draft3_nested_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_nested_scatter.test
@@ -1,0 +1,16 @@
+name: draft3_nested_scatter
+testFormat: workflowsuccess
+workflowType: WDL
+workflowTypeVersion: draft-3
+
+files {
+  wdl: wdl_draft3/nested_scatter/nested_scatter.wdl
+}
+
+metadata {
+  workflowName: nested_scatter
+  status: Succeeded
+  "outputs.nested_scatter.ks.0": "[[60,61,62],[62,63,64],[64,65,66]]"
+  "outputs.nested_scatter.ks.1": "[[62,63,64],[64,65,66],[66,67,68]]"
+  "outputs.nested_scatter.ks.2": "[[64,65,66],[66,67,68],[68,69,70]]"
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/nested_scatter/nested_scatter.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/nested_scatter/nested_scatter.wdl
@@ -1,0 +1,23 @@
+version draft-3
+
+workflow nested_scatter {
+
+  Array[Int] indices = [1,2,3]
+  Int y = 55
+
+  scatter(a in indices) {
+    scatter(b in indices) {
+      Int x = a + b
+      scatter(c in indices) {
+        Int j = a + b + c + x
+      }
+      scatter(d in j) {
+        Int k = d + y
+      }
+    }
+  }
+
+  output {
+    Array[Array[Array[Int]]] ks = k
+  }
+}

--- a/core/src/test/scala/cromwell/util/WomMocks.scala
+++ b/core/src/test/scala/cromwell/util/WomMocks.scala
@@ -21,7 +21,7 @@ object WomMocks {
   }
   
   def mockWorkflowCall(identifier: WomIdentifier, definition: WorkflowDefinition = EmptyWorkflowDefinition) = {
-    WorkflowCallNode(identifier, definition, Set.empty, List.empty)
+    WorkflowCallNode(identifier, definition, Set.empty, List.empty, compoundOutputIdentifiers = true)
   }
 
   def mockWorkflowDefinition(name: String) = {

--- a/cwl/src/main/scala/cwl/WorkflowStep.scala
+++ b/cwl/src/main/scala/cwl/WorkflowStep.scala
@@ -201,7 +201,7 @@ case class WorkflowStep(
     val haveWeSeenThisStep: Boolean = knownNodes.collect {
       case CommandCallNode(identifier, _, _, _) => identifier
       case ExpressionCallNode(identifier, _, _, _) => identifier
-      case WorkflowCallNode(identifier, _, _, _) => identifier
+      case WorkflowCallNode(identifier, _, _, _, _) => identifier
     }.contains(unqualifiedStepId)
 
     if (haveWeSeenThisStep) Right(knownNodes)

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ScatterElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ScatterElement.scala
@@ -1,5 +1,6 @@
 package wdl.model.draft3.elements
 
-final case class ScatterElement(scatterExpression: ExpressionElement,
+final case class ScatterElement(scatterName: String,
+                                scatterExpression: ExpressionElement,
                                 scatterVariableName: String,
                                 graphElements: Seq[WorkflowGraphElement]) extends WorkflowGraphElement

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstToScatterElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstToScatterElement.scala
@@ -3,19 +3,21 @@ package wdl.draft3.transforms.ast2wdlom
 import cats.syntax.apply._
 import cats.syntax.either._
 import common.validation.ErrorOr.ErrorOr
-import wdl.draft3.parser.WdlParser.Ast
+import wdl.draft3.parser.WdlParser.{Ast, Terminal}
 import wdl.draft3.transforms.ast2wdlom.EnhancedDraft3Ast._
 import wdl.model.draft3.elements._
 
 object AstToScatterElement {
   def convert(ast: Ast): ErrorOr[ScatterElement] = {
 
-    val scatterVariableValidation: ErrorOr[String] = ast.getAttributeAs[String]("item").toValidated
+    val scatterVariableValidation: ErrorOr[Terminal] = ast.getAttributeAs[Terminal]("item").toValidated
+
     val scatterCollectionExpressionValidation: ErrorOr[ExpressionElement] = ast.getAttributeAs[ExpressionElement]("collection").toValidated
     val bodyValidation: ErrorOr[Vector[WorkflowGraphElement]] = ast.getAttributeAsVector[WorkflowGraphElement]("body").toValidated
 
     (scatterVariableValidation, scatterCollectionExpressionValidation, bodyValidation) mapN { (variable, collection, body) =>
-      ScatterElement(collection, variable, body)
+      val scatterName = s"ScatterAt${variable.line}_${variable.col}"
+      ScatterElement(scatterName, collection, variable.source_string, body)
     }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/package.scala
@@ -16,6 +16,11 @@ package object ast2wdlom {
     case other => s"Cannot convert from AstNode type '${other.getClass.getSimpleName}' into Ast".invalidNelCheck
   }
 
+  implicit val astNodeToTerminal: CheckedAtoB[AstNode, Terminal] = CheckedAtoB.fromCheck {
+    case t: Terminal => t.validNelCheck
+    case other => s"Cannot convert from AstNode type '${other.getClass.getSimpleName}' into Terminal".invalidNelCheck
+  }
+
   implicit val astToFileElement: CheckedAtoB[Ast, FileElement] = CheckedAtoB.fromErrorOr(AstToFileElement.convert)
   implicit val astToFileBodyElement: CheckedAtoB[AstNode, FileBodyElement] = astNodeToAst andThen CheckedAtoB.fromCheck(AstToFileBodyElement.convert)
   implicit val astNodeToStructEntry: CheckedAtoB[AstNode, StructElement] = astNodeToAst andThen CheckedAtoB.fromErrorOr(AstToStructElement.convert)

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/package.scala
@@ -4,7 +4,6 @@ import cats.syntax.apply._
 import cats.syntax.validated._
 import cats.syntax.traverse._
 import cats.instances.list._
-
 import common.validation.ErrorOr.ErrorOr
 import wdl.model.draft3.graph.GraphElementValueConsumer
 import wdl.model.draft3.graph.GraphElementValueConsumer.ops._
@@ -15,7 +14,7 @@ import wdl.draft3.transforms.linking.expression.consumed._
 import wdl.draft3.transforms.linking.typemakers._
 import wdl.model.draft3.elements.{DeclarationElement, InputDeclarationElement, ScatterElement, WorkflowGraphElement}
 import wdl.model.draft3.graph._
-import wom.types.WomType
+import wom.types.{WomArrayType, WomType}
 
 package object graph {
   implicit val graphElementUnlinkedValueGenerator: UnlinkedValueGenerator[WorkflowGraphElement] = new UnlinkedValueGenerator[WorkflowGraphElement] {
@@ -32,7 +31,10 @@ package object graph {
 
   implicit val scatterElementUnlinkedValueGenerater: UnlinkedValueGenerator[ScatterElement] = new UnlinkedValueGenerator[ScatterElement] {
     override def generatedValueHandles(a: ScatterElement, typeAliases: Map[String, WomType]): ErrorOr[Set[GeneratedValueHandle]] = {
-      a.graphElements.toList.traverse(_.generatedValueHandles(typeAliases)).map(_.toSet.flatten)
+      a.graphElements.toList.traverse(_.generatedValueHandles(typeAliases)).map(_.toSet.flatten) map { _.map {
+        case GeneratedIdentifierValueHandle(id, womType) => GeneratedIdentifierValueHandle(id, WomArrayType(womType))
+        case GeneratedCallOutputValueHandle(first, second, womType) => GeneratedCallOutputValueHandle(first, second, WomArrayType(womType))
+      } }
     }
   }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
@@ -73,7 +73,6 @@ object ScatterElementToGraphNode {
 
       innerGraph map { ig =>
         val withOutputs = WomGraphMakerTools.addDefaultOutputs(ig, compoundCallIdentifiers = false)
-        println(s"nodes in this scatter: ${withOutputs.nodes.map(n => n.getClass.getSimpleName + " " + n.localName)}")
         val generatedAndNew = ScatterNode.scatterOverGraph(withOutputs, womInnerGraphScatterVariableInput)
         generatedAndNew.nodes
       }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
@@ -1,20 +1,14 @@
 package wdl.draft3.transforms.wdlom2wom.graph
 
-import java.util.UUID
-
 import cats.syntax.apply._
 import cats.syntax.validated._
 import cats.syntax.traverse._
 import cats.instances.list._
 import common.validation.ErrorOr.{ErrorOr, _}
 import shapeless.Coproduct
-import wdl.model.draft3.graph.expression.WomTypeMaker.ops._
 import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
 import wdl.model.draft3.graph.GraphElementValueConsumer.ops._
 import wdl.model.draft3.graph.UnlinkedValueGenerator.ops._
-import wdl.model.draft3.graph.expression.WomExpressionMaker.ops._
-import wdl.draft3.transforms.linking.typemakers._
-import wdl.draft3.transforms.linking.expression._
 import wdl.draft3.transforms.linking.expression.types._
 import wdl.draft3.transforms.linking.graph._
 import wdl.draft3.transforms.wdlom2wom.WorkflowDefinitionElementToWomWorkflowDefinition
@@ -25,12 +19,11 @@ import wdl.model.draft3.graph._
 import wdl.shared.transforms.wdlom2wom.WomGraphMakerTools
 import wom.callable.Callable.InputDefinition
 import wom.callable.WorkflowDefinition
-import wom.expression.WomExpression
 import wom.graph.CallNode.{CallNodeBuilder, InputDefinitionFold, InputDefinitionPointer}
 import wom.graph.GraphNode.GraphNodeSetter
 import wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort}
 import wom.graph._
-import wom.graph.expression.{AnonymousExpressionNode, ExposedExpressionNode, PlainAnonymousExpressionNode}
+import wom.graph.expression.{AnonymousExpressionNode, PlainAnonymousExpressionNode}
 import wom.types.{WomArrayType, WomType}
 
 object ScatterElementToGraphNode {
@@ -102,8 +95,7 @@ object ScatterElementToGraphNode {
       subWorkflowGraph map { WomGraphMakerTools.addDefaultOutputs(_) }
     }
 
-    val name = UUID.randomUUID().toString
-    val subWorkflowDefinitionValidation = subWorkflowGraphValidation map { subWorkflowGraph => WorkflowDefinition(name, subWorkflowGraph, Map.empty, Map.empty) }
+    val subWorkflowDefinitionValidation = subWorkflowGraphValidation map { subWorkflowGraph => WorkflowDefinition(a.node.scatterName, subWorkflowGraph, Map.empty, Map.empty) }
 
     val scatterableGraphValidation = subWorkflowDefinitionValidation map { subWorkflowDefinition =>
       val callNodeBuilder = new CallNodeBuilder()
@@ -115,7 +107,7 @@ object ScatterElementToGraphNode {
       }
       val mapping = mappingAndPorts.map(_._1)
       val inputPorts = mappingAndPorts.map(_._2).toSet
-      val result = callNodeBuilder.build(WomIdentifier(name), subWorkflowDefinition, InputDefinitionFold(mappings = mapping, callInputPorts = inputPorts), compoundOutputIdentifiers = false)
+      val result = callNodeBuilder.build(WomIdentifier(a.node.scatterName), subWorkflowDefinition, InputDefinitionFold(mappings = mapping, callInputPorts = inputPorts), compoundOutputIdentifiers = false)
       graphNodeSetter._graphNode = result.node
       result
     }

--- a/wdl/transforms/draft3/src/test/cases/nested_scatter.wdl
+++ b/wdl/transforms/draft3/src/test/cases/nested_scatter.wdl
@@ -1,0 +1,23 @@
+version draft-3
+
+workflow nested_scatter {
+
+  Array[Int] indices = [1,2,3]
+  Int y = 55
+
+  scatter(a in indices) {
+    scatter(b in indices) {
+      Int x = a + b
+      scatter(c in indices) {
+        Int j = a + b + c + x
+      }
+      scatter(d in j) {
+        Int k = d + y
+      }
+    }
+  }
+
+  output {
+    Array[Array[Array[Int]]] ks = k
+  }
+}

--- a/wdl/transforms/draft3/src/test/cases/ogin_scatter.wdl
+++ b/wdl/transforms/draft3/src/test/cases/ogin_scatter.wdl
@@ -1,0 +1,15 @@
+version draft-3
+
+workflow ogin_scatter {
+
+  Array[Int] indices = [1,2,3]
+  Int ogin_me = 10
+
+  scatter(i in indices) {
+    Int j = i + ogin_me
+  }
+
+  output {
+    Array[Int] js = j
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -378,6 +378,79 @@ object WdlFileToWdlomSpec {
       )),
       tasks = Vector.empty
     ),
+    "ogin_scatter" -> FileElement(
+      imports = Vector.empty,
+      structs = Vector.empty,
+      workflows = Vector(WorkflowDefinitionElement(
+        name= "ogin_scatter",
+        inputsSection = None,
+        graphElements = Set(
+          IntermediateValueDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "indices", ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(2)), PrimitiveLiteralExpressionElement(WomInteger(3))))),
+          IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "ogin_me", PrimitiveLiteralExpressionElement(WomInteger(10))),
+          ScatterElement(
+            scatterExpression = IdentifierLookup("indices"),
+            scatterVariableName = "i",
+            graphElements = Vector(
+              IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "j", Add(IdentifierLookup("i"), IdentifierLookup("ogin_me")))
+            )
+          )
+        ),
+        outputsSection = Some(
+          OutputsSectionElement(Vector(OutputDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "js", IdentifierLookup("j"))))
+        ),
+        metaSection = None,
+        parameterMetaSection = None
+      )),
+      tasks = Vector.empty
+    ),
+    "nested_scatter" -> FileElement(
+      Vector(),
+      Vector(),
+      Vector(WorkflowDefinitionElement(
+        "nested_scatter",
+        None,
+        Set(
+          IntermediateValueDeclarationElement(
+            ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)),
+            "indices",
+            ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(2)), PrimitiveLiteralExpressionElement(WomInteger(3))))
+          ),
+          IntermediateValueDeclarationElement(
+            PrimitiveTypeElement(WomIntegerType),
+            "y",
+            PrimitiveLiteralExpressionElement(WomInteger(55))
+          ),
+          ScatterElement(
+            IdentifierLookup("indices"),
+            "a",
+            Vector(
+              ScatterElement(
+                IdentifierLookup("indices"), "b",
+                Vector(
+                  IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "x", Add(IdentifierLookup("a"),IdentifierLookup("b"))),
+                  ScatterElement(
+                    IdentifierLookup("indices"),
+                    "c",
+                    Vector(
+                      IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "j", Add(Add(Add(IdentifierLookup("a"), IdentifierLookup("b")), IdentifierLookup("c")), IdentifierLookup("x"))))),
+                  ScatterElement(
+                    IdentifierLookup("j"),
+                    "d",
+                    Vector(IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "k", Add(IdentifierLookup("d"), IdentifierLookup("y"))))
+                  )
+                )
+              )
+            )
+          )
+        ),
+        Some(
+          OutputsSectionElement(Vector(OutputDeclarationElement(ArrayTypeElement(ArrayTypeElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)))), "ks", IdentifierLookup("k"))))
+        ),
+        None,
+        None)
+      ),
+      Vector()
+    ),
     "simple_conditional" -> FileElement(
       imports = Vector.empty,
       structs = Vector.empty,

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -363,6 +363,7 @@ object WdlFileToWdlomSpec {
         graphElements = Set(
           IntermediateValueDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "indices", ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(2)), PrimitiveLiteralExpressionElement(WomInteger(3))))),
           ScatterElement(
+            scatterName = "ScatterAt6_11",
             scatterExpression = IdentifierLookup("indices"),
             scatterVariableName = "i",
             graphElements = Vector(
@@ -388,6 +389,7 @@ object WdlFileToWdlomSpec {
           IntermediateValueDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "indices", ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(2)), PrimitiveLiteralExpressionElement(WomInteger(3))))),
           IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "ogin_me", PrimitiveLiteralExpressionElement(WomInteger(10))),
           ScatterElement(
+            scatterName = "ScatterAt8_11",
             scatterExpression = IdentifierLookup("indices"),
             scatterVariableName = "i",
             graphElements = Vector(
@@ -421,19 +423,23 @@ object WdlFileToWdlomSpec {
             PrimitiveLiteralExpressionElement(WomInteger(55))
           ),
           ScatterElement(
+            scatterName = "ScatterAt8_11",
             IdentifierLookup("indices"),
             "a",
             Vector(
               ScatterElement(
+                scatterName = "ScatterAt9_13",
                 IdentifierLookup("indices"), "b",
                 Vector(
                   IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "x", Add(IdentifierLookup("a"),IdentifierLookup("b"))),
                   ScatterElement(
+                    scatterName = "ScatterAt11_15",
                     IdentifierLookup("indices"),
                     "c",
                     Vector(
                       IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "j", Add(Add(Add(IdentifierLookup("a"), IdentifierLookup("b")), IdentifierLookup("c")), IdentifierLookup("x"))))),
                   ScatterElement(
+                    scatterName = "ScatterAt14_15",
                     IdentifierLookup("j"),
                     "d",
                     Vector(IntermediateValueDeclarationElement(PrimitiveTypeElement(WomIntegerType), "k", Add(IdentifierLookup("d"), IdentifierLookup("y"))))

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
@@ -57,8 +57,9 @@ class WdlFileToWomSpec extends FlatSpec with Matchers {
     "nested_struct" -> anyWomWillDo,
     "struct_definition" -> validateStructDefinitionWom,
     "simple_scatter" -> anyWomWillDo,
+    "ogin_scatter" -> anyWomWillDo,
+    "nested_scatter" -> anyWomWillDo,
     "simple_conditional" -> anyWomWillDo
-
   )
 
   private def anyWomWillDo(b: WomBundle) = Succeeded

--- a/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/wdlom2wom/WomGraphMakerTools.scala
+++ b/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/wdlom2wom/WomGraphMakerTools.scala
@@ -9,9 +9,9 @@ object WomGraphMakerTools {
   // - A scatter block
   // - An if block
   // - (NB: top level workflows are already given wildcard outputs in the WDL Workflow building phase)
-  def addDefaultOutputs(g: Graph): Graph = Graph(g.nodes.union((g.nodes collect {
+  def addDefaultOutputs(g: Graph, compoundCallIdentifiers: Boolean = true): Graph = Graph(g.nodes.union((g.nodes collect {
     case node: CallNode => node.outputPorts.map(op => {
-      val identifier = node.identifier.combine(op.name)
+      val identifier = if (node.compoundOutputIdentifiers) node.identifier.combine(op.name) else WomIdentifier(op.name)
       PortBasedGraphOutputNode(identifier, op.womType, op)
     })
     case node: ExposedExpressionNode => node.outputPorts.map(op => {
@@ -24,5 +24,4 @@ object WomGraphMakerTools {
       PortBasedGraphOutputNode(op.identifier, op.womType, op)
     })
   }).flatten))
-
 }

--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -141,14 +141,17 @@ class WomGraph(graphName: String, graph: Graph) {
     innerGraph.withLinks(outputLinks)
   }
 
-  def internalSubworkflowNodesAndLinks(subworkflow: WorkflowCallNode): NodesAndLinks = listAllGraphNodes(subworkflow.callable.innerGraph) wrapNodes { n =>
-    s"""
-       |subgraph $nextCluster {
-       |  style=filled;
-       |  fillcolor=white;
-       |${indentAndCombine(n)}
-       |}
-       |""".stripMargin
+  def internalSubworkflowNodesAndLinks(subworkflow: WorkflowCallNode): NodesAndLinks = {
+
+    listAllGraphNodes(subworkflow.callable.innerGraph) wrapNodes { n =>
+      s"""
+         |subgraph $nextCluster {
+         |  style=filled;
+         |  fillcolor=white;
+         |${indentAndCombine(n)}
+         |}
+         |""".stripMargin
+    }
   }
 
   private def nextCluster: String = "cluster_" + clusterCount.getAndIncrement()


### PR DESCRIPTION
- [x] Rebase onto develop after #3374 

### Sample WDL

```wdl
version draft-3

workflow nested_scatter {

  Array[Int] indices = [1,2,3]
  Int y = 55

  scatter(a in indices) {
    scatter(b in indices) {
      Int x = a + b
      scatter(c in indices) {
        Int j = a + b + c + x
      }
      scatter(d in j) {
        Int k = d + y
      }
    }
  }

  output {
    Array[Array[Array[Int]]] ks = k
  }
}
```

### Sample output
```json
{
  "nested_scatter.ks": [[[60, 61, 62], [62, 63, 64], [64, 65, 66]], [[62, 63, 64], [64, 65, 66], [66, 67, 68]], [[64, 65, 66], [66, 67, 68], [68, 69, 70]]]
}
```