### PR TITLE
Bug Fix: Response error codes in releaseHold endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cromwell Change Log
 
+## 35 Release Notes
+
+### Bug Fixes
+
+The `releaseHold` endpoint will now return `404 Not Found` for an unrecognized workflow ID and `400 Bad Request` for a malformed or invalid workflow ID.
+
 ## 34 Release Notes
 
 ### Query API

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -250,6 +250,7 @@ trait CromwellApiService extends HttpInstrumentation {
           case Success(WorkflowStoreEngineActor.WorkflowOnHoldToSubmittedFailure(_, e: NotInOnHoldStateException)) => e.errorRequest(StatusCodes.Forbidden)
           case Success(WorkflowStoreEngineActor.WorkflowOnHoldToSubmittedFailure(_, e)) => e.errorRequest(StatusCodes.InternalServerError)
           case Success(r: WorkflowStoreEngineActor.WorkflowOnHoldToSubmittedSuccess) => completeResponse(StatusCodes.OK, toResponse(r.workflowId, WorkflowSubmitted), Seq.empty)
+          case Failure(e: UnrecognizedWorkflowException) => e.failRequest(StatusCodes.NotFound)
           case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
         }
       }

--- a/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/CromwellApiService.scala
@@ -251,6 +251,7 @@ trait CromwellApiService extends HttpInstrumentation {
           case Success(WorkflowStoreEngineActor.WorkflowOnHoldToSubmittedFailure(_, e)) => e.errorRequest(StatusCodes.InternalServerError)
           case Success(r: WorkflowStoreEngineActor.WorkflowOnHoldToSubmittedSuccess) => completeResponse(StatusCodes.OK, toResponse(r.workflowId, WorkflowSubmitted), Seq.empty)
           case Failure(e: UnrecognizedWorkflowException) => e.failRequest(StatusCodes.NotFound)
+          case Failure(e: InvalidWorkflowException) => e.failRequest(StatusCodes.BadRequest)
           case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
         }
       }

--- a/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/CromwellApiServiceSpec.scala
@@ -240,19 +240,19 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
       }
   }
 
-  it should "return 500 when invalid workflow id is submitted to onHoldToSubmitted API end point" in {
+  it should "return 404 when invalid workflow id is submitted to onHoldToSubmitted API end point" in {
     val id = UnrecognizedWorkflowId
     Post(s"/workflows/$version/$id/releaseHold") ~>
       akkaHttpService.workflowRoutes ~>
       check {
         assertResult(
           s"""{
-             |  "status": "error",
+             |  "status": "fail",
              |  "message": "Unrecognized workflow ID: ${CromwellApiServiceSpec.UnrecognizedWorkflowId.toString}"
              |}""".stripMargin) {
           responseAs[String].parseJson.prettyPrint
         }
-        assertResult(StatusCodes.InternalServerError) {
+        assertResult(StatusCodes.NotFound) {
           status
         }
         headers should be(Seq.empty)


### PR DESCRIPTION
This fixes the response error codes. It will now return `404 Not Found` for an unrecognized workflow ID and `400 Bad Request` for a malformed or invalid workflow ID.