### PR TITLE
Changes to Requester Pays retries

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchCommandContext.scala
+++ b/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchCommandContext.scala
@@ -95,7 +95,7 @@ final case class GcsBatchCommandContext[T, U](request: GcsBatchIoCommand[T, U],
     * On failure callback. Fail the promise with a StorageException
     */
   private def onFailureCallback(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders) = {
-    if (isProjectNotProvidedError(googleJsonError)) {
+    if (retryWithBillingProject(googleJsonError)) {
       // Returning an Either.Right here means that the operation is not complete and that we need to do another request
       handleSuccessOrNextRequest(Right(request.withUserProject))
     } else {

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/RequesterPaysErrors.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/RequesterPaysErrors.scala
@@ -9,6 +9,12 @@ object RequesterPaysErrors {
   val DoesNotHaveServiceUsePermissionErrorCode = 403
   val DoesNotHaveServiceUsePermissionErrorMessage = "does not have serviceusage.services.use"
 
+  def retryWithBillingProject(storageException: StorageException) = isProjectNotProvidedError || isServiceUsageNotProvided
+
+  def retryWithBillingProject(googleJsonError: GoogleJsonError) = isProjectNotProvidedError || isServiceUsageNotProvided
+
+  def retryWithBillingProject(googleJsonError: GoogleJsonResponseException) = isProjectNotProvidedError || isServiceUsageNotProvided
+
   def isProjectNotProvidedError(storageException: StorageException) = 
     storageException.getCode == BucketIsRequesterPaysErrorCode &&
     storageException.getMessage == BucketIsRequesterPaysErrorMessage
@@ -20,4 +26,16 @@ object RequesterPaysErrors {
   def isProjectNotProvidedError(googleJsonError: GoogleJsonResponseException) =
     googleJsonError.getStatusCode == BucketIsRequesterPaysErrorCode &&
       googleJsonError.getContent == BucketIsRequesterPaysErrorMessage
+
+  def isServiceUsageNotProvided(storageException: StorageException) =
+    storageException.getCode == DoesNotHaveServiceUsePermissionErrorCode &&
+      storageException.getMessage == DoesNotHaveServiceUsePermissionErrorMessage
+
+  def isServiceUsageNotProvided(googleJsonError: GoogleJsonError) =
+    googleJsonError.getCode == DoesNotHaveServiceUsePermissionErrorCode &&
+      googleJsonError.getMessage == DoesNotHaveServiceUsePermissionErrorMessage
+
+  def isServiceUsageNotProvided(googleJsonError: GoogleJsonResponseException) =
+    googleJsonError.getStatusCode == DoesNotHaveServiceUsePermissionErrorCode &&
+      googleJsonError.getContent == DoesNotHaveServiceUsePermissionErrorMessage
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -81,7 +81,7 @@ trait Delocalization {
          * We can't use the gsutil -I flag here because it would lose the directory structure once it gets copied to the bucket
          * sh -c 'gsutil cp % $(echo % | sed -e "s/^\///")'
          */
-        s""" | xargs -I % sh -c '${recoverRequesterPaysError(cloudCallRoot)(gsutilCommand)}'"""
+        s""" | xargs -I % sh -c '${retryFailedCopyErrorWithProjectFlag(cloudCallRoot)(gsutilCommand)}'"""
     
     ActionBuilder.cloudSdkShellAction(command)(mounts)
   }

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
@@ -14,7 +14,7 @@ class ActionCommandsSpec extends FlatSpec with Matchers with Mockito {
   
   it should "inject project flag when request fails because of requester pays" in {
     val path = GcsPath(any[Path], any[com.google.api.services.storage.Storage], any[com.google.cloud.storage.Storage], "my-project")
-    val recovered = recoverRequesterPaysError(path) { flag =>
+    val recovered = retryFailedCopyErrorWithProjectFlag(path) { flag =>
       s"flag is $flag"
     }
     


### PR DESCRIPTION
- The engine now retries both of the known Requester pays errors
- The backend (localization/delocalization logic) retries copy failures (no matter what the error) with a project flag. 