### PR TITLE
realign to a bovine design

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
@@ -56,8 +56,14 @@ ____    __    ____  ______   .______       __  ___  _______  __        ______   
     * Retrieves up to limit workflows which have not already been pulled into the engine and updates their state.
     * NOTE: Rows are returned with the query state, NOT the update state.
     */
-  def fetchStartableWorkflows(limit: Int, cromwellId: Option[String], heartbeatTtl: FiniteDuration)
+  def fetchStartableWorkflows(limit: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                              (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]]
+
+  /**
+    * Clears out cromwellId and heartbeatTimestamp for all workflow store entries currently assigned
+    * the specified cromwellId.
+    */
+  def releaseWorkflowStoreEntries(cromwellId: String)(implicit ec: ExecutionContext): Future[Unit]
 
   /**
     * Deletes a workflow from the database, returning the number of rows affected.

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
@@ -26,7 +26,7 @@ class InMemoryWorkflowStore extends WorkflowStore {
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  override def fetchStartableWorkflows(n: Int, cromwellId: Option[String], heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
+  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
     val startableWorkflows = workflowStore filter { _._2 == WorkflowStoreState.Submitted } take n
     val updatedWorkflows = startableWorkflows map { _._1 -> WorkflowStoreState.Running }
     workflowStore = workflowStore ++ updatedWorkflows

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -21,14 +21,9 @@ import scala.concurrent.{ExecutionContext, Future}
 case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends WorkflowStore {
   lazy val cromwellId = ConfigFactory.load().as[Option[String]]("system.cromwell_id")
 
-  override def initialize(implicit ec: ExecutionContext): Future[Unit] = {
-    if (ConfigFactory.load().as[Option[Boolean]]("system.workflow-restart").getOrElse(true)) {
-      // Workflows in Running or Aborting state get their restarted flag set to true on restart  
-      sqlDatabase.markRunningAndAbortingAsRestarted(cromwellId)
-    } else {
-      Future.successful(())
-    }
-  }
+  /** This is currently hardcoded to success but used to do stuff, left in place for now as a useful
+    *  startup initialization hook. */
+  override def initialize(implicit ec: ExecutionContext): Future[Unit] = Future.successful(())
 
   override def aborting(id: WorkflowId)(implicit ec: ExecutionContext): Future[Option[Boolean]] = {
     sqlDatabase.setToAborting(id.toString)
@@ -48,7 +43,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  override def fetchStartableWorkflows(n: Int, cromwellId: Option[String], heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
+  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
     import cats.instances.list._
     import cats.syntax.traverse._
     import common.validation.Validation._

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -27,7 +27,7 @@ trait WorkflowStore {
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  def fetchStartableWorkflows(n: Int, cromwellId: Option[String], heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
+  def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
 
   def remove(id: WorkflowId)(implicit ec: ExecutionContext): Future[Boolean]
 }

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -1,5 +1,7 @@
 package cromwell.server
 
+import java.util.UUID
+
 import akka.actor.SupervisorStrategy.{Escalate, Restart}
 import akka.actor.{Actor, ActorInitializationException, ActorLogging, ActorRef, OneForOneStrategy}
 import akka.event.Logging
@@ -58,6 +60,12 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   private val config = ConfigFactory.load()
   private implicit val system = context.system
 
+  val cromwellId: String = config.as[Option[String]]("system.cromwell_id").getOrElse("cromid-" + UUID.randomUUID().toString.take(7))
+
+  // Entries in the workflow store with heartbeats older than heartbeatTtl ago are presumed abandoned and up for grabs.
+  val DefaultWorkflowStoreHeartbeatTtl: FiniteDuration = 1.hour
+  val heartbeatTtl: FiniteDuration = config.getOrElse("system.workflow_heartbeat_ttl", DefaultWorkflowStoreHeartbeatTtl)
+
   val serverMode: Boolean
 
   lazy val systemConfig = config.getConfig("system")
@@ -66,7 +74,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
 
   lazy val workflowStore: WorkflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
   lazy val workflowStoreActor =
-    context.actorOf(WorkflowStoreActor.props(workflowStore, serviceRegistryActor, abortJobsOnTerminate), "WorkflowStoreActor")
+    context.actorOf(WorkflowStoreActor.props(workflowStore, serviceRegistryActor, abortJobsOnTerminate, cromwellId, heartbeatTtl), "WorkflowStoreActor")
 
   lazy val jobStore: JobStore = new SqlJobStore(EngineServicesStore.engineDatabaseInterface)
   lazy val jobStoreActor = context.actorOf(JobStoreActor.props(jobStore, serviceRegistryActor), "JobStoreActor")
@@ -134,6 +142,7 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   if (gracefulShutdown) {
     // If abortJobsOnTerminate is true, aborting all workflows will be handled by the graceful shutdown process
     CromwellShutdown.registerShutdownTasks(
+      cromwellId = cromwellId,
       abortJobsOnTerminate,
       actorSystem = context.system,
       workflowManagerActor = workflowManagerActor,

--- a/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -22,6 +22,8 @@ import scala.language.postfixOps
 class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with BeforeAndAfter with Mockito with Eventually {
   val helloWorldSourceFiles = HelloWorld.asWorkflowSources()
   val helloCwlWorldSourceFiles = HelloWorld.asWorkflowSources(workflowType = Option("CWL"), workflowTypeVersion = Option("v1.0"))
+  val cromwellId = "f00ba4"
+  val heartbeatTtl = 1 hour
 
   /**
     * Fold down a list of WorkflowToStart's, checking that their IDs are all unique
@@ -48,14 +50,14 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
   "The WorkflowStoreActor" should {
     "return an ID for a submitted workflow" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
       storeActor ! SubmitWorkflow(helloWorldSourceFiles)
       expectMsgType[WorkflowSubmittedToStore](10 seconds)
     }
 
     "return 3 IDs for a batch submission of 3" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloWorldSourceFiles))
       expectMsgPF(10 seconds) {
         case WorkflowsBatchSubmittedToStore(ids) => ids.toList.size shouldBe 3
@@ -64,7 +66,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "fetch exactly N workflows" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloCwlWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
@@ -107,7 +109,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
 
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
       val readMetadataActor = system.actorOf(ReadMetadataActor.props())
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(optionedSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
@@ -150,7 +152,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "return only the remaining workflows if N is larger than size" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
@@ -170,7 +172,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with Matchers with 
 
     "remain responsive if you ask to remove a workflow it doesn't have" in {
       val store = new InMemoryWorkflowStore
-      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false))
+      val storeActor = system.actorOf(WorkflowStoreActor.props(store, CromwellTestKitSpec.ServiceRegistryActorInstance, abortAllJobsOnTerminate = false, cromwellId, heartbeatTtl))
 
       storeActor ! FetchRunnableWorkflows(100)
       expectMsgPF(10 seconds) {

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -57,7 +57,7 @@ object SingleWorkflowRunnerActorSpec {
 
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec with Mockito {
   private val workflowStore =
-    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false))
+    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, cromwellId = "f00ba4", heartbeatTtl = 1.hour))
   private val serviceRegistry = TestProbe().ref
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
   private val ioActor = system.actorOf(SimpleIoActor.props)

--- a/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -32,7 +32,7 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
       val subWorkflowStoreService = system.actorOf(SubWorkflowStoreActor.props(subWorkflowStore))
 
       lazy val workflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
-      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false))
+      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false, cromwellId = "f00ba4", heartbeatTtl = 1.hour))
 
       val parentWorkflowId = WorkflowId.randomId()
       val subWorkflowId = WorkflowId.randomId()

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -434,7 +434,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
         _ <- dataAccess.addWorkflowStoreEntries(workflowStoreEntries)
         queried <- dataAccess.fetchStartableWorkflows(
           limit = Int.MaxValue,
-          cromwellId = Option("crom-f00ba4"),
+          cromwellId = "crom-f00ba4",
           heartbeatTtl = 1.hour)
 
         _ = {


### PR DESCRIPTION
1. Takes a `cromwell_id` from config or will just make up a `cromwell_id` based off a randomly generated UUID if none is provided.
2. Clears `cromwell_id`s and heartbeats on workflow store entries on clean shutdown.
3. Any workflow with a null or expired heartbeat is fair game when sweeping for workflows.
4. Actual SQL generated with Slick's`forUpdate` looks like the following when using the MySQL profile: ```select `WORKFLOW_EXECUTION_UUID`, `WORKFLOW_DEFINITION`, `WORKFLOW_ROOT`, `WORKFLOW_TYPE`, `WORKFLOW_TYPE_VERSION`, `WORKFLOW_INPUTS`, `WORKFLOW_OPTIONS`, `WORKFLOW_STATE`, `SUBMISSION_TIME`, `IMPORTS_ZIP`, `CUSTOM_LABELS`, `CROMWELL_ID`, `HEARTBEAT_TIMESTAMP`, `WORKFLOW_STORE_ENTRY_ID` from `WORKFLOW_STORE_ENTRY` where (`HEARTBEAT_TIMESTAMP` is null) or (`HEARTBEAT_TIMESTAMP` < ?) order by `SUBMISSION_TIME` limit ? for update```
