### PR TITLE
Input expressions with IoFunctions

### DIFF
--- a/centaur/src/main/resources/standardTestCases/input_expressions.test
+++ b/centaur/src/main/resources/standardTestCases/input_expressions.test
@@ -1,0 +1,10 @@
+name: input_expressions
+testFormat: workflowsuccess
+
+files {
+  workflow: input_expressions/input_expressions.wdl
+}
+
+metadata {
+    "outputs.input_expressions.wf_out": 256.0
+}

--- a/centaur/src/main/resources/standardTestCases/input_expressions.test
+++ b/centaur/src/main/resources/standardTestCases/input_expressions.test
@@ -1,5 +1,6 @@
 name: input_expressions
 testFormat: workflowsuccess
+backends: [Papi, Local]
 
 files {
   workflow: input_expressions/input_expressions.wdl

--- a/centaur/src/main/resources/standardTestCases/input_expressions/input_expressions.wdl
+++ b/centaur/src/main/resources/standardTestCases/input_expressions/input_expressions.wdl
@@ -1,0 +1,6 @@
+workflow input_expressions {
+    Float size256k = size("gs://cloud-cromwell-dev/file_256k", "KiB")
+    output {
+        Float wf_out = size256k
+    }
+}

--- a/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
+++ b/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
@@ -55,7 +55,7 @@ class CwlV1_0LanguageFactory(override val config: Map[String, Any]) extends Lang
       _ <- unzipDependencies(cwlFile)
       cwl <- CwlDecoder.decodeCwlFile(cwlFile, source.workflowRoot)
       executable <- fromEither[IO](cwl.womExecutable(AcceptAllRequirements, Option(source.inputsJson), ioFunctions, standardConfig.strictValidation))
-      validatedWomNamespace <- fromEither[IO](LanguageFactoryUtil.validateWomNamespace(executable))
+      validatedWomNamespace <- fromEither[IO](LanguageFactoryUtil.validateWomNamespace(executable, ioFunctions))
       _ <- CwlDecoder.todoDeleteCwlFileParentDirectory(cwlFile.parent)
     } yield validatedWomNamespace
   }

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -1,18 +1,18 @@
 package cromwell.languages.util
 
-import cats.syntax.validated._
 import cats.data.NonEmptyList
+import cats.syntax.validated._
 import common.Checked
 import common.validation.ErrorOr.ErrorOr
+import cromwell.core.CromwellGraphNode.CromwellEnhancedOutputPort
 import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.{DefaultPathBuilder, Path}
-import wom.executable.Executable.ResolvedExecutableInputs
+import cromwell.languages.ValidatedWomNamespace
 import wom.executable.Executable
-import wom.expression.{IoFunctionSet, NoIoFunctionSet}
+import wom.executable.Executable.ResolvedExecutableInputs
+import wom.expression.IoFunctionSet
 import wom.graph.GraphNodePort.OutputPort
 import wom.values.{WomSingleFile, WomValue}
-import cromwell.core.CromwellGraphNode.CromwellEnhancedOutputPort
-import cromwell.languages.ValidatedWomNamespace
 
 import scala.util.{Failure, Success, Try}
 
@@ -44,8 +44,8 @@ object LanguageFactoryUtil {
     }
   }
 
-  def validateWomNamespace(womExecutable: Executable): Checked[ValidatedWomNamespace] = for {
-    evaluatedInputs <- validateExecutableInputs(womExecutable.resolvedExecutableInputs, NoIoFunctionSet).toEither
+  def validateWomNamespace(womExecutable: Executable, ioFunctions: IoFunctionSet): Checked[ValidatedWomNamespace] = for {
+    evaluatedInputs <- validateExecutableInputs(womExecutable.resolvedExecutableInputs, ioFunctions).toEither
     validatedWomNamespace = ValidatedWomNamespace(womExecutable, evaluatedInputs, Map.empty)
     _ <- validateWdlFiles(validatedWomNamespace.womValueInputs)
   } yield validatedWomNamespace

--- a/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
+++ b/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
@@ -95,7 +95,7 @@ class WdlDraft2LanguageFactory(override val config: Map[String, Any]) extends La
       _ <- validateWorkflowNameLengths(wdlNamespace)
       importedUris = evaluateImports(wdlNamespace)
       womExecutable <- wdlNamespace.toWomExecutable(Option(source.inputsJson), ioFunctions, standardConfig.strictValidation)
-      validatedWomNamespaceBeforeMetadata <- LanguageFactoryUtil.validateWomNamespace(womExecutable)
+      validatedWomNamespaceBeforeMetadata <- LanguageFactoryUtil.validateWomNamespace(womExecutable, ioFunctions)
       _ <- checkTypes(wdlNamespace, validatedWomNamespaceBeforeMetadata.womValueInputs)
     } yield validatedWomNamespaceBeforeMetadata.copy(importedFileContent = importedUris)
 
@@ -124,7 +124,7 @@ class WdlDraft2LanguageFactory(override val config: Map[String, Any]) extends La
   override def createExecutable(womBundle: WomBundle, inputs: WorkflowJson, ioFunctions: IoFunctionSet): Checked[ValidatedWomNamespace] = for {
     _ <- standardConfig.enabledCheck
     executable <- WdlSharedInputParsing.buildWomExecutable(womBundle, Option(inputs), ioFunctions, standardConfig.strictValidation)
-    validatedNamespace <- LanguageFactoryUtil.validateWomNamespace(executable)
+    validatedNamespace <- LanguageFactoryUtil.validateWomNamespace(executable, ioFunctions)
   } yield validatedNamespace
 
   // Commentary: we'll set this as the default in the reference.conf, so most people will get WDL draft 2 if nothing else looks parsable.

--- a/languageFactories/wdl-draft3/src/main/scala/languages/wdl/draft3/WdlDraft3LanguageFactory.scala
+++ b/languageFactories/wdl-draft3/src/main/scala/languages/wdl/draft3/WdlDraft3LanguageFactory.scala
@@ -54,7 +54,7 @@ class WdlDraft3LanguageFactory(override val config: Map[String, Any]) extends La
     for {
       _ <- standardConfig.enabledCheck
       executable <- womBundle.toWomExecutable(Option(inputsJson), ioFunctions, standardConfig.strictValidation)
-      validated <- LanguageFactoryUtil.validateWomNamespace(executable)
+      validated <- LanguageFactoryUtil.validateWomNamespace(executable, ioFunctions)
     } yield validated
   }
 


### PR DESCRIPTION
The `validateWomNamespace` method was using `NoIoFunctionSet` instead of the available ioFunctions, causing the workflow in the centaur test to fail