### PR TITLE
Pass workflow inputs through the input value mapper

### DIFF
--- a/backend/src/test/scala/cromwell/backend/BackendSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/BackendSpec.scala
@@ -35,7 +35,7 @@ trait BackendSpec extends ScalaFutures with Matchers with Mockito {
                               runtime: String = "") = {
     val wdlNamespace = WdlNamespaceWithWorkflow.load(workflowSource.replaceAll("RUNTIME", runtime),
       Seq.empty[Draft2ImportResolver]).get
-    val executable = wdlNamespace.toWomExecutable(inputFileAsJson) match {
+    val executable = wdlNamespace.toWomExecutable(inputFileAsJson, NoIoFunctionSet) match {
       case Left(errors) => fail(s"Fail to build wom executable: ${errors.toList.mkString(", ")}")
       case Right(e) => e
     }

--- a/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow.test
@@ -1,0 +1,20 @@
+name: cwl_secondary_files_workflow
+testFormat: workflowsuccess
+workflowType: CWL
+workflowTypeVersion: v1.0
+workflowRoot: cwl_secondary_files_workflow
+backendsMode: "any"
+backends: [Local, LocalNoDocker]
+tags: [localdockertest]
+
+files {
+  wdl: cwl_secondary_files_workflow/cwl_secondary_files_workflow.cwl
+  inputs: cwl_secondary_files_workflow/cwl_secondary_files_workflow.yaml
+  options: cwl_secondary_files_workflow/cwl_secondary_files_workflow.options
+}
+
+metadata {
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "outputs.cwl_secondary_files_workflow.the_answer": "$(42)"
+}

--- a/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.cwl
@@ -1,0 +1,55 @@
+cwlVersion: v1.0
+$graph:
+# The inputs of the workflow specify secondary files but NOT of the tool
+# Verify that they are still propagated through
+- id: cwl_secondary_files_workflow
+  class: Workflow
+  inputs:
+  - id: command
+    type: string
+  - id: wf_file_input
+    type: File
+    secondaryFiles: [.also]
+  - id: wf_file_input_array
+    type:
+      type: array
+      items: File
+    secondaryFiles: [.also]
+  outputs:
+  - id: the_answer
+    type: string
+    outputSource: run_tool/the_answer
+  steps:
+  - id: run_tool
+    run: "#cwl_secondary_files_workflow_tool"
+    in:
+      command: command
+      f: wf_file_input
+      fs: wf_file_input_array
+    out:
+    - id: the_answer
+- id: cwl_secondary_files_workflow_tool
+  class: CommandLineTool
+  hints:
+    DockerRequirement:
+      dockerPull: "debian:stretch-slim"
+  inputs:
+    - id: command
+      type: string
+    - id: f
+      type: File
+      inputBinding:
+        position: 2
+    - id: fs
+      type:
+        type: array
+        items: File
+        inputBinding:
+          position: 3
+  outputs:
+    the_answer:
+      type: string
+      outputBinding:
+        outputEval: ${ return "$(" + 42 + ")"; }
+  baseCommand: []
+  arguments: ["bash", "-c", $(inputs.command)]

--- a/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.options
+++ b/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.options
@@ -1,0 +1,3 @@
+{
+  "backend": "Local"
+}

--- a/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.yaml
+++ b/centaur/src/main/resources/standardTestCases/cwl_secondary_files_workflow/cwl_secondary_files_workflow.yaml
@@ -1,0 +1,10 @@
+# This command will stat the secondaryFiles and if they're missing bad times
+command: stat $(echo $* | sed 's/.txt/.txt.also/g') > /dev/null
+wf_file_input:
+  class: File
+  path: "centaur/src/main/resources/standardTestCases/cwl_secondary_files/foo.txt"
+wf_file_input_array:
+  - class: File
+    path: "centaur/src/main/resources/standardTestCases/cwl_secondary_files/bar.txt"
+  - class: File
+    path: "centaur/src/main/resources/standardTestCases/cwl_secondary_files/baz.txt"

--- a/cwl/src/main/scala/cwl/CwlExecutableValidation.scala
+++ b/cwl/src/main/scala/cwl/CwlExecutableValidation.scala
@@ -10,9 +10,6 @@ import wom.executable.Executable
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
 import wom.expression.IoFunctionSet
 
-// WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
-// If you're making changes here, you'll also need to update ../../scala-2.12/cwl/CwlExecutableValidation.scala
-// (ExecutableValidation.scala has more info on why this was necessary)
 object CwlExecutableValidation {
 
   // Decodes the input file, and build the ParsedInputMap

--- a/cwl/src/main/scala/cwl/CwlExecutableValidation.scala
+++ b/cwl/src/main/scala/cwl/CwlExecutableValidation.scala
@@ -8,6 +8,7 @@ import io.circe.yaml
 import wom.callable.{ExecutableCallable, TaskDefinition}
 import wom.executable.Executable
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
+import wom.expression.IoFunctionSet
 
 // WARNING! Because of 2.11 vs 2.12 incompatibilities, there are two versions of this file.
 // If you're making changes here, you'll also need to update ../../scala-2.12/cwl/CwlExecutableValidation.scala
@@ -23,18 +24,18 @@ object CwlExecutableValidation {
       }
     }
 
-  def buildWomExecutableCallable(callable: Checked[ExecutableCallable], inputFile: Option[String]): Checked[Executable] = {
+  def buildWomExecutableCallable(callable: Checked[ExecutableCallable], inputFile: Option[String], ioFunctions: IoFunctionSet): Checked[Executable] = {
     for {
       womDefinition <- callable
-      executable <- Executable.withInputs(womDefinition, inputCoercionFunction, inputFile)
+      executable <- Executable.withInputs(womDefinition, inputCoercionFunction, inputFile, ioFunctions)
     } yield executable
   }
 
-  def buildWomExecutable(callableTaskDefinition: Checked[TaskDefinition], inputFile: Option[String]): Checked[Executable] = {
+  def buildWomExecutable(callableTaskDefinition: Checked[TaskDefinition], inputFile: Option[String], ioFunctions: IoFunctionSet): Checked[Executable] = {
     for {
       taskDefinition <- callableTaskDefinition
       executableTaskDefinition = taskDefinition.toExecutable.toEither
-      executable <- CwlExecutableValidation.buildWomExecutableCallable(executableTaskDefinition, inputFile)
+      executable <- CwlExecutableValidation.buildWomExecutableCallable(executableTaskDefinition, inputFile, ioFunctions)
     } yield executable
   }
 }

--- a/cwl/src/main/scala/cwl/InputParameter.scala
+++ b/cwl/src/main/scala/cwl/InputParameter.scala
@@ -118,7 +118,7 @@ object InputParameter {
                 parameterContext,
                 expressionLib
               )
-              updated = loaded.copy(secondaryFiles = secondaries)
+              updated = loaded.copy(secondaryFiles = loaded.secondaryFiles ++ secondaries)
             } yield updated
 
           case WomArray(_, values) => values.toList.traverse(populateFiles).map(WomArray(_))

--- a/cwl/src/main/scala/cwl/Tool.scala
+++ b/cwl/src/main/scala/cwl/Tool.scala
@@ -14,7 +14,7 @@ import wom.RuntimeAttributes
 import wom.callable.Callable.{InputDefinitionWithDefault, OptionalInputDefinition, OutputDefinition, RequiredInputDefinition}
 import wom.callable.{Callable, TaskDefinition}
 import wom.executable.Executable
-import wom.expression.{ValueAsAnExpression, WomExpression}
+import wom.expression.{IoFunctionSet, ValueAsAnExpression, WomExpression}
 import wom.types.WomOptionalType
 
 import scala.util.Try
@@ -47,9 +47,9 @@ trait Tool {
   def asCwl: Cwl
 
   /** Builds an `Executable` directly from a `Tool` CWL with no parent workflow. */
-  def womExecutable(validator: RequirementsValidator, inputFile: Option[String] = None): Checked[Executable] = {
+  def womExecutable(validator: RequirementsValidator, inputFile: Option[String] = None, ioFunctions: IoFunctionSet): Checked[Executable] = {
     val taskDefinition = buildTaskDefinition(validator, Vector.empty)
-    CwlExecutableValidation.buildWomExecutable(taskDefinition, inputFile)
+    CwlExecutableValidation.buildWomExecutable(taskDefinition, inputFile, ioFunctions)
   }
 
   protected def buildTaskDefinition(taskName: String,

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -90,17 +90,18 @@ case class Workflow private(
       val womType: WomType = womTypeForInputParameter(wip).get
       val parsedInputId = FileAndId(wip.id).id
       val womId = WomIdentifier(parsedInputId, wip.id)
+      val valueMapper = InputParameter.inputValueMapper(wip, wip.`type`.get, expressionLib)
 
       def optionalWithDefault(memberType: WomType): OptionalGraphInputNodeWithDefault = {
         val defaultValue = wip.default.get.fold(InputParameter.DefaultToWomValuePoly).apply(womType).toTry.get
-        OptionalGraphInputNodeWithDefault(womId, memberType, ValueAsAnExpression(defaultValue), parsedInputId)
+        OptionalGraphInputNodeWithDefault(womId, memberType, ValueAsAnExpression(defaultValue), parsedInputId, valueMapper)
       }
 
       womType match {
         case WomOptionalType(memberType) if wip.default.isDefined => optionalWithDefault(memberType)
         case _ if wip.default.isDefined => optionalWithDefault(womType)
-        case optional @ WomOptionalType(_) => OptionalGraphInputNode(womId, optional, parsedInputId)
-        case _ => RequiredGraphInputNode(womId, womType, parsedInputId)
+        case optional @ WomOptionalType(_) => OptionalGraphInputNode(womId, optional, parsedInputId, valueMapper)
+        case _ => RequiredGraphInputNode(womId, womType, parsedInputId, valueMapper)
       }
     }.toSet
 

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -17,7 +17,7 @@ import shapeless._
 import shapeless.syntax.singleton._
 import wom.callable.WorkflowDefinition
 import wom.executable.Executable
-import wom.expression.ValueAsAnExpression
+import wom.expression.{IoFunctionSet, ValueAsAnExpression}
 import wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 import wom.graph._
 import wom.types.{WomOptionalType, WomType}
@@ -35,8 +35,8 @@ case class Workflow private(
   steps.foreach { _.parentWorkflow = this }
 
   /** Builds an `Executable` from a `Workflow` CWL with no parent `Workflow` */
-  def womExecutable(validator: RequirementsValidator, inputFile: Option[String] = None): Checked[Executable] = {
-    CwlExecutableValidation.buildWomExecutableCallable(womDefinition(validator, Vector.empty), inputFile)
+  def womExecutable(validator: RequirementsValidator, inputFile: Option[String] = None, ioFunctions: IoFunctionSet): Checked[Executable] = {
+    CwlExecutableValidation.buildWomExecutableCallable(womDefinition(validator, Vector.empty), inputFile, ioFunctions)
   }
 
   // Circe can't create bidirectional links between workflow steps and runs (including `Workflow`s) so this

--- a/cwl/src/main/scala/cwl/package.scala
+++ b/cwl/src/main/scala/cwl/package.scala
@@ -7,6 +7,7 @@ import cwl.ExpressionEvaluator.{ECMAScriptExpression, ECMAScriptFunction}
 import cwl.command.ParentName
 import shapeless._
 import wom.executable.Executable
+import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.types._
 
 import scala.util.{Failure, Success, Try}
@@ -85,11 +86,11 @@ package object cwl extends TypeAliases {
   val AcceptAllRequirements: RequirementsValidator = _.validNel
 
   implicit class CwlHelper(val cwl: Cwl) extends AnyVal {
-    def womExecutable(validator: RequirementsValidator, inputsFile: Option[String] = None): Checked[Executable] = {
+    def womExecutable(validator: RequirementsValidator, inputsFile: Option[String] = None, ioFunctions: IoFunctionSet = NoIoFunctionSet): Checked[Executable] = {
       def executable = cwl match {
-        case Cwl.Workflow(w) => w.womExecutable(validator, inputsFile)
-        case Cwl.CommandLineTool(clt) => clt.womExecutable(validator, inputsFile)
-        case Cwl.ExpressionTool(et) => et.womExecutable(validator, inputsFile)
+        case Cwl.Workflow(w) => w.womExecutable(validator, inputsFile, ioFunctions)
+        case Cwl.CommandLineTool(clt) => clt.womExecutable(validator, inputsFile, ioFunctions)
+        case Cwl.ExpressionTool(et) => et.womExecutable(validator, inputsFile, ioFunctions)
       }
       Try(executable) match {
         case Success(s) => s

--- a/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
@@ -5,7 +5,7 @@ import cwl.CwlDecoder.decodeCwlFile
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import shapeless.Coproduct
-import wom.expression.WomExpression
+import wom.expression.{NoIoFunctionSet, WomExpression}
 import wom.graph.Graph.ResolvedExecutableInput
 import wom.graph.GraphNodePort
 import wom.types.{WomArrayType, WomStringType}
@@ -87,7 +87,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
   lazy val w10OutputPort = getOutputPort(10)
   
   def validate(inputFile: String): Map[GraphNodePort.OutputPort, ResolvedExecutableInput] = {
-    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile)) match {
+    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile), NoIoFunctionSet) match {
       case Left(errors) => fail(s"Failed to build a wom executable: ${errors.toList.mkString(", ")}")
       case Right(executable) => executable.resolvedExecutableInputs
     }
@@ -178,7 +178,7 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
         w2: hello !
       """.stripMargin
 
-    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile)) match {
+    cwlWorkflow.womExecutable(AcceptAllRequirements, Option(inputFile), NoIoFunctionSet) match {
       case Right(booh) => fail(s"Expected failed validation but got valid input map: $booh")
       case Left(errors) => errors.toList.toSet shouldBe Set(
         "Required workflow input 'w1' not specified",

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -228,7 +228,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
           case Some(other) => s"Unknown version '$other' for workflow language '$languageName'".invalidNel
           case _ => language.allVersions.head._2.valid
         }
-        errorOrParse(factory).flatMap(_.validateNamespace(sourceFiles, workflowOptions, importLocalFilesystem, workflowIdForLogging))
+        errorOrParse(factory).flatMap(_.validateNamespace(sourceFiles, workflowOptions, importLocalFilesystem, workflowIdForLogging, engineIoFunctions))
       case Some(other) => fromEither[IO](s"Unknown workflow type: $other".invalidNelCheck[ValidatedWomNamespace])
       case None => fromEither[IO]("Need a workflow type here !".invalidNelCheck[ValidatedWomNamespace])
     }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -12,6 +12,7 @@ import spray.json.DefaultJsonProtocol
 import wdl.draft2.model.WdlNamespaceWithWorkflow
 import wom.graph.{CommandCallNode, ScatterNode}
 import wdl.transforms.draft2.wdlom2wom.WdlDraft2WomExecutableMakers._
+import wom.expression.NoIoFunctionSet
 import wom.transforms.WomExecutableMaker.ops._
 
 /**
@@ -31,7 +32,7 @@ object ExecutionStoreBenchmark extends Bench[Double] with DefaultJsonProtocol {
   
   val inputJson = Option(SampleWdl.PrepareScatterGatherWdl().rawInputs.toJson.compactPrint)
   val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.PrepareScatterGatherWdl().workflowSource(), Seq.empty).get
-  val graph = namespace.toWomExecutable(inputJson).getOrElse(throw new Exception("Failed to build womExecutable")).graph
+  val graph = namespace.toWomExecutable(inputJson, NoIoFunctionSet).getOrElse(throw new Exception("Failed to build womExecutable")).graph
   val prepareCall: CommandCallNode = graph.calls.find(_.localName == "do_prepare").get.asInstanceOf[CommandCallNode]
   val scatterCall: CommandCallNode = graph.allNodes.find(_.localName == "do_scatter").get.asInstanceOf[CommandCallNode]
   val scatter: ScatterNode = graph.scatters.head

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
@@ -7,6 +7,7 @@ import cromwell.core.{WorkflowId, WorkflowOptions, WorkflowSourceFilesCollection
 import cromwell.languages.LanguageFactory.ImportResolver
 import wom.core._
 import wom.executable.WomBundle
+import wom.expression.IoFunctionSet
 
 trait LanguageFactory {
   def getWomBundle(workflowSource: WorkflowSource,
@@ -15,12 +16,14 @@ trait LanguageFactory {
                    languageFactories: List[LanguageFactory]): Checked[WomBundle]
 
   def createExecutable(womBundle: WomBundle,
-                       inputs: WorkflowJson): Checked[ValidatedWomNamespace]
+                       inputs: WorkflowJson,
+                       ioFunctions: IoFunctionSet): Checked[ValidatedWomNamespace]
 
   def validateNamespace(source: WorkflowSourceFilesCollection,
                         workflowOptions: WorkflowOptions,
                         importLocalFilesystem: Boolean,
-                        workflowIdForLogging: WorkflowId): Parse[ValidatedWomNamespace]
+                        workflowIdForLogging: WorkflowId,
+                        ioFunctions: IoFunctionSet): Parse[ValidatedWomNamespace]
 }
 
 object LanguageFactory {

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -40,6 +40,7 @@ import org.slf4j.Logger
 import org.specs2.mock.Mockito
 import spray.json._
 import wom.WomFileMapper
+import wom.expression.NoIoFunctionSet
 import wom.graph.CommandCallNode
 import wom.types._
 import wom.values._
@@ -156,7 +157,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
       Seq.empty[Draft2ImportResolver]).get
     val womDefinition = wdlNamespace.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
 
-    wdlNamespace.toWomExecutable(Option(Inputs.toJson.compactPrint)) match {
+    wdlNamespace.toWomExecutable(Option(Inputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val inputs = for {
           combined <- womExecutable.resolvedExecutableInputs
@@ -387,7 +388,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
     val wdlNamespace = WdlNamespaceWithWorkflow.load(YoSup.replace("[PREEMPTIBLE]", ""),
       Seq.empty[Draft2ImportResolver]).get
     val womWorkflow = wdlNamespace.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
-    wdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint)) match {
+    wdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val wdlInputs = womExecutable.resolvedExecutableInputs.flatMap({case (port, v) => v.select[WomValue] map { port -> _ }})
 
@@ -461,7 +462,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
     }
 
     val womWorkflow = dockerAndDiskWdlNamespace.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
-    dockerAndDiskWdlNamespace.toWomExecutable(Option(workflowInputs.toJson.compactPrint)) match {
+    dockerAndDiskWdlNamespace.toWomExecutable(Option(workflowInputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val wdlInputs = womExecutable.resolvedExecutableInputs.flatMap({case (port, v) => v.select[WomValue] map { port -> _ }})
         val workflowDescriptor = BackendWorkflowDescriptor(
@@ -509,7 +510,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
   TestActorRef[TestableJesJobExecutionActor] = {
     val womWorkflow = WdlNamespaceWithWorkflow.load(sampleWdl.asWorkflowSources(DockerAndDiskRuntime).workflowSource,
       Seq.empty[Draft2ImportResolver]).get.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
-    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint)) match {
+    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val wdlInputs = womExecutable.resolvedExecutableInputs.flatMap({case (port, v) => v.select[WomValue] map { port -> _ }})
         val workflowDescriptor = BackendWorkflowDescriptor(
@@ -576,7 +577,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
     )
 
     val womWorkflow = dockerAndDiskWdlNamespace.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
-    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint)) match {
+    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val wdlInputs = womExecutable.resolvedExecutableInputs.flatMap({case (port, v) => v.select[WomValue] map { port -> _ }})
         val workflowDescriptor = BackendWorkflowDescriptor(
@@ -611,7 +612,7 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
     )
 
     val womWorkflow = dockerAndDiskWdlNamespace.workflow.toWomWorkflowDefinition.getOrElse(fail("failed to get WomDefinition from WdlWorkflow"))
-    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint)) match {
+    dockerAndDiskWdlNamespace.toWomExecutable(Option(inputs.toJson.compactPrint), NoIoFunctionSet) match {
       case Right(womExecutable) =>
         val wdlInputs = womExecutable.resolvedExecutableInputs.flatMap({case (port, v) => v.select[WomValue] map { port -> _ }})
         val workflowDescriptor = BackendWorkflowDescriptor(

--- a/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomExecutableMakers.scala
+++ b/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomExecutableMakers.scala
@@ -8,24 +8,25 @@ import wdl.transforms.draft2.wdlom2wom.WdlDraft2WomBundleMakers._
 import wdl.shared.transforms.wdlom2wom.WdlSharedInputParsing
 import wom.core.WorkflowJson
 import wom.executable.Executable
+import wom.expression.IoFunctionSet
 import wom.transforms.WomExecutableMaker
 import wom.transforms.WomBundleMaker.ops._
 
 object WdlDraft2WomExecutableMakers {
   implicit val namespaceWomExecutableMaker: WomExecutableMaker[WdlNamespace] = new WomExecutableMaker[WdlNamespace] {
-    override def toWomExecutable(a: WdlNamespace, inputs: Option[WorkflowJson]): Checked[Executable] = {
+    override def toWomExecutable(a: WdlNamespace, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable] = {
       a.toWomBundle flatMap { bundle =>
-        WdlSharedInputParsing.buildWomExecutable(bundle, inputs)
+        WdlSharedInputParsing.buildWomExecutable(bundle, inputs, ioFunctions)
       }
     }
   }
 
   implicit val namespaceWithWorkflowWomExecutableMaker: WomExecutableMaker[WdlNamespaceWithWorkflow] = new WomExecutableMaker[WdlNamespaceWithWorkflow] {
-    override def toWomExecutable(a: WdlNamespaceWithWorkflow, inputs: Option[WorkflowJson]): Checked[Executable] = namespaceWomExecutableMaker.toWomExecutable(a, inputs)
+    override def toWomExecutable(a: WdlNamespaceWithWorkflow, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable] = namespaceWomExecutableMaker.toWomExecutable(a, inputs, ioFunctions)
   }
 
   implicit val namespaceWithoutWorkflowWomExecutableMaker: WomExecutableMaker[WdlNamespaceWithoutWorkflow] = new WomExecutableMaker[WdlNamespaceWithoutWorkflow] {
-    override def toWomExecutable(a: WdlNamespaceWithoutWorkflow, inputs: Option[WorkflowJson]): Checked[Executable] = namespaceWomExecutableMaker.toWomExecutable(a, inputs)
+    override def toWomExecutable(a: WdlNamespaceWithoutWorkflow, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable] = namespaceWomExecutableMaker.toWomExecutable(a, inputs, ioFunctions)
   }
 
 }

--- a/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/WdlInputValidationSpec.scala
+++ b/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/WdlInputValidationSpec.scala
@@ -15,6 +15,7 @@ import wom.transforms.WomExecutableMaker.ops._
 import wom.transforms.WomWorkflowDefinitionMaker.ops._
 import wdl.transforms.draft2.wdlom2wom._
 import wdl.transforms.draft2.wdlom2wom.WdlDraft2WomExecutableMakers._
+import wom.expression.NoIoFunctionSet
 import wom.types._
 import wom.values._
 
@@ -55,7 +56,7 @@ class WdlInputValidationSpec extends FlatSpec with Matchers with BeforeAndAfterA
   val u2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.u.t2").getOrElse(fail("Failed to find an input node for u2")).singleOutputPort
 
   def validate(inputFile: String): Checked[ResolvedExecutableInputs] = {
-    namespace.toWomExecutable(Option(inputFile)) match {
+    namespace.toWomExecutable(Option(inputFile), NoIoFunctionSet) match {
       case Left(errors) => Left(errors)
       case Right(e) => e.resolvedExecutableInputs.validNelCheck
     }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WomBundleToWomExecutable.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/WomBundleToWomExecutable.scala
@@ -4,11 +4,12 @@ import common.Checked
 import wdl.shared.transforms.wdlom2wom.WdlSharedInputParsing
 import wom.core.WorkflowJson
 import wom.executable.{Executable, WomBundle}
+import wom.expression.IoFunctionSet
 import wom.transforms.WomExecutableMaker
 
 object WomBundleToWomExecutable {
 
   implicit val draft3WomBundleToWomExecutable: WomExecutableMaker[WomBundle] = new WomExecutableMaker[WomBundle] {
-    override def toWomExecutable(a: WomBundle, inputs: Option[WorkflowJson]): Checked[Executable] = WdlSharedInputParsing.buildWomExecutable(a, inputs)
+    override def toWomExecutable(a: WomBundle, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable] = WdlSharedInputParsing.buildWomExecutable(a, inputs, ioFunctions)
   }
 }

--- a/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/wdlom2wom/WdlSharedInputParsing.scala
+++ b/wdl/transforms/shared/src/main/scala/wdl/shared/transforms/wdlom2wom/WdlSharedInputParsing.scala
@@ -9,6 +9,7 @@ import wom.callable.WorkflowDefinition
 import wom.core.WorkflowJson
 import wom.executable.{Executable, WomBundle}
 import wom.executable.Executable.{InputParsingFunction, ParsedInputMap}
+import wom.expression.IoFunctionSet
 import wom.types.WomType
 
 import scala.util.Try
@@ -27,7 +28,7 @@ object WdlSharedInputParsing {
     }
   }
 
-  def buildWomExecutable(bundle: WomBundle, inputs: Option[WorkflowJson]): Checked[Executable] = {
+  def buildWomExecutable(bundle: WomBundle, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable] = {
 
     val workflows: Set[WorkflowDefinition] = bundle.callables.filterByType[WorkflowDefinition]
     val executableWorkflowCheck = if (workflows.size == 1) {
@@ -38,7 +39,7 @@ object WdlSharedInputParsing {
 
     for {
       executableWorkflow <- executableWorkflowCheck
-      executable <- Executable.withInputs(executableWorkflow, inputCoercionFunction, inputs)
+      executable <- Executable.withInputs(executableWorkflow, inputCoercionFunction, inputs, ioFunctions)
     } yield executable
   }
 }

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -7,6 +7,7 @@ import shapeless.Coproduct
 import wom.callable.ExecutableCallable
 import wom.executable.Executable.ResolvedExecutableInputs
 import wom.executable.ExecutableValidation._
+import wom.expression.NoIoFunctionSet
 import wom.graph.Graph.ResolvedExecutableInput
 import wom.graph.GraphNodePort.OutputPort
 import wom.graph._
@@ -42,7 +43,11 @@ object Executable {
     */
   private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction]): ErrorOr[ResolvedExecutableInputs] = {
     def fromInputMapping(gin: ExternalGraphInputNode): Option[ErrorOr[ResolvedExecutableInput]] = {
-      inputCoercionMap.get(gin.nameInInputSet).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
+      inputCoercionMap
+        .get(gin.nameInInputSet)
+        .map(_(gin.womType)
+        .map(gin.valueMapper(NoIoFunctionSet)(_))
+        .map(Coproduct[ResolvedExecutableInput](_)))
     }
 
     def fallBack(gin: ExternalGraphInputNode): ErrorOr[ResolvedExecutableInput] = gin match {

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -7,7 +7,7 @@ import shapeless.Coproduct
 import wom.callable.ExecutableCallable
 import wom.executable.Executable.ResolvedExecutableInputs
 import wom.executable.ExecutableValidation._
-import wom.expression.NoIoFunctionSet
+import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.graph.Graph.ResolvedExecutableInput
 import wom.graph.GraphNodePort.OutputPort
 import wom.graph._
@@ -34,19 +34,19 @@ object Executable {
    */
   type ResolvedExecutableInputs = Map[OutputPort, ResolvedExecutableInput]
 
-  def withInputs(entryPoint: ExecutableCallable, inputParsingFunction: InputParsingFunction, inputFile: Option[String]): Checked[Executable] = {
-    validateExecutable(entryPoint, inputParsingFunction, parseGraphInputs, inputFile)
+  def withInputs(entryPoint: ExecutableCallable, inputParsingFunction: InputParsingFunction, inputFile: Option[String], ioFunctions: IoFunctionSet): Checked[Executable] = {
+    validateExecutable(entryPoint, inputParsingFunction, parseGraphInputs, inputFile, ioFunctions)
   }
 
   /**
     * Given the graph and the Map[String, DelayedCoercionFunction], attempts to find a value in the map for each ExternalGraphInputNode of the graph
     */
-  private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction]): ErrorOr[ResolvedExecutableInputs] = {
+  private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction], ioFunctions: IoFunctionSet): ErrorOr[ResolvedExecutableInputs] = {
     def fromInputMapping(gin: ExternalGraphInputNode): Option[ErrorOr[ResolvedExecutableInput]] = {
       inputCoercionMap
         .get(gin.nameInInputSet)
         .map(_(gin.womType)
-        .map(gin.valueMapper(NoIoFunctionSet)(_))
+        .map(gin.valueMapper(ioFunctions)(_))
         .map(Coproduct[ResolvedExecutableInput](_)))
     }
 

--- a/wom/src/main/scala/wom/executable/ExecutableValidation.scala
+++ b/wom/src/main/scala/wom/executable/ExecutableValidation.scala
@@ -6,15 +6,17 @@ import common.validation.Checked._
 import common.validation.ErrorOr.ErrorOr
 import wom.callable.ExecutableCallable
 import wom.executable.Executable.{DelayedCoercionFunction, InputParsingFunction, ResolvedExecutableInputs}
+import wom.expression.IoFunctionSet
 import wom.graph.Graph
 
 private [executable] object ExecutableValidation {
 
   private [executable] def validateExecutable(entryPoint: ExecutableCallable,
                                               inputParsingFunction: InputParsingFunction,
-                                              parseGraphInputs: (Graph, Map[String, DelayedCoercionFunction]) => ErrorOr[ResolvedExecutableInputs],
-                                              inputFile: Option[String]): Checked[Executable] = for {
+                                              parseGraphInputs: (Graph, Map[String, DelayedCoercionFunction], IoFunctionSet) => ErrorOr[ResolvedExecutableInputs],
+                                              inputFile: Option[String],
+                                              ioFunctions: IoFunctionSet): Checked[Executable] = for {
     parsedInputs <- inputFile.map(inputParsingFunction).getOrElse(Map.empty[String, DelayedCoercionFunction].validNelCheck)
-    validatedInputs <- parseGraphInputs(entryPoint.graph, parsedInputs).toEither
+    validatedInputs <- parseGraphInputs(entryPoint.graph, parsedInputs, ioFunctions).toEither
   } yield Executable(entryPoint, validatedInputs)
 }

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -1,5 +1,6 @@
 package wom.graph
 
+import wom.callable.Callable
 import wom.callable.Callable.InputDefinition.InputValueMapper
 import wom.expression.WomExpression
 import wom.graph.GraphNodePort.GraphNodeOutputPort
@@ -52,19 +53,19 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
 final case class RequiredGraphInputNode(override val identifier: WomIdentifier,
                                         womType: WomType,
                                         nameInInputSet: String,
-                                        valueMapper: InputValueMapper) extends ExternalGraphInputNode
+                                        valueMapper: InputValueMapper = Callable.InputDefinition.IdentityValueMapper) extends ExternalGraphInputNode
 
 final case class OptionalGraphInputNode(override val identifier: WomIdentifier,
                                         womType: WomOptionalType,
                                         nameInInputSet: String,
-                                        valueMapper: InputValueMapper) extends ExternalGraphInputNode
+                                        valueMapper: InputValueMapper = Callable.InputDefinition.IdentityValueMapper) extends ExternalGraphInputNode
 
 // If we want to allow defaults to be "complex" expressions with dependencies we may need to make it an InstantiatedExpression here instead
 final case class OptionalGraphInputNodeWithDefault(override val identifier: WomIdentifier,
                                                    womType: WomType,
                                                    default: WomExpression,
                                                    nameInInputSet: String,
-                                                   valueMapper: InputValueMapper) extends ExternalGraphInputNode
+                                                   valueMapper: InputValueMapper = Callable.InputDefinition.IdentityValueMapper) extends ExternalGraphInputNode
 
 object OuterGraphInputNode {
   def apply(forIdentifier: WomIdentifier, linkToOuterGraph: GraphNodePort.OutputPort, preserveScatterIndex: Boolean): OuterGraphInputNode = {

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -1,5 +1,6 @@
 package wom.graph
 
+import wom.callable.Callable.InputDefinition.InputValueMapper
 import wom.expression.WomExpression
 import wom.graph.GraphNodePort.GraphNodeOutputPort
 import wom.graph.expression.ExpressionNode
@@ -44,21 +45,26 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
     * Key that should be looked for in the input set to satisfy this EGIN
     */
   def nameInInputSet: String
+  
+  def valueMapper: InputValueMapper
 }
 
 final case class RequiredGraphInputNode(override val identifier: WomIdentifier,
                                         womType: WomType,
-                                        nameInInputSet: String) extends ExternalGraphInputNode
+                                        nameInInputSet: String,
+                                        valueMapper: InputValueMapper) extends ExternalGraphInputNode
 
 final case class OptionalGraphInputNode(override val identifier: WomIdentifier,
                                         womType: WomOptionalType,
-                                        nameInInputSet: String) extends ExternalGraphInputNode
+                                        nameInInputSet: String,
+                                        valueMapper: InputValueMapper) extends ExternalGraphInputNode
 
 // If we want to allow defaults to be "complex" expressions with dependencies we may need to make it an InstantiatedExpression here instead
 final case class OptionalGraphInputNodeWithDefault(override val identifier: WomIdentifier,
                                                    womType: WomType,
                                                    default: WomExpression,
-                                                   nameInInputSet: String) extends ExternalGraphInputNode
+                                                   nameInInputSet: String,
+                                                   valueMapper: InputValueMapper) extends ExternalGraphInputNode
 
 object OuterGraphInputNode {
   def apply(forIdentifier: WomIdentifier, linkToOuterGraph: GraphNodePort.OutputPort, preserveScatterIndex: Boolean): OuterGraphInputNode = {

--- a/wom/src/main/scala/wom/transforms/WomExecutableMaker.scala
+++ b/wom/src/main/scala/wom/transforms/WomExecutableMaker.scala
@@ -4,12 +4,13 @@ import common.Checked
 import wom.executable.{Executable, WomBundle}
 import simulacrum._
 import wom.core.WorkflowJson
+import wom.expression.IoFunctionSet
 
 import scala.language.implicitConversions
 
 @typeclass
 trait WomExecutableMaker[A] {
-  def toWomExecutable(a: A, inputs: Option[WorkflowJson]): Checked[Executable]
+  def toWomExecutable(a: A, inputs: Option[WorkflowJson], ioFunctions: IoFunctionSet): Checked[Executable]
 }
 
 @typeclass


### PR DESCRIPTION
This properly processes workflow inputs by applying the value mapper to them once they have been bound to their `WomValue`.
For instance it enables support for the case where secondaryFiles are declared at the workflow input level but not the tool input level.
The real change is the addition of the `InputValueMapper` to `ExternalGraphInputNode`s and its use in `Executable.scala`
The rest of it is wiring the io functions through.