### PR TITLE
plug workflow log filehandle leaks

### DIFF
--- a/core/src/main/scala/cromwell/core/logging/WorkflowLogger.scala
+++ b/core/src/main/scala/cromwell/core/logging/WorkflowLogger.scala
@@ -2,6 +2,7 @@ package cromwell.core.logging
 
 import akka.actor.{Actor, ActorLogging}
 import akka.event.LoggingAdapter
+import ch.qos.logback.classic
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Level, LoggerContext}
@@ -108,7 +109,15 @@ class WorkflowLogger(loggerName: String,
 
   override def getName = loggerName
 
-  def deleteLogFile() = Try { workflowLogPath foreach { _.delete() } }
+  /**
+    * Stop all log appenders to release file handles, delete the file if requested.
+    */
+  def close(andDelete: Boolean = false) = Try {
+    workflowLogPath foreach { path =>
+      if (andDelete) path.delete()
+      if (fileLogger != NOPLogger.NOP_LOGGER) fileLogger.asInstanceOf[classic.Logger].detachAndStopAllAppenders()
+    }
+  }
 
   import WorkflowLogger._
 

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -425,7 +425,7 @@ class WorkflowActor(val workflowId: WorkflowId,
         workflowOptions.get(FinalWorkflowLogDir).toOption match {
           case Some(destinationDir) =>
             pathBuilders.map(pb => workflowLogCopyRouter ! CopyWorkflowLogsActor.Copy(workflowId, PathFactory.buildPath(destinationDir, pb)))(ec)
-          case None if WorkflowLogger.isTemporary => workflowLogger.deleteLogFile() match {
+          case None if WorkflowLogger.isTemporary => workflowLogger.close(andDelete = true) match {
             case Failure(f) => log.error(f, "Failed to delete workflow log")
             case _ =>
           }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
@@ -42,7 +42,7 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
   }
 
   def deleteLog(src: Path) = if (WorkflowLogger.isTemporary) {
-    sendIoCommand(GcsBatchCommandBuilder.deleteCommand(src))
+    sendIoCommand(DefaultIoCommandBuilder.deleteCommand(src))
   } else removeWork()
   
   def updateLogsPathInMetadata(workflowId: WorkflowId, path: Path) = {
@@ -60,6 +60,8 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
           workflowLogger.info(s"Copying workflow logs from $src to $destPath")
 
           copyLog(src, destPath, workflowId)
+          // Deliberately not deleting the file here, that will be done in batch in `deleteLog` after the copy is terminal.
+          workflowLogger.close()
         }
       }
       


### PR DESCRIPTION
Prevent workflow log file handle leakage. There are two distinct workflow log shutdown paths depending on whether the `final_workflow_log_dir` workflow option is set, this addresses both.