### PR TITLE
Make find ' ' in filename safe

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -351,7 +351,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |(
         |# add a .file in every empty directory to facilitate directory delocalization on the cloud
         |cd $cwd
-        |find . -type d -empty -print0 | xargs --null -I % touch %/.file
+        |find . -type d -empty -print0 | xargs -0 -I % touch %/.file
         |)
         |(
         |cd $cwd

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -351,7 +351,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         |(
         |# add a .file in every empty directory to facilitate directory delocalization on the cloud
         |cd $cwd
-        |find . -type d -empty -print | xargs -I % touch %/.file
+        |find . -type d -empty -print0 | xargs --null -I % touch %/.file
         |)
         |(
         |cd $cwd


### PR DESCRIPTION
I cannot test this change as I do not have the build environment set up. Is is intentional that this 'cloud' feature is inherited by the SGE backend? I am fixing an issue caused by a feature I do not need. I wonder if it could be placed in the epilogue for user configurations. Isn't that the purpose of epilogue and configuration?