### PR TITLE
Fix edge case on restart in EJEA

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -6,6 +6,7 @@ import cromwell.backend.io.WorkflowPathsWithDocker
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.core.CallOutputs
 import cromwell.core.path.Path
+import cromwell.core.path.PathFactory.PathBuilders
 import net.ceedubs.ficus.Ficus._
 import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.graph.CommandCallNode
@@ -96,6 +97,8 @@ trait BackendLifecycleActorFactory {
                                   initializationData: Option[BackendInitializationData],
                                   ioActor: ActorRef,
                                   ec: ExecutionContext): IoFunctionSet = NoIoFunctionSet
+  
+  def pathBuilders(initializationDataOption: Option[BackendInitializationData]): PathBuilders = List.empty
 
   def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config, initializationData: Option[BackendInitializationData]): Path = {
     new WorkflowPathsWithDocker(workflowDescriptor, backendConfig).executionRoot

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -182,6 +182,11 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
     val jobPaths = standardInitializationData.workflowPaths.toJobPaths(jobKey, workflowDescriptor)
     standardInitializationData.expressionFunctions(jobPaths, ioActorProxy, ec)
   }
+  
+  override def pathBuilders(initializationDataOption: Option[BackendInitializationData]) = {
+    val standardInitializationData = BackendInitializationData.as[StandardInitializationData](initializationDataOption)
+    standardInitializationData.workflowPaths.pathBuilders
+  } 
 
   override def getExecutionRootPath(workflowDescriptor: BackendWorkflowDescriptor, backendConfig: Config,
                                     initializationData: Option[BackendInitializationData]): Path = {

--- a/core/src/main/scala/cromwell/core/callcaching/HashResultMessage.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/HashResultMessage.scala
@@ -1,13 +1,17 @@
 package cromwell.core.callcaching
 
+import cromwell.core.callcaching.HashKey.KeySeparator
+
 
 object HashKey {
+  private val KeySeparator = ": "
   def apply(keyComponents: String*) = new HashKey(true, keyComponents.toList)
   def apply(checkForHitOrMiss: Boolean, keyComponents: String*) = new HashKey(checkForHitOrMiss, keyComponents.toList)
+  def deserialize(serializedKey: String) = HashKey(true, serializedKey.split(KeySeparator).map(_.trim): _*)
 }
 
 case class HashKey(checkForHitOrMiss: Boolean, keyComponents: List[String]) {
-  val key = keyComponents.mkString(": ")
+  val key = keyComponents.mkString(KeySeparator)
 }
 case class HashValue(value: String)
 case class HashResult(hashKey: HashKey, hashValue: HashValue)

--- a/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
+++ b/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
@@ -15,13 +15,13 @@ import scala.language.postfixOps
 object WomValueBuilder {
 
   /**
-    * Looks for a WDL identifier possibly followed by a metacharacter and more stuff.
+    * Looks for a WOM identifier possibly followed by a metacharacter and more stuff.
     *
     * Capture groups:
     *
     * <ol>
-    * <li>A WDL identifier</li>
-    * <li>Possibly a metacharacter and more stuff after the WDL identifier</li>
+    * <li>A WOM identifier</li>
+    * <li>Possibly a metacharacter and more stuff after the WOM identifier</li>
     * </ol>
     */
   private val IdentifierAndPathPattern = "^([a-zA-Z][a-zA-Z0-9_]*)(.*)".r
@@ -143,13 +143,13 @@ object WomValueBuilder {
       case arrayType: WomArrayType =>
         WomArray(arrayType, components.asArray map { toWomValue(arrayType.memberType, _) })
       case mapType: WomMapType =>
-        // map keys are guaranteed by the WDL spec to be primitives, so the "coerceRawValue(..).get" is safe.
+        // map keys are guaranteed by WOM to be primitives, so the "coerceRawValue(..).get" is safe.
         WomMap(mapType, components.asMap map { case (k, ss) => mapType.keyType.coerceRawValue(k).get -> toWomValue(mapType.valueType, ss) })
       case pairType: WomPairType =>
         val groupedByLeftOrRight: Map[PairLeftOrRight, Traversable[SimpletonComponent]] = group(components map descendIntoPair)
         WomPair(toWomValue(pairType.leftType, groupedByLeftOrRight(PairLeft)), toWomValue(pairType.rightType, groupedByLeftOrRight(PairRight)))
       case WomObjectType =>
-        // map keys are guaranteed by the WDL spec to be primitives, so the "coerceRawValue(..).get" is safe.
+        // map keys are guaranteed by WOM to be primitives, so the "coerceRawValue(..).get" is safe.
         val map: Map[String, WomValue] = components.asMap map { case (k, ss) => k -> toWomValue(WomAnyType, ss) }
         WomObject(map)
       case composite: WomCompositeType =>
@@ -212,13 +212,13 @@ object WomValueBuilder {
     * path to the element.  e.g. for a `WomValueSimpleton` of
     *
     * {{{
-    * WomValueSimpleton("foo:bar[0]", WdlString("baz"))
+    * WomValueSimpleton("foo:bar[0]", WomString("baz"))
     * }}}
     *
     * the corresponding `SimpletonComponent` would be
     *
     * {{{
-    * SimpletonComponent(":bar[0]", WdlString("baz"))
+    * SimpletonComponent(":bar[0]", WomString("baz"))
     * }}}
     */
   private case class SimpletonComponent(path: String, value: WomValue)
@@ -233,7 +233,7 @@ object WomValueBuilder {
       SimpletonComponent(simpleton.simpletonKey.drop(name.length), simpleton.simpletonValue)
     }
 
-    // This is meant to "rehydrate" simpletonized WdlValues back to WdlValues.  It is assumed that these WdlValues were
+    // This is meant to "rehydrate" simpletonized WomValues back to WomValues.  It is assumed that these WomValues were
     // "dehydrated" to WomValueSimpletons correctly. This code is not robust to corrupt input whatsoever.
     val types = taskOutputs map { o => o -> o.womType } toMap
     val simpletonsByOutputName = simpletons groupBy { _.simpletonKey match { case IdentifierAndPathPattern(i, _) => i } }

--- a/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
+++ b/core/src/main/scala/cromwell/core/simpleton/WomValueBuilder.scala
@@ -224,10 +224,10 @@ object WomValueBuilder {
   private case class SimpletonComponent(path: String, value: WomValue)
 
   def toJobOutputs(taskOutputs: Traversable[OutputPort], simpletons: Traversable[WomValueSimpleton]): CallOutputs = {
-    CallOutputs(toWdlValues(taskOutputs, simpletons))
+    CallOutputs(toWomValues(taskOutputs, simpletons))
   }
 
-  def toWdlValues(taskOutputs: Traversable[OutputPort], simpletons: Traversable[WomValueSimpleton]): Map[OutputPort, WomValue] = {
+  def toWomValues(taskOutputs: Traversable[OutputPort], simpletons: Traversable[WomValueSimpleton]): Map[OutputPort, WomValue] = {
 
     def simpletonToComponent(name: String)(simpleton: WomValueSimpleton): SimpletonComponent = {
       SimpletonComponent(simpleton.simpletonKey.drop(name.length), simpleton.simpletonValue)

--- a/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
+++ b/core/src/test/scala/cromwell/core/simpleton/WomValueBuilderSpec.scala
@@ -216,7 +216,7 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
       // The task output is used to tell us the type of output we're expecting:
       val outputPort = WomMocks.mockOutputPort(OutputDefinition(name, womValue.womType, IgnoredExpression))
       val taskOutputPorts = List(outputPort)
-      val rebuiltValues = WomValueBuilder.toWdlValues(taskOutputPorts, expectedSimpletons)
+      val rebuiltValues = WomValueBuilder.toWomValues(taskOutputPorts, expectedSimpletons)
       rebuiltValues.size should be(1)
       rebuiltValues(outputPort) should be(womValue)
     }
@@ -230,7 +230,7 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
     val actualSimpletons = wdlValues.simplify
     assertSimpletonsEqual(allSimpletons, actualSimpletons)
 
-    val actual = WomValueBuilder.toWdlValues(wdlValues.keys.toSeq, actualSimpletons)
+    val actual = WomValueBuilder.toWomValues(wdlValues.keys.toSeq, actualSimpletons)
     actual shouldEqual wdlValues
   }
 
@@ -269,7 +269,7 @@ class WomValueBuilderSpec extends FlatSpec with Matchers with Mockito {
     // Reconstruct:
     val outputPort = WomMocks.mockOutputPort(OutputDefinition("map_in_object", initial.womType, IgnoredExpression))
     val taskOutputPorts = List(outputPort)
-    val rebuiltValues = WomValueBuilder.toWdlValues(taskOutputPorts, actualSimpletons)
+    val rebuiltValues = WomValueBuilder.toWomValues(taskOutputPorts, actualSimpletons)
 
     rebuiltValues.size should be(1)
     val rebuiltObject = rebuiltValues.head._2

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -3,7 +3,9 @@ package cromwell.database.slick
 import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.instances.tuple._
+import cats.syntax.apply._
 import cats.syntax.foldable._
+import com.rms.miu.slickcats.DBIOInstances._
 import cromwell.database.sql._
 import cromwell.database.sql.joins.CallCachingJoin
 import cromwell.database.sql.tables._
@@ -93,18 +95,21 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
   }
 
   private def callCacheJoinFromEntryQuery(callCachingEntry: CallCachingEntry)
-                            (implicit ec: ExecutionContext) = {
+                            (implicit ec: ExecutionContext): DBIO[CallCachingJoin] = {
     val callCachingEntryId = callCachingEntry.callCachingEntryId.get
-    for {
-      callCachingSimpletonEntries <- dataAccess.
-        callCachingSimpletonEntriesForCallCachingEntryId(callCachingEntryId).result
-      callCachingDetritusEntries <- dataAccess.
-        callCachingDetritusEntriesForCallCachingEntryId(callCachingEntryId).result
-      callCachingHashEntries <- dataAccess.
-        callCachingHashEntriesForCallCachingEntryId(callCachingEntryId).result
-      callCachingAggregationEntries <- dataAccess.
-        callCachingAggregationForCacheEntryId(callCachingEntryId).result.headOption
-    } yield CallCachingJoin(callCachingEntry, callCachingHashEntries, callCachingAggregationEntries, callCachingSimpletonEntries, callCachingDetritusEntries)
+    val callCachingSimpletonEntries: DBIO[Seq[CallCachingSimpletonEntry]] = dataAccess.
+      callCachingSimpletonEntriesForCallCachingEntryId(callCachingEntryId).result
+    val callCachingDetritusEntries: DBIO[Seq[CallCachingDetritusEntry]] = dataAccess.
+      callCachingDetritusEntriesForCallCachingEntryId(callCachingEntryId).result
+    val callCachingHashEntries: DBIO[Seq[CallCachingHashEntry]] = dataAccess.
+      callCachingHashEntriesForCallCachingEntryId(callCachingEntryId).result
+    val callCachingAggregationEntries: DBIO[Option[CallCachingAggregationEntry]] = dataAccess.
+      callCachingAggregationForCacheEntryId(callCachingEntryId).result.headOption
+    
+    (callCachingHashEntries, callCachingAggregationEntries, callCachingSimpletonEntries, callCachingDetritusEntries) mapN { 
+      case (hashes, aggregation, simpletons, detrituses) =>
+        CallCachingJoin(callCachingEntry, hashes, aggregation, simpletons, detrituses)
+    }
   }
 
   override def callCacheJoinForCall(workflowExecutionUuid: String, callFqn: String, index: Int)
@@ -113,7 +118,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
       callCachingEntryOption <- dataAccess.
         callCachingEntriesForWorkflowFqnIndex((workflowExecutionUuid, callFqn, index)).result.headOption
       callCacheJoin <- callCachingEntryOption
-        .fold[DBIOAction[Option[CallCachingJoin], NoStream, Effect.Read]](DBIO.successful(None))(callCacheJoinFromEntryQuery(_).map(Option.apply))
+        .fold[DBIOAction[Option[CallCachingJoin], NoStream, Effect.All]](DBIO.successful(None))(callCacheJoinFromEntryQuery(_).map(Option.apply))
     } yield callCacheJoin
 
     runTransaction(action)

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -112,10 +112,8 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     val action = for {
       callCachingEntryOption <- dataAccess.
         callCachingEntriesForWorkflowFqnIndex((workflowExecutionUuid, callFqn, index)).result.headOption
-      callCacheJoin <- callCachingEntryOption match {
-        case Some(entry) => callCacheJoinFromEntryQuery(entry).map(Option.apply)
-        case _ => DBIO.successful(None)
-      }
+      callCacheJoin <- callCachingEntryOption
+        .fold[DBIOAction[Option[CallCachingJoin], NoStream, Effect.Read]](DBIO.successful(None))(callCacheJoinFromEntryQuery(_).map(Option.apply))
     } yield callCacheJoin
 
     runTransaction(action)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -32,6 +32,13 @@ trait CallCachingAggregationEntryComponent {
 
   val callCachingAggregationEntryIdsAutoInc = callCachingAggregationEntries returning
     callCachingAggregationEntries.map(_.callCachingAggregationEntryId)
+  
+  val callCachingAggregationForCacheEntryId = Compiled(
+    (callCachingEntryId: Rep[Int]) => for {
+      callCachingAggregationEntry <- callCachingAggregationEntries 
+      if callCachingAggregationEntry.callCachingEntryId === callCachingEntryId
+    } yield callCachingAggregationEntry
+  )
 
   val existsCallCachingEntriesForBaseAggregationHash = Compiled(
     (baseAggregation: Rep[String]) => (for {

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
@@ -32,6 +32,16 @@ trait CallCachingHashEntryComponent {
 
   val callCachingHashEntryIdsAutoInc = callCachingHashEntries returning
     callCachingHashEntries.map(_.callCachingHashEntryId)
+  
+  /**
+    * Find all hashes for a CALL_CACHING_ENTRY_ID
+    */
+  val callCachingHashEntriesForCallCachingEntryId = Compiled(
+    (callCachingHashEntryId: Rep[Int]) => for {
+      callCachingHashEntry <- callCachingHashEntries
+      if callCachingHashEntry.callCachingEntryId === callCachingHashEntryId
+    } yield callCachingHashEntry
+  )
 
   /**
     * Returns true if there exists a row in callCachingHashEntries that matches the parameters.

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -21,8 +21,8 @@ trait CallCachingSqlDatabase {
   def queryResultsForCacheId(callCachingEntryId: Int)
                             (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
   
-  def cacheEntryExistsForCall(workflowExecutionUuid: String, callFqn: String, index: Int)
-                             (implicit ec: ExecutionContext): Future[Boolean]
+  def callCacheJoinForCall(workflowExecutionUuid: String, callFqn: String, index: Int)
+                          (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
 
   def invalidateCall(callCachingEntryId: Int)
                     (implicit ec: ExecutionContext): Future[Option[CallCachingEntry]]

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -162,9 +162,9 @@ object CallCache {
     
     def callCacheHashes: Set[HashResult] = {
       val hashResults = callCachingJoin.callCachingHashEntries.map({
-        case CallCachingHashEntry(k, v, _, _) => HashResult(HashKey(k), HashValue(v)) 
+        case CallCachingHashEntry(k, v, _, _) => HashResult(HashKey.deserialize(k), HashValue(v)) 
       }) ++ callCachingJoin.callCachingAggregationEntry.collect({
-        case CallCachingAggregationEntry(k, Some(v), _, _) => HashResult(HashKey(k), HashValue(v))
+        case CallCachingAggregationEntry(k, Some(v), _, _) => HashResult(HashKey.deserialize(k), HashValue(v))
       })
 
       hashResults.toSet

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -147,7 +147,7 @@ object CallCache {
                                          )
   
   implicit class EnhancedCallCachingJoin(val callCachingJoin: CallCachingJoin) extends AnyVal {
-    def toJobSuccess(key: BackendJobDescriptorKey, pathBuilders: List[PathBuilder]) = {
+    def toJobSuccess(key: BackendJobDescriptorKey, pathBuilders: List[PathBuilder]): JobSucceededResponse = {
       import cromwell.Simpletons._
       import cromwell.core.path.PathFactory._
       val detritus = callCachingJoin.callCachingDetritusEntries.map({ jobDetritusEntry =>

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -1,12 +1,13 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import cats.data.NonEmptyList
+import cromwell.backend.BackendJobDescriptorKey
 import cromwell.backend.BackendJobExecutionActor.{JobFailedNonRetryableResponse, JobSucceededResponse}
 import cromwell.core.ExecutionIndex.{ExecutionIndex, IndexEnhancedIndex}
-import cromwell.core.callcaching.HashResult
-import cromwell.core.path.Path
-import cromwell.core.simpleton.WomValueSimpleton
+import cromwell.core.callcaching.{HashKey, HashResult, HashValue}
+import cromwell.core.path.{Path, PathBuilder}
 import cromwell.core.simpleton.WomValueSimpleton._
+import cromwell.core.simpleton.{WomValueBuilder, WomValueSimpleton}
 import cromwell.core.{CallOutputs, WorkflowId}
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql._
@@ -94,8 +95,8 @@ class CallCache(database: CallCachingSqlDatabase) {
     database.queryResultsForCacheId(callCachingEntryId.id)
   }
 
-  def cacheEntryExistsForCall(workflowUuid: String, callFqn: String, index: Int)(implicit ec: ExecutionContext): Future[Boolean] = {
-    database.cacheEntryExistsForCall(workflowUuid, callFqn, index)
+  def callCachingJoinForCall(workflowUuid: String, callFqn: String, index: Int)(implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {
+    database.callCacheJoinForCall(workflowUuid, callFqn, index)
   }
 
   def invalidate(callCachingEntryId: CallCachingEntryId)(implicit ec: ExecutionContext) = {
@@ -144,4 +145,29 @@ object CallCache {
                                            callOutputs: CallOutputs,
                                            jobDetritusFiles: Option[Map[String, Path]]
                                          )
+  
+  implicit class EnhancedCallCachingJoin(val callCachingJoin: CallCachingJoin) extends AnyVal {
+    def toJobSuccess(key: BackendJobDescriptorKey, pathBuilders: List[PathBuilder]) = {
+      import cromwell.Simpletons._
+      import cromwell.core.path.PathFactory._
+      val detritus = callCachingJoin.callCachingDetritusEntries.map({ jobDetritusEntry =>
+        jobDetritusEntry.detritusKey -> buildPath(jobDetritusEntry.detritusValue.toRawString, pathBuilders)
+      }).toMap
+
+      val outputs = if (callCachingJoin.callCachingSimpletonEntries.isEmpty) CallOutputs(Map.empty)
+      else WomValueBuilder.toJobOutputs(key.call.outputPorts, callCachingJoin.callCachingSimpletonEntries map toSimpleton)
+      
+      JobSucceededResponse(key, callCachingJoin.callCachingEntry.returnCode,outputs, Option(detritus), Seq.empty, None)
+    }
+    
+    def callCacheHashes: Set[HashResult] = {
+      val hashResults = callCachingJoin.callCachingHashEntries.map({
+        case CallCachingHashEntry(k, v, _, _) => HashResult(HashKey(k), HashValue(v)) 
+      }) ++ callCachingJoin.callCachingAggregationEntry.collect({
+        case CallCachingAggregationEntry(k, Some(v), _, _) => HashResult(HashKey(k), HashValue(v))
+      })
+
+      hashResults.toSet
+    }
+  }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -44,9 +44,9 @@ class CallCacheReadActor(cache: CallCache,
         }
       case call @ CallCacheEntryForCall(workflowId, jobKey) =>
         import cromwell.core.ExecutionIndex._
-        cache.cacheEntryExistsForCall(workflowId.toString, jobKey.call.fullyQualifiedName, jobKey.index.fromIndex) map {
-          case true => HasCallCacheEntry(call)
-          case false => NoCallCacheEntry(call)
+        cache.callCachingJoinForCall(workflowId.toString, jobKey.call.fullyQualifiedName, jobKey.index.fromIndex) map {
+          case Some(join) => join
+          case None => NoCallCacheEntry(call)
         }
     }
 
@@ -96,7 +96,6 @@ object CallCacheReadActor {
   final case class CacheLookupNextHit(hit: CallCachingEntryId) extends CallCacheReadActorResponse
   case object CacheLookupNoHit extends CallCacheReadActorResponse
 
-  final case class HasCallCacheEntry(call: CallCacheEntryForCall) extends CallCacheReadActorResponse
   final case class NoCallCacheEntry(call: CallCacheEntryForCall) extends CallCacheReadActorResponse
 
   // Failure Response

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -143,11 +143,9 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   // When we're restarting but the job store says the job is not complete.
   // This is to cover for the case where Cromwell was stopped after writing Cache Info to the DB but before
-  // writing to the JobStore. In that case, we don't want to cache to ourselves (turn cache read off), nor do we want to 
-  // try and write the cache info again, which would fail (turn cache write off).
-  // This means call caching should be disabled.
-  // Note that we check that there is not a Cache entry for *this* current job. It's still technically possible
-  // to call cache to another job that finished while this one was running (before the restart).
+  // writing to the JobStore. In that case, we can re-use the cached results and save them to the job store directly.
+  // Note that this checks that *this* particular job has a cache entry, not that there is *a* cache hit (possibly from another jobs)
+  // There's no need to copy the outputs because they're already *this* job's outputs
   when(CheckingCacheEntryExistence) {
     // There was already a cache entry for this job
     case Event(join: CallCachingJoin, NoData) =>

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -149,6 +149,9 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     // There was already a cache entry for this job
     case Event(join: CallCachingJoin, NoData) =>
       Try(join.toJobSuccess(jobDescriptorKey, factory.pathBuilders(initializationData))).map({ jobSuccess =>
+        // We can't create a CallCacheHashes to give to the SucceededResponseData here because it involves knowledge of
+        // which hashes are file hashes and which are not. We can't know that (nor do we care) when pulling them from the 
+        // database. So instead manually publish the hashes here.
         publishHashResultsToMetadata(Option(Success(join.callCacheHashes)))
         saveJobCompletionToJobStore(SucceededResponseData(jobSuccess, None))
       }).recover({

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
@@ -6,13 +6,14 @@ import cromwell.core.Tags.DbmsTest
 import cromwell.core.WorkflowId
 import cromwell.database.slick.EngineSlickDatabase
 import cromwell.database.sql.joins.CallCachingJoin
-import cromwell.database.sql.tables.{CallCachingAggregationEntry, CallCachingEntry, CallCachingHashEntry}
+import cromwell.database.sql.tables._
 import cromwell.services.EngineServicesStore
 import cromwell.services.ServicesStore.EnhancedSqlDatabase
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.specs2.mock.Mockito
+import cromwell.database.sql.SqlConverters._
 
 import scala.concurrent.ExecutionContext
 
@@ -30,9 +31,11 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
     lazy val dataAccess = new EngineSlickDatabase(databaseConfig)
       .initialized(EngineServicesStore.EngineLiquibaseSettings)
 
+    val idA = WorkflowId.randomId().toString
+    val callA = "AwesomeWorkflow.GoodJob"
     val callCachingEntryA = CallCachingEntry(
-      WorkflowId.randomId().toString,
-      "AwesomeWorkflow.GoodJob",
+      idA,
+      callA,
       1,
       None,
       None,
@@ -54,6 +57,14 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
       )
     )
 
+    val callCachingSimpletonsA = Seq(
+      CallCachingSimpletonEntry("simpleKey", "simpleValue".toClobOption, "string")
+    )
+
+    val callCachingDetritusesA = Seq(
+      CallCachingDetritusEntry("detritusKey", "detritusValue".toClobOption)
+    )
+
     val aggregation = Option(CallCachingAggregationEntry("BASE_AGGREGATION", Option("FILE_AGGREGATION")))
 
     it should "honor allowResultReuse" taggedAs DbmsTest in {
@@ -63,7 +74,7 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
             callCachingEntryA,
             callCachingHashEntriesA,
             aggregation,
-            Seq.empty, Seq.empty
+            callCachingSimpletonsA, callCachingDetritusesA
           )
         ),
           100
@@ -76,6 +87,27 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
         _ = hasHashPairMatch shouldBe false
         hit <- dataAccess.findCacheHitForAggregation("BASE_AGGREGATION", Option("FILE_AGGREGATION"), 1)
         _ = hit shouldBe empty
+      } yield ()).futureValue
+    }
+
+    it should "retrieve CallCacheJoin for call" taggedAs DbmsTest in {
+      (for {
+        join <- dataAccess.callCacheJoinForCall(idA, callA, 1)
+        _ = join shouldBe defined
+        getJoin = join.get
+        // We can't compare directly because the ones out from the DB have IDs filled in, so just compare the relevant values
+        _ = getJoin
+          .callCachingHashEntries
+          .map(e => (e.hashKey, e.hashValue)) should contain theSameElementsAs callCachingHashEntriesA.map(e => (e.hashKey, e.hashValue))
+        _ = getJoin
+          .callCachingSimpletonEntries
+          .map(e => (e.simpletonKey, e.simpletonValue.map(_.toRawString)))should contain theSameElementsAs callCachingSimpletonsA.map(e => (e.simpletonKey, e.simpletonValue.map(_.toRawString)))
+        _ = getJoin
+          .callCachingAggregationEntry
+          .map(e => (e.baseAggregation, e.inputFilesAggregation)) shouldBe aggregation.map(e => (e.baseAggregation, e.inputFilesAggregation))
+        _ = getJoin
+          .callCachingDetritusEntries
+          .map(e => (e.detritusKey, e.detritusValue.map(_.toRawString))) should contain theSameElementsAs callCachingDetritusesA.map(e => (e.detritusKey, e.detritusValue.map(_.toRawString)))
       } yield ()).futureValue
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,7 @@ object Dependencies {
   val shapelessV = "2.3.2"
   val slf4jV = "1.7.24"
   val slickV = "3.2.3"
+  val slickCatsV = "0.7.1"
   val snakeyamlV = "1.17"
   val specs2MockV = "3.8.9" // 3.9.X doesn't enjoy the spark backend or refined
   val sprayJsonV = "1.3.3"
@@ -172,7 +173,8 @@ object Dependencies {
 
   private val slickDependencies = List(
     "com.typesafe.slick" %% "slick" % slickV,
-    "com.typesafe.slick" %% "slick-hikaricp" % slickV
+    "com.typesafe.slick" %% "slick-hikaricp" % slickV,
+    "com.rms.miu" %% "slick-cats" % slickCatsV
   )
 
   private val liquibaseDependencies = List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
   val shapelessV = "2.3.2"
   val slf4jV = "1.7.24"
   val slickV = "3.2.3"
-  val slickCatsV = "0.7.1"
+  val slickCatsV = "0.7-MF"
   val snakeyamlV = "1.17"
   val specs2MockV = "3.8.9" // 3.9.X doesn't enjoy the spark backend or refined
   val sprayJsonV = "1.3.3"

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCacheEntryExistenceSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCacheEntryExistenceSpec.scala
@@ -1,24 +1,29 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
-import cromwell.core.callcaching.CallCachingOff
-import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
+import cromwell.database.sql.joins.CallCachingJoin
+import cromwell.database.sql.tables._
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.RequestValueStore
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec.EnhancedTestEJEA
+import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
+import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
 
 class EjeaCheckingCacheEntryExistenceSpec extends EngineJobExecutionActorSpec {
 
   override implicit val stateUnderTest = CheckingJobStore
 
   "An EJEA in EjeaCheckingCacheEntryExistence state should" should {
-    "disable call caching and prepare job if a cache entry already exists for this job" in {
+    "re-use the results from the cache hit" in {
       createCheckingCacheEntryExistenceEjea()
       
-      ejea ! HasCallCacheEntry(CallCacheEntryForCall(helper.workflowId, helper.jobDescriptorKey))
-      helper.replyToProbe.expectMsg(RequestValueStore)
-      ejea.stateName should be(WaitingForValueStore)
-      
-      ejea.underlyingActor.effectiveCallCachingMode shouldBe CallCachingOff
+      ejea ! CallCachingJoin(CallCachingEntry(helper.workflowId.toString, helper.jobFqn, 0, None, None, allowResultReuse = true),
+        List.empty,
+        None,
+        List.empty,
+        List.empty
+      )
+      helper.jobStoreProbe.expectMsgClass(classOf[RegisterJobCompleted])
+      ejea.stateName should be(UpdatingJobStore)
     }
 
     "prepare job if no cache entry already exists" in {

--- a/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
+++ b/supportedBackends/spark/src/main/scala/cromwell/backend/impl/spark/SparkBackendFactory.scala
@@ -5,6 +5,7 @@ import cromwell.backend._
 import cromwell.backend.io.JobPathsWithDocker
 import cromwell.backend.sfs.SharedFileSystemExpressionFunctions
 import cromwell.core.CallContext
+import cromwell.core.path.DefaultPathBuilder
 import wom.expression.IoFunctionSet
 import wom.graph.CommandCallNode
 
@@ -37,4 +38,6 @@ case class SparkBackendFactory(name: String, configurationDescriptor: BackendCon
 
     new SharedFileSystemExpressionFunctions(SparkJobExecutionActor.DefaultPathBuilders, callContext, ioActorProxy, ec)
   }
+
+  override def pathBuilders(initializationDataOption: Option[BackendInitializationData]) = List(DefaultPathBuilder)
 }


### PR DESCRIPTION
See https://github.com/broadinstitute/cromwell/issues/3074 for a description of the problem

This re-uses the values from the cache instead of re-running the job.
The call cache capoeira test was failing in centaur intermittently because a side effect of the issue was that the hashes were not published to metadata, which was failing the test.