### PR TITLE
Dos Script: Martha url can be passed as environment variable

### DIFF
--- a/scripts/docker-dos/dosUrlLocalizer.sc
+++ b/scripts/docker-dos/dosUrlLocalizer.sc
@@ -82,7 +82,6 @@ def resolveDosThroughMartha(dosUrl: String, marthaUrl: Uri) : Try[MarthaResponse
 
   val marthaResponseIo: IO[MarthaResponse] = for {
     httpClient <- Http1Client[IO]()
-    //request to fake Martha
     postRequest <- Request[IO](
       method = Method.POST,
       uri = marthaUrl,

--- a/scripts/docker-dos/dosUrlLocalizer.sc
+++ b/scripts/docker-dos/dosUrlLocalizer.sc
@@ -77,15 +77,17 @@ def dosUrlResolver(dosUrl: String, downloadLoc: String) : Unit = {
 def resolveDosThroughMartha(dosUrl: String, marthaUrl: Uri) : Try[MarthaResponse] = {
   import MarthaResponseJsonSupport._
 
-  val userAccessToken = sys.env("USER_ACCESS_TOKEN")
   val requestBody = json"""{"url":$dosUrl}"""
+
+  val credentials = GoogleCredentials.getApplicationDefault()
+  val accessToken = credentials.refreshAccessToken().getTokenValue()
 
   val marthaResponseIo: IO[MarthaResponse] = for {
     httpClient <- Http1Client[IO]()
     postRequest <- Request[IO](method = Method.POST,
-      uri = marthaUrl,
-      headers = Headers(Header("Authorization", s"bearer $userAccessToken")))
-      .withBody(requestBody)
+                               uri = marthaUrl,
+                               headers = Headers(Header("Authorization", s"bearer $accessToken")))
+                              .withBody(requestBody)
     httpResponse <- httpClient.expect[String](postRequest)
     marthaResObj = httpResponse.parseJson.convertTo[MarthaResponse]
   } yield marthaResObj


### PR DESCRIPTION
This PR will allow Martha's url to be passed as an environment variable during `docker run`. The variable can be set as `--env MARTHA_URL=<url>`.