### PR TITLE
Correct Mysql version in Persistent Server Doc

### DIFF
--- a/docs/tutorials/PersistentServer.md
+++ b/docs/tutorials/PersistentServer.md
@@ -13,12 +13,10 @@ Cromwell remembers everything it knows!
 
 ### Let's get started!
 
-- Pull the MySQL docker image from dockerhub:
-`docker pull mysql:5.5`
 - Start the MySQL docker container with the following line:
 
 ```bash
-docker run -p 3306:3306 --name NameOfTheContainer -e MYSQL_ROOT_PASSWORD=YourPassword -e MYSQL_DATABASE=DatabaseName -e MYSQL_USER=ChooseAName -e MYSQL_PASSWORD=YourOtherPassword -d mysql/mysql-server:latest
+docker run -p 3306:3306 --name NameOfTheContainer -e MYSQL_ROOT_PASSWORD=YourPassword -e MYSQL_DATABASE=DatabaseName -e MYSQL_USER=ChooseAName -e MYSQL_PASSWORD=YourOtherPassword -d mysql/mysql-server:5.5
 ```
 
 - Update your `application.conf` file.


### PR DESCRIPTION
pointing to version `latest` doesn't work, fixing to `5.5` does