### PR TITLE
Centaur upgrade

### DIFF
--- a/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPaths.scala
@@ -83,7 +83,9 @@ trait JobPaths {
   private lazy val commonMetadataPaths: Map[String, Path] =
     standardOutputAndErrorPaths + (CallMetadataKeys.CallRoot -> callRoot)
 
-  private lazy val commonDetritusPaths: Map[String, Path] = Map(
+  // This is a `def` because `standardPaths` is a `var` that may be reassigned during the calculation of
+  // standard output and error file names.
+  private def commonDetritusPaths: Map[String, Path] = Map(
     JobPaths.CallRootPathKey -> callRoot,
     JobPaths.ScriptPathKey -> script,
     JobPaths.StdoutPathKey -> standardPaths.output,
@@ -101,7 +103,7 @@ trait JobPaths {
   protected lazy val customLogPaths: Map[String, Path] = Map.empty
 
   lazy val metadataPaths = commonMetadataPaths ++ customMetadataPaths
-  lazy val detritusPaths = commonDetritusPaths ++ customDetritusPaths
+  def detritusPaths = commonDetritusPaths ++ customDetritusPaths
   lazy val logPaths = commonLogPaths ++ customLogPaths
 
   lazy val callContext = CallContext(callExecutionRoot, standardPaths, isDocker)

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -247,8 +247,6 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   /** Any custom code that should be run within commandScriptContents before the instantiated command. */
   def scriptPreamble: String = ""
 
-  // TODO: Discuss if this lift is appropriate, and if they should be functions
-  //       of lazy vals
   def cwd: Path = commandDirectory
   def rcPath: Path = cwd./(jobPaths.returnCodeFilename)
 
@@ -297,7 +295,6 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     val relativePath = string.stripPrefix(cwdString)
     jobPaths.callExecutionRoot.resolve(relativePath)
   }
-  // End added lift code
 
   /** A bash script containing the custom preamble, the instantiated command, and output globbing behavior. */
   def commandScriptContents: ErrorOr[String] = {

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -252,7 +252,6 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   def cwd: Path = commandDirectory
   def rcPath: Path = cwd./(jobPaths.returnCodeFilename)
 
-  // It's here at instantiation time that the names of standard input/output/error files are calculated.
   // The standard input filename can be as ephemeral as the execution: the name needs to match the expectations of
   // the command, but the standard input file will never be accessed after the command completes. standard output and
   // error on the other hand will be accessed and the names of those files need to be known to be delocalized and read

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -8,7 +8,7 @@ import cats.instances.set._
 import cats.instances.tuple._
 import cats.syntax.foldable._
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
-import cromwell.backend.BackendJobExecutionActor.{CallCached, JobAbortedResponse, JobFailedNonRetryableResponse, JobSucceededResponse}
+import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend.io.JobPaths
 import cromwell.backend.standard.StandardCachingActorHelper
@@ -117,7 +117,8 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   protected val commandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
 
   lazy val destinationCallRootPath: Path = jobPaths.callRoot
-  lazy val destinationJobDetritusPaths: Map[String, Path] = jobPaths.detritusPaths
+  def destinationJobDetritusPaths: Map[String, Path] = jobPaths.detritusPaths
+  
   lazy val ioActor = standardParams.ioActor
 
   startWith(Idle, None)

--- a/backend/src/test/scala/cromwell/backend/io/TestWorkflows.scala
+++ b/backend/src/test/scala/cromwell/backend/io/TestWorkflows.scala
@@ -67,11 +67,11 @@ object TestWorkflows {
       |}
     """.stripMargin
 
-  val Sleep10 =
+  val Sleep20 =
     """
       |task abort {
       |  command {
-      |    sleep 10
+      |    sleep 20
       |    echo "something after sleep"
       |  }
       |}

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val wdlTransformsDraft2 = (project in wdlTransformsRoot / "draft2")
   .withLibrarySettings("cromwell-wdl-transforms-draft2", wdlDependencies)
   .dependsOn(wdlSharedTransforms)
   .dependsOn(wdlModelDraft2)
+  .dependsOn(core % "test->test")
 
 lazy val wdlTransformsDraft3 = (project in wdlTransformsRoot / "draft3")
   .withLibrarySettings("cromwell-wdl-transforms-draft3", wdlDependencies)

--- a/centaur/src/it/resources/application.conf
+++ b/centaur/src/it/resources/application.conf
@@ -1,1 +1,3 @@
 akka.http.host-connection-pool.max-open-requests: 1024
+akka.http.host-connection-pool.max-connections: 20
+akka.http.host-connection-pool.min-connections: 10

--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -6,10 +6,12 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.instances.list._
 import cats.syntax.traverse._
 import centaur.test.standard.CentaurTestCase
-import org.scalatest.{DoNotDiscover, FlatSpec, Matchers, Tag}
+import org.scalatest._
+
+import scala.concurrent.Future
 
 @DoNotDiscover
-abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) extends FlatSpec with Matchers {
+abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) extends AsyncFlatSpec with Matchers {
 
   private def testCases(basePath: Path): List[CentaurTestCase] = {
     val files = basePath.toFile.listFiles.toList collect { case x if x.isFile => x.toPath }
@@ -29,9 +31,8 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) exten
 
   def executeStandardTest(testCase: CentaurTestCase): Unit = {
     def nameTest = s"${testCase.testFormat.testSpecString} ${testCase.workflow.testName}"
-    def runTest(): Unit = {
-      testCase.testFunction.run.get
-      ()
+    def runTest() = {
+      testCase.testFunction.run.unsafeToFuture().map(_ => assert(true))
     }
 
     // Make tags, but enforce lowercase:
@@ -41,7 +42,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) exten
     runOrDont(nameTest, tags, isIgnored, runTest())
   }
 
-  private def runOrDont(testName: String, tags: List[Tag], ignore: Boolean, runTest: => Any): Unit = {
+  private def runOrDont(testName: String, tags: List[Tag], ignore: Boolean, runTest: => Future[Assertion]): Unit = {
 
     val itShould: ItVerbString = it should testName
 
@@ -52,7 +53,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) exten
     }
   }
 
-  private def runOrDont(itVerbString: ItVerbString, ignore: Boolean, runTest: => Any): Unit = {
+  private def runOrDont(itVerbString: ItVerbString, ignore: Boolean, runTest: => Future[Assertion]): Unit = {
     if (ignore) {
       itVerbString ignore runTest
     } else {
@@ -60,7 +61,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String]) exten
     }
   }
 
-  private def runOrDont(itVerbStringTaggedAs: ItVerbStringTaggedAs, ignore: Boolean, runTest: => Any): Unit = {
+  private def runOrDont(itVerbStringTaggedAs: ItVerbStringTaggedAs, ignore: Boolean, runTest: => Future[Assertion]): Unit = {
     if (ignore) {
       itVerbStringTaggedAs ignore runTest
     } else {

--- a/centaur/src/it/scala/centaur/CentaurTestSuite.scala
+++ b/centaur/src/it/scala/centaur/CentaurTestSuite.scala
@@ -35,11 +35,11 @@ class CentaurTestSuite extends Suites(new SequentialTestCaseSpec(), new Standard
   private var shutdownHook: Option[ShutdownHookThread] = _
 
   override def beforeAll() = {
-    shutdownHook = Option(sys.addShutdownHook { CromwellManager.stopCromwell() })
+    shutdownHook = Option(sys.addShutdownHook { CromwellManager.stopCromwell("JVM Shutdown Hook") })
   }
 
   override def afterAll() = {
-    CromwellManager.stopCromwell()
+    CromwellManager.stopCromwell("ScalaTest AfterAll")
     shutdownHook.foreach(_.remove())
   }
 }

--- a/centaur/src/main/resources/reference.conf
+++ b/centaur/src/main/resources/reference.conf
@@ -37,7 +37,7 @@ centaur {
   # The maximal length of a workflow, intended as a sanity check and not actually a test in and of itself
   maxWorkflowLength: 3 hours
   # Cromwell's metadata is eventually consistent. Set a timeout such that we expect it to have eventually consisted
-  metadataConsistencyTimeout: 10 seconds
+  metadataConsistencyTimeout: 30 seconds
 
   # Path (absolute or relative) where Centaur will look for test cases. The expectation is that each test
   # case will be in a subdirectory named FOO with workflow, inputs, and options files.

--- a/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
+++ b/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
@@ -16,12 +16,12 @@ task sleep_exit {
 
 workflow restart_while_failing {
     # A will fail after 5 minutes
-    call sleep_exit as A { input: s = 300, exit_code = 1 }
+    call sleep_exit as A { input: s = 240, exit_code = 1 }
     
     # B starts at the same time as A and finishes immediately
     call sleep_exit as B { input: s = 1 }
     # B1 starts as soon as B is done
-    call sleep_exit as B1 { input: s = 600, flow_control = B.done }
+    call sleep_exit as B1 { input: s = 360, flow_control = B.done }
     # B2 depends on B1. Note that B2 should never be run because by the time we get to it, A will have failed.
     call sleep_exit as B2 { input: s = 1, flow_control = B1.done }
     

--- a/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
+++ b/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
@@ -16,12 +16,12 @@ task sleep_exit {
 
 workflow restart_while_failing {
     # A will fail after 5 minutes
-    call sleep_exit as A { input: s = 240, exit_code = 1 }
+    call sleep_exit as A { input: s = 300, exit_code = 1 }
     
     # B starts at the same time as A and finishes immediately
     call sleep_exit as B { input: s = 1 }
     # B1 starts as soon as B is done
-    call sleep_exit as B1 { input: s = 360, flow_control = B.done }
+    call sleep_exit as B1 { input: s = 600, flow_control = B.done }
     # B2 depends on B1. Note that B2 should never be run because by the time we get to it, A will have failed.
     call sleep_exit as B2 { input: s = 1, flow_control = B1.done }
     

--- a/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
+++ b/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.wdl
@@ -15,15 +15,15 @@ task sleep_exit {
 }
 
 workflow restart_while_failing {
-    # A will fail after 2 minutes
-    call sleep_exit as A { input: s = 120, exit_code = 1 }
+    # A will fail after 5 minutes
+    call sleep_exit as A { input: s = 300, exit_code = 1 }
     
     # B starts at the same time as A and finishes immediately
-    call sleep_exit as B { input: s = 10 }
+    call sleep_exit as B { input: s = 1 }
     # B1 starts as soon as B is done
-    call sleep_exit as B1 { input: s = 180, flow_control = B.done }
+    call sleep_exit as B1 { input: s = 600, flow_control = B.done }
     # B2 depends on B1. Note that B2 should never be run because by the time we get to it, A will have failed.
-    call sleep_exit as B2 { input: s = 10, flow_control = B1.done }
+    call sleep_exit as B2 { input: s = 1, flow_control = B1.done }
     
     Array[Int] sleep_array = [1, 60, 20, 60, 30]
     # Independently, we start a scatter with a few jobs, some of them will still be running when we restart 

--- a/centaur/src/main/scala/centaur/CromwellManager.scala
+++ b/centaur/src/main/scala/centaur/CromwellManager.scala
@@ -66,19 +66,25 @@ object CromwellManager {
       else {
         println("Timeout waiting for cromwell server - failing test run")
         println(logFile.contentAsString)
-        stopCromwell()
+        stopCromwell("Timed out waiting for server")
         System.exit(timeoutExitStatus)
       }
     }
   }
 
-  def stopCromwell() = {
+  def stopCromwell(reason: String) = {
     _ready = false
-    println("Stopping Cromwell...")
-    cromwellProcess foreach { process =>
-      process.getOutputStream.flush()
-      process.destroy()
-      process.waitFor()
+    println(s"Stopping Cromwell... ($reason)")
+    try {
+      cromwellProcess foreach { process =>
+        process.getOutputStream.flush()
+        process.destroy()
+        process.waitFor()
+      }
+    } catch {
+      case e: Exception => 
+        println("Caught exception while stopping Cromwell")
+        e.printStackTrace()
     }
     
     cromwellProcess = None

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -76,7 +76,7 @@ object CentaurCromwellClient {
 
   lazy val backends: Try[CromwellBackends] = Try(Await.result(cromwellClient.backends, CromwellManager.timeout * 2))
 
-  def retryedRequest[T](x: () => Future[T], timeout: FiniteDuration): IO[T] = {
+  def retryRequest[T](x: () => Future[T], timeout: FiniteDuration): IO[T] = {
     // If Cromwell is known not to be ready, delay the request to avoid requests bound to fail 
     val ioDelay = if (!CromwellManager.isReady) IO.sleep(10.seconds) else IO.unit
 
@@ -88,7 +88,7 @@ object CentaurCromwellClient {
   }
 
   def sendReceiveFutureCompletion[T](x: () => Future[T]) = {
-    retryedRequest(x, CentaurConfig.sendReceiveTimeout)
+    retryRequest(x, CentaurConfig.sendReceiveTimeout)
   }
 
   private def isTransient(f: Throwable) = f match {

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -8,18 +8,19 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, BufferOverflowException, StreamTcpException}
+import cats.effect.IO
 import centaur.test.metadata.WorkflowMetadata
 import centaur.test.workflow.Workflow
 import centaur.{CentaurConfig, CromwellManager}
 import com.typesafe.config.ConfigFactory
 import cromwell.api.CromwellClient
 import cromwell.api.CromwellClient.UnsuccessfulRequestException
-import cromwell.api.model.{CromwellBackends, SubmittedWorkflow, WorkflowId, WorkflowOutputs, WorkflowStatus}
+import cromwell.api.model.{CallCacheDiff, CromwellBackends, ShardIndex, SubmittedWorkflow, WorkflowId, WorkflowOutputs, WorkflowStatus}
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.util.{Failure, Try}
-import net.ceedubs.ficus.Ficus._
+import scala.util.Try
 
 object CentaurCromwellClient {
   val LogFailures = ConfigFactory.load().as[Option[Boolean]]("centaur.log-request-failures").getOrElse(false)
@@ -27,7 +28,7 @@ object CentaurCromwellClient {
   // See https://github.com/akka/akka-http/issues/602
   // And https://github.com/viktorklang/blog/blob/master/Futures-in-Scala-2.12-part-7.md
   final implicit val blockingEc: ExecutionContextExecutor = ExecutionContext.fromExecutor(
-    Executors.newCachedThreadPool(DaemonizedDefaultThreadFactory))
+    Executors.newFixedThreadPool(100, DaemonizedDefaultThreadFactory))
 
   // Akka HTTP needs both the actor system and a materializer
   final implicit val system = ActorSystem("centaur-acting-like-a-system")
@@ -35,20 +36,24 @@ object CentaurCromwellClient {
   final val apiVersion = "v1"
   val cromwellClient = new CromwellClient(CentaurConfig.cromwellUrl, apiVersion)
 
-  def submit(workflow: Workflow): Try[SubmittedWorkflow] = {
+  def submit(workflow: Workflow): IO[SubmittedWorkflow] = {
     sendReceiveFutureCompletion(() => cromwellClient.submit(workflow.toWorkflowSubmission(refreshToken = CentaurConfig.optionalToken)))
   }
 
-  def status(workflow: SubmittedWorkflow): Try[WorkflowStatus] = {
+  def status(workflow: SubmittedWorkflow): IO[WorkflowStatus] = {
     sendReceiveFutureCompletion(() => cromwellClient.status(workflow.id))
   }
 
-  def abort(workflow: SubmittedWorkflow): Try[WorkflowStatus] = {
+  def abort(workflow: SubmittedWorkflow): IO[WorkflowStatus] = {
     sendReceiveFutureCompletion(() => cromwellClient.abort(workflow.id))
   }
 
-  def outputs(workflow: SubmittedWorkflow): Try[WorkflowOutputs] = {
+  def outputs(workflow: SubmittedWorkflow): IO[WorkflowOutputs] = {
     sendReceiveFutureCompletion(() => cromwellClient.outputs(workflow.id))
+  }
+
+  def callCacheDiff(workflowA: SubmittedWorkflow, callA: String, workflowB: SubmittedWorkflow, callB: String): IO[CallCacheDiff] = {
+    sendReceiveFutureCompletion(() => cromwellClient.callCacheDiff(workflowA.id, callA, ShardIndex(None), workflowB.id, callB, ShardIndex(None)))
   }
 
   /*
@@ -61,58 +66,40 @@ object CentaurCromwellClient {
     Try(Await.result(request, CentaurConfig.sendReceiveTimeout)).isSuccess
   }
 
-  def metadata(workflow: SubmittedWorkflow): Try[WorkflowMetadata] = metadata(workflow.id)
+  def metadata(workflow: SubmittedWorkflow): IO[WorkflowMetadata] = metadata(workflow.id)
 
-  def metadata(id: WorkflowId): Try[WorkflowMetadata] = {
+  def metadata(id: WorkflowId): IO[WorkflowMetadata] = {
     sendReceiveFutureCompletion(() => cromwellClient.metadata(id)) map { m =>
+      if (LogFailures) Console.err.println(s"Got metadata for $id")
       WorkflowMetadata.fromMetadataJson(m.value).toOption.get
     }
   }
 
-  lazy val backends: Try[CromwellBackends] = sendReceiveFutureCompletion(() => cromwellClient.backends)
+  lazy val backends: Try[CromwellBackends] = Try(Await.result(cromwellClient.backends, CromwellManager.timeout * 2))
 
-  // The total time waiting for a Future, including network hiccups, must be longer than the time for a restart.
-  private val awaitTotalTimeout: FiniteDuration = CromwellManager.timeout * 2
-  private val awaitSleep: FiniteDuration = 5.seconds
-  private val awaitMaxAttempts: Long = awaitTotalTimeout.toSeconds / awaitSleep.toSeconds
+  def retryedRequest[T](x: () => Future[T], timeout: FiniteDuration): IO[T] = {
+    // If Cromwell is known not to be ready, delay the request to avoid requests bound to fail 
+    val ioDelay = if (!CromwellManager.isReady) IO.sleep(10.seconds) else IO.unit
 
-  /**
-    * Ensure that the Future completes within the specified timeout. If it does not, or if the Future fails,
-    * will return a Failure, otherwise a Success
-    */
-  def awaitFutureCompletion[T](x: () => Future[T], timeout: FiniteDuration, attempt: Int = 1): Try[T] = {
-    def sleepAndRetry(throwable: Throwable): Try[T] = {
-      if (LogFailures) Console.err.println(s"Failed to execute request to Cromwell, retrying: ${throwable.getMessage}")
-      Thread.sleep(awaitSleep.toMillis)
-      awaitFutureCompletion(x, timeout, attempt + 1)
-    }
-
-    // We can't recover the future itself with a "recoverWith retry pattern" because it'll timeout anyway from the Await.result
-    // We want to keep timing out to catch cases where Cromwell becomes unresponsive
-    Try(Await.result(x(), timeout)) recoverWith {
-      case throwable if attempt >= awaitMaxAttempts => Failure(throwable)
-      case throwable@(_: TimeoutException |
-                      _: StreamTcpException |
-                      _: IOException |
-                      _: UnsupportedContentTypeException) =>
-        sleepAndRetry(throwable)
-      case unsuccessful: UnsuccessfulRequestException if unsuccessful.httpResponse.status == StatusCodes.NotFound =>
-        sleepAndRetry(unsuccessful)
-      case unexpected: RuntimeException
-        if unexpected.getMessage.contains("The http server closed the connection unexpectedly") =>
-        // https://github.com/akka/akka-http/issues/768
-        sleepAndRetry(unexpected)
-      case exception@BufferOverflowException(message) if message.contains("Please retry the request later.") =>
-        // http://doc.akka.io/docs/akka-http/current/scala/http/client-side/pool-overflow.html
-        sleepAndRetry(exception)
-    }
+    ioDelay.flatMap( _ =>
+      IO.fromFuture(IO(Retry.withRetry(x, Option(5), 5.seconds, isTransient = isTransient, onRetry = onRetry)).timeout(timeout))
+    )
   }
 
   def sendReceiveFutureCompletion[T](x: () => Future[T]) = {
-    awaitFutureCompletion(x, CentaurConfig.sendReceiveTimeout)
+    retryedRequest(x, CentaurConfig.sendReceiveTimeout)
   }
 
-  def maxWorkflowLengthCompletion[T](x: () => Future[T]) = {
-    awaitFutureCompletion(x, CentaurConfig.maxWorkflowLength)
+  private def onRetry(t: Throwable) = if (LogFailures) Console.err.println(s"Retrying due to ${t.getMessage}")
+  
+  private def isTransient(f: Throwable) = f match {
+    case _: TimeoutException |
+                    _: StreamTcpException |
+                    _: IOException |
+                    _: UnsupportedContentTypeException => true
+    case BufferOverflowException(message) => message.contains("Please retry the request later.")
+    case unsuccessful: UnsuccessfulRequestException => unsuccessful.httpResponse.status == StatusCodes.NotFound
+    case unexpected: RuntimeException => unexpected.getMessage.contains("The http server closed the connection unexpectedly") 
+    case _ => false
   }
 }

--- a/centaur/src/main/scala/centaur/api/Retry.scala
+++ b/centaur/src/main/scala/centaur/api/Retry.scala
@@ -1,0 +1,41 @@
+package centaur.api
+
+import akka.actor.ActorSystem
+import akka.pattern.after
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+object Retry {
+  /**
+    * Copied from cromwell.core
+    * Replaced the backoff with a fixed retry delay
+    */
+  def withRetry[A](f: () => Future[A],
+                   maxRetries: Option[Int] = Option(10),
+                   delay: FiniteDuration,
+                   isTransient: Throwable => Boolean = throwableToFalse,
+                   isFatal: Throwable => Boolean = throwableToFalse,
+                   onRetry: Throwable => Unit = noopOnRetry)
+                   (implicit actorSystem: ActorSystem): Future[A] = {
+    // In the future we might want EC passed in separately but at the moment it caused more issues than it solved to do so
+    implicit val ec: ExecutionContext = actorSystem.dispatcher
+
+    f() recoverWith {
+      case throwable if isFatal(throwable) => Future.failed(throwable)
+      case throwable if !isFatal(throwable) =>
+        val retriesLeft = if (isTransient(throwable)) maxRetries else maxRetries map { _ - 1 }
+        
+        if (retriesLeft.forall(_ > 0)) {
+          onRetry(throwable)
+          after(delay, actorSystem.scheduler)(withRetry(f, delay = delay, maxRetries = retriesLeft, isTransient = isTransient, isFatal = isFatal, onRetry = onRetry))
+        } else {
+          Future.failed(throwable)
+        }
+    }
+  }
+
+  def throwableToFalse(t: Throwable) = false
+  def noopOnRetry(t: Throwable) = {}
+}
+

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -44,6 +44,7 @@ object TestFormulas {
     for {
       firstWF <- runSuccessfulWorkflow(workflowDefinition)
       secondWf <- runSuccessfulWorkflow(workflowDefinition)
+      _ <- printHashDifferential(firstWF, secondWf)
       metadata <- validateMetadata(secondWf, workflowDefinition, Option(firstWF.id.id))
       _ <- validateNoCacheMisses(metadata, workflowDefinition.testName)
       _ <- validateDirectoryContentsCounts(workflowDefinition, secondWf)

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -76,7 +76,7 @@ object TestFormulas {
       for {
         w <- submitWorkflow(workflowDefinition)
         jobId <- pollUntilCallIsRunning(w, callMarker.callKey)
-        _ = CromwellManager.stopCromwell()
+        _ = CromwellManager.stopCromwell(s"Scheduled restart from ${workflowDefinition.testName}")
         _ = CromwellManager.startCromwell(postRestart)
         _ <- pollUntilStatus(w, workflowDefinition, finalStatus)
         _ <- validateMetadata(w, workflowDefinition)
@@ -99,7 +99,7 @@ object TestFormulas {
   def scheduledAbort(workflowDefinition: Workflow, callMarker: CallMarker, restart: Boolean): Test[SubmitResponse] = {
     def withRestart() = CentaurConfig.runMode match {
       case ManagedCromwellServer(_, postRestart, withRestart) if withRestart =>
-        CromwellManager.stopCromwell()
+        CromwellManager.stopCromwell(s"Scheduled restart from ${workflowDefinition.testName}")
         CromwellManager.startCromwell(postRestart)
       case _ =>
     }

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunner.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunner.scala
@@ -168,12 +168,12 @@ object CentaurCwlRunner extends StrictLogging {
       import CentaurCromwellClient.{blockingEc, system}
       lazy val pathBuilder = Await.result(pathBuilderFactory.withOptions(WorkflowOptions.empty), Duration.Inf)
 
-      testCase.testFunction.run.get match {
+      testCase.testFunction.run.unsafeRunSync() match {
         case unexpected: SubmitHttpResponse =>
           logger.error(s"Unexpected response: $unexpected")
           ExitCode.Failure
         case SubmitWorkflowResponse(submittedWorkflow) =>
-          val status = CentaurCromwellClient.status(submittedWorkflow).get
+          val status = CentaurCromwellClient.status(submittedWorkflow).unsafeRunSync()
           status match {
             case unexpected: NonTerminalStatus =>
               logger.error(s"Unexpected status: $unexpected")

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/Outputs.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/Outputs.scala
@@ -16,7 +16,7 @@ object Outputs {
 
   //When the string returned is not valid JSON, it is effectively an exception as CWL runner expects JSON to be returned
   def handleOutput(submittedWorkflow: SubmittedWorkflow, pathBuilder: PathBuilder): String = {
-    val metadata: Map[String, JsValue] = CentaurCromwellClient.metadata(submittedWorkflow).get.value
+    val metadata: Map[String, JsValue] = CentaurCromwellClient.metadata(submittedWorkflow).unsafeRunSync().value
 
     // Wrapper function to provide the right signature for `intersectWith` below.
     def outputResolver(schemaOption: Option[Schema])(jsValue: JsValue, mot: MyriadOutputType): Json = {
@@ -37,7 +37,7 @@ object Outputs {
         parseCwl.value.attempt.unsafeRunSync() match {
           case Right(Right(cwl)) =>
 
-            CentaurCromwellClient.outputs(submittedWorkflow).get.outputs match {
+            CentaurCromwellClient.outputs(submittedWorkflow).unsafeRunSync().outputs match {
               case JsObject(map) =>
                 val typeMap: Map[String, MyriadOutputType] = cwl.fold(CwlOutputsFold)
                 val mungeTypeMap = typeMap.mapKeys(stripTypeMapKey)

--- a/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
@@ -42,12 +42,12 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     delegateActor.expectMsg("world")
     
     // remote actor doesn't receives new messages
-    remoteActor.expectNoMsg()
+    remoteActor.expectNoMessage()
     
     // Wait long enough that to make sure that we won't receive a ServiceUnreachable message, meaning the timeout timer
     // has been cancelled. Note that it is the responsibility of the actor to cancel it, the RobustClientHelper does not
     // handle that part.
-    delegateActor.expectNoMsg(8 seconds)
+    delegateActor.expectNoMessage(8 seconds)
   }
 
   it should "handle a successful response" in {
@@ -73,8 +73,8 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     delegateActor.expectMsg("world")
     
     // remote actor doesn't receives new messages
-    remoteActor.expectNoMsg()
-    delegateActor.expectNoMsg()
+    remoteActor.expectNoMessage()
+    delegateActor.expectNoMessage()
   }
 
   it should "timeout if no response" in {
@@ -99,8 +99,8 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     delegateActor.expectMsg(TestActor.ServiceUnreachable)
 
     // remote actor doesn't receives new messages
-    remoteActor.expectNoMsg()
-    delegateActor.expectNoMsg()
+    remoteActor.expectNoMessage()
+    delegateActor.expectNoMessage()
   }
 
   it should "reset timeout when backpressured is received" in {
@@ -133,9 +133,9 @@ class RobustClientHelperSpec extends TestKitSuite with FlatSpecLike with Matcher
     delegateActor.expectMsg("world")
 
     // remote actor doesn't receives new messages
-    remoteActor.expectNoMsg()
+    remoteActor.expectNoMessage()
     // ensure that no ServiceUnreachable message was sent
-    delegateActor.expectNoMsg(4 seconds)
+    delegateActor.expectNoMessage(4 seconds)
   }
   
   it should "randomize backpressure timings" in {

--- a/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
@@ -39,7 +39,7 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     delegateProbe.expectMsg(response)
     
     // And nothing else, meaning the timeout timer has been cancelled
-    delegateProbe.expectNoMsg()
+    delegateProbe.expectNoMessage()
 
     // timeouts map should be empty
     testActor.underlyingActor.timeouts.isEmpty shouldBe true
@@ -72,7 +72,7 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
     }
 
     // And nothing else, meaning the timeout timer has been cancelled
-    delegateProbe.expectNoMsg()
+    delegateProbe.expectNoMessage()
 
     // timeouts map should be empty
     testActor.underlyingActor.timeouts.isEmpty shouldBe true

--- a/core/src/test/scala/cromwell/util/GracefulShutdownHelperSpec.scala
+++ b/core/src/test/scala/cromwell/util/GracefulShutdownHelperSpec.scala
@@ -28,12 +28,12 @@ class GracefulShutdownHelperSpec extends TestKitSuite with FlatSpecLike with Mat
     testProbeB.expectMsg(ShutdownCommand)
 
     // Make sure it's still alive
-    expectNoMsg()
+    expectNoMessage()
 
     system stop testProbeA.ref
 
     // Make sure it's still alive
-    expectNoMsg()
+    expectNoMessage()
 
     system stop testProbeB.ref
     

--- a/dockerHashing/src/test/scala/cromwell/docker/registryv2/flows/HttpFlowWithRetrySpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/registryv2/flows/HttpFlowWithRetrySpec.scala
@@ -60,7 +60,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeFailure.expectNoMsg(1 second)
+    probeFailure.expectNoMessage(1 second)
     probeSuccess.expectMsgPF(1 second) {
       case (response: HttpResponse, _) => response.status shouldBe StatusCodes.OK
     }
@@ -79,7 +79,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeFailure.expectNoMsg(1 second)
+    probeFailure.expectNoMessage(1 second)
     probeSuccess.expectMsgPF(1 second) {
       case (response: HttpResponse, _) => response.status shouldBe StatusCodes.BadRequest
     }
@@ -99,7 +99,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeSuccess.expectNoMsg(1 second)
+    probeSuccess.expectNoMessage(1 second)
     probeFailure.expectMsgPF(1 second) {
       case (failure: Throwable, _) => failure shouldBe mockFailure.failed.get
     }
@@ -118,7 +118,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeFailure.expectNoMsg(1 second)
+    probeFailure.expectNoMessage(1 second)
     probeSuccess.expectMsgPF(1 second) {
       case (response: HttpResponse, _) => response.status shouldBe StatusCodes.OK
     }
@@ -142,7 +142,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeFailure.expectNoMsg(1 second)
+    probeFailure.expectNoMessage(1 second)
     // backoff starts at 1 second, multiplier is 3 and default randomization is 20%
     // which means, worst case scenario, we need to wait
     // (1 + 0.2) + (3 + 0.6) + (9 + 1.8) = 15.06 -> 20 to account for test latency
@@ -167,7 +167,7 @@ class HttpFlowWithRetrySpec extends TestKitSuite with FlatSpecLike with Matchers
 
     graph.run()
 
-    probeFailure.expectNoMsg(1 second)
+    probeFailure.expectNoMessage(1 second)
     probeSuccess.expectMsgPF(20 seconds) {
       case (response: HttpResponse, _) => response.status shouldBe StatusCodes.RequestTimeout
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -33,7 +33,7 @@ class FetchCachedResultsActor(cacheResultId: CallCachingEntryId, replyTo: ActorR
         val jobDetritusFiles = result.callCachingDetritusEntries map { jobDetritusEntry =>
           jobDetritusEntry.detritusKey -> jobDetritusEntry.detritusValue.toRawString
         }
-        println(s"Fetched detrituses: ${jobDetritusFiles.map({case (k, v) => s"$k -> $v"}).mkString("\n")}")
+
         val sourceCacheDetails = Seq(result.callCachingEntry.workflowExecutionUuid,
                                     result.callCachingEntry.callFullyQualifiedName,
                                     result.callCachingEntry.jobIndex).mkString(":")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -33,6 +33,7 @@ class FetchCachedResultsActor(cacheResultId: CallCachingEntryId, replyTo: ActorR
         val jobDetritusFiles = result.callCachingDetritusEntries map { jobDetritusEntry =>
           jobDetritusEntry.detritusKey -> jobDetritusEntry.detritusValue.toRawString
         }
+        println(s"Fetched detrituses: ${jobDetritusFiles.map({case (k, v) => s"$k -> $v"}).mkString("\n")}")
         val sourceCacheDetails = Seq(result.callCachingEntry.workflowExecutionUuid,
                                     result.callCachingEntry.callFullyQualifiedName,
                                     result.callCachingEntry.jobIndex).mkString(":")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -663,7 +663,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   }
 
   private def saveCacheResults(hashes: CallCacheHashes, data: SucceededResponseData) = {
-    workflowLogger.info(s"Writing detrituses to cache DB: ${data.response.jobDetritusFiles.map(_.map({case (k, v) => s"$k -> $v"}).mkString("\n")).getOrElse("N/A")}")
     callCacheWriteActor ! SaveCallCacheHashes(CallCacheHashBundle(workflowIdForLogging, hashes, data.response))
     val updatedData = data.copy(hashes = Option(Success(hashes)))
     goto(UpdatingCallCache) using updatedData

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -663,6 +663,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   }
 
   private def saveCacheResults(hashes: CallCacheHashes, data: SucceededResponseData) = {
+    workflowLogger.info(s"Writing detrituses to cache DB: ${data.response.jobDetritusFiles.map(_.map({case (k, v) => s"$k -> $v"}).mkString("\n")).getOrElse("N/A")}")
     callCacheWriteActor ! SaveCallCacheHashes(CallCacheHashBundle(workflowIdForLogging, hashes, data.response))
     val updatedData = data.copy(hashes = Option(Success(hashes)))
     goto(UpdatingCallCache) using updatedData

--- a/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
@@ -65,7 +65,7 @@ class WorkflowDockerLookupActorSpec extends TestKitSuite("WorkflowDockerLookupAc
 
     // Now the WorkflowDockerLookupActor should now have this hash in its mappings and should not query the dockerHashingActor again.
     lookupActor ! LatestRequest
-    dockerHashingActor.expectNoMsg()
+    dockerHashingActor.expectNoMessage()
     // The WorkflowDockerLookupActor should forward the success message to this actor.
     expectMsg(LatestSuccessResponse)
     numWrites should equal(1)
@@ -147,7 +147,7 @@ class WorkflowDockerLookupActorSpec extends TestKitSuite("WorkflowDockerLookupAc
     lookupActor ! LatestRequest
     lookupActor ! OlderRequest
 
-    dockerHashingActor.expectNoMsg()
+    dockerHashingActor.expectNoMessage()
 
     val results = receiveN(2, 2 seconds).toSet
     val successes = results collect { case result: DockerHashSuccessResponse => result }
@@ -207,7 +207,7 @@ class WorkflowDockerLookupActorSpec extends TestKitSuite("WorkflowDockerLookupAc
     val lookupActor = TestActorRef(WorkflowDockerLookupActor.props(workflowId, dockerHashingActor.ref, isRestart = true, db))
     lookupActor ! LatestRequest
 
-    dockerHashingActor.expectNoMsg()
+    dockerHashingActor.expectNoMessage()
     expectMsgClass(classOf[WorkflowDockerTerminalFailure])
     numReads should equal(1)
   }
@@ -225,7 +225,7 @@ class WorkflowDockerLookupActorSpec extends TestKitSuite("WorkflowDockerLookupAc
     val lookupActor = TestActorRef(WorkflowDockerLookupActor.props(workflowId, dockerHashingActor.ref, isRestart = true, db))
     lookupActor ! LatestRequest
 
-    dockerHashingActor.expectNoMsg()
+    dockerHashingActor.expectNoMessage()
     expectMsgClass(classOf[WorkflowDockerTerminalFailure])
     numReads should equal(1)
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
@@ -249,8 +249,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
 
     cchja ! FileHashResponse(mock[HashResult])
 
-    callCacheReadProbe.expectNoMsg()
-    parent.expectNoMsg()
+    callCacheReadProbe.expectNoMessage()
+    parent.expectNoMessage()
     cchja.stateName shouldBe HashingFiles
   }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActorSpec.scala
@@ -39,7 +39,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
     expectMsgPF(1.second) {
       case CallPreparationFailed(_, ex) => ex.getMessage shouldBe "Call input and runtime attributes evaluation failed for JobPreparationSpec_call:\nFailed to prepare inputs/attributes - part of test flow"
     }
-    helper.workflowDockerLookupActor.expectNoMsg(100 millis)
+    helper.workflowDockerLookupActor.expectNoMessage(100 millis)
   }
 
   it should "prepare successfully a job without docker attribute" in {
@@ -51,7 +51,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
       case success: BackendJobPreparationSucceeded =>
         success.jobDescriptor.maybeCallCachingEligible.dockerHash shouldBe None
     }
-    helper.workflowDockerLookupActor.expectNoMsg(1 second)
+    helper.workflowDockerLookupActor.expectNoMessage(1 second)
   }
 
   it should "not ask for the docker hash if the attribute already contains a hash" in {
@@ -67,7 +67,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
         success.jobDescriptor.runtimeAttributes("docker").valueString shouldBe dockerValue
         success.jobDescriptor.maybeCallCachingEligible shouldBe DockerWithHash("ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950")
     }
-    helper.workflowDockerLookupActor.expectNoMsg(1 second)
+    helper.workflowDockerLookupActor.expectNoMessage(1 second)
   }
 
   it should "lookup any requested key/value prefetches after (not) performing a docker hash lookup" in {
@@ -97,7 +97,7 @@ class JobPreparationActorSpec extends TestKitSuite("JobPrepActorSpecSystem") wit
       }
     }
     respondFromKv()
-    helper.workflowDockerLookupActor.expectNoMsg(max = 100 milliseconds)
+    helper.workflowDockerLookupActor.expectNoMessage(max = 100 milliseconds)
     respondFromKv()
 
     expectMsgPF(5 seconds) {

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -108,7 +108,7 @@ class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec
     actorRefUnderTest ! JobExecutionTokenRequest(LimitedTo5Tokens)
     // Force token distribution
     actorRefUnderTest ! TokensAvailable(100)
-    expectNoMsg()
+    expectNoMessage()
     // We should be enqueued and the last in the queue though
     actorRefUnderTest.underlyingActor.tokenQueues(LimitedTo5Tokens).queue.last shouldBe self
 
@@ -172,7 +172,7 @@ class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec
     actorRefUnderTest.tell(JobExecutionTokenReturn, senders.head.ref)
 
     // Nothing should happen, specifically Sender 6 should not get his token
-    senders(6).expectNoMsg(MaxWaitTime)
+    senders(6).expectNoMessage(MaxWaitTime)
   }
 
   AkkaTestUtil.actorDeathMethods(system) foreach { case (name, stopMethod) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  private val akkaHttpV = "10.0.10"
-  private val akkaV = "2.5.4"
+  private val akkaHttpV = "10.1.3"
+  private val akkaV = "2.5.13"
   private val alibabaCloudCoreV = "3.6.0"
   private val alibabaCloudOssV = "3.1.0"
   private val alibabaCloudBcsV = "5.3.2"
@@ -12,7 +12,7 @@ object Dependencies {
   private val awsSdkV = "2.0.0-preview-9"
   private val s3fsV = "1.0.1"
   private val betterFilesV = "2.17.1"
-  private val catsEffectV = "0.10"
+  private val catsEffectV = "1.0.0-RC2"
   private val catsV = "1.0.1"
   private val circeV = "0.9.3"
   private val circeYamlV = "0.7.0"

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import akka.actor.ActorSystem
+import akka.actor.CoordinatedShutdown.JvmExitReason
 import akka.pattern.GracefulStopSupport
 import akka.stream.ActorMaterializer
 import cats.data.Validated._
@@ -58,7 +59,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
     val runner = cromwellSystem.actorSystem.actorOf(runnerProps, "SingleWorkflowRunnerActor")
 
     import cromwell.util.PromiseActor.EnhancedActorRef
-    waitAndExit(() => runner.askNoTimeout(RunWorkflow), () => CromwellShutdown.instance(cromwellSystem.actorSystem).run())
+    waitAndExit(() => runner.askNoTimeout(RunWorkflow), () => CromwellShutdown.instance(cromwellSystem.actorSystem).run(JvmExitReason))
   }
 
   def submitToServer(args: CommandLineArguments): Unit = {

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -89,7 +89,7 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
 
       probe.expectTerminated(workflowActor, TestExecutionTimeout)
       // Check the parent didn't see anything:
-      supervisor.expectNoMsg(AwaitAlmostNothing) // The actor's already terminated. No point hanging around waiting...
+      supervisor.expectNoMessage(AwaitAlmostNothing) // The actor's already terminated. No point hanging around waiting...
 
     }
 

--- a/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
@@ -104,7 +104,7 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       finalizationProbe.expectMsg(StartFinalizationCommand)
       actor.stateName should be(FinalizingWorkflowState)
       actor ! WorkflowFinalizationSucceededResponse
-      supervisorProbe.expectNoMsg(AwaitAlmostNothing)
+      supervisorProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
 
@@ -131,7 +131,7 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       finalizationProbe.expectMsg(StartFinalizationCommand)
       actor.stateName should be(FinalizingWorkflowState)
       actor ! WorkflowFinalizationSucceededResponse
-      supervisorProbe.expectNoMsg(AwaitAlmostNothing)
+      supervisorProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
 
@@ -142,7 +142,7 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       finalizationProbe.expectMsg(StartFinalizationCommand)
       actor.stateName should be(FinalizingWorkflowState)
       actor ! WorkflowFinalizationSucceededResponse
-      supervisorProbe.expectNoMsg(AwaitAlmostNothing)
+      supervisorProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
 
@@ -150,7 +150,7 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       val actor = createWorkflowActor(WorkflowUnstartedState)
       deathwatch watch actor
       actor ! AbortWorkflowCommand
-      finalizationProbe.expectNoMsg(AwaitAlmostNothing)
+      finalizationProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
 
@@ -158,7 +158,7 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       val actor = createWorkflowActor(MaterializingWorkflowDescriptorState)
       deathwatch watch actor
       actor ! AbortWorkflowCommand
-      finalizationProbe.expectNoMsg(AwaitAlmostNothing)
+      finalizationProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
 
@@ -166,11 +166,11 @@ class WorkflowActorSpec extends CromwellTestKitWordSpec with WorkflowDescriptorB
       val actor = createWorkflowActor(MaterializingWorkflowDescriptorState)
       deathwatch watch actor
 
-      copyWorkflowLogsProbe.expectNoMsg(AwaitAlmostNothing)
+      copyWorkflowLogsProbe.expectNoMessage(AwaitAlmostNothing)
       actor ! MaterializeWorkflowDescriptorFailureResponse(new Exception("Intentionally failing workflow materialization to test log copying"))
       copyWorkflowLogsProbe.expectMsg(CopyWorkflowLogsActor.Copy(currentWorkflowId, mockDir))
 
-      finalizationProbe.expectNoMsg(AwaitAlmostNothing)
+      finalizationProbe.expectNoMessage(AwaitAlmostNothing)
       deathwatch.expectTerminated(actor)
     }
   }

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -52,7 +52,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           ejhaResponse foreach { ejea ! _ }
 
           // Nothing should happen here:
-          helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
+          helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
 
           // Send the response from the copying actor
           ejea ! successResponse
@@ -77,7 +77,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
 
           ejhaResponse foreach { resp =>
             // Nothing should have happened yet:
-            helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
+            helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
 
             // Ok, now send the response from the EJHA (if there was one!):
             ejea ! resp
@@ -137,7 +137,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
             }
 
             // Nothing should happen here:
-            helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
+            helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
 
             // Send the response from the copying actor
             ejea ! failureNonRetryableResponse

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
@@ -23,7 +23,7 @@ class EjeaInvalidatingCacheEntrySpec extends EngineJobExecutionActorSpec {
         // Send the response from the invalidate actor
         ejea ! invalidateActorResponse
 
-        helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
+        helper.bjeaProbe.expectNoMessage(awaitAlmostNothing)
         helper.ejhaProbe.expectMsg(NextHit)
         eventually { ejea.stateName should be(CheckingCallCache) }
         ejea.stateData should be(ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, Option(helper.ejhaProbe.ref), None))

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRequestingExecutionTokenSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRequestingExecutionTokenSpec.scala
@@ -17,7 +17,7 @@ class EjeaRequestingExecutionTokenSpec extends EngineJobExecutionActorSpec with 
       s"do nothing when denied a token (with restarting=$restarting)" in {
         ejea = helper.buildEJEA(restarting = restarting)
 
-        helper.jobTokenDispenserProbe.expectNoMsg(max = awaitAlmostNothing)
+        helper.jobTokenDispenserProbe.expectNoMessage(max = awaitAlmostNothing)
         helper.jobPreparationProbe.msgAvailable should be(false)
         helper.jobStoreProbe.msgAvailable should be(false)
 
@@ -35,7 +35,7 @@ class EjeaRequestingExecutionTokenSpec extends EngineJobExecutionActorSpec with 
             validateJobStoreKey(jobKey)
             taskOutputs should be(helper.call.outputPorts.toSeq)
         }
-        helper.bjeaProbe.expectNoMsg(awaitAlmostNothing)
+        helper.bjeaProbe.expectNoMessage(awaitAlmostNothing)
         helper.jobHashingInitializations shouldBe NothingYet
         ejea.stateName should be(CheckingJobStore)
       }

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRunningJobSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaRunningJobSpec.scala
@@ -35,8 +35,8 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
 
         helper.deathwatch.expectTerminated(ejea, awaitTimeout)
         // Make sure nothing was sent to the JobStore or CacheResultSaver in the meanwhile:
-        helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
-        helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+        helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
+        helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
       }
 
       s"Handle receiving a JobAbortedResponse correctly in $mode mode with successful hashes" in {
@@ -51,8 +51,8 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
 
         helper.deathwatch.expectTerminated(ejea, awaitTimeout)
         // Make sure nothing was sent to the JobStore or CacheResultSaver in the meanwhile:
-        helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
-        helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+        helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
+        helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
       }
 
       s"Handle receiving a JobAbortedResponse correctly in $mode mode with failed hashes" in {
@@ -67,8 +67,8 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
 
         helper.deathwatch.expectTerminated(ejea, awaitTimeout)
         // Make sure nothing was sent to the JobStore or CacheResultSaver in the meanwhile:
-        helper.jobStoreProbe.expectNoMsg(awaitAlmostNothing)
-        helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+        helper.jobStoreProbe.expectNoMessage(awaitAlmostNothing)
+        helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
       }
 
       /* ********************************************* */
@@ -129,7 +129,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea ! SuccessfulCallCacheHashes
             // Don't expect cache write here (the job failed !) but do expect job store write
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Option(Success(SuccessfulCallCacheHashes))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
 
           s"Handle receiving CallCacheHashes then $name correctly in $mode mode" in {
@@ -141,7 +141,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea ! failedResponse
             // Don't expect cache write here (the job failed !) but do expect job store write
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Option(Success(SuccessfulCallCacheHashes))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
 
           s"Handle receiving $name then HashError correctly in $mode mode" in {
@@ -152,7 +152,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea.stateName should be(RunningJob)
             ejea ! hashError
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Some(Failure(hashError.reason))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
 
           s"Handle receiving HashError then $name correctly in $mode mode" in {
@@ -163,7 +163,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea.stateName should be(RunningJob)
             ejea ! failedResponse
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Some(Failure(hashError.reason))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
         }
         // writeToCache = false
@@ -172,7 +172,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
           ejea = ejeaInRunningState(mode)
           ejea ! successResponse
           expectJobStoreWrite(SucceededResponseData(successResponse, None))
-          helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+          helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
         }
 
         s"Handle receiving a SucceededResponse correctly in $mode mode with successful hashes" in {
@@ -183,7 +183,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
           ejea ! successResponse
           // Even if we received hashes, writeToCache is false so we go straight to job store and don't write them to the cache
           expectJobStoreWrite(SucceededResponseData(successResponse, Some(Success(SuccessfulCallCacheHashes))))
-          helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+          helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
         }
 
         s"Handle receiving a SucceededResponse correctly in $mode mode with failed hashes" in {
@@ -194,7 +194,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
           ejea ! successResponse
           // Even if we received hashes, writeToCache is false so we go straight to job store and don't write them to the cache
           expectJobStoreWrite(SucceededResponseData(successResponse, Some(Failure(hashError.reason))))
-          helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+          helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
         }
 
         failureCases foreach { case (name, responseMaker, retryable) =>
@@ -204,7 +204,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea ! failedResponse
             // writeToCache is off, we don't need to wait for hashes
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, None), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
 
           s"Handle receiving a $name correctly in $mode mode with successful hashes" in {
@@ -215,7 +215,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea.stateName should be(RunningJob)
             ejea ! failedResponse
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Some(Success(SuccessfulCallCacheHashes))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
 
           s"Handle receiving a $name correctly in $mode mode with failed hashes" in {
@@ -226,7 +226,7 @@ class EjeaRunningJobSpec extends EngineJobExecutionActorSpec with Eventually wit
             ejea.stateName should be(RunningJob)
             ejea ! failedResponse
             expectJobStoreWriteFailed(FailedResponseData(failedResponse, Some(Failure(hashError.reason))), retryable)
-            helper.callCacheWriteActorProbe.expectNoMsg(awaitAlmostNothing)
+            helper.callCacheWriteActorProbe.expectNoMessage(awaitAlmostNothing)
           }
         }
       }

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -45,7 +45,7 @@ class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with 
           am <- a.status.messages.toList.flatten.headOption
           em <- e.status.messages.toList.flatten.headOption
         } yield am.startsWith(em)
-        assert(isEmpty || actualPrefixedByExpected.contains(true))
+        assert(isEmpty || actualPrefixedByExpected.contains(true), clue = s"Instead, a.status.messages = ${a.status.messages.toList.flatten} and e.status.messages = ${e.status.messages.toList.flatten}")
       } head
     }
   }

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -45,7 +45,7 @@ class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with 
           am <- a.status.messages.toList.flatten.headOption
           em <- e.status.messages.toList.flatten.headOption
         } yield am.startsWith(em)
-        assert(isEmpty || actualPrefixedByExpected.contains(true), clue = s"Instead, a.status.messages = ${a.status.messages.toList.flatten} and e.status.messages = ${e.status.messages.toList.flatten}")
+        assert(isEmpty || actualPrefixedByExpected.contains(true), s"Instead, a.status.messages = ${a.status.messages.toList.flatten} and e.status.messages = ${e.status.messages.toList.flatten}")
       } head
     }
   }

--- a/services/src/test/scala/cromwell/services/keyvalue/KvClientSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/KvClientSpec.scala
@@ -32,22 +32,22 @@ class KvClientSpec extends TestKit(ActorSystem("KvClientSpec")) with FlatSpecLik
     val futureResult = kvTestClient.underlyingActor.makeKvRequest(requests)
 
     serviceActorProbe.expectMsgAllOf(putRequest, getRequest)
-    serviceActorProbe.expectNoMsg(max = 50 milliseconds)
+    serviceActorProbe.expectNoMessage(max = 50 milliseconds)
 
     kvTestClient.underlyingActor.currentKvClientRequests.size should be(2)
 
     kvTestClient.tell(getResponse, sender = serviceActorProbe.ref)
-    serviceActorProbe.expectNoMsg(max = 50 milliseconds)
+    serviceActorProbe.expectNoMessage(max = 50 milliseconds)
     futureResult.isCompleted should be(false)
 
     kvTestClient.underlyingActor.currentKvClientRequests.size should be(1)
 
     kvTestClient.tell(putResponse, sender = serviceActorProbe.ref)
-    serviceActorProbe.expectNoMsg(max = 50 milliseconds)
+    serviceActorProbe.expectNoMessage(max = 50 milliseconds)
 
     // Make sure the future completes promptly and the original order is preserved:
     Await.result(futureResult, atMost = 100 milliseconds) should be(Seq(putResponse, getResponse))
-    serviceActorProbe.expectNoMsg(max = 50 milliseconds)
+    serviceActorProbe.expectNoMessage(max = 50 milliseconds)
 
     kvTestClient.underlyingActor.currentKvClientRequests.size should be(0)
   }

--- a/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/loadcontroller/impl/LoadControllerServiceActorSpec.scala
@@ -79,7 +79,7 @@ class LoadControllerServiceActorSpec extends TestKitSuite with FlatSpecLike with
     expectMsg(max = 2.seconds, HighLoad)
 
     // And only one
-    expectNoMsg(2.seconds)
+    expectNoMessage(2.seconds)
 
     // Set the load level back to normal
     loadActor ! LoadMetric("itsme", NormalLoad)

--- a/src/bin/ci/resources/local_provider_config.inc.conf
+++ b/src/bin/ci/resources/local_provider_config.inc.conf
@@ -1,7 +1,7 @@
 include required(classpath("reference_local_provider_config.inc.conf"))
 
 # Overrides/Updates for CI environments
-concurrent-job-limit = 20
+concurrent-job-limit = 1000
 script-epilogue = "sleep 5 && sync"
 filesystems.local.caching.duplication-strategy = ["copy"]
 filesystems.local.localization = ["soft-link", "copy"]

--- a/src/bin/ci/resources/papi_provider_config.inc.conf
+++ b/src/bin/ci/resources/papi_provider_config.inc.conf
@@ -1,8 +1,7 @@
 project = "broad-dsde-cromwell-dev"
 root = "gs://cloud-cromwell-dev/cromwell_execution/travis"
 maximum-polling-interval = 600
-concurrent-job-limit = 20
-concurrent-job-limit = ${?PAPI_CONCURRENT_JOB_LIMIT}
+concurrent-job-limit = 1000
 
 genomics {
   auth = "service_account"

--- a/src/bin/ci/resources/tes_application.conf
+++ b/src/bin/ci/resources/tes_application.conf
@@ -10,7 +10,7 @@ backend {
         root = "cromwell-executions"
         dockerRoot = "/cromwell-executions"
         endpoint = "http://127.0.0.1:9000/v1/tasks"
-        concurrent-job-limit = 20
+        concurrent-job-limit = 1000
       }
     }
   }

--- a/src/bin/ci/testCentaurPapiV1.sh
+++ b/src/bin/ci/testCentaurPapiV1.sh
@@ -29,11 +29,11 @@ if [ "${CROMWELL_BUILD_IS_CRON}" = "true" ]; then
     INTEGRATION_TESTS=(-i "${CROMWELL_BUILD_CENTAUR_INTEGRATION_TESTS}")
     # Increase concurrent job limit to get tests to finish under three hours.
     # Increase read_lines limit because of read_lines call on hg38.even.handcurated.20k.intervals.
-    PAPI_CONCURRENT_JOB_LIMIT=9001
     CENTAUR_READ_LINES_LIMIT=512000
-    export PAPI_CONCURRENT_JOB_LIMIT
     export CENTAUR_READ_LINES_LIMIT
 fi
+PAPI_CONCURRENT_JOB_LIMIT=9001
+export PAPI_CONCURRENT_JOB_LIMIT
 
 centaur/test_cromwell.sh \
     -j "${CROMWELL_BUILD_JAR}" \

--- a/src/bin/ci/testCentaurPapiV1.sh
+++ b/src/bin/ci/testCentaurPapiV1.sh
@@ -32,8 +32,6 @@ if [ "${CROMWELL_BUILD_IS_CRON}" = "true" ]; then
     CENTAUR_READ_LINES_LIMIT=512000
     export CENTAUR_READ_LINES_LIMIT
 fi
-PAPI_CONCURRENT_JOB_LIMIT=9001
-export PAPI_CONCURRENT_JOB_LIMIT
 
 centaur/test_cromwell.sh \
     -j "${CROMWELL_BUILD_JAR}" \

--- a/src/bin/ci/testCentaurPapiV2.sh
+++ b/src/bin/ci/testCentaurPapiV2.sh
@@ -32,8 +32,6 @@ if [ "${CROMWELL_BUILD_IS_CRON}" = "true" ]; then
     CENTAUR_READ_LINES_LIMIT=512000
     export CENTAUR_READ_LINES_LIMIT
 fi
-PAPI_CONCURRENT_JOB_LIMIT=9001
-export PAPI_CONCURRENT_JOB_LIMIT
 
 # Excluded tests:
 # docker_hash_dockerhub_private: https://github.com/broadinstitute/cromwell/issues/3587

--- a/src/bin/ci/testCentaurPapiV2.sh
+++ b/src/bin/ci/testCentaurPapiV2.sh
@@ -29,11 +29,11 @@ if [ "${CROMWELL_BUILD_IS_CRON}" = "true" ]; then
     INTEGRATION_TESTS=(-i "${CROMWELL_BUILD_CENTAUR_INTEGRATION_TESTS}")
     # Increase concurrent job limit to get tests to finish under three hours.
     # Increase read_lines limit because of read_lines call on hg38.even.handcurated.20k.intervals.
-    PAPI_CONCURRENT_JOB_LIMIT=9001
     CENTAUR_READ_LINES_LIMIT=512000
-    export PAPI_CONCURRENT_JOB_LIMIT
     export CENTAUR_READ_LINES_LIMIT
 fi
+PAPI_CONCURRENT_JOB_LIMIT=9001
+export PAPI_CONCURRENT_JOB_LIMIT
 
 # Excluded tests:
 # docker_hash_dockerhub_private: https://github.com/broadinstitute/cromwell/issues/3587

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobExecutionActorSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobExecutionActorSpec.scala
@@ -74,8 +74,8 @@ class AwsBatchJobExecutionActorSpec extends TestKitSuite("AwsBatchJobExecutionAc
     deathwatch watch testJJEA
 
     // Nothing happens:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
 
     testJJEA.tell(msg = ExecuteJobCommand, sender = parent.ref)
 
@@ -108,14 +108,14 @@ class AwsBatchJobExecutionActorSpec extends TestKitSuite("AwsBatchJobExecutionAc
     deathwatch watch testJJEA
 
     // Nothing happens:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
 
     testJJEA.tell(msg = ExecuteJobCommand, sender = parent.ref)
 
     // Wait for the JABJEA to be spawned. Then kill it:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
     constructionPromise.future onComplete {
       case Success(jabjea) =>
         jabjea ! JabjeaExplode

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobExecutionActorSpec.scala
@@ -43,8 +43,8 @@ class PipelinesApiJobExecutionActorSpec extends TestKitSuite("PipelinesApiJobExe
     deathwatch watch testJJEA
 
     // Nothing happens:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
 
     testJJEA.tell(msg = ExecuteJobCommand, sender = parent.ref)
 
@@ -77,14 +77,14 @@ class PipelinesApiJobExecutionActorSpec extends TestKitSuite("PipelinesApiJobExe
     deathwatch watch testJJEA
 
     // Nothing happens:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
 
     testJJEA.tell(msg = ExecuteJobCommand, sender = parent.ref)
 
     // Wait for the JABJEA to be spawned. Then kill it:
-    parent.expectNoMsg(max = AwaitAlmostNothing)
-    deathwatch.expectNoMsg(max = AwaitAlmostNothing)
+    parent.expectNoMessage(max = AwaitAlmostNothing)
+    deathwatch.expectNoMessage(max = AwaitAlmostNothing)
     jabjeaConstructionPromise.future onComplete {
       case Success(jabjea) =>
         jabjea ! JabjeaExplode

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
@@ -55,7 +55,7 @@ class PipelinesApiRequestManagerSpec extends TestKitSuite("PipelinesApiRequestMa
     }
 
     // Should have no messages to the actual statusPoller yet:
-    statusPoller.expectNoMsg(max = AwaitAlmostNothing)
+    statusPoller.expectNoMessage(max = AwaitAlmostNothing)
 
     // Verify batches:
     2 times {

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorkerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorkerSpec.scala
@@ -45,7 +45,7 @@ abstract class PipelinesApiRequestWorkerSpec[O >: Null]
 
   it should "query for work and wait for a reply" in {
     managerProbe.expectMsgClass(max = TestExecutionTimeout, c = classOf[PipelinesApiRequestManager.PipelinesWorkerRequestWork])
-    managerProbe.expectNoMsg(max = AwaitAlmostNothing)
+    managerProbe.expectNoMessage(max = AwaitAlmostNothing)
   }
 
   it should "respond correctly with various run statuses" in {
@@ -72,14 +72,14 @@ abstract class PipelinesApiRequestWorkerSpec[O >: Null]
     eventually { batchHandler.runBatchRequested should be(true) }
 
     // The manager shouldn't have been asked for more work yet:
-    managerProbe.expectNoMsg(max = AwaitAlmostNothing)
+    managerProbe.expectNoMessage(max = AwaitAlmostNothing)
 
     // Ok, let's trigger the callbacks:
     batchHandler.executeBatch()
 
     requester1.expectMsg(successStatus)
     requester2.expectMsg(failureStatus)
-    requester3.expectNoMsg(max = AwaitAlmostNothing)
+    requester3.expectNoMessage(max = AwaitAlmostNothing)
 
     // Requester3 expected nothing... Instead, the manager expects an API failure notification and then a request for more work:
     managerProbe.expectMsgPF(TestExecutionTimeout) {
@@ -88,7 +88,7 @@ abstract class PipelinesApiRequestWorkerSpec[O >: Null]
         if (failure.query != query2 && failure.query != query3) fail("Unexpected query caused failure: " + failure.query)
     }
     managerProbe.expectMsg(PipelinesWorkerRequestWork(PipelinesApiRequestWorker.MaxBatchSize))
-    managerProbe.expectNoMsg(max = AwaitAlmostNothing)
+    managerProbe.expectNoMessage(max = AwaitAlmostNothing)
   }
 }
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -160,7 +160,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
   }
 
   it should "abort a job and kill a process" in {
-    val workflowDescriptor = buildWdlWorkflowDescriptor(Sleep10)
+    val workflowDescriptor = buildWdlWorkflowDescriptor(Sleep20)
     val jobDescriptor: BackendJobDescriptor = jobDescriptorFromSingleCallWorkflow(workflowDescriptor, Map.empty, WorkflowOptions.empty, runtimeAttributeDefinitions)
     val backendRef = createBackendRef(jobDescriptor, TestConfig.backendRuntimeConfigDescriptor)
     val backend = backendRef.underlyingActor

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/command/ParameterCommandPart.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/command/ParameterCommandPart.scala
@@ -53,7 +53,7 @@ case class ParameterCommandPart(attributes: Map[String, String], expression: Wdl
         case _ => v.validNel
       }
       case Failure(OptionalNotSuppliedException(_)) => defaultString.validNel
-      case Failure(_) => s"Could not evaluate expression: ${expression.toWomString}".invalidNel
+      case Failure(e) => s"Could not evaluate expression: ${expression.toWomString}: ${e.getMessage}".invalidNel
     }
 
     // Create the stringified version of the command and record any file created in the process.

--- a/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/Draft2ReadFileLimitsSpec.scala
+++ b/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/Draft2ReadFileLimitsSpec.scala
@@ -8,7 +8,7 @@ import wom.expression.EmptyIoFunctionSet
 import scala.concurrent.Future
 
 class Draft2ReadFileLimitsSpec extends FlatSpec with Matchers {
-  behavior of "ReadLikeFunctions Size Limit Draft 3"
+  behavior of "ReadLikeFunctions Size Limit Draft 2"
   
   it should "pass correct size limits to the ioFunctions for read_lines" in {
     new WdlWomExpression(WdlExpression.fromString("""read_lines("blah")"""), null)

--- a/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/draft3/src/main/scala/wdl/draft3/transforms/linking/expression/values/EngineFunctionEvaluators.scala
@@ -205,7 +205,7 @@ object EngineFunctionEvaluators {
           read <- readFile(fileToRead, ioFunctionSet, fileSizeLimitationConfig.readBoolLimit)
           asBool <- Try(read.trim.toBoolean)
         } yield WomBoolean(asBool)
-        tryResult.map(EvaluatedValue(_, Seq.empty)).toErrorOr.contextualizeErrors(s"""read_int("${fileToRead.value}")""")
+        tryResult.map(EvaluatedValue(_, Seq.empty)).toErrorOr.contextualizeErrors(s"""read_boolean("${fileToRead.value}")""")
       }
     }
   }


### PR DESCRIPTION
Seems to generally improve centaur robustness, although it still drops the ball sometimes and the test script just exits for no apparent reason.
Fixes the `cwl_cache_between_workflows` and `cwl_cache_within_workflows` tests
Unit tests transient failures remain