### PR TITLE
bump Slick

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -12,9 +12,9 @@ trait CallCachingAggregationEntryComponent {
   class CallCachingAggregationEntries(tag: Tag) extends Table[CallCachingAggregationEntry](tag, "CALL_CACHING_AGGREGATION_ENTRY") {
     def callCachingAggregationEntryId = column[Int]("CALL_CACHING_AGGREGATION_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def baseAggregation = column[String]("BASE_AGGREGATION")
+    def baseAggregation = column[String]("BASE_AGGREGATION", O.Length(255))
 
-    def inputFilesAggregation = column[Option[String]]("INPUT_FILES_AGGREGATION")
+    def inputFilesAggregation = column[Option[String]]("INPUT_FILES_AGGREGATION", O.Length(255))
 
     def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
@@ -14,7 +14,7 @@ trait CallCachingDetritusEntryComponent {
     extends Table[CallCachingDetritusEntry](tag, "CALL_CACHING_DETRITUS_ENTRY") {
     def callCachingDetritusEntryId = column[Int]("CALL_CACHING_DETRITUS_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def detritusKey = column[String]("DETRITUS_KEY")
+    def detritusKey = column[String]("DETRITUS_KEY", O.Length(255))
 
     def detritusValue = column[Option[Clob]]("DETRITUS_VALUE")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -11,9 +11,9 @@ trait CallCachingEntryComponent {
   class CallCachingEntries(tag: Tag) extends Table[CallCachingEntry](tag, "CALL_CACHING_ENTRY") {
     def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
-    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME")
+    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME", O.Length(255))
 
     def jobIndex = column[Int]("JOB_INDEX")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
@@ -12,9 +12,9 @@ trait CallCachingHashEntryComponent {
   class CallCachingHashEntries(tag: Tag) extends Table[CallCachingHashEntry](tag, "CALL_CACHING_HASH_ENTRY") {
     def callCachingHashEntryId = column[Int]("CALL_CACHING_HASH_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def hashKey = column[String]("HASH_KEY")
+    def hashKey = column[String]("HASH_KEY", O.Length(255))
 
-    def hashValue = column[String]("HASH_VALUE")
+    def hashValue = column[String]("HASH_VALUE", O.Length(255))
 
     def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
@@ -14,11 +14,11 @@ trait CallCachingSimpletonEntryComponent {
     extends Table[CallCachingSimpletonEntry](tag, "CALL_CACHING_SIMPLETON_ENTRY") {
     def callCachingSimpletonEntryId = column[Int]("CALL_CACHING_SIMPLETON_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def simpletonKey = column[String]("SIMPLETON_KEY")
+    def simpletonKey = column[String]("SIMPLETON_KEY", O.Length(255))
 
     def simpletonValue = column[Option[Clob]]("SIMPLETON_VALUE")
 
-    def wdlType = column[String]("WDL_TYPE")
+    def wdlType = column[String]("WDL_TYPE", O.Length(255))
 
     def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/DockerHashStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/DockerHashStoreEntryComponent.scala
@@ -11,11 +11,11 @@ trait DockerHashStoreEntryComponent {
   class DockerHashStoreEntries(tag: Tag) extends Table[DockerHashStoreEntry](tag, "DOCKER_HASH_STORE_ENTRY") {
     def dockerHashStoreEntryId = column[Int]("DOCKER_HASH_STORE_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
-    def dockerTag = column[String]("DOCKER_TAG")
+    def dockerTag = column[String]("DOCKER_TAG", O.Length(255))
 
-    def dockerHash = column[String]("DOCKER_HASH")
+    def dockerHash = column[String]("DOCKER_HASH", O.Length(255))
 
     override def * = (workflowExecutionUuid, dockerTag, dockerHash, dockerHashStoreEntryId.?) <> (DockerHashStoreEntry.tupled, DockerHashStoreEntry.unapply)
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
@@ -11,17 +11,17 @@ trait JobKeyValueEntryComponent {
   class JobKeyValueEntries(tag: Tag) extends Table[JobKeyValueEntry](tag, "JOB_KEY_VALUE_ENTRY") {
     def jobKeyValueEntryId = column[Int]("JOB_KEY_VALUE_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
-    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME")
+    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME", O.Length(255))
 
     def jobIndex = column[Int]("JOB_INDEX")
 
     def jobAttempt = column[Int]("JOB_ATTEMPT")
 
-    def storeKey = column[String]("STORE_KEY")
+    def storeKey = column[String]("STORE_KEY", O.Length(255))
 
-    def storeValue = column[String]("STORE_VALUE")
+    def storeValue = column[String]("STORE_VALUE", O.Length(255))
 
     override def * = (workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt, storeKey, storeValue,
       jobKeyValueEntryId.?) <> (JobKeyValueEntry.tupled, JobKeyValueEntry.unapply)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreEntryComponent.scala
@@ -13,9 +13,9 @@ trait JobStoreEntryComponent {
   class JobStoreEntries(tag: Tag) extends Table[JobStoreEntry](tag, "JOB_STORE_ENTRY") {
     def jobStoreEntryId = column[Int]("JOB_STORE_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
-    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME")
+    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME", O.Length(255))
 
     def jobIndex = column[Int]("JOB_INDEX")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobStoreSimpletonEntryComponent.scala
@@ -14,11 +14,11 @@ trait JobStoreSimpletonEntryComponent {
   class JobStoreSimpletonEntries(tag: Tag) extends Table[JobStoreSimpletonEntry](tag, "JOB_STORE_SIMPLETON_ENTRY") {
     def jobStoreSimpletonEntryId = column[Int]("JOB_STORE_SIMPLETON_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def simpletonKey = column[String]("SIMPLETON_KEY")
+    def simpletonKey = column[String]("SIMPLETON_KEY", O.Length(255))
 
     def simpletonValue = column[Option[Clob]]("SIMPLETON_VALUE")
 
-    def wdlType = column[String]("WDL_TYPE")
+    def wdlType = column[String]("WDL_TYPE", O.Length(255))
 
     def jobStoreEntryId = column[Int]("JOB_STORE_ENTRY_ID")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -26,15 +26,15 @@ trait MetadataEntryComponent {
 
     def metadataEntryId = column[Long]("METADATA_JOURNAL_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID") // TODO: rename column via libquibase
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255)) // TODO: rename column via liquibase
 
-    def callFullyQualifiedName = column[Option[String]]("CALL_FQN") // TODO: rename column via libquibase
+    def callFullyQualifiedName = column[Option[String]]("CALL_FQN", O.Length(255)) // TODO: rename column via liquibase
 
-    def jobIndex = column[Option[Int]]("JOB_SCATTER_INDEX") // TODO: rename column via libquibase
+    def jobIndex = column[Option[Int]]("JOB_SCATTER_INDEX") // TODO: rename column via liquibase
 
-    def jobAttempt = column[Option[Int]]("JOB_RETRY_ATTEMPT") // TODO: rename column via libquibase
+    def jobAttempt = column[Option[Int]]("JOB_RETRY_ATTEMPT") // TODO: rename column via liquibase
 
-    def metadataKey = column[String]("METADATA_KEY")
+    def metadataKey = column[String]("METADATA_KEY", O.Length(255))
 
     def metadataValue = column[Option[Clob]]("METADATA_VALUE")
 
@@ -45,14 +45,14 @@ trait MetadataEntryComponent {
     override def * = (workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt, metadataKey, metadataValue,
       metadataValueType, metadataTimestamp, metadataEntryId.?) <> (MetadataEntry.tupled, MetadataEntry.unapply)
 
-    // TODO: rename index via libquibase
+    // TODO: rename index via liquibase
     def ixMetadataEntryWeu = index("METADATA_WORKFLOW_IDX", workflowExecutionUuid, unique = false)
 
-    // TODO: rename index via libquibase
+    // TODO: rename index via liquibase
     def ixMetadataEntryWeuCfqnJiJa = index("METADATA_JOB_IDX",
       (workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt), unique = false)
 
-    // TODO: rename index via libquibase, and change column order from WEU_[MK]_CFQN_JI_JA to WEU_CFQN_JI_JA_[MK]
+    // TODO: rename index via liquibase, and change column order from WEU_[MK]_CFQN_JI_JA to WEU_CFQN_JI_JA_[MK]
     def ixMetadataEntryWeuCfqnJiJaMk = index("METADATA_JOB_AND_KEY_IDX",
       (workflowExecutionUuid, metadataKey, callFullyQualifiedName, jobIndex, jobAttempt), unique = false)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/SubWorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/SubWorkflowStoreEntryComponent.scala
@@ -14,15 +14,15 @@ trait SubWorkflowStoreEntryComponent {
 
     def rootWorkflowId = column[Int]("ROOT_WORKFLOW_ID")
     
-    def parentWorkflowExecutionUuid = column[String]("PARENT_WORKFLOW_EXECUTION_UUID")
+    def parentWorkflowExecutionUuid = column[String]("PARENT_WORKFLOW_EXECUTION_UUID", O.Length(255))
 
-    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME")
+    def callFullyQualifiedName = column[String]("CALL_FULLY_QUALIFIED_NAME", O.Length(255))
 
     def callIndex = column[Int]("CALL_INDEX")
 
     def callAttempt = column[Int]("CALL_ATTEMPT")
 
-    def subWorkflowExecutionUuid = column[String]("SUB_WORKFLOW_EXECUTION_UUID")
+    def subWorkflowExecutionUuid = column[String]("SUB_WORKFLOW_EXECUTION_UUID", O.Length(255))
 
     override def * = (rootWorkflowId.?, parentWorkflowExecutionUuid, callFullyQualifiedName, callIndex, callAttempt, subWorkflowExecutionUuid, subWorkflowStoreEntryId.?) <> (SubWorkflowStoreEntry.tupled, SubWorkflowStoreEntry.unapply)
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/SummaryStatusEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/SummaryStatusEntryComponent.scala
@@ -10,9 +10,9 @@ trait SummaryStatusEntryComponent {
   class SummaryStatusEntries(tag: Tag) extends Table[SummaryStatusEntry](tag, "SUMMARY_STATUS_ENTRY") {
     def summaryStatusEntryId = column[Int]("SUMMARY_STATUS_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def summaryTableName = column[String]("SUMMARY_TABLE_NAME")
+    def summaryTableName = column[String]("SUMMARY_TABLE_NAME", O.Length(255))
 
-    def summarizedTableName = column[String]("SUMMARIZED_TABLE_NAME")
+    def summarizedTableName = column[String]("SUMMARIZED_TABLE_NAME", O.Length(255))
 
     def maximumId = column[Long]("MAXIMUM_ID")
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -24,13 +24,13 @@ trait WorkflowStoreEntryComponent {
   class WorkflowStoreEntries(tag: Tag) extends Table[WorkflowStoreEntry](tag, "WORKFLOW_STORE_ENTRY") {
     def workflowStoreEntryId = column[Int]("WORKFLOW_STORE_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
-    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID")
+    def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
     def workflowRoot = column[Option[String]]("WORKFLOW_ROOT", O.Length(100))
 
     def workflowType = column[Option[String]]("WORKFLOW_TYPE", O.Length(30))
 
-    def workflowTypeVersion = column[Option[String]]("WORKFLOW_TYPE_VERSION")
+    def workflowTypeVersion = column[Option[String]]("WORKFLOW_TYPE_VERSION", O.Length(255))
 
     def workflowDefinition = column[Option[Clob]]("WORKFLOW_DEFINITION")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
   val scoptV = "3.6.0"
   val shapelessV = "2.3.2"
   val slf4jV = "1.7.24"
-  val slickV = "3.2.0"
+  val slickV = "3.2.2"
   val snakeyamlV = "1.17"
   val specs2MockV = "3.8.9" // 3.9.X doesn't enjoy the spark backend or refined
   val sprayJsonV = "1.3.3"


### PR DESCRIPTION
Bump to [~3.2.1~ 3.2.2 patch version](http://slick.lightbend.com/news/2017/07/20/slick-3.2.1-released.html) that may help with this problem:

```
Exception in thread "db-10602" java.lang.IllegalArgumentException: requirement failed: count cannot be decreased
    at scala.Predef$.require(Predef.scala:277)
    at slick.util.ManagedArrayBlockingQueue.$anonfun$decreaseInUseCount$1(ManagedArrayBlockingQueue.scala:53)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
    at slick.util.ManagedArrayBlockingQueue.slick$util$ManagedArrayBlockingQueue$$locked(ManagedArrayBlockingQueue.scala:217)
    at slick.util.ManagedArrayBlockingQueue.decreaseInUseCount(ManagedArrayBlockingQueue.scala:52)
    at slick.util.AsyncExecutor$$anon$2$$anon$1.afterExecute(AsyncExecutor.scala:87)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1157)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

Most of the changes in this PR are for the default length of strings in Slick going from 255 to 16777216 in this patch release (!)