### PR TITLE
Re-enable draft3_read_write_functions test

### DIFF
--- a/centaur/src/main/resources/standardTestCases/draft3_read_write_functions.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_read_write_functions.test
@@ -2,9 +2,7 @@ name: draft3_read_write_functions
 testFormat: workflowsuccess
 workflowType: WDL
 workflowTypeVersion: 1.0
-tags: [localdockertest, "wdl_1.0"]
-backendsMode: "only"
-backends: [Local, LocalNoDocker, Papi]
+tags: ["wdl_1.0"]
 
 files {
   workflow: wdl_draft3/read_write_functions/read_write_functions.wdl


### PR DESCRIPTION
No reason to limit this now that the BCS tests are turned off

(also I'm not sure this was actually doing what it looks like it should be doing)