### PR TITLE
Fix member access on scatter variables

### DIFF
--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/package.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/graph/package.scala
@@ -96,7 +96,8 @@ package object graph {
       (bodyConsumedValuesValidation, bodyGeneratedValuesValidation) mapN { (bodyConsumedValues, bodyGeneratedValues) =>
         val unsatisfiedBodyElementHooks = bodyConsumedValues.filterNot {
           case UnlinkedIdentifierHook(id) => bodyGeneratedValues.contains(id) || id == a.scatterVariableName
-          case UnlinkedCallOutputOrIdentifierAndMemberAccessHook(first, second) => bodyGeneratedValues.contains(first) || bodyGeneratedValues.contains(s"$first.$second")
+          case UnlinkedCallOutputOrIdentifierAndMemberAccessHook(first, second) =>
+            bodyGeneratedValues.contains(first) || bodyGeneratedValues.contains(s"$first.$second") || a.scatterVariableName == first
         }
 
         unsatisfiedBodyElementHooks ++ scatterExpressionHooks

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
@@ -52,7 +52,9 @@ object ScatterElementToGraphNode {
 
       (required, generated) mapN { (r, g) => r collect {
         case hook @ UnlinkedIdentifierHook(id) if id != scatterVariableName && !g.exists(_.linkableName == id) => a.linkableValues(hook).linkableName
-        case hook @ UnlinkedCallOutputOrIdentifierAndMemberAccessHook(first, second) if !g.exists(_.linkableName == first) && !g.exists(_.linkableName == s"$first.$second") => a.linkableValues(hook).linkableName
+        case hook @ UnlinkedCallOutputOrIdentifierAndMemberAccessHook(first, second)
+          // NB: mirrors logic in scatterElementUnlinkedValueConsumer
+          if !g.exists(_.linkableName == first) && !g.exists(_.linkableName == s"$first.$second") && (first != scatterVariableName) => a.linkableValues(hook).linkableName
       }}
     }
 

--- a/wdl/transforms/draft3/src/test/cases/scatter_var_member_access.wdl
+++ b/wdl/transforms/draft3/src/test/cases/scatter_var_member_access.wdl
@@ -1,0 +1,8 @@
+version 1.0
+
+workflow scatter_var_member_access {
+  Array[Pair[Int, Int]] pairs = [(1, 2), (3, 4), (5, 6)]
+  scatter (p in pairs) {
+    Int x = p.left
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
@@ -56,6 +56,7 @@ class WdlFileToWomSpec extends FlatSpec with Matchers {
     "input_types" -> anyWomWillDo,
     "input_values" -> anyWomWillDo,
     "passthrough_workflow" -> anyWomWillDo,
+    "scatter_var_member_access" -> anyWomWillDo,
     "simple_first_test" -> anyWomWillDo,
     "static_value_workflow" -> anyWomWillDo,
     "nested_struct" -> anyWomWillDo,


### PR DESCRIPTION
The workflow
```
version 1.0

workflow scatter_chain {
  Array[Pair[Int, Int]] pairs = [(1, 2), (3, 4), (5, 6)]
  scatter (p in pairs) {
    Int x = p.left
  }
}
```
used to fail WOM validation because expressions consisting of member access on the scatter variable were erroneously counted as being consumed within the scatter's inner graph. This PR stops this misaccounting.

( On Friday @cjllanwarne and I hypothesized that `ifElementUnlinkedValueConsumer` would need a similar adjustment, but I no longer think this is the case; an `IfElement` does not create a new variable in the scope of its graph like a `ScatterElement` does. )