### PR TITLE
Allow task-only validation in draft 2 WDL

### DIFF
--- a/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
+++ b/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
@@ -116,7 +116,7 @@ class WdlDraft2LanguageFactory(override val config: Map[String, Any]) extends La
   override def getWomBundle(workflowSource: WorkflowSource, workflowOptionsJson: WorkflowOptionsJson, importResolvers: List[ImportResolver], languageFactories: List[LanguageFactory]): Checked[WomBundle] = {
     for {
       _ <- standardConfig.enabledCheck
-      namespace <- WdlNamespaceWithWorkflow.load(workflowSource, importResolvers map resolverConverter).toChecked
+      namespace <- WdlNamespace.loadUsingSource(workflowSource, None, Some(importResolvers map resolverConverter)).toChecked
       womBundle <- namespace.toWomBundle
     } yield womBundle
   }

--- a/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
+++ b/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
@@ -20,11 +20,10 @@ object WdlDraft2WomBundleMakers {
       val tasksValidation: ErrorOr[List[TaskDefinition]] = from.tasks.toList.traverse(_.toWomTaskDefinition)
 
       val errorOr = (workflowsValidation, tasksValidation) mapN { (workflows, tasks) =>
-        val primary = if (workflows.size == 1) {
-          workflows.headOption
-        } else if (workflows.isEmpty && tasks.size == 1) {
-          tasks.headOption
-        } else None
+        val primary =
+          if (workflows.size == 1) {
+            workflows.headOption
+          } else None
         WomBundle(primary, (tasks ++ workflows).map(c => c.name -> c).toMap, Map.empty) }
       errorOr.toEither
     }

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomBundle.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/FileElementToWomBundle.scala
@@ -56,11 +56,12 @@ object FileElementToWomBundle {
           }
 
           workflowsValidation map { workflows =>
-            val primary: Option[Callable] = if (workflows.size == 1) {
-              workflows.headOption
-            } else if (workflows.isEmpty && tasks.size == 1) {
-              localTaskMapping.headOption map { case (_, callable) => callable }
-            } else None
+            val primary: Option[Callable] =
+              if (workflows.size == 1) {
+                workflows.headOption
+              } else if (workflows.isEmpty && tasks.size == 1) {
+                localTaskMapping.headOption map { case (_, callable) => callable }
+              } else None
 
             val bundledCallableMap = (localTaskMapping.values.toSet ++ workflows).map(c => c.name -> c).toMap
 

--- a/womtool/src/main/scala/womtool/validate/Validate.scala
+++ b/womtool/src/main/scala/womtool/validate/Validate.scala
@@ -5,8 +5,13 @@ import womtool.WomtoolMain.{SuccessfulTermination, Termination, UnsuccessfulTerm
 import womtool.input.WomGraphMaker
 
 object Validate {
-  def validate(main: Path, inputs: Option[Path]): Termination = {
+  def validate(main: Path, inputs: Option[Path]): Termination = if (inputs.isDefined) {
     WomGraphMaker.fromFiles(main, inputs) match {
+      case Right(_) => SuccessfulTermination("")
+      case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
+    }
+  } else {
+    WomGraphMaker.getBundle(main) match {
       case Right(_) => SuccessfulTermination("")
       case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
     }

--- a/womtool/src/test/resources/validate/wdl_draft2/valid/task_only/task_only.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft2/valid/task_only/task_only.wdl
@@ -1,0 +1,16 @@
+task task_only {
+
+  File in_file
+
+  command {
+    wc -w < ${in_file}
+  }
+
+  runtime {
+    docker: "ubuntu:latest"
+  }
+
+  output {
+    String word_count = read_int(stdout())
+  }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/task_only/task_only.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/task_only/task_only.wdl
@@ -1,0 +1,16 @@
+version 1.0
+
+task task_only {
+  input {
+    File in_file
+  }
+  command {
+    wc -w < ~{in_file}
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+  output {
+    String word_count = read_int(stdout())
+  }
+}

--- a/womtool/src/test/scala/womtool/WomtoolMainSpec.scala
+++ b/womtool/src/test/scala/womtool/WomtoolMainSpec.scala
@@ -55,7 +55,7 @@ class WomtoolMainSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
   it should "not return inputs when there is no workflow" in {
     testWdl(EmptyTask) { wdlAndInputs =>
       val res = WomtoolMain.runWomtool(Seq("inputs", wdlAndInputs.wdl))
-      res should be(UnsuccessfulTermination("Namespace does not have a local workflow to run"))
+      res should be(UnsuccessfulTermination("Cannot convert WOM bundle to executable. No primary callable was available."))
     }
   }
 }


### PR DESCRIPTION
Allows for and tests `womtool validate draft2_task.wdl`

Fixes #3762 