### PR TITLE
Add some tests to CromIAM

### DIFF
--- a/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
+++ b/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
@@ -103,10 +103,7 @@ object CromwellClient {
     import Collection.collectionJsonReader
 
     def caasCollection: Option[Collection] = {
-      wl.labels.fields.get(CollectionLabelName) map {
-        _.convertTo[Collection]
-      }
+      wl.labels.fields.get(CollectionLabelName).map(_.convertTo[Collection])
     }
   }
-
 }

--- a/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
+++ b/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
@@ -34,7 +34,7 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
 
   override val statusUri = uri"$cromwellUrl/engine/$cromwellApiVersion/status"
 
-  val cromwellApiClient: CromwellApiClient =  new CromwellApiClient(cromwellUrl, cromwellApiVersion)
+  val cromwellApiClient: CromwellApiClient = new CromwellApiClient(cromwellUrl, cromwellApiVersion)
 
   def collectionForWorkflow(workflowId: String, user: User): Future[Collection] = {
     import CromwellClient.EnhancedWorkflowLabels
@@ -42,7 +42,7 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
     log.info("Requesting collection for " + workflowId + " for user " + user.userId + " from metadata")
 
     // Look up in Cromwell what the collection is for this workflow. If it doesn't exist, fail the Future
-    cromwellApiClient.labels(WorkflowId.fromString(workflowId), headers=List(user.authorization)) flatMap {
+    cromwellApiClient.labels(WorkflowId.fromString(workflowId), headers = List(user.authorization)) flatMap {
       _.caasCollection match {
         case Some(c) => Future.successful(c)
         case None => Future.failed(new IllegalArgumentException(s"Workflow $workflowId has no associated collection"))
@@ -51,11 +51,11 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
   }
 
   def forwardToCromwell(httpRequest: HttpRequest): Future[HttpResponse] = {
-      val headers = httpRequest.headers.filterNot(header => header.name == TimeoutAccessHeader)
-      val cromwellRequest = httpRequest
-        .copy(uri = httpRequest.uri.withAuthority(interface, port).withScheme(scheme))
-        .withHeaders(headers)
-      Http().singleRequest(cromwellRequest)
+    val headers = httpRequest.headers.filterNot(header => header.name == TimeoutAccessHeader)
+    val cromwellRequest = httpRequest
+      .copy(uri = httpRequest.uri.withAuthority(interface, port).withScheme(scheme))
+      .withHeaders(headers)
+    Http().singleRequest(cromwellRequest)
   } recoverWith {
     case e => Future.failed(CromwellConnectionFailure(e))
   }
@@ -83,8 +83,8 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
       root workflow ID itself
      */
     cromwellApiClient.metadata(WorkflowId.fromString(workflowId),
-      args=Option(Map("includeKey" -> List("rootWorkflowId"))),
-      headers=List(user.authorization)).map(metadataToRootWorkflowId)
+      args = Option(Map("includeKey" -> List("rootWorkflowId"))),
+      headers = List(user.authorization)).map(metadataToRootWorkflowId)
   }
 }
 
@@ -98,10 +98,15 @@ object CromwellClient {
   final case class CromwellConnectionFailure(f: Throwable) extends Exception(s"Unable to connect to Cromwell (${f.getMessage})", f)
 
   implicit class EnhancedWorkflowLabels(val wl: WorkflowLabels) extends AnyVal {
+
     import Collection.CollectionLabelName
     import Collection.collectionJsonReader
+
     def caasCollection: Option[Collection] = {
-      wl.labels.fields.get(CollectionLabelName) map { _.convertTo[Collection] }
+      wl.labels.fields.get(CollectionLabelName) map {
+        _.convertTo[Collection]
+      }
     }
   }
+
 }

--- a/CromIAM/src/test/scala/cromiam/cromwell/CromwellClientSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/cromwell/CromwellClientSpec.scala
@@ -1,0 +1,108 @@
+package cromiam.cromwell
+
+import java.net.URL
+
+import akka.actor.ActorSystem
+import akka.event.NoLogging
+import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.stream.ActorMaterializer
+import cromiam.auth.User
+import cromwell.api.model.{WorkflowId, WorkflowLabels, WorkflowMetadata}
+import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
+import cromwell.api.{CromwellClient => CromwellApiClient}
+import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import spray.json.{JsObject, JsString}
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+
+class CromwellClientSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
+  import CromwellClientSpec._
+
+  import ExecutionContext.Implicits.global
+
+  implicit val actorSystem: ActorSystem = ActorSystem("CromwellClientSpec")
+  implicit val ece: ExecutionContextExecutor = actorSystem.dispatcher
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  val cromwellClient = new MockCromwellClient()
+
+  override protected def afterAll(): Unit = {
+    actorSystem.terminate()
+    super.afterAll()
+  }
+
+  "CromwellClient" should "eventually return a subworkflow's root workflow id" in {
+    cromwellClient.getRootWorkflow(SubworkflowId.id.toString, FictitousUser).map(w => assert(w == RootWorkflowId.id.toString))
+  }
+
+  it should "eventually return a top level workflow's ID when requesting root workflow id" in {
+    cromwellClient.getRootWorkflow(RootWorkflowId.id.toString, FictitousUser).map(w => assert(w == RootWorkflowId.id.toString))
+  }
+
+  it should "properly fetch the collection for a workflow with a collection name" in {
+    cromwellClient.collectionForWorkflow(RootWorkflowId.id.toString, FictitousUser).map(c =>
+      assert(c.name == CollectionName)
+    )
+  }
+
+  it should "throw an exception if the workflow doesn't have a collection" in {
+    recoverToExceptionIf[IllegalArgumentException] {
+      cromwellClient.collectionForWorkflow(WorkflowIdWithoutCollection.id.toString, FictitousUser)
+    } map { exception =>
+      assert(exception.getMessage == s"Workflow $WorkflowIdWithoutCollection has no associated collection")
+    }
+  }
+}
+
+object CromwellClientSpec {
+  final class MockCromwellClient()(implicit system: ActorSystem,
+                                   ece: ExecutionContextExecutor,
+                                   materializer: ActorMaterializer)
+  extends CromwellClient("http", "bar", 1, NoLogging) {
+    override val cromwellApiClient: CromwellApiClient = new MockCromwellApiClient()
+  }
+
+  final class MockCromwellApiClient()(implicit actorSystem: ActorSystem, materializer: ActorMaterializer)
+    extends CromwellApiClient(new URL("http://foo.com"), "bar") {
+
+    override def labels(workflowId: WorkflowId, headers: List[HttpHeader] = defaultHeaders)(implicit ec: ExecutionContext): Future[WorkflowLabels] = {
+      if (workflowId == RootWorkflowId) Future.successful(FictitiousWorkflowLabelsWithCollection)
+      else if (workflowId == WorkflowIdWithoutCollection) Future.successful(FictitiousWorkflowLabelsWithoutCollection)
+      else Future.failed(new RuntimeException("Unexpected workflow ID sent to MockCromwelApiClient"))
+    }
+
+    override def metadata(workflowId: WorkflowId,
+                 args: Option[Map[String, List[String]]] = None,
+                 headers: List[HttpHeader] = defaultHeaders
+                )(implicit ec: ExecutionContext): Future[WorkflowMetadata] = {
+      if (workflowId == RootWorkflowId) Future.successful(RootWorkflowMetadata)
+      else if (workflowId == SubworkflowId) Future.successful(SubWorkflowMetadata)
+      else Future.failed(new RuntimeException("Unexpected workflow ID sent to MockCromwellApiClient"))
+    }
+  }
+
+  private val SubworkflowId = WorkflowId.fromString("58114f5c-f439-4488-8d73-092273cf92d9")
+  private val RootWorkflowId = WorkflowId.fromString("998d137e-7213-44ac-8f6f-24e6e23adaa5")
+  private val WorkflowIdWithoutCollection = WorkflowId.fromString("472234d-7213-44ac-8f6f-24e6e23adaa5")
+
+  val FictitousUser = User(WorkbenchUserId("123456780"), Authorization(OAuth2BearerToken("my-token")))
+
+  val RootWorkflowMetadata = WorkflowMetadata("""{
+                                               "workflowName": "wf_echo",
+                                               "calls": {},
+                                               "id": "998d137e-7213-44ac-8f6f-24e6e23adaa5"
+                                             }""")
+
+  val SubWorkflowMetadata = WorkflowMetadata("""{
+                                                "workflowName": "wf_echo",
+                                                "calls": {},
+                                                "id": "58114f5c-f439-4488-8d73-092273cf92d9",
+                                                "rootWorkflowId": "998d137e-7213-44ac-8f6f-24e6e23adaa5"
+                                              }""")
+
+  val CollectionName = "foo"
+  val FictitiousWorkflowLabelsWithCollection = WorkflowLabels(RootWorkflowId.id.toString, JsObject(Map("caas-collection-name" -> JsString(CollectionName))))
+  val FictitiousWorkflowLabelsWithoutCollection = WorkflowLabels(RootWorkflowId.id.toString, JsObject(Map("something" -> JsString("foo"))))
+}
+

--- a/CromIAM/src/test/scala/cromiam/cromwell/CromwellClientSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/cromwell/CromwellClientSpec.scala
@@ -33,22 +33,22 @@ class CromwellClientSpec extends AsyncFlatSpec with Matchers with BeforeAndAfter
   }
 
   "CromwellClient" should "eventually return a subworkflow's root workflow id" in {
-    cromwellClient.getRootWorkflow(SubworkflowId.id.toString, FictitousUser).map(w => assert(w == RootWorkflowId.id.toString))
+    cromwellClient.getRootWorkflow(SubworkflowId.id.toString, FictitiousUser).map(w => assert(w == RootWorkflowId.id.toString))
   }
 
   it should "eventually return a top level workflow's ID when requesting root workflow id" in {
-    cromwellClient.getRootWorkflow(RootWorkflowId.id.toString, FictitousUser).map(w => assert(w == RootWorkflowId.id.toString))
+    cromwellClient.getRootWorkflow(RootWorkflowId.id.toString, FictitiousUser).map(w => assert(w == RootWorkflowId.id.toString))
   }
 
   it should "properly fetch the collection for a workflow with a collection name" in {
-    cromwellClient.collectionForWorkflow(RootWorkflowId.id.toString, FictitousUser).map(c =>
+    cromwellClient.collectionForWorkflow(RootWorkflowId.id.toString, FictitiousUser).map(c =>
       assert(c.name == CollectionName)
     )
   }
 
   it should "throw an exception if the workflow doesn't have a collection" in {
     recoverToExceptionIf[IllegalArgumentException] {
-      cromwellClient.collectionForWorkflow(WorkflowIdWithoutCollection.id.toString, FictitousUser)
+      cromwellClient.collectionForWorkflow(WorkflowIdWithoutCollection.id.toString, FictitiousUser)
     } map { exception =>
       assert(exception.getMessage == s"Workflow $WorkflowIdWithoutCollection has no associated collection")
     }
@@ -69,7 +69,7 @@ object CromwellClientSpec {
     override def labels(workflowId: WorkflowId, headers: List[HttpHeader] = defaultHeaders)(implicit ec: ExecutionContext): Future[WorkflowLabels] = {
       if (workflowId == RootWorkflowId) Future.successful(FictitiousWorkflowLabelsWithCollection)
       else if (workflowId == WorkflowIdWithoutCollection) Future.successful(FictitiousWorkflowLabelsWithoutCollection)
-      else Future.failed(new RuntimeException("Unexpected workflow ID sent to MockCromwelApiClient"))
+      else Future.failed(new RuntimeException("Unexpected workflow ID sent to MockCromwellApiClient"))
     }
 
     override def metadata(workflowId: WorkflowId,
@@ -86,7 +86,7 @@ object CromwellClientSpec {
   private val RootWorkflowId = WorkflowId.fromString("998d137e-7213-44ac-8f6f-24e6e23adaa5")
   private val WorkflowIdWithoutCollection = WorkflowId.fromString("472234d-7213-44ac-8f6f-24e6e23adaa5")
 
-  val FictitousUser = User(WorkbenchUserId("123456780"), Authorization(OAuth2BearerToken("my-token")))
+  val FictitiousUser = User(WorkbenchUserId("123456780"), Authorization(OAuth2BearerToken("my-token")))
 
   val RootWorkflowMetadata = WorkflowMetadata("""{
                                                "workflowName": "wf_echo",

--- a/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
@@ -21,10 +21,13 @@ import cromwell.api.CromwellClient._
 
 import scala.util.{Failure, Success, Try}
 
-class CromwellClient(val cromwellUrl: URL, val apiVersion: String, val credentials: Option[HttpCredentials]=None)(implicit actorSystem: ActorSystem, materializer: ActorMaterializer) {
+class CromwellClient(val cromwellUrl: URL,
+                     val apiVersion: String,
+                     val defaultCredentials: Option[HttpCredentials]=None)
+                    (implicit actorSystem: ActorSystem, materializer: ActorMaterializer) {
 
-  lazy val authHeader = credentials.map { Authorization(_) }
-  lazy val commonHeaders = authHeader.toList
+  lazy val defaultAuthorization: Option[Authorization] = defaultCredentials.map { Authorization(_) }
+  lazy val defaultHeaders: List[HttpHeader] = defaultAuthorization.toList
 
   lazy val engineEndpoint = s"$cromwellUrl/engine/$apiVersion"
   lazy val submitEndpoint = s"$cromwellUrl/api/workflows/$apiVersion"
@@ -104,26 +107,34 @@ class CromwellClient(val cromwellUrl: URL, val apiVersion: String, val credentia
   def abort(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowStatus] = simpleRequest[CromwellStatus](uri = abortEndpoint(workflowId), method = HttpMethods.POST) map WorkflowStatus.apply
   def status(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowStatus] = simpleRequest[CromwellStatus](statusEndpoint(workflowId)) map WorkflowStatus.apply
 
-  def metadata(workflowId: WorkflowId, args: Option[Map[String, List[String]]] = None)(implicit ec: ExecutionContext): Future[WorkflowMetadata] = {
-    simpleRequest[String](metadataEndpoint(workflowId)) map WorkflowMetadata
+  def metadata(workflowId: WorkflowId,
+               args: Option[Map[String, List[String]]] = None,
+               headers: List[HttpHeader] = defaultHeaders
+               )(implicit ec: ExecutionContext): Future[WorkflowMetadata] = {
+    simpleRequest[String](metadataEndpoint(workflowId), headers=headers) map WorkflowMetadata
   }
 
   def outputs(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowOutputs] = simpleRequest[WorkflowOutputs](outputsEndpoint(workflowId))
-  def labels(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowLabels] = simpleRequest[WorkflowLabels](labelsEndpoint(workflowId))
+
+  def labels(workflowId: WorkflowId, headers: List[HttpHeader] = defaultHeaders)(implicit ec: ExecutionContext): Future[WorkflowLabels] = {
+    simpleRequest[WorkflowLabels](labelsEndpoint(workflowId), headers=headers)
+  }
+
   def logs(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowLogs] = simpleRequest[WorkflowLogsStruct](outputsEndpoint(workflowId)) map WorkflowLogs.apply
   def callCacheDiff(workflowA: WorkflowId, callA: String, shardIndexA: ShardIndex, workflowB: WorkflowId, callB: String, shardIndexB: ShardIndex)(implicit ec: ExecutionContext): Future[CallCacheDiff] =
     simpleRequest[CallCacheDiff](diffEndpoint(workflowA, callA, shardIndexA, workflowB, callB, shardIndexB))
   def backends(implicit ec: ExecutionContext): Future[CromwellBackends] = simpleRequest[CromwellBackends](backendsEndpoint)
   def version(implicit ec: ExecutionContext): Future[CromwellVersion] = simpleRequest[CromwellVersion](versionEndpoint)
 
-  private [api] def executeRequest(request: HttpRequest) = Http().singleRequest(request.withHeaders(commonHeaders))
+  private [api] def executeRequest(request: HttpRequest, headers: List[HttpHeader]) = Http().singleRequest(request.withHeaders(headers))
 
   /**
     *
     * @tparam A The type of response expected. Must be supported by an implicit unmarshaller from ResponseEntity.
     */
-  private def makeRequest[A](request: HttpRequest)(implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = for {
-    response <- executeRequest(request)
+  private def makeRequest[A](request: HttpRequest, headers: List[HttpHeader] = defaultHeaders)
+                            (implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = for {
+    response <- executeRequest(request, headers)
     decoded <- Future.fromTry(decodeResponse(response))
     entity <- Future.fromTry(decoded.toEntity)
     unmarshalled <- unmarshall(response, entity)(um, ec)
@@ -136,7 +147,12 @@ class CromwellClient(val cromwellUrl: URL, val apiVersion: String, val credentia
     else entity.to[CromwellFailedResponseException] flatMap Future.failed
   }
 
-  private def simpleRequest[A](uri: String, method: HttpMethod = HttpMethods.GET)(implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = makeRequest[A](HttpRequest(uri = uri, method = method))
+  private def simpleRequest[A](uri: String,
+                               method: HttpMethod = HttpMethods.GET,
+                               headers: List[HttpHeader] = defaultHeaders)
+                              (implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = {
+    makeRequest[A](HttpRequest(uri = uri, method = method), headers)
+  }
 
   private val decoders = Map(
     HttpEncodings.gzip -> Gzip,

--- a/cromwellApiClient/src/test/scala/cromwell/api/CromwellResponseFailedSpec.scala
+++ b/cromwellApiClient/src/test/scala/cromwell/api/CromwellResponseFailedSpec.scala
@@ -22,7 +22,7 @@ class CromwellResponseFailedSpec extends TestKit(ActorSystem()) with AsyncFlatSp
   
   "CromwellAPIClient" should "try to fail the Future with a CromwellFailedResponseException if the HttpResponse is unsuccessful" in {
     val client = new CromwellClient(new URL("http://fakeurl"), "v1") {
-      override def executeRequest(request: HttpRequest): Future[HttpResponse] = Future.successful(
+      override def executeRequest(request: HttpRequest, headers: List[HttpHeader]): Future[HttpResponse] = Future.successful(
         new HttpResponse(StatusCodes.ServiceUnavailable, List.empty[HttpHeader], HttpEntity(ContentTypes.`application/json`,
           """{
             |  "status": "fail",


### PR DESCRIPTION
- Allow CromIAM to specify headers per-request and thus use a single instance of the API CromwellClient
- Make use of the above to provide a few unit tests in CromIAM CromwellClient