### PR TITLE
Avoid unnecessary IO

### DIFF
--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -21,6 +21,8 @@ trait EvenBetterPathMethods {
 
   final def swapExt(oldExt: String, newExt: String): Path = swapSuffix(s".$oldExt", s".$newExt")
 
+  final def nameWithoutExtensionNoIo: String = if (name contains ".") name.substring(0, name lastIndexOf ".") else name
+
   final def plusSuffix(suffix: String): Path = swapSuffix("", suffix)
 
   final def swapSuffix(oldSuffix: String, newSuffix: String): Path = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -42,11 +42,11 @@ trait Delocalization {
     val gcsLegacyLogPath = createPipelineParameters.logGcsPath.pathAsString
 
     val stdoutPath = createPipelineParameters.logGcsPath
-      .sibling(createPipelineParameters.logGcsPath.nameWithoutExtension + "-stdout.log")
+      .sibling(createPipelineParameters.logGcsPath.nameWithoutExtensionNoIo + "-stdout.log")
       .pathAsString
 
     val stderrPath = createPipelineParameters.logGcsPath
-      .sibling(createPipelineParameters.logGcsPath.nameWithoutExtension + "-stderr.log")
+      .sibling(createPipelineParameters.logGcsPath.nameWithoutExtensionNoIo + "-stderr.log")
       .pathAsString
 
     createPipelineParameters.outputParameters.map(_.toAction(mounts)) ++


### PR DESCRIPTION
It appears that the better file implementation of `nameWithoutExtension` can check for the existence of the file under some circumstances. For GCS files this means an http request which seems unnecessary and and prone to failures