### PR TITLE
Write workflow heartbeats.

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -173,12 +173,19 @@ system {
     object = 128000
   }
 
-  # Rate at which Cromwell updates it's instrumentation gauge metrics (e.g: Number of workflows running, queued, etc..)
+  # Rate at which Cromwell updates its instrumentation gauge metrics (e.g: Number of workflows running, queued, etc..)
   instrumentation-rate = 5 seconds
   
   job-rate-control {
     jobs = 50
     per = 1 second
+  }
+
+  workflow-heartbeats {
+    heartbeat-interval: 2 minutes
+    ttl: 10 minutes
+    write-batch-size: 10000
+    write-threshold: 10000
   }
 }
 

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -11,7 +11,6 @@ import scala.concurrent.duration._
 /**
   * By removing the periodic flush and setting the batch size to 1,
   * this actor modifies the behavior of BatchActor so that it throttles processing commands one at a time.
-  * Having 
   */
 abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
   override protected def logOnStartUp = false

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -8,7 +8,7 @@ import cromwell.database.sql.SqlDatabase
 import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
-import slick.jdbc.{JdbcCapabilities, JdbcProfile, MySQLProfile}
+import slick.jdbc.{JdbcCapabilities, JdbcProfile}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -72,6 +72,13 @@ trait WorkflowStoreEntryComponent {
     } yield workflowStoreEntry
   )
 
+  val heartbeatForWorkflowStoreEntry = Compiled(
+    (workflowExecutionUuid: Rep[String]) => for {
+      workflowStoreEntry <- workflowStoreEntries
+      if workflowStoreEntry.workflowExecutionUuid === workflowExecutionUuid
+    } yield workflowStoreEntry.heartbeatTimestamp
+  )
+
   /**
     * Returns up to "limit" startable workflows, sorted by submission time.
     */

--- a/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
@@ -59,6 +59,8 @@ ____    __    ____  ______   .______       __  ___  _______  __        ______   
   def fetchStartableWorkflows(limit: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                              (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]]
 
+  def writeWorkflowHeartbeats(workflowExecutionUuids: List[String])(implicit ec: ExecutionContext): Future[Int]
+
   /**
     * Clears out cromwellId and heartbeatTimestamp for all workflow store entries currently assigned
     * the specified cromwellId.

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -12,7 +12,7 @@ import cromwell.core.{WorkflowAborted, WorkflowId}
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.WorkflowActor._
 import cromwell.engine.workflow.WorkflowManagerActor._
-import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStoreEngineActor}
+import cromwell.engine.workflow.workflowstore.{WorkflowHeartbeatConfig, WorkflowStoreActor, WorkflowStoreEngineActor}
 import cromwell.jobstore.JobStoreActor.{JobStoreWriteFailure, JobStoreWriteSuccess, RegisterWorkflowCompleted}
 import cromwell.webservice.EngineStatsActor
 import net.ceedubs.ficus.Ficus._
@@ -51,10 +51,23 @@ object WorkflowManagerActor {
             dockerHashActor: ActorRef,
             jobTokenDispenserActor: ActorRef,
             backendSingletonCollection: BackendSingletonCollection,
-            serverMode: Boolean): Props = {
-    val params = WorkflowManagerActorParams(ConfigFactory.load, workflowStore, ioActor, serviceRegistryActor,
-      workflowLogCopyRouter, jobStoreActor, subWorkflowStoreActor, callCacheReadActor, callCacheWriteActor,
-      dockerHashActor, jobTokenDispenserActor, backendSingletonCollection, serverMode)
+            serverMode: Boolean,
+            workflowHeartbeatConfig: WorkflowHeartbeatConfig): Props = {
+    val params = WorkflowManagerActorParams(
+      config = ConfigFactory.load,
+      workflowStore = workflowStore,
+      ioActor = ioActor,
+      serviceRegistryActor = serviceRegistryActor,
+      workflowLogCopyRouter = workflowLogCopyRouter,
+      jobStoreActor = jobStoreActor,
+      subWorkflowStoreActor = subWorkflowStoreActor,
+      callCacheReadActor = callCacheReadActor,
+      callCacheWriteActor = callCacheWriteActor,
+      dockerHashActor = dockerHashActor,
+      jobTokenDispenserActor = jobTokenDispenserActor,
+      backendSingletonCollection = backendSingletonCollection,
+      serverMode = serverMode,
+      workflowHeartbeatConfig = workflowHeartbeatConfig)
     Props(new WorkflowManagerActor(params)).withDispatcher(EngineDispatcher)
   }
 
@@ -99,7 +112,8 @@ case class WorkflowManagerActorParams(config: Config,
                                       dockerHashActor: ActorRef,
                                       jobTokenDispenserActor: ActorRef,
                                       backendSingletonCollection: BackendSingletonCollection,
-                                      serverMode: Boolean)
+                                      serverMode: Boolean,
+                                      workflowHeartbeatConfig: WorkflowHeartbeatConfig)
 
 class WorkflowManagerActor(params: WorkflowManagerActorParams)
   extends LoggingFSM[WorkflowManagerState, WorkflowManagerData] with WorkflowMetadataHelper {
@@ -261,10 +275,24 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       logger.info(s"$tag Starting workflow UUID($workflowId)")
     }
 
-    val wfProps = WorkflowActor.props(workflowId, workflow.state, workflow.sources, config, params.ioActor, params.serviceRegistryActor,
-      params.workflowLogCopyRouter, params.jobStoreActor, params.subWorkflowStoreActor, params.callCacheReadActor, params.callCacheWriteActor,
-      params.dockerHashActor, params.jobTokenDispenserActor,
-      params.backendSingletonCollection, params.serverMode)
+    val wfProps = WorkflowActor.props(
+      workflowId = workflowId,
+      startMode = workflow.state,
+      workflowSourceFilesCollection = workflow.sources,
+      conf = config,
+      ioActor = params.ioActor,
+      serviceRegistryActor = params.serviceRegistryActor,
+      workflowLogCopyRouter = params.workflowLogCopyRouter,
+      jobStoreActor = params.jobStoreActor,
+      subWorkflowStoreActor = params.subWorkflowStoreActor,
+      callCacheReadActor = params.callCacheReadActor,
+      callCacheWriteActor = params.callCacheWriteActor,
+      dockerHashActor = params.dockerHashActor,
+      jobTokenDispenserActor = params.jobTokenDispenserActor,
+      workflowStoreActor = params.workflowStore,
+      backendSingletonCollection = params.backendSingletonCollection,
+      serverMode = params.serverMode,
+      workflowHeartbeatConfig = params.workflowHeartbeatConfig)
     val wfActor = context.actorOf(wfProps, name = s"WorkflowActor-$workflowId")
 
     wfActor ! SubscribeTransitionCallBack(self)

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
@@ -70,6 +70,9 @@ class InMemoryWorkflowStore extends WorkflowStore {
       Future.successful(None)
     }
   }
+
+  override def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int] =
+    Future.successful(workflowIds.size)
 }
 
 final case class SubmittedWorkflow(id: WorkflowId, sources: WorkflowSourceFilesCollection)

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -53,6 +53,10 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
     }
   }
 
+  override def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int] = {
+    sqlDatabase.writeWorkflowHeartbeats(workflowIds map { _.toString })
+  }
+
   /**
     * Adds the requested WorkflowSourceFiles to the store and returns a WorkflowId for each one (in order)
     * for tracking purposes.

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfig.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfig.scala
@@ -1,0 +1,64 @@
+package cromwell.engine.workflow.workflowstore
+
+import java.util.UUID
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.circe.generic.auto._
+import io.circe.literal._
+import io.circe.syntax._
+import io.circe._
+import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+
+/**
+  *
+  * @param cromwellId         Identifier for this Cromwell for horizontaling purposes.
+  * @param heartbeatInterval  How long between `WorkflowActor` heartbeats and `WorkflowStoreHeartbeatWriteActor` database flushes.
+  * @param ttl                Entries in the workflow store with heartbeats older than `ttl` ago are presumed abandoned and up for grabs.
+  * @param writeBatchSize     The maximum size of a write batch.
+  * @param writeThreshold     The threshold of heartbeat writes above which load is considered high.
+  */
+case class WorkflowHeartbeatConfig(
+                                    cromwellId: String,
+                                    heartbeatInterval: FiniteDuration,
+                                    ttl: FiniteDuration,
+                                    writeBatchSize: Int,
+                                    writeThreshold: Int)
+{
+
+  // An `Encoder[FiniteDuration]` is needed for the `.asJson.toString()` shenanigans below. Unfortunately the compiler
+  // appears to get confused about this encoder actually being used. If this is made fully private or a local the compiler
+  // wrongly emits a warning about it being unused, which our compiler flag settings then promote to an error.
+  private [engine] implicit val finiteDurationEncoder: Encoder[FiniteDuration] = (d: FiniteDuration) => d.toString.asJson
+
+  override def toString: String = this.asJson.toString()
+}
+
+object WorkflowHeartbeatConfig {
+
+  def apply(config: Config): WorkflowHeartbeatConfig = {
+    val cromwellId: String = config.as[Option[String]]("system.cromwell_id").getOrElse("cromid-" + UUID.randomUUID().toString.take(7))
+
+    val heartbeats: Config = config.getOrElse("system.workflow-heartbeats", ConfigFactory.empty())
+    // Default to 10 minutes and don't allow values less than 10 seconds even for testing purposes.
+    val minHeartbeatTtl = 10 seconds
+    val ttl: FiniteDuration = heartbeats.getOrElse("ttl", 10 minutes).max(minHeartbeatTtl)
+    // Default to one third the TTL and don't allow values less than one third of the minimum heartbeat TTL.
+    val heartbeatInterval: FiniteDuration = heartbeats.getOrElse("heartbeat-interval", ttl / 3).max(minHeartbeatTtl / 3)
+
+    // Default and sanity bound all other parameters as well.
+    val writeBatchSize: Int = Math.max(heartbeats.getOrElse("write-batch-size", 100), 1)
+    val writeThreshold: Int = Math.max(heartbeats.getOrElse("write-threshold", 100), 1)
+
+    WorkflowHeartbeatConfig(
+      cromwellId = cromwellId,
+      heartbeatInterval = heartbeatInterval,
+      ttl = ttl,
+      writeBatchSize = writeBatchSize,
+      writeThreshold = writeThreshold
+    )
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -29,5 +29,7 @@ trait WorkflowStore {
     */
   def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
 
+  def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int]
+
   def remove(id: WorkflowId)(implicit ec: ExecutionContext): Future[Boolean]
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActor.scala
@@ -1,0 +1,53 @@
+package cromwell.engine.workflow.workflowstore
+
+import akka.actor.{ActorRef, Props}
+import cats.data.{NonEmptyList, NonEmptyVector}
+import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.core.WorkflowId
+import cromwell.core.instrumentation.InstrumentationPrefixes
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowStoreWriteHeartbeatCommand
+import cromwell.services.EnhancedBatchActor
+
+import scala.concurrent.Future
+
+case class WorkflowStoreHeartbeatWriteActor(workflowStore: WorkflowStore,
+                                            workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+                                            override val serviceRegistryActor: ActorRef)
+
+  extends EnhancedBatchActor[WorkflowId](
+    flushRate = workflowHeartbeatConfig.heartbeatInterval,
+    batchSize = workflowHeartbeatConfig.writeBatchSize) {
+
+  override val threshold = workflowHeartbeatConfig.writeThreshold
+
+  /**
+    * Process the data asynchronously
+    *
+    * @return the number of elements processed
+    */
+  override protected def process(data: NonEmptyVector[WorkflowId]): Future[Int] = instrumentedProcess {
+    workflowStore.writeWorkflowHeartbeats(data.toVector.toList)
+  }
+
+  override def receive = enhancedReceive.orElse(super.receive)
+  override protected def weightFunction(command: WorkflowId) = 1
+  override protected def instrumentationPath = NonEmptyList.of("store", "heartbeat-writes")
+  override protected def instrumentationPrefix = InstrumentationPrefixes.WorkflowPrefix
+  override def commandToData(snd: ActorRef): PartialFunction[Any, WorkflowId] = {
+    case command: WorkflowStoreWriteHeartbeatCommand => command.workflowId
+  }
+}
+
+object WorkflowStoreHeartbeatWriteActor {
+  def props(
+             workflowStoreDatabase: WorkflowStore,
+             workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+             serviceRegistryActor: ActorRef
+           ): Props =
+    Props(
+      WorkflowStoreHeartbeatWriteActor(
+        workflowStore = workflowStoreDatabase,
+        workflowHeartbeatConfig = workflowHeartbeatConfig,
+        serviceRegistryActor = serviceRegistryActor
+      )).withDispatcher(EngineDispatcher)
+}

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -1,7 +1,5 @@
 package cromwell.server
 
-import java.util.UUID
-
 import akka.actor.SupervisorStrategy.{Escalate, Restart}
 import akka.actor.{Actor, ActorInitializationException, ActorLogging, ActorRef, OneForOneStrategy}
 import akka.event.Logging
@@ -10,9 +8,9 @@ import akka.pattern.GracefulStopSupport
 import akka.routing.RoundRobinPool
 import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
+import cromwell.core._
 import cromwell.core.actor.StreamActorHelper.ActorRestartException
 import cromwell.core.io.Throttle
-import cromwell.core._
 import cromwell.docker.DockerHashActor
 import cromwell.docker.DockerHashActor.DockerHashContext
 import cromwell.docker.local.DockerCliFlow
@@ -27,7 +25,7 @@ import cromwell.engine.workflow.WorkflowManagerActor.AbortAllWorkflowsCommand
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCache, CallCacheReadActor, CallCacheWriteActor}
 import cromwell.engine.workflow.lifecycle.finalization.CopyWorkflowLogsActor
 import cromwell.engine.workflow.tokens.{DynamicRateLimiter, JobExecutionTokenDispenserActor}
-import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowStore, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowHeartbeatConfig, WorkflowStore, WorkflowStoreActor}
 import cromwell.jobstore.{JobStore, JobStoreActor, SqlJobStore}
 import cromwell.services.{EngineServicesStore, ServiceRegistryActor}
 import cromwell.subworkflowstore.{SqlSubWorkflowStore, SubWorkflowStoreActor}
@@ -60,11 +58,8 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   private val config = ConfigFactory.load()
   private implicit val system = context.system
 
-  val cromwellId: String = config.as[Option[String]]("system.cromwell_id").getOrElse("cromid-" + UUID.randomUUID().toString.take(7))
-
-  // Entries in the workflow store with heartbeats older than heartbeatTtl ago are presumed abandoned and up for grabs.
-  val DefaultWorkflowStoreHeartbeatTtl: FiniteDuration = 1.hour
-  val heartbeatTtl: FiniteDuration = config.getOrElse("system.workflow_heartbeat_ttl", DefaultWorkflowStoreHeartbeatTtl)
+  private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(config)
+  logger.info("Workflow heartbeat configuation:\n{}", workflowHeartbeatConfig)
 
   val serverMode: Boolean
 
@@ -74,7 +69,12 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
 
   lazy val workflowStore: WorkflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
   lazy val workflowStoreActor =
-    context.actorOf(WorkflowStoreActor.props(workflowStore, serviceRegistryActor, abortJobsOnTerminate, cromwellId, heartbeatTtl), "WorkflowStoreActor")
+    context.actorOf(WorkflowStoreActor.props(
+      workflowStoreDatabase = workflowStore,
+      serviceRegistryActor = serviceRegistryActor,
+      abortAllJobsOnTerminate = abortJobsOnTerminate,
+      workflowHeartbeatConfig = workflowHeartbeatConfig),
+      "WorkflowStoreActor")
 
   lazy val jobStore: JobStore = new SqlJobStore(EngineServicesStore.engineDatabaseInterface)
   lazy val jobStoreActor = context.actorOf(JobStoreActor.props(jobStore, serviceRegistryActor), "JobStoreActor")
@@ -135,14 +135,25 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
 
   lazy val workflowManagerActor = context.actorOf(
     WorkflowManagerActor.props(
-      workflowStoreActor, ioActorProxy, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, subWorkflowStoreActor, callCacheReadActor, callCacheWriteActor,
-      dockerHashActor, jobExecutionTokenDispenserActor, backendSingletonCollection, serverMode),
+      workflowStore = workflowStoreActor,
+      ioActor = ioActorProxy,
+      serviceRegistryActor = serviceRegistryActor,
+      workflowLogCopyRouter = workflowLogCopyRouter,
+      jobStoreActor = jobStoreActor,
+      subWorkflowStoreActor = subWorkflowStoreActor,
+      callCacheReadActor = callCacheReadActor,
+      callCacheWriteActor = callCacheWriteActor,
+      dockerHashActor = dockerHashActor,
+      jobTokenDispenserActor = jobExecutionTokenDispenserActor,
+      backendSingletonCollection = backendSingletonCollection,
+      serverMode = serverMode,
+      workflowHeartbeatConfig = workflowHeartbeatConfig),
     "WorkflowManagerActor")
 
   if (gracefulShutdown) {
     // If abortJobsOnTerminate is true, aborting all workflows will be handled by the graceful shutdown process
     CromwellShutdown.registerShutdownTasks(
-      cromwellId = cromwellId,
+      cromwellId = workflowHeartbeatConfig.cromwellId,
       abortJobsOnTerminate,
       actorSystem = context.system,
       workflowManagerActor = workflowManagerActor,

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -11,15 +11,16 @@ import cromwell.core.{SimpleIoActor, WorkflowId, WorkflowSourceFilesWithoutImpor
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.WorkflowActor
 import cromwell.engine.workflow.WorkflowActor._
-import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
-import cromwell.engine.workflow.workflowstore.Submitted
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
+import cromwell.engine.workflow.workflowstore.{Submitted, WorkflowHeartbeatConfig}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.HelloWorld.Addressee
 import org.scalatest.BeforeAndAfter
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
+import scala.language.postfixOps
 
 object SimpleWorkflowActorSpec {
 
@@ -50,8 +51,9 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
     val promise = Promise[Unit]()
     val watchActor = system.actorOf(MetadataWatchActor.props(promise, matchers: _*), s"service-registry-$workflowId-${UUID.randomUUID()}")
     val supervisor = TestProbe()
+    val config = ConfigFactory.load()
     val workflowActor = TestFSMRef(
-      factory = new WorkflowActor(workflowId, Submitted, workflowSources, ConfigFactory.load(),
+      factory = new WorkflowActor(workflowId, Submitted, workflowSources, config,
         ioActor = system.actorOf(SimpleIoActor.props),
         serviceRegistryActor = watchActor,
         workflowLogCopyRouter = system.actorOf(Props.empty, s"workflow-copy-log-router-$workflowId-${UUID.randomUUID()}"),
@@ -62,7 +64,9 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
         dockerHashActor = system.actorOf(EmptyDockerHashActor.props),
         jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second))),
         backendSingletonCollection = BackendSingletonCollection(Map("Local" -> None)),
-        serverMode = true),
+        serverMode = true,
+        workflowStoreActor = system.actorOf(Props.empty),
+        workflowHeartbeatConfig = WorkflowHeartbeatConfig(config)),
       supervisor = supervisor.ref,
       name = s"workflow-actor-$workflowId"
     )

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -17,7 +17,7 @@ import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
-import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
@@ -26,6 +26,7 @@ import spray.json._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util._
 
 /**
@@ -56,8 +57,9 @@ object SingleWorkflowRunnerActorSpec {
 }
 
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec with Mockito {
+  private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
   private val workflowStore =
-    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, cromwellId = "f00ba4", heartbeatTtl = 1.hour))
+    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
   private val serviceRegistry = TestProbe().ref
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
   private val ioActor = system.actorOf(SimpleIoActor.props)
@@ -81,7 +83,8 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec wit
       dockerHashActor = dockerHashActor,
       jobTokenDispenserActor = jobTokenDispenserActor,
       backendSingletonCollection = BackendSingletonCollection(Map.empty),
-      serverMode = false)
+      serverMode = false,
+      workflowHeartbeatConfig)
     system.actorOf(Props(new WorkflowManagerActor(params)), "WorkflowManagerActor")
   }
   

--- a/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.engine.workflow
 
-import akka.actor.{Actor, ActorRef}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.testkit.{TestActorRef, TestFSMRef, TestProbe}
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell._
@@ -16,12 +16,13 @@ import cromwell.engine.workflow.lifecycle.finalization.CopyWorkflowLogsActor
 import cromwell.engine.workflow.lifecycle.finalization.WorkflowFinalizationActor.{StartFinalizationCommand, WorkflowFinalizationSucceededResponse}
 import cromwell.engine.workflow.lifecycle.initialization.WorkflowInitializationActor.{WorkflowInitializationAbortedResponse, WorkflowInitializationFailedResponse}
 import cromwell.engine.workflow.lifecycle.materialization.MaterializeWorkflowDescriptorActor.MaterializeWorkflowDescriptorFailureResponse
-import cromwell.engine.workflow.workflowstore.{StartableState, Submitted}
+import cromwell.engine.workflow.workflowstore.{StartableState, Submitted, WorkflowHeartbeatConfig}
 import cromwell.util.SampleWdl.ThreeStep
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.Eventually
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorBuilder with BeforeAndAfter with Eventually {
   override implicit val actorSystem = system
@@ -51,6 +52,8 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
     copyWorkflowLogsProbe = TestProbe()
   }
 
+  private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
+
   private def createWorkflowActor(state: WorkflowActorState) = {
     val actor = TestFSMRef(
       factory = new MockWorkflowActor(
@@ -67,7 +70,9 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
         callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props),
         callCacheWriteActor = system.actorOf(EmptyCallCacheWriteActor.props),
         dockerHashActor = system.actorOf(EmptyDockerHashActor.props),
-        jobTokenDispenserActor = TestProbe().ref
+        jobTokenDispenserActor = TestProbe().ref,
+        workflowStoreActor = system.actorOf(Props.empty),
+        workflowHeartbeatConfig = workflowHeartbeatConfig
       ),
       supervisor = supervisorProbe.ref)
     actor.setState(stateName = state, stateData = WorkflowActorData(Option(currentLifecycleActor.ref), Option(descriptor),
@@ -186,7 +191,26 @@ class MockWorkflowActor(val finalizationProbe: TestProbe,
                         callCacheReadActor: ActorRef,
                         callCacheWriteActor: ActorRef,
                         dockerHashActor: ActorRef,
-                        jobTokenDispenserActor: ActorRef) extends WorkflowActor(workflowId, startState, workflowSources, conf, ioActor, serviceRegistryActor, workflowLogCopyRouter, jobStoreActor, subWorkflowStoreActor, callCacheReadActor, callCacheWriteActor, dockerHashActor, jobTokenDispenserActor, BackendSingletonCollection(Map.empty), serverMode = true) {
+                        jobTokenDispenserActor: ActorRef,
+                        workflowStoreActor: ActorRef,
+                        workflowHeartbeatConfig: WorkflowHeartbeatConfig) extends WorkflowActor(
+  workflowId = workflowId,
+  initialStartableState = startState,
+  workflowSourceFilesCollection = workflowSources,
+  conf = conf,
+  ioActor = ioActor,
+  serviceRegistryActor = serviceRegistryActor,
+  workflowLogCopyRouter = workflowLogCopyRouter,
+  jobStoreActor = jobStoreActor,
+  subWorkflowStoreActor = subWorkflowStoreActor,
+  callCacheReadActor = callCacheReadActor,
+  callCacheWriteActor = callCacheWriteActor,
+  dockerHashActor = dockerHashActor,
+  jobTokenDispenserActor = jobTokenDispenserActor,
+  backendSingletonCollection = BackendSingletonCollection(Map.empty),
+  workflowStoreActor = workflowStoreActor,
+  serverMode = true,
+  workflowHeartbeatConfig = workflowHeartbeatConfig) {
 
   override def makeFinalizationActor(workflowDescriptor: EngineWorkflowDescriptor, jobExecutionMap: JobExecutionMap, worfklowOutputs: CallOutputs) = finalizationProbe.ref
 }

--- a/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -1,13 +1,14 @@
 package cromwell.subworkflowstore
 
 import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
 import cromwell.CromwellTestKitWordSpec
 import cromwell.core.ExecutionIndex._
 import cromwell.core.{JobKey, WorkflowId, WorkflowSourceFilesWithoutImports}
 import cromwell.database.sql.tables.SubWorkflowStoreEntry
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
 import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.WorkflowSubmittedToStore
-import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor}
 import cromwell.services.EngineServicesStore
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import cromwell.subworkflowstore.SubWorkflowStoreSpec._
@@ -32,7 +33,8 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
       val subWorkflowStoreService = system.actorOf(SubWorkflowStoreActor.props(subWorkflowStore))
 
       lazy val workflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
-      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false, cromwellId = "f00ba4", heartbeatTtl = 1.hour))
+      val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
+      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
 
       val parentWorkflowId = WorkflowId.randomId()
       val subWorkflowId = WorkflowId.randomId()

--- a/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/CromwellInstrumentation.scala
@@ -1,9 +1,9 @@
 package cromwell.services.instrumentation
 
-import akka.actor.{Actor, ActorRef, Cancellable, Timers}
+import akka.actor.{Actor, ActorRef, Cancellable}
 import cats.data.NonEmptyList
 import com.typesafe.config.ConfigFactory
-import cromwell.services.instrumentation.CromwellInstrumentation.{InstrumentationPath, _}
+import cromwell.services.instrumentation.CromwellInstrumentation._
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
 import net.ceedubs.ficus.Ficus._
 


### PR DESCRIPTION
The current heartbeat-scanning code is incorrect and will attempt to relaunch workflows an hour after they start. Fortunately there is an error check that prevents workflows from actually being restarted but this situation is still less than ideal since these workflows cycle back to the top of the runnable queue an hour later (running workflows will have submission times earlier than submitted-but-never-started workflows and the sort is by submission time). Also some semi-alarming warning messages are generated for these failed starts.

These changes should fix this problem by actually writing workflow heartbeats for running workflows. The current vitality logic is simply "is this workflow actor not dead".