### PR TITLE
Requester pays functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ Please update your configuration accordingly.
 If you don't update the `actor-factory` value, you'll get a deprecation warning in the logs, and Cromwell will default back to
 **PAPI V1**
 
+**Requester Pays**
+
+Cromwell now supports [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) feature for Cloud Storage. With Requester Pays enabled on your bucket,
+you can require requesters to include a billing project in their requests, thus billing the requester's project. More information about it and how to include billing project can be found [here](backends/Google#requester-pays).
+It is highly recommended to add the billing project id as part of google configuration as shown in [`Getting started on Google Pipelines API`](http://cromwell.readthedocs.io/en/develop/tutorials/PipelinesApi101/)
+by replacing the `<google-billing-project-id>` with the project id.
+
 ### Labels
 * Cromwell has removed most of the formatting restrictions from custom labels. Please check the [README](README.md#label-format) for more detailed documentation.
 * Custom labels won't be submitted to Google backend as they are now decoupled from Google's default labels.
@@ -48,7 +55,7 @@ All language factories can now be configured on a per-language-version basis. Al
 
 * More accurately returns 503 instead of 500 when Cromwell can not respond in a timely manner
 * Cromwell now allows a user to submit a workflow but in a state where it will not automatically be picked up for execution. This new state is called 'On Hold'. To do this you need to set the parameter workflowOnHold to true while submitting the workflow.
-* API end point 'release' will allow the user to send a signal to Cromwell to allow a workflow to be startable, at which point it will be picked up by normal execution schemes.
+* API end point 'releaseHold' will allow the user to send a signal to Cromwell to allow a workflow to be startable, at which point it will be picked up by normal execution schemes.
 
 ### GPU
 

--- a/centaur/src/main/resources/standardTestCases/globbing_behavior_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/globbing_behavior_with_requester_pays.test
@@ -1,0 +1,13 @@
+name: globbing_behavior_with_requester_pays
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: globbing_behavior_with_requester_pays/globbing_behavior_with_requester_pays.wdl
+}
+
+metadata {
+  workflowName: globbing_behavior_with_requester_pays
+  status: Succeeded
+  "outputs.globbing_behavior_with_requester_pays.globArrayContent": "globArray"
+}

--- a/centaur/src/main/resources/standardTestCases/globbing_behavior_with_requester_pays/globbing_behavior_with_requester_pays.wdl
+++ b/centaur/src/main/resources/standardTestCases/globbing_behavior_with_requester_pays/globbing_behavior_with_requester_pays.wdl
@@ -1,0 +1,26 @@
+task globbing_behavior_task{
+    command {
+        echo "staticFile" > staticFile.txt
+        echo "staticArray" > staticArray.txt
+        echo "globFile" > globFile.txt
+        echo "globArray" > globArray.txt
+    }
+
+    output {
+        Array[File] globArray = glob("*.txt")
+        String globArrayContent = read_string(globArray[0])
+    }
+
+    runtime {
+        docker: "us.gcr.io/google-containers/ubuntu-slim:0.14"
+    }
+}
+
+
+workflow globbing_behavior_with_requester_pays{
+    call globbing_behavior_task
+
+    output {
+        String globArrayContent = globbing_behavior_task.globArrayContent
+    }
+}

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
@@ -1,6 +1,9 @@
 name: input_from_bucket_with_requester_pays
 testFormat: workflowsuccess
 backends: [Papiv2]
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0"]
 
 files {
   workflow: input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
@@ -1,0 +1,13 @@
+name: input_from_bucket_with_requester_pays
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl
+  inputs: input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.inputs
+}
+
+metadata {
+  workflowName: input_from_bucket_with_requester_pays
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.inputs
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.inputs
@@ -1,0 +1,3 @@
+{
+  "input_from_bucket_with_requester_pays.file": "gs://cromwell_bucket_with_requester_pays/gumby.png"
+}

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl
@@ -1,0 +1,22 @@
+task size_task {
+  Float sz
+
+  command {
+    echo "file has size ${sz}"
+  }
+  output {
+    File out = stdout()
+  }
+  runtime {
+    docker: "us.gcr.io/google-containers/ubuntu-slim:0.14"
+  }
+}
+
+workflow input_from_bucket_with_requester_pays {
+  File file
+  call size_task { input: sz = size(file) }
+
+  output {
+    String out = read_string(size_task.out)
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays/input_from_bucket_with_requester_pays.wdl
@@ -1,5 +1,9 @@
+version 1.0
+
 task size_task {
-  Float sz
+  input {
+    Float sz
+   }
 
   command {
     echo "file has size ${sz}"
@@ -13,7 +17,9 @@ task size_task {
 }
 
 workflow input_from_bucket_with_requester_pays {
-  File file
+  input {
+    File file
+  }
   call size_task { input: sz = size(file) }
 
   output {

--- a/centaur/src/main/resources/standardTestCases/missing_input_failure.test
+++ b/centaur/src/main/resources/standardTestCases/missing_input_failure.test
@@ -11,5 +11,5 @@ metadata {
     workflowName: missing_input_failure
     status: Failed
     "failures.0.message": "Workflow failed"
-    "failures.0.causedBy.0.message": "Failed to evaluate 'missing_input_failure.hello.addressee' (reason 1 of 1): Evaluating read_string(wf_hello_input) failed: java.nio.file.NoSuchFileException: gs://nonexistingbucket/path/doesnt/exist"
+    "failures.0.causedBy.0.message": "Failed to evaluate 'missing_input_failure.hello.addressee' (reason 1 of 1): Evaluating read_string(wf_hello_input) failed: java.io.IOException: Failed to open an input stream for gs://nonexistingbucket/path/doesnt/exist"
 }

--- a/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays.test
@@ -1,6 +1,9 @@
 name: read_file_from_bucket_with_requester_pays
 testFormat: workflowsuccess
 backends: [Papiv2]
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0"]
 
 files {
   workflow: read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl

--- a/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays.test
@@ -1,0 +1,13 @@
+name: read_file_from_bucket_with_requester_pays
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl
+  inputs: read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.inputs
+}
+
+metadata {
+  workflowName: read_file_from_bucket_with_requester_pays
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.inputs
+++ b/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.inputs
@@ -1,0 +1,3 @@
+{
+  "read_file_from_bucket_with_requester_pays.file": "gs://cromwell_bucket_with_requester_pays/lorem ipsum.txt"
+}

--- a/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl
+++ b/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl
@@ -1,0 +1,21 @@
+task concat_task{
+    Array[String] array
+
+    command {
+        echo $${sep = ' ' array} > concat
+      }
+      output {
+        String out = read_string("concat")
+      }
+    runtime {
+        docker: "us.gcr.io/google-containers/ubuntu-slim:0.14"
+    }
+}
+
+
+workflow read_file_from_bucket_with_requester_pays {
+    File file
+    Array[String] in_array = read_lines(file)
+
+    call concat_task{input: array = in_array}
+}

--- a/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl
+++ b/centaur/src/main/resources/standardTestCases/read_file_from_bucket_with_requester_pays/read_file_from_bucket_with_requester_pays.wdl
@@ -1,8 +1,12 @@
+version 1.0
+
 task concat_task{
-    Array[String] array
+    input {
+      Array[String] array
+    }
 
     command {
-        echo $${sep = ' ' array} > concat
+        echo ${sep = ' ' array} > concat
       }
       output {
         String out = read_string("concat")
@@ -14,8 +18,14 @@ task concat_task{
 
 
 workflow read_file_from_bucket_with_requester_pays {
-    File file
+    input{
+        File file
+    }
     Array[String] in_array = read_lines(file)
 
     call concat_task{input: array = in_array}
+
+    output {
+        String out = concat_task.out
+    }
 }

--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -1,9 +1,11 @@
 package cromwell.core.path
 
+import java.io.InputStream
 import java.nio.file.{FileAlreadyExistsException, Files}
 import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
 
 import scala.collection.JavaConverters._
+import scala.io.Codec
 
 /**
   * Implements methods beyond those implemented in NioPathMethods and BetterFileMethods
@@ -82,4 +84,10 @@ trait EvenBetterPathMethods {
   final def untailed = UntailedWriter(this)
 
   final def tailed(tailedSize: Int) = TailedWriter(this, tailedSize)
+
+  def mediaInputStream: InputStream = newInputStream
+
+  def readContentAsString(implicit codec: Codec): String = contentAsString
+
+  def readAllLinesInFile(implicit codec: Codec): Traversable[String] = lines
 }

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -187,6 +187,8 @@ engine {
   filesystems {
     #  gcs {
     #    auth = "application-default"
+    #    # Google project which will be billed for the requests
+    #    project = "google-billing-project"
     #  }
     #  oss {
     #    auth {
@@ -628,6 +630,8 @@ backend {
     #      gcs {
     #        # A reference to a potentially different auth for manipulating files via engine functions.
     #        auth = "application-default"
+    #        # Google project which will be billed for the requests
+    #        project = "google-billing-project"
     #
     #        caching {
     #          # When a cache hit is found, the following duplication strategy will be followed to use the cached outputs

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -167,6 +167,19 @@ precedence over the `root` specified at `backend.providers.JES.config.root` in t
 workflows using the Google backend.
 
 
+#### Requester Pays
+
+Cromwell supports [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) feature for Cloud Storage. With Requester Pays enabled on your bucket,
+you can require requesters to include a billing project in their requests, thus billing the requester's project. If the bucket you are accessing has requester pays enabled,
+to access the file inside that bucket you need to mention the Google project id which can be billed for that request. The billing project information can be added in ways described below. Cromwell will
+look for this information in this order.
+1. It can be added as `'google_project':'project-id'` as part of workflow options during workflow submission
+2. It can be included inside configuration file as shown in [`Getting started on Google Pipelines API`](http://cromwell.readthedocs.io/en/develop/tutorials/PipelinesApi101/) where you need to replace the `<google-billing-project-id>` with the project id **(HIGHLY RECOMMENDED)**
+3. Cromwell will use the default project that has been configured with gcloud
+
+It is highly recommended to add the project id as part of configuration if you don't want to specify as part of workflow options each time you submit request.
+
+
 #### Google Labels
 
 Every call run on the Pipelines API backend is given certain labels by default, so that Google resources can be queried by these labels later. The current default label set automatically applied is:

--- a/docs/tutorials/PipelinesApi101.md
+++ b/docs/tutorials/PipelinesApi101.md
@@ -78,7 +78,8 @@ workflow wf_hello {
 **Google Configuration File**
 
 Copy over the sample `google.conf` file utilizing <a href="https://developers.google.com/identity/protocols/application-default-credentials" target="_blank">Application Default credentials</a> to the same directory that contains your sample WDL, inputs and Cromwell jar.
-Replace `<google-project-id>` and `<google-bucket-name>`in the configuration file with the project id and bucket name.  
+Replace `<google-project-id>` and `<google-bucket-name>`in the configuration file with the project id and bucket name. Replace `<google-billing-project-id>` with the project id that has to be billed for the request (more information for Requester Pays can be found at:
+<a href="https://cloud.google.com/storage/docs/requester-pays" target="_blank">Requester Pays</a>)
 
 ***google.conf***
 ```
@@ -100,6 +101,7 @@ engine {
   filesystems {
     gcs {
       auth = "application-default"
+      project = "<google-billing-project-id>"
     }
   }
 }
@@ -140,6 +142,7 @@ backend {
           gcs {
             // A reference to a potentially different auth for manipulating files via engine functions.
             auth = "application-default"
+            project = "<google-billing-project-id>"
           }
         }
       }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilderFactory.scala
@@ -28,8 +28,10 @@ final case class GcsPathBuilderFactory(globalConfig: Config, instanceConfig: Con
 
   val authMode = authModeValidation.unsafe(s"Failed to create authentication mode for $authModeAsString")
 
+  val defaultProject = instanceConfig.as[Option[String]]("project")
+
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = {
-    GcsPathBuilder.fromAuthMode(authMode, applicationName, DefaultRetrySettings, GcsStorage.DefaultCloudStorageConfiguration, options)
+    GcsPathBuilder.fromAuthMode(authMode, applicationName, DefaultRetrySettings, GcsStorage.DefaultCloudStorageConfiguration, options, defaultProject)
   }
 }
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
@@ -50,7 +50,9 @@ case class GcsBatchCopyCommand(
   val destinationBlob = destination.blob
   
   override def operation: StorageRequest[RewriteResponse] = {
-    val rewriteOperation = source.apiStorage.objects().rewrite(sourceBlob.getBucket, sourceBlob.getName, destinationBlob.getBucket, destinationBlob.getName, null)
+    val rewriteOperation = source.apiStorage.objects()
+      .rewrite(sourceBlob.getBucket, sourceBlob.getName, destinationBlob.getBucket, destinationBlob.getName, null)
+      .setUserProject(source.projectId)
     // Set the rewrite token if present
     rewriteToken foreach rewriteOperation.setRewriteToken 
     rewriteOperation
@@ -76,7 +78,7 @@ case class GcsBatchDeleteCommand(
                                   override val swallowIOExceptions: Boolean
                                 ) extends IoDeleteCommand(file, swallowIOExceptions) with GcsBatchIoCommand[Unit, Void] {
   private val blob = file.blob
-  def operation = file.apiStorage.objects().delete(blob.getBucket, blob.getName)
+  def operation = file.apiStorage.objects().delete(blob.getBucket, blob.getName).setUserProject(file.projectId)
   override protected def mapGoogleResponse(response: Void): Unit = ()
   override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders) = {
     if (swallowIOExceptions) Option(Left(())) else None
@@ -89,7 +91,7 @@ case class GcsBatchDeleteCommand(
 sealed trait GcsBatchGetCommand[T] extends GcsBatchIoCommand[T, StorageObject] {
   def file: GcsPath
   private val blob = file.blob
-  override def operation: StorageRequest[StorageObject] = file.apiStorage.objects().get(blob.getBucket, blob.getName)
+  override def operation: StorageRequest[StorageObject] = file.apiStorage.objects().get(blob.getBucket, blob.getName).setUserProject(file.projectId)
 }
 
 case class GcsBatchSizeCommand(override val file: GcsPath) extends IoSizeCommand(file) with GcsBatchGetCommand[Long] {

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -23,7 +23,8 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
       "cromwell-test",
       RetrySettings.newBuilder().build(),
       CloudStorageConfiguration.DEFAULT,
-      wfOptionsWithProject
+      wfOptionsWithProject,
+      Option("default_project")
     )
 
     gcsPathBuilderWithProjectInfo.projectId shouldBe "my_project"
@@ -319,7 +320,8 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
       "cromwell-test",
       RetrySettings.newBuilder().build(),
       CloudStorageConfiguration.DEFAULT,
-      WorkflowOptions.empty
+      WorkflowOptions.empty,
+      Option("default_project")
     )
   }
 }

--- a/src/bin/ci/resources/papiv1_centaur.conf.ctmpl
+++ b/src/bin/ci/resources/papiv1_centaur.conf.ctmpl
@@ -23,7 +23,10 @@ backend {
           token = "{{$cromwellDockerhub.Data.token}}"
         }
         filesystems {
-          gcs.auth = "service_account"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+          }
         }
       }
     }
@@ -43,7 +46,10 @@ backend {
           token = "{{$cromwellDockerhub.Data.token}}"
         }
         filesystems {
-          gcs.auth = "service_account"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+          }
         }
       }
     }
@@ -58,7 +64,10 @@ backend {
           endpoint-url = "https://genomics.googleapis.com/"
         }
         filesystems {
-          gcs.auth = "refresh_token"
+          gcs {
+            auth = "refresh_token"
+            project = "broad-dsde-cromwell-dev"
+          }
         }
       }
     }
@@ -73,8 +82,11 @@ backend {
           endpoint-url = "https://genomics.googleapis.com/"
         }
         filesystems {
-          gcs.auth = "service_account"
-          gcs.caching.duplication-strategy = "reference"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+            caching.duplication-strategy = "reference"
+          }
         }
       }
     }
@@ -105,7 +117,10 @@ call-caching {
 
 engine {
   filesystems {
-    gcs.auth = "service_account"
+    gcs {
+      auth = "service_account"
+      project = "broad-dsde-cromwell-dev"
+    }
   }
 }
 

--- a/src/bin/ci/resources/papiv2_centaur.conf.ctmpl
+++ b/src/bin/ci/resources/papiv2_centaur.conf.ctmpl
@@ -19,7 +19,10 @@ backend {
           endpoint-url = "https://genomics.googleapis.com/"
         }
         filesystems {
-          gcs.auth = "service_account"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+          }
         }
       }
     }
@@ -35,7 +38,10 @@ backend {
           endpoint-url = "https://genomics.googleapis.com/"
         }
         filesystems {
-          gcs.auth = "service_account"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+          }
         }
       }
     }
@@ -50,8 +56,11 @@ backend {
           endpoint-url = "https://genomics.googleapis.com/"
         }
         filesystems {
-          gcs.auth = "service_account"
-          gcs.caching.duplication-strategy = "reference"
+          gcs {
+            auth = "service_account"
+            project = "broad-dsde-cromwell-dev"
+            caching.duplication-strategy = "reference"
+          }
         }
       }
     }
@@ -82,7 +91,10 @@ call-caching {
 
 engine {
   filesystems {
-    gcs.auth = "service_account"
+    gcs {
+      auth = "service_account"
+      project = "broad-dsde-cromwell-dev"
+    }
   }
 }
 

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
@@ -43,7 +43,8 @@ case class PipelinesApiWorkflowPaths(workflowDescriptor: BackendWorkflowDescript
       papiConfiguration.googleConfig.applicationName,
       RetrySettings.newBuilder().build(),
       GcsStorage.DefaultCloudStorageConfiguration,
-      workflowOptions
+      workflowOptions,
+      Option(papiConfiguration.jesAttributes.project)
     )
 
     val authBucket = pathBuilderWithGenomicsAuth.build(bucket) recover {

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
@@ -54,7 +54,7 @@ import scala.util.Success
 class PipelinesApiAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsyncBackendJobExecutionActorSpec")
   with FlatSpecLike with Matchers with ImplicitSender with Mockito with BackendSpec with BeforeAndAfter with DefaultJsonProtocol {
   val mockPathBuilder: GcsPathBuilder = GcsPathBuilder.fromCredentials(NoCredentials.getInstance(),
-    "test-cromwell", RetrySettings.newBuilder().build(), GcsStorage.DefaultCloudStorageConfiguration, WorkflowOptions.empty)
+    "test-cromwell", RetrySettings.newBuilder().build(), GcsStorage.DefaultCloudStorageConfiguration, WorkflowOptions.empty, Option("default_project") )
 
   var kvService: ActorRef = system.actorOf(Props(new InMemoryKvServiceActor))
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesConversions.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesConversions.scala
@@ -34,7 +34,7 @@ object PipelinesConversions {
   implicit class EnhancedFileInput(val fileInput: PipelinesApiFileInput) extends AnyVal {
     def toEnvironment = Map(fileInput.name -> fileInput.containerPath)
 
-    def toAction(mounts: List[Mount]) = gsutil("cp", fileInput.cloudPath, fileInput.containerPath.pathAsString)(mounts, description = Option("localizing"))
+    def toAction(mounts: List[Mount], projectId: String) = gsutil("-u", projectId, "cp", fileInput.cloudPath, fileInput.containerPath.pathAsString)(mounts, description = Option("localizing"))
 
     def toMount = {
       new Mount()
@@ -46,7 +46,7 @@ object PipelinesConversions {
   implicit class EnhancedFileOutput(val fileOutput: PipelinesApiFileOutput) extends AnyVal {
     def toEnvironment = Map(fileOutput.name -> fileOutput.containerPath.pathAsString)
 
-    def toAction(mounts: List[Mount]): Action = delocalize(fileOutput, mounts)
+    def toAction(mounts: List[Mount], projectId: String): Action = delocalize(fileOutput, mounts, projectId)
 
     def toMount = {
       new Mount()

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -54,11 +54,11 @@ object ActionBuilder {
       .setLabels(description.map("description" -> _).toMap.asJava)
   }
 
-  def delocalize(fileOutput: PipelinesApiFileOutput, mounts: List[Mount]) = {
+  def delocalize(fileOutput: PipelinesApiFileOutput, mounts: List[Mount], projectId: String) = {
     // The command String runs in Bourne shell to get the conditional logic for optional outputs so shell metacharacters in filenames must be escaped.
     val List(containerPath, cloudPath) = List(fileOutput.containerPath.pathAsString, fileOutput.cloudPath) map ESCAPE_XSI.translate
 
-    val copy = s"gsutil cp $containerPath $cloudPath"
+    val copy = s"gsutil -u $projectId cp $containerPath $cloudPath"
     lazy val copyOnlyIfExists = s"if [[ -a $containerPath ]]; then $copy; fi"
 
     cloudSdkAction

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
@@ -20,7 +20,7 @@ trait Localization {
       )
       .setMounts(mounts.asJava)
 
-    val jobInputLocalization = createPipelineParameters.inputOutputParameters.fileInputParameters.map(_.toAction(mounts))
+    val jobInputLocalization = createPipelineParameters.inputOutputParameters.fileInputParameters.map(_.toAction(mounts, createPipelineParameters.projectId))
     
     List(containerRootSetup) ++ jobInputLocalization
   }


### PR DESCRIPTION
Requester pays is now added to Cromwell. The user can set the billing project id using one of the methods listed below:

- It can be added as `'google_project':'project-id'` as part of workflow options during workflow submission
- It can be included inside configuration file as shown in Getting started on Google Pipelines API where you need to replace the <google-billing-project-id> with the project id
- If it is not mentioned using above 2 ways, Cromwell will use the default project that has been configured with gcloud

More information about Requester pays can be found [here](https://cloud.google.com/storage/docs/requester-pays)