### PR TITLE
Allow language factories to infer appropriateness

### DIFF
--- a/centaur/src/main/resources/standardTestCases/draft3_infer_version.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_infer_version.test
@@ -1,0 +1,15 @@
+name: draft3_infer_version
+testFormat: workflowsuccess
+workflowType: WDL
+# Note: no workflowTypeVersion specified!
+tags: ["wdl_1.0"]
+
+files {
+  workflow: wdl_draft3/draft3_infer_version/draft3_infer_version.wdl
+}
+
+metadata {
+  workflowName: draft3_infer_version
+  status: Succeeded
+  "outputs.draft3_infer_version.j": 660
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_infer_version/draft3_infer_version.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_infer_version/draft3_infer_version.wdl
@@ -1,0 +1,14 @@
+
+# Some heading commentary...
+
+version 1.0
+
+workflow draft3_infer_version {
+  input {
+    Int i = 12
+  }
+
+  output {
+    Int j = i * 55
+  }
+}

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
@@ -30,5 +30,10 @@ trait LanguageFactory {
                         importLocalFilesystem: Boolean,
                         workflowIdForLogging: WorkflowId,
                         ioFunctions: IoFunctionSet): Parse[ValidatedWomNamespace]
-}
 
+  /**
+    * In case no version is specified: does this language factory feel like it might be suitable for this file?
+    * @param content The workflow description
+    */
+  def looksParsable(content: String): Boolean = false
+}

--- a/languageFactories/wdl-draft3/src/main/scala/languages/wdl/draft3/WdlDraft3LanguageFactory.scala
+++ b/languageFactories/wdl-draft3/src/main/scala/languages/wdl/draft3/WdlDraft3LanguageFactory.scala
@@ -54,4 +54,11 @@ class WdlDraft3LanguageFactory(override val config: Map[String, Any]) extends La
       validated <- LanguageFactoryUtil.validateWomNamespace(executable)
     } yield validated
   }
+
+  override def looksParsable(content: String): Boolean = {
+    val trimStart = content.lines.dropWhile { l =>
+      l.forall(_.isWhitespace) || l.dropWhile(_.isWhitespace).startsWith("#")
+    }
+    trimStart.next.dropWhile(_.isWhitespace).startsWith("version 1.0")
+  }
 }


### PR DESCRIPTION
I think this'll be a nice quality of life improvement for people who aren't already in the habit of supplying a "workflowTypeVersion" in their submissions (ie everyone)