### PR TITLE
Fix delocalization path issue

### DIFF
--- a/centaur/src/main/resources/integrationTestCases/germline/joint-discovery-gatk/joint-discovery-gatk4.wdl
+++ b/centaur/src/main/resources/integrationTestCases/germline/joint-discovery-gatk/joint-discovery-gatk4.wdl
@@ -329,24 +329,6 @@ workflow JointGenotyping {
   }
 }
 
-task GetNumberOfSamples {
-  File sample_name_map
-  String mem_size
-  Int preemptibles
-
-  command <<<
-    wc -l ${sample_name_map} | awk '{print $1}'
-  >>>
-  runtime {
-    docker: docker_image
-    memory: mem_size
-    preemptible: preemptibles
-  }
-  output {
-    Int sample_count = read_int(stdout())
-  }
-}
-
 task ImportGVCFs {
   File sample_name_map
   String interval

--- a/centaur/src/main/resources/standardTestCases/custom_mount_point.test
+++ b/centaur/src/main/resources/standardTestCases/custom_mount_point.test
@@ -9,4 +9,7 @@ files {
 metadata {
   "calls.custom_mount_point.t.backend": "Papi"
   "calls.custom_mount_point.t.backendStatus": "Success"
+  
+  "outputs.custom_mount_point.o1": "bazqux"
+  "outputs.custom_mount_point.o2": "foobar"
 }

--- a/centaur/src/main/resources/standardTestCases/custom_mount_point/custom_mount_point.wdl
+++ b/centaur/src/main/resources/standardTestCases/custom_mount_point/custom_mount_point.wdl
@@ -1,30 +1,35 @@
-#  1) Mounting a SSD to a custom location
+#  1) Mounting a SSD to a custom location and default location with custom disk size
 #  2) Write a file to that mount
 #  3) Changing directory within a command shouldn't break Cromwell
 #  4) Use the file that was written on the mount as an output
 
+# ChrisTM
 task t {
-  String version
+  String v
 
   command {
+    echo "bazqux" > some_file
+
     cd /some/mnt
     echo "foobar" > some_file
   }
 
   output {
+    String out1 = read_string("some_file")
     String out2 = read_string("/some/mnt/some_file")
   }
 
   runtime {
-    docker: "ubuntu:" + version
+    docker: "ubuntu:" + v
     disks: "local-disk 20 SSD, /some/mnt 20 SSD"
   }
 }
 
 workflow custom_mount_point {
-  call t {input: version="latest"}
+  call t {input: v="latest"}
 
   output {
-     t.out2
+     String o1 = t.out1
+     String o2 = t.out2
    }
 }

--- a/src/bin/ci/resources/build_application.inc.conf
+++ b/src/bin/ci/resources/build_application.inc.conf
@@ -1,3 +1,5 @@
+akka.http.host-connection-pool.max-open-requests = 1024
+
 call-caching {
   enabled = true
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -309,13 +309,8 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
   }
 
   protected def generateSingleFileOutputs(womFile: WomSingleFile, fileEvaluation: FileEvaluation): List[PipelinesApiFileOutput] = {
+    val destination = callRootPath.resolve(womFile.value.stripPrefix("/"))
     val (relpath, disk) = relativePathAndAttachedDisk(womFile.value, runtimeAttributes.disks)
-    // If the file is on a custom mount point, resolve it so that the full mount path will show up in the cloud path
-    // For the default one (cromwell_root), the expctation is that it does not appear
-    val mountedPath = if (disk != PipelinesApiWorkingDisk.Default) disk.mountPoint.resolve(relpath) else relpath
-    // Normalize the local path (to get rid of ".." and "."). Also strip any potential leading / so that it gets appended to the call root
-    val normalizedPath = mountedPath.normalize().pathAsString.stripPrefix("/")
-    val destination = callRootPath.resolve(normalizedPath)
     val jesFileOutput = PipelinesApiFileOutput(makeSafeReferenceName(womFile.value), destination, relpath, disk, fileEvaluation.optional, fileEvaluation.secondary)
     List(jesFileOutput)
   }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -2,11 +2,12 @@ package cromwell.backend.google.pipelines.v2alpha1
 
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.google.pipelines.common._
+import cromwell.backend.google.pipelines.common.io.PipelinesApiWorkingDisk
 import cromwell.backend.standard.StandardAsyncExecutionActorParams
 import cromwell.core.path.DefaultPathBuilder
 import wom.core.FullyQualifiedName
 import wom.expression.FileEvaluation
-import wom.values.{GlobFunctions, WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomUnlistedDirectory}
+import wom.values.{GlobFunctions, WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomSingleFile, WomUnlistedDirectory}
 
 class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExecutionActorParams) extends cromwell.backend .google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor(standardParams) {
   
@@ -85,5 +86,17 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
           pipelinesApiInputsFromWomFiles(makeSafeReferenceName(womFile.valueString), List(womFile), List(relativeLocalizationPath(womFile)), jobDescriptor)
       })
     case _ => List.empty
+  }
+
+  override def generateSingleFileOutputs(womFile: WomSingleFile, fileEvaluation: FileEvaluation) = {
+    val (relpath, disk) = relativePathAndAttachedDisk(womFile.value, runtimeAttributes.disks)
+    // If the file is on a custom mount point, resolve it so that the full mount path will show up in the cloud path
+    // For the default one (cromwell_root), the expctation is that it does not appear
+    val mountedPath = if (disk != PipelinesApiWorkingDisk.Default) disk.mountPoint.resolve(relpath) else relpath
+    // Normalize the local path (to get rid of ".." and "."). Also strip any potential leading / so that it gets appended to the call root
+    val normalizedPath = mountedPath.normalize().pathAsString.stripPrefix("/")
+    val destination = callRootPath.resolve(normalizedPath)
+    val jesFileOutput = PipelinesApiFileOutput(makeSafeReferenceName(womFile.value), destination, relpath, disk, fileEvaluation.optional, fileEvaluation.secondary)
+    List(jesFileOutput)
   }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -91,8 +91,8 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
   override def generateSingleFileOutputs(womFile: WomSingleFile, fileEvaluation: FileEvaluation) = {
     val (relpath, disk) = relativePathAndAttachedDisk(womFile.value, runtimeAttributes.disks)
     // If the file is on a custom mount point, resolve it so that the full mount path will show up in the cloud path
-    // For the default one (cromwell_root), the expctation is that it does not appear
-    val mountedPath = if (disk != PipelinesApiWorkingDisk.Default) disk.mountPoint.resolve(relpath) else relpath
+    // For the default one (cromwell_root), the expectation is that it does not appear
+    val mountedPath = if (!disk.mountPoint.isSamePathAs(PipelinesApiWorkingDisk.Default.mountPoint)) disk.mountPoint.resolve(relpath) else relpath
     // Normalize the local path (to get rid of ".." and "."). Also strip any potential leading / so that it gets appended to the call root
     val normalizedPath = mountedPath.normalize().pathAsString.stripPrefix("/")
     val destination = callRootPath.resolve(normalizedPath)


### PR DESCRIPTION
This fixes the issue in PAPI2 and revert it to what it was before for PAPI1. Since this change was targeted at CWL and we don't plan to support CWL on PAPI1, it seems safer to revert it entirely in case it still breaks something else