### PR TITLE
Create backing directories for Directories.

### DIFF
--- a/cwl/src/main/scala/cwl/CwlType.scala
+++ b/cwl/src/main/scala/cwl/CwlType.scala
@@ -235,8 +235,16 @@ case class Directory private
   }
 
   lazy val asWomValue: ErrorOr[WomFile] = {
+    // Callers expect the directory's last component to match the basename if this Directory has a basename.
+    def tempDirectory: String = {
+      val dir = better.files.File.newTemporaryDirectory()
+      basename match {
+        case None => dir.pathAsString
+        case Some(b) => dir.createChild(b, asDirectory = true)().pathAsString
+      }
+    }
     errorOrListingOption flatMap { listingOption =>
-      val valueOption = path.orElse(location).orElse(basename).orElse(Option(better.files.File.newTemporaryDirectory().pathAsString))
+      val valueOption = path.orElse(location).orElse(Option(tempDirectory))
       WomMaybeListedDirectory(valueOption, listingOption, basename).valid
     }
   }

--- a/src/bin/ci/testCentaurCwlConformanceLocal.sh
+++ b/src/bin/ci/testCentaurCwlConformanceLocal.sh
@@ -12,7 +12,7 @@ CENTAUR_CWL_RUNNER="$(pwd)/centaurCwlRunner/src/bin/centaur-cwl-runner.bash"
 git clone https://github.com/common-workflow-language/common-workflow-language.git
 cd common-workflow-language
 # checkout a known git hash to prevent the tests from changing out from under us
-git checkout dbca5a59e33b677a3b0fe4095e2f5ee33703044e
+git checkout e7ae597e79d426feca3d4faa474806070c3fa7d5
 cd ..
 
 CWL_TEST_DIR=$(pwd)/common-workflow-language/v1.0/v1.0

--- a/src/bin/ci/testCentaurCwlConformancePAPIv2.sh
+++ b/src/bin/ci/testCentaurCwlConformancePAPIv2.sh
@@ -55,7 +55,7 @@ ENABLE_COVERAGE=true sbt assembly
 git clone https://github.com/common-workflow-language/common-workflow-language.git
 cd common-workflow-language
 # checkout a known git hash to prevent the tests from changing out from under us
-git checkout dbca5a59e33b677a3b0fe4095e2f5ee33703044e
+git checkout e7ae597e79d426feca3d4faa474806070c3fa7d5
 cd ..
 
 CROMWELL_JAR=$(find "$(pwd)/server/target/scala-2.12" -name "cromwell-*.jar")


### PR DESCRIPTION
Re-pin the conformance hash and fix the most recently added CWL conformance test by creating a directory for Directories without a `path` or `location`.