### PR TITLE
Support docker images and tags from local registry

### DIFF
--- a/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
@@ -35,6 +35,7 @@ object DockerImageIdentifier {
        
        (                                        # Begin capturing group for name
           [a-z0-9]+(?:[._-][a-z0-9]+)*          # API v2 name component regex - see https://docs.docker.com/registry/spec/api/#/overview
+          (?::[0-9]+)?                          # Optional port
           (?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*    # Optional additional name components separated by /
        )                                        # End capturing group for name
        
@@ -61,7 +62,7 @@ object DockerImageIdentifier {
     }
   }
   
-  private def isRegistryHostName(str: String) = str.contains('.')
+  private def isRegistryHostName(str: String) = str.contains('.') || str.startsWith("localhost")
   
   private def buildId(name: String, tag: Option[String], hash: Option[String]) = {
     val (dockerHost, dockerRepo, dockerImage): (Option[String], Option[String], String) = name.split('/').toList match {

--- a/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
@@ -19,6 +19,8 @@ class DockerImageIdentifierSpec extends FlatSpec with Matchers with TableDrivenP
       ("ubuntu:latest",                           None,               None,                   "ubuntu",     "latest"),
       ("ubuntu:1235-SNAP",                        None,               None,                   "ubuntu",     "1235-SNAP"),
       ("ubuntu:V3.8-5_1",                         None,               None,                   "ubuntu",     "V3.8-5_1"),
+      ("index.docker.io:9999/ubuntu:170904",  Some("index.docker.io:9999"), None,             "ubuntu",    "170904"),
+      ("localhost:5000/capture/transwf:170904", Some("localhost:5000"), Some("capture"),      "transwf",    "170904"),
       ("quay.io/biocontainers/platypus-variant:0.8.1.1--htslib1.5_0", Option("quay.io"), Some("biocontainers"), "platypus-variant", "0.8.1.1--htslib1.5_0")
     )
     


### PR DESCRIPTION
The regular expression that verifies docker image is modified to handle optional port. It allows using private and local registries with a port. Test cases covering this situation are provided.
 
**Resolves:** [Support docker images and tags from local registry](https://github.com/broadinstitute/cromwell/issues/2592)