### PR TITLE
Remove teeing, keep command and wrapper stdout/err from writing the same files

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -304,9 +304,6 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     lazy val environmentVariables = instantiatedCommand.environmentVariables map { case (k, v) => s"""export $k="$v"""" } mkString("", "\n", "\n")
 
     val home = jobDescriptor.taskCall.callable.homeOverride.map { _ (runtimeEnvironment) }.getOrElse("$HOME")
-    val shortId = jobDescriptor.workflowDescriptor.id.shortString
-    // Give the out and error FIFO variables names that are unlikely to conflict with anything the user is doing.
-    val (out, err) = (s"out$shortId", s"err$shortId")
 
     val dockerOutputDir = jobDescriptor.taskCall.callable.dockerOutputDirectory map { d =>
       s"ln -s $cwd $d"
@@ -328,16 +325,11 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |cd $cwd
         |SCRIPT_PREAMBLE
         |)
-        |$out="$${tmpDir}/out.$$$$" $err="$${tmpDir}/err.$$$$"
-        |mkfifo "$$$out" "$$$err"
-        |trap 'rm "$$$out" "$$$err"' EXIT
-        |tee $stdoutRedirection < "$$$out" &
-        |tee $stderrRedirection < "$$$err" >&2 &
         |(
         |cd $cwd
         |ENVIRONMENT_VARIABLES
         |INSTANTIATED_COMMAND
-        |) $stdinRedirection > "$$$out" 2> "$$$err"
+        |) $stdinRedirection > $stdoutRedirection 2> $stderrRedirection
         |echo $$? > $rcTmpPath
         |(
         |cd $cwd

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -437,8 +437,8 @@ backend {
     #    -b y \
     #    -N ${job_name} \
     #    -wd ${cwd} \
-    #    -o ${out} \
-    #    -e ${err} \
+    #    -o ${out}.qsub \
+    #    -e ${err}.qsub \
     #    -pe smp ${cpu} \
     #    ${"-l mem_free=" + memory_gb + "g"} \
     #    ${"-q " + sge_queue} \

--- a/docs/backends/SGE.md
+++ b/docs/backends/SGE.md
@@ -37,8 +37,8 @@ qsub \
     -b n \
     -N ${job_name} \
     -wd ${cwd} \
-    -o ${out} \
-    -e ${err} \
+    -o ${out}.qsub \
+    -e ${err}.qsub \
     -pe smp ${cpu} \
     ${"-l m_mem_free=" + memory_gb + "gb"} \
     ${"-q " + sge_queue} \
@@ -71,8 +71,8 @@ backend {
             -b n \
             -N ${job_name} \
             -wd ${cwd} \
-            -o ${out} \
-            -e ${err} \
+            -o ${out}.qsub \
+            -e ${err}.qsub \
             ${script}
         """
       }
@@ -100,8 +100,8 @@ backend {
             -b n \
             -N ${job_name} \
             -wd ${cwd} \
-            -o ${out} \
-            -e ${err} \
+            -o ${out}.qsub \
+            -e ${err}.qsub \
             -l docker,docker_images="${docker}"
             -xdv ${cwd}:${docker_cwd}
             ${script}

--- a/docs/tutorials/HPCIntro.md
+++ b/docs/tutorials/HPCIntro.md
@@ -139,8 +139,8 @@ When Cromwell runs a task, it will fill in a template for the job using the decl
 ```bash
 qsub -terse -V -b y -N my_job_name \
   -wd /path/to/working_directory \
-  -o /path/to/stdout \
-  -e /path/to/stderr \
+  -o /path/to/stdout.qsub \
+  -e /path/to/stderr.qsub \
   -pe smp 1 -l mem_free=0.5g -q short \
   /usr/bin/env bash myScript.bash
 ```
@@ -158,8 +158,8 @@ backend.providers.SGE.config {
   -b y \
   -N ${job_name} \
   -wd ${cwd} \
-  -o ${out} \
-  -e ${err} \
+  -o ${out}.qsub \
+  -e ${err}.qsub \
   -pe smp ${cpu} \
   ${"-l mem_free=" + memory_gb + "g"} \
   ${"-q " + sge_queue} \


### PR DESCRIPTION
Addresses #3705. This requires the fixes in #3695 that puts command stdout/err in separate files from the wrapper exec script.