### PR TITLE
 Disallow array autoboxing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Bug Fixes
 
-The `releaseHold` endpoint will now return `404 Not Found` for an unrecognized workflow ID and `400 Bad Request` for a malformed or invalid workflow ID.
+#### API
+- The `releaseHold` endpoint will now return `404 Not Found` for an unrecognized workflow ID and `400 Bad Request` for a malformed or invalid workflow ID.
+
+#### Languages
+
+- Fixed a bug that allowed values to be "auto-boxed" into a single-element `Array` of that type, which is not allowed in the WDL spec (Closes [#3478](https://github.com/broadinstitute/cromwell/issues/3478)). 
 
 ## 34 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/single_to_array_conversion.test
+++ b/centaur/src/main/resources/standardTestCases/single_to_array_conversion.test
@@ -1,9 +1,9 @@
 # Tests that we can pass a single element in to an array as an input
-name: single_to_array_coercion
+name: single_to_array_conversion
 testFormat: workflowsuccess
 
 files {
-  workflow: single_to_array_coercion/single_to_array_coercion.wdl
+  workflow: single_to_array_conversion/single_to_array_conversion.wdl
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/single_to_array_conversion/single_to_array_conversion.wdl
+++ b/centaur/src/main/resources/standardTestCases/single_to_array_conversion/single_to_array_conversion.wdl
@@ -21,5 +21,5 @@ task listFiles {
 
 workflow oneToMany {
   call singleFile
-  call listFiles { input: manyIn = singleFile.out }
+  call listFiles { input: manyIn = [ singleFile.out ] }
 }

--- a/wom/src/main/scala/wom/types/WomArrayType.scala
+++ b/wom/src/main/scala/wom/types/WomArrayType.scala
@@ -41,11 +41,6 @@ sealed trait WomArrayType extends WomType {
     case womArray: WomArray if (allowEmpty || womArray.nonEmpty) && memberType.isCoerceableFrom(womArray.womType.memberType) =>
       womArray.map(v => memberType.coerceRawValue(v).get) // .get because isCoerceableFrom should make it safe
     case WomArrayLike(womArray) if this.isCoerceableFrom(womArray.womType) => coercion.apply(womArray)
-    case womValue: WomValue if memberType.isCoerceableFrom(womValue.womType) =>
-      memberType.coerceRawValue(womValue) match {
-        case Success(coercedValue) => WomArray(this, Seq(coercedValue))
-        case Failure(ex) => throw ex
-      }
   }
 
   override def typeSpecificIsCoerceableFrom(otherType: WomType): Boolean = otherType match {

--- a/wom/src/test/scala/wom/types/WomArrayTypeSpec.scala
+++ b/wom/src/test/scala/wom/types/WomArrayTypeSpec.scala
@@ -56,10 +56,10 @@ class WomArrayTypeSpec extends FlatSpec with Matchers  {
       case Failure(f) => fail(s"exception while coercing Java List: $f")
     }
   }
-  it should "coerce single values into one-element arrays" in {
+  it should "not coerce single values into one-element arrays" in {
     WomArrayType(WomStringType).coerceRawValue(WomString("edamame is tasty")) match {
-      case Success(array) => array shouldEqual WomArray(WomArrayType(WomStringType), Seq(WomString("edamame is tasty")))
-      case Failure(f) => fail("exception coercing single value to array", f)
+      case Success(_) => fail("Unexpected success coercing single value to array")
+      case Failure(f) => f.getMessage shouldEqual "No coercion defined from wom value(s) '\"edamame is tasty\"' of type 'String' to 'Array[String]'."
     }
   }
   it should "stringify its type" in {

--- a/womtool/src/test/resources/validate/wdl_draft2/invalid/array_autoboxing/array_autoboxing.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft2/invalid/array_autoboxing/array_autoboxing.wdl
@@ -1,0 +1,9 @@
+workflow bad_autobox {
+  Int i = 5
+
+  # Bad autobox!
+  Array[Int] bad_is = i
+
+  # Good manual-box!
+  Array[Int] good_is = [ i ]
+}

--- a/womtool/src/test/resources/validate/wdl_draft2/invalid/array_autoboxing/error.txt
+++ b/womtool/src/test/resources/validate/wdl_draft2/invalid/array_autoboxing/error.txt
@@ -1,0 +1,4 @@
+ERROR: bad_is is declared as a Array[Int] but the expression evaluates to a Int:
+
+  Array[Int] bad_is = i
+             ^

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing/array_autoboxing.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing/array_autoboxing.wdl
@@ -1,0 +1,11 @@
+version 1.0
+
+workflow bad_autobox {
+  Int i = 5
+
+  # Bad autobox!
+  Array[Int] bad_is = i
+
+  # Good manual-box!
+  Array[Int] good_is = [ i ]
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing/error.txt
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing/error.txt
@@ -1,0 +1,1 @@
+Failed to process workflow definition 'bad_autobox' (reason 1 of 1): Failed to process declaration 'Array[Int] bad_is = i' (reason 1 of 1): Cannot coerce expression of type 'Int' to 'Array[Int]'


### PR DESCRIPTION
Closes #3478 

Best explained by the new test case:

```wdl
workflow bad_autobox {
  Int i = 5

  # Bad autobox!
  Array[Int] bad_is = i

  # Good manual-box!
  Array[Int] good_is = [ i ]
}

```