### PR TITLE
Docs: Explicity invoke bash in SGE, instead of relying on #!

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -307,7 +307,7 @@ backend {
         String? docker
         String? docker_user
         """
-        submit = "/bin/bash ${script}"
+        submit = "/usr/bin/env bash ${script}"
         submit-docker = """
           # run as in the original configuration without --rm flag (will remove later)
           docker run \

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -252,7 +252,7 @@ backend {
         """
 
         # Submit string when there is no "docker" runtime attribute.
-        submit = "/bin/bash ${script}"
+        submit = "/usr/bin/env bash ${script}"
 
         # Submit string when there is a "docker" runtime attribute.
         submit-docker = """
@@ -395,7 +395,7 @@ backend {
     #    ${"-l mem_free=" + memory_gb + "g"} \
     #    ${"-q " + sge_queue} \
     #    ${"-P " + sge_project} \
-    #    bash ${script}
+    #    /usr/bin/env bash ${script}
     #    """
     #
     #    kill = "qdel ${job_id}"
@@ -407,7 +407,7 @@ backend {
     #LSF {
     #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
     #  config {
-    #    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /bin/bash ${script}"
+    #    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /usr/bin/env bash ${script}"
     #    kill = "bkill ${job_id}"
     #    check-alive = "bjobs ${job_id}"
     #    job-id-regex = "Job <(\\d+)>.*"
@@ -428,7 +428,7 @@ backend {
     #        sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
     #        ${"-n " + cpus} \
     #        --mem-per-cpu=${requested_memory_mb_per_core} \
-    #        --wrap "/bin/bash ${script}"
+    #        --wrap "/usr/bin/env bash ${script}"
     #    """
     #    kill = "scancel ${job_id}"
     #    check-alive = "squeue -j ${job_id}"

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -386,7 +386,7 @@ backend {
     #    qsub \
     #    -terse \
     #    -V \
-    #    -b n \
+    #    -b y \
     #    -N ${job_name} \
     #    -wd ${cwd} \
     #    -o ${out} \
@@ -395,7 +395,7 @@ backend {
     #    ${"-l mem_free=" + memory_gb + "g"} \
     #    ${"-q " + sge_queue} \
     #    ${"-P " + sge_project} \
-    #    ${script}
+    #    bash ${script}
     #    """
     #
     #    kill = "qdel ${job_id}"

--- a/docs/backends/LSF.md
+++ b/docs/backends/LSF.md
@@ -4,7 +4,7 @@ The following configuration can be used as a base to allow Cromwell to interact 
 LSF {
   actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
   config {
-    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /bin/bash ${script}"
+    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /usr/bin/env bash ${script}"
     kill = "bkill ${job_id}"
     check-alive = "bjobs ${job_id}"
     job-id-regex = "Job <(\\d+)>.*"

--- a/docs/tutorials/HPCIntro.md
+++ b/docs/tutorials/HPCIntro.md
@@ -146,7 +146,7 @@ qsub -terse -V -b y -N my_job_name \
   -o /path/to/stdout \
   -e /path/to/stderr \
   -pe smp 1 -l mem_free=0.5g -q short \
-  bash myScript.bash
+  /usr/bin/env bash myScript.bash
 ```
 
 For this particular SGE cluster, the above sets the working directory, stdout and stderr paths, the number of cpus to 1, the memory to half a gigabyte, and runs on the short queue.
@@ -168,7 +168,7 @@ backend.providers.SGE.config {
   ${"-l mem_free=" + memory_gb + "g"} \
   ${"-q " + sge_queue} \
   ${"-P " + sge_project} \
-  /bin/bash ${script}
+  /usr/bin/env bash ${script}
   """
 }
 ```
@@ -245,11 +245,11 @@ backend {
         ${"-l mem_free=" + memory_gb + "g"} \
         ${"-q " + sge_queue} \
         ${"-P " + sge_project} \
-        /bin/bash ${script}
+        /usr/bin/env bash ${script}
         """
-    
+
         job-id-regex = "(\\d+)"
-    
+
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
       }

--- a/docs/tutorials/HPCIntro.md
+++ b/docs/tutorials/HPCIntro.md
@@ -141,12 +141,12 @@ backend.providers.SGE.config {
 When Cromwell runs a task, it will fill in a template for the job using the declared runtime attributes. This specific template will vary depending on the requirements of your HPC cluster. For example, say you normally submit jobs to SGE using:
 
 ```bash
-qsub -terse -V -b n -N my_job_name \
+qsub -terse -V -b y -N my_job_name \
   -wd /path/to/working_directory \
   -o /path/to/stdout \
   -e /path/to/stderr \
   -pe smp 1 -l mem_free=0.5g -q short \
-  myScript.bash
+  bash myScript.bash
 ```
 
 For this particular SGE cluster, the above sets the working directory, stdout and stderr paths, the number of cpus to 1, the memory to half a gigabyte, and runs on the short queue.
@@ -159,7 +159,7 @@ backend.providers.SGE.config {
   qsub \
   -terse \
   -V \
-  -b n \
+  -b y \
   -N ${job_name} \
   -wd ${cwd} \
   -o ${out} \
@@ -168,7 +168,7 @@ backend.providers.SGE.config {
   ${"-l mem_free=" + memory_gb + "g"} \
   ${"-q " + sge_queue} \
   ${"-P " + sge_project} \
-  ${script}
+  /bin/bash ${script}
   """
 }
 ```
@@ -236,7 +236,7 @@ backend {
         qsub \
         -terse \
         -V \
-        -b n \
+        -b y \
         -N ${job_name} \
         -wd ${cwd} \
         -o ${out} \
@@ -245,7 +245,7 @@ backend {
         ${"-l mem_free=" + memory_gb + "g"} \
         ${"-q " + sge_queue} \
         ${"-P " + sge_project} \
-        ${script}
+        /bin/bash ${script}
         """
     
         job-id-regex = "(\\d+)"


### PR DESCRIPTION
SGE defaults to csh, and at least in my environment, even with #!/bin/bash bash was not launched in the job. This could well just be a quirk of my environment, and I am happy if you decide to not take this change. However it seems like a more generally robust default for different environments.