### PR TITLE
Annotate job name with task name

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -197,7 +197,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
     val definitionArn = createDefinition(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}""", taskId)
 
     val job = client.submitJob(SubmitJobRequest.builder()
-                .jobName(sanitize(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}"""))
+                .jobName(sanitize(jobDescriptor.taskCall.fullyQualifiedName))
                 .parameters(parameters.collect({ case i: AwsBatchInput => i.toStringString }).toMap.asJava)
                 .jobQueue(runtimeAttributes.queueArn)
                 .jobDefinition(definitionArn).build)


### PR DESCRIPTION
This adds more information to the aws batch job name to more easily identify jobs as they move through AWS batch.