### PR TITLE
Cromwell agent

### DIFF
--- a/supportedBackends/aws/src/main/resources/agent/Dockerfile
+++ b/supportedBackends/aws/src/main/resources/agent/Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+#  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+FROM golang:1.10.3-alpine
+
+WORKDIR /go/src/spawnoninput
+
+COPY spawnoninput.go .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -v .
+
+FROM docker:latest
+
+WORKDIR /root/
+
+COPY --from=0 /go/src/spawnoninput/spawnoninput .
+
+RUN apk --no-cache add curl grep jq coreutils
+
+COPY monitor .
+
+COPY launch_sidecar .
+
+CMD ["/root/monitor", "/root/spawnoninput"]

--- a/supportedBackends/aws/src/main/resources/agent/build-agent
+++ b/supportedBackends/aws/src/main/resources/agent/build-agent
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Copyright 2018 Amazon.com, Inc. or its affiliates.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+#  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+docker build -t batch-cromwell-agent:latest .

--- a/supportedBackends/aws/src/main/resources/agent/launch_sidecar
+++ b/supportedBackends/aws/src/main/resources/agent/launch_sidecar
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Copyright 2018 Amazon.com, Inc. or its affiliates.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+#  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+environmentVariable() {
+  query=".[0].Config.Env[] | select(startswith(\"${1}\"))"
+  echo "$containerInfo" |jq -r "$query" | cut -d= -f2
+}
+
+# $1 is passed in by spawnoninput, which originally will come from a single
+# line from the docker event stream (endpoint /events)
+line=$1
+
+# These commands are for "start", "create", "attach"
+# While jq is functionally preferred, cut should be slightly faster. We're
+# somewhat against the clock here as the container is going to do some work
+dockerid=$(echo "$line" | cut -d: -f3 | cut -d\" -f2)
+# If we need jq, this is the command: dockerid=$(echo "$1" | jq -r '.id')
+echo 'pausing id: ' "$dockerid"
+docker pause "$dockerid"
+# Docker pause can happen based on the "create" event from docker
+#
+# The infrastructure around this seems to take between 10 and 20ms in my tests.
+# This is likely due to the processing time needed for jq to parse the json.
+#
+# It is possible, though unlikely, that some dependent work starts happening
+# within that time. If so, we may need a sleep 0.02 in the script preamble
+# to accomodate this scenario and/or find something more performant than jq.
+# Because of this, we are using cut above rather than jq, which should be slightly faster
+containerInfo=$(docker inspect "$dockerid")
+
+if [ -z "$(environmentVariable "AWS_CRMWLL_PROCESS_MONITOR_MARKER")" ]; then
+ echo "Container does not match target profile, exiting"
+ docker unpause "$dockerid"
+ exit 0
+fi
+
+dockerRootedRcFile=$(environmentVariable "AWS_CROMWELL_RC_FILE")
+cromwellPath=$(environmentVariable "AWS_CROMWELL_PATH")
+localdisk=$(environmentVariable "AWS_CROMWELL_LOCAL_DISK")
+callRoot=$(environmentVariable "AWS_CROMWELL_CALL_ROOT")
+# Container credentials may be empty. The others should be there
+containerCredentials=$(environmentVariable "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+if [ ! -z "$containerCredentials" ]; then
+  containerCredentials="-e AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=${containerCredentials}"
+fi
+removeContainer="--rm"
+containerDebugLevel=""
+if [ ! -z "$AWS_CROMWELL_AGENT_DEBUG_LEVEL" ]; then
+  removeContainer=""
+  containerDebugLevel="-e AWS_CROMWELL_AGENT_DEBUG_LEVEL=${AWS_CROMWELL_AGENT_DEBUG_LEVEL}"
+fi
+# Copy inputs from S3 into place
+echo "RC File location (inside container):" "$dockerRootedRcFile"
+echo "Call Root:" "$callRoot"
+echo "Local disk:" "$localdisk"
+echo "Cromwell path:" "$cromwellPath"
+
+set -x
+docker run -d \
+  $removeContainer \
+  --volumes-from "$dockerid" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -e AWS_CROMWELL_TASK_DOCKER_ID="$dockerid" \
+  -e AWS_CROMWELL_RC_FILE="$dockerRootedRcFile" \
+  -e AWS_CROMWELL_PATH="$cromwellPath" \
+  -e AWS_CROMWELL_LOCAL_DISK="$localdisk" \
+  -e AWS_CROMWELL_CALL_ROOT="$callRoot" \
+  -e AWS_CROMWELL_WORKFLOW_ROOT="$(environmentVariable "AWS_CROMWELL_WORKFLOW_ROOT")" \
+  $containerCredentials \
+  $containerDebugLevel \
+  --name sidecar-"$dockerid" \
+  batch-cromwell-sidecar:latest
+rc=$?
+set +x
+
+echo "Return from docker: $rc"

--- a/supportedBackends/aws/src/main/resources/agent/monitor
+++ b/supportedBackends/aws/src/main/resources/agent/monitor
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Copyright 2018 Amazon.com, Inc. or its affiliates.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+#  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+curl -s       \
+  --no-buffer \
+  -XGET       \
+  --unix-socket /var/run/docker.sock http://localhost/events | \
+  grep create --line-buffered | \
+  /root/spawnoninput /root/launch_sidecar

--- a/supportedBackends/aws/src/main/resources/agent/run-agent
+++ b/supportedBackends/aws/src/main/resources/agent/run-agent
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright 2018 Amazon.com, Inc. or its affiliates.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#  this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright
+#  notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its
+#  contributors may be used to endorse or promote products derived from
+#  this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+#  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+#  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+#  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+#  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+#  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+#  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+env=""
+if [ ! -z "$AWS_CROMWELL_AGENT_DEBUG_LEVEL" ]; then
+  env="-e AWS_CROMWELL_AGENT_DEBUG_LEVEL=${AWS_CROMWELL_AGENT_DEBUG_LEVEL}"
+fi
+docker run -d \
+  -v=/var/run/docker.sock:/var/run/docker.sock \
+  $env \
+  --name=cromwell-agent batch-cromwell-agent:latest

--- a/supportedBackends/aws/src/main/resources/agent/spawnoninput.go
+++ b/supportedBackends/aws/src/main/resources/agent/spawnoninput.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ *  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ *  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ *  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package main
+
+import (
+        "bufio"
+        "fmt"
+        "os"
+        "os/exec"
+)
+
+// spawnoninput will spawn a new command every time new input is detected
+// it operates on stdin. It is useful with grep --line-buffered to spawn
+// on specific strings in the inbound stream. The actual line of input
+// on stdin will be sent in as the last argument to the process, so
+// "spawnoninput my_snazzy_program -vv -q -l -a" will result in the arguments
+// -vv, -q, -l, -a, <single line from stdin>" being sent to the program
+func main() {
+        cmdName := os.Args[1]
+        cmdArgs := os.Args[2:]
+
+        reader := bufio.NewReaderSize(os.Stdin, 80)
+        scanner := bufio.NewScanner(reader)
+        for scanner.Scan() {
+                execute(cmdName, cmdArgs, scanner.Text())
+        }
+        if err := scanner.Err(); err != nil {
+                fmt.Fprintln(os.Stderr, "error reading stdin: ", err)
+        }
+}
+
+func execute(cmdName string, cmdArgs []string, line string) {
+        argsWithLine := append(cmdArgs, line)
+        cmd := exec.Command(cmdName, argsWithLine...)
+        cmdOut, err := cmd.Output()
+        if err != nil {
+                fmt.Fprintln(os.Stderr, "error running command: ", err)
+        }
+        fmt.Println(string(cmdOut))
+}


### PR DESCRIPTION
This implements the cromwell agent (process that monitors docker for Cromwell tasks) as part of #3804. I will include the sidecar process later as a separate PR. After building the agent and running the agent with the build-agent/run-agent scripts, a "cromwell-agent" container will be shown in docker ps. This agent will be reading the docker event stream from /events, filter for starts with grep, and pass any start events to the small go program "spawnoninput".

This program simply spawns a new process when it sees input. In this case, the process is a shell script that pauses the container, checks to see if it matches the target condition, then either resumes/exits (when not meeting the target condition) or leaves the container paused and launches a sidecar, which is still in development.

If the target condition does not match, this has an effect of slowing startup for the launched container of approximately 100ms for the inspection process. This image should ideally be under the Broad's account on Dockerhub or ECR - it's based on alpine Linux and is relatively small. It should also be run automatically in the AWS Batch/Cromwell AMI.

More documentation will be forthcoming in a later PR, though some inline comments are in the code here.