### PR TITLE
Thou shalt not mapValues.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -126,12 +126,12 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   def preProcessWomFile(womFile: WomFile): WomFile = womFile
   
   /** @see [[Command.instantiate]] */
-  final lazy val commandLinePreProcessor: WomEvaluatedCallInputs => Try[WomEvaluatedCallInputs] = {
-    inputs =>
-      TryUtil.sequenceMap(inputs mapValues WomFileMapper.mapWomFiles(preProcessWomFile, inputsToNotLocalize)).
-        recoverWith {
-          case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)
-        }
+  final def commandLinePreProcessor(inputs: WomEvaluatedCallInputs): Try[WomEvaluatedCallInputs] = {
+    val map = inputs map { case (k, v) => k -> WomFileMapper.mapWomFiles(preProcessWomFile, inputsToNotLocalize)(v) }
+    TryUtil.sequenceMap(map).
+      recoverWith {
+        case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)
+      }
   }
   
   final lazy val localizedInputs: Try[WomEvaluatedCallInputs] = commandLinePreProcessor(jobDescriptor.evaluatedTaskInputs)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -210,7 +210,7 @@ trait SharedFileSystem extends PathFactory {
     * @param womFile WomFile to localize
     * @return localized WomFile
     */
-  private def localizeWomFile(toDestPath: (WomFile => String => Try[PairOfFiles]), strategies: Stream[DuplicationStrategy], docker: Boolean)
+  private def localizeWomFile(toDestPath: WomFile => String => Try[PairOfFiles], strategies: Stream[DuplicationStrategy], docker: Boolean)
                              (womFile: WomFile): WomFile = {
     val localized = womFile mapWomFile { file =>
       val result = toDestPath(file)(file.value) flatMap {


### PR DESCRIPTION
Remove use of mapValues to prevent files from being unnecessarily localized three times.