### PR TITLE
Initial volume support

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -31,7 +31,6 @@
 package cromwell.backend.impl.aws
 
 import java.security.MessageDigest
-import java.util.UUID
 import software.amazon.awssdk.services.batch.BatchClient
 import software.amazon.awssdk.services.batch.model.
                                         {
@@ -179,7 +178,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
     """).stripMargin
   }
   def submitJob(): Try[SubmitJobResponse] = Try {
-    val taskId = UUID.randomUUID.toString.replace("-", "")
+    val taskId = jobDescriptor.key.call.fullyQualifiedName + "-" + jobDescriptor.key.index + "-" + jobDescriptor.key.attempt
     Log.info(s"""Submitting job to AWS Batch""")
     Log.info(s"""dockerImage: ${runtimeAttributes.dockerImage}""")
     Log.info(s"""jobQueueArn: ${runtimeAttributes.queueArn}""")

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -31,6 +31,7 @@
 package cromwell.backend.impl.aws
 
 import java.security.MessageDigest
+import java.util.UUID
 import software.amazon.awssdk.services.batch.BatchClient
 import software.amazon.awssdk.services.batch.model.
                                         {
@@ -178,11 +179,13 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
     """).stripMargin
   }
   def submitJob(): Try[SubmitJobResponse] = Try {
+    val taskId = UUID.randomUUID.toString.replace("-", "")
     Log.info(s"""Submitting job to AWS Batch""")
     Log.info(s"""dockerImage: ${runtimeAttributes.dockerImage}""")
     Log.info(s"""jobQueueArn: ${runtimeAttributes.queueArn}""")
     Log.info(s"""commandLine: $commandLine""")
     Log.info(s"""reconfiguredScript: $reconfiguredScript""")
+    Log.info(s"""taskId: $taskId""")
     // Log.info(s"""logFileName: $logFileName""")
 
     // runtimeAttributes
@@ -192,7 +195,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
 
     // Build the Job definition before we submit. Eventually this should be
     // done separately and cached.
-    val definitionArn = createDefinition(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}""")
+    val definitionArn = createDefinition(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}""", taskId)
 
     val job = client.submitJob(SubmitJobRequest.builder()
                 .jobName(sanitize(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}"""))
@@ -213,9 +216,9 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
    *  @return Arn for newly created job definition
    *
    */
-  private def createDefinition(name: String): String = {
+  private def createDefinition(name: String, taskId: String): String = {
     val jobDefinitionBuilder = StandardAwsBatchJobDefinitionBuilder
-    val jobDefinition = jobDefinitionBuilder.build(reconfiguredScript, runtimeAttributes, runtimeAttributes.dockerImage)
+    val jobDefinition = jobDefinitionBuilder.build(reconfiguredScript, runtimeAttributes, runtimeAttributes.dockerImage, taskId)
 
     // See:
     //

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -150,10 +150,11 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
   lazy val reconfiguredScript = {
     // We'll use the MD5 of the dockerRc so the boundary is "random" but consistent
     val boundary = MessageDigest.getInstance("MD5").digest(dockerRc.getBytes).map("%02x".format(_)).mkString
-    //TODO: Ugly hack due to lack of time. cromwell_root is not guaranteed in the container and I don't want to change the global cromwell script
-    """#!/bin/bash
-    |mkdir -p /cromwell_root
-    """.stripMargin + 
+
+    // NOTE: We are assuming the presence of a volume named "local-disk".
+    //       This requires a custom AMI with the volume defined. But, since
+    //       we need a custom AMI anyway for any real workflow, we just need
+    //       to make sure this requirement is documented.
     script.concat(s"""
     |echo "MIME-Version: 1.0
     |Content-Type: multipart/alternative; boundary="${boundary}"
@@ -191,10 +192,10 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor,           // W
 
     // Build the Job definition before we submit. Eventually this should be
     // done separately and cached.
-    val definitionArn = createDefinition(workflow.callable.name)
+    val definitionArn = createDefinition(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}""")
 
     val job = client.submitJob(SubmitJobRequest.builder()
-                .jobName(sanitize(workflow.callable.name))
+                .jobName(sanitize(s"""${workflow.callable.name}-${jobDescriptor.taskCall.callable.name}"""))
                 .parameters(parameters.collect({ case i: AwsBatchInput => i.toStringString }).toMap.asJava)
                 .jobQueue(runtimeAttributes.queueArn)
                 .jobDefinition(definitionArn).build)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -71,9 +71,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
     |mv /cromwell_root/hello-rc.txt.tmp /cromwell_root/hello-rc.txt"""
 
     val boundary = "d283898f11be0dee6f9ac01470450bee"
-    val expectedscript = """#!/bin/bash
-    |mkdir -p /cromwell_root
-    """.stripMargin + script.concat(s"""
+    val expectedscript = script.concat(s"""
     |echo "MIME-Version: 1.0
     |Content-Type: multipart/alternative; boundary="${boundary}"
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -190,7 +190,7 @@ class AwsBatchRuntimeAttributesSpec extends WordSpecLike with Matchers with Mock
     // TODO: This is working ok (appropriate error messages), though test is throwing due to message inconsistency
     // "fail to validate a valid disks array entry" in {
     //   val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "disks" -> WomArray(WomArrayType(WomStringType), Array(WomString("blah"), WomString("blah blah"))))
-    //   assertAwsBatchRuntimeAttributesFailedCreation(runtimeAttributes, "Disk strings should be of the format 'local-disk SIZE TYPE' or '/mount/point SIZE TYPE' but got 'blah blah'")
+    //   assertAwsBatchRuntimeAttributesFailedCreation(runtimeAttributes, "Disk strings should be of the format 'local-disk' or '/mount/point' but got 'blah blah'")
     // }
 
     "validate a valid memory entry" in {


### PR DESCRIPTION
This implements the remaining pieces necessary to mount volumes from the container host to the container. I am using a runtime attibutes disk format that looks like the following:

```disks: "local-disk, /mount/point, /other/mount/point"```

I add a random guid "task id" to the host directory to allow for multiple containers on the host instance. The task id is generated at run time to disambiguate this job from any other job, and is passed through to the container in the environment variable AWS_CROMWELL_TASK_ID) to allow for tracking at a later stage of the project.

The host mount scheme is designed in the following manner:

/mount/point/<taskid>

Contrary to the suggestion in issue #3744, the task id is added to the end. This is a conscious decision such that mounts that refer to external volumes can be setup such that the filesystems can properly match the type of container workloads that might be using them.

Note that when these mounts have files copied to S3, this should scheme should be reversed (e.g. <taskid>/mount/point to encourage proper spread and optimal S3 performance. This will be addressed when #3804 is implemented. 