### PR TITLE
Changed repo url so that Edit on Github link on docs works correctly

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: http://www.software.broadinstitute.org/WDL
 site_description: Cromwell documentation
 site_author: Red Team at Broad Institute
 
-repo_url: https://github.com/broadinstitute/cromwell/tree/develop/docs
+repo_url: https://github.com/broadinstitute/cromwell/
 
 pages:
 - Introduction: index.md


### PR DESCRIPTION
Fixed the "Edit on Github" link on the documentation pages so now it directs to the Cromwell Github repo.