### PR TITLE
Catch sub-workflow task input passing from inputs.json at validation time.

### DIFF
--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/CallElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/CallElementToGraphNode.scala
@@ -26,7 +26,12 @@ object CallElementToGraphNode {
     def callableValidation: ErrorOr[Callable] =
       a.callables.get(a.node.callableReference) match {
         // pass in specific constructor depending on callable type
-        case Some(c: Callable) => c.valid
+        case Some(w: WorkflowDefinition) =>
+          val unsuppliedInputs = w.inputs.collect {
+            case r: RequiredInputDefinition if r.localName.value.contains(".") => r.localName.value
+          }
+          if (unsuppliedInputs.isEmpty) { w.validNel } else { s"Cannot call '${a.node.callableReference}'. To be called as a sub-workflow it must declare and pass-through the following values via workflow inputs: ${unsuppliedInputs.mkString(", ")}".invalidNel }
+        case Some(c: Callable) => c.validNel
         case None => s"Cannot resolve a callable with name ${a.node.callableReference}".invalidNel
       }
 

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/error.txt
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/error.txt
@@ -1,0 +1,1 @@
+Cannot call 'import_me.sub_wf'. To be called as a sub-workflow it must declare and pass-through the following values via workflow inputs: sub_wf.foo.x

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/import_me.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/import_me.wdl
@@ -1,0 +1,20 @@
+version 1.0
+
+workflow sub_wf {
+  # Calls foo but doesn't provide an 'x', so this workflow shouldn't (strictly) be allowed as a sub-workflow
+  call foo
+}
+
+task foo {
+  input {
+    Int x
+  }
+  command {
+  }
+  output {
+    Int y = x
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/subwf_sub_inputs.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/subwf_sub_inputs/subwf_sub_inputs.wdl
@@ -1,0 +1,8 @@
+version 1.0
+
+import "import_me.wdl"
+
+workflow main {
+  # Shouldn't (strictly) be able to call this sub-workflow because the inputs are not passed through
+  call import_me.sub_wf
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/error.txt
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/error.txt
@@ -1,0 +1,1 @@
+WARNING: Unexpected input provided: supplied_optional_subwf_sub_inputs.sub_wf.foo.x

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/import_me.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/import_me.wdl
@@ -1,0 +1,24 @@
+version 1.0
+
+workflow sub_wf {
+  input {
+    Int y
+  }
+  # Calls foo but doesn't provide an 'x'. That's fine because the input was optional, but now the outer WF cannot override it.
+  call foo { input: y = y }
+}
+
+task foo {
+  input {
+    Int? x
+    Int y
+  }
+  command {
+  }
+  output {
+    Int z = y
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/supplied_optional_subwf_sub_inputs.inputs.json
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/supplied_optional_subwf_sub_inputs.inputs.json
@@ -1,0 +1,4 @@
+{
+  "supplied_optional_subwf_sub_inputs.sub_wf.y": 5,
+  "supplied_optional_subwf_sub_inputs.sub_wf.foo.x": 5
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/supplied_optional_subwf_sub_inputs.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/supplied_optional_subwf_sub_inputs/supplied_optional_subwf_sub_inputs.wdl
@@ -1,0 +1,8 @@
+version 1.0
+
+import "import_me.wdl"
+
+workflow supplied_optional_subwf_sub_inputs {
+  # Shouldn't (strictly) be able to call this sub-workflow because the inputs are not passed through
+  call import_me.sub_wf
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/subwf_sub_inputs/import_me.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/subwf_sub_inputs/import_me.wdl
@@ -1,0 +1,24 @@
+version 1.0
+
+workflow sub_wf {
+  input {
+    Int y
+  }
+  # Calls foo but doesn't provide an 'x'. That's fine because the inputs are optional
+  call foo { input: y = y }
+}
+
+task foo {
+  input {
+    Int? x
+    Int y
+  }
+  command {
+  }
+  output {
+    Int z = y
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/subwf_sub_inputs/subwf_sub_inputs.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/subwf_sub_inputs/subwf_sub_inputs.wdl
@@ -1,0 +1,8 @@
+version 1.0
+
+import "import_me.wdl"
+
+workflow main {
+  # Shouldn't (strictly) be able to call this sub-workflow because the inputs are not passed through
+  call import_me.sub_wf
+}


### PR DESCRIPTION
This prevents the WOM model being constructed if an invalid call is made to a sub-workflow with unfixed inputs.

Red thumb required for the womtool changes