### PR TITLE
Parse scientific notation on numbers, some coercions from filled optionals.

### DIFF
--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -71,8 +71,9 @@ abstract class CommandLineBindingCommandPart(commandLineBinding: CommandLineBind
     }
     
     def processValue(womValue: WomValue): List[String] = womValue match {
-      case WomOptionalValue(_, Some(womInnerValue)) => processValue(valueMapper(womInnerValue))
-      case _: WomString | _: WomInteger | _: WomFile => handlePrefix(valueMapper(womValue).valueString)
+      case WomOptionalValue(_, Some(value)) => processValue(valueMapper(value))
+      case WomOptionalValue(_, None) => List.empty
+      case _: WomString | _: WomInteger | _: WomFile | _: WomLong | _: WomFloat => handlePrefix(valueMapper(womValue).valueString)
       // For boolean values, use the value of the boolean to choose whether to print the prefix or not
       case WomBoolean(false) => List.empty
       case WomBoolean(true) => prefixAsList
@@ -99,7 +100,7 @@ abstract class CommandLineBindingCommandPart(commandLineBinding: CommandLineBind
         case _ => prefixAsList
       }
       case _: WomObjectLike => prefixAsList
-      case _ => List.empty
+      case w => throw new RuntimeException(s"Unhandled CwlExpressionCommandPart value '$w' of type ${w.womType.toDisplayString}")
     }
 
     evaluatedWomValue map { v => processValue(v) map applyShellQuote map (InstantiatedCommand(_)) } toValidated

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -2,7 +2,7 @@ package cromwell.webservice
 
 import java.util.UUID
 
-import akka.actor.{Actor, ActorRef, ActorRefFactory}
+import akka.actor.{ActorRef, ActorRefFactory}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallable}
 import akka.http.scaladsl.model._
@@ -245,7 +245,7 @@ trait CromwellApiService extends HttpInstrumentation {
     }
 
     def askSubmit(command: WorkflowStoreActor.WorkflowStoreActorSubmitCommand, warnings: Seq[String]): Route = {
-      // NOTE: Do not blindly coppy the akka-http -to- ask-actor pattern below without knowing the pros and cons.
+      // NOTE: Do not blindly copy the akka-http -to- ask-actor pattern below without knowing the pros and cons.
       onComplete(workflowStoreActor.ask(command).mapTo[WorkflowStoreSubmitActor.WorkflowStoreSubmitActorResponse]) {
         case Success(w) =>
           w match {

--- a/wom/src/main/scala/wom/callable/CommandTaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/CommandTaskDefinition.scala
@@ -51,7 +51,7 @@ object CommandTaskDefinition {
   * Interface for a TaskDefinition.
   * There are 2 types of TaskDefinition:
   *   - CommandTaskDefinition
-  *   - ExpressionTaskDefinition (coming soon)
+  *   - ExpressionTaskDefinition
   */
 sealed trait TaskDefinition extends Callable {
   def runtimeAttributes: RuntimeAttributes

--- a/wom/src/main/scala/wom/types/WomBooleanType.scala
+++ b/wom/src/main/scala/wom/types/WomBooleanType.scala
@@ -1,7 +1,7 @@
 package wom.types
 
 import spray.json.{JsBoolean, JsString}
-import wom.values.{WomBoolean, WomValue}
+import wom.values.WomBoolean
 
 import scala.util.{Success, Try}
 

--- a/wom/src/main/scala/wom/types/WomIntegerLike.scala
+++ b/wom/src/main/scala/wom/types/WomIntegerLike.scala
@@ -1,0 +1,8 @@
+package wom.types
+
+
+object WomIntegerLike {
+  implicit class EnhancedLong(val long: Long) extends AnyVal {
+    def inIntRange: Boolean = long >= Int.MinValue && long <= Int.MaxValue
+  }
+}

--- a/wom/src/main/scala/wom/types/WomIntegerType.scala
+++ b/wom/src/main/scala/wom/types/WomIntegerType.scala
@@ -1,6 +1,7 @@
 package wom.types
 
 import spray.json.{JsNumber, JsString}
+import wom.types.WomIntegerLike._
 import wom.values.{WomInteger, WomLong, WomString}
 
 import scala.util.{Success, Try}
@@ -12,8 +13,9 @@ case object WomIntegerType extends WomPrimitiveType {
     case i: Integer => WomInteger(i)
     case n: JsNumber if n.value.isValidInt => WomInteger(n.value.intValue())
     case i: WomInteger => i
-    case WomLong(i) if (i >= Int.MinValue && i <= Int.MaxValue) => WomInteger(i.toInt)
-    case WomLong(i) => throw new RuntimeException(s"Tried to convert a long value $i into an integer but it was outside the bounds of acceptable Integers, namely ${Int.MinValue} <-> ${Int.MaxValue}")
+    case WomLong(i) if i.inIntRange => WomInteger(i.toInt)
+    case WomLong(i) => throw new RuntimeException(
+      s"Tried to convert a Long value $i into an Int but it was outside the bounds of acceptable Ints, namely ${Int.MinValue} <-> ${Int.MaxValue}")
     case s: WomString => WomInteger(s.value.toInt)
     case s: String => WomInteger(s.toInt)
     case s: JsString => WomInteger(s.value.toInt)

--- a/wom/src/main/scala/wom/types/WomStringType.scala
+++ b/wom/src/main/scala/wom/types/WomStringType.scala
@@ -1,9 +1,9 @@
 package wom.types
 
 import spray.json.JsString
-import wom.values.{WomPrimitive, WomPrimitiveFile, WomString, WomValue}
+import wom.values.{WomPrimitive, WomPrimitiveFile, WomString}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 case object WomStringType extends WomPrimitiveType {
   val toDisplayString: String = "String"

--- a/wom/src/main/scala/wom/types/WomType.scala
+++ b/wom/src/main/scala/wom/types/WomType.scala
@@ -1,7 +1,7 @@
 package wom.types
 
 import wom.WomExpressionException
-import wom.values.WomValue
+import wom.values.{WomOptionalValue, WomValue}
 
 import scala.runtime.ScalaRunTime
 import scala.util.{Failure, Success, Try}
@@ -27,6 +27,7 @@ trait WomType {
   final def coerceRawValue(any: Any): Try[WomValue] = {
     any match {
       case womValue: WomValue if womValue.womType == this => Success(womValue)
+      case WomOptionalValue(_, Some(v)) => coerceRawValue(v)
       case womValue: WomValue if !coercion.isDefinedAt(any) => Failure(new IllegalArgumentException(
         s"No coercion defined from '${WomValue.takeMaxElements(womValue, 3).toWomString}' of type" +
           s" '${womValue.womType.toDisplayString}' to '$toDisplayString'."))

--- a/wom/src/test/scala/wom/types/WomOptionalTypeSpec.scala
+++ b/wom/src/test/scala/wom/types/WomOptionalTypeSpec.scala
@@ -82,7 +82,6 @@ private object WomOptionalTypeSpecDefs {
 
   val badCoercionTable: TableFor2[Any, WomType] = Table[Any, WomType](
     ("fromValue", "toType"),
-    (WomOptionalValue(WomString("hi")), WomStringType),
     (WomOptionalValue(WomOptionalValue(WomFloat(75.0))), WomOptionalType(WomIntegerType)),
     (WomOptionalValue(WomInteger(3)), WomOptionalType(WomBooleanType)),
     (WomOptionalValue(WomOptionalValue(WomInteger(3))), WomOptionalType(WomOptionalType(WomBooleanType)))

--- a/wom/src/test/scala/wom/types/WomTypeSpec.scala
+++ b/wom/src/test/scala/wom/types/WomTypeSpec.scala
@@ -86,18 +86,6 @@ class WomTypeSpec extends FlatSpec with Matchers {
       """No coercion defined from '\[null\]' of type 'Array\[Int\?\]' to 'Array\[Int\]\?'."""
     ),
     (
-      WomOptionalValue(WomArray(WomArrayType(WomIntegerType), Seq(
-        WomInteger(0),
-        WomInteger(1),
-        WomInteger(2),
-        WomInteger(3),
-        WomInteger(4)
-      ))),
-      WomMaybeEmptyArrayType(WomOptionalType(WomIntegerType)),
-      classOf[IllegalArgumentException],
-      """No coercion defined from '\[0, 1, 2\]' of type 'Array\[Int\]\?' to 'Array\[Int\?\]'."""
-    ),
-    (
       WomOptionalValue.none(WomArrayType(WomIntegerType)),
       WomMaybeEmptyArrayType(WomOptionalType(WomIntegerType)),
       classOf[IllegalArgumentException],
@@ -124,22 +112,25 @@ class WomTypeSpec extends FlatSpec with Matchers {
     WomBooleanType.coerceRawValue("true").get shouldEqual WomBoolean.True
     WomBooleanType.coerceRawValue("FALSE").get shouldEqual WomBoolean.False
     WomBooleanType.coerceRawValue(false).get shouldEqual WomBoolean.False
-
+    WomBooleanType.coerceRawValue(WomOptionalValue(WomBooleanType, Option(WomBoolean(true)))).get shouldEqual WomBoolean.True
     WomBooleanType.coerceRawValue("I like turtles").isFailure shouldBe true
   }
 
   "WomString" should "support expected coercions" in {
     WomStringType.coerceRawValue("foo").get shouldEqual WomString("foo")
+    WomStringType.coerceRawValue(WomOptionalValue(WomStringType, Option(WomString("foo")))).get shouldEqual WomString("foo")
     WomStringType.coerceRawValue(-1).isFailure shouldBe true
   }
 
   "WomFile" should "support expected coercions" in {
     WomSingleFileType.coerceRawValue("/etc/passwd").get shouldEqual WomSingleFile("/etc/passwd")
+    WomSingleFileType.coerceRawValue(WomOptionalValue(WomSingleFileType, Option(WomSingleFile("/etc/passwd")))).get shouldEqual WomSingleFile("/etc/passwd")
     WomSingleFileType.coerceRawValue(-1).isFailure shouldBe true
   }
 
   "WomInteger" should "support expected coercions" in {
     WomIntegerType.coerceRawValue(42).get shouldEqual WomInteger(42)
+    WomIntegerType.coerceRawValue(WomOptionalValue(WomIntegerType, Option(WomInteger(42)))).get shouldEqual WomInteger(42)
     WomIntegerType.coerceRawValue("42").get shouldEqual WomInteger(42)
     WomIntegerType.coerceRawValue(JsString("42")).get shouldEqual WomInteger(42)
     WomIntegerType.coerceRawValue("FAIL").isFailure shouldBe true
@@ -147,6 +138,7 @@ class WomTypeSpec extends FlatSpec with Matchers {
 
   "WomFloatType" should "support expected coercions" in {
     WomFloatType.coerceRawValue(33.3).get shouldEqual WomFloat(33.3)
+    WomFloatType.coerceRawValue(WomOptionalValue(WomFloatType, Option(WomFloat(33.3)))).get shouldEqual WomFloat(33.3)
     WomFloatType.coerceRawValue("33.3").get shouldEqual WomFloat(33.3)
     WomFloatType.coerceRawValue(JsString("33.3")).get shouldEqual WomFloat(33.3)
     WomFloatType.coerceRawValue("FAIL").isFailure shouldBe true


### PR DESCRIPTION
Still driving on the Wash U workflow, this is a pregull checkpoint with some ~hacks~ work I did for blockers:

We round trip inputs YAML through Circe which uses its own "Big" number types that stringify with scientific notation. Our existing WomInteger / WomLong code didn't deal with that so the changes here add some flexibility.

CWL explicitly allows filled optional to non-optional assignments with warnings, with an error at runtime if it turns out the optional wasn't actually filled. I expect some discussion on this 🙂 