### PR TITLE
Remove mkdir -p /cromwell_root from command script

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -150,10 +150,11 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
   lazy val reconfiguredScript = {
     // We'll use the MD5 of the dockerRc so the boundary is "random" but consistent
     val boundary = MessageDigest.getInstance("MD5").digest(dockerRc.getBytes).map("%02x".format(_)).mkString
-    //TODO: Ugly hack due to lack of time. cromwell_root is not guaranteed in the container and I don't want to change the global cromwell script
-    """#!/bin/bash
-    |mkdir -p /cromwell_root
-    """.stripMargin + 
+
+    // NOTE: We are assuming the presence of a volume named "local-disk".
+    //       This requires a custom AMI with the volume defined. But, since
+    //       we need a custom AMI anyway for any real workflow, we just need
+    //       to make sure this requirement is documented.
     script.concat(s"""
     |echo "MIME-Version: 1.0
     |Content-Type: multipart/alternative; boundary="${boundary}"
@@ -191,10 +192,10 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
 
     // Build the Job definition before we submit. Eventually this should be
     // done separately and cached.
-    val definitionArn = createDefinition(workflow.callable.name)
+    val definitionArn = createDefinition(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}""")
 
     val job = client.submitJob(SubmitJobRequest.builder()
-                .jobName(sanitize(workflow.callable.name))
+                .jobName(sanitize(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}"""))
                 .parameters(parameters.collect({ case i: AwsBatchInput => i.toStringString }).toMap.asJava)
                 .jobQueue(runtimeAttributes.queueArn)
                 .jobDefinition(definitionArn).build)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -71,9 +71,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
     |mv /cromwell_root/hello-rc.txt.tmp /cromwell_root/hello-rc.txt"""
 
     val boundary = "d283898f11be0dee6f9ac01470450bee"
-    val expectedscript = """#!/bin/bash
-    |mkdir -p /cromwell_root
-    """.stripMargin + script.concat(s"""
+    val expectedscript = script.concat(s"""
     |echo "MIME-Version: 1.0
     |Content-Type: multipart/alternative; boundary="${boundary}"
 


### PR DESCRIPTION
This was an ugly hack and should not have been there to begin with. However,
this does add a requirement that the AMI running jobs have a docker volume named
"local-disk"