### PR TITLE
Query for 'On Hold' workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cromwell Change Log
 
+## 33 Release Notes
+
+### Bug Fixes
+
+Workflows which are in 'On Hold' state can now be fetched using the query endpoint.
+
 ## 32 Release Notes
 
 ### Backends

--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -12,7 +12,7 @@ sealed trait WorkflowState {
 object WorkflowState {
   lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
 
-  def withName(str: String): WorkflowState = WorkflowStateValues.find(_.toString == str).getOrElse(
+  def withName(str: String): WorkflowState = WorkflowStateValues.find(_.toString.equalsIgnoreCase(str)).getOrElse(
     throw new NoSuchElementException(s"No such WorkflowState: $str"))
 
   implicit val WorkflowStateSemigroup = new Semigroup[WorkflowState] {

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -103,7 +103,10 @@ object WorkflowQueryKey {
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList
       val nels = values map { v =>
-        if (Try(WorkflowState.withName(v.toLowerCase.capitalize)).isSuccess) v.validNel[String] else v.invalidNel[String]
+        Try(WorkflowState.withName(v)) match {
+          case Success(workflowState) => workflowState.toString.validNel[String]
+          case _ => v.invalidNel[String]
+        }
       }
       sequenceListOfValidatedNels("Unrecognized status values", nels)
     }


### PR DESCRIPTION
Bug where querying for workflows which are in 'On Hold' state and would give 

```
{
"status": "fail",
"message": "Unrecognized status values: On Hold"
}
```

is resolved. Comparison of string for state matching is now case insensitive, and instead of sending the user submitted state, the actual string associated with each WorkflowState is sent.