### PR TITLE
Pluggable filesystems

### DIFF
--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -83,7 +83,7 @@ case class BackendConfigurationDescriptor(backendConfig: Config, globalConfig: C
     else
       None
 
-  private lazy val configuredPathBuilderFactories: Map[String, PathBuilderFactory] = {
+  private [backend] lazy val configuredPathBuilderFactories: Map[String, PathBuilderFactory] = {
     CromwellFileSystems.instance.factoriesFromConfig(backendConfig).unsafe("Failed to instantiate backend filesystem")
   }
 

--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -1,15 +1,19 @@
 package cromwell.backend
 
 import _root_.wdl.draft2.model._
+import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import common.validation.Validation._
 import cromwell.core.WorkflowOptions.WorkflowOption
 import cromwell.core.callcaching.MaybeCallCachingEligible
+import cromwell.core.filesystem.CromwellFileSystems
 import cromwell.core.labels.Labels
+import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilderFactory}
 import cromwell.core.{CallKey, WorkflowId, WorkflowOptions}
 import cromwell.services.keyvalue.KeyValueServiceActor.KvResponse
 import wom.callable.ExecutableCallable
-import wom.graph.GraphNodePort.OutputPort
 import wom.graph.CommandCallNode
+import wom.graph.GraphNodePort.OutputPort
 import wom.values.{WomEvaluatedCallInputs, WomValue}
 
 import scala.util.Try
@@ -78,6 +82,28 @@ case class BackendConfigurationDescriptor(backendConfig: Config, globalConfig: C
       Option(backendConfig.getConfig("default-runtime-attributes"))
     else
       None
+
+  private lazy val configuredPathBuilderFactories: Map[String, PathBuilderFactory] = {
+    CromwellFileSystems.instance.factoriesFromConfig(backendConfig).unsafe("Failed to instantiate backend filesystem")
+  }
+
+  private lazy val configuredFactoriesWithDefault = if (configuredPathBuilderFactories.values.exists(_ == DefaultPathBuilderFactory)) {
+    configuredPathBuilderFactories
+  } else configuredPathBuilderFactories + DefaultPathBuilderFactory.tuple
+
+  /**
+    * Creates path builders using only the configured factories.
+    */
+  def pathBuilders(workflowOptions: WorkflowOptions)(implicit as: ActorSystem) = {
+    PathBuilderFactory.instantiatePathBuilders(configuredPathBuilderFactories.values.toList, workflowOptions)
+  }
+
+  /**
+    * Creates path builders using only the configured factories + the default factory
+    */
+  def pathBuildersWithDefault(workflowOptions: WorkflowOptions)(implicit as: ActorSystem) = {
+    PathBuilderFactory.instantiatePathBuilders(configuredFactoriesWithDefault.values.toList, workflowOptions)
+  }
 }
 
 final case class AttemptedLookupResult(name: String, value: Try[WomValue]) {

--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -82,9 +82,12 @@ case class BackendConfigurationDescriptor(backendConfig: Config, globalConfig: C
       Option(backendConfig.getConfig("default-runtime-attributes"))
     else
       None
+  
+  // So it can be overridden in tests
+  private [backend] lazy val cromwellFileSystems = CromwellFileSystems.instance
 
   private [backend] lazy val configuredPathBuilderFactories: Map[String, PathBuilderFactory] = {
-    CromwellFileSystems.instance.factoriesFromConfig(backendConfig).unsafe("Failed to instantiate backend filesystem")
+    cromwellFileSystems.factoriesFromConfig(backendConfig).unsafe("Failed to instantiate backend filesystem")
   }
 
   private lazy val configuredFactoriesWithDefault = if (configuredPathBuilderFactories.values.exists(_ == DefaultPathBuilderFactory)) {

--- a/backend/src/main/scala/cromwell/backend/standard/StandardInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardInitializationActor.scala
@@ -6,7 +6,7 @@ import cromwell.backend.validation.RuntimeAttributesDefault
 import cromwell.backend.wfs.WorkflowPathBuilder
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor, BackendWorkflowInitializationActor}
 import cromwell.core.WorkflowOptions
-import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
+import cromwell.core.path.PathBuilder
 import wom.expression.WomExpression
 import wom.graph.CommandCallNode
 import wom.values.WomValue
@@ -44,6 +44,8 @@ case class DefaultInitializationActorParams
 class StandardInitializationActor(val standardParams: StandardInitializationActorParams)
   extends BackendWorkflowInitializationActor {
 
+  implicit protected val system = context.system
+
   override lazy val serviceRegistryActor: ActorRef = standardParams.serviceRegistryActor
 
   override lazy val calls: Set[CommandCallNode] = standardParams.calls
@@ -57,7 +59,7 @@ class StandardInitializationActor(val standardParams: StandardInitializationActo
 
   lazy val expressionFunctions: Class[_ <: StandardExpressionFunctions] = classOf[StandardExpressionFunctions]
 
-  lazy val pathBuilders: Future[List[PathBuilder]] = Future.successful(List(DefaultPathBuilder))
+  lazy val pathBuilders: Future[List[PathBuilder]] = standardParams.configurationDescriptor.pathBuilders(workflowDescriptor.workflowOptions)
 
   lazy val workflowPaths: Future[WorkflowPaths] =
     pathBuilders map { WorkflowPathBuilder.workflowPaths(configurationDescriptor, workflowDescriptor, _) }
@@ -70,7 +72,7 @@ class StandardInitializationActor(val standardParams: StandardInitializationActo
     * @return runtime attributes builder with possible custom validations
     */
   def runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder =
-      StandardValidatedRuntimeAttributesBuilder.default(configurationDescriptor.backendRuntimeConfig)
+    StandardValidatedRuntimeAttributesBuilder.default(configurationDescriptor.backendRuntimeConfig)
 
   override protected lazy val runtimeAttributeValidators: Map[String, (Option[WomExpression]) => Boolean] = {
     runtimeAttributesBuilder.validatorMap

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
@@ -3,8 +3,6 @@ package centaur.cwl
 import better.files.File
 import com.typesafe.config.Config
 import common.validation.Parse.{Parse, _}
-import common.validation.Validation._
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.core.path.Obsolete.Paths
 import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilderFactory}
 import cromwell.filesystems.gcs.GcsPathBuilderFactory
@@ -62,15 +60,13 @@ case object LocalRunMode extends CentaurCwlRunnerRunMode {
 }
 
 case class PapiRunMode(conf: Config) extends CentaurCwlRunnerRunMode {
-  private lazy val googleConf = GoogleConfiguration(conf)
-  private lazy val authName = conf.getString("google.auth")
-  private lazy val auth = googleConf.auth(authName).toTry.get
+  private lazy val googleConfig = conf.getConfig("google")
   private lazy val preprocessor = new PAPIPreprocessor(conf)
 
-  override lazy val description: String = s"papi $authName"
+  override lazy val description: String = s"papi ${googleConfig.getString("auth")}"
 
   override lazy val pathBuilderFactory: PathBuilderFactory = {
-    GcsPathBuilderFactory(auth, googleConf.applicationName, None)
+    GcsPathBuilderFactory(conf, googleConfig)
   }
 
   override def preProcessWorkflow(workflow: String): String = preprocessor.preProcessWorkflow(workflow)

--- a/common/src/main/scala/common/validation/Validation.scala
+++ b/common/src/main/scala/common/validation/Validation.scala
@@ -59,6 +59,12 @@ object Validation {
       case Valid(options) => Success(options)
       case Invalid(err) => Failure(AggregatedMessageException(context, err.toList))
     }
+    
+    def unsafe(context: String): A = e.valueOr(errors => throw AggregatedMessageException(context, errors.toList))
+  }
+
+  implicit class ValidationChecked[A](val e: Checked[A]) extends AnyVal {
+    def unsafe(context: String): A = e.valueOr(errors => throw AggregatedMessageException(context, errors.toList))
   }
 
   implicit class OptionValidation[A](val o: Option[A]) extends AnyVal {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -235,8 +235,8 @@ google {
   ]
 }
 # Filesystems available in this Crowmell instance
-# They can be enabled individually in the engine.filesystems stanza and in the config.filesystems sanza of backends
-# There is a default built-in local filesytem that can also be reference as "local" as well.
+# They can be enabled individually in the engine.filesystems stanza and in the config.filesystems stanza of backends
+# There is a default built-in local filesytem that can also be referenced as "local" as well.
 filesystems {
   gcs {
     class = "cromwell.filesystems.gcs.GcsPathBuilderFactory"

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -234,6 +234,17 @@ google {
     }
   ]
 }
+# Filesystems available in this Crowmell instance
+# They can be enabled individually in the engine.filesystems stanza and in the config.filesystems sanza of backends
+# There is a default built-in local filesytem that can also be reference as "local" as well.
+filesystems {
+  gcs {
+    class = "cromwell.filesystems.gcs.GcsPathBuilderFactory"
+  }
+  oss {
+    class = "cromwell.filesystems.oss.OssPathBuilderFactory"
+  }
+}
 
 docker {
   hash-lookup {

--- a/core/src/main/scala/cromwell/core/filesystem/CromwellFileSystems.scala
+++ b/core/src/main/scala/cromwell/core/filesystem/CromwellFileSystems.scala
@@ -1,0 +1,101 @@
+package cromwell.core.filesystem
+
+import java.lang.reflect.Constructor
+
+import cats.instances.list._
+import cats.syntax.either._
+import cats.syntax.traverse._
+import cats.syntax.validated._
+import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
+import common.Checked
+import common.validation.Checked._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilderFactory}
+import net.ceedubs.ficus.Ficus._
+import shapeless.syntax.typeable._
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Try}
+
+/**
+  * Validates filesystem configuration and provide methods to build PathBuilderFactories.
+  */
+class CromwellFileSystems(globalConfig: Config) {
+  // Validate the configuration and creates a Map of PathBuilderFactory constructors
+  private [filesystem] val factoryBuilders: Map[String, Constructor[_]] = if (globalConfig.hasPath("filesystems")) {
+    val rawConfigSet = globalConfig.getObject("filesystems").entrySet.asScala
+    val configMap = rawConfigSet.toList.map({ entry => entry.getKey -> entry.getValue })
+    val constructorMap = configMap.traverse[ErrorOr, (String, Constructor[_])]({
+      case (key, fsConfig: ConfigObject) => createConstructor(key, fsConfig).toValidated
+      case (key, _) => s"Invalid filesystem configuration for $key".invalidNel
+    }).map(_.toMap)
+
+    constructorMap.unsafe("Failed to initialize Cromwell filesystems")
+  } else Map.empty
+
+  // Create a constructor from a configuration object
+  private def createConstructor(key: String, configObject: ConfigObject): Checked[(String, Constructor[_])] = for {
+    clazz <- configObject.toConfig.as[Option[String]]("class").toChecked(s"Filesystem configuration $key doesn't have a class field")
+    constructor <- createConstructor(key, clazz)
+  } yield constructor
+
+  // Create a constructor from a class name
+  private def createConstructor(filesystem: String, className: String): Checked[(String, Constructor[_])] = Try (
+    filesystem -> Class.forName(className).getConstructor(classOf[Config], classOf[Config])
+  ).recoverWith({
+    case e: ClassNotFoundException => Failure(
+      new RuntimeException(s"Class $className for filesystem $filesystem cannot be found in the class path.", e)
+    )
+    case e: NoSuchMethodException => Failure(
+      new RuntimeException(s"Class $className for filesystem $filesystem does not have the required constructor signature.", e)
+    )
+  }).toChecked
+
+  // Instantiate a PathBuilderFactor from its constructor and instance config
+  private def instantiate(name: String, constructor: Constructor[_], instanceConfig: Config): Checked[PathBuilderFactory] = {
+    for {
+      instance <- Try(constructor.newInstance(globalConfig, instanceConfig)).toChecked
+      cast <- instance.cast[PathBuilderFactory].toChecked(s"The filesystem class for $name is not an instance of PathBuilderFactory")
+    } yield cast
+  }
+
+  // Look for a constructor in the map of known filesystems
+  private def getConstructor(fileSystemName: String): Checked[Constructor[_]] = factoryBuilders
+    .get(fileSystemName)
+    .toChecked(s"Cannot find a filesystem with name $fileSystemName in the configuration. Available filesystems: ${factoryBuilders.keySet.mkString(", ")}")
+
+  /**
+    * Try to find a configured filesystem with the given name and to build a PathFactory for it
+    * @param name name of the filesystem
+    * @param instanceConfig filesystem specific configuration for this instance of the factory to build
+    */
+  def buildFactory(name: String, instanceConfig: Config): Checked[PathBuilderFactory] = {
+    if (DefaultPathBuilderFactory.name.equalsIgnoreCase(name)) DefaultPathBuilderFactory.validNelCheck
+    else for {
+      constructor <- getConstructor(name)
+      factory <- instantiate(name, constructor, instanceConfig)
+    } yield factory
+  }
+
+  /**
+    * Given a filesystems config, build the PathBuilderFactories
+    */
+  def factoriesFromConfig(filesystemsConfig: Config): Checked[Map[String, PathBuilderFactory]] = {
+    if (filesystemsConfig.hasPath("filesystems")) {
+      // Iterate over the config entries under the "filesystems" config
+      val rawConfigSet = filesystemsConfig.getObject("filesystems").entrySet().asScala
+      val configMap = rawConfigSet.toList.map({ entry => entry.getKey -> entry.getValue })
+
+      configMap.traverse[ErrorOr, (String, PathBuilderFactory)]({
+        // build the factory for each entry
+        case (key, config: ConfigObject) => buildFactory(key, config.toConfig).toValidated.map(key -> _)
+        case (key, _) => s"Invalid filesystem backend configuration for $key".invalidNel
+      }).map(_.toMap).toEither
+    } else Map.empty[String, PathBuilderFactory].validNelCheck
+  }
+}
+
+object CromwellFileSystems {
+  val instance = new CromwellFileSystems(ConfigFactory.load())
+}

--- a/core/src/main/scala/cromwell/core/filesystem/CromwellFileSystems.scala
+++ b/core/src/main/scala/cromwell/core/filesystem/CromwellFileSystems.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Try}
 
 /**
-  * Validates filesystem configuration and provide methods to build PathBuilderFactories.
+  * Validates filesystem configuration and provides methods to build PathBuilderFactories.
   */
 class CromwellFileSystems(globalConfig: Config) {
   // Validate the configuration and creates a Map of PathBuilderFactory constructors
@@ -40,7 +40,7 @@ class CromwellFileSystems(globalConfig: Config) {
     constructor <- createConstructor(key, clazz)
   } yield constructor
 
-  // Create a constructor from a class name
+  // Getting a constructor from a class name
   private def createConstructor(filesystem: String, className: String): Checked[(String, Constructor[_])] = Try (
     filesystem -> Class.forName(className).getConstructor(classOf[Config], classOf[Config])
   ).recoverWith({
@@ -48,11 +48,11 @@ class CromwellFileSystems(globalConfig: Config) {
       new RuntimeException(s"Class $className for filesystem $filesystem cannot be found in the class path.", e)
     )
     case e: NoSuchMethodException => Failure(
-      new RuntimeException(s"Class $className for filesystem $filesystem does not have the required constructor signature.", e)
+      new RuntimeException(s"Class $className for filesystem $filesystem does not have the required constructor signature: (com.typesafe.config.Config, com.typesafe.config.Config)", e)
     )
   }).toChecked
 
-  // Instantiate a PathBuilderFactor from its constructor and instance config
+  // Instantiate a PathBuilderFactory from its constructor and instance config
   private def instantiate(name: String, constructor: Constructor[_], instanceConfig: Config): Checked[PathBuilderFactory] = {
     for {
       instance <- Try(constructor.newInstance(globalConfig, instanceConfig)).toChecked
@@ -66,7 +66,7 @@ class CromwellFileSystems(globalConfig: Config) {
     .toChecked(s"Cannot find a filesystem with name $fileSystemName in the configuration. Available filesystems: ${factoryBuilders.keySet.mkString(", ")}")
 
   /**
-    * Try to find a configured filesystem with the given name and to build a PathFactory for it
+    * Try to find a configured filesystem with the given name and build a PathFactory for it
     * @param name name of the filesystem
     * @param instanceConfig filesystem specific configuration for this instance of the factory to build
     */

--- a/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/DefaultPathBuilderFactory.scala
@@ -7,4 +7,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case object DefaultPathBuilderFactory extends PathBuilderFactory {
   override def withOptions(options: WorkflowOptions)(implicit actorSystem: ActorSystem, ec: ExecutionContext) = Future.successful(DefaultPathBuilder)
+  val name = "local"
+  val tuple = name -> this
 }

--- a/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
@@ -2,8 +2,27 @@ package cromwell.core.path
 
 import akka.actor.ActorSystem
 import cromwell.core.WorkflowOptions
+import cats.syntax.traverse._
+import cats.instances.list._
+import cats.instances.future._
 
 import scala.concurrent.{ExecutionContext, Future}
+
+object PathBuilderFactory {
+  // Given a list of factories, instantiates the corresponding path builders
+  def instantiatePathBuilders(factories: List[PathBuilderFactory], workflowOptions: WorkflowOptions)(implicit as: ActorSystem): Future[List[PathBuilder]] = {
+    implicit val ec = as.dispatcher
+    // The DefaultPathBuilderFactory always needs to be last.
+    // The reason is path builders are tried in order, and the default one is very generous in terms of paths it "thinks" it supports
+    // For instance, it will return a Path for a gcs url even though it doesn't really supports it
+    val sortedFactories = factories.sortWith({
+      case (_, DefaultPathBuilderFactory) => true
+      case (DefaultPathBuilderFactory, _) => false
+      case (a, b) => factories.indexOf(a) < factories.indexOf(b)
+    })
+    sortedFactories.traverse(_.withOptions(workflowOptions))
+  }
+}
 
 /**
   * Provide a method that can instantiate a path builder with the specified workflow options.

--- a/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathBuilderFactory.scala
@@ -14,7 +14,7 @@ object PathBuilderFactory {
     implicit val ec = as.dispatcher
     // The DefaultPathBuilderFactory always needs to be last.
     // The reason is path builders are tried in order, and the default one is very generous in terms of paths it "thinks" it supports
-    // For instance, it will return a Path for a gcs url even though it doesn't really supports it
+    // For instance, it will return a Path for a gcs url even though it doesn't really support it
     val sortedFactories = factories.sortWith({
       case (_, DefaultPathBuilderFactory) => true
       case (DefaultPathBuilderFactory, _) => false

--- a/core/src/test/scala/cromwell/core/filesystem/CromwellFileSystemsSpec.scala
+++ b/core/src/test/scala/cromwell/core/filesystem/CromwellFileSystemsSpec.scala
@@ -61,7 +61,7 @@ class CromwellFileSystemsSpec extends FlatSpec with Matchers {
 
   val wrongSignatureException = AggregatedMessageException(
     "Failed to initialize Cromwell filesystems",
-    List("Class cromwell.core.filesystem.MockPathBuilderFactoryWrongSignature for filesystem fs1 does not have the required constructor signature.")
+    List("Class cromwell.core.filesystem.MockPathBuilderFactoryWrongSignature for filesystem fs1 does not have the required constructor signature: (com.typesafe.config.Config, com.typesafe.config.Config)")
   )
 
   val invalidConfigException = AggregatedMessageException(

--- a/core/src/test/scala/cromwell/core/filesystem/CromwellFileSystemsSpec.scala
+++ b/core/src/test/scala/cromwell/core/filesystem/CromwellFileSystemsSpec.scala
@@ -1,0 +1,92 @@
+package cromwell.core.filesystem
+
+import cats.data.NonEmptyList
+import com.typesafe.config.{Config, ConfigFactory}
+import common.exception.AggregatedMessageException
+import cromwell.core.path.MockPathBuilderFactory
+import org.scalatest.{FlatSpec, Matchers}
+
+class CromwellFileSystemsSpec extends FlatSpec with Matchers {
+  behavior of "CromwellFileSystems"
+
+  val globalConfig = ConfigFactory.parseString(
+    """
+      |filesystems {
+      |  fs1.class = "cromwell.core.path.MockPathBuilderFactory"
+      |  fs2.class = "cromwell.core.path.MockPathBuilderFactory"
+      |  fs3.class = "cromwell.core.filesystem.MockNotPathBuilderFactory"
+      |}
+    """.stripMargin)
+
+  val cromwellFileSystems = new CromwellFileSystems(globalConfig)
+  
+  it should "build factory builders and factories for valid configuration" in {
+    cromwellFileSystems.factoryBuilders.keySet shouldBe Set("fs1", "fs2", "fs3")
+    
+    val factoriesConfig = ConfigFactory.parseString(
+      """
+        |filesystems {
+        | fs1.somekey = "somevalue"
+        | fs2.someotherkey = "someothervalue"
+        |}
+      """.stripMargin)
+
+    val pathFactories = cromwellFileSystems.factoriesFromConfig(factoriesConfig)
+    pathFactories.isRight shouldBe true
+    val fs1 = pathFactories.right.get("fs1")
+    val fs2 = pathFactories.right.get("fs2")
+    fs1 shouldBe a[MockPathBuilderFactory]
+    fs2 shouldBe a[MockPathBuilderFactory]
+    fs1.asInstanceOf[MockPathBuilderFactory].instanceConfig.getString("somekey") shouldBe "somevalue"
+    fs2.asInstanceOf[MockPathBuilderFactory].instanceConfig.getString("someotherkey") shouldBe "someothervalue"
+  }
+
+  List(
+    ("if the filesystem does not exist", "filesystems.fs4.key = value", NonEmptyList.one("Cannot find a filesystem with name fs4 in the configuration. Available filesystems: fs1, fs2, fs3")),
+    ("if the config is invalid", "filesystems.fs1 = true", NonEmptyList.one("Invalid filesystem backend configuration for fs1")),
+    ("the class is not a PathBuilderFactory", "filesystems.fs3.key = value", NonEmptyList.one("The filesystem class for fs3 is not an instance of PathBuilderFactory"))
+  ) foreach {
+    case (description, config, expected) =>
+      it should s"fail to build factories $description" in {
+        val result = cromwellFileSystems.factoriesFromConfig(ConfigFactory.parseString(config))
+          result.isLeft shouldBe true
+        result.left.get shouldBe expected
+      }
+  }
+  
+  val classNotFoundException = AggregatedMessageException(
+    "Failed to initialize Cromwell filesystems",
+    List("Class do.not.exists for filesystem fs1 cannot be found in the class path.")
+  )
+
+  val wrongSignatureException = AggregatedMessageException(
+    "Failed to initialize Cromwell filesystems",
+    List("Class cromwell.core.filesystem.MockPathBuilderFactoryWrongSignature for filesystem fs1 does not have the required constructor signature.")
+  )
+
+  val invalidConfigException = AggregatedMessageException(
+    "Failed to initialize Cromwell filesystems",
+    List("Invalid filesystem configuration for gcs")
+  )
+
+  val missingClassFieldException = AggregatedMessageException(
+    "Failed to initialize Cromwell filesystems",
+    List("Filesystem configuration fs1 doesn't have a class field")
+  )
+  
+  List(
+    ("is invalid", "filesystems.gcs = true", invalidConfigException),
+    ("is missing class fields", "filesystems.fs1.notclass = hello", missingClassFieldException),
+    ("can't find class", "filesystems.fs1.class = do.not.exists", classNotFoundException),
+    ("has invalid class signature", "filesystems.fs1.class = cromwell.core.filesystem.MockPathBuilderFactoryWrongSignature", wrongSignatureException)
+  ) foreach {
+    case (description, config, expected) =>
+      it should s"fail if global filesystems config $description" in {
+        val ex = the[Exception] thrownBy { new CromwellFileSystems(ConfigFactory.parseString(config)) }
+        ex shouldBe expected
+      }
+  }
+}
+
+class MockPathBuilderFactoryWrongSignature()
+class MockNotPathBuilderFactory(globalConfig: Config, val instanceConfig: Config)

--- a/core/src/test/scala/cromwell/core/path/PathBuilderFactorySpec.scala
+++ b/core/src/test/scala/cromwell/core/path/PathBuilderFactorySpec.scala
@@ -1,0 +1,34 @@
+package cromwell.core.path
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{Config, ConfigFactory}
+import cromwell.core.{TestKitSuite, WorkflowOptions}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class PathBuilderFactorySpec extends TestKitSuite with FlatSpecLike with ScalaFutures with Matchers {
+  behavior of "PathBuilderFactory"
+  implicit val ec = system.dispatcher
+  
+  it should "sort factories when instantiating path builders" in {
+    val factory1 = new MockPathBuilderFactory(ConfigFactory.empty(), ConfigFactory.parseString("name=factory1"))
+    val factory2 = new MockPathBuilderFactory(ConfigFactory.empty(), ConfigFactory.parseString("name=factory2"))
+    PathBuilderFactory
+      .instantiatePathBuilders(List(DefaultPathBuilderFactory, factory1, factory2), WorkflowOptions.empty).map({ pathBuilders =>
+      pathBuilders.last shouldBe DefaultPathBuilder
+      // check that the order of the other factories has not been changed
+      pathBuilders.map(_.name) shouldBe List("factory1", "factory2", DefaultPathBuilder.name)
+    }).futureValue
+  }
+}
+
+class MockPathBuilderFactory(globalConfig: Config, val instanceConfig: Config) extends cromwell.core.path.PathBuilderFactory {
+  override def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = Future.successful(
+    new PathBuilder {
+      override def name = instanceConfig.getString("name")
+      override def build(pathAsString: String) = ???
+    }
+  )
+}

--- a/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineFilesystems.scala
@@ -1,70 +1,29 @@
 package cromwell.engine
 
 import akka.actor.ActorSystem
-import cats.data.Validated.{Invalid, Valid}
-import cats.instances.future._
-import cats.instances.list._
-import cats.syntax.traverse._
 import com.typesafe.config.{Config, ConfigFactory}
-import cromwell.cloudsupport.gcp.GoogleConfiguration
-import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
+import common.validation.Validation._
 import cromwell.core.WorkflowOptions
-import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.GcsPathBuilderFactory
-import common.exception.MessageAggregation
-import common.validation.ErrorOr.ErrorOr
-import cromwell.filesystems.oss.OssPathBuilderFactory
+import cromwell.core.filesystem.CromwellFileSystems
+import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilder, PathBuilderFactory}
 import net.ceedubs.ficus.Ficus._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
 
 object EngineFilesystems {
   private val config: Config = ConfigFactory.load
-  
-  private val gcsPathBuilderFactory: Try[Option[GcsPathBuilderFactory]] = Try {
-    // Parse the configuration and create a GoogleConfiguration
-    val googleConf: GoogleConfiguration = GoogleConfiguration(config)
-    // Extract the specified authentication mode for engine gcs filesystem, if any
-    val engineAuthModeAsString: Option[String] = config.as[Option[String]]("engine.filesystems.gcs.auth")
-    // Validate it agasint the google configuration
-    val engineAuthModeValidation: Option[ErrorOr[GoogleAuthMode]] = engineAuthModeAsString map googleConf.auth
-    
-    engineAuthModeValidation map {
-      // If the authentication mode is recognized, create a GcsPathBuilderFactory for the engine
-      case Valid(mode) => GcsPathBuilderFactory(mode, googleConf.applicationName, None)
-      // Otherwise fail
-      case Invalid(errors) => throw new RuntimeException() with MessageAggregation {
-        override def exceptionContext: String = s"Failed to create authentication mode for $engineAuthModeAsString"
-        override def errorMessages: Traversable[String] = errors.toList
-      }
-    }
+
+  private val defaultFileSystemFactory: Map[String, PathBuilderFactory] =
+    Option(DefaultPathBuilderFactory.tuple)
+      .filter(_ => config.as[Boolean]("engine.filesystems.local.enabled"))
+      .toMap
+
+  private val pathBuilderFactories = {
+    CromwellFileSystems.instance.factoriesFromConfig(config.as[Config]("engine"))
+      .unsafe("Failed to instantiate engine filesystem") ++ defaultFileSystemFactory
   }
 
-  private val ossPathBuilderFactory: Try[Option[OssPathBuilderFactory]] = Try {
-    for {
-      endpoint <- config.as[Option[String]]("engine.filesystems.oss.auth.endpoint")
-      accessId <- config.as[Option[String]]("engine.filesystems.oss.auth.access-id")
-      accessKey <- config.as[Option[String]]("engine.filesystems.oss.auth.access-key")
-      securityToken = config.as[Option[String]]("engine.filesystems.oss.auth.security-token")
-    } yield OssPathBuilderFactory(endpoint, accessId, accessKey, securityToken)
-  }
-
-  private val defaultFileSystem =
-    Option(DefaultPathBuilder).filter(_ => config.as[Boolean]("engine.filesystems.local.enabled"))
-
-  def pathBuildersForWorkflow(workflowOptions: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[List[PathBuilder]] = {
-    val maybeWithGcs = gcsPathBuilderFactory match {
-      case Success(maybeBuilderFactory) => maybeBuilderFactory.toList.traverse(_.withOptions(workflowOptions)).map(_ ++ defaultFileSystem)
-      case Failure(failure) => Future.failed(failure)
-    }
-
-    ossPathBuilderFactory match {
-      case Success(maybeBuilderFactory) => for {
-          oss <- maybeBuilderFactory.toList.traverse(_.withOptions(workflowOptions))
-          gcs <- maybeWithGcs
-        } yield oss ++ gcs
-      case Failure(failure) => Future.failed(failure)
-    }
+  def pathBuildersForWorkflow(workflowOptions: WorkflowOptions)(implicit as: ActorSystem): Future[List[PathBuilder]] = {
+    PathBuilderFactory.instantiatePathBuilders(pathBuilderFactories.values.toList, workflowOptions)
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -415,7 +415,7 @@ class WorkflowActor(val workflowId: WorkflowId,
         def bruteForceWorkflowOptions: WorkflowOptions = WorkflowOptions.fromJsonString(workflowSourceFilesCollection.workflowOptionsJson).getOrElse(WorkflowOptions.fromJsonString("{}").get)
         val system = context.system
         val ec = context.system.dispatcher
-        def bruteForcePathBuilders: Future[List[PathBuilder]] = EngineFilesystems.pathBuildersForWorkflow(bruteForceWorkflowOptions)(system, ec)
+        def bruteForcePathBuilders: Future[List[PathBuilder]] = EngineFilesystems.pathBuildersForWorkflow(bruteForceWorkflowOptions)(system)
 
         val (workflowOptions, pathBuilders) = stateData.workflowDescriptor match {
           case Some(wd) => (wd.backendDescriptor.workflowOptions, Future.successful(wd.pathBuilders))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -209,7 +209,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
   private def workflowOptionsAndPathBuilders(sourceFiles: WorkflowSourceFilesCollection): ErrorOr[(WorkflowOptions, Future[List[PathBuilder]])] = {
     val workflowOptionsValidation = validateWorkflowOptions(sourceFiles.workflowOptionsJson)
     workflowOptionsValidation map { workflowOptions =>
-      val pathBuilders = EngineFilesystems.pathBuildersForWorkflow(workflowOptions)(context.system, context.dispatcher)
+      val pathBuilders = EngineFilesystems.pathBuildersForWorkflow(workflowOptions)(context.system)
       (workflowOptions, pathBuilders)
     }
   }

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -10,6 +10,7 @@ import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import cromwell.core._
 import cromwell.core.actor.StreamActorHelper.ActorRestartException
+import cromwell.core.filesystem.CromwellFileSystems
 import cromwell.core.io.Throttle
 import cromwell.docker.DockerHashActor
 import cromwell.docker.DockerHashActor.DockerHashContext
@@ -53,6 +54,9 @@ import scala.util.{Failure, Success, Try}
   */
 abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate: Boolean)(implicit materializer: ActorMaterializer) extends Actor with ActorLogging with GracefulShutdownHelper {
   import CromwellRootActor._
+  
+  // Make sure the filesystems are initialized at startup
+  val _ = CromwellFileSystems.instance
 
   private val logger = Logging(context.system, this)
   private val config = ConfigFactory.load()

--- a/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
-import cromwell.cloudsupport.gcp.auth.ApplicationDefaultMode
+import com.typesafe.config.ConfigFactory
 import cromwell.core.Tags.IntegrationTest
 import cromwell.core.io._
 import cromwell.core.{TestKitSuite, WorkflowOptions}
@@ -13,8 +13,8 @@ import cromwell.filesystems.gcs.{GcsPathBuilder, GcsPathBuilderFactory}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
 
-import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
 import scala.language.postfixOps
 
 class IoActorProxyGcsBatchSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
@@ -23,6 +23,8 @@ class IoActorProxyGcsBatchSpec extends TestKitSuite with FlatSpecLike with Match
   implicit val actorSystem = system
   implicit val ec: ExecutionContext = system.dispatcher
   implicit val materializer = ActorMaterializer()
+  
+  val instanceConfig = ConfigFactory.parseString("auth = \"application-default\"")
 
   override def afterAll() = {
     materializer.shutdown()
@@ -33,7 +35,7 @@ class IoActorProxyGcsBatchSpec extends TestKitSuite with FlatSpecLike with Match
     super.afterAll()
   }
   
-  lazy val gcsPathBuilder = GcsPathBuilderFactory(ApplicationDefaultMode("default"), "cromwell-test", None)
+  lazy val gcsPathBuilder = GcsPathBuilderFactory(ConfigFactory.load(), instanceConfig)
   lazy val pathBuilder: GcsPathBuilder = Await.result(gcsPathBuilder.withOptions(WorkflowOptions.empty), 1 second)
 
   lazy val randomUUID = UUID.randomUUID().toString

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -2,46 +2,38 @@ package cromwell.filesystems.gcs
 
 import akka.actor.ActorSystem
 import com.google.api.gax.retrying.RetrySettings
-import com.google.cloud.storage.contrib.nio.CloudStorageConfiguration
-import com.google.auth.Credentials
+import com.typesafe.config.Config
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import cromwell.cloudsupport.gcp.gcs.GcsStorage
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.PathBuilderFactory
+import cromwell.filesystems.gcs.GcsPathBuilderFactory.DefaultRetrySettings
 import org.threeten.bp.Duration
 
 import scala.concurrent.ExecutionContext
 
-final case class GcsPathBuilderFactory private(authMode: GoogleAuthMode,
-                                               applicationName: String,
-                                               retrySettings: RetrySettings,
-                                               cloudStorageConfiguration: CloudStorageConfiguration)
+final case class GcsPathBuilderFactory(globalConfig: Config, instanceConfig: Config)
   extends PathBuilderFactory {
+  import net.ceedubs.ficus.Ficus._
+  // Parse the configuration and create a GoogleConfiguration
+  val googleConf: GoogleConfiguration = GoogleConfiguration(globalConfig)
+  // Extract the specified authentication mode for engine gcs filesystem, if any
+  val authModeAsString: String = instanceConfig.as[String]("auth")
+  // Validate it against the google configuration
+  val authModeValidation: ErrorOr[GoogleAuthMode] = googleConf.auth(authModeAsString)
+  val applicationName = googleConf.applicationName
+
+  val authMode = authModeValidation.unsafe(s"Failed to create authentication mode for $authModeAsString")
 
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {
-    GcsPathBuilder.fromAuthMode(authMode, applicationName, retrySettings, GcsStorage.DefaultCloudStorageConfiguration, options)
-  }
-
-  /**
-    * Ignores the authMode and creates a GcsPathBuilder using the passed credentials directly.
-    * Can be used when the Credentials are already available.
-    */
-  def fromCredentials(options: WorkflowOptions, credentials: Credentials) = {
-    GcsPathBuilder.fromCredentials(credentials, applicationName, retrySettings, GcsStorage.DefaultCloudStorageConfiguration, options)
+    GcsPathBuilder.fromAuthMode(authMode, applicationName, DefaultRetrySettings, GcsStorage.DefaultCloudStorageConfiguration, options)
   }
 }
 
 object GcsPathBuilderFactory {
-  def apply(authMode: GoogleAuthMode,
-            applicationName: String,
-            retrySettings: Option[RetrySettings]): GcsPathBuilderFactory = {
-
-    val actualRetrySettings: RetrySettings = retrySettings.getOrElse(DefaultRetrySettings)
-    val actualCloudStorage = DefaultCloudStorageConfiguration
-
-    new GcsPathBuilderFactory(authMode, applicationName, actualRetrySettings, actualCloudStorage)
-  }
-
   lazy val DefaultRetrySettings: RetrySettings = RetrySettings.newBuilder()
     .setTotalTimeout(Duration.ofSeconds(30))
     .setInitialRetryDelay(Duration.ofMillis(100))

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
@@ -78,6 +78,9 @@ case class GcsBatchDeleteCommand(
   private val blob = file.blob
   def operation = file.apiStorage.objects().delete(blob.getBucket, blob.getName)
   override protected def mapGoogleResponse(response: Void): Unit = ()
+  override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders) = {
+    if (swallowIOExceptions) Option(Left(())) else None
+  }
 }
 
 /**

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/OssPathBuilderFactory.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/OssPathBuilderFactory.scala
@@ -16,9 +16,7 @@ final case class OssPathBuilderFactory(globalConfig: Config, instanceConfig: Con
     validate { instanceConfig.as[String]("auth.access-id") },
     validate { instanceConfig.as[String]("auth.access-key") },
     validate { instanceConfig.as[Option[String]]("auth.security-token") }
-  ).mapN({
-    case (e, i, k, t) => (e, i, k, t)
-  }).unsafe("OSS filesystem configuration is invalid")
+  ).tupled.unsafe("OSS filesystem configuration is invalid")
   
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {
     Future.successful(OssPathBuilder.fromConfiguration(endpoint, accessId, accessKey, securityToken, options))

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/OssPathBuilderFactory.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/OssPathBuilderFactory.scala
@@ -1,16 +1,25 @@
 package cromwell.filesystems.oss
 
 import akka.actor.ActorSystem
+import cats.syntax.apply._
+import com.typesafe.config.Config
+import common.validation.Validation._
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.PathBuilderFactory
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final case class OssPathBuilderFactory(endpoint: String,
-                                 accessId: String,
-                                 accessKey: String,
-                                 securityToken: Option[String]
-                                ) extends PathBuilderFactory {
+final case class OssPathBuilderFactory(globalConfig: Config, instanceConfig: Config) extends PathBuilderFactory {
+  val (endpoint, accessId, accessKey, securityToken) = (
+    validate { instanceConfig.as[String]("auth.endpoint") },
+    validate { instanceConfig.as[String]("auth.access-id") },
+    validate { instanceConfig.as[String]("auth.access-key") },
+    validate { instanceConfig.as[Option[String]]("auth.security-token") }
+  ).mapN({
+    case (e, i, k, t) => (e, i, k, t)
+  }).unsafe("OSS filesystem configuration is invalid")
+  
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {
     Future.successful(OssPathBuilder.fromConfiguration(endpoint, accessId, accessKey, securityToken, options))
   }

--- a/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsInitializationActor.scala
+++ b/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsInitializationActor.scala
@@ -28,21 +28,9 @@ final class BcsInitializationActor(params: BcsInitializationActorParams)
   extends StandardInitializationActor(params) {
 
   private val bcsConfiguration = params.bcsConfiguration
-  private implicit val system = context.system
-
-  lazy val ossPathBuilderFactory: Option[OssPathBuilderFactory] = {
-    for {
-      endpoint <- configurationDescriptor.backendConfig.as[Option[String]]("filesystems.oss.auth.endpoint")
-      accessId <- configurationDescriptor.backendConfig.as[Option[String]]("filesystems.oss.auth.access-id")
-      accessKey <- configurationDescriptor.backendConfig.as[Option[String]]("filesystems.oss.auth.access-key")
-      securityToken = configurationDescriptor.backendConfig.as[Option[String]]("filesystems.oss.auth.security-token")
-    } yield new OssPathBuilderFactory(endpoint, accessId, accessKey, securityToken)
-  }
-
 
   override lazy val pathBuilders: Future[List[PathBuilder]] =
-    ossPathBuilderFactory.toList.traverse(_.withOptions(workflowDescriptor.workflowOptions)).map(_ ++ Option(DefaultPathBuilder))
-
+    standardParams.configurationDescriptor.pathBuildersWithDefault(workflowDescriptor.workflowOptions)
 
   override lazy val workflowPaths: Future[BcsWorkflowPaths] = pathBuilders map {
     BcsWorkflowPaths(workflowDescriptor, bcsConfiguration.configurationDescriptor.backendConfig, _)

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesConfiguration.scala
@@ -16,7 +16,6 @@ class JesConfiguration(val configurationDescriptor: BackendConfigurationDescript
   val jesAttributes = JesAttributes(googleConfig, configurationDescriptor.backendConfig)
   val jesAuths = jesAttributes.auths
   val jesComputeServiceAccount = jesAttributes.computeServiceAccount
-  val gcsPathBuilderFactory = GcsPathBuilderFactory(jesAuths.gcs, googleConfig.applicationName, None)
   val genomicsFactory = GenomicsFactory(googleConfig.applicationName, jesAuths.genomics, jesAttributes.endpointUrl)
   val dockerCredentials = BackendDockerConfiguration.build(configurationDescriptor.backendConfig).dockerCredentials map JesDockerCredentials.apply
   val needAuthFileUpload = jesAuths.gcs.requiresAuthFile || dockerCredentials.isDefined || jesAttributes.restrictMetadataAccess

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -40,7 +40,9 @@ class JesFinalizationActor(val jesParams: JesFinalizationActorParams)
 
   private def deleteAuthenticationFile(): Future[Unit] = {
     (jesConfiguration.needAuthFileUpload, workflowPaths) match {
-      case (true, Some(paths: JesWorkflowPaths)) => asyncIo.deleteAsync(paths.gcsAuthFilePath)
+      case (true, Some(paths: JesWorkflowPaths)) =>
+        println(s"DELETING AUTH FILE PATH ${paths.gcsAuthFilePath.pathAsString}")
+        asyncIo.deleteAsync(paths.gcsAuthFilePath)
       case _ => Future.successful(())
     }
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesFinalizationActor.scala
@@ -40,9 +40,7 @@ class JesFinalizationActor(val jesParams: JesFinalizationActorParams)
 
   private def deleteAuthenticationFile(): Future[Unit] = {
     (jesConfiguration.needAuthFileUpload, workflowPaths) match {
-      case (true, Some(paths: JesWorkflowPaths)) =>
-        println(s"DELETING AUTH FILE PATH ${paths.gcsAuthFilePath.pathAsString}")
-        asyncIo.deleteAsync(paths.gcsAuthFilePath)
+      case (true, Some(paths: JesWorkflowPaths)) => asyncIo.deleteAsync(paths.gcsAuthFilePath, swallowIoExceptions = true)
       case _ => Future.successful(())
     }
   }

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesInitializationActor.scala
@@ -43,7 +43,6 @@ class JesInitializationActor(jesParams: JesInitializationActorParams)
   override lazy val ioActor = jesParams.ioActor
   private val jesConfiguration = jesParams.jesConfiguration
   private val workflowOptions = workflowDescriptor.workflowOptions
-  implicit private val system = context.system
 
   override lazy val runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder =
     JesRuntimeAttributes.runtimeAttributesBuilder(jesConfiguration)
@@ -73,7 +72,8 @@ class JesInitializationActor(jesParams: JesInitializationActorParams)
   override lazy val workflowPaths: Future[JesWorkflowPaths] = for {
     gcsCred <- gcsCredentials
     genomicsCred <- genomicsCredentials
-  } yield new JesWorkflowPaths(workflowDescriptor, gcsCred, genomicsCred, jesConfiguration)
+    validatedPathBuilders <- pathBuilders
+  } yield new JesWorkflowPaths(workflowDescriptor, gcsCred, genomicsCred, jesConfiguration, validatedPathBuilders)
 
   override lazy val initializationData: Future[JesBackendInitializationData] = for {
     jesWorkflowPaths <- workflowPaths

--- a/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
+++ b/supportedBackends/jes/src/main/scala/cromwell/backend/impl/jes/JesWorkflowPaths.scala
@@ -9,7 +9,8 @@ import cromwell.backend.io.WorkflowPaths
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.gcs.GcsStorage
 import cromwell.core.WorkflowOptions
-import cromwell.core.path.{Path, PathBuilder}
+import cromwell.core.path.Path
+import cromwell.core.path.PathFactory.PathBuilders
 import cromwell.filesystems.gcs.GcsPathBuilder
 
 import scala.language.postfixOps
@@ -22,14 +23,13 @@ object JesWorkflowPaths {
 case class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
                             gcsCredentials: Credentials,
                             genomicsCredentials: Credentials,
-                            jesConfiguration: JesConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
+                            jesConfiguration: JesConfiguration,
+                            override val pathBuilders: PathBuilders) extends WorkflowPaths {
 
   override lazy val executionRootString: String =
     workflowDescriptor.workflowOptions.getOrElse(JesWorkflowPaths.GcsRootOptionKey, jesConfiguration.root)
 
   private val workflowOptions: WorkflowOptions = workflowDescriptor.workflowOptions
-
-  private val gcsPathBuilder: GcsPathBuilder = jesConfiguration.gcsPathBuilderFactory.fromCredentials(workflowOptions, gcsCredentials)
 
   val gcsAuthFilePath: Path = {
     // The default auth file bucket is always at the root of the root workflow
@@ -67,5 +67,4 @@ case class JesWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
   override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
 
   override def config: Config = jesConfiguration.configurationDescriptor.backendConfig
-  override def pathBuilders: List[PathBuilder] = List(gcsPathBuilder)
 }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesAsyncBackendJobExecutionActorSpec.scala
@@ -100,7 +100,8 @@ class JesAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackend
   }
 
   private def buildInitializationData(jobDescriptor: BackendJobDescriptor, configuration: JesConfiguration) = {
-    val workflowPaths = JesWorkflowPaths(jobDescriptor.workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), configuration)(system)
+    val pathBuilders = Await.result(configuration.configurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
+    val workflowPaths = JesWorkflowPaths(jobDescriptor.workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), configuration, pathBuilders)
     val runtimeAttributesBuilder = JesRuntimeAttributes.runtimeAttributesBuilder(configuration)
     JesBackendInitializationData(workflowPaths, runtimeAttributesBuilder, configuration, null, null)
   }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesCallPathsSpec.scala
@@ -26,7 +26,7 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
     
     val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -45,7 +45,7 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
 
     val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -68,7 +68,7 @@ class JesCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers with
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
 
     val callPaths = JesJobPaths(workflowPaths, jobDescriptorKey)
     

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import common.validation.Validation._
 import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed, InitializationSuccess, Initialize}
 import cromwell.backend.async.RuntimeAttributeValidationFailures
-import cromwell.backend.impl.jes.JesTestConfig.{JesBackendConfig, cromwellFileSystems}
+import cromwell.backend.impl.jes.JesTestConfig.JesBackendConfig
 import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendSpec, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.GoogleConfiguration
@@ -168,7 +168,7 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
       | """.stripMargin))
 
   val defaultBackendConfig = new BackendConfigurationDescriptor(backendConfig, globalConfig) {
-    override lazy val configuredPathBuilderFactories = cromwellFileSystems.factoriesFromConfig(JesBackendConfig).unsafe("Failed to instantiate backend filesystem")
+    override lazy val configuredPathBuilderFactories = JesTestConfig.mockFilesystems.factoriesFromConfig(JesBackendConfig).unsafe("Failed to instantiate backend filesystem")
   }
 
   val refreshTokenConfig: Config = ConfigFactory.parseString(refreshTokenConfigTemplate)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesInitializationActorSpec.scala
@@ -5,16 +5,18 @@ import java.util.UUID
 import akka.actor.Props
 import akka.testkit._
 import com.typesafe.config.{Config, ConfigFactory}
+import common.validation.Validation._
 import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed, InitializationSuccess, Initialize}
 import cromwell.backend.async.RuntimeAttributeValidationFailures
+import cromwell.backend.impl.jes.JesTestConfig.{JesBackendConfig, cromwellFileSystems}
 import cromwell.backend.impl.jes.authentication.{GcsLocalizing, JesAuthObject}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendSpec, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.auth.{GoogleAuthModeSpec, RefreshTokenMode, SimpleClientSecrets}
 import cromwell.core.Dispatcher.BackendDispatcher
 import cromwell.core.Tags.{IntegrationTest, PostWomTest}
-import cromwell.core.{TestKitSuite, WorkflowOptions}
 import cromwell.core.logging.LoggingTest._
+import cromwell.core.{TestKitSuite, WorkflowOptions}
 import cromwell.util.{EncryptionSpec, SampleWdl}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -32,21 +34,21 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
 
   val HelloWorld: String =
     s"""
-      |task hello {
-      |  String addressee = "you"
-      |  command {
-      |    echo "Hello $${addressee}!"
-      |  }
-      |  output {
-      |    String salutation = read_string(stdout())
-      |  }
-      |
+       |task hello {
+       |  String addressee = "you"
+       |  command {
+       |    echo "Hello $${addressee}!"
+       |  }
+       |  output {
+       |    String salutation = read_string(stdout())
+       |  }
+       |
       |  RUNTIME
-      |}
-      |
+       |}
+       |
       |workflow wf_hello {
-      |  call hello
-      |}
+       |  call hello
+       |}
     """.stripMargin
 
   val globalConfig: Config = ConfigFactory.parseString(
@@ -165,7 +167,9 @@ class JesInitializationActorSpec extends TestKitSuite("JesInitializationActorSpe
       |}
       | """.stripMargin))
 
-  val defaultBackendConfig = BackendConfigurationDescriptor(backendConfig, globalConfig)
+  val defaultBackendConfig = new BackendConfigurationDescriptor(backendConfig, globalConfig) {
+    override lazy val configuredPathBuilderFactories = cromwellFileSystems.factoriesFromConfig(JesBackendConfig).unsafe("Failed to instantiate backend filesystem")
+  }
 
   val refreshTokenConfig: Config = ConfigFactory.parseString(refreshTokenConfigTemplate)
 

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
@@ -1,8 +1,12 @@
 package cromwell.backend.impl.jes
 
+import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import cromwell.backend.BackendConfigurationDescriptor
+import cromwell.core.WorkflowOptions
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
 object JesTestConfig {
 
   private val JesBackendConfigString =
@@ -15,11 +19,7 @@ object JesTestConfig {
       |  endpoint-url = "https://genomics.googleapis.com/"
       |}
       |
-      |filesystems {
-      |  gcs {
-      |    auth = "application-default"
-      |  }
-      |}
+      |filesystems.gcs.auth = "application-default"
       |
       |request-workers = 1
       |
@@ -67,6 +67,12 @@ object JesTestConfig {
        |  ]
        |}
        |
+       |filesystems {
+       |  gcs {
+       |    class = "cromwell.filesystems.gcs.GcsPathBuilderFactory"
+       |  }
+       |}
+       |
        |backend {
        |  default = "JES"
        |  providers {
@@ -85,5 +91,6 @@ object JesTestConfig {
   val JesGlobalConfig = ConfigFactory.parseString(JesGlobalConfigString)
   val JesBackendNoDefaultConfig = ConfigFactory.parseString(NoDefaultsConfigString)
   val JesBackendConfigurationDescriptor = BackendConfigurationDescriptor(JesBackendConfig, JesGlobalConfig)
+  def pathBuilders()(implicit as: ActorSystem) = Await.result(JesBackendConfigurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
   val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(JesBackendNoDefaultConfig, JesGlobalConfig)
 }

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesTestConfig.scala
@@ -92,9 +92,9 @@ object JesTestConfig {
   val JesBackendConfig = ConfigFactory.parseString(JesBackendConfigString)
   val JesGlobalConfig = ConfigFactory.parseString(JesGlobalConfigString)
   val JesBackendNoDefaultConfig = ConfigFactory.parseString(NoDefaultsConfigString)
-  val cromwellFileSystems = new CromwellFileSystems(JesGlobalConfig)
+  val mockFilesystems = new CromwellFileSystems(JesGlobalConfig)
   val JesBackendConfigurationDescriptor = new BackendConfigurationDescriptor(JesBackendConfig, JesGlobalConfig) {
-    override lazy val configuredPathBuilderFactories = cromwellFileSystems.factoriesFromConfig(JesBackendConfig).unsafe("Failed to instantiate backend filesystem")
+    override lazy val configuredPathBuilderFactories = mockFilesystems.factoriesFromConfig(JesBackendConfig).unsafe("Failed to instantiate backend filesystem")
   }
   def pathBuilders()(implicit as: ActorSystem) = Await.result(JesBackendConfigurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
   val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(JesBackendNoDefaultConfig, JesGlobalConfig)

--- a/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
+++ b/supportedBackends/jes/src/test/scala/cromwell/backend/impl/jes/JesWorkflowPathsSpec.scala
@@ -24,7 +24,7 @@ class JesWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with Matchers 
     )
     val jesConfiguration = new JesConfiguration(JesBackendConfigurationDescriptor)
 
-    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration)(system)
+    val workflowPaths = JesWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
     workflowPaths.executionRoot.pathAsString should be("gs://my-cromwell-workflows-bucket/")
     workflowPaths.workflowRoot.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemInitializationActor.scala
@@ -1,45 +1,19 @@
 package cromwell.backend.sfs
 
-import cats.data.Validated.{Invalid, Valid}
-import cats.instances.future._
-import cats.instances.list._
-import cats.syntax.traverse._
 import cromwell.backend.BackendInitializationData
 import cromwell.backend.io.WorkflowPaths
 import cromwell.backend.standard.{StandardExpressionFunctions, StandardInitializationActor, StandardInitializationActorParams}
 import cromwell.backend.wfs.WorkflowPathBuilder
-import cromwell.cloudsupport.gcp.GoogleConfiguration
-import cromwell.core.path.{DefaultPathBuilder, PathBuilder}
-import cromwell.filesystems.gcs.GcsPathBuilderFactory
-import common.exception.MessageAggregation
-import net.ceedubs.ficus.Ficus._
+import cromwell.core.path.PathBuilderFactory
 
 import scala.concurrent.Future
 
 class SharedFileSystemInitializationActor(standardParams: StandardInitializationActorParams)
   extends StandardInitializationActor(standardParams) {
 
-  private implicit val system = context.system
-
-  /**
-    * If the backend sets a gcs authentication mode, try to create a PathBuilderFactory with it.
-    */
-  lazy val gcsPathBuilderFactory: Option[GcsPathBuilderFactory] = {
-    configurationDescriptor.backendConfig.as[Option[String]]("filesystems.gcs.auth") map { configAuth =>
-      val googleConfiguration = GoogleConfiguration(configurationDescriptor.globalConfig)
-      googleConfiguration.auth(configAuth) match {
-        case Valid(auth) => GcsPathBuilderFactory(auth, googleConfiguration.applicationName, None)
-        case Invalid(error) => throw new MessageAggregation {
-          override def exceptionContext: String = "Failed to parse gcs auth configuration"
-
-          override def errorMessages: Traversable[String] = error.toList
-        }
-      }
-    }
+  override lazy val pathBuilders = {
+    standardParams.configurationDescriptor.pathBuildersWithDefault(workflowDescriptor.workflowOptions)
   }
-
-  override lazy val pathBuilders: Future[List[PathBuilder]] =
-    gcsPathBuilderFactory.toList.traverse(_.withOptions(workflowDescriptor.workflowOptions)).map(_ ++ Option(DefaultPathBuilder))
 
   override lazy val workflowPaths: Future[WorkflowPaths] = pathBuilders map {
     WorkflowPathBuilder.workflowPaths(configurationDescriptor, workflowDescriptor, _)

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
@@ -50,9 +50,9 @@ class SharedFileSystemInitializationActorSpec extends TestKitSuite("SharedFileSy
     "log a warning message when there are unsupported runtime attributes" in {
       within(Timeout) {
         val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { unsupported: 1 }""")
-        val cromwellFileSystems = new CromwellFileSystems(ConfigFactory.empty())
+        val mockFileSystems = new CromwellFileSystems(ConfigFactory.empty())
         val conf = new BackendConfigurationDescriptor(TestConfig.sampleBackendRuntimeConfig, ConfigFactory.empty()) {
-          override lazy val configuredPathBuilderFactories = cromwellFileSystems.factoriesFromConfig(TestConfig.sampleBackendRuntimeConfig).unsafe("Failed to instantiate backend filesystem")
+          override lazy val configuredPathBuilderFactories = mockFileSystems.factoriesFromConfig(TestConfig.sampleBackendRuntimeConfig).unsafe("Failed to instantiate backend filesystem")
         }
         val backend: ActorRef = getActorRef(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, conf)
         val pattern = "Key/s [unsupported] is/are not supported by backend. " +

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemInitializationActorSpec.scala
@@ -3,11 +3,13 @@ package cromwell.backend.sfs
 import akka.actor.{ActorRef, Props}
 import akka.testkit.{EventFilter, ImplicitSender, TestDuration}
 import com.typesafe.config.ConfigFactory
+import common.validation.Validation._
 import cromwell.backend.BackendSpec._
 import cromwell.backend.BackendWorkflowInitializationActor.Initialize
 import cromwell.backend.standard.DefaultInitializationActorParams
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor, TestConfig}
 import cromwell.core.TestKitSuite
+import cromwell.core.filesystem.CromwellFileSystems
 import cromwell.core.logging.LoggingTest._
 import org.scalatest.{Matchers, WordSpecLike}
 import wom.graph.CommandCallNode
@@ -48,7 +50,10 @@ class SharedFileSystemInitializationActorSpec extends TestKitSuite("SharedFileSy
     "log a warning message when there are unsupported runtime attributes" in {
       within(Timeout) {
         val workflowDescriptor = buildWdlWorkflowDescriptor(HelloWorld, runtime = """runtime { unsupported: 1 }""")
-        val conf = BackendConfigurationDescriptor(TestConfig.sampleBackendRuntimeConfig, ConfigFactory.empty())
+        val cromwellFileSystems = new CromwellFileSystems(ConfigFactory.empty())
+        val conf = new BackendConfigurationDescriptor(TestConfig.sampleBackendRuntimeConfig, ConfigFactory.empty()) {
+          override lazy val configuredPathBuilderFactories = cromwellFileSystems.factoriesFromConfig(TestConfig.sampleBackendRuntimeConfig).unsafe("Failed to instantiate backend filesystem")
+        }
         val backend: ActorRef = getActorRef(workflowDescriptor, workflowDescriptor.callable.taskCallNodes, conf)
         val pattern = "Key/s [unsupported] is/are not supported by backend. " +
           "Unsupported attributes will not be part of job executions."

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
@@ -11,6 +11,7 @@ import cromwell.backend.async.RuntimeAttributeValidationFailures
 import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor}
 import cromwell.core.Tags.PostWomTest
 import cromwell.core.TestKitSuite
+import cromwell.core.filesystem.CromwellFileSystems
 import cromwell.core.logging.LoggingTest._
 import org.scalatest.{Matchers, WordSpecLike}
 import wom.graph.CommandCallNode
@@ -73,7 +74,9 @@ class TesInitializationActorSpec extends TestKitSuite("TesInitializationActorSpe
   }
 
   val backendConfig: Config = ConfigFactory.parseString(backendConfigTemplate)
-  val conf = BackendConfigurationDescriptor(backendConfig, globalConfig)
+  val conf = new BackendConfigurationDescriptor(backendConfig, globalConfig) {
+    override private[backend] lazy val cromwellFileSystems = new CromwellFileSystems(globalConfig)
+  } 
 
   // TODO WOM: needs runtime attributes validation working again
   "TesInitializationActor" should {


### PR DESCRIPTION
This started more as a POC that I had in mind but it ended up being a lot less refactoring than I anticipated so I'm making a PR for it.
Following the way we can plug services and languages this allows to plug in filesystems. All you need is a `PathBuilderFactory`.
How to make a `PathBuilderFactory` could still be made simpler but that's a separate issue.
This has the advantage that a filesystem can automatically be added to Cromwell engine or standard backend without code changes.
Available filesystems are defined in the config with their corresponding class, and the engine and backends can pick which ones they want to enable.
It removes some dependency of `engine` over the individual filesystem sub projects but it's not all the way there yet.
Thinking about PAPI2 this possibly opens the door to automatically support new filesystems for (de)localization as well if we were to go down that road.