### PR TITLE
PAPI2 error reporting

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -318,7 +318,8 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
         } getOrElse ""
         reason.getMessage + stderrMessage
       case reason =>
-        reason.getMessage + "\n" + ExceptionUtils.getStackTrace(reason)
+        val m = ExceptionUtils.getStackTrace(reason)
+        m
     } mkString "\n"
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -317,9 +317,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
           s"\nCheck the content of stderr for potential additional information: ${path.pathAsString}.\n $content" 
         } getOrElse ""
         reason.getMessage + stderrMessage
-      case reason =>
-        val m = ExceptionUtils.getStackTrace(reason)
-        m
+      case reason => ExceptionUtils.getStackTrace(reason)
     } mkString "\n"
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   private val googleCloudCoreV = "1.8.0"
   private val googleCloudNioV = "0.20.1-alpha"
   private val googleCredentialsV = "0.8.0"
-  private val googleGenomicsServicesV2ApiV = "v2alpha1-rev9-1.23.0"
+  private val googleGenomicsServicesV2ApiV = "v2alpha1-rev15-1.23.0"
   private val googleGenomicsServicesV1ApiV = "v1alpha2-rev495-1.23.0"
   private val googleHttpClientV = googleApiClientV
   private val googleOauth2V = "0.8.0"

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
@@ -28,8 +28,8 @@ object RunStatus {
   }
 
   sealed trait UnsuccessfulRunStatus extends TerminalRunStatus {
-    val errorMessage: Option[String]
-    lazy val prettyPrintedError: String = errorMessage map { e => s" Message: $e" } getOrElse ""
+    val errorMessages: List[String]
+    lazy val prettyPrintedError: String = errorMessages.mkString("\n")
     val errorCode: Status
 
     /**
@@ -66,13 +66,13 @@ object RunStatus {
         case Status.CANCELLED => Cancelled.apply _
         case _ => Failed.apply _
       }
-      unsuccessfulStatusBuilder.apply(errorCode, jesCode, errorMessage, eventList, machineType, zone, instanceName)
+      unsuccessfulStatusBuilder.apply(errorCode, jesCode, errorMessage.toList, eventList, machineType, zone, instanceName)
     }
   }
 
   final case class Failed(errorCode: Status,
                           jesCode: Option[Int],
-                          errorMessage: Option[String],
+                          errorMessages: List[String],
                           eventList: Seq[ExecutionEvent],
                           machineType: Option[String],
                           zone: Option[String],
@@ -85,7 +85,7 @@ object RunStatus {
     */
   final case class Cancelled(errorCode: Status,
                           jesCode: Option[Int],
-                          errorMessage: Option[String],
+                          errorMessages: List[String],
                           eventList: Seq[ExecutionEvent],
                           machineType: Option[String],
                           zone: Option[String],
@@ -95,7 +95,7 @@ object RunStatus {
 
   final case class Preempted(errorCode: Status,
                              jesCode: Option[Int],
-                             errorMessage: Option[String],
+                             errorMessages: List[String],
                              eventList: Seq[ExecutionEvent],
                              machineType: Option[String],
                              zone: Option[String],

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/errors/PipelinesApiKnownJobFailure.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/errors/PipelinesApiKnownJobFailure.scala
@@ -5,20 +5,24 @@ import cromwell.core.path.Path
 
 sealed trait PipelinesApiKnownJobFailure extends KnownJobFailureException
 
+case class FailToLocalizeFailure(messages: List[String]) extends PipelinesApiKnownJobFailure {
+  override def stderrPath = None
+}
+
 case class FailedToDelocalizeFailure(message: String, jobTag: String, stderrPath: Option[Path])
   extends PipelinesApiKnownJobFailure {
   lazy val stderrMessage = stderrPath map { p =>
     s"3) Look into the stderr (${p.pathAsString}) file for evidence that some of the output files the command is expected to create were not created."
   } getOrElse ""
-  
+
   lazy val missingFilesMessage = if (message.contains("No URLs matched")) {
     s"""It appears that some of the expected output files for task $jobTag did not exist when the command exited.
        |A few things to try
-       |1) Check that the output section in your WDL is correct. Remember that all output files declared in a task must exist when the command exits.
+       |1) Check that the output section in your workflow is correct. Remember that all non optional output files declared in a task must exist when the command exits.
        |2) Check that the return code is available and is valid with respect to your command expected exit code
        |$stderrMessage
      """.stripMargin
   } else ""
-  
+
   override def getMessage = missingFilesMessage + message
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -7,30 +7,28 @@ import cromwell.core.path.DefaultPathBuilder
 import wom.core.FullyQualifiedName
 import wom.values.{GlobFunctions, WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomUnlistedDirectory}
 
-import scala.language.postfixOps
-
 class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExecutionActorParams) extends cromwell.backend .google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor(standardParams) {
   
   // The original implementation assumes the WomFiles are all WomMaybePopulatedFiles and wraps everything in a PipelinesApiFileInput
   // In v2 we can differentiate files from directories 
-  override protected def pipelinesApiInputsFromWomFiles(jesNamePrefix: String,
+  override protected def pipelinesApiInputsFromWomFiles(inputName: String,
                                                         remotePathArray: Seq[WomFile],
                                                         localPathArray: Seq[WomFile],
                                                         jobDescriptor: BackendJobDescriptor): Iterable[PipelinesApiInput] = {
-    (remotePathArray zip localPathArray zipWithIndex) flatMap {
-      case ((remotePath: WomMaybeListedDirectory, localPath), index) =>
-        maybeListedDirectoryToPipelinesParameters(jesNamePrefix, remotePath, index, localPath.valueString)
-      case ((remotePath: WomUnlistedDirectory, localPath), index) =>
-        Seq(PipelinesApiDirectoryInput(s"$jesNamePrefix-$index", getPath(remotePath.valueString).get, DefaultPathBuilder.get(localPath.valueString), workingDisk))
-      case ((remotePath: WomMaybePopulatedFile, localPath), index) =>
-        maybePopulatedFileToPipelinesParameters(jesNamePrefix, remotePath, index, localPath.valueString)
-      case ((remotePath, localPath), index) =>
-        Seq(PipelinesApiFileInput(s"$jesNamePrefix-$index", getPath(remotePath.valueString).get, DefaultPathBuilder.get(localPath.valueString), workingDisk))
+    (remotePathArray zip localPathArray) flatMap {
+      case (remotePath: WomMaybeListedDirectory, localPath) =>
+        maybeListedDirectoryToPipelinesParameters(inputName, remotePath, localPath.valueString)
+      case (remotePath: WomUnlistedDirectory, localPath) =>
+        Seq(PipelinesApiDirectoryInput(inputName, getPath(remotePath.valueString).get, DefaultPathBuilder.get(localPath.valueString), workingDisk))
+      case (remotePath: WomMaybePopulatedFile, localPath) =>
+        maybePopulatedFileToPipelinesParameters(inputName, remotePath, localPath.valueString)
+      case (remotePath, localPath) =>
+        Seq(PipelinesApiFileInput(inputName, getPath(remotePath.valueString).get, DefaultPathBuilder.get(localPath.valueString), workingDisk))
     }
   }
 
   // The original implementation recursively finds all non directory files, in V2 we can keep directory as is
-  override protected def callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs map {
+  override protected def callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.localInputs map {
     case (key, womFile) =>
       key -> womFile.collectAsSeq({
         case womFile: WomFile => womFile
@@ -64,18 +62,18 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
     )
   }
   
-  private def maybePopulatedFileToPipelinesParameters(jesNamePrefix: String, maybePopulatedFile: WomMaybePopulatedFile, index: Int, localPath: String) = {
+  private def maybePopulatedFileToPipelinesParameters(inputName: String, maybePopulatedFile: WomMaybePopulatedFile, localPath: String) = {
     val secondaryFiles = maybePopulatedFile.secondaryFiles.flatMap({ secondaryFile =>
       pipelinesApiInputsFromWomFiles(secondaryFile.valueString, List(secondaryFile), List(relativeLocalizationPath(secondaryFile)), jobDescriptor)
     })
 
-    Seq(PipelinesApiFileInput(s"$jesNamePrefix-$index", getPath(maybePopulatedFile.valueString).get, DefaultPathBuilder.get(localPath), workingDisk)) ++ secondaryFiles
+    Seq(PipelinesApiFileInput(inputName, getPath(maybePopulatedFile.valueString).get, DefaultPathBuilder.get(localPath), workingDisk)) ++ secondaryFiles
   }
   
-  private def maybeListedDirectoryToPipelinesParameters(jesNamePrefix: String, womMaybeListedDirectory: WomMaybeListedDirectory, index: Int, localPath: String) = womMaybeListedDirectory match {
+  private def maybeListedDirectoryToPipelinesParameters(inputName: String, womMaybeListedDirectory: WomMaybeListedDirectory, localPath: String) = womMaybeListedDirectory match {
      // If there is a path, simply localize as a directory
     case WomMaybeListedDirectory(Some(path), _, _) =>
-      List(PipelinesApiDirectoryInput(s"$jesNamePrefix-$index", getPath(path).get, DefaultPathBuilder.get(localPath), workingDisk))
+      List(PipelinesApiDirectoryInput(inputName, getPath(path).get, DefaultPathBuilder.get(localPath), workingDisk))
 
     // If there is a listing, recurse and call pipelinesApiInputsFromWomFiles on all the listed files
     case WomMaybeListedDirectory(_, Some(listing), _) if listing.nonEmpty =>

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesParameterConversions.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesParameterConversions.scala
@@ -3,6 +3,7 @@ package cromwell.backend.google.pipelines.v2alpha1
 import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
 import cromwell.backend.google.pipelines.common._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder._
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionFlag
 import simulacrum.typeclass
 
@@ -20,7 +21,11 @@ import scala.language.implicitConversions
 trait PipelinesParameterConversions {
   implicit val fileInputToParameter = new ToParameter[PipelinesApiFileInput] {
     override def toActions(fileInput: PipelinesApiFileInput, mounts: List[Mount], projectId: String) = {
-      List(gsutil("cp", fileInput.cloudPath.pathAsString, fileInput.containerPath.pathAsString)(mounts, description = Option("localizing")))
+      val labels = Map(
+        Key.Tag -> Value.Localization,
+        Key.InputName -> fileInput.name
+      )
+      List(gsutil("cp", fileInput.cloudPath.pathAsString, fileInput.containerPath.pathAsString)(mounts, labels = labels))
     }
   }
 
@@ -31,7 +36,7 @@ trait PipelinesParameterConversions {
         .withCommand("mkdir", "-p", directoryInput.containerPath.pathAsString)
         .withMounts(mounts)
 
-      val gsutilAction = gsutil("-m", "rsync", "-r", directoryInput.cloudPath.pathAsString, directoryInput.containerPath.pathAsString)(mounts, description = Option("localizing"))
+      val gsutilAction = gsutil("-m", "rsync", "-r", directoryInput.cloudPath.pathAsString, directoryInput.containerPath.pathAsString)(mounts, labels =  Map(Key.Tag -> Value.Localization))
 
       List(mkdirAction, gsutilAction)
     }
@@ -45,7 +50,7 @@ trait PipelinesParameterConversions {
 
   implicit val directoryOutputToParameter = new ToParameter[PipelinesApiDirectoryOutput] {
     override def toActions(directoryOutput: PipelinesApiDirectoryOutput, mounts: List[Mount], projectId: String) = {
-      List(gsutil("-m", "rsync", "-r", directoryOutput.containerPath.pathAsString, directoryOutput.cloudPath.pathAsString)(mounts, List(ActionFlag.AlwaysRun), description = Option("delocalizing")))
+      List(gsutil("-m", "rsync", "-r", directoryOutput.containerPath.pathAsString, directoryOutput.cloudPath.pathAsString)(mounts, List(ActionFlag.AlwaysRun), labels =  Map(Key.Tag -> Value.Delocalization)))
     }
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -26,7 +26,7 @@ object ActionBuilder {
     object Value {
       val UserAction = "UserAction"
       val Localization = "Localization"
-      val Delocalization = "DeLocalization"
+      val Delocalization = "Delocalization"
     }
   }
   

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -98,7 +98,7 @@ trait Delocalization {
 
     val projectId = createPipelineParameters.projectId
 
-    createPipelineParameters.outputParameters.flatMap(_.toActions(mounts, projectId)) ++
+    createPipelineParameters.outputParameters.flatMap(_.toActions(mounts, projectId).toList) ++
       List(parseAction, delocalizeAction) :+
       copyAggregatedLogToLegacyPath(callExecutionContainerRoot, gcsLegacyLogPath, projectId) :+
       delocalizeLogsAction(gcsLogDirectoryPath.pathAsString, projectId)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -78,10 +78,6 @@ trait Delocalization {
       .withMounts(mounts)
   }
 
-  /**
-    * The user action number is the index of the user's action in the list of actions
-    * It's used to copy stdout / stderr and the logs back to the execution directory
-    */
   def deLocalizeActions(createPipelineParameters: CreatePipelineParameters,
                         mounts: List[Mount]): List[Action] = {
     val cloudCallRoot = createPipelineParameters.cloudCallRoot.pathAsString

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
@@ -10,7 +10,6 @@ import com.google.api.services.genomics.v2alpha1.model._
 import common.validation.ErrorOr._
 import common.validation.Validation._
 import cromwell.backend.google.pipelines.v2alpha1.api.request.ErrorReporter._
-import cromwell.core.WorkflowId
 import mouse.all._
 
 import scala.collection.JavaConverters._
@@ -27,12 +26,12 @@ import scala.util.{Failure, Success, Try}
   */
 private [api] object Deserialization {
   def findEvent[T <: GenericJson](events: List[Event],
-                                  filter: T => Boolean = Function.const(true) _)(implicit tag: ClassTag[T], workflowId: WorkflowId, operation: Operation): Option[T] =
+                                  filter: T => Boolean = Function.const(true) _)(implicit tag: ClassTag[T]): Option[RequestContextReader[Option[T]]] =
     events.toStream
       .map(_.details(tag))
       .collectFirst({
         case Some(event) if event.map(filter).getOrElse(false) => event.toErrorOr.fallBack
-      }).flatten
+      })
   
   implicit class EventDeserialization(val event: Event) extends AnyVal {
     /**

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
@@ -3,16 +3,19 @@ package cromwell.backend.google.pipelines.v2alpha1.api
 import java.lang.reflect.ParameterizedType
 import java.util.{ArrayList => JArrayList, Map => JMap}
 
+import cats.instances.list._
+import cats.syntax.traverse._
 import com.google.api.client.json.GenericJson
 import com.google.api.services.genomics.v2alpha1.model._
-import mouse.all._
 import common.validation.ErrorOr._
 import common.validation.Validation._
+import cromwell.backend.google.pipelines.v2alpha1.api.request.ErrorReporter._
+import cromwell.core.WorkflowId
+import mouse.all._
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
-import cats.syntax.traverse._
-import cats.instances.list._
 /**
   * This bundles up some code to work around the fact that Operation is not deserialized
   * completely from the JSON HTTP response.
@@ -23,6 +26,14 @@ import cats.instances.list._
   * However it is only used once, when the job completes, which should limit the performance hit.
   */
 private [api] object Deserialization {
+  def findEvent[T <: GenericJson](events: List[Event],
+                                  filter: T => Boolean = Function.const(true) _)(implicit tag: ClassTag[T], workflowId: WorkflowId, operation: Operation): Option[T] =
+    events.toStream
+      .map(_.details(tag))
+      .collectFirst({
+        case Some(event) if event.map(filter).getOrElse(false) => event.toErrorOr.fallBack
+      }).flatten
+  
   implicit class EventDeserialization(val event: Event) extends AnyVal {
     /**
       * Attempts to deserialize the details map to T

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
@@ -21,7 +21,7 @@ trait Localization {
       )
       .setMounts(mounts.asJava)
 
-    val jobInputLocalization = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toActions(mounts, createPipelineParameters.projectId))
+    val jobInputLocalization = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toActions(mounts, createPipelineParameters.projectId).toList)
     
     List(containerRootSetup) ++ jobInputLocalization
   }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/ErrorReporter.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/ErrorReporter.scala
@@ -47,7 +47,7 @@ class ErrorReporter(machineType: Option[String],
   def toUnsuccessfulRunStatus(error: Status, events: List[Event]) = {
     val status = GStatus.fromCodeValue(error.getCode)
     val builder = status match {
-      case GStatus.ABORTED if wasPreemptible => Preempted.apply _
+      case GStatus.UNAVAILABLE if wasPreemptible => Preempted.apply _
       case GStatus.CANCELLED => Cancelled.apply _
       case _ => Failed.apply _
     }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/ErrorReporter.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/ErrorReporter.scala
@@ -1,0 +1,96 @@
+package cromwell.backend.google.pipelines.v2alpha1.api.request
+
+import cats.data.Validated.{Invalid, Valid}
+import com.google.api.services.genomics.v2alpha1.model._
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import cromwell.backend.google.pipelines.common.api.RunStatus.{Cancelled, Failed, Preempted}
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels.Key
+import cromwell.backend.google.pipelines.v2alpha1.api.Deserialization._
+import cromwell.backend.google.pipelines.v2alpha1.api.request.RequestHandler.logger
+import cromwell.core.{ExecutionEvent, WorkflowId}
+import io.grpc.{Status => GStatus}
+import mouse.all._
+
+import scala.collection.JavaConverters._
+
+object ErrorReporter {
+  // This can be used to log non-critical deserialization failures and not fail the task
+  implicit class ErrorOrLogger[A](val t: ErrorOr[A]) extends AnyVal {
+    private def errorMessage(workflowId: WorkflowId, operation: Operation, exception: Option[Throwable] = None) =
+      s"[$workflowId] Failed to parse PAPI response. Operation Id: ${operation.getName}"
+    
+    def fallBack(implicit workflowId: WorkflowId, operation: Operation): Option[A] = t match {
+      case Valid(s) => Option(s)
+      case Invalid(f) =>
+        logger.error(errorMessage(workflowId, operation) + s" ${f.toList.mkString(", ")}")
+        None
+    }
+
+    def fallBackTo(to: A)(implicit workflowId: WorkflowId, operation: Operation): A = t match {
+      case Valid(s) => s
+      case Invalid(f) =>
+        logger.error(s"[$workflowId] Failed to parse PAPI response. Operation Id: ${operation.getName}. ${f.toList.mkString(", ")}")
+        to
+    }
+  }
+}
+
+class ErrorReporter(machineType: Option[String],
+                    wasPreemptible: Boolean,
+                    executionEvents: List[ExecutionEvent],
+                    zone: Option[String],
+                    instanceName: Option[String],
+                    actions: List[Action])(implicit operation: Operation, workflowId: WorkflowId) {
+  import ErrorReporter._
+
+  def toUnsuccessfulRunStatus(error: Status, events: List[Event]) = {
+    val status = GStatus.fromCodeValue(error.getCode)
+    val builder = status match {
+      case GStatus.ABORTED if wasPreemptible => Preempted.apply _
+      case GStatus.CANCELLED => Cancelled.apply _
+      case _ => Failed.apply _
+    }
+
+    val failed: Option[String] = summaryFailure(events)
+    // Reverse the list because the first failure (likely the most relevant, will appear last otherwise)
+    val unexpectedExitEvents: List[String] = unexpectedExitStatusErrorStrings(events, actions).reverse
+
+    builder(status, None, failed.toList ++ unexpectedExitEvents, executionEvents, machineType, zone, instanceName)
+  }
+
+  // There's maybe one FailedEvent per operation with a summary error message
+  private def unexpectedExitStatusErrorStrings(events: List[Event], actions: List[Action]): List[String] = {
+    for {
+      event <- events
+      detail <- event.details[UnexpectedExitStatusEvent].flatMap(_.toErrorOr.fallBack)
+      stderr = detail.getActionId |> stderrForAction(events)
+      // Try to find the action and its tag label. -1 because action ids are 1-based
+      action = actions.lift(detail.getActionId.toInt - 1)
+      labelTag = action.flatMap(actionLabelTag)
+      inputNameTag = action.flatMap(actionLabelInputName)
+    } yield unexpectedStatusErrorString(event, stderr, labelTag, inputNameTag)
+  }
+
+  // It would probably be good to define a richer error structure than String, but right now that's what the backend interface expects
+  private def unexpectedStatusErrorString(event: Event, stderr: Option[String], labelTag: Option[String], inputNameTag: Option[String]) = {
+    labelTag.map("[" + _ + "] ").getOrElse("") +
+      inputNameTag.map("Input name: " +  _ + " - ").getOrElse("") +
+      event.getDescription +
+      stderr.map(": " + _).getOrElse("")
+  }
+
+  // There may be one FailedEvent per operation with a summary error message
+  private def summaryFailure(events: List[Event]): Option[String] = {
+    findEvent[FailedEvent](events).map(_.getCause)
+  }
+
+  // Try to find the stderr for the given action ID
+  private def stderrForAction(events: List[Event])(actionId: Integer) = {
+    findEvent[ContainerStoppedEvent](events, _.getActionId == actionId).map(_.getStderr)
+  }
+
+  private def actionLabelValue(action: Action, k: String) = action.getLabels.asScala.get(k)
+  private def actionLabelTag(action: Action) = actionLabelValue(action, Key.Tag)
+  private def actionLabelInputName(action: Action) = actionLabelValue(action, Key.InputName)
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -3,39 +3,22 @@ package cromwell.backend.google.pipelines.v2alpha1.api.request
 import java.time.OffsetDateTime
 
 import akka.actor.ActorRef
-import cats.data.EitherT
-import cats.instances.option._
-import cats.syntax.apply._
-import cats.syntax.either._
-import cats.syntax.functor._
-import cats.syntax.traverse._
-import cats.instances.list._
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.services.genomics.model.UnexpectedExitStatusEvent
 import com.google.api.services.genomics.v2alpha1.model._
-import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.RunStatus
-import cromwell.backend.google.pipelines.common.api.RunStatus.{Initializing, Running, Success, UnsuccessfulRunStatus}
+import cromwell.backend.google.pipelines.common.api.RunStatus.{Initializing, Running, Success}
 import cromwell.backend.google.pipelines.v2alpha1.PipelinesConversions._
 import cromwell.backend.google.pipelines.v2alpha1.api.Deserialization._
-import cromwell.backend.google.pipelines.v2alpha1.api.request.GetRequestHandler.{unexpectedExistStatus, _}
-import cromwell.backend.google.pipelines.v2alpha1.api.request.RequestHandler._
+import cromwell.backend.google.pipelines.v2alpha1.api.request.ErrorReporter._
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import cromwell.core.ExecutionEvent
-import io.grpc.Status
-import mouse.all._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Try, Success => TrySuccess}
-
-object GetRequestHandler {
-  private val failedEvent = classOf[FailedEvent].getSimpleName
-  private val unexpectedExistStatus = classOf[UnexpectedExitStatusEvent].getSimpleName
-}
 
 trait GetRequestHandler { this: RequestHandler =>
   // the Genomics batch endpoint doesn't seem to be able to handle get requests on V2 operations at the moment
@@ -58,63 +41,34 @@ trait GetRequestHandler { this: RequestHandler =>
       Failure(e)
   }
 
-  private def findWorkerEvent(events: List[Event]) = EitherT.apply(
-    events
-      .map(_.details[WorkerAssignedEvent])
-      .collectFirst({ case Some(defined) => defined.toChecked })
-  )
-
   private [request] def interpretOperationStatus(operation: Operation, pollingRequest: PAPIStatusPollRequest): RunStatus = {
-    require(operation != null, "Operation must not be null.")
+    implicit val workflowId = pollingRequest.workflowId
+    implicit val op = operation
 
-    def withDefault[T](default: T, context: String)(value: ErrorOr[T]): T = value.valueOr({ errors =>
-      val errorString = errors.toList.mkString(", ")
-      logger.error(s"Could not $context from the pipelines API response for workflow ${pollingRequest.workflowId}, operation ${operation.getName}: $errorString")
-      default
-    })
+    require(operation != null, "Operation must not be null.")
 
     try {
       if (operation.getDone) {
         val metadata = operation.getMetadata.asScala.toMap
         // Deserialize the response
-        val events: ErrorOr[List[Event]] = operation.events
-        val pipeline: ErrorOr[Pipeline] = operation.pipeline.toErrorOr
-
-        val workerEvent: Option[WorkerAssignedEvent] =
-          (for {
-            validEvents <- EitherT.fromEither[Option](events.toEither)
-            maybeWorkerEvent <- findWorkerEvent(validEvents)
-          } yield maybeWorkerEvent)
-            .value.map(_.toValidated)
-            .sequence[ErrorOr, WorkerAssignedEvent] |> withDefault(None, "parse details of the worker event")
-
-        val executionEvents = events.map(getEventList(metadata, _)) |> withDefault(List.empty, "parse the events")
-
+        val events: List[Event] = operation.events.fallBackTo(List.empty)
+        val pipeline: Option[Pipeline] = operation.pipeline.toErrorOr.fallBack
+        val workerEvent: Option[WorkerAssignedEvent] = findEvent[WorkerAssignedEvent](events)
+        val executionEvents = getEventList(metadata, events).toList
+        val machineType = pipeline.map(_.getResources.getVirtualMachine.getMachineType)
         // preemptible is only used if the job fails, as a heuristic to guess if the VM was preempted.
         // If we can't get the value of preempted we still need to return something, returning false will not make the failure count
         // as a preemption which seems better than saying that it was preemptible when we really don't know
-        val (machineType, preemptible): (Option[String], Boolean) = {
-          pipeline.map({ pipeline =>
-            val machineType = pipeline.getResources.getVirtualMachine.getMachineType
-            val preemptible = pipeline.getResources.getVirtualMachine.getPreemptible
-            Option(machineType) -> preemptible.booleanValue()
-          }) |> withDefault[(Option[String], Boolean)]((None, false), "parse the pipeline")
-        }
-
+        val preemptible = pipeline.exists(_.getResources.getVirtualMachine.getPreemptible.booleanValue())
         val instanceName = workerEvent.map(_.getInstance())
         val zone = workerEvent.map(_.getZone)
 
         // If there's an error, generate an unsuccessful status. Otherwise, we were successful!
         Option(operation.getError) match {
           case Some(error) =>
-            val errorCode = Status.fromCodeValue(error.getCode)
-            val actions: ErrorOr[List[Action]] = pipeline.map(_.getActions.asScala.toList)
-
-            val errorMessage = (events, actions) mapN {
-              case (e, a) => augmentedErrorMessage(e, a, error.getMessage)
-            } getOrElse error.getMessage
-
-            UnsuccessfulRunStatus(errorCode, Option(errorMessage), executionEvents, machineType, zone, instanceName, preemptible)
+            val actions = pipeline.map(_.getActions.asScala.toList).toList.flatten
+            val errorReporter = new ErrorReporter(machineType, preemptible, executionEvents, zone, instanceName, actions)(operation, pollingRequest.workflowId)
+            errorReporter.toUnsuccessfulRunStatus(error, events)
           case None => Success(executionEvents, machineType, zone, instanceName)
         }
       } else if (operation.hasStarted) {
@@ -134,22 +88,5 @@ trait GetRequestHandler { this: RequestHandler =>
     }
 
     starterEvent.toList ++ events.map(toExecutionEvent)
-  }
-
-  private def augmentedErrorMessage(events: List[Event], actions: List[Action], error: String): String = {
-    val failedEvents = events
-      .flatMap(_.details[FailedEvent])
-      .traverse(_.toErrorOr)
-
-    val unexpectedExitStatusEvents = events
-      .flatMap(_.details[UnexpectedExitStatusEvent])
-      .traverse(_.toErrorOr)
-    
-    (failedEvents, unexpectedExitStatusEvents) mapN {
-      case (failed, unexpected) =>
-        unexpected.map(_.getActionId)
-    }
-    
-    error + failedEvents
   }
 }


### PR DESCRIPTION
Cleans up a little the error reporting for PAPI2 failure and add some context.
It's not perfect and can be improved but is better than what's there now and will hopefully make it a bit easier to debug failures going forward.
e.g:

```
WorkflowManagerActor Workflow 0c939095-9e15-4a20-9d35-9b3a7494304c failed (during ExecutingWorkflowState): java.lang.Exception: Task my_workflow.my_task:NA:1 failed. The job was stopped before the command finished. PAPI error code 9. Execution failed: action 2: unexpected exit status 1 was not ignored
[Localization] Input name: my_input - Unexpected exit status 1 while running "gsutil cp gs://my_bucket/input.txt /cromwell_root/my_bucket/input.txt": CommandException: No URLs matched: gs://my_bucket/input.txt

[DeLocalization] Unexpected exit status 1 while running "/bin/sh -c gsutil cp /cromwell_root/stdout gs://my_bucket/my_workflow/0c939095-9e15-4a20-9d35-9b3a7494304c/call-my_task/stdout": CommandException: No URLs matched: /cromwell_root/stdout

[DeLocalization] Unexpected exit status 1 while running "/bin/sh -c gsutil cp /cromwell_root/stderr gs://my_bucket/my_workflow/0c939095-9e15-4a20-9d35-9b3a7494304c/call-my_task/stderr": CommandException: No URLs matched: /cromwell_root/stderr

[DeLocalization] Unexpected exit status 1 while running "/bin/sh -c gsutil cp /cromwell_root/rc gs://my_bucket/my_workflow/0c939095-9e15-4a20-9d35-9b3a7494304c/call-my_task/rc": CommandException: No URLs matched: /cromwell_root/rc
```

I thought about omitting the delocalization failures if there was a localization failure (as the task did not run so obviously there won't be any stdout/stderr/rc), but it seemed a bit too magical. Can always be done later.