### PR TITLE
Extract status code from base service exceptions

### DIFF
--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
@@ -3,6 +3,7 @@ package cromwell.filesystems.gcs
 import akka.actor.ActorSystem
 import com.google.api.client.http.HttpResponseException
 import com.google.auth.Credentials
+import com.google.cloud.BaseServiceException
 import cromwell.cloudsupport.gcp.auth.{GoogleAuthMode, OptionLookupException}
 import cromwell.core.retry.Retry
 import cromwell.core.{CromwellFatalExceptionMarker, WorkflowOptions}
@@ -16,6 +17,7 @@ object GoogleUtil {
   def extractStatusCode(exception: Throwable): Option[Int] = {
     exception match {
       case t: HttpResponseException => Option(t.getStatusCode)
+      case t: BaseServiceException => Option(t.getCode)
       case _ => None
     }
   }


### PR DESCRIPTION
This will add to the instrumentation metric path the http return code in case of failure, giving better insight as to the reason of the failures