### PR TITLE
Explicitly wait for a result from docker run

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -309,13 +309,23 @@ backend {
         """
         submit = "/bin/bash ${script}"
         submit-docker = """
-        docker run \
-          --cidfile ${docker_cid} \
-          --rm -i \
-          ${"--user " + docker_user} \
-          --entrypoint /bin/bash \
-          -v ${cwd}:${docker_cwd} \
-          ${docker} ${script}
+        # run as in the original configuration without --rm flag (will remove later)
+docker run \
+  --cidfile ${docker_cid} \
+  -i \
+  ${"--user " + docker_user} \
+  --entrypoint /bin/bash \
+  -v ${cwd}:${docker_cwd} \
+  ${docker} ${script}
+
+# get the return code (working even if the container was detached)
+rc=$(docker wait `cat ${docker_cid}`)
+
+# remove the container after waiting
+docker rm `cat ${docker_cid}`
+
+# return exit code
+exit $rc
         """
 
         kill-docker = "docker kill `cat ${docker_cid}`"

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -309,23 +309,23 @@ backend {
         """
         submit = "/bin/bash ${script}"
         submit-docker = """
-        # run as in the original configuration without --rm flag (will remove later)
-docker run \
-  --cidfile ${docker_cid} \
-  -i \
-  ${"--user " + docker_user} \
-  --entrypoint /bin/bash \
-  -v ${cwd}:${docker_cwd} \
-  ${docker} ${script}
+          # run as in the original configuration without --rm flag (will remove later)
+          docker run \
+            --cidfile ${docker_cid} \
+            -i \
+            ${"--user " + docker_user} \
+            --entrypoint /bin/bash \
+            -v ${cwd}:${docker_cwd} \
+            ${docker} ${script}
 
-# get the return code (working even if the container was detached)
-rc=$(docker wait `cat ${docker_cid}`)
+          # get the return code (working even if the container was detached)
+          rc=$(docker wait `cat ${docker_cid}`)
 
-# remove the container after waiting
-docker rm `cat ${docker_cid}`
+          # remove the container after waiting
+          docker rm `cat ${docker_cid}`
 
-# return exit code
-exit $rc
+          # return exit code
+          exit $rc
         """
 
         kill-docker = "docker kill `cat ${docker_cid}`"


### PR DESCRIPTION
This approach allows docker to re-connect to container that it had been detached from in order to retrieve the exit status. 

See attached issue for background.