### PR TITLE
Call cache capoeira for 1.0 (plus ensure task hashes match draft-2)

### DIFF
--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -1,0 +1,53 @@
+name: draft3_call_cache_capoeira_jes
+testFormat: workflowsuccess
+backends: [Papi, Local]
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0"]
+
+files {
+  workflow: wdl_draft3/draft3_call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+}
+
+metadata {
+  workflowName: draft3_call_cache_capoeira
+  status: Succeeded
+  "calls.draft3_call_cache_capoeira.make_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.make_files_cached.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.make_files:-1"
+
+  "calls.draft3_call_cache_capoeira.read_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.modify_file_gcs.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_after_modify.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_copied_files.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.read_files:-1"
+  "calls.draft3_call_cache_capoeira.read_files_swapped.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_command.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_expressions.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_names.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_non_file_input_switcheroo.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_inputs_renamed.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_docker.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode_2.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_failOnStderr.callCaching.hit": false
+
+  "calls.draft3_call_cache_capoeira.read_files_whitespace.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_continueOnReturnCode.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_failOnStderr.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_failOnStderr_expression.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_array_files_rearranged.callCaching.hit": false
+  
+  // Check that hashes are published to metadata
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output count": "C81E728D9D4C2F636F067F89CC14862C"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.docker": "09F611634147800124391D34D57A3A9F"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.failOnStderr": "68934A3E9455FA72420237EB05902327"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "EQWINA=="
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "T53tZg=="
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.backend name": "36EF4A8AB268D1A1C74D8108C93D48ED"
+}

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -45,7 +45,7 @@ metadata {
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
-  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "ED56C94E5CD5871CDB6D9A702F299073"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "EQWINA=="
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "T53tZg=="

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -6,7 +6,7 @@ workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]
 
 files {
-  workflow: wdl_draft3/draft3_call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+  workflow: wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_local.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_local.test
@@ -1,0 +1,54 @@
+name: draft3_call_cache_capoeira_local
+testFormat: workflowsuccess
+backends: [Local]
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0", localdockertest]
+
+files {
+  workflow: wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
+}
+
+metadata {
+  workflowName: draft3_call_cache_capoeira
+  status: Succeeded
+  "calls.draft3_call_cache_capoeira.make_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.make_files_cached.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.make_files:-1"
+
+  "calls.draft3_call_cache_capoeira.read_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.modify_file_sfs.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_after_modify.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_copied_files.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.read_files:-1"
+  "calls.draft3_call_cache_capoeira.read_files_swapped.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_command.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_expressions.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_names.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_non_file_input_switcheroo.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_inputs_renamed.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_docker.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_without_docker.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode_2.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_failOnStderr.callCaching.hit": false
+
+  "calls.draft3_call_cache_capoeira.read_files_whitespace.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_continueOnReturnCode.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_failOnStderr.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_failOnStderr_expression.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_array_files_rearranged.callCaching.hit": false
+  
+  // Check that hashes are published to metadata
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output count": "C81E728D9D4C2F636F067F89CC14862C"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.docker": "09F611634147800124391D34D57A3A9F"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.failOnStderr": "68934A3E9455FA72420237EB05902327"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "388a16fd2d5d64d96cc14c95125d4b21"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "0e4a079e970c7802de92f5151e0dc2b9"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.backend name": "509820290D57F333403F490DDE7316F4"
+}

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_local.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_local.test
@@ -46,7 +46,7 @@ metadata {
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
-  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "ED56C94E5CD5871CDB6D9A702F299073"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "388a16fd2d5d64d96cc14c95125d4b21"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "0e4a079e970c7802de92f5151e0dc2b9"

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
@@ -45,7 +45,7 @@ metadata {
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
-  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "ED56C94E5CD5871CDB6D9A702F299073"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "388a16fd2d5d64d96cc14c95125d4b21"
   "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "0e4a079e970c7802de92f5151e0dc2b9"

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
@@ -1,0 +1,53 @@
+name: draft3_call_cache_capoeira_tes
+testFormat: workflowsuccess
+backends: [TES]
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0", localdockertest]
+
+files {
+  workflow: wdl_draft3/draft3_call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+}
+
+metadata {
+  workflowName: draft3_call_cache_capoeira
+  status: Succeeded
+  "calls.draft3_call_cache_capoeira.make_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.make_files_cached.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.make_files:-1"
+
+  "calls.draft3_call_cache_capoeira.read_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.modify_file_sfs.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_after_modify.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_copied_files.callCaching.result": "Cache Hit: <<UUID>>:draft3_call_cache_capoeira.read_files:-1"
+  "calls.draft3_call_cache_capoeira.read_files_swapped.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_command.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_expressions.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_new_output_names.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_non_file_input_switcheroo.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_inputs_renamed.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_docker.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_continueOnReturnCode_2.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_files_different_failOnStderr.callCaching.hit": false
+
+  "calls.draft3_call_cache_capoeira.read_files_whitespace.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_continueOnReturnCode.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_without_failOnStderr.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_files_failOnStderr_expression.callCaching.hit": true
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hit": false
+  "calls.draft3_call_cache_capoeira.read_array_files_rearranged.callCaching.hit": false
+  
+  // Check that hashes are published to metadata
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output count": "C81E728D9D4C2F636F067F89CC14862C"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.docker": "09F611634147800124391D34D57A3A9F"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.runtime attribute.failOnStderr": "68934A3E9455FA72420237EB05902327"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File b.0": "388a16fd2d5d64d96cc14c95125d4b21"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.input.File a.0": "0e4a079e970c7802de92f5151e0dc2b9"
+  "calls.draft3_call_cache_capoeira.read_array_files.callCaching.hashes.backend name": "08E789053DE980E0F1AC70A61125A17D"
+}

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_tes.test
@@ -6,7 +6,7 @@ workflowTypeVersion: 1.0
 tags: ["wdl_1.0", localdockertest]
 
 files {
-  workflow: wdl_draft3/draft3_call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+  workflow: wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/draft3_write_lines.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_write_lines.test
@@ -1,0 +1,17 @@
+name: draft3_write_lines
+testFormat: workflowsuccess
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0"]
+
+files {
+  workflow: wdl_draft3/draft3_write_lines/draft3_write_lines.wdl
+}
+
+metadata {
+  workflowName: draft3_write_lines
+  status: Succeeded
+  "calls.draft3_write_lines.a2f.executionStatus": Done
+  "calls.draft3_write_lines.f2a.executionStatus": Done
+  "outputs.draft3_write_lines.x_out": "a\nb\nc\nd"
+}

--- a/centaur/src/main/resources/standardTestCases/draft3_write_lines_files.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_write_lines_files.test
@@ -1,0 +1,19 @@
+name: draft3_write_lines_files
+testFormat: workflowsuccess
+workflowType: WDL
+workflowTypeVersion: 1.0
+tags: ["wdl_1.0"]
+
+files {
+  workflow: wdl_draft3/draft3_write_lines_files/draft3_write_lines_files.wdl
+}
+
+metadata {
+  workflowName: draft3_write_lines_files
+  status: Succeeded
+  "outputs.draft3_write_lines_files.reversed_contents.0": "contents_4"
+  "outputs.draft3_write_lines_files.reversed_contents.1": "contents_3"
+  "outputs.draft3_write_lines_files.reversed_contents.2": "contents_2"
+  "outputs.draft3_write_lines_files.reversed_contents.3": "contents_1"
+  "outputs.draft3_write_lines_files.reversed_contents.4": "contents_0"
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
@@ -69,6 +69,7 @@ task make_files {
     Boolean ready
   }
   command {
+    # Comment to change hash from d2 capoeira
     echo bananeira > bananeira.txt
     echo balanca > balanca.txt
   }
@@ -86,6 +87,7 @@ task modify_file_gcs {
     String file_path_raw
   }
   command {
+    # Comment to change hash from d2 capoeira
     echo "override" | gsutil cp - ~{file_path_raw}
   }
   runtime {
@@ -103,7 +105,10 @@ task read_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -119,7 +124,10 @@ task sleep {
     Int duration
     Boolean ready
   }
-  command { sleep ~{duration} }
+  command {
+    # Comment to change hash from d2 capoeira
+    sleep ~{duration}
+  }
   output { Boolean done = true }
   runtime {
     docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
@@ -136,7 +144,10 @@ task read_copied_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -154,7 +165,10 @@ task read_files_swapped {
     File a
     File b
   }
-  command { cat ~{b} ~{a} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+     cat ~{b} ~{a} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -175,7 +189,9 @@ task read_files_whitespace {
   }
   command {
 
-        cat ~{a} ~{b} > out
+
+      # Comment to change hash from d2 capoeira
+      cat ~{a} ~{b} > out
   }
   output {
     String s = read_string("out")
@@ -196,6 +212,7 @@ task read_files_new_command {
     File b
   }
   command {
+    # Comment to change hash from d2 capoeira
     for i in ~{a} ~{b}
     do
     cat $i >> out
@@ -218,7 +235,10 @@ task read_files_new_output_expressions {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") + "_suffix" }
@@ -236,7 +256,10 @@ task read_files_new_output_names {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean dunn = true
     String ess = read_string("out") }
@@ -254,7 +277,10 @@ task read_files_inputs_renamed {
     File c
     File d
   }
-  command { cat ~{c} ~{d} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{c} ~{d} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -272,7 +298,10 @@ task read_files_different_docker {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -290,7 +319,10 @@ task read_files_different_continueOnReturnCode {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
 
   output {
     Boolean done = true
@@ -309,7 +341,10 @@ task read_files_different_continueOnReturnCode_2 {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -327,7 +362,10 @@ task read_files_without_continueOnReturnCode {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -344,7 +382,10 @@ task read_files_different_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -362,7 +403,10 @@ task read_files_without_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -379,7 +423,10 @@ task read_files_failOnStderr_expression {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+     cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -397,7 +444,10 @@ task read_array_files {
     Array[File] a
     Array[File] b
   }
-  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{sep = " " a} ~{sep = " " b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
@@ -425,7 +425,7 @@ task read_files_failOnStderr_expression {
   }
   command {
     # Comment to change hash from d2 capoeira
-     cat ~{a} ~{b} > out
+    cat ~{a} ~{b} > out
   }
   output {
     Boolean done = true

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
@@ -1,0 +1,409 @@
+version 1.0
+
+workflow draft3_call_cache_capoeira {
+  # Make some files:
+  call make_files { input: ready = true }
+  # Call cache the made files, creating some copies:
+  call make_files as make_files_cached { input: ready = make_files.done }
+
+  # Make sure read_files is in the call cache:
+  call read_files { input: ready = true, a = make_files.bananeira, b = make_files.balanca }
+
+  # Modify that file! Oh so crafty!
+  call modify_file_gcs { input: ready = read_files.done, file_path_raw = make_files.bananeira }
+
+  # The file inputs are different., shouldn't hit the call cache.
+  call read_files as read_files_after_modify { input: ready = modify_file_gcs.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep { input: duration = 5, ready = read_files_after_modify.done }
+
+  # Using the copied files after modification, even if the task name is different, should still call cache to read_files:
+  # ** Should call cache to read_files **
+  call read_copied_files { input: ready = sleep.done, a = make_files_cached.bananeira, b = make_files_cached.balanca }
+
+  # Task with inputs in the other order. Should not call cache:
+  call read_files_swapped { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Extra whitespace and rearranged task definition.
+  # Should call cache to read_files_after_modify:
+  call read_files_whitespace { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different command? Don't call cache!
+  call read_files_new_command { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output expressions? Don't call cache!
+  call read_files_new_output_expressions { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output names? Can't call cache (yet, at least)!
+  call read_files_new_output_names { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different non-File input? Can't call cache!
+  call read_files as read_files_non_file_input_switcheroo { input: ready = !sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different input names? Don't call cache!
+  call read_files_inputs_renamed { input: ready = sleep.done, c = make_files.bananeira, d = make_files.balanca }
+  
+  # Like read_files but with 2 Array[File] instead of File
+  call read_array_files { input: ready = sleep.done, a = [make_files.bananeira], b = [make_files.balanca] }
+  
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep as sleep_some_more { input: duration = 5, ready = read_array_files.done }
+  
+  # Same as read_array_files except a is empty and b contains both, in the same order. Don't call cache!
+  call read_array_files as read_array_files_rearranged { input: ready = sleep_some_more.done, a = [], b = [make_files.bananeira, make_files.balanca] }
+
+
+  # Local runtime attributes:
+  call read_files_different_docker { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode_2 { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_failOnStderr_expression { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+}
+
+task make_files {
+  input {
+    Boolean ready
+  }
+  command {
+    echo bananeira > bananeira.txt
+    echo balanca > balanca.txt
+  }
+  runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+  output {
+    Boolean done = true
+    File bananeira = "bananeira.txt"
+    File balanca = "balanca.txt"
+  }
+}
+
+task modify_file_gcs {
+  input {
+    Boolean ready
+    String file_path_raw
+  }
+  command {
+    echo "override" | gsutil cp - ~{file_path_raw}
+  }
+  runtime {
+    docker: "google/cloud-sdk"
+  }
+  output {
+    Boolean done = true
+  }
+}
+
+task read_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task sleep {
+  input {
+    Int duration
+    Boolean ready
+  }
+  command { sleep ~{duration} }
+  output { Boolean done = true }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+# Identical to read_files, apart from the name...
+task read_copied_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_swapped {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{b} ~{a} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_whitespace {
+  input {
+    # Just like read_files, but with additional whitespace!
+    Boolean   ready
+
+    File b
+    File a
+  }
+  command {
+
+        cat ~{a} ~{b} > out
+  }
+  output {
+    String s = read_string("out")
+    Boolean done = true
+  }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_command {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command {
+    for i in ~{a} ~{b}
+    do
+    cat $i >> out
+    done
+  }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_expressions {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") + "_suffix" }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_names {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean dunn = true
+    String ess = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_inputs_renamed {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File c
+    File d
+  }
+  command { cat ~{c} ~{d} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_docker {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: false
+    failOnStderr: false
+  }
+ }
+
+task read_files_different_continueOnReturnCode_2 {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: [ 0 ]
+    failOnStderr: false
+  }
+}
+
+task read_files_without_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    failOnStderr: false
+  }
+}
+
+task read_files_different_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: true
+  }
+}
+
+task read_files_without_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+  }
+}
+
+task read_files_failOnStderr_expression {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}
+
+task read_array_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    Array[File] a
+    Array[File] b
+  }
+  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
@@ -69,6 +69,8 @@ task make_files {
     Boolean ready
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     echo bananeira > bananeira.txt
     chmod go+w bananeira.txt
     echo balanca > balanca.txt
@@ -90,6 +92,8 @@ task modify_file_sfs {
     # String file_path = sub(file_path_raw, "file://", "")
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     echo "ginga" > ~{file_path_raw}
   }
   output {
@@ -109,7 +113,10 @@ task read_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -125,7 +132,10 @@ task sleep {
     Int duration
     Boolean ready
   }
-  command { sleep ~{duration} }
+  command {
+    # Comment to change hash from d2 capoeira
+    sleep ~{duration}
+  }
   output { Boolean done = true }
   runtime {
     docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
@@ -142,7 +152,10 @@ task read_copied_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -160,7 +173,10 @@ task read_files_swapped {
     File a
     File b
   }
-  command { cat ~{b} ~{a} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{b} ~{a} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -180,7 +196,11 @@ task read_files_whitespace {
     File a
   }
   command {
-    cat ~{a} ~{b} > out
+
+
+
+      # Comment to change hash from d2 capoeira
+      cat ~{a} ~{b} > out
   }
   output {
     String s = read_string("out")
@@ -201,6 +221,8 @@ task read_files_new_command {
     File b
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     for i in ~{a} ~{b}
     do
     cat $i >> out
@@ -223,7 +245,10 @@ task read_files_new_output_expressions {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") + "_suffix" }
@@ -241,7 +266,10 @@ task read_files_new_output_names {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean dunn = true
     String ess = read_string("out") }
@@ -259,7 +287,10 @@ task read_files_inputs_renamed {
     File c
     File d
   }
-  command { cat ~{c} ~{d} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{c} ~{d} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -277,7 +308,10 @@ task read_files_different_docker {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -295,7 +329,10 @@ task read_files_without_docker {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -312,7 +349,10 @@ task read_files_different_continueOnReturnCode {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -330,7 +370,10 @@ task read_files_different_continueOnReturnCode {
     File a
     File b
   }
-    command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
     output {
       Boolean done = true
       String s = read_string("out") }
@@ -348,7 +391,10 @@ task read_files_without_continueOnReturnCode {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -365,7 +411,10 @@ task read_files_different_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -383,7 +432,10 @@ task read_files_without_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -400,7 +452,10 @@ task read_files_failOnStderr_expression {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -418,7 +473,10 @@ task read_array_files {
     Array[File] a
     Array[File] b
   }
-  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{sep = " " a} ~{sep = " " b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
@@ -1,0 +1,430 @@
+version 1.0
+
+workflow draft3_call_cache_capoeira {
+  # Make some files:
+  call make_files { input: ready = true }
+  # Call cache the made files, creating some copies:
+  call make_files as make_files_cached { input: ready = make_files.done }
+
+  # Make sure read_files is in the call cache:
+  call read_files { input: ready = true, a = make_files.bananeira, b = make_files.balanca }
+
+  # Modify that file! Oh so crafty!
+  call modify_file_sfs { input: ready = read_files.done, file_path_raw = make_files.bananeira }
+
+  # The file inputs are different., shouldn't hit the call cache.
+  call read_files as read_files_after_modify { input: ready = modify_file_sfs.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep { input: duration = 5, ready = read_files_after_modify.done }
+
+  # Using the copied files after modification, even if the task name is different, should still call cache to read_files:
+  # ** Should call cache to read_files **
+  call read_copied_files { input: ready = sleep.done, a = make_files_cached.bananeira, b = make_files_cached.balanca }
+
+  # Task with inputs in the other order. Should not call cache:
+  call read_files_swapped { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Extra whitespace and rearranged task definition.
+  # Should call cache to read_files_after_modify:
+  call read_files_whitespace { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different command? Don't call cache!
+  call read_files_new_command { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output expressions? Don't call cache!
+  call read_files_new_output_expressions { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output names? Can't call cache (yet, at least)!
+  call read_files_new_output_names { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different non-File input? Can't call cache!
+  call read_files as read_files_non_file_input_switcheroo { input: ready = !sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different input names? Don't call cache!
+  call read_files_inputs_renamed { input: ready = sleep.done, c = make_files.bananeira, d = make_files.balanca }
+  
+  # Like read_files but with 2 Array[File] instead of File
+  call read_array_files { input: ready = sleep.done, a = [make_files.bananeira], b = [make_files.balanca] }
+  
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep as sleep_some_more { input: duration = 5, ready = read_array_files.done }
+  
+  # Same as read_array_files except a is empty and b contains both, in the same order. Don't call cache!
+  call read_array_files as read_array_files_rearranged { input: ready = sleep_some_more.done, a = [], b = [make_files.bananeira, make_files.balanca] }
+
+  # Local runtime attributes:
+  call read_files_different_docker { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_docker { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode_2 { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_failOnStderr_expression { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+}
+
+task make_files {
+  input {
+    Boolean ready
+  }
+  command {
+    echo bananeira > bananeira.txt
+    chmod go+w bananeira.txt
+    echo balanca > balanca.txt
+  }
+  runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+  output {
+    Boolean done = true
+    File bananeira = "bananeira.txt"
+    File balanca = "balanca.txt"
+  }
+}
+
+task modify_file_sfs {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    String file_path_raw
+    # Remove if this task works without it:
+    # String file_path = sub(file_path_raw, "file://", "")
+  }
+  command {
+    echo "ginga" > ~{file_path_raw}
+  }
+  output {
+    Boolean done = true
+  }
+  runtime {
+    # No docker, we need this to run against the same FS as Cromwell so it can modify the right file!
+    # docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    backend: "Local"
+  }
+}
+
+task read_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task sleep {
+  input {
+    Int duration
+    Boolean ready
+  }
+  command { sleep ~{duration} }
+  output { Boolean done = true }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+# Identical to read_files, apart from the name...
+task read_copied_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_swapped {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{b} ~{a} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_whitespace {
+  input {
+    # Just like read_files, but with additional whitespace!
+    Boolean   ready
+  
+    File b
+    File a
+  }
+  command {
+    cat ~{a} ~{b} > out
+  }
+  output {
+    String s = read_string("out")
+    Boolean done = true
+  }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_command {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command {
+    for i in ~{a} ~{b}
+    do
+    cat $i >> out
+    done
+  }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_expressions {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") + "_suffix" }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_names {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean dunn = true
+    String ess = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_inputs_renamed {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File c
+    File d
+  }
+  command { cat ~{c} ~{d} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_docker {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_without_docker {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: false
+    failOnStderr: false
+  }
+ }
+
+ task read_files_different_continueOnReturnCode_2 {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+    command { cat ~{a} ~{b} > out }
+    output {
+      Boolean done = true
+      String s = read_string("out") }
+    runtime {
+      docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+      continueOnReturnCode: [ 0 ]
+      failOnStderr: false
+    }
+  }
+
+task read_files_without_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    failOnStderr: false
+  }
+}
+
+task read_files_different_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: true
+  }
+}
+
+task read_files_without_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+  }
+}
+
+task read_files_failOnStderr_expression {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}
+
+task read_array_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    Array[File] a
+    Array[File] b
+  }
+  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
@@ -68,6 +68,8 @@ task make_files {
     Boolean ready
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     echo bananeira > bananeira.txt
     chmod go+w bananeira.txt
     echo balanca > balanca.txt
@@ -89,6 +91,8 @@ task modify_file_sfs {
     # String file_path = sub(file_path_raw, "file://", "")
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     echo "ginga" > ~{file_path_raw}
   }
   output {
@@ -108,7 +112,10 @@ task read_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -124,7 +131,10 @@ task sleep {
     Int duration
     Boolean ready
   }
-  command { sleep ~{duration} }
+  command {
+    # Comment to change hash from d2 capoeira
+    sleep ~{duration}
+  }
   output { Boolean done = true }
   runtime {
     docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
@@ -141,7 +151,10 @@ task read_copied_files {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -159,7 +172,10 @@ task read_files_swapped {
     File a
     File b
   }
-  command { cat ~{b} ~{a} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{b} ~{a} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -180,7 +196,9 @@ task read_files_whitespace {
   }
   command {
 
-        cat ~{a} ~{b} > out
+
+      # Comment to change hash from d2 capoeira
+      cat ~{a} ~{b} > out
   }
   output {
     String s = read_string("out")
@@ -201,6 +219,8 @@ task read_files_new_command {
     File b
   }
   command {
+    # Comment to change hash from d2 capoeira
+
     for i in ~{a} ~{b}
     do
     cat $i >> out
@@ -223,7 +243,10 @@ task read_files_new_output_expressions {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") + "_suffix" }
@@ -241,7 +264,10 @@ task read_files_new_output_names {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean dunn = true
     String ess = read_string("out") }
@@ -259,7 +285,10 @@ task read_files_inputs_renamed {
     File c
     File d
   }
-  command { cat ~{c} ~{d} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{c} ~{d} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -277,7 +306,10 @@ task read_files_different_docker {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -295,7 +327,10 @@ task read_files_different_continueOnReturnCode {
     File a
     File b
    }
-   command { cat ~{a} ~{b} > out }
+   command {
+     # Comment to change hash from d2 capoeira
+     cat ~{a} ~{b} > out
+   }
    output {
      Boolean done = true
      String s = read_string("out") }
@@ -313,7 +348,10 @@ task read_files_different_continueOnReturnCode_2 {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -331,7 +369,10 @@ task read_files_without_continueOnReturnCode {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -348,7 +389,10 @@ task read_files_different_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -366,7 +410,10 @@ task read_files_without_failOnStderr {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -383,7 +430,10 @@ task read_files_failOnStderr_expression {
     File a
     File b
   }
-  command { cat ~{a} ~{b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{a} ~{b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }
@@ -401,7 +451,10 @@ task read_array_files {
     Array[File] a
     Array[File] b
   }
-  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  command {
+    # Comment to change hash from d2 capoeira
+    cat ~{sep = " " a} ~{sep = " " b} > out
+  }
   output {
     Boolean done = true
     String s = read_string("out") }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
@@ -1,0 +1,413 @@
+version 1.0
+
+workflow draft3_call_cache_capoeira {
+  # Make some files:
+  call make_files { input: ready = true }
+  # Call cache the made files, creating some copies:
+  call make_files as make_files_cached { input: ready = make_files.done }
+
+  # Make sure read_files is in the call cache:
+  call read_files { input: ready = true, a = make_files.bananeira, b = make_files.balanca }
+
+  # Modify that file! Oh so crafty!
+  call modify_file_sfs { input: ready = read_files.done, file_path_raw = make_files.bananeira }
+
+  # The file inputs are different., shouldn't hit the call cache.
+  call read_files as read_files_after_modify { input: ready = modify_file_sfs.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep { input: duration = 5, ready = read_files_after_modify.done }
+
+  # Using the copied files after modification, even if the task name is different, should still call cache to read_files:
+  # ** Should call cache to read_files **
+  call read_copied_files { input: ready = sleep.done, a = make_files_cached.bananeira, b = make_files_cached.balanca }
+
+  # Task with inputs in the other order. Should not call cache:
+  call read_files_swapped { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Extra whitespace and rearranged task definition.
+  # Should call cache to read_files_after_modify:
+  call read_files_whitespace { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different command? Don't call cache!
+  call read_files_new_command { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output expressions? Don't call cache!
+  call read_files_new_output_expressions { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different output names? Can't call cache (yet, at least)!
+  call read_files_new_output_names { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different non-File input? Can't call cache!
+  call read_files as read_files_non_file_input_switcheroo { input: ready = !sleep.done, a = make_files.bananeira, b = make_files.balanca }
+
+  # Different input names? Don't call cache!
+  call read_files_inputs_renamed { input: ready = sleep.done, c = make_files.bananeira, d = make_files.balanca }
+  
+  # Like read_files but with 2 Array[File] instead of File
+  call read_array_files { input: ready = sleep.done, a = [make_files.bananeira], b = [make_files.balanca] }
+  
+  # Give the last call a chance to be writen to the call caching DB
+  call sleep as sleep_some_more { input: duration = 5, ready = read_array_files.done }
+  
+  # Same as read_array_files except a is empty and b contains both, in the same order. Don't call cache!
+  call read_array_files as read_array_files_rearranged { input: ready = sleep_some_more.done, a = [], b = [make_files.bananeira, make_files.balanca] }
+
+  # Local runtime attributes:
+  call read_files_different_docker { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_continueOnReturnCode_2 { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_continueOnReturnCode { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_different_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_without_failOnStderr { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+  call read_files_failOnStderr_expression { input: ready = sleep.done, a = make_files.bananeira, b = make_files.balanca }
+}
+
+task make_files {
+  input {
+    Boolean ready
+  }
+  command {
+    echo bananeira > bananeira.txt
+    chmod go+w bananeira.txt
+    echo balanca > balanca.txt
+  }
+  runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+  output {
+    Boolean done = true
+    File bananeira = "bananeira.txt"
+    File balanca = "balanca.txt"
+  }
+}
+
+task modify_file_sfs {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    String file_path_raw
+    # Remove if this task works without it:
+    # String file_path = sub(file_path_raw, "file://", "")
+  }
+  command {
+    echo "ginga" > ~{file_path_raw}
+  }
+  output {
+    Boolean done = true
+  }
+  runtime {
+    # No docker, we need this to run against the same FS as Cromwell so it can modify the right file!
+    # docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    backend: "Local"
+  }
+}
+
+task read_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task sleep {
+  input {
+    Int duration
+    Boolean ready
+  }
+  command { sleep ~{duration} }
+  output { Boolean done = true }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+# Identical to read_files, apart from the name...
+task read_copied_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_swapped {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{b} ~{a} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_whitespace {
+  input {
+    # Just like read_files, but with additional whitespace!
+    Boolean   ready
+
+    File b
+    File a
+  }
+  command {
+
+        cat ~{a} ~{b} > out
+  }
+  output {
+    String s = read_string("out")
+    Boolean done = true
+  }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_command {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command {
+    for i in ~{a} ~{b}
+    do
+    cat $i >> out
+    done
+  }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_expressions {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") + "_suffix" }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_new_output_names {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean dunn = true
+    String ess = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_inputs_renamed {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File c
+    File d
+  }
+  command { cat ~{c} ~{d} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_docker {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    continueOnReturnCode: 0
+    failOnStderr: false
+  }
+}
+
+task read_files_different_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+   }
+   command { cat ~{a} ~{b} > out }
+   output {
+     Boolean done = true
+     String s = read_string("out") }
+   runtime {
+     docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+     continueOnReturnCode: false
+     failOnStderr: false
+   }
+ }
+
+task read_files_different_continueOnReturnCode_2 {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: [ 0 ]
+    failOnStderr: false
+  }
+}
+
+task read_files_without_continueOnReturnCode {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    failOnStderr: false
+  }
+}
+
+task read_files_different_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: true
+  }
+}
+
+task read_files_without_failOnStderr {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+  }
+}
+
+task read_files_failOnStderr_expression {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    File a
+    File b
+  }
+  command { cat ~{a} ~{b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}
+
+task read_array_files {
+  input {
+    # 'ready' is ignored, but useful for flow-control
+    Boolean ready
+    Array[File] a
+    Array[File] b
+  }
+  command { cat ~{sep = " " a} ~{sep = " " b} > out }
+  output {
+    Boolean done = true
+    String s = read_string("out") }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    continueOnReturnCode: 0
+    failOnStderr: !ready
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_write_lines/draft3_write_lines.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_write_lines/draft3_write_lines.wdl
@@ -1,0 +1,57 @@
+version 1.0
+
+# Testing write_lines() within a command block
+workflow draft3_write_lines {
+  call a2f {
+    input: strings = ["a","b","c","d"]
+  }
+
+  call f2a {
+    input: i=a2f.out
+  }
+
+  call a2f as a2f_second {
+    input: strings = f2a.out
+  }
+
+  output {
+    String x_out = a2f_second.x
+  }
+}
+
+task f2a {
+  input {
+    File i
+  }
+
+  command {
+    cat ~{i}
+  }
+
+  output {
+    Array[String] out = read_lines(stdout())
+  }
+
+  runtime {
+    docker:"ubuntu:latest"
+  }
+}
+
+task a2f {
+  input {
+    Array[String] strings
+  }
+
+  command {
+    cat ~{write_lines(strings)}
+  }
+
+  output {
+    File out = stdout()
+    String x = read_string(out)
+  }
+
+  runtime {
+    docker:"ubuntu:latest"
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_write_lines_files/draft3_write_lines_files.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_write_lines_files/draft3_write_lines_files.wdl
@@ -1,0 +1,52 @@
+version 1.0
+
+task make_file {
+  input {
+    Int index
+  }
+
+  command {
+    echo contents_~{index} > out
+  }
+
+  output {
+    File out = "out"
+  }
+  runtime { docker:"ubuntu:latest" }
+}
+
+task switcho_reverso {
+  input {
+    Array[File] files
+  }
+
+  command {
+    F="~{write_lines(files)}"
+    for f in $(tac $F)
+    do
+      cat $f
+    done
+  }
+
+  output {
+    Array[String] out = read_lines(stdout())
+  }
+  runtime {
+    docker:"ubuntu:latest"
+    failOnStderr: true
+  }
+}
+
+workflow draft3_write_lines_files {
+  Array[Int] is = range(5)
+
+  scatter(i in is) {
+    call make_file { input: index = i }
+  }
+
+  call switcho_reverso { input: files = make_file.out }
+
+  output {
+    Array[String] reversed_contents = switcho_reverso.out
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
@@ -148,7 +148,11 @@ class CallCacheHashingJobActor(jobDescriptor: BackendJobDescriptor,
 
   private def calculateInitialHashes(nonFileInputs: Iterable[WomValueSimpleton], fileInputs: Iterable[WomValueSimpleton]): Set[HashResult] = {
 
-    val commandTemplateHash = HashResult(HashKey("command template"), jobDescriptor.taskCall.callable.commandTemplateString(jobDescriptor.evaluatedTaskInputs).md5HashValue)
+    val commandTemplateHash = {
+      val commandTemplate: String = jobDescriptor.taskCall.callable.commandTemplateString(jobDescriptor.evaluatedTaskInputs)
+      println(s"%%% command template hash: ${commandTemplate.md5HashValue} (${commandTemplate})")
+      HashResult(HashKey("command template"), commandTemplate.md5HashValue)
+    }
     val backendNameHash = HashResult(HashKey("backend name"), backendName.md5HashValue)
     val inputCountHash = HashResult(HashKey("input count"), (nonFileInputs.size + fileInputs.size).toString.md5HashValue)
     val outputCountHash = HashResult(HashKey("output count"), jobDescriptor.taskCall.callable.outputs.size.toString.md5HashValue)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
@@ -149,7 +149,6 @@ class CallCacheHashingJobActor(jobDescriptor: BackendJobDescriptor,
   private def calculateInitialHashes(nonFileInputs: Iterable[WomValueSimpleton], fileInputs: Iterable[WomValueSimpleton]): Set[HashResult] = {
 
     val commandTemplateHash = HashResult(HashKey("command template"), jobDescriptor.taskCall.callable.commandTemplateString(jobDescriptor.evaluatedTaskInputs).md5HashValue)
-
     val backendNameHash = HashResult(HashKey("backend name"), backendName.md5HashValue)
     val inputCountHash = HashResult(HashKey("input count"), (nonFileInputs.size + fileInputs.size).toString.md5HashValue)
     val outputCountHash = HashResult(HashKey("output count"), jobDescriptor.taskCall.callable.outputs.size.toString.md5HashValue)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
@@ -148,11 +148,8 @@ class CallCacheHashingJobActor(jobDescriptor: BackendJobDescriptor,
 
   private def calculateInitialHashes(nonFileInputs: Iterable[WomValueSimpleton], fileInputs: Iterable[WomValueSimpleton]): Set[HashResult] = {
 
-    val commandTemplateHash = {
-      val commandTemplate: String = jobDescriptor.taskCall.callable.commandTemplateString(jobDescriptor.evaluatedTaskInputs)
-      println(s"%%% command template hash: ${commandTemplate.md5HashValue} (${commandTemplate})")
-      HashResult(HashKey("command template"), commandTemplate.md5HashValue)
-    }
+    val commandTemplateHash = HashResult(HashKey("command template"), jobDescriptor.taskCall.callable.commandTemplateString(jobDescriptor.evaluatedTaskInputs).md5HashValue)
+
     val backendNameHash = HashResult(HashKey("backend name"), backendName.md5HashValue)
     val inputCountHash = HashResult(HashKey("input count"), (nonFileInputs.size + fileInputs.size).toString.md5HashValue)
     val outputCountHash = HashResult(HashKey("output count"), jobDescriptor.taskCall.callable.outputs.size.toString.md5HashValue)

--- a/src/bin/ci/testCentaurTes.sh
+++ b/src/bin/ci/testCentaurTes.sh
@@ -38,6 +38,7 @@ FUNNEL_PID=$!
 # The following tests are skipped:
 #
 # call_cache_capoeira_local: fails on task 'read_files_without_docker' since the 'docker' runtime key is required for this backend
+# draft3_call_cache_capoeira_local: same as above
 # lots_of_inputs:            Funnel mounts in each input separately, this task surpasses the docker limit for volumes
 # no_new_calls:              TES does not support checking job status after restart, and cannot tell if shouldSucceed is done or failed
 # non_root_specified_user:   TES doesn't support switching users in the image
@@ -48,6 +49,7 @@ centaur/test_cromwell.sh \
     -c "${CROMWELL_BUILD_SCRIPTS_RESOURCES}/tes_application.conf" \
     -g \
     -e call_cache_capoeira_local \
+    -e draft3_call_cache_capoeira_local \
     -e lots_of_inputs \
     -e no_new_calls \
     -e non_root_default_user \

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wdl/WdlWriterImpl.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wdl/WdlWriterImpl.scala
@@ -300,7 +300,6 @@ object WdlWriterImpl {
         "false" -> a.falseAttribute,
         "default" -> a.defaultAttribute
       ).collect({ case (attrKey: String, Some(value)) => attrKey + "=\"" + value + "\"" })
-        .filterNot(_.length == 0)
 
       if (attrStrings.isEmpty) "" else attrStrings.mkString(start = "", sep = " ", end = " ")
     }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wdl/WdlWriterImpl.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wdl/WdlWriterImpl.scala
@@ -294,17 +294,15 @@ object WdlWriterImpl {
 
   implicit val placeholderAttributeSetWriter: WdlWriter[PlaceholderAttributeSet] = new WdlWriter[PlaceholderAttributeSet] {
     override def toWdlV1(a: PlaceholderAttributeSet): String = {
-      Map(
+      val attrStrings = Map(
         "sep" -> a.sepAttribute,
         "true" -> a.trueAttribute,
         "false" -> a.falseAttribute,
         "default" -> a.defaultAttribute
-      ).map({ case (attrKey: String, maybeValue: Option[String]) =>
-        maybeValue match {
-          case Some(value) => attrKey + "=\"" + value + "\""
-          case None => ""
-        }
-      }).filterNot(_.length == 0).mkString(sep = " ")
+      ).collect({ case (attrKey: String, Some(value)) => attrKey + "=\"" + value + "\"" })
+        .filterNot(_.length == 0)
+
+      if (attrStrings.isEmpty) "" else attrStrings.mkString(start = "", sep = " ", end = " ")
     }
   }
 

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/CommandPartElementToWomCommandPart.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/CommandPartElementToWomCommandPart.scala
@@ -19,6 +19,9 @@ import wdl.draft3.transforms.linking.graph.LinkedGraphMaker
 import wdl.draft3.transforms.wdlom2wom.expression.WdlomWomExpression
 import wdl.model.draft3.graph.expression.{EvaluatedValue, ForCommandInstantiationOptions}
 import wom.types.{WomArrayType, WomPrimitiveType, WomType}
+import wdl.draft3.transforms.wdlom2wdl.WdlWriter.ops._
+import wdl.draft3.transforms.wdlom2wdl.WdlWriterImpl.placeholderAttributeSetWriter
+import wdl.draft3.transforms.wdlom2wdl.WdlWriterImpl.expressionElementWriter
 
 object CommandPartElementToWomCommandPart {
   def convert(commandPart: CommandPartElement, typeAliases: Map[String, WomType], availableHandles: Set[GeneratedValueHandle]): ErrorOr[CommandPart] = commandPart match {
@@ -39,6 +42,7 @@ object CommandPartElementToWomCommandPart {
 }
 
 case class WdlomWomStringCommandPart(stringCommandPartElement: StringCommandPartElement) extends CommandPart {
+  override def toString: String = stringCommandPartElement.value
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
                            valueMapper: WomValue => WomValue,
@@ -46,6 +50,10 @@ case class WdlomWomStringCommandPart(stringCommandPartElement: StringCommandPart
 }
 
 case class WdlomWomPlaceholderCommandPart(attributes: PlaceholderAttributeSet, expression: WdlomWomExpression) extends CommandPart {
+  def attributesToString: String = attributes.toWdlV1
+  // Yes, it's sad that we need to put ${} here, but otherwise we won't cache hit from draft-2 command sections
+  override def toString: String = "${" + s"$attributesToString${expression.expressionElement.toWdlV1}" + "}"
+
   override def instantiate(inputsMap: Map[LocalName, WomValue],
                            functions: IoFunctionSet,
                            valueMapper: WomValue => WomValue,


### PR DESCRIPTION
Hint: these are barely changed from the draft-2 versions. 
You probably only *need* to review the `.scala` changes, although obviously another pair of eyes on the call cache capoeira tests never hurt.

I made a mistake - no red thumb is required now but a red thumb is of course always welcome...