### PR TITLE
Extend localization_optional to complex types (for least surprise)

### DIFF
--- a/centaur/src/main/resources/standardTestCases/draft3_nio_file.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_nio_file.test
@@ -15,6 +15,8 @@ metadata {
   "outputs.draft3_nio_file.f_path_prefix": "gs://"
   "outputs.draft3_nio_file.g_path_prefix": "gs://"
   "outputs.draft3_nio_file.h_path_prefix": "gs://"
+  "outputs.draft3_nio_file.x_path_prefix": "gs://"
+  "outputs.draft3_nio_file.y_path_prefix": "gs://"
   "outputs.draft3_nio_file.errors": ""
 
   "calls.draft3_nio_file.cc_nio_file.callCaching.hit": true

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_nio_file/draft3_nio_file.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_nio_file/draft3_nio_file.wdl
@@ -7,28 +7,41 @@ workflow draft3_nio_file {
   call nio_file { input:
     ready = true,
     f = mk_files.f,
-    h = mk_files.h
+    h = mk_files.h,
+    x = mk_files.x,
+    y = mk_files.y
   }
 
   call nio_file as cc_nio_file { input:
     ready = nio_file.done,
     f = mk_files.f,
-    h = mk_files.h
+    h = mk_files.h,
+    x = mk_files.x,
+    y = mk_files.y
   }
 
   call nio_file as non_cc_nio_file { input:
     ready = nio_file.done,
     f = mk_more_files.f,
-    h = mk_more_files.h
+    h = mk_more_files.h,
+    x = mk_more_files.x,
+    y = mk_more_files.y
   }
 
   output {
     String f_path_prefix = nio_file.result[0]
     String g_path_prefix = nio_file.result[1]
     String h_path_prefix = nio_file.result[2]
+    String x_path_prefix = nio_file.result[3]
+    String y_path_prefix = nio_file.result[4]
 
     String errors = nio_file.errors
   }
+}
+
+struct FileBox {
+  File val0
+  File val1
 }
 
 task mk_files {
@@ -44,6 +57,10 @@ task mk_files {
   command {
     echo "f~{salt}" > f
     echo "h~{salt}" > h
+    echo "x0~{salt}" > x0
+    echo "x1~{salt}" > x1
+    echo "y0~{salt}" > y0
+    echo "y1~{salt}" > y1
   }
 
   runtime {
@@ -53,6 +70,8 @@ task mk_files {
   output {
     File f = "f"
     File h = "h"
+    Array[File] x = ["x0", "x1"]
+    FileBox y = object { val0: "y0", val1: "y1" }
   }
 }
 
@@ -70,6 +89,8 @@ task nio_file {
       localization_optional: true,
       after: "... and after it..."
     }
+    x: { localization_optional: true }
+    y: { localization_optional: true }
     done: "Always true, can be chained into the 'ready' of a subsequent invocation"
   }
 
@@ -78,6 +99,8 @@ task nio_file {
     File f
     File g = f
     File? h
+    Array[File] x
+    FileBox y
   }
 
   command {
@@ -86,6 +109,8 @@ task nio_file {
     echo ~{f} | cut -c 1-5
     echo ~{g} | cut -c 1-5
     echo ~{h} | cut -c 1-5
+    echo ~{x[0]} | cut -c 1-5
+    echo ~{y.val1} | cut -c 1-5
 
     # Check that the NIO files were not localized
     INSTANCE=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google")
@@ -102,6 +127,8 @@ task nio_file {
     grep -q "draft3_nio_file.nio_file.g" <<< $PAPI_METADATA && echo "g was incorrectly localized" >> errors.txt
     grep -q "draft3_nio_file.nio_file.__g" <<< $PAPI_METADATA && echo "__g was incorrectly localized" >> errors.txt
     grep -q "draft3_nio_file.nio_file.h" <<< $PAPI_METADATA && echo "h was incorrectly localized" >> errors.txt
+    grep -q "draft3_nio_file.nio_file.x" <<< $PAPI_METADATA && echo "x was incorrectly localized" >> errors.txt
+    grep -q "draft3_nio_file.nio_file.y" <<< $PAPI_METADATA && echo "y was incorrectly localized" >> errors.txt
   }
   runtime {
     docker: "google/cloud-sdk:alpine"

--- a/docs/optimizations/FileLocalization.md
+++ b/docs/optimizations/FileLocalization.md
@@ -2,14 +2,14 @@
 
 ## Scope
 
-The 'localization_optional' optimization applies to `File` and `File?` inputs on `task`s. It allows
-you to save time and money by identifying `File` inputs which do not need to be localized for the task to succeed.
+The 'localization_optional' optimization can be applied to a task's individual input declarations containing files, specifically `File` and `File?` values and any complex types containing them. 
+It allows you to save time and money by identifying files which do not need to be localized for the task to succeed.
 
 ## Condition
 
 The optimization signals to Cromwell that a task has been written in such a way that:
-
- * The task **will work** if Cromwell does localize the specified file input 
+ 
+ * The task **will work** if Cromwell does localize the specified file inputs
    * For example if a file is localized for a local dockerized execution environment.
 
 **And**:
@@ -39,17 +39,25 @@ an input's entry in the task's `parameter_meta` section. Here's an example:
 task nio_task {
   input {
     File foo_file
+    File bar_file
   }
   
   parameter_meta {
     foo_file: {
+      description: "a foo file",
       localization_optional: true
+    }
+    bar_file: {
+      description: "a bar file"
     }
   }
   
   command <<<
     # This tool must work for **BOTH** local file paths **AND** object store URL values:
-    java -jar my_tool.jar ~{foo_file}
+    java -jar my_tool_1.jar ~{foo_file}
+    
+    # Because the optimization is not applied to 'bar_file' in parameter_meta, this file **WILL** be localized:
+    java -jar my_tool_2.jar ~{bar_file}
   >>>
 }
 ```


### PR DESCRIPTION
- [x] Requires rebase to develop after #3738 

Not perfectly fine-grained but I think `"applies to everything in the complex value"` is definitely less surprising than `"gets completely ignored"` for files in (for example):
```wdl
task foo {
  parameter_meta {
    file_array: {
      description: "an array containing a bunch of files, none of which need localization",
      localization_optional: true
    }
    struct_value: {
      description: "a struct containing a bunch of files (amongst other things), none of which need localization",
      localization_optional: true
    }
  }
  input {
    Array[File] file_array
    BamStruct struct_value
  }

  ...
}
```