### PR TITLE
fix temp dir in TES to use a containerized path

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -80,6 +80,8 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
         case p if p.startsWith(tesJobPaths.workflowPaths.DockerRoot) => p.pathAsString
         case p if p.startsWith(tesJobPaths.callExecutionRoot) =>
           tesJobPaths.containerExec(commandDirectory, localPath.getFileName.pathAsString)
+        case p if p.startsWith(tesJobPaths.callRoot) =>
+          tesJobPaths.callDockerRoot.resolve(localPath.getFileName.pathAsString).pathAsString
         case p => tesJobPaths.containerInput(p.pathAsString)
       }
     }


### PR DESCRIPTION
Fixes a bug found while looking at #3743 that the temporary directory in TES was not using a containerized path.