### PR TITLE
Increase gauge processing throughput

### DIFF
--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec")) with ImplicitSender with FlatSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll with Eventually {
 
-  val MaxWaitTime = 5.seconds
+  val MaxWaitTime = 10.seconds
   implicit val pc: PatienceConfig = PatienceConfig(MaxWaitTime)
 
   behavior of "JobExecutionTokenDispenserActor"
@@ -238,7 +238,7 @@ class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec
   var actorRefUnderTest: TestActorRef[JobExecutionTokenDispenserActor] = _
 
   before {
-    actorRefUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(10, 2.second)))
+    actorRefUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(10, 4.second)))
   }
   after {
     actorRefUnderTest = null

--- a/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
@@ -68,8 +68,7 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
     * We use a meter instead of a counter so we can at least get a rate (events / second)
     * The count is never reset though so the number keeps growing indefinitely until Cromwell is stopped / restarted
     */
-  private [statsd] def meterFor(bucket: CromwellBucket): Meter = {
-    // Because everything is a gauge, for clarity prepend "count" for counters so it counts events instead of giving a current value
+  private def meterFor(bucket: CromwellBucket): Meter = {
     val name = bucket.toStatsDString()
     val counterName = metricBaseName.append(name).name
     metricRegistry.getMeters.asScala.get(counterName) match {

--- a/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActor.scala
@@ -1,6 +1,6 @@
 package cromwell.services.instrumentation.impl.statsd
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import akka.actor.{Actor, ActorRef, Props}
 import com.readytalk.metrics.{CromwellStatsD, StatsDReporter}
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 object StatsDInstrumentationServiceActor {
   def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(new StatsDInstrumentationServiceActor(serviceConfig, globalConfig, serviceRegistryActor))
-  
+
   implicit class CromwellBucketEnhanced(val cromwellBucket: CromwellBucket) extends AnyVal {
     /**
       * Transforms a CromwellBucket to a StatsD path, optionally inserting a value between prefix and path 
@@ -30,13 +30,13 @@ object StatsDInstrumentationServiceActor {
   * Adapted from Workbench stack for StatsD instrumentation
   * Uses metrics-scala (https://github.com/erikvanoosten/metrics-scala) in combination with metrics-statsd (https://github.com/ReadyTalk/metrics-statsd)
   * metrics-scala is just a scala wrapper around dropwizard metrics which is a Java metric aggregation library (https://github.com/dropwizard/metrics)
-  * 
+  *
   * Metrics are stored and aggregated at the application level and periodically sent to a StatsD server via UDP.
   * Although StatsD supports a few different metric types, this infrastructure only send gauges that are pre-computed in a metrics registry.
   * This is not ideal because StatsD does not compute any statistics for gauges and simply forwards them to a backend.
   * It also adds some overhead on the application side that needs to compute its own statistics.
   * However it's simple working solution that is good enough for the current use case.
-  * 
+  *
   * If performance or statistics accuracy becomes a problem one might implement a more efficient solution
   * by making use of downsampling and / or multi metrics packets: https://github.com/etsy/statsd/blob/master/docs/metric_types.md
   */
@@ -44,6 +44,7 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
   val statsDConfig = StatsDConfig(serviceConfig)
 
   override lazy val metricBaseName = MetricName("cromwell")
+  val gaugeFunctions = new ConcurrentHashMap[CromwellBucket, Long]()
 
   StatsDReporter
     .forRegistry(metricRegistry)
@@ -67,14 +68,14 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
     * We use a meter instead of a counter so we can at least get a rate (events / second)
     * The count is never reset though so the number keeps growing indefinitely until Cromwell is stopped / restarted
     */
-  private def meterFor(bucket: CromwellBucket): Meter = {
+  private [statsd] def meterFor(bucket: CromwellBucket): Meter = {
     // Because everything is a gauge, for clarity prepend "count" for counters so it counts events instead of giving a current value
     val name = bucket.toStatsDString()
     val counterName = metricBaseName.append(name).name
     metricRegistry.getMeters.asScala.get(counterName) match {
-        // Make a new one if none is found
+      // Make a new one if none is found
       case None => metrics.meter(name)
-        // Otherwise use the existing one (after wrapping it in a metrics-scala object)
+      // Otherwise use the existing one (after wrapping it in a metrics-scala object)
       case Some(meter) => new Meter(meter)
     }
   }
@@ -93,12 +94,11 @@ class StatsDInstrumentationServiceActor(serviceConfig: Config, globalConfig: Con
     * Update the gauge value for this bucket
     */
   private def updateGauge(bucket: CromwellBucket, value: Long): Unit = {
-    val name = bucket.toStatsDString()
-    val gaugeName = metricBaseName.append(name).name
-    // Replace the metric entirely as its value needs to be bound to a function, whereas this actor expects
-    // periodic updates via messages
-    metricRegistry.remove(gaugeName)
-    metrics.gauge(name){ value }
+    val newGauge = !gaugeFunctions.containsKey(bucket)
+    gaugeFunctions.put(bucket, value)
+    if (newGauge) {
+      metrics.gauge(bucket.toStatsDString()){ gaugeFunctions.get(bucket) }
+    }
     ()
   }
 

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorBenchmarkSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorBenchmarkSpec.scala
@@ -27,7 +27,7 @@ class StatsDInstrumentationServiceActorBenchmarkSpec extends TestKitSuite with F
 
   val registryProbe = TestProbe().ref
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(3.seconds))
-  val testBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "metric", "bucket"))
+  val testBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "metric", "benchmark", "bucket"))
 
 
   it should "have good throughput for gauges" in {

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorBenchmarkSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorBenchmarkSpec.scala
@@ -1,0 +1,43 @@
+package cromwell.services.instrumentation.impl.statsd
+
+import akka.testkit.{TestActorRef, TestProbe}
+import cats.data.NonEmptyList
+import com.typesafe.config.ConfigFactory
+import cromwell.core.TestKitSuite
+import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
+import cromwell.services.instrumentation._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import StatsDInstrumentationServiceActor._
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+class StatsDInstrumentationServiceActorBenchmarkSpec extends TestKitSuite with FlatSpecLike with BeforeAndAfterAll with Matchers with Eventually {
+  behavior of "StatsDInstrumentationServiceActor"
+
+  val config = ConfigFactory.parseString(
+    """statsd {
+      |hostname = "localhost"
+      |port = 8125
+      |prefix = "prefix_value" # can be used to prefix all metrics with an api key for example
+      |flush-rate = 100 ms # rate at which aggregated metrics will be sent to statsd
+      |}
+    """.stripMargin
+  )
+
+  val registryProbe = TestProbe().ref
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(scaled(3.seconds))
+  val testBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "metric", "bucket"))
+
+
+  it should "have good throughput for gauges" in {
+    val instrumentationActor = TestActorRef(new StatsDInstrumentationServiceActor(config, ConfigFactory.load(), registryProbe))
+    val gaugeName = instrumentationActor.underlyingActor.metricBaseName.append(testBucket.toStatsDString()).name
+    Stream.range(0, 1 * 1000 * 1000, 1).foreach({ i =>
+      instrumentationActor ! InstrumentationServiceMessage(CromwellGauge(testBucket, i.toLong))
+    })
+    eventually {
+      instrumentationActor.underlyingActor.metricRegistry.getGauges.asScala.get(gaugeName).map(_.getValue) shouldBe Some(999999)
+    }
+  }
+}

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -30,6 +30,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
   val udpProbe = TestProbe()
   val patience = 1.second
   val testBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "metric", "bucket"))
+  val testGaugeBucket = CromwellBucket(List("test_prefix"), NonEmptyList.of("test", "gauge", "metric", "bucket"))
   
   var udpListenerActor: ActorRef = _
   
@@ -60,8 +61,8 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
         "prefix_value.cromwell.test_prefix.test.metric.bucket.m1_rate:0.00|g"
       )
     ),
-    StatsDTestBit("set gauges", CromwellGauge(testBucket, 89),
-      Set("prefix_value.cromwell.test_prefix.test.metric.bucket:89|g")
+    StatsDTestBit("set gauges", CromwellGauge(testGaugeBucket, 89),
+      Set("prefix_value.cromwell.test_prefix.test.gauge.metric.bucket:89|g")
     ),
     StatsDTestBit("set timings", CromwellTiming(testBucket.expand("timing"), 5.seconds),
       Set("prefix_value.cromwell.test_prefix.test.metric.bucket.timing.stddev:0.00|g",


### PR DESCRIPTION
While testing C31 perf I noticed the statsd service can get very slow which translates in metrics being largely out of dates.
I traced this to an issue with how gauges are being updated.
