### PR TITLE
More CI updates/fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dockerhub_provider_config.inc.conf
 github_private_deploy_key
 papi_application.inc.conf
 papi_refresh_token.txt
+artifactory_credentials.properties
+dockerhub_auth.sh

--- a/centaur/src/main/scala/centaur/CromwellManager.scala
+++ b/centaur/src/main/scala/centaur/CromwellManager.scala
@@ -13,8 +13,9 @@ import scala.language.postfixOps
   */
 object CromwellManager {
   val ManagedCromwellPort = 8008
-  val timeout = 60 seconds
-  private val interval = 1 second
+  val timeout = 120 seconds
+  private val interval = 5 second
+  private val timeoutExitStatus = 66
   private var cromwellProcess: Option[Process] = None
   private var _ready: Boolean = false
   private var _isManaged: Boolean = false
@@ -66,7 +67,7 @@ object CromwellManager {
         println("Timeout waiting for cromwell server - failing test run")
         println(logFile.contentAsString)
         stopCromwell()
-        System.exit(1)
+        System.exit(timeoutExitStatus)
       }
     }
   }

--- a/centaur/test_cromwell.sh
+++ b/centaur/test_cromwell.sh
@@ -108,8 +108,8 @@ cd "${RUN_DIR}"
 
 TEST_STATUS="failed"
 
-ENABLE_COVERAGE=${CENTAUR_SBT_COVERAGE} sbt centaur/it:compile
-CP=$(ENABLE_COVERAGE=${CENTAUR_SBT_COVERAGE} sbt "export centaur/it:dependencyClasspath" -error)
+CROMWELL_SBT_COVERAGE=${CENTAUR_SBT_COVERAGE} sbt centaur/it:compile
+CP=$(CROMWELL_SBT_COVERAGE=${CENTAUR_SBT_COVERAGE} sbt "export centaur/it:dependencyClasspath" -error)
 
 if [ -n "${TEST_CASE_DIR}" ]; then
     RUN_SPECIFIED_TEST_DIR_CMD="-Dcentaur.standardTestCasePath=${TEST_CASE_DIR}"

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -12,12 +12,14 @@ object Publishing {
     repoName at repoUrl
   }
 
-  private val artifactoryCredentials: Credentials = {
-    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
-    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
-    Credentials("Artifactory Realm", "broadinstitute.jfrog.io", username, password)
+  private val artifactoryCredentials: Seq[Credentials] = {
+    val credentialsFile = file("src/bin/ci/resources/artifactory_credentials.properties").getAbsoluteFile
+    if (credentialsFile.exists)
+      List(Credentials(credentialsFile))
+    else
+      Nil
   }
 
   def publishingSettings: Seq[Setting[_]] =
-    Seq(publishTo := Option(artifactoryResolver(isSnapshot.value)), credentials += artifactoryCredentials)
+    Seq(publishTo := Option(artifactoryResolver(isSnapshot.value)), credentials ++= artifactoryCredentials)
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -93,7 +93,7 @@ object Settings {
     test in assembly := {},
     assemblyMergeStrategy in assembly := customMergeStrategy.value,
     logLevel in assembly :=
-      sys.env.get("ASSEMBLY_LOG_LEVEL").flatMap(Level.apply).getOrElse((logLevel in assembly).value)
+      sys.env.get("CROMWELL_SBT_ASSEMBLY_LOG_LEVEL").flatMap(Level.apply).getOrElse((logLevel in assembly).value)
   )
 
   val Scala2_12Version = "2.12.6"
@@ -127,12 +127,12 @@ object Settings {
     NOTE: Like below, gave up coming with an SBT setting. Using an environment variable instead.
 
     Once 2.11 is gone, instead of
-      `ENABLE_COVERAGE=true sbt +test coverageReport`
+      `CROMWELL_SBT_COVERAGE=true sbt +test coverageReport`
     one can run
       `sbt coverage test coverageReport`
      */
     coverageEnabled := (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 12)) => sys.env.get("ENABLE_COVERAGE").exists(_.toBoolean)
+      case Some((2, 12)) => sys.env.get("CROMWELL_SBT_COVERAGE").exists(_.toBoolean)
       case _ =>
         throw new NotImplementedError(
           s"Found unsupported Scala version '${scalaVersion.value}'." +
@@ -158,11 +158,13 @@ object Settings {
       ArrayBuffer(broadinstitute/womtool:30, broadinstitute/womtool:30-c33be41-SNAP)
       ArrayBuffer(broadinstitute/cromwell:30, broadinstitute/cromwell:30-c33be41-SNAP)
 
-    `CROMWELL_DOCKER_TAGS=dev,develop sbt 'show docker::imageNames'` returns:
+    `CROMWELL_SBT_DOCKER_TAGS=dev,develop sbt 'show docker::imageNames'` returns:
       ArrayBuffer(broadinstitute/womtool:dev, broadinstitute/womtool:develop)
       ArrayBuffer(broadinstitute/cromwell:dev, broadinstitute/cromwell:develop)
     */
-    dockerTags := sys.env.getOrElse("CROMWELL_DOCKER_TAGS", s"$cromwellVersion,${version.value}").split(","),
+    dockerTags := sys.env
+      .getOrElse("CROMWELL_SBT_DOCKER_TAGS", s"$cromwellVersion,${version.value}")
+      .split(","),
     imageNames in docker := dockerTags.value map { tag =>
       ImageName(namespace = Option("broadinstitute"), repository = name.value, tag = Option(tag))
     },

--- a/src/bin/ci/resources/artifactory_credentials.properties.ctmpl
+++ b/src/bin/ci/resources/artifactory_credentials.properties.ctmpl
@@ -1,0 +1,6 @@
+{{with $cromwellArtifactory := vault (printf "secret/dsde/cromwell/common/cromwell-artifactory")}}
+realm=Artifactory Realm
+host=broadinstitute.jfrog.io
+user={{$cromwellArtifactory.Data.username}}
+password={{$cromwellArtifactory.Data.password}}
+{{end}}

--- a/src/bin/ci/resources/dockerhub_auth.sh.ctmpl
+++ b/src/bin/ci/resources/dockerhub_auth.sh.ctmpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Used to login docker from the command line. If/when there is a better way to command line docker login please update
+# test.inc.sh and remove all traces of this include.
+
+{{with $cromwellDockerhub := vault (printf "secret/dsde/cromwell/common/cromwell-dockerhub")}}
+CROMWELL_SECURE_DOCKER_USERNAME="{{$cromwellDockerhub.Data.username}}"
+CROMWELL_SECURE_DOCKER_PASSWORD="{{$cromwellDockerhub.Data.password}}"
+{{end}}

--- a/src/bin/ci/test.inc.sh
+++ b/src/bin/ci/test.inc.sh
@@ -16,7 +16,7 @@
 #     Variables for use in other scripts.
 #
 #   - CROMWELL_SECURE_*
-#     Should not be used/printed/echoed! They are only exported for subshells that turn of logging using set +x.
+#     Should not be used/printed/echoed!
 #
 #   - crmdbg
 #     Quick debug scripts. Example: `crmdbg=y src/bin/ci/testCentaulLocal.sh`
@@ -26,12 +26,12 @@
 #
 cromwell::private::check_debug() {
     # shellcheck disable=SC2154
-    if [ -n "${crmdbg+set}" ]; then
+    if [ -n "${crmdbg:+set}" ]; then
         set -x
     fi
 
     # shellcheck disable=SC2154
-    if [ -n "${crmcrn+set}" ]; then
+    if [ -n "${crmcrn:+set}" ]; then
         CROMWELL_BUILD_IS_CRON=true
     fi
 }
@@ -143,14 +143,14 @@ cromwell::private::verify_cron_build() {
     fi
 }
 
-cromwell::private::export_secure_variables() {
-    CROMWELL_SECURE_DOCKER_USERNAME="${DOCKER_USERNAME}"
-    CROMWELL_SECURE_DOCKER_PASSWORD="${DOCKER_PASSWORD}"
-    CROMWELL_SECURE_VAULT_TOKEN="${JES_TOKEN}"
-
-    export CROMWELL_SECURE_DOCKER_USERNAME
-    export CROMWELL_SECURE_DOCKER_PASSWORD
-    export CROMWELL_SECURE_VAULT_TOKEN
+cromwell::private::setup_secure_variables() {
+    if cromwell::private::is_xtrace_enabled; then
+        cromwell::private::exec_silent_function cromwell::private::setup_secure_variables
+    else
+        CROMWELL_SECURE_DOCKER_USERNAME="${DOCKER_USERNAME}"
+        CROMWELL_SECURE_DOCKER_PASSWORD="${DOCKER_PASSWORD}"
+        CROMWELL_SECURE_VAULT_TOKEN="${JES_TOKEN}"
+    fi
 }
 
 cromwell::private::export_conformance_variables() {
@@ -177,15 +177,6 @@ cromwell::private::exec_test_script() {
     local upper_build_type
     upper_build_type="$(tr '[:lower:]' '[:upper:]' <<< "${CROMWELL_BUILD_TYPE:0:1}")${CROMWELL_BUILD_TYPE:1}"
     exec "${CROMWELL_BUILD_SCRIPTS_DIRECTORY}/test${upper_build_type}.sh"
-}
-
-cromwell::private::setup_common_environment() {
-    cromwell::private::delete_boto_config
-    cromwell::private::delete_sbt_boot
-    cromwell::private::upgrade_pip
-    cromwell::private::create_mysql_cromwell_test
-    cromwell::private::pull_common_docker_images
-    cromwell::private::install_cwltool
 }
 
 cromwell::private::delete_boto_config() {
@@ -241,26 +232,31 @@ cromwell::private::checkout_pinned_cwl() {
 }
 
 cromwell::private::docker_login() {
-    (
-        # TURN OFF LOGGING WHILE WE TALK TO DOCKER
-        set +x
-
-        # Login to docker to access the dsde-toolbox
-        docker login -u="${CROMWELL_SECURE_DOCKER_USERNAME}" -p="${CROMWELL_SECURE_DOCKER_PASSWORD}"
-    )
+    if cromwell::private::is_xtrace_enabled; then
+        cromwell::private::exec_silent_function cromwell::private::docker_login
+    else
+        local dockerhub_auth_include
+        dockerhub_auth_include="${CROMWELL_BUILD_SCRIPTS_RESOURCES}/dockerhub_auth.sh"
+        if [ -f "${dockerhub_auth_include}" ]; then
+            # shellcheck source=/dev/null
+            source "${dockerhub_auth_include}"
+        fi
+        docker login \
+            --username "${CROMWELL_SECURE_DOCKER_USERNAME}" \
+            --password "${CROMWELL_SECURE_DOCKER_PASSWORD}"
+    fi
 }
 
 cromwell::private::vault_login() {
-    (
-        # TURN OFF LOGGING WHILE WE TALK TO VAULT
-        set +x
-
+    if cromwell::private::is_xtrace_enabled; then
+        cromwell::private::exec_silent_function cromwell::private::vault_login
+    else
         # Login to vault to access secrets
         docker run --rm \
             -v "${CROMWELL_BUILD_HOME_DIRECTORY}:/root:rw" \
             broadinstitute/dsde-toolbox \
             vault auth "${CROMWELL_SECURE_VAULT_TOKEN}" < /dev/null > /dev/null && echo vault auth success
-    )
+    fi
 }
 
 cromwell::private::render_secure_resources() {
@@ -270,7 +266,30 @@ cromwell::private::render_secure_resources() {
         -e ENVIRONMENT=not_used \
         -e INPUT_PATH=/resources \
         -e OUT_PATH=/resources \
-        broadinstitute/dsde-toolbox render-templates.sh
+        broadinstitute/dsde-toolbox render-templates.sh \
+    || {
+        echo "**************************************************************"
+        echo "**************************************************************"
+        echo "**                                                          **"
+        echo "**        WARNING: Unable to render vault resources.        **"
+        echo "**  '*.ctmpl' files should be copied and updated manually.  **"
+        echo "**                                                          **"
+        echo "**************************************************************"
+        echo "**************************************************************"
+    }
+}
+
+cromwell::private::setup_secure_resources() {
+    if [ "${CROMWELL_BUILD_IS_CI}" = "true" ]; then
+            cromwell::private::setup_secure_variables
+            # Ignore premature login errors that occur once dsde-toolbox is public and u/p are only in vault
+            cromwell::private::docker_login || true
+            cromwell::private::vault_login
+            cromwell::private::render_secure_resources
+            cromwell::private::docker_login
+    else
+            cromwell::private::render_secure_resources
+    fi
 }
 
 cromwell::private::generate_code_coverage() {
@@ -279,7 +298,11 @@ cromwell::private::generate_code_coverage() {
     bash <(curl -s https://codecov.io/bash) > /dev/null || true
 }
 
-cromwell::private::publish_docker() {
+cromwell::private::publish_artifacts_only() {
+    sbt "$@" +publish
+}
+
+cromwell::private::publish_artifacts_and_docker() {
     sbt "$@" +publish dockerBuildAndPush
 }
 
@@ -344,19 +367,19 @@ cromwell::private::cat_conformance_log() {
 }
 
 cromwell::private::kill_build_heartbeat() {
-    if [ -n "${CROMWELL_BUILD_HEARTBEAT_PID+set}" ]; then
+    if [ -n "${CROMWELL_BUILD_HEARTBEAT_PID:+set}" ]; then
         cromwell::private::kill_tree "${CROMWELL_BUILD_HEARTBEAT_PID}"
     fi
 }
 
 cromwell::private::kill_cromwell_log_tail() {
-    if [ -n "${CROMWELL_BUILD_CROMWELL_LOG_TAIL_PID+set}" ]; then
+    if [ -n "${CROMWELL_BUILD_CROMWELL_LOG_TAIL_PID:+set}" ]; then
         cromwell::private::kill_tree "${CROMWELL_BUILD_CROMWELL_LOG_TAIL_PID}"
     fi
 }
 
 cromwell::private::kill_centaur_log_tail() {
-    if [ -n "${CROMWELL_BUILD_CENTAUR_LOG_TAIL_PID+set}" ]; then
+    if [ -n "${CROMWELL_BUILD_CENTAUR_LOG_TAIL_PID:+set}" ]; then
         cromwell::private::kill_tree ${CROMWELL_BUILD_CENTAUR_LOG_TAIL_PID}
     fi
 }
@@ -380,6 +403,21 @@ cromwell::private::add_exit_function() {
     trap cromwell::private::run_exit_functions TERM EXIT
 }
 
+cromwell::private::exec_silent_function() {
+    local silent_function
+    local xtrace_restore_function
+    silent_function="${1:?exec_silent_function called without a function}"
+    xtrace_restore_function="$(shopt -po xtrace)"
+    shopt -uo xtrace
+    ${silent_function}
+    ${xtrace_restore_function}
+}
+
+cromwell::private::is_xtrace_enabled() {
+    # Return 0 if xtrace is disabled (set +x), 1 if xtrace is enabled (set -x).
+    shopt -qo xtrace
+}
+
 cromwell::private::kill_tree() {
   local pid
   local cpid
@@ -396,27 +434,22 @@ cromwell::build::exec_test_script() {
     cromwell::private::exec_test_script
 }
 
-cromwell::build::setup_everyone_environment() {
+cromwell::build::setup_common_environment() {
     cromwell::private::check_debug
     cromwell::private::create_build_variables
     cromwell::private::verify_cron_build
     if [ "${CROMWELL_BUILD_IS_CI}" = "true" ]; then
-        cromwell::private::setup_common_environment
+        cromwell::private::delete_boto_config
+        cromwell::private::delete_sbt_boot
+        cromwell::private::upgrade_pip
+        cromwell::private::create_mysql_cromwell_test
+        cromwell::private::pull_common_docker_images
+        cromwell::private::install_cwltool
     fi
 }
 
-cromwell::build::setup_secure_environment() {
-    cromwell::private::check_debug
-    cromwell::private::create_build_variables
-    cromwell::private::verify_cron_build
-    if [ "${CROMWELL_BUILD_IS_CI}" = "true" ]; then
-        cromwell::private::verify_secure_variables
-        cromwell::private::export_secure_variables
-        cromwell::private::setup_common_environment
-        cromwell::private::docker_login
-        cromwell::private::vault_login
-    fi
-    cromwell::private::render_secure_resources
+cromwell::build::setup_secure_resources() {
+    cromwell::private::setup_secure_resources
 }
 
 cromwell::build::setup_centaur_environment() {
@@ -446,7 +479,7 @@ cromwell::build::setup_conformance_environment() {
 
 cromwell::build::assemble_jars() {
     if [ "${CROMWELL_BUILD_IS_CI}" = "true" ]; then
-        ASSEMBLY_LOG_LEVEL=error ENABLE_COVERAGE=true sbt assembly -error
+        CROMWELL_SBT_ASSEMBLY_LOG_LEVEL=error CROMWELL_SBT_COVERAGE=true sbt assembly -error
     fi
     CROMWELL_BUILD_JAR="$( \
         find "${CROMWELL_BUILD_ROOT_DIRECTORY}/server/target/scala-2.12" -name "cromwell-*.jar" \
@@ -463,19 +496,27 @@ cromwell::build::generate_code_coverage() {
 }
 
 cromwell::build::publish_artifacts() {
-    if [ "$CROMWELL_BUILD_TYPE" == "sbt" ] && [ "$CROMWELL_BUILD_EVENT" == "push" ]; then
+    if [ "${CROMWELL_BUILD_TYPE}" == "sbt" ] && [ "${CROMWELL_BUILD_EVENT}" == "push" ]; then
 
-        if [ "$CROMWELL_BUILD_BRANCH" == "develop" ]; then
+        if [ "${CROMWELL_BUILD_BRANCH}" = "develop" ]; then
             # Publish images for both the "cromwell develop branch" and the "cromwell dev environment".
-            cromwell::private::docker_login
-            CROMWELL_DOCKER_TAGS=develop,dev cromwell::private::publish_docker
-            cromwell::private::vault_login
-            cromwell::private::render_secure_resources
+            cromwell::private::setup_secure_resources
+            CROMWELL_SBT_DOCKER_TAGS=develop,dev \
+                cromwell::private::publish_artifacts_and_docker \
+                -Dproject.isSnapshot=true
             cromwell::private::push_publish_complete
 
-        elif [[ "$CROMWELL_BUILD_BRANCH" =~ ^[0-9\.]+_hotfix$ ]]; then
-            cromwell::private::docker_login
-            cromwell::private::publish_docker -Dproject.isSnapshot=false
+        elif [[ "${CROMWELL_BUILD_BRANCH}" =~ ^[0-9\.]+_hotfix$ ]]; then
+            # Docker tags float. "30" is the latest hotfix. Those dockers are published here on each hotfix commit.
+            cromwell::private::setup_secure_resources
+            cromwell::private::publish_artifacts_and_docker -Dproject.isSnapshot=false
+
+        elif [ -n "${CROMWELL_BUILD_TAG:+set}" ]; then
+            # Artifact tags are static. Once "30" is set that is only "30" forever. Those artifacts are published here.
+            cromwell::private::setup_secure_resources
+            cromwell::private::publish_artifacts_only \
+                -Dproject.version="${CROMWELL_BUILD_TAG}" \
+                -Dproject.isSnapshot=false
 
         fi
     fi

--- a/src/bin/ci/testCentaurBcs.sh
+++ b/src/bin/ci/testCentaurBcs.sh
@@ -10,11 +10,13 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_secure_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
 cromwell::build::assemble_jars
+
+cromwell::build::setup_secure_resources
 
 # https://github.com/broadinstitute/cromwell/issues/3522
 # https://github.com/broadinstitute/cromwell/issues/3523

--- a/src/bin/ci/testCentaurLocal.sh
+++ b/src/bin/ci/testCentaurLocal.sh
@@ -5,7 +5,7 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_everyone_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 

--- a/src/bin/ci/testCentaurPapiV1.sh
+++ b/src/bin/ci/testCentaurPapiV1.sh
@@ -6,11 +6,13 @@ export CROMWELL_BUILD_SUPPORTS_CRON=true
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_secure_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
 cromwell::build::assemble_jars
+
+cromwell::build::setup_secure_resources
 
 GOOGLE_AUTH_MODE="service-account"
 GOOGLE_REFRESH_TOKEN_PATH="${CROMWELL_BUILD_SCRIPTS_RESOURCES}/papi_refresh_token.txt"

--- a/src/bin/ci/testCentaurPapiV2.sh
+++ b/src/bin/ci/testCentaurPapiV2.sh
@@ -6,11 +6,13 @@ export CROMWELL_BUILD_SUPPORTS_CRON=true
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_secure_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
 cromwell::build::assemble_jars
+
+cromwell::build::setup_secure_resources
 
 GOOGLE_AUTH_MODE="service-account"
 GOOGLE_REFRESH_TOKEN_PATH="${CROMWELL_BUILD_SCRIPTS_RESOURCES}/papi_refresh_token.txt"

--- a/src/bin/ci/testCentaurTes.sh
+++ b/src/bin/ci/testCentaurTes.sh
@@ -5,7 +5,7 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_everyone_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 

--- a/src/bin/ci/testCheckPublish.sh
+++ b/src/bin/ci/testCheckPublish.sh
@@ -5,6 +5,6 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_everyone_environment
+cromwell::build::setup_common_environment
 
 sbt +clean +package assembly +doc

--- a/src/bin/ci/testConformanceLocal.sh
+++ b/src/bin/ci/testConformanceLocal.sh
@@ -5,7 +5,7 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_everyone_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_conformance_environment
 

--- a/src/bin/ci/testConformancePapiV2.sh
+++ b/src/bin/ci/testConformancePapiV2.sh
@@ -5,11 +5,13 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_secure_environment
+cromwell::build::setup_common_environment
 
 cromwell::build::setup_conformance_environment
 
 cromwell::build::assemble_jars
+
+cromwell::build::setup_secure_resources
 
 CENTAUR_CWL_RUNNER_MODE="papi"
 GOOGLE_AUTH_MODE="service-account"

--- a/src/bin/ci/testSbt.sh
+++ b/src/bin/ci/testSbt.sh
@@ -5,9 +5,9 @@ set -e
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-cromwell::build::setup_everyone_environment
+cromwell::build::setup_common_environment
 
-ENABLE_COVERAGE=true sbt \
+CROMWELL_SBT_COVERAGE=true sbt \
     -Dbackend.providers.Local.config.filesystems.local.localization.0=copy \
     +clean +nointegration:test
 


### PR DESCRIPTION
Give Centaur-managed Cromwell more time to restart and a custom exit code.
Publish artifacts again on each build tag.
Login to docker before trying to push images.
Functions using secure variables ensure that xtrace is not enabled, thus no longer need a subshell, thus do not need to be exported.
Artifactory and Docker Hub credentials added to vault.
Docker login can use environment variables or vault once dsde-toolbox is public.
Split setup_secure_environment into setup_common_environment and setup_secure_resources.
Sbt environment variables prefixed as CROMWELL_SBT_*.
Print out a warning instead of exiting when vault resources cannot be rendered when testing locally.
Minor updates for more consistent shell variable usage.