### PR TITLE
Correct HPC tutorial config error

### DIFF
--- a/docs/tutorials/HPCIntro.md
+++ b/docs/tutorials/HPCIntro.md
@@ -36,11 +36,7 @@ The `actor-factory` above tells cromwell that you will be using the `config` sec
 You'll likely also want to change the default backend to your new backend, by setting this configuration value:
 
 ```hocon
-backend {
-  providers {
-    default = SGE
-  }
-}
+backend.default = SGE
 ```
 
 #### Specifying the runtime attributes for your HPC tasks


### PR DESCRIPTION
The HPC tutorial config causes the server to error. 