### PR TITLE
Allow conditionals and scatters based on 'WomAnyType' values

### DIFF
--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/IfElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/IfElementToGraphNode.scala
@@ -20,7 +20,7 @@ import wom.callable.Callable
 import wom.graph.GraphNodePort.OutputPort
 import wom.graph._
 import wom.graph.expression.{AnonymousExpressionNode, PlainAnonymousExpressionNode}
-import wom.types.{WomBooleanType, WomType}
+import wom.types.{WomAnyType, WomBooleanType, WomType}
 
 object IfElementToGraphNode {
   def convert(a: ConditionalNodeMakerInputs): ErrorOr[Set[GraphNode]] = {
@@ -30,8 +30,8 @@ object IfElementToGraphNode {
     val conditionWomExpression: WdlomWomExpression = WdlomWomExpression(conditionExpression, a.linkableValues)
     val conditionExpressionNodeValidation: ErrorOr[AnonymousExpressionNode] = AnonymousExpressionNode.fromInputMapping(WomIdentifier("if_condition"), conditionWomExpression, a.linkablePorts, PlainAnonymousExpressionNode.apply)
 
-    val scatterVariableTypeValidation: ErrorOr[Unit] = conditionExpression.evaluateType(a.linkableValues) flatMap {
-      case WomBooleanType => ().validNel
+    val conditionVariableTypeValidation: ErrorOr[Unit] = conditionExpression.evaluateType(a.linkableValues) flatMap {
+      case WomBooleanType | WomAnyType => ().validNel
       case other => s"Invalid type for condition variable: ${other.toDisplayString}".invalidNel
     }
 
@@ -51,7 +51,7 @@ object IfElementToGraphNode {
       }).toMap
     }
 
-    (conditionExpressionNodeValidation, scatterVariableTypeValidation, foundOuterGeneratorsValidation) flatMapN { (expressionNode, _, foundOuterGenerators) =>
+    (conditionExpressionNodeValidation, conditionVariableTypeValidation, foundOuterGeneratorsValidation) flatMapN { (expressionNode, _, foundOuterGenerators) =>
       val ogins: Set[GraphNode] = (foundOuterGenerators.toList map { case (name: String, port: OutputPort) =>
         OuterGraphInputNode(WomIdentifier(name), port, preserveScatterIndex = true)
       }).toSet

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/wdlom2wom/graph/ScatterElementToGraphNode.scala
@@ -24,7 +24,7 @@ import wom.graph.GraphNode.GraphNodeSetter
 import wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort}
 import wom.graph._
 import wom.graph.expression.{AnonymousExpressionNode, PlainAnonymousExpressionNode}
-import wom.types.{WomArrayType, WomType}
+import wom.types.{WomAnyType, WomArrayType, WomType}
 
 object ScatterElementToGraphNode {
   def convert(a: ScatterNodeMakerInputs): ErrorOr[Set[GraphNode]] = if (a.insideAnotherScatter) {
@@ -43,6 +43,7 @@ object ScatterElementToGraphNode {
 
     val scatterVariableTypeValidation: ErrorOr[WomType] = scatterExpression.evaluateType(a.linkableValues) flatMap {
       case a: WomArrayType => a.memberType.validNel
+      case WomAnyType => WomAnyType.validNel
       case other => s"Invalid type for scatter variable '$scatterVariableName': ${other.toDisplayString}".invalidNel
     }
 

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/member_access_types/member_access_types.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/member_access_types/member_access_types.wdl
@@ -1,0 +1,40 @@
+version 1.0
+
+workflow member_access {
+  # Object access:
+  Object myObj = object { an_int: 5 }
+  if (myObj.an_int == 10) {
+    Boolean a = true
+  }
+
+  # Array access:
+  Array[Int] is = [0, 1]
+  if (is[1] == 1) {
+    Boolean b = true
+  }
+
+  # Map access:
+  Map[String, Int] msb = { "an_int": 55 }
+  if (msb["an_int"] == 55) {
+    Boolean c = true
+  }
+
+  # Array[Pair] access:
+  Array[Pair[Boolean, Boolean]] apbb = [ (true, false), (false, true) ]
+  if (apbb[0].left && apbb[1].right) {
+    Boolean d = true
+  }
+
+  Object wrapped_array = object { an_array: [0, 1, 2] }
+  scatter (x in wrapped_array.an_array) {
+    Boolean e = true
+  }
+
+  output {
+    Boolean a_out = select_first([a, false])
+    Boolean b_out = select_first([b, false])
+    Boolean c_out = select_first([c, false])
+    Boolean d_out = select_first([d, false])
+    Boolean e_out = e[0]
+  }
+}


### PR DESCRIPTION
Closes #3790 

I went down the "allow WomAnyType" values route for now, to solve the general case of:
```
Object o = read_json(some_file)
scatter (x in o.blah) {
  ...
}
```

Ideally directing people to `struct`s will mean this problem goes away, but in the mean time, we'll need to handle scatters over `WomAnyType`s (at least in the static analysis).
