### PR TITLE
Taskless engine functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val wdlSharedModel = (project in wdlModelRoot / "shared")
 
 lazy val wdlModelDraft2 = (project in wdlModelRoot / "draft2")
   .withLibrarySettings("cromwell-wdl-model-draft2", wdlDependencies, crossCompile = true)
+  .dependsOn(wdlSharedTransforms)
   .dependsOn(wdlSharedModel)
 
 lazy val wdlModelDraft3 = (project in wdlModelRoot / "draft3")

--- a/centaur/src/main/resources/standardTestCases/draft3_taskless_engine_functions.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_taskless_engine_functions.test
@@ -1,0 +1,46 @@
+name: draft3_taskless_engine_functions
+testFormat: workflowsuccess
+workflowType: WDL
+workflowTypeVersion: draft-3
+
+files {
+  wdl: wdl_draft3/taskless_engine_functions/taskless_engine_functions.wdl
+}
+
+metadata {
+
+  "outputs.taskless_engine_functions.int_cross_string.0.left": 1
+  "outputs.taskless_engine_functions.int_cross_string.0.right": "a"
+  "outputs.taskless_engine_functions.int_cross_string.1.left": 1
+  "outputs.taskless_engine_functions.int_cross_string.1.right": "b"
+  "outputs.taskless_engine_functions.int_cross_string.2.left": 2
+  "outputs.taskless_engine_functions.int_cross_string.2.right": "a"
+  "outputs.taskless_engine_functions.int_cross_string.3.left": 2
+  "outputs.taskless_engine_functions.int_cross_string.3.right": "b"
+
+  "outputs.taskless_engine_functions.transposed_matrix.0": "[1,1]"
+  "outputs.taskless_engine_functions.transposed_matrix.1": "[0,0]"
+
+  "outputs.taskless_engine_functions.flattened_matrix.0": 1
+  "outputs.taskless_engine_functions.flattened_matrix.1": 0
+  "outputs.taskless_engine_functions.flattened_matrix.2": 1
+  "outputs.taskless_engine_functions.flattened_matrix.3": 0
+  "outputs.taskless_engine_functions.matrix_length": 2
+  "outputs.taskless_engine_functions.flattened_matrix_length": 4
+
+  "outputs.taskless_engine_functions.flattened_map.0.left": 1
+  "outputs.taskless_engine_functions.flattened_map.0.right": "one"
+  "outputs.taskless_engine_functions.flattened_map.1.left": 2
+  "outputs.taskless_engine_functions.flattened_map.1.right": "two"
+  "outputs.taskless_engine_functions.flattened_map.2.left": 11
+  "outputs.taskless_engine_functions.flattened_map.2.right": "eleven"
+  "outputs.taskless_engine_functions.flattened_map.3.left": 22
+  "outputs.taskless_engine_functions.flattened_map.3.right": "twenty-two"
+
+  "outputs.taskless_engine_functions.file_basename": "file.txt"
+  "outputs.taskless_engine_functions.file_basename_extensionless": "file"
+
+  "outputs.taskless_engine_functions.f_floor": "1"
+  "outputs.taskless_engine_functions.f_ceiling": "2"
+  "outputs.taskless_engine_functions.f_round": "1"
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/taskless_engine_functions/taskless_engine_functions.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/taskless_engine_functions/taskless_engine_functions.wdl
@@ -1,0 +1,39 @@
+version draft-3
+
+workflow taskless_engine_functions {
+
+  Array[Int] ints = [ 1, 2 ]
+
+  Array[String] strings = ["a", "b"]
+
+  String filepath = "gs://not/a/real/file.txt"
+
+  Array[Array[Int]] matrix = [
+    [1, 0],
+    [1, 0]
+  ]
+
+  Array[Map[Int, String]] list_of_maps = [
+    { 1: "one", 2: "two" },
+    { 11: "eleven", 22: "twenty-two" }
+  ]
+
+  Float f = 1.024
+
+  output {
+    Array[Pair[Int, String]] int_cross_string = cross(ints, strings)
+    Array[Array[Int]] transposed_matrix = transpose(matrix)
+
+    Array[Int] flattened_matrix = flatten(matrix)
+    Int matrix_length = length(matrix)
+    Int flattened_matrix_length = length(flattened_matrix)
+    Array[Pair[Int, String]] flattened_map = flatten(list_of_maps)
+
+    String file_basename = basename(filepath)
+    String file_basename_extensionless = basename(filepath, ".txt")
+
+    Int f_floor = floor(f)
+    Int f_ceiling = ceil(f)
+    Int f_round = round(f)
+  }
+}

--- a/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
+++ b/wdl/model/draft3/src/main/scala/wdl/model/draft3/elements/ExpressionElement.scala
@@ -95,21 +95,39 @@ object ExpressionElement {
   final case class Range(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Transpose(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Length(param: ExpressionElement) extends OneParamFunctionCallElement
-  final case class Prefix(param: ExpressionElement) extends OneParamFunctionCallElement
+  final case class Flatten(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class SelectFirst(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class SelectAll(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Defined(param: ExpressionElement) extends OneParamFunctionCallElement
-  final case class Basename(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Floor(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Ceil(param: ExpressionElement) extends OneParamFunctionCallElement
   final case class Round(param: ExpressionElement) extends OneParamFunctionCallElement
 
   // 1- or 2-param functions:
-  final case class Size(file: ExpressionElement, unit: Option[ExpressionElement]) extends FunctionCallElement
+  sealed trait OneOrTwoParamFunctionCallElement extends FunctionCallElement {
+    def firstParam: ExpressionElement
+    def secondParam: Option[ExpressionElement]
+  }
+  final case class Size(file: ExpressionElement, unit: Option[ExpressionElement]) extends OneOrTwoParamFunctionCallElement {
+    override def firstParam: ExpressionElement = file
+    override def secondParam: Option[ExpressionElement] = unit
+  }
+  final case class Basename(param: ExpressionElement, suffixToRemove: Option[ExpressionElement]) extends OneOrTwoParamFunctionCallElement {
+    override def firstParam: ExpressionElement = param
+    override def secondParam: Option[ExpressionElement] = suffixToRemove
+  }
 
   // 2-param functions:
-  final case class Zip(array1: ExpressionElement, array2: ExpressionElement) extends FunctionCallElement
-  final case class Cross(array1: ExpressionElement, array2: ExpressionElement) extends FunctionCallElement
+  sealed trait TwoParamFunctionCallElement extends FunctionCallElement {
+    def arg1: ExpressionElement
+    def arg2: ExpressionElement
+  }
+  final case class Zip(arg1: ExpressionElement, arg2: ExpressionElement) extends TwoParamFunctionCallElement
+  final case class Cross(arg1: ExpressionElement, arg2: ExpressionElement) extends TwoParamFunctionCallElement
+  final case class Prefix(prefix: ExpressionElement, array: ExpressionElement) extends TwoParamFunctionCallElement {
+    override def arg1: ExpressionElement = prefix
+    override def arg2: ExpressionElement = array
+  }
 
   // 3-param functions:
   final case class Sub(input: ExpressionElement, pattern: ExpressionElement, replace: ExpressionElement) extends FunctionCallElement

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/AstNodeToExpressionElement.scala
@@ -138,21 +138,22 @@ object AstNodeToExpressionElement {
     "range" -> validateOneParamEngineFunction(Range, "range"),
     "transpose" -> validateOneParamEngineFunction(Transpose, "transpose"),
     "length" -> validateOneParamEngineFunction(Length, "length"),
-    "prefix" -> validateOneParamEngineFunction(Prefix, "prefix"),
+    "flatten" -> validateOneParamEngineFunction(Flatten, "flatten"),
     "select_first" -> validateOneParamEngineFunction(SelectFirst, "select_first"),
     "select_all" -> validateOneParamEngineFunction(SelectAll, "select_all"),
     "defined" -> validateOneParamEngineFunction(Defined, "defined"),
-    "basename" -> validateOneParamEngineFunction(Basename, "basename"),
     "floor" -> validateOneParamEngineFunction(Floor, "floor"),
     "ceil" -> validateOneParamEngineFunction(Ceil, "ceil"),
     "round" -> validateOneParamEngineFunction(Round, "round"),
 
     // 1- or 2-param functions:
-    "size" -> validateSizeEngineFunction,
+    "size" -> validateOneOrTwoParamEngineFunction(Size, "size"),
+    "basename" -> validateOneOrTwoParamEngineFunction(Basename, "basename"),
 
     // 2-param functions:
     "zip" -> validateTwoParamEngineFunction(Zip, "zip"),
     "cross" -> validateTwoParamEngineFunction(Cross, "cross"),
+    "prefix" -> validateTwoParamEngineFunction(Prefix, "prefix"),
 
     // 3-param functions:
     "sub" -> validateThreeParamEngineFunction(Sub, "sub")
@@ -174,13 +175,15 @@ object AstNodeToExpressionElement {
       s"Function $functionName expects exactly 1 argument but got ${params.size}".invalidNel
     }
 
-  private def validateSizeEngineFunction(params: Vector[ExpressionElement]): ErrorOr[ExpressionElement] =
+  private def validateOneOrTwoParamEngineFunction(elementMaker: (ExpressionElement, Option[ExpressionElement]) => ExpressionElement,
+                                                  functionName: String)
+                                                 (params: Vector[ExpressionElement]): ErrorOr[ExpressionElement] =
     if (params.size == 1) {
-      Size(params.head, None).validNel
+      elementMaker(params.head, None).validNel
     } else if (params.size == 2) {
-      Size(params.head, Option(params(1))).validNel
+      elementMaker(params.head, Option(params(1))).validNel
     } else {
-      s"Function size expects 1 or 2 arguments but got ${params.size}".invalidNel
+      s"Function $functionName expects 1 or 2 arguments but got ${params.size}".invalidNel
     }
 
   private def validateTwoParamEngineFunction(elementMaker: (ExpressionElement, ExpressionElement) => ExpressionElement, functionName: String)

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/consumed/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/consumed/EngineFunctionEvaluators.scala
@@ -1,13 +1,66 @@
 package wdl.draft3.transforms.linking.expression.consumed
 
+import wdl.model.draft3.elements.ExpressionElement
 import wdl.model.draft3.graph.{ExpressionValueConsumer, UnlinkedConsumedValueHook}
 import wdl.model.draft3.elements.ExpressionElement._
 import wdl.model.draft3.graph.ExpressionValueConsumer.ops._
 
 object EngineFunctionEvaluators {
-  implicit val rangeFunctionEvaluator: ExpressionValueConsumer[Range] = forOneParamFunction[Range]
 
-  private def forOneParamFunction[A <: OneParamFunctionCallElement] = new ExpressionValueConsumer[A] {
+  implicit val readLinesValueConsumer: ExpressionValueConsumer[ReadLines] = forOneParamFunction
+  implicit val readTsvValueConsumer: ExpressionValueConsumer[ReadTsv] = forOneParamFunction
+  implicit val readMapValueConsumer: ExpressionValueConsumer[ReadMap] = forOneParamFunction
+  implicit val readObjectValueConsumer: ExpressionValueConsumer[ReadObject] = forOneParamFunction
+  implicit val readObjectsValueConsumer: ExpressionValueConsumer[ReadObjects] = forOneParamFunction
+  implicit val readJsonValueConsumer: ExpressionValueConsumer[ReadJson] = forOneParamFunction
+  implicit val readIntValueConsumer: ExpressionValueConsumer[ReadInt] = forOneParamFunction
+  implicit val readStringValueConsumer: ExpressionValueConsumer[ReadString] = forOneParamFunction
+  implicit val readFloatValueConsumer: ExpressionValueConsumer[ReadFloat] = forOneParamFunction
+  implicit val readBooleanValueConsumer: ExpressionValueConsumer[ReadBoolean] = forOneParamFunction
+  implicit val writeLinesValueConsumer: ExpressionValueConsumer[WriteLines] = forOneParamFunction
+  implicit val writeTsvValueConsumer: ExpressionValueConsumer[WriteTsv] = forOneParamFunction
+  implicit val writeMapValueConsumer: ExpressionValueConsumer[WriteMap] = forOneParamFunction
+  implicit val writeObjectValueConsumer: ExpressionValueConsumer[WriteObject] = forOneParamFunction
+  implicit val writeObjectsValueConsumer: ExpressionValueConsumer[WriteObjects] = forOneParamFunction
+  implicit val writeJsonValueConsumer: ExpressionValueConsumer[WriteJson] = forOneParamFunction
+  implicit val rangeValueConsumer: ExpressionValueConsumer[Range] = forOneParamFunction
+  implicit val transposeValueConsumer: ExpressionValueConsumer[Transpose] = forOneParamFunction
+  implicit val lengthValueConsumer: ExpressionValueConsumer[Length] = forOneParamFunction
+  implicit val flattenValueConsumer: ExpressionValueConsumer[Flatten] = forOneParamFunction
+  implicit val selectFirstValueConsumer: ExpressionValueConsumer[SelectFirst] = forOneParamFunction
+  implicit val selectAllValueConsumer: ExpressionValueConsumer[SelectAll] = forOneParamFunction
+  implicit val definedValueConsumer: ExpressionValueConsumer[Defined] = forOneParamFunction
+  implicit val floorValueConsumer: ExpressionValueConsumer[Floor] = forOneParamFunction
+  implicit val ceilValueConsumer: ExpressionValueConsumer[Ceil] = forOneParamFunction
+  implicit val roundValueConsumer: ExpressionValueConsumer[Round] = forOneParamFunction
+
+  implicit val sizeValueConsumer: ExpressionValueConsumer[Size] = forOneOrTwoParamFunction
+  implicit val basenameValueConsumer: ExpressionValueConsumer[Basename] = forOneOrTwoParamFunction
+
+  implicit val zipValueConsumer: ExpressionValueConsumer[Zip] = forTwoParamFunction
+  implicit val crossValueConsumer: ExpressionValueConsumer[Cross] = forTwoParamFunction
+  implicit val prefixValueConsumer: ExpressionValueConsumer[Prefix] = forTwoParamFunction
+
+  implicit val subFunctionValueConsumer: ExpressionValueConsumer[Sub] = new ExpressionValueConsumer[Sub] {
+    override def expressionConsumedValueHooks(a: Sub): Set[UnlinkedConsumedValueHook] = {
+      a.input.expressionConsumedValueHooks ++ a.pattern.expressionConsumedValueHooks ++ a.replace.expressionConsumedValueHooks
+    }
+  }
+
+  private def forOneParamFunction[A <: OneParamFunctionCallElement]: ExpressionValueConsumer[A] = new ExpressionValueConsumer[A] {
     override def expressionConsumedValueHooks(a: A): Set[UnlinkedConsumedValueHook] = a.param.expressionConsumedValueHooks
+  }
+
+  private def forOneOrTwoParamFunction[A <: OneOrTwoParamFunctionCallElement]: ExpressionValueConsumer[A] = new ExpressionValueConsumer[A] {
+    override def expressionConsumedValueHooks(a: A): Set[UnlinkedConsumedValueHook] = {
+      a.firstParam.expressionConsumedValueHooks ++
+        a.secondParam.toSet.flatMap { secondParam: ExpressionElement => secondParam.expressionConsumedValueHooks }
+    }
+  }
+
+  private def forTwoParamFunction[A <: TwoParamFunctionCallElement]: ExpressionValueConsumer[A] = new ExpressionValueConsumer[A] {
+    override def expressionConsumedValueHooks(a: A): Set[UnlinkedConsumedValueHook] = {
+      a.arg1.expressionConsumedValueHooks ++ a.arg2.expressionConsumedValueHooks
+    }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/consumed/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/consumed/package.scala
@@ -56,7 +56,6 @@ package object consumed {
       case a: IdentifierLookup => a.expressionConsumedValueHooks
       case a: IdentifierMemberAccess => a.expressionConsumedValueHooks
 
-      // Binary operators (at some point we might want to split these into separate cases):
       case a: LogicalOr => a.expressionConsumedValueHooks
       case a: LogicalAnd => a.expressionConsumedValueHooks
       case a: Equals => a.expressionConsumedValueHooks
@@ -72,7 +71,41 @@ package object consumed {
       case a: Remainder => a.expressionConsumedValueHooks
 
       // Engine functions:
+      case a: ReadLines => a.expressionConsumedValueHooks
+      case a: ReadTsv => a.expressionConsumedValueHooks
+      case a: ReadMap => a.expressionConsumedValueHooks
+      case a: ReadObject => a.expressionConsumedValueHooks
+      case a: ReadObjects => a.expressionConsumedValueHooks
+      case a: ReadJson => a.expressionConsumedValueHooks
+      case a: ReadInt => a.expressionConsumedValueHooks
+      case a: ReadString => a.expressionConsumedValueHooks
+      case a: ReadFloat => a.expressionConsumedValueHooks
+      case a: ReadBoolean => a.expressionConsumedValueHooks
+      case a: WriteLines => a.expressionConsumedValueHooks
+      case a: WriteTsv => a.expressionConsumedValueHooks
+      case a: WriteMap => a.expressionConsumedValueHooks
+      case a: WriteObject => a.expressionConsumedValueHooks
+      case a: WriteObjects => a.expressionConsumedValueHooks
+      case a: WriteJson => a.expressionConsumedValueHooks
       case a: Range => a.expressionConsumedValueHooks
+      case a: Transpose => a.expressionConsumedValueHooks
+      case a: Length => a.expressionConsumedValueHooks
+      case a: Flatten => a.expressionConsumedValueHooks
+      case a: Prefix => a.expressionConsumedValueHooks
+      case a: SelectFirst => a.expressionConsumedValueHooks
+      case a: SelectAll => a.expressionConsumedValueHooks
+      case a: Defined => a.expressionConsumedValueHooks
+      case a: Floor => a.expressionConsumedValueHooks
+      case a: Ceil => a.expressionConsumedValueHooks
+      case a: Round => a.expressionConsumedValueHooks
+
+      case a: Size => a.expressionConsumedValueHooks
+      case a: Basename => a.expressionConsumedValueHooks
+
+      case a: Zip => a.expressionConsumedValueHooks
+      case a: Cross => a.expressionConsumedValueHooks
+
+      case a: Sub => a.expressionConsumedValueHooks
 
       // TODO fill in other expression types
       case other => throw new Exception(s"Cannot generate consumed values for ExpressionElement ${other.getClass.getSimpleName}")

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/EngineFunctionEvaluators.scala
@@ -1,5 +1,7 @@
 package wdl.draft3.transforms.linking.expression.types
 
+import cats.data.Validated.Valid
+import cats.syntax.apply._
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
 import common.validation.ErrorOr._
@@ -8,12 +10,239 @@ import wdl.model.draft3.graph.{GeneratedValueHandle, UnlinkedConsumedValueHook}
 import wdl.model.draft3.elements.ExpressionElement._
 import wdl.model.draft3.graph.expression.TypeEvaluator
 import wdl.model.draft3.graph.expression.TypeEvaluator.ops._
-import wom.types.{WomArrayType, WomIntegerType, WomType}
+import wom.types._
+import wom.values.WomArray.WomArrayLike
 
 object EngineFunctionEvaluators {
+
+  implicit val readLinesFunctionEvaluator: TypeEvaluator[ReadLines] = new TypeEvaluator[ReadLines] {
+    override def evaluateType(a: ReadLines, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomArrayType(WomStringType))
+    }
+  }
+
+  implicit val readTsvFunctionEvaluator: TypeEvaluator[ReadTsv] = new TypeEvaluator[ReadTsv] {
+    override def evaluateType(a: ReadTsv, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomArrayType(WomArrayType(WomStringType)))
+    }
+  }
+
+  implicit val readMapFunctionEvaluator: TypeEvaluator[ReadMap] = new TypeEvaluator[ReadMap] {
+    override def evaluateType(a: ReadMap, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomMapType(WomStringType, WomStringType))
+    }
+  }
+
+  implicit val readObjectFunctionEvaluator: TypeEvaluator[ReadObject] = new TypeEvaluator[ReadObject] {
+    override def evaluateType(a: ReadObject, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomObjectType)
+    }
+  }
+
+  implicit val readObjectsFunctionEvaluator: TypeEvaluator[ReadObjects] = new TypeEvaluator[ReadObjects] {
+    override def evaluateType(a: ReadObjects, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomArrayType(WomObjectType))
+    }
+  }
+
+  implicit val readJsonFunctionEvaluator: TypeEvaluator[ReadJson] = new TypeEvaluator[ReadJson] {
+    override def evaluateType(a: ReadJson, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomObjectType)
+    }
+  }
+
+  implicit val readIntFunctionEvaluator: TypeEvaluator[ReadInt] = new TypeEvaluator[ReadInt] {
+    override def evaluateType(a: ReadInt, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomIntegerType)
+    }
+  }
+
+  implicit val readStringFunctionEvaluator: TypeEvaluator[ReadString] = new TypeEvaluator[ReadString] {
+    override def evaluateType(a: ReadString, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomStringType)
+    }
+  }
+
+  implicit val readFloatFunctionEvaluator: TypeEvaluator[ReadFloat] = new TypeEvaluator[ReadFloat] {
+    override def evaluateType(a: ReadFloat, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomFloatType)
+    }
+  }
+
+  implicit val readBooleanFunctionEvaluator: TypeEvaluator[ReadBoolean] = new TypeEvaluator[ReadBoolean] {
+    override def evaluateType(a: ReadBoolean, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomSingleFileType).map(_ => WomBooleanType)
+    }
+  }
+
+  implicit val writeLinesFunctionEvaluator: TypeEvaluator[WriteLines] = new TypeEvaluator[WriteLines] {
+    override def evaluateType(a: WriteLines, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomArrayType(WomStringType)).map(_ => WomSingleFileType)
+    }
+  }
+
+  implicit val writeTsvFunctionEvaluator: TypeEvaluator[WriteTsv] = new TypeEvaluator[WriteTsv] {
+    override def evaluateType(a: WriteTsv, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomArrayType(WomArrayType(WomStringType))).map(_ => WomSingleFileType)
+    }
+  }
+
+  implicit val writeMapFunctionEvaluator: TypeEvaluator[WriteMap] = new TypeEvaluator[WriteMap] {
+    override def evaluateType(a: WriteMap, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomMapType(WomAnyType, WomAnyType)).map(_ => WomSingleFileType)
+    }
+  }
+
+  implicit val writeObjectFunctionEvaluator: TypeEvaluator[WriteObject] = new TypeEvaluator[WriteObject] {
+    override def evaluateType(a: WriteObject, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomObjectType).map(_ => WomSingleFileType)
+    }
+  }
+
+  implicit val writeObjectsFunctionEvaluator: TypeEvaluator[WriteObjects] = new TypeEvaluator[WriteObjects] {
+    override def evaluateType(a: WriteObjects, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomArrayType(WomObjectType)).map(_ => WomSingleFileType)
+    }
+  }
+
+  implicit val writeJsonFunctionEvaluator: TypeEvaluator[WriteJson] = new TypeEvaluator[WriteJson] {
+    override def evaluateType(a: WriteJson, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomObjectType).map(_ => WomSingleFileType)
+    }
+  }
+
   implicit val rangeFunctionEvaluator: TypeEvaluator[Range] = new TypeEvaluator[Range] {
     override def evaluateType(a: Range, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
       validateParamType(a.param, linkedValues, WomIntegerType).map(_ => WomArrayType(WomIntegerType))
+    }
+  }
+
+  implicit val transposeFunctionEvaluator: TypeEvaluator[Transpose] = new TypeEvaluator[Transpose] {
+    override def evaluateType(a: Transpose, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.param.evaluateType(linkedValues).flatMap {
+        case a @ WomArrayType(WomArrayType(_)) => a.validNel
+        case foundType => s"Invalid parameter '${a.param}'. Expected 'Array[Array[_]]' but got '${foundType.toDisplayString}'".invalidNel
+      }
+    }
+  }
+
+  implicit val lengthFunctionEvaluator: TypeEvaluator[Length] = new TypeEvaluator[Length] {
+    override def evaluateType(a: Length, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomArrayType(WomAnyType)).map(_ => WomIntegerType)
+    }
+  }
+
+  implicit val flattenFunctionEvaluator: TypeEvaluator[Flatten] = new TypeEvaluator[Flatten] {
+    override def evaluateType(a: Flatten, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.param.evaluateType(linkedValues).flatMap {
+        case WomArrayType(inner @ WomArrayType(_)) => inner.validNel
+        case foundType => s"Invalid parameter '${a.param}'. Expected 'Array[Array[_]]' but got '${foundType.toDisplayString}'".invalidNel
+      }
+    }
+  }
+
+  implicit val selectFirstFunctionEvaluator: TypeEvaluator[SelectFirst] = new TypeEvaluator[SelectFirst] {
+    override def evaluateType(a: SelectFirst, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.param.evaluateType(linkedValues).flatMap {
+        case WomArrayType(WomOptionalType(inner)) => inner.validNel
+        case foundType => s"Invalid parameter '${a.param}'. Expected an array of optional values (eg 'Array[X?]') but got '${foundType.toDisplayString}'".invalidNel
+      }
+    }
+  }
+
+  implicit val selectAllFunctionEvaluator: TypeEvaluator[SelectAll] = new TypeEvaluator[SelectAll] {
+    override def evaluateType(a: SelectAll, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      a.param.evaluateType(linkedValues).flatMap {
+        case WomArrayType(WomOptionalType(inner)) => WomArrayType(inner).validNel
+        case foundType => s"Invalid parameter '${a.param}'. Expected an array of optional values (eg 'Array[X?]') but got '${foundType.toDisplayString}'".invalidNel
+      }
+    }
+  }
+
+  implicit val definedFunctionEvaluator: TypeEvaluator[Defined] = new TypeEvaluator[Defined] {
+    override def evaluateType(a: Defined, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomOptionalType(WomAnyType)).map(_ => WomBooleanType)
+    }
+  }
+
+  implicit val floorFunctionEvaluator: TypeEvaluator[Floor] = new TypeEvaluator[Floor] {
+    override def evaluateType(a: Floor, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomFloatType).map(_ => WomIntegerType)
+    }
+  }
+
+  implicit val ceilFunctionEvaluator: TypeEvaluator[Ceil] = new TypeEvaluator[Ceil] {
+    override def evaluateType(a: Ceil, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomFloatType).map(_ => WomIntegerType)
+    }
+  }
+
+  implicit val roundFunctionEvaluator: TypeEvaluator[Round] = new TypeEvaluator[Round] {
+    override def evaluateType(a: Round, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      validateParamType(a.param, linkedValues, WomFloatType).map(_ => WomIntegerType)
+    }
+  }
+
+  implicit val sizeFunctionEvaluator: TypeEvaluator[Size] = new TypeEvaluator[Size] {
+    override def evaluateType(a: Size, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      val validatedSecondArg: ErrorOr[Unit] = a.secondParam match {
+        case None => ().validNel
+        case Some(arg) => validateParamType(arg, linkedValues, WomStringType)
+      }
+      (validateParamType(a.firstParam, linkedValues, WomSingleFileType),
+        validatedSecondArg) mapN { (_, _) => WomFloatType }
+    }
+  }
+
+  implicit val basenameFunctionEvaluator: TypeEvaluator[Basename] = new TypeEvaluator[Basename] {
+    override def evaluateType(a: Basename, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      val validatedSecondArg: ErrorOr[Unit] = a.secondParam match {
+        case None => ().validNel
+        case Some(arg) => validateParamType(arg, linkedValues, WomStringType)
+      }
+      (validateParamType(a.firstParam, linkedValues, WomSingleFileType),
+        validatedSecondArg) mapN { (_, _) => WomStringType }
+    }
+  }
+
+  implicit val zipFunctionEvaluator: TypeEvaluator[Zip] = new TypeEvaluator[Zip] {
+    override def evaluateType(a: Zip, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      (a.arg1.evaluateType(linkedValues), a.arg2.evaluateType(linkedValues)) match {
+        case (Valid(WomArrayLike(left)), Valid(WomArrayLike(right))) => WomPairType(left.arrayType.memberType, right.arrayType.memberType).validNel
+        case (Valid(otherLeft), Valid(WomArrayLike(_))) => s"Invalid left parameter '${a.arg1}'. Expected Array type but got '${otherLeft.toDisplayString}'".invalidNel
+        case (Valid(WomArrayLike(_)), Valid(otherRight)) => s"Invalid right parameter '${a.arg2}'. Expected Array type but got '${otherRight.toDisplayString}'".invalidNel
+        // One or more are invalid, so mapN function won't actually ever run:
+        case (otherLeft, otherRight) => (otherLeft, otherRight) mapN { (_, _) => WomNothingType }
+      }
+    }
+  }
+
+  implicit val crossFunctionEvaluator: TypeEvaluator[Cross] = new TypeEvaluator[Cross] {
+    override def evaluateType(a: Cross, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      (a.arg1.evaluateType(linkedValues), a.arg2.evaluateType(linkedValues)) match {
+        case (Valid(WomArrayLike(left)), Valid(WomArrayLike(right))) => WomPairType(left.arrayType.memberType, right.arrayType.memberType).validNel
+        case (Valid(otherLeft), Valid(WomArrayLike(_))) => s"Invalid left parameter '${a.arg1}'. Expected Array type but got '${otherLeft.toDisplayString}'".invalidNel
+        case (Valid(WomArrayLike(_)), Valid(otherRight)) => s"Invalid right parameter '${a.arg2}'. Expected Array type but got '${otherRight.toDisplayString}'".invalidNel
+        // One or more are invalid, so mapN function won't actually ever run:
+        case (otherLeft, otherRight) => (otherLeft, otherRight) mapN { (_, _) => WomNothingType }
+      }
+    }
+  }
+
+  implicit val prefixFunctionEvaluator: TypeEvaluator[Prefix] = new TypeEvaluator[Prefix] {
+    override def evaluateType(a: Prefix, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+      (validateParamType(a.prefix, linkedValues, WomStringType),
+        validateParamType(a.array, linkedValues, WomArrayType(WomStringType))
+      ) mapN { (_, _) => WomArrayType(WomStringType) }
+    }
+  }
+
+  implicit val subFunctionEvaluator: TypeEvaluator[Sub] = new TypeEvaluator[Sub] {
+    override def evaluateType(a: Sub, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
+
+      (validateParamType(a.input, linkedValues, WomSingleFileType),
+        validateParamType(a.pattern, linkedValues, WomSingleFileType),
+        validateParamType(a.replace, linkedValues, WomSingleFileType)) mapN { (_, _, _) => WomStringType }
     }
   }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/package.scala
@@ -56,7 +56,41 @@ package object types {
         case a: TernaryIf => a.evaluateType(linkedValues)
 
         // Engine functions:
+        case a: ReadLines => a.evaluateType(linkedValues)
+        case a: ReadTsv => a.evaluateType(linkedValues)
+        case a: ReadMap => a.evaluateType(linkedValues)
+        case a: ReadObject => a.evaluateType(linkedValues)
+        case a: ReadObjects => a.evaluateType(linkedValues)
+        case a: ReadJson => a.evaluateType(linkedValues)
+        case a: ReadInt => a.evaluateType(linkedValues)
+        case a: ReadString => a.evaluateType(linkedValues)
+        case a: ReadFloat => a.evaluateType(linkedValues)
+        case a: ReadBoolean => a.evaluateType(linkedValues)
+        case a: WriteLines => a.evaluateType(linkedValues)
+        case a: WriteTsv => a.evaluateType(linkedValues)
+        case a: WriteMap => a.evaluateType(linkedValues)
+        case a: WriteObject => a.evaluateType(linkedValues)
+        case a: WriteObjects => a.evaluateType(linkedValues)
+        case a: WriteJson => a.evaluateType(linkedValues)
         case a: Range => a.evaluateType(linkedValues)
+        case a: Transpose => a.evaluateType(linkedValues)
+        case a: Length => a.evaluateType(linkedValues)
+        case a: Flatten => a.evaluateType(linkedValues)
+        case a: Prefix => a.evaluateType(linkedValues)
+        case a: SelectFirst => a.evaluateType(linkedValues)
+        case a: SelectAll => a.evaluateType(linkedValues)
+        case a: Defined => a.evaluateType(linkedValues)
+        case a: Floor => a.evaluateType(linkedValues)
+        case a: Ceil => a.evaluateType(linkedValues)
+        case a: Round => a.evaluateType(linkedValues)
+
+        case a: Size => a.evaluateType(linkedValues)
+        case a: Basename => a.evaluateType(linkedValues)
+
+        case a: Zip => a.evaluateType(linkedValues)
+        case a: Cross => a.evaluateType(linkedValues)
+
+        case a: Sub => a.evaluateType(linkedValues)
 
         case other => s"Unable to process ${other.getClass.getSimpleName}: No evaluateType exists for that type.".invalidNel
       }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
@@ -1,22 +1,229 @@
 package wdl.draft3.transforms.linking.expression.values
 
+import cats.syntax.traverse._
 import cats.syntax.validated._
+import cats.instances.list._
 import common.validation.ErrorOr._
 import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
 import wdl.model.draft3.elements.ExpressionElement._
 import wdl.model.draft3.graph.expression.ValueEvaluator
 import wdl.model.draft3.graph.expression.ValueEvaluator.ops._
+import wdl.shared.transforms.evaluation.values.EngineFunctions
 import wom.expression.IoFunctionSet
-import wom.types.{WomArrayType, WomIntegerType}
-import wom.values.{WomArray, WomInteger, WomValue}
+import wom.types._
+import wom.values.WomArray.WomArrayLike
+import wom.values.{WomArray, WomFloat, WomInteger, WomPair, WomString, WomValue}
+import wom.types.coercion.ops._
+import wom.types.coercion.defaults._
+import wom.types.coercion.WomTypeCoercer
 
 object EngineFunctionEvaluators {
+  implicit val readLinesFunctionEvaluator: ValueEvaluator[ReadLines] = new ValueEvaluator[ReadLines] {
+    override def evaluateValue(a: ReadLines, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readTsvFunctionEvaluator: ValueEvaluator[ReadTsv] = new ValueEvaluator[ReadTsv] {
+    override def evaluateValue(a: ReadTsv, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readMapFunctionEvaluator: ValueEvaluator[ReadMap] = new ValueEvaluator[ReadMap] {
+    override def evaluateValue(a: ReadMap, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readObjectFunctionEvaluator: ValueEvaluator[ReadObject] = new ValueEvaluator[ReadObject] {
+    override def evaluateValue(a: ReadObject, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readObjectsFunctionEvaluator: ValueEvaluator[ReadObjects] = new ValueEvaluator[ReadObjects] {
+    override def evaluateValue(a: ReadObjects, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readJsonFunctionEvaluator: ValueEvaluator[ReadJson] = new ValueEvaluator[ReadJson] {
+    override def evaluateValue(a: ReadJson, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readIntFunctionEvaluator: ValueEvaluator[ReadInt] = new ValueEvaluator[ReadInt] {
+    override def evaluateValue(a: ReadInt, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readStringFunctionEvaluator: ValueEvaluator[ReadString] = new ValueEvaluator[ReadString] {
+    override def evaluateValue(a: ReadString, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readFloatFunctionEvaluator: ValueEvaluator[ReadFloat] = new ValueEvaluator[ReadFloat] {
+    override def evaluateValue(a: ReadFloat, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val readBooleanFunctionEvaluator: ValueEvaluator[ReadBoolean] = new ValueEvaluator[ReadBoolean] {
+    override def evaluateValue(a: ReadBoolean, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeLinesFunctionEvaluator: ValueEvaluator[WriteLines] = new ValueEvaluator[WriteLines] {
+    override def evaluateValue(a: WriteLines, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeTsvFunctionEvaluator: ValueEvaluator[WriteTsv] = new ValueEvaluator[WriteTsv] {
+    override def evaluateValue(a: WriteTsv, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeMapFunctionEvaluator: ValueEvaluator[WriteMap] = new ValueEvaluator[WriteMap] {
+    override def evaluateValue(a: WriteMap, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeObjectFunctionEvaluator: ValueEvaluator[WriteObject] = new ValueEvaluator[WriteObject] {
+    override def evaluateValue(a: WriteObject, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeObjectsFunctionEvaluator: ValueEvaluator[WriteObjects] = new ValueEvaluator[WriteObjects] {
+    override def evaluateValue(a: WriteObjects, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val writeJsonFunctionEvaluator: ValueEvaluator[WriteJson] = new ValueEvaluator[WriteJson] {
+    override def evaluateValue(a: WriteJson, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
   implicit val rangeFunctionEvaluator: ValueEvaluator[Range] = new ValueEvaluator[Range] {
     override def evaluateValue(a: Range, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
-      a.param.evaluateValue(inputs, ioFunctionSet) flatMap {
-        case WomInteger(i) => WomArray(WomArrayType(WomIntegerType, guaranteedNonEmpty = i > 0), (0 until i).map(WomInteger)).validNel
-        case other => s"Could not evaluate $a: Expected integer argument but got ${other.womType}".invalidNel
+      processValidatedSingleValue[WomInteger](a.param.evaluateValue(inputs, ioFunctionSet)) { integer =>
+        WomArray(
+          womType = WomArrayType(WomIntegerType, guaranteedNonEmpty = integer.value > 0),
+          value = (0 until integer.value).map(WomInteger)
+        ).validNel
       }
+    }
+  }
+
+  implicit val transposeFunctionEvaluator: ValueEvaluator[Transpose] = new ValueEvaluator[Transpose] {
+    override def evaluateValue(a: Transpose, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] =
+      processValidatedSingleValue[WomArray](a.param.evaluateValue(inputs, ioFunctionSet)) { array =>
+        EngineFunctions.transpose(array).toErrorOr
+      }
+  }
+
+  implicit val lengthFunctionEvaluator: ValueEvaluator[Length] = new ValueEvaluator[Length] {
+    override def evaluateValue(a: Length, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] =
+      processValidatedSingleValue[WomArray](a.param.evaluateValue(inputs, ioFunctionSet)) { a => WomInteger(a.value.size).validNel }
+  }
+
+  implicit val flattenFunctionEvaluator: ValueEvaluator[Flatten] = new ValueEvaluator[Flatten] {
+    override def evaluateValue(a: Flatten, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      def flatValues(v: WomValue): ErrorOr[Seq[WomValue]] = v match {
+        case WomArrayLike(arrayLike) => arrayLike.value.validNel
+        case other => s"inner item ${other.toWomString} was not an array-like".invalidNel
+      }
+
+      processValidatedSingleValue[WomArray](a.param.evaluateValue(inputs, ioFunctionSet)) { array =>
+        val expandedValidation = array.value.toList.traverse[ErrorOr, Seq[WomValue]] { flatValues }
+        expandedValidation map { expanded => WomArray(expanded.flatten) }
+      } (coercer = WomArrayType(WomArrayType(WomAnyType)))
+    }
+  }
+
+  implicit val selectFirstFunctionEvaluator: ValueEvaluator[SelectFirst] = new ValueEvaluator[SelectFirst] {
+    override def evaluateValue(a: SelectFirst, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val selectAllFunctionEvaluator: ValueEvaluator[SelectAll] = new ValueEvaluator[SelectAll] {
+    override def evaluateValue(a: SelectAll, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val definedFunctionEvaluator: ValueEvaluator[Defined] = new ValueEvaluator[Defined] {
+    override def evaluateValue(a: Defined, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val floorFunctionEvaluator: ValueEvaluator[Floor] = new ValueEvaluator[Floor] {
+    override def evaluateValue(a: Floor, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      processValidatedSingleValue[WomFloat](a.param.evaluateValue(inputs, ioFunctionSet)) { float =>
+        WomInteger(math.floor(float.value).toInt).validNel
+      }
+    }
+  }
+
+  implicit val ceilFunctionEvaluator: ValueEvaluator[Ceil] = new ValueEvaluator[Ceil] {
+    override def evaluateValue(a: Ceil, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      processValidatedSingleValue[WomFloat](a.param.evaluateValue(inputs, ioFunctionSet)) { float =>
+        WomInteger(math.ceil(float.value).toInt).validNel
+      }
+    }
+  }
+
+  implicit val roundFunctionEvaluator: ValueEvaluator[Round] = new ValueEvaluator[Round] {
+    override def evaluateValue(a: Round, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      processValidatedSingleValue[WomFloat](a.param.evaluateValue(inputs, ioFunctionSet)) { float =>
+        WomInteger(math.round(float.value).toInt).validNel
+      }
+    }
+  }
+
+  implicit val sizeFunctionEvaluator: ValueEvaluator[Size] = new ValueEvaluator[Size] {
+    override def evaluateValue(a: Size, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val basenameFunctionEvaluator: ValueEvaluator[Basename] = new ValueEvaluator[Basename] {
+    override def evaluateValue(a: Basename, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      def simpleBasename(fileNameAsString: WomString) = fileNameAsString.valueString.split('/').last
+
+      a.suffixToRemove match {
+        case None => processValidatedSingleValue[WomString](a.param.evaluateValue(inputs, ioFunctionSet)) { str =>
+          WomString(simpleBasename(str)).validNel
+        }
+        case Some(suffixToRemove) => processTwoValidatedValues[WomString, WomString](
+          a.param.evaluateValue(inputs, ioFunctionSet),
+          suffixToRemove.evaluateValue(inputs, ioFunctionSet)) { (name, suffix) =>
+            WomString(simpleBasename(name).stripSuffix(suffix.valueString)).validNel
+          }
+      }
+    }
+  }
+
+  implicit val zipFunctionEvaluator: ValueEvaluator[Zip] = new ValueEvaluator[Zip] {
+    override def evaluateValue(a: Zip, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      processTwoValidatedValues[WomArray, WomArray](a.arg1.evaluateValue(inputs, ioFunctionSet), a.arg2.evaluateValue(inputs, ioFunctionSet)) { (arr1, arr2) =>
+        if (arr1.size == arr2.size) {
+          val pairs = arr1.value.zip(arr2.value) map { case (a, b) => WomPair(a, b) }
+          WomArray(WomArrayType(WomPairType(arr1.arrayType.memberType, arr2.arrayType.memberType)), pairs).validNel
+        } else {
+          s"Mismatching array sizes for zip function: ${arr1.size} vs ${arr2.size}".invalidNel
+        }
+      }
+    }
+  }
+
+  implicit val crossFunctionEvaluator: ValueEvaluator[Cross] = new ValueEvaluator[Cross] {
+    override def evaluateValue(a: Cross, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = {
+      processTwoValidatedValues[WomArray, WomArray](a.arg1.evaluateValue(inputs, ioFunctionSet), a.arg2.evaluateValue(inputs, ioFunctionSet)) { (arr1, arr2) =>
+        val pairs = for {
+          a <- arr1.value
+          b <- arr2.value
+        } yield WomPair(a, b)
+        WomArray(WomArrayType(WomPairType(arr1.arrayType.memberType, arr2.arrayType.memberType)), pairs).validNel
+      }
+    }
+  }
+
+  implicit val prefixFunctionEvaluator: ValueEvaluator[Prefix] = new ValueEvaluator[Prefix] {
+    override def evaluateValue(a: Prefix, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  implicit val subFunctionEvaluator: ValueEvaluator[Sub] = new ValueEvaluator[Sub] {
+    override def evaluateValue(a: Sub, inputs: Map[String, WomValue], ioFunctionSet: IoFunctionSet): ErrorOr[WomValue] = ???
+  }
+
+  private def processValidatedSingleValue[A <: WomValue](arg: ErrorOr[WomValue])(f: A => ErrorOr[WomValue])(implicit coercer: WomTypeCoercer[A]): ErrorOr[WomValue] = {
+    arg flatMap {
+      case a: WomValue if a.coercionDefined[A] => a.coerceToType[A] flatMap { f.apply }
+      case other => s"Expected ${coercer.toDisplayString} argument but got ${other.womType.toDisplayString}".invalidNel
+    }
+  }
+
+  private def processTwoValidatedValues[A <: WomValue, B <: WomValue](arg1: ErrorOr[WomValue], arg2: ErrorOr[WomValue])
+                                                                     (f: (A, B) => ErrorOr[WomValue])
+                                                                     (implicit coercerA: WomTypeCoercer[A],
+                                                                      coercerB: WomTypeCoercer[B]): ErrorOr[WomValue] = {
+    (arg1, arg2) flatMapN {
+      case (a, b) if a.coercionDefined[A] && b.coercionDefined[B] => (a.coerceToType[A], b.coerceToType[B]) flatMapN { f.apply }
+      case (otherA, otherB) => s"Expected (${coercerA.toDisplayString}, ${coercerB.toDisplayString}) argument but got (${otherA.womType.toDisplayString}, ${otherB.womType.toDisplayString})".invalidNel
     }
   }
 }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/package.scala
@@ -57,7 +57,41 @@ package object values {
         case a: TernaryIf => a.evaluateValue(inputs, ioFunctionSet)
 
         // Engine functions:
+        case a: ReadLines => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadTsv => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadMap => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadObject => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadObjects => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadJson => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadInt => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadString => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadFloat => a.evaluateValue(inputs, ioFunctionSet)
+        case a: ReadBoolean => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteLines => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteTsv => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteMap => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteObject => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteObjects => a.evaluateValue(inputs, ioFunctionSet)
+        case a: WriteJson => a.evaluateValue(inputs, ioFunctionSet)
         case a: Range => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Transpose => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Length => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Flatten => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Prefix => a.evaluateValue(inputs, ioFunctionSet)
+        case a: SelectFirst => a.evaluateValue(inputs, ioFunctionSet)
+        case a: SelectAll => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Defined => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Floor => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Ceil => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Round => a.evaluateValue(inputs, ioFunctionSet)
+
+        case a: Size => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Basename => a.evaluateValue(inputs, ioFunctionSet)
+
+        case a: Zip => a.evaluateValue(inputs, ioFunctionSet)
+        case a: Cross => a.evaluateValue(inputs, ioFunctionSet)
+
+        case a: Sub => a.evaluateValue(inputs, ioFunctionSet)
 
         case other => s"Unable to process ${other.getClass.getSimpleName}: No evaluateValue exists for that type.".invalidNel
       }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/WorkflowGraphElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/WorkflowGraphElementToGraphNode.scala
@@ -41,7 +41,7 @@ object WorkflowGraphElementToGraphNode {
           case _: IntermediateValueDeclarationElement =>
             ExposedExpressionNode.fromInputMapping(WomIdentifier(name), womExpr, womType, a.linkablePorts) map { Set(_) }
           case _: OutputDeclarationElement =>
-            ExpressionBasedGraphOutputNode.fromInputMapping(WomIdentifier(s"${a.workflowName}.$name"), womExpr, womType, a.linkablePorts) map {Set(_)}
+            ExpressionBasedGraphOutputNode.fromInputMapping(WomIdentifier(name, s"${a.workflowName}.$name"), womExpr, womType, a.linkablePorts) map {Set(_)}
         }
       }
 

--- a/wdl/transforms/draft3/src/test/cases/taskless_engine_functions.wdl
+++ b/wdl/transforms/draft3/src/test/cases/taskless_engine_functions.wdl
@@ -1,0 +1,39 @@
+version draft-3
+
+workflow taskless_engine_functions {
+
+  Array[Int] ints = [ 1, 2 ]
+
+  Array[String] strings = ["a", "b"]
+
+  String filepath = "gs://not/a/real/file.txt"
+
+  Array[Array[Int]] matrix = [
+    [1, 0],
+    [1, 0]
+  ]
+
+  Array[Map[Int, String]] list_of_maps = [
+    { 1: "one", 2: "two" },
+    { 11: "eleven", 22: "twenty-two" }
+  ]
+
+  Float f = 1.024
+
+  output {
+    Array[Pair[Int, String]] int_cross_string = cross(ints, strings)
+    Array[Array[Int]] transposed_matrix = transpose(matrix)
+
+    Array[Int] flattened_matrix = flatten(matrix)
+    Int matrix_length = length(matrix)
+    Int flattened_matrix_length = length(flattened_matrix)
+    Array[Pair[Int, String]] flattened_map = flatten(list_of_maps)
+
+    String file_basename = basename(filepath)
+    String file_basename_extensionless = basename(filepath, ".txt")
+
+    Int f_floor = floor(f)
+    Int f_ceiling = ceil(f)
+    Int f_round = round(f)
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -561,6 +561,50 @@ object WdlFileToWdlomSpec {
             runtimeSection = None,
             metaSection = None,
             parameterMetaSection = None))
+    ),
+    "taskless_engine_functions" -> FileElement(
+      imports = Vector.empty,
+      structs = Vector.empty,
+      workflows = Vector(WorkflowDefinitionElement(
+        name = "taskless_engine_functions",
+        inputsSection = None,
+        graphElements = Set(
+          IntermediateValueDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "ints", ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(2))))),
+          IntermediateValueDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomStringType)), "strings", ArrayLiteral(Vector(StringLiteral("a"), StringLiteral("b")))),
+          IntermediateValueDeclarationElement(PrimitiveTypeElement(WomStringType), "filepath", StringLiteral("gs://not/a/real/file.txt")),
+          IntermediateValueDeclarationElement(ArrayTypeElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType))), "matrix",
+            ArrayLiteral(Vector(
+              ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(0)))),
+              ArrayLiteral(Vector(PrimitiveLiteralExpressionElement(WomInteger(1)), PrimitiveLiteralExpressionElement(WomInteger(0))))
+            ))
+          ),
+          IntermediateValueDeclarationElement(ArrayTypeElement(MapTypeElement(PrimitiveTypeElement(WomIntegerType), PrimitiveTypeElement(WomStringType))), "list_of_maps",
+            ArrayLiteral(Vector(
+              MapLiteral(Map(PrimitiveLiteralExpressionElement(WomInteger(1)) -> StringLiteral("one"), PrimitiveLiteralExpressionElement(WomInteger(2)) -> StringLiteral("two"))),
+              MapLiteral(Map(PrimitiveLiteralExpressionElement(WomInteger(11)) -> StringLiteral("eleven"), PrimitiveLiteralExpressionElement(WomInteger(22)) -> StringLiteral("twenty-two")))
+            ))
+          ),
+          IntermediateValueDeclarationElement(PrimitiveTypeElement(WomFloatType), "f", PrimitiveLiteralExpressionElement(WomFloat(1.024)))
+        ),
+        outputsSection = Some(
+          OutputsSectionElement(Vector(
+            OutputDeclarationElement(ArrayTypeElement(PairTypeElement(PrimitiveTypeElement(WomIntegerType),PrimitiveTypeElement(WomStringType))), "int_cross_string", Cross(IdentifierLookup("ints"),IdentifierLookup("strings"))),
+            OutputDeclarationElement(ArrayTypeElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType))), "transposed_matrix", Transpose(IdentifierLookup("matrix"))),
+            OutputDeclarationElement(ArrayTypeElement(PrimitiveTypeElement(WomIntegerType)), "flattened_matrix", Flatten(IdentifierLookup("matrix"))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "matrix_length", Length(IdentifierLookup("matrix"))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "flattened_matrix_length", Length(IdentifierLookup("flattened_matrix"))),
+            OutputDeclarationElement(ArrayTypeElement(PairTypeElement(PrimitiveTypeElement(WomIntegerType),PrimitiveTypeElement(WomStringType))), "flattened_map", Flatten(IdentifierLookup("list_of_maps"))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomStringType), "file_basename", Basename(IdentifierLookup("filepath"),None)),
+            OutputDeclarationElement(PrimitiveTypeElement(WomStringType), "file_basename_extensionless", Basename(IdentifierLookup("filepath"),Some(StringLiteral(".txt")))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "f_floor",Floor(IdentifierLookup("f"))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "f_ceiling",Ceil(IdentifierLookup("f"))),
+            OutputDeclarationElement(PrimitiveTypeElement(WomIntegerType), "f_round",Round(IdentifierLookup("f")))
+          ))
+        ),
+        metaSection = None,
+        parameterMetaSection = None
+      )),
+      tasks = Vector.empty
     )
   )
 }

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
@@ -63,7 +63,9 @@ class WdlFileToWomSpec extends FlatSpec with Matchers {
     "simple_conditional" -> anyWomWillDo,
     "lots_of_nesting" -> anyWomWillDo,
     "standalone_task" -> anyWomWillDo,
-    "simple_task" -> validateTaskDefinitionWom
+    "simple_task" -> validateTaskDefinitionWom,
+    "lots_of_nesting" -> anyWomWillDo,
+    "taskless_engine_functions" -> anyWomWillDo
   )
 
   private def anyWomWillDo(b: WomBundle) = Succeeded

--- a/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/evaluation/values/EngineFunctions.scala
+++ b/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/evaluation/values/EngineFunctions.scala
@@ -1,0 +1,32 @@
+package wdl.shared.transforms.evaluation.values
+
+import wom.types.{WomArrayType, WomType}
+import wom.values.{WomArray, WomValue}
+
+import scala.util.{Failure, Try}
+
+object EngineFunctions {
+  def transpose(a: WomValue): Try[WomArray] = {
+    case class ExpandedTwoDimensionalArray(innerType: WomType, value: Seq[Seq[WomValue]])
+    def validateAndExpand(value: WomValue): Try[ExpandedTwoDimensionalArray] = value match {
+      case WomArray(WomArrayType(WomArrayType(innerType)), array: Seq[WomValue]) => expandWdlArray(array) map { ExpandedTwoDimensionalArray(innerType, _) }
+      case WomArray(WomArrayType(nonArrayType), _) => Failure(new IllegalArgumentException(s"Array must be two-dimensional to be transposed but given array of $nonArrayType"))
+      case otherValue => Failure(new IllegalArgumentException(s"Function 'transpose' must be given a two-dimensional array but instead got ${otherValue.typeName}"))
+    }
+
+    def expandWdlArray(outerArray: Seq[WomValue]): Try[Seq[Seq[WomValue]]] = Try {
+      outerArray map {
+        case array: WomArray => array.value
+        case otherValue => throw new IllegalArgumentException(s"Function 'transpose' must be given a two-dimensional array but instead got WdlArray[${otherValue.typeName}]")
+      }
+    }
+
+    def transpose(expandedTwoDimensionalArray: ExpandedTwoDimensionalArray): Try[WomArray] = Try {
+      val innerType = expandedTwoDimensionalArray.innerType
+      val array = expandedTwoDimensionalArray.value
+      WomArray(WomArrayType(WomArrayType(innerType)), array.transpose map { WomArray(WomArrayType(innerType), _) })
+    }
+
+    validateAndExpand(a) flatMap transpose
+  }
+}

--- a/wom/src/main/scala/wom/types/coercion/WomTypeCoercer.scala
+++ b/wom/src/main/scala/wom/types/coercion/WomTypeCoercer.scala
@@ -1,0 +1,9 @@
+package wom.types.coercion
+
+import common.validation.ErrorOr.ErrorOr
+
+trait WomTypeCoercer[A] {
+  def toDisplayString: String
+  def coercionDefined(any: Any): Boolean
+  def coerceToType(any: Any): ErrorOr[A]
+}

--- a/wom/src/main/scala/wom/types/coercion/defaults/package.scala
+++ b/wom/src/main/scala/wom/types/coercion/defaults/package.scala
@@ -1,0 +1,29 @@
+package wom.types.coercion
+
+import cats.syntax.validated._
+import common.validation.Validation._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.ErrorOr._
+import wom.types._
+import wom.values._
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+package object defaults {
+  implicit val womIntegerCoercer: WomTypeCoercer[WomInteger] = defaultCoercionForType[WomInteger](WomIntegerType)
+  implicit val womFloatCoercer: WomTypeCoercer[WomFloat] = defaultCoercionForType[WomFloat](WomFloatType)
+  implicit val womStringCoercer: WomTypeCoercer[WomString] = defaultCoercionForType[WomString](WomStringType)
+
+  implicit val womArrayOfAnyCoercer = defaultCoercionForType[WomArray](WomArrayType(WomAnyType))
+  implicit def womArrayTypeCoercer(arrayType: WomArrayType): WomTypeCoercer[WomArray] = defaultCoercionForType[WomArray](arrayType)
+
+  private def defaultCoercionForType[A](typeObject: WomType)(implicit classTag: ClassTag[A]): WomTypeCoercer[A] = new WomTypeCoercer[A] {
+    override def coerceToType(any: Any): ErrorOr[A] = typeObject.coerceRawValue(any).toErrorOr flatMap {
+      case womValue: A => womValue.validNel
+      case other => s"Bad coercion in ${getClass.getSimpleName}! Coercion should have created ${typeObject.toDisplayString} but instead created ${other.womType.toDisplayString}".invalidNel
+    }
+    override def coercionDefined(any: Any): Boolean = typeObject.coercionDefined(any)
+    override def toDisplayString: String = typeObject.toDisplayString
+  }
+}

--- a/wom/src/main/scala/wom/types/coercion/ops/package.scala
+++ b/wom/src/main/scala/wom/types/coercion/ops/package.scala
@@ -1,0 +1,10 @@
+package wom.types.coercion
+
+import common.validation.ErrorOr.ErrorOr
+
+package object ops {
+  implicit class AnyCoercer(val a: Any) extends AnyVal {
+    def coercionDefined[A](implicit coercer: WomTypeCoercer[A]): Boolean = coercer.coercionDefined(a)
+    def coerceToType[A](implicit coercer: WomTypeCoercer[A]): ErrorOr[A] = coercer.coerceToType(a)
+  }
+}


### PR DESCRIPTION
- Ports an existing draft 2 test of taskless engine functions into draft 3.
- Also adds implementation or placeholders for all of the type evaluation and value evaluation for engine functions (so apologies about the high line count!)

- [x] Rebase on develop after #3403 

Red thumb requirement triggered by the addition of a `WomTypeCoercer` typeclass. I added it so that I didn't have to keep casting results but I think this could be even useful-er if CWL and WDL coercions start to (or need to) diverge.