### PR TITLE
Initial code for integration with cromwell agent

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -134,7 +134,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
                                   instantiatedCommand.commandString,
                                   script.toString,
                                   rcPath.toString, executionStdout, executionStderr,
-                                  Seq.empty[AwsBatchParameter])
+                                  jobPaths.callExecutionRoot, Seq.empty[AwsBatchParameter])
   }
   /* Tries to abort the job in flight
    *

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -31,6 +31,7 @@
 
 package cromwell.backend.impl.aws
 
+import cromwell.core.path.DefaultPathBuilder
 import cromwell.core.TestKitSuite
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.specs2.mock.Mockito
@@ -95,7 +96,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
     |exit $$(cat /cromwell_root/hello-rc.txt)
     """).stripMargin
     val job = AwsBatchJob(null, null, "commandLine", script,
-      "/cromwell_root/hello-rc.txt", "/cromwell_root/hello-stdout.log", "/cromwell_root/hello-stderr.log", Seq.empty[AwsBatchParameter])
+      "/cromwell_root/hello-rc.txt", "/cromwell_root/hello-stdout.log", "/cromwell_root/hello-stderr.log", DefaultPathBuilder.get("/"), Seq.empty[AwsBatchParameter])
 
     job.reconfiguredScript should be(expectedscript)
   }


### PR DESCRIPTION
This is a partial implementation of #3804. It incorporates the remaining changes in the Cromwell code base I believe are necessary to allow the docker containers to communicate with S3 (via the Cromwell agent in development).

Note that this PR and #3914 might cause a merge conflict on AwsBatchJob.scala. Either PR should merge fine with develop branch, but once one is merged the other might show a conflict. If this is the case I'm happy to rebase the change after one of the two PRs is merged.