### PR TITLE
scala 2.12.5 

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,6 +72,8 @@ object Settings {
     "-Ywarn-unused:implicits",
     "-Ywarn-unused:privates",
     "-Ywarn-unused:locals",
+    "-Ycache-macro-class-loader:last-modified",
+    "-Ycache-plugin-class-loader:last-modified",
     "-Ywarn-unused:patvars"
   )
 
@@ -90,7 +92,7 @@ object Settings {
   )
 
   val ScalaVersion211 = "2.11.11"
-  val ScalaVersion212 = "2.12.4"
+  val ScalaVersion212 = "2.12.5"
   val ScalaVersion = ScalaVersion212
   val sharedSettings = ReleasePlugin.projectSettings ++
     cromwellVersionWithGit ++ publishingSettings ++ List(


### PR DESCRIPTION
doc for flags:

> enable caching of classloaders for compiler plugins and macro definitions. This can lead to significant performance improvements