### PR TITLE
temporary directory should not be world readable

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -314,7 +314,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |DOCKER_OUTPUT_DIR_LINK
         |cd $cwd
         |tmpDir=`$temporaryDirectory`
-        |chmod 777 "$$tmpDir"
+        |chmod 711 "$$tmpDir"
         |export _JAVA_OPTIONS=-Djava.io.tmpdir="$$tmpDir"
         |export TMPDIR="$$tmpDir"
         |export HOME="$home"


### PR DESCRIPTION
Setting the tmpdir to be word accessible poses a security risk at some high-performance compute clusters.

Original idea seems to make it world writabled: https://github.com/broadinstitute/cromwell/pull/2053

I would even prefer to set it to be *only* accessable for the `cromwell` user (mod: `700`)... or just leave it as it was provided...