### PR TITLE
Synchronize access to workflow store 

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
@@ -72,12 +72,12 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
     runTransaction(action)
   }
 
-  override def writeWorkflowHeartbeats(workflowExecutionUuids: List[String])(implicit ec: ExecutionContext): Future[Int] = {
+  override def writeWorkflowHeartbeats(workflowExecutionUuids: Set[String])(implicit ec: ExecutionContext): Future[Int] = {
     val optionNow = Option(now)
     // Return the count of heartbeats written. This could legitimately be less than the size of the `workflowExecutionUuids`
     // List if any of those workflows completed and their workflow store entries were removed.
     val action = for {
-      counts <- DBIO.sequence(workflowExecutionUuids map { i => dataAccess.heartbeatForWorkflowStoreEntry(i).update(optionNow) })
+      counts <- DBIO.sequence(workflowExecutionUuids.toList map { i => dataAccess.heartbeatForWorkflowStoreEntry(i).update(optionNow) })
     } yield counts.sum
     runTransaction(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
@@ -59,7 +59,7 @@ ____    __    ____  ______   .______       __  ___  _______  __        ______   
   def fetchStartableWorkflows(limit: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                              (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]]
 
-  def writeWorkflowHeartbeats(workflowExecutionUuids: List[String])(implicit ec: ExecutionContext): Future[Int]
+  def writeWorkflowHeartbeats(workflowExecutionUuids: Set[String])(implicit ec: ExecutionContext): Future[Int]
 
   /**
     * Clears out cromwellId and heartbeatTimestamp for all workflow store entries currently assigned

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
@@ -75,7 +75,7 @@ class InMemoryWorkflowStore extends WorkflowStore {
     }
   }
 
-  override def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int] =
+  override def writeWorkflowHeartbeats(workflowIds: Set[WorkflowId])(implicit ec: ExecutionContext): Future[Int] =
     Future.successful(workflowIds.size)
 
   override def switchOnHoldToSubmitted(id: WorkflowId)(implicit ec: ExecutionContext): Future[Unit] = Future.successful(())

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -58,7 +58,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
     }
   }
 
-  override def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int] = {
+  override def writeWorkflowHeartbeats(workflowIds: Set[WorkflowId])(implicit ec: ExecutionContext): Future[Int] = {
     sqlDatabase.writeWorkflowHeartbeats(workflowIds map { _.toString })
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -30,7 +30,7 @@ trait WorkflowStore {
     */
   def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
 
-  def writeWorkflowHeartbeats(workflowIds: List[WorkflowId])(implicit ec: ExecutionContext): Future[Int]
+  def writeWorkflowHeartbeats(workflowIds: Set[WorkflowId])(implicit ec: ExecutionContext): Future[Int]
 
   def remove(id: WorkflowId)(implicit ec: ExecutionContext): Future[Boolean]
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedWriteActor.scala
@@ -1,0 +1,45 @@
+package cromwell.engine.workflow.workflowstore
+
+import akka.actor.{Actor, Props}
+import cats.data.NonEmptyVector
+import cromwell.core.{Dispatcher, WorkflowId}
+import cromwell.engine.workflow.workflowstore.WorkflowStoreCoordinatedWriteActor._
+import mouse.all._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.postfixOps
+import scala.util.{Failure, Success, Try}
+
+
+/**
+  * Serializes access to the workflow store for workflow store writers that acquire locks to multiple rows inside a single
+  * transaction and otherwise are prone to deadlock.
+  */
+class WorkflowStoreCoordinatedWriteActor(workflowStore: WorkflowStore) extends Actor {
+  implicit val ec: ExecutionContext = context.system.dispatcher
+
+  def run[A](future: Future[A]): Unit = {
+    val result = Try(Await.result(future, Timeout)) match {
+      case Success(s) => s
+      case f: Failure[_] => f
+    }
+    sender() ! result
+  }
+
+  override def receive: Receive = {
+    case WriteHeartbeats(ids) =>
+      workflowStore.writeWorkflowHeartbeats(ids.toVector.toSet) |> run
+    case FetchStartableWorkflows(count, cromwellId, heartbeatTtl) =>
+      workflowStore.fetchStartableWorkflows(count, cromwellId, heartbeatTtl) |> run
+  }
+}
+
+object WorkflowStoreCoordinatedWriteActor {
+  final case class WriteHeartbeats(workflowIds: NonEmptyVector[WorkflowId])
+  final case class FetchStartableWorkflows(count: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
+
+  val Timeout = 1 minute
+
+  def props(workflowStore: WorkflowStore): Props = Props(new WorkflowStoreCoordinatedWriteActor(workflowStore)).withDispatcher(Dispatcher.IoDispatcher)
+}

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -17,7 +17,7 @@ import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
-import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor, WorkflowStoreCoordinatedWriteActor}
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
@@ -58,8 +58,10 @@ object SingleWorkflowRunnerActorSpec {
 
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec with Mockito {
   private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
+  val store = new InMemoryWorkflowStore
+  val coordinator = system.actorOf(WorkflowStoreCoordinatedWriteActor.props(store))
   private val workflowStore =
-    system.actorOf(WorkflowStoreActor.props(new InMemoryWorkflowStore, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
+    system.actorOf(WorkflowStoreActor.props(store, coordinator, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
   private val serviceRegistry = TestProbe().ref
   private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
   private val ioActor = system.actorOf(SimpleIoActor.props)

--- a/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
+++ b/server/src/test/scala/cromwell/subworkflowstore/SubWorkflowStoreSpec.scala
@@ -8,7 +8,7 @@ import cromwell.core.{JobKey, WorkflowId, WorkflowSourceFilesWithoutImports}
 import cromwell.database.sql.tables.SubWorkflowStoreEntry
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
 import cromwell.engine.workflow.workflowstore.WorkflowStoreSubmitActor.WorkflowSubmittedToStore
-import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor}
+import cromwell.engine.workflow.workflowstore.{SqlWorkflowStore, WorkflowHeartbeatConfig, WorkflowStoreActor, WorkflowStoreCoordinatedWriteActor}
 import cromwell.services.EngineServicesStore
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import cromwell.subworkflowstore.SubWorkflowStoreSpec._
@@ -34,7 +34,8 @@ class SubWorkflowStoreSpec extends CromwellTestKitWordSpec with Matchers with Mo
 
       lazy val workflowStore = SqlWorkflowStore(EngineServicesStore.engineDatabaseInterface)
       val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
-      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, TestProbe().ref, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
+      val coordinator = system.actorOf(WorkflowStoreCoordinatedWriteActor.props(workflowStore))
+      val workflowStoreService = system.actorOf(WorkflowStoreActor.props(workflowStore, coordinator, TestProbe().ref, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
 
       val parentWorkflowId = WorkflowId.randomId()
       val subWorkflowId = WorkflowId.randomId()


### PR DESCRIPTION
The batched heartbeat writer and workflow picker upper both try to lock multiple rows in the workflow store table inside a transaction and were often observed to deadlock. These two workflow store accesses are now routed through an actor that effectively serializes access to the workflow store table (other accesses are not affected). If this manages to run the gauntlet of gulls [batch abort](https://github.com/broadinstitute/cromwell/issues/3753) would likely need to be added to this system.

Known shortcomings:
- ~~Should probably give more thought as to the thread on which the blocking happens.~~ now on the IO dispatcher
- ~~Should consider actor supervision because if this one actor ever dies that will be bad times.~~ default Akka supervision is reasonable here
- ~~May keep one writer Cromwell from tripping over itself but wouldn't keep multiple writer Cromwells from tripping over each other~~ ticketed in #3795 