### PR TITLE
Don't do the weird unzip thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cromwell Change Log
 
+## 32 Release Notes
+
+### Bug Fixes
+
+The imports zip no longer unpacks a single (arbitrary) internal directory if it finds one (or more). Instead, import statements should now be made relative to the base of the import zip root.
+
 ## 31 Release Notes
 
 * **Cromwell server**  

--- a/docs/Imports.md
+++ b/docs/Imports.md
@@ -1,4 +1,4 @@
-Sometimes you might want to break up your 1000 line WDL file into smaller components for easier maintenance or for reuse in multiple workflows.  Have no fear, imports are here to help!  Imports allow you to reference other WDL files that contain entire workflows or even just raw tasks.
+Sometimes you might want to break up a long WDL file into smaller components for easier maintenance. Sometimes you'll want to do it to reuse components in multiple workflows.  Have no fear, imports are here!  Imports allow you to reference other WDL files that contain entire workflows or even just raw tasks.
 
 To import a WDL, you can use the `import` WDL construct at the top of your workflow:
 
@@ -36,6 +36,19 @@ _imports.zip_
 ```
 imports
 └── imported.wdl
+```
+
+A more common scenario might have the imports at the root of the imports.zip:
+
+_workflow.wdl_
+```wdl
+import "my_wdl_1.wdl"
+import "my_wdl_2.wdl"
+```
+_imports.zip_
+```
+my_wdl_1.wdl
+my_wdl_2.wdl
 ```
 
 ---

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -25,11 +25,7 @@ object LanguageFactoryUtil {
       DefaultPathBuilder.createTempFile("", ".zip", parentPath).writeByteArray(zipContents)(OpenOptions.default)
     }
 
-    def unZipFile(f: Path) = Try {
-      val unzippedFile = f.unzipTo(parentPath)
-      val unzippedFileContents = unzippedFile.list.toSeq.head
-      if (unzippedFileContents.isDirectory) unzippedFileContents else unzippedFile
-    }
+    def unZipFile(f: Path) = Try(f.unzipTo(parentPath))
 
     val importsFile = for {
       zipFile <- makeZipFile


### PR DESCRIPTION
Closes #3297.

If you unzip a zip file containing a directory, don't assume the user wants to reference things from within that directory.

Especially don't ignore the fact that there might be *other* directories in the zip file as well, which now cannot be accessed at all