### PR TITLE
Partial Unification Compiler Flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .artifactory
 .idea/*
 .ensime_cache/*
+.config/*
 .ensime
 tags
 !/.idea/inspectionProfiles/

--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -79,7 +79,7 @@ object BackendWorkflowInitializationActor {
       //This map append will overwrite default key/values with runtime settings upon key collisions
       val lookups = defaultRuntimeAttributes.mapValues(_.asWomExpression) ++ runtimeAttributes
 
-      runtimeAttributeValidators.toList.traverse[ValidatedNel[RuntimeAttributeValidationFailure, ?], Unit]{
+      runtimeAttributeValidators.toList.traverse{
         case (attributeName, validator) =>
           val runtimeAttributeValue: Option[WomExpression] = lookups.get(attributeName)
           validator(runtimeAttributeValue).fold(
@@ -154,7 +154,7 @@ trait BackendWorkflowInitializationActor extends BackendWorkflowLifecycleActor w
       defaultRuntimeAttributes <- coerceDefaultRuntimeAttributes(workflowDescriptor.workflowOptions) |> Future.fromTry _
       taskList = calls.toList.map(_.callable).map(t => t.name -> t.runtimeAttributes.attributes)
       _ <- taskList.
-            traverse[ValidatedNel[RuntimeAttributeValidationFailure, ?], Unit]{
+            traverse{
               case (name, runtimeAttributes) => validateRuntimeAttributes(name, defaultRuntimeAttributes, runtimeAttributes, runtimeAttributeValidators)
             }.toFuture(errors => RuntimeAttributeValidationFailures(errors.toList))
       _ <- validate()

--- a/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
@@ -20,7 +20,7 @@ trait DirectoryFunctions extends IoFunctionSet with PathFactory {
 
   def findDirectoryOutputs(call: CommandCallNode,
                            jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomUnlistedDirectory]] = {
-    call.callable.outputs.flatTraverse[ErrorOr, WomUnlistedDirectory] { outputDefinition =>
+    call.callable.outputs.flatTraverse { outputDefinition =>
       outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, this, outputDefinition.womType) map {
         _.toList.flatMap(_.flattenFiles) collect { case unlistedDirectory: WomUnlistedDirectory => unlistedDirectory }
       }

--- a/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
@@ -18,7 +18,7 @@ trait GlobFunctions extends IoFunctionSet with AsyncIoFunctions {
   def callContext: CallContext
 
   def findGlobOutputs(call: CommandCallNode, jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomGlobFile]] = {
-    def fromOutputs = call.callable.outputs.flatTraverse[ErrorOr, WomGlobFile] { outputDefinition =>
+    def fromOutputs = call.callable.outputs.flatTraverse { outputDefinition =>
       outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, this, outputDefinition.womType) map {
         _.toList.flatMap(_.flattenFiles) collect { case glob: WomGlobFile => glob }
       }

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -372,7 +372,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
       val preprocessedInputs = instantiatedCommand.preprocessedInputs |> makeStringKeyedMap
       val valueMappedPreprocessedInputs = instantiatedCommand.valueMappedPreprocessedInputs |> makeStringKeyedMap
 
-      val adHocFileCreations: ErrorOr[List[WomFile]] = callable.adHocFileCreation.toList.flatTraverse(
+      val adHocFileCreations = callable.adHocFileCreation.toList.flatTraverse(
         _.evaluate(preprocessedInputs, valueMappedPreprocessedInputs, backendEngineFunctions).flatMap(validateAdHocFile)
       )
 
@@ -391,7 +391,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
       // redirection or override of the filename of a redirection. Evaluate that expression if present and stringify.
       val List(stdinRedirect, stdoutOverride, stderrOverride) = List[CommandTaskDefinition => Option[WomExpression]](
         _.stdinRedirection, _.stdoutOverride, _.stderrOverride) map {
-        _.apply(callable).traverse[ErrorOr, String] { _.evaluateValue(valueMappedPreprocessedInputs, backendEngineFunctions) map { _.valueString} }
+        _.apply(callable).traverse{ _.evaluateValue(valueMappedPreprocessedInputs, backendEngineFunctions) map { _.valueString} }
       }
 
       (adHocFileCreationSideEffectFiles, environmentVariables, stdinRedirect, stdoutOverride, stderrOverride) mapN {

--- a/backend/src/test/scala/cromwell/backend/validation/RuntimeAttributesDefaultSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/validation/RuntimeAttributesDefaultSpec.scala
@@ -32,7 +32,7 @@ class RuntimeAttributesDefaultSpec extends FlatSpec with Matchers {
 
     val defaults = workflowOptionsDefault(workflowOptions, coercionMap)
     defaults.isSuccess shouldBe true
-    defaults.get should contain theSameElementsAs Map(
+    defaults.get.toList should contain theSameElementsAs Map(
       "str" -> WomString("myString"),
       "bool" -> WomBoolean.True,
       "number" -> WomInteger(8),
@@ -52,7 +52,7 @@ class RuntimeAttributesDefaultSpec extends FlatSpec with Matchers {
 
     val defaults = workflowOptionsDefault(workflowOptions, coercionMap)
     defaults.isSuccess shouldBe true
-    defaults.get should contain theSameElementsAs Map(
+    defaults.get.toList should contain theSameElementsAs Map(
       "str" -> WomString("myString"),
       "number" -> WomInteger(8)
     )
@@ -96,7 +96,7 @@ class RuntimeAttributesDefaultSpec extends FlatSpec with Matchers {
       "c" -> WomString("c")
     )
 
-    withDefaults(rawAttributes, List(default1, default2)) should contain theSameElementsAs Map(
+    withDefaults(rawAttributes, List(default1, default2)).toList should contain theSameElementsAs Map(
       "a" -> WomString("a"),
       "b" -> WomString("b"),
       "c" -> WomString("c")

--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -6,7 +6,6 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.instances.list._
 import cats.syntax.traverse._
 import centaur.test.standard.CentaurTestCase
-import common.validation.ErrorOr.ErrorOr
 import org.scalatest.{DoNotDiscover, FlatSpec, Matchers, Tag}
 
 @DoNotDiscover

--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -14,7 +14,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) exten
 
   private def testCases(basePath: Path): List[CentaurTestCase] = {
     val files = basePath.toFile.listFiles.toList collect { case x if x.isFile => x.toPath }
-    val testCases = files.traverse[ErrorOr, CentaurTestCase](CentaurTestCase.fromPath)
+    val testCases = files.traverse(CentaurTestCase.fromPath)
 
     testCases match {
       case Valid(l) => l

--- a/common/src/test/scala/common/util/TryUtilSpec.scala
+++ b/common/src/test/scala/common/util/TryUtilSpec.scala
@@ -63,7 +63,7 @@ class TryUtilSpec extends FlatSpec with Matchers {
   it should "sequence successful maps" in {
     val result: Try[Map[String, String]] = sequenceMap(Map("key" -> Success("success")), "prefix")
     result.isSuccess should be(true)
-    result.get should contain theSameElementsAs Map("key" -> "success")
+    result.get.toList should contain theSameElementsAs Map("key" -> "success")
   }
 
   it should "sequence failed maps" in {
@@ -80,7 +80,7 @@ class TryUtilSpec extends FlatSpec with Matchers {
     val result: Try[Map[String, String]] = sequenceKeyValues(
       Map(Success("success key") -> Success("success value")), "prefix")
     result.isSuccess should be(true)
-    result.get should contain theSameElementsAs Map("success key" -> "success value")
+    result.get.toList should contain theSameElementsAs Map("success key" -> "success value")
   }
 
   it should "sequence successful keys and failed values" in {

--- a/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
+++ b/core/src/main/scala/cromwell/core/actor/ThrottlerActor.scala
@@ -23,7 +23,7 @@ abstract class ThrottlerActor[C] extends BatchActor[C](Duration.Zero, 1) {
     // there's a bug in the batch actor.
     if (data.tail.nonEmpty) {
       log.error("{} is throttled and is not supposed to process more than one element at a time !", self.path.name)
-      data.toVector.traverse[Future, Any](processHead).map(_.length)
+      data.toVector.traverse(processHead).map(_.length)
     } else processHead(data.head).map(_ => 1)
   }
   def processHead(head: C): Future[Int]

--- a/cwl/src/main/scala/cwl/CommandLineTool.scala
+++ b/cwl/src/main/scala/cwl/CommandLineTool.scala
@@ -148,7 +148,7 @@ case class CommandLineTool private(
     def jsonToOutputs(json: Map[String, Json]): Checked[List[(OutputPort, WomValue)]] = {
       import cats.instances.list._
 
-      outputPorts.toList.traverse[ErrorOr, (OutputPort, WomValue)]({ outputPort =>
+      outputPorts.toList.traverse({ outputPort =>
         // If the type is optional, then we can set the value to none if there's nothing in the json
         def emptyValue = outputPort.womType match {
           case optional: WomOptionalType => Option((outputPort -> optional.none).validNel)

--- a/cwl/src/main/scala/cwl/CommandOutputBinding.scala
+++ b/cwl/src/main/scala/cwl/CommandOutputBinding.scala
@@ -79,7 +79,7 @@ object CommandOutputBinding {
     }
 
     def secondaryFilesToWomFiles(primaryWomFiles: List[WomFile], ioFunctionSet: IoFunctionSet): ErrorOr[List[WomFile]] = {
-      primaryWomFiles.flatTraverse[ErrorOr, WomFile] { primaryWomFile =>
+      primaryWomFiles.flatTraverse{ primaryWomFile =>
         FileParameter.secondaryFiles(primaryWomFile,
           primaryWomFile.womFileType, secondaryFilesOption, parameterContext, expressionLib, ioFunctionSet)
       }
@@ -172,7 +172,7 @@ object CommandOutputBinding {
       primaryPaths <- GlobEvaluator.globs(commandOutputBinding.glob, parameterContext, expressionLib)
 
       // 2. loadContents: load the contents of the primary files
-      primaryAsDirectoryOrFiles <- primaryPaths.flatTraverse[ErrorOr, WomFile] {
+      primaryAsDirectoryOrFiles <- primaryPaths.flatTraverse{
         loadPrimaryWithContents(ioFunctionSet, outputWomType, commandOutputBinding)
       }
 

--- a/cwl/src/main/scala/cwl/CommandOutputBinding.scala
+++ b/cwl/src/main/scala/cwl/CommandOutputBinding.scala
@@ -10,7 +10,7 @@ import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values._
 
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 /** @see <a href="http://www.commonwl.org/v1.0/Workflow.html#CommandOutputBinding">CommandOutputBinding</a> */
@@ -180,7 +180,7 @@ object CommandOutputBinding {
       absolutePaths = primaryAsDirectoryOrFiles.map(_.mapFile(ioFunctionSet.pathFunctions.relativeToHostCallRoot))
       
       // Load file size
-      withFileSizes <- FileParameter.sync(absolutePaths.traverse[Future, WomFile](_.withSize(ioFunctionSet))).toErrorOr
+      withFileSizes <- FileParameter.sync(absolutePaths.traverse(_.withSize(ioFunctionSet))).toErrorOr
 
       womFilesArray = WomArray(withFileSizes)
 

--- a/cwl/src/main/scala/cwl/CwlJsonToDelayedCoercionFunction.scala
+++ b/cwl/src/main/scala/cwl/CwlJsonToDelayedCoercionFunction.scala
@@ -50,7 +50,7 @@ private [cwl] object CwlJsonToDelayedCoercionFunction extends Json.Folder[Delaye
     case WomAnyType =>
       // Make an array of WomAny
       value.toList
-        .traverse[ErrorOr, WomValue](_.foldWith(this).apply(WomAnyType))
+        .traverse(_.foldWith(this).apply(WomAnyType))
         .map {
           WomArray(WomArrayType(WomAnyType), _)
         }
@@ -70,7 +70,7 @@ private [cwl] object CwlJsonToDelayedCoercionFunction extends Json.Folder[Delaye
         case Right(directory) => directory.asWomValue
       }
     case composite: WomCompositeType =>
-      val foldedMap = value.toList.traverse[ErrorOr, (String, WomValue)]({
+      val foldedMap = value.toList.traverse({
         case (k, v) =>
           composite.typeMap.get(k).map({ valueType =>
             v.foldWith(this).apply(valueType).map(k -> _)

--- a/cwl/src/main/scala/cwl/CwlJsonToDelayedCoercionFunction.scala
+++ b/cwl/src/main/scala/cwl/CwlJsonToDelayedCoercionFunction.scala
@@ -37,7 +37,7 @@ private [cwl] object CwlJsonToDelayedCoercionFunction extends Json.Folder[Delaye
   override def onArray(value: Vector[Json]) = {
     case womArrayType: WomArrayType =>
       value.toList
-        .traverse[ErrorOr, WomValue](_.foldWith(this).apply(womArrayType.memberType))
+        .traverse(_.foldWith(this).apply(womArrayType.memberType))
         .map {
           WomArray(womArrayType, _)
         }
@@ -79,7 +79,7 @@ private [cwl] object CwlJsonToDelayedCoercionFunction extends Json.Folder[Delaye
 
       foldedMap.map(WomObject.withType(_, composite))
     case WomObjectType =>
-      val foldedMap = value.toList.traverse[ErrorOr, (String, WomValue)]({
+      val foldedMap = value.toList.traverse({
         case (k, v) => v.foldWith(this).apply(WomAnyType).map(k -> _)
       }).map(_.toMap[String, WomValue])
 

--- a/cwl/src/main/scala/cwl/CwlType.scala
+++ b/cwl/src/main/scala/cwl/CwlType.scala
@@ -48,7 +48,7 @@ case class File private
 
   lazy val errorOrSecondaryFiles: ErrorOr[List[WomFile]] = {
     val dirsOrFiles: List[FileOrDirectory] = secondaryFiles.getOrElse(Array.empty).toList
-    dirsOrFiles.traverse[ErrorOr, WomFile] {
+    dirsOrFiles.traverse{
       _.fold(CwlDirectoryOrFileAsWomSingleDirectoryOrFile)
     }
   }
@@ -114,7 +114,7 @@ object File {
   private def recursivelyBuildDirectory(directory: String, ioFunctions: IoFunctionSet): ErrorOr[WomMaybeListedDirectory] = {
     for {
       listing <- sync(ioFunctions.listDirectory(directory)).toErrorOr
-      fileListing <- listing.toList.traverse[ErrorOr, WomFile] {
+      fileListing <- listing.toList.traverse{
         case e if sync(ioFunctions.isDirectory(e)).getOrElse(false) => recursivelyBuildDirectory(e, ioFunctions)
         case e => WomMaybePopulatedFile(e).validNel
       }

--- a/cwl/src/main/scala/cwl/CwlType.scala
+++ b/cwl/src/main/scala/cwl/CwlType.scala
@@ -226,7 +226,7 @@ case class Directory private
   lazy val errorOrListingOption: ErrorOr[Option[List[WomFile]]] = {
     val maybeErrorOrList: Option[ErrorOr[List[WomFile]]] =
       listing map {
-        _.toList.traverse[ErrorOr, WomFile] {
+        _.toList.traverse {
           _.fold(CwlDirectoryOrFileAsWomSingleDirectoryOrFile)
         }
       }

--- a/cwl/src/main/scala/cwl/InputParameter.scala
+++ b/cwl/src/main/scala/cwl/InputParameter.scala
@@ -59,7 +59,7 @@ object InputParameter {
           womType =>
             fileOrDirectoryArray
               .toList
-              .traverse[ErrorOr, WomValue](_.fold(this).apply(womType))
+              .traverse(_.fold(this).apply(womType))
               .map(WomArray(_))
       }
     }
@@ -169,7 +169,7 @@ object InputParameter {
           case WomOptionalValue(_, Some(innerValue)) => populateFiles(innerValue).map(WomOptionalValue(_))
           case obj: WomObjectLike =>
             // Map the values
-            obj.values.toList.traverse[ErrorOr, (String, WomValue)]({
+            obj.values.toList.traverse({
               case (key, value) => populateFiles(value).map(key -> _)
             })
               .map(_.toMap)

--- a/cwl/src/main/scala/cwl/InputParameter.scala
+++ b/cwl/src/main/scala/cwl/InputParameter.scala
@@ -142,7 +142,7 @@ object InputParameter {
             val secondaryFilesFromType = inputType.fold(MyriadInputTypeToSecondaryFiles)
             val secondaryFiles = secondaryFilesFromInputParameter orElse secondaryFilesFromType
             val inputFormatsErrorOr = inputParameter.format
-                .traverse[ErrorOr, List[String]](_.fold(InputParameterFormatPoly).apply(parameterContext))
+                .traverse(_.fold(InputParameterFormatPoly).apply(parameterContext))
 
             for {
               inputFormatsOption <- inputFormatsErrorOr

--- a/cwl/src/main/scala/cwl/MyriadInputTypeToSortedCommandParts.scala
+++ b/cwl/src/main/scala/cwl/MyriadInputTypeToSortedCommandParts.scala
@@ -132,7 +132,7 @@ object MyriadInputInnerTypeToSortedCommandParts extends Poly1 {
         // iterate through the fields and fold over their type
         val partsFromFields:Option[CommandPartsList] =
           irs.fields.toList.flatten.
-            flatTraverse[Option, SortKeyAndCommandPart]{
+            flatTraverse{
               case InputRecordField(name, tpe, _, inputBinding, _) =>
                 // Parse the name to get a clean id
                 val parsedName = FullyQualifiedName(name)(ParentName.empty).id
@@ -205,7 +205,7 @@ object MyriadInputInnerTypeToSortedCommandParts extends Poly1 {
           sortKeyFromInputBindingFromInputerParameterParent.toList.some
         } else {
           // If neither valueFrom nor itemSeparator were defined, we need to process each item of the array
-          val fromArray: Option[CommandPartsList] = womArray.value.zipWithIndex.toList.flatTraverse[Option, SortKeyAndCommandPart]({
+          val fromArray: Option[CommandPartsList] = womArray.value.zipWithIndex.toList.flatTraverse({
             case (item, index) =>
               // Update the sorting key with the binding position (if any), add the index
               val itemSortingKey = {

--- a/cwl/src/main/scala/cwl/MyriadOutputTypeToWomFiles.scala
+++ b/cwl/src/main/scala/cwl/MyriadOutputTypeToWomFiles.scala
@@ -22,7 +22,7 @@ object MyriadOutputTypeToWomFiles extends Poly1 {
 
   implicit def acwl: Aux[Array[MyriadOutputInnerType], EvaluationFunction => ErrorOr[Set[WomFile]]] = at[Array[MyriadOutputInnerType]] { types => 
     evalFunction =>
-      types.toList.traverse[ErrorOr, Set[WomFile]](_.fold(MyriadOutputInnerTypeToWomFiles).apply(evalFunction)).map(_.toSet.flatten)
+      types.toList.traverse(_.fold(MyriadOutputInnerTypeToWomFiles).apply(evalFunction)).map(_.toSet.flatten)
   }
 }
 
@@ -39,7 +39,7 @@ object MyriadOutputInnerTypeToWomFiles extends Poly1 {
   implicit def ors: Aux[OutputRecordSchema, EvaluationFunction => ErrorOr[Set[WomFile]]] = at[OutputRecordSchema] {
     case OutputRecordSchema(_, Some(fields), _) =>
       evalFunction =>
-        fields.toList.traverse[ErrorOr, Set[WomFile]]({ field =>
+        fields.toList.traverse({ field =>
           field.outputBinding match {
             case Some(binding) => evalFunction(binding)
             case None => field.`type`.fold(MyriadOutputTypeToWomFiles).apply(evalFunction)

--- a/cwl/src/main/scala/cwl/MyriadOutputTypeToWomValue.scala
+++ b/cwl/src/main/scala/cwl/MyriadOutputTypeToWomValue.scala
@@ -55,7 +55,7 @@ object MyriadOutputInnerTypeToWomValue extends Poly1 {
   implicit def ors: Aux[OutputRecordSchema, Output] = at[OutputRecordSchema] { ors => (evalFunction, schemaDefRequirement) => ors match {
     case OutputRecordSchema(_, Some(fields), _) =>
         // Go over each field and evaluate the binding if there's one, otherwise keep folding over field types
-        def evaluateValues = fields.toList.traverse[ErrorOr, ((String, WomValue), (String, WomType))]({ field =>
+        def evaluateValues = fields.toList.traverse({ field =>
           val womType = field.`type`.fold(MyriadOutputTypeToWomType).apply(schemaDefRequirement)
           val womValue: ErrorOr[WomValue] = field.outputBinding match {
             case Some(binding) => evalFunction(binding, womType)

--- a/cwl/src/main/scala/cwl/OutputParameter.scala
+++ b/cwl/src/main/scala/cwl/OutputParameter.scala
@@ -27,7 +27,7 @@ object OutputParameter {
   def format(formatOption: Option[StringOrExpression],
              parameterContext: ParameterContext,
              expressionLib: ExpressionLib): ErrorOr[Option[String]] = {
-    formatOption.traverse[ErrorOr, String] {
+    formatOption.traverse{
       format(_, parameterContext, expressionLib)
     }
   }

--- a/cwl/src/main/scala/cwl/ScatterLogic.scala
+++ b/cwl/src/main/scala/cwl/ScatterLogic.scala
@@ -95,7 +95,7 @@ object ScatterLogic {
       // If there's no scatter make it an empty list
       .getOrElse(List.empty)
       // Traverse the list to create ScatterVariableNodes that will be used later on to create the ScatterNode
-      .traverse[ErrorOr, (WorkflowStepInput, ScatterVariableNode)](buildScatterVariable)
+      .traverse(buildScatterVariable)
       .toEither
       .map(_.toMap)
   }

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -133,7 +133,7 @@ case class Workflow private(
           (nodes, step) => nodes.flatMap(step.callWithInputs(typeMap, this, _, workflowInputs, validator, expressionLib)))
 
     val graphFromOutputs: Checked[Set[GraphNode]] =
-      outputs.toList.traverse[ErrorOr, GraphNode] {
+      outputs.toList.traverse{
         case WorkflowOutputParameter(id, _, _, _, _, _, _, Some(Inl(outputSource: String)), _, Some(tpe)) =>
           val womType: WomType = tpe.fold(MyriadOutputTypeToWomType).apply(allRequirements.schemaDefRequirement)
 

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -133,7 +133,7 @@ case class Workflow private(
           (nodes, step) => nodes.flatMap(step.callWithInputs(typeMap, this, _, workflowInputs, validator, expressionLib)))
 
     val graphFromOutputs: Checked[Set[GraphNode]] =
-      outputs.toList.traverse{
+      outputs.toList.traverse[ErrorOr, GraphNode] {
         case WorkflowOutputParameter(id, _, _, _, _, _, _, Some(Inl(outputSource: String)), _, Some(tpe)) =>
           val womType: WomType = tpe.fold(MyriadOutputTypeToWomType).apply(allRequirements.schemaDefRequirement)
 

--- a/cwl/src/main/scala/cwl/WorkflowStepInputMergeExpression.scala
+++ b/cwl/src/main/scala/cwl/WorkflowStepInputMergeExpression.scala
@@ -33,7 +33,7 @@ final case class WorkflowStepInputMergeExpression(input: WorkflowStepInput,
 
     def validateSources(sources: List[String]): ErrorOr[List[WomValue]] =
       sources.
-        traverse[ErrorOr, WomValue](lookupValue)
+        traverse(lookupValue)
 
     def isEmptyOptionalValue(womValue: WomValue): Boolean = womValue match {
       case WomOptionalValue(_, None) => true

--- a/cwl/src/main/scala/cwl/internal/CommandPartSortingAlgorithm.scala
+++ b/cwl/src/main/scala/cwl/internal/CommandPartSortingAlgorithm.scala
@@ -17,7 +17,7 @@ object CommandPartSortingAlgorithm {
       // arguments is an Option[Array[Argument]], the toList.flatten gives a List[Argument]
     arguments.toList.flatten
       // zip the index because we need it in the sorting key
-      .zipWithIndex.flatTraverse[CommandPartExpression, SortKeyAndCommandPart](argumentToCommandPart.tupled)
+      .zipWithIndex.flatTraverse(argumentToCommandPart.tupled)
 
   def argumentToCommandPart: (Argument, Int) => CommandPartExpression[List[SortKeyAndCommandPart]] = (argument, index) => ReaderT {
     case ((requirementsAndHints, expressionLib, _)) =>
@@ -34,7 +34,7 @@ object CommandPartSortingAlgorithm {
   }
 
   def inputBindingsCommandParts(inputs: Array[CommandInputParameter]): CommandPartExpression[List[SortKeyAndCommandPart]] =
-    inputs.toList.flatTraverse[CommandPartExpression, SortKeyAndCommandPart](inputBindingsCommandPart)
+    inputs.toList.flatTraverse(inputBindingsCommandPart)
 
   def inputBindingsCommandPart(inputParameter: CommandInputParameter): CommandPartExpression[List[SortKeyAndCommandPart]] =
     ReaderT{ case ((hintsAndRequirements, expressionLib, inputValues)) =>

--- a/cwl/src/main/scala/cwl/internal/CwlEcmaScriptDecoder.scala
+++ b/cwl/src/main/scala/cwl/internal/CwlEcmaScriptDecoder.scala
@@ -79,7 +79,7 @@ class CwlEcmaScriptDecoder {
     * Called to decode a map value using a supplied function.
     */
   def decodeMapValue[A](map: Map[Any, Any], key: String, f: Any => A): ErrorOr[Option[A]] = {
-    map.get(key).traverse[ErrorOr, A](anyRef => validate(f(anyRef)))
+    map.get(key).traverse(anyRef => validate(f(anyRef)))
   }
 
   /**

--- a/cwl/src/main/scala/cwl/internal/CwlEcmaScriptDecoder.scala
+++ b/cwl/src/main/scala/cwl/internal/CwlEcmaScriptDecoder.scala
@@ -46,7 +46,7 @@ class CwlEcmaScriptDecoder {
   def decodeMap(map: Map[Any, Any]): ErrorOr[WomValue] = {
     val realMap: Map[AnyRef, AnyRef] = map.asInstanceOf[Map[AnyRef, AnyRef]]
 
-    val tupleList = realMap.toList.traverse[ErrorOr,(String, WomValue)]{ 
+    val tupleList = realMap.toList.traverse{
       case (k,v) => (k.toString.validNel: ErrorOr[String], decode(v)).tupled
     }
     val mapWomValues =  tupleList.map(_.toMap)
@@ -71,7 +71,7 @@ class CwlEcmaScriptDecoder {
     */
   def decodeDirectoryOrFiles(value: Any): ErrorOr[Array[FileOrDirectory]] = {
     value match {
-      case na: NativeArray => na.asScala.toList.traverse[ErrorOr, FileOrDirectory](decodeDirectoryOrFile).map(_.toArray)
+      case na: NativeArray => na.asScala.toList.traverse(decodeDirectoryOrFile).map(_.toArray)
     }
   }
 
@@ -87,7 +87,7 @@ class CwlEcmaScriptDecoder {
     */
   def decodeMapDirectoryOrFiles(map: Map[Any, Any],
                                 key: String): ErrorOr[Option[Array[FileOrDirectory]]] = {
-    map.get(key).traverse[ErrorOr, Array[FileOrDirectory]](decodeDirectoryOrFiles)
+    map.get(key).traverse(decodeDirectoryOrFiles)
   }
 
   /**

--- a/cwl/src/main/scala/cwl/ontology/Schema.scala
+++ b/cwl/src/main/scala/cwl/ontology/Schema.scala
@@ -65,7 +65,7 @@ case class Schema(schemaIris: Seq[String],
     }
 
     val errorOr: ErrorOr[Unit] = for {
-      ontologies <- schemaIris.toList.traverse[ErrorOr, OWLOntology](loadOntologyFromIri(ontologyManager))
+      ontologies <- schemaIris.toList.traverse(loadOntologyFromIri(ontologyManager))
       _ = ontologies.foreach(addToSchema)
     } yield ()
     errorOr.toTry("Error loading schemas").get

--- a/cwl/src/test/scala/cwl/CommandLineToolSpec.scala
+++ b/cwl/src/test/scala/cwl/CommandLineToolSpec.scala
@@ -2,7 +2,6 @@ package cwl
 
 import cats.instances.list._
 import cats.syntax.traverse._
-import common.validation.ErrorOr.ErrorOr
 import org.scalatest.{FlatSpec, Matchers, ParallelTestExecution}
 import shapeless.Coproduct
 import wom.callable.Callable.RequiredInputDefinition
@@ -46,7 +45,7 @@ class CommandLineToolSpec extends FlatSpec with Matchers with ParallelTestExecut
       .buildCommandTemplate.run((RequirementsAndHints(List.empty), Vector.empty,inputs))
       .valueOr(errors => fail(errors.toList.mkString(", ")))
     template
-      .flatTraverse[ErrorOr, String](_.instantiate(localNameValues, noIoFunctionSet, identity[WomValue], runtimeEnv).map(_.map(_.commandString)))
+      .flatTraverse(_.instantiate(localNameValues, noIoFunctionSet, identity[WomValue], runtimeEnv).map(_.map(_.commandString)))
       .valueOr(errors => fail(errors.toList.mkString(", "))) shouldBe expectation
     
     cltFile.delete(true)

--- a/cwl/src/test/scala/cwl/CwlEcmaScriptEncoderSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlEcmaScriptEncoderSpec.scala
@@ -26,7 +26,7 @@ class CwlEcmaScriptEncoderSpec extends FlatSpec with Matchers with TableDrivenPr
     )
     val result: EcmaScriptUtil.ECMAScriptVariable = encoder.encode(file)
     val resultMap = result.asInstanceOf[ESObject].fields
-    resultMap.filterKeys(_ != "secondaryFiles") should contain theSameElementsAs expected
+    resultMap.filterKeys(_ != "secondaryFiles").toList should contain theSameElementsAs expected
     resultMap("secondaryFiles") should be(a[ESArray])
     resultMap("secondaryFiles").asInstanceOf[ESArray].array should be(empty)
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -54,7 +54,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
 
   private val backendFactories: Map[String, BackendLifecycleActorFactory] = {
     val factoriesValidation = workflowDescriptor.backendAssignments.values.toList
-      .traverse[ErrorOr, (String, BackendLifecycleActorFactory)] {
+      .traverse {
       backendName => CromwellBackends.backendLifecycleFactoryActorByName(backendName) map { backendName -> _ }
     }
 
@@ -308,7 +308,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       .map(outputNode =>
       outputNode -> data.valueStore.get(outputNode.graphOutputPort, None)
     )
-      .toList.traverse[ErrorOr, (GraphOutputNode, WomValue)]({
+      .toList.traverse({
       case (name, Some(value)) => (name -> value).validNel
       case (name, None) =>
         s"Cannot find an output value for ${name.identifier.fullyQualifiedName.value}".invalidNel
@@ -434,7 +434,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       case (jobKey, WaitingForQueueSpace) => pushWaitingForQueueSpaceCallMetadata(jobKey)
     })
 
-    val diffValidation = runnableKeys.traverse[ErrorOr, WorkflowExecutionDiff]({
+    val diffValidation = runnableKeys.traverse({
       case key: BackendJobDescriptorKey => processRunnableJob(key, data)
       case key: SubWorkflowKey => processRunnableSubWorkflow(key, data)
       case key: ConditionalCollectorKey => key.processRunnable(data)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
@@ -72,7 +72,7 @@ private [execution] case class ScatterKey(node: ScatterNode) extends JobKey {
       // Get all the iteration nodes (there will be as many as variables we're scattering over)
       .scatterVariableNodes
       // Retrieve the values of the collection nodes value from the ValueStore
-      .traverse[ErrorOr, ScatterVariableAndValue](getScatterArray)
+      .traverse(getScatterArray)
       // Convert to either so we can flatMap later
       .toEither
 

--- a/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
+++ b/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
@@ -103,7 +103,7 @@ object PartialWorkflowSources {
         case Some(inputs) => workflowInputsValidation(inputs)
         case None => Vector.empty.validNel
       }
-      val workflowInputsAux: ErrorOr[Map[Int, String]] = formData.toList.flatTraverse[ErrorOr, (Int, String)]({
+      val workflowInputsAux: ErrorOr[Map[Int, String]] = formData.toList.flatTraverse({
         case (name, value) if name.startsWith(WorkflowInputsAuxPrefix) =>
           Try(name.stripPrefix(WorkflowInputsAuxPrefix).toInt).toErrorOr.map(index => List((index, value.utf8String)))
         case _ => List.empty.validNel

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -61,7 +61,7 @@ object LanguageFactoryUtil {
    */
   private def validateExecutableInputs(inputs: ResolvedExecutableInputs, ioFunctions: IoFunctionSet): ErrorOr[Map[OutputPort, WomValue]] = {
     import common.validation.ErrorOr.MapTraversal
-    inputs.traverse[OutputPort, WomValue] {
+    inputs.traverse {
       case (key, value) => value.fold(ResolvedExecutableInputsPoly).apply(ioFunctions) map { key -> _ }
     }
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,6 +72,7 @@ object Settings {
     "-Ywarn-unused:implicits",
     "-Ywarn-unused:privates",
     "-Ywarn-unused:locals",
+    "-Ypartial-unification",
     "-Ywarn-unused:patvars"
   )
 

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
@@ -295,7 +295,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         for {
           _ <- dataAccess.addMetadataEvents(metadataEvents)
           _ <- dataAccess.refreshWorkflowMetadataSummaries().map(_ should be > 0L)
-          _ <- dataAccess.getWorkflowLabels(workflowId).map(_ should contain(customLabelKey -> customLabelValue))
+          _ <- dataAccess.getWorkflowLabels(workflowId).map(_.toList should contain(customLabelKey -> customLabelValue))
         } yield ()
       }
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -43,7 +43,7 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
     val result = sharedFS.localizeInputs(callDir, docker = docker)(inputs)
 
     result.isSuccess shouldBe true
-    result.get should contain theSameElementsAs localizedinputs
+    result.get.toList should contain theSameElementsAs localizedinputs
 
     dest.exists shouldBe true
     countLinks(dest) should be(linkNb)

--- a/wdl/model/draft2/src/test/scala/wdl/WdlWorkflowSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/WdlWorkflowSpec.scala
@@ -162,7 +162,7 @@ class WdlWorkflowSpec extends WordSpec with Matchers {
 
       val evaluatedOutputs = evaluateOutputs(ns.workflow, workflowInputs, NoFunctions, outputResolver)
       evaluatedOutputs match {
-        case Success(v) => v map { case (output, outputValue) => output.unqualifiedName -> outputValue } should contain theSameElementsAs evaluationExpectations
+        case Success(v) => v.map { case (output, outputValue) => output.unqualifiedName -> outputValue }.toList should contain theSameElementsAs evaluationExpectations
         case Failure(e) => fail(e)
       }
     }

--- a/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
+++ b/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
@@ -16,8 +16,8 @@ object WdlDraft2WomBundleMakers {
 
   implicit val wdlDraft2NamespaceWomBundleMaker: WomBundleMaker[WdlNamespace] = new WomBundleMaker[WdlNamespace] {
     override def toWomBundle(from: WdlNamespace): Checked[WomBundle] = {
-      val workflowsValidation: ErrorOr[List[WorkflowDefinition]] = from.workflows.toList.traverse[ErrorOr, WorkflowDefinition](_.toWomWorkflowDefinition(isASubworkflow = false))
-      val tasksValidation: ErrorOr[List[TaskDefinition]] = from.tasks.toList.traverse[ErrorOr, TaskDefinition](_.toWomTaskDefinition)
+      val workflowsValidation: ErrorOr[List[WorkflowDefinition]] = from.workflows.toList.traverse(_.toWomWorkflowDefinition(isASubworkflow = false))
+      val tasksValidation: ErrorOr[List[TaskDefinition]] = from.tasks.toList.traverse(_.toWomTaskDefinition)
 
       val errorOr = (workflowsValidation, tasksValidation) mapN { (workflows, tasks) =>
         val primary = if (workflows.size == 1) {

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/EnhancedDraft3Ast.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/ast2wdlom/EnhancedDraft3Ast.scala
@@ -6,7 +6,6 @@ import cats.syntax.traverse._
 import common.Checked
 import common.transforms.CheckedAtoB
 import common.validation.Checked._
-import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
 import wdl.draft3.parser.WdlParser.{Ast, AstList, AstNode}
 
@@ -47,7 +46,7 @@ object EnhancedDraft3Ast {
         // This toValidated/toEither dance is necessary to
         // (1) collect all errors from the traverse as an ErrorOr, then
         // (2) convert back into a Checked for the flatMap
-        result <- asVector.traverse[ErrorOr, A](item => toA.run(item).toValidated).toEither
+        result <- asVector.traverse(item => toA.run(item).toValidated).toEither
       } yield result
     }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/package.scala
@@ -22,7 +22,7 @@ package object expression {
                                    consumedValueLookup: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomExpression] = {
       val consumedValueHooks = a.expressionConsumedValueHooks
 
-      val neededLinkedValues = consumedValueHooks.toList.traverse[ErrorOr, (UnlinkedConsumedValueHook, GeneratedValueHandle)] {
+      val neededLinkedValues = consumedValueHooks.toList.traverse {
         case c if consumedValueLookup.contains(c) => (c -> consumedValueLookup(c)).validNel
         case missing => s"Could not create WOM expression for '$a': Found no generated value for consumed value $missing".invalidNel
       }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LiteralEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/types/LiteralEvaluators.scala
@@ -32,10 +32,10 @@ object LiteralEvaluators {
   implicit val mapLiteralTypeEvaluator: TypeEvaluator[MapLiteral] = new TypeEvaluator[MapLiteral] {
     override def evaluateType(a: MapLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
 
-      val keyTypes = a.elements.keySet.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val keyTypes = a.elements.keySet.toList.traverse { x: ExpressionElement => x.evaluateType(linkedValues) }
       val commonKeyType: ErrorOr[WomType] = keyTypes.map(WomType.homogeneousTypeFromTypes)
 
-      val valueTypes = a.elements.keySet.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val valueTypes = a.elements.keySet.toList.traverse { x: ExpressionElement => x.evaluateType(linkedValues) }
       val commonValueType: ErrorOr[WomType] = valueTypes.map(WomType.homogeneousTypeFromTypes)
 
       (commonKeyType, commonValueType) mapN { (k, v) => WomMapType(k, v) }
@@ -45,7 +45,7 @@ object LiteralEvaluators {
   implicit val arrayLiteralTypeEvaluator: TypeEvaluator[ArrayLiteral] = new TypeEvaluator[ArrayLiteral] {
     override def evaluateType(a: ArrayLiteral, linkedValues: Map[UnlinkedConsumedValueHook, GeneratedValueHandle]): ErrorOr[WomType] = {
 
-      val types = a.elements.toList.traverse[ErrorOr, WomType] { x: ExpressionElement => x.evaluateType(linkedValues) }
+      val types = a.elements.toList.traverse { x: ExpressionElement => x.evaluateType(linkedValues) }
       val commonType: ErrorOr[WomType] = types.map(WomType.homogeneousTypeFromTypes)
 
       commonType.map(WomArrayType.apply(_, guaranteedNonEmpty = a.elements.nonEmpty))

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
@@ -361,7 +361,7 @@ object EngineFunctionEvaluators {
       }
 
       processValidatedSingleValue[WomArray, WomArray](a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { array =>
-        val expandedValidation = array.value.toList.traverse[ErrorOr, Seq[WomValue]] { flatValues }
+        val expandedValidation = array.value.toList.traverse{ flatValues }
         expandedValidation map { expanded => EvaluatedValue(WomArray(expanded.flatten), Seq.empty) }
       } (coercer = WomArrayType(WomArrayType(WomAnyType)))
     }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/LiteralEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/LiteralEvaluators.scala
@@ -36,7 +36,7 @@ object LiteralEvaluators {
                                inputs: Map[String, WomValue],
                                ioFunctionSet: IoFunctionSet,
                                forCommandInstantiationOptions: Option[ForCommandInstantiationOptions]): ErrorOr[EvaluatedValue[_ <: WomValue]] = {
-      val evaluatedPieces = a.pieces.toList.traverse[ErrorOr, EvaluatedValue[_]] {
+      val evaluatedPieces = a.pieces.toList.traverse{
         case e: StringPlaceholder => e.expr.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)
         case s: StringLiteral => s.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)
       }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/LinkedGraphMaker.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/LinkedGraphMaker.scala
@@ -21,11 +21,11 @@ object LinkedGraphMaker {
            typeAliases: Map[String, WomType],
            callables: Map[String, Callable]): ErrorOr[LinkedGraph] = {
 
-    val generatedValuesByGraphNodeValidation = nodes.toList.traverse[ErrorOr, (WorkflowGraphElement, Set[GeneratedValueHandle])] { node =>
+    val generatedValuesByGraphNodeValidation = nodes.toList.traverse{ node =>
       node.generatedValueHandles(typeAliases, callables).map(node -> _)
     } map (_.toMap)
 
-    val consumedValuesByGraphNodeValidation: ErrorOr[Map[WorkflowGraphElement, Set[UnlinkedConsumedValueHook]]] = nodes.toList.traverse[ErrorOr, (WorkflowGraphElement, Set[UnlinkedConsumedValueHook])](n => n.graphElementConsumedValueHooks(typeAliases, callables).map(n -> _)).map(_.toMap)
+    val consumedValuesByGraphNodeValidation: ErrorOr[Map[WorkflowGraphElement, Set[UnlinkedConsumedValueHook]]] = nodes.toList.traverse(n => n.graphElementConsumedValueHooks(typeAliases, callables).map(n -> _)).map(_.toMap)
 
     for {
       generatedValuesByGraphNode <- generatedValuesByGraphNodeValidation
@@ -86,7 +86,7 @@ object LinkedGraphMaker {
     }
 
 
-    consumedValues.toList.traverse[ErrorOr, (UnlinkedConsumedValueHook, GeneratedValueHandle)] { findHandle } map {_.toMap}
+    consumedValues.toList.traverse { findHandle } map {_.toMap}
 
   }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomBundle.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomBundle.scala
@@ -37,7 +37,7 @@ object FileElementToWomBundle {
         val allStructs = structs ++ imports.flatMap(_.typeAliases)
 
         val localTasksValidation: ErrorOr[Map[String, Callable]] = {
-          tasks.traverse[ErrorOr, (String, CallableTaskDefinition)] { taskDefinition =>
+          tasks.traverse { taskDefinition =>
             taskConverter
               .run(TaskDefinitionElementToWomInputs(taskDefinition, structs))
               .map(t => t.name -> t).toValidated
@@ -47,7 +47,7 @@ object FileElementToWomBundle {
         localTasksValidation flatMap { localTaskMapping =>
 
           val workflowsValidation: ErrorOr[Vector[WorkflowDefinition]] = {
-            a.fileElement.workflows.toVector.traverse[ErrorOr, WorkflowDefinition] { workflowDefinition =>
+            a.fileElement.workflows.toVector.traverse { workflowDefinition =>
 
               val convertInputs = WorkflowDefinitionConvertInputs(workflowDefinition, allStructs, localTaskMapping ++ imports.flatMap(_.allCallables))
               workflowConverter.run(convertInputs).toValidated
@@ -69,7 +69,7 @@ object FileElementToWomBundle {
       }
 
       val taskDefValidation: ErrorOr[Vector[TaskDefinitionElement]] = a.fileElement.tasks.toVector.validNel
-      val importsValidation: ErrorOr[Vector[WomBundle]] = a.fileElement.imports.toVector.traverse[ErrorOr, WomBundle] { importWomBundle(_, a.workflowOptionsJson, a.importResolvers, a.languageFactories) }
+      val importsValidation: ErrorOr[Vector[WomBundle]] = a.fileElement.imports.toVector.traverse { importWomBundle(_, a.workflowOptionsJson, a.importResolvers, a.languageFactories) }
 
       (importsValidation flatMap { imports =>
         val structsValidation: ErrorOr[Map[String, WomType]] = StructEvaluation.convert(StructEvaluationInputs(a.fileElement.structs, imports.flatMap(_.typeAliases).toMap))

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
@@ -39,7 +39,7 @@ object TaskDefinitionElementToWomTaskDefinition {
       }
 
       val validCommand: ErrorOr[Seq[CommandPart]] = {
-        expandLines(a.taskDefinitionElement.commandSection.parts).toList.traverse[ErrorOr, CommandPart] { parts =>
+        expandLines(a.taskDefinitionElement.commandSection.parts).toList.traverse { parts =>
           CommandPartElementToWomCommandPart.convert(parts, taskGraph.linkedGraph.typeAliases, taskGraph.linkedGraph.generatedHandles)
         }.map(_.toSeq)
       }

--- a/wom/src/main/scala/wom/types/WomCompositeType.scala
+++ b/wom/src/main/scala/wom/types/WomCompositeType.scala
@@ -20,7 +20,7 @@ case class WomCompositeType(typeMap: Map[String, WomType]) extends WomObjectType
   }
 
   override def validateAndCoerceValues(values: Map[String, Any]): ErrorOr[Map[String, WomValue]] = {
-    typeMap.toList.traverse[ErrorOr, (String, WomValue)](Function.tupled(validateType(values))).map(_.toMap)
+    typeMap.toList.traverse(Function.tupled(validateType(values))).map(_.toMap)
   }
 
   override protected def coercion = {

--- a/wom/src/main/scala/wom/types/WomObjectType.scala
+++ b/wom/src/main/scala/wom/types/WomObjectType.scala
@@ -18,7 +18,7 @@ trait WomObjectTypeLike extends WomType {
     * See apply method in WomObject.
    */
   def validateAndCoerceValues(values: Map[String, Any]): ErrorOr[Map[String, WomValue]] = {
-    values.toList.traverse[ErrorOr, (String, WomValue)]({
+    values.toList.traverse({
       case (k, v) => WomAnyType.coerceRawValue(v).toErrorOr.map(k -> _)
     }).map(_.toMap)
   }


### PR DESCRIPTION
This compiler flags allows the compiler to take types of kind `F[_,_]` and infers `F[_]` by parameterizing the right most argument and fixing the other ones.

This allows us to omit type args when traversing to `Either` and `ErrorOr`, because scala can now see them as shape `F[_]` instead of "you gave me a type w/ 2 type args and I was expecting one"

**I did a find/replace on all our traverses, this may be controversial**, chime in if you disagree.

[Longer explanation](https://gist.github.com/djspiewak/7a81a395c461fd3a09a6941d4cd040f2)