### PR TITLE
A strict version of `mapValues` that avoids the nasty surprises of the original.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendWorkflowInitializationActor.scala
@@ -6,6 +6,7 @@ import cats.data.Validated.{Invalid, Valid, _}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.instances.list._
 import cats.syntax.traverse._
+import common.collections.EnhancedCollections._
 import common.validation.Validation._
 import cromwell.backend.BackendLifecycleActor._
 import cromwell.backend.BackendWorkflowInitializationActor._
@@ -77,7 +78,7 @@ object BackendWorkflowInitializationActor {
                                  ): ValidatedNel[RuntimeAttributeValidationFailure, Unit] = {
 
       //This map append will overwrite default key/values with runtime settings upon key collisions
-      val lookups = defaultRuntimeAttributes.mapValues(_.asWomExpression) ++ runtimeAttributes
+      val lookups = defaultRuntimeAttributes.safeMapValues(_.asWomExpression) ++ runtimeAttributes
 
       runtimeAttributeValidators.toList.traverse{
         case (attributeName, validator) =>

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
@@ -4,6 +4,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, Validated}
 import cats.syntax.validated._
 import com.typesafe.config.Config
+import common.collections.EnhancedCollections._
 import common.validation.ErrorOr._
 import cromwell.backend.RuntimeAttributeDefinition
 import eu.timepit.refined.api.Refined
@@ -134,7 +135,7 @@ object RuntimeAttributesValidation {
     * @return The keys and extracted values.
     */
   def toMetadataStrings(validatedRuntimeAttributes: ValidatedRuntimeAttributes): Map[String, String] = {
-    val attributeOptions: Map[String, Option[Any]] = validatedRuntimeAttributes.attributes.mapValues(unpackOption)
+    val attributeOptions: Map[String, Option[Any]] = validatedRuntimeAttributes.attributes.safeMapValues(unpackOption)
 
     val attributes: Map[String, String] = attributeOptions collect {
       case (name, Some(values: Traversable[_])) => (name, values.mkString(","))

--- a/centaur/src/main/scala/centaur/test/metadata/WorkflowMetadata.scala
+++ b/centaur/src/main/scala/centaur/test/metadata/WorkflowMetadata.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import cats.data.Validated._
 import com.typesafe.config.Config
+import common.collections.EnhancedCollections._
 import configs.syntax._
 import spray.json._
 import centaur.json.JsonUtils.EnhancedJsValue
@@ -63,7 +64,7 @@ case class WorkflowMetadata(value: Map[String, JsValue]) extends AnyVal {
 object WorkflowMetadata {
   def fromConfig(config: Config): ErrorOr[WorkflowMetadata] = {
     config.extract[Map[String, Option[String]]] match {
-      case Result.Success(m) => Valid(WorkflowMetadata(m mapValues { _.map(JsString.apply).getOrElse(JsNull) }))
+      case Result.Success(m) => Valid(WorkflowMetadata(m safeMapValues { _.map(JsString.apply).getOrElse(JsNull) }))
       case Result.Failure(_) => invalidNel(s"Metadata block can not be converted to a Map: $config")
     }
   }

--- a/common/src/main/scala/common/collections/EnhancedCollections.scala
+++ b/common/src/main/scala/common/collections/EnhancedCollections.scala
@@ -3,7 +3,7 @@ package common.collections
 import scala.annotation.tailrec
 import scala.collection.TraversableLike
 import scala.collection.generic.CanBuildFrom
-import scala.collection.immutable.Queue
+import scala.collection.immutable.{MapLike, Queue}
 import scala.reflect.ClassTag
 
 object EnhancedCollections {
@@ -91,5 +91,13 @@ object EnhancedCollections {
         DeQueued(head, tail)
       }
     }
+  }
+
+  implicit class EnhancedMapLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]](val mapLike: MapLike[A, B, This]) {
+    /**
+      * 'safe' in that unlike the implementation hiding behind `MapLike#mapValues` this is strict. i.e. this will only
+      * evaluate the supplied function once on each value and at the time this method is called.
+      */
+    def safeMapValues[C](f: B => C): Map[A, C] = mapLike map { case (k, v) => k -> f(v) }
   }
 }

--- a/common/src/main/scala/common/util/TryUtil.scala
+++ b/common/src/main/scala/common/util/TryUtil.scala
@@ -3,6 +3,7 @@ package common.util
 import java.io.{PrintWriter, StringWriter}
 
 import common.exception.AggregatedException
+import common.collections.EnhancedCollections._
 
 import scala.util.{Failure, Success, Try}
 
@@ -42,7 +43,7 @@ object TryUtil {
   }
 
   def sequenceMap[T, U](tries: Map[T, Try[U]], prefixErrorMessage: String = ""): Try[Map[T, U]] = {
-    def unbox = tries mapValues { _.get }
+    def unbox = tries safeMapValues { _.get }
     sequenceIterable(tries.values, unbox _, prefixErrorMessage)
   }
 

--- a/cwl/src/main/scala/cwl/ExpressionEvaluator.scala
+++ b/cwl/src/main/scala/cwl/ExpressionEvaluator.scala
@@ -67,11 +67,11 @@ object ExpressionEvaluator {
     } else {
       parameterContext.expressionLib.mkString("", ";", s";$expr")
     }
-    val (rawValues, mapValues) = paramValues(parameterContext)
+    val (rawVals, mapVals) = paramValues(parameterContext)
     EcmaScriptUtil.evalStructish(
       script,
-      rawValues,
-      mapValues,
+      rawVals,
+      mapVals,
       new EcmaScriptEncoder(parameterContext.ioFunctionSet),
       cwlJsDecoder
     )

--- a/cwl/src/main/scala/cwl/internal/EcmaScriptUtil.scala
+++ b/cwl/src/main/scala/cwl/internal/EcmaScriptUtil.scala
@@ -1,5 +1,6 @@
 package cwl.internal
 
+import common.collections.EnhancedCollections._
 import common.validation.ErrorOr._
 import common.validation.Validation._
 import org.mozilla.javascript._
@@ -103,7 +104,7 @@ object EcmaScriptUtil {
       val field = writeValue(jsValue)(context, scope)
       ScriptableObject.putProperty(scope, key, field)
 
-      val jsMap = mapValues.mapValues{ _.mapValues(encoder.encode) }
+      val jsMap = mapValues.safeMapValues{ _.safeMapValues(encoder.encode) }
 
       jsMap foreach {
         case (scopeId, nestedMap) =>

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.stores
 
 import common.collections.Table
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import cromwell.core.ExecutionStatus._
@@ -134,7 +135,7 @@ final case class SealedExecutionStore private[stores](private val statusStore: M
   */
 sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, ExecutionStatus], val needsUpdate: Boolean) {
   // View of the statusStore more suited for lookup based on status
-  lazy val store: Map[ExecutionStatus, List[JobKey]] = statusStore.groupBy(_._2).mapValues(_.keys.toList)
+  lazy val store: Map[ExecutionStatus, List[JobKey]] = statusStore.groupBy(_._2).safeMapValues(_.keys.toList)
   lazy val queuedJobsAboveThreshold = queuedJobs > MaxJobsToStartPerTick
 
   def keyForNode(node: GraphNode): Option[JobKey] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/WorkflowFinalizationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/WorkflowFinalizationActor.scala
@@ -5,6 +5,7 @@ import akka.actor.{ActorRef, FSM, OneForOneStrategy, Props}
 import common.exception.AggregatedMessageException
 import cromwell.backend.BackendWorkflowFinalizationActor.{FinalizationFailed, FinalizationSuccess, Finalize}
 import cromwell.backend._
+import common.collections.EnhancedCollections._
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.{CallOutputs, WorkflowId}
 import cromwell.engine.EngineWorkflowDescriptor
@@ -77,7 +78,7 @@ case class WorkflowFinalizationActor(workflowIdForLogging: WorkflowId,
     case Event(StartFinalizationCommand, _) =>
       val backendFinalizationActors = Try {
         for {
-          (backend, calls) <- workflowDescriptor.backendAssignments.groupBy(_._2).mapValues(_.keySet)
+          (backend, calls) <- workflowDescriptor.backendAssignments.groupBy(_._2).safeMapValues(_.keySet)
           props <- CromwellBackends.backendLifecycleFactoryActorByName(backend).map(
             _.workflowFinalizationActorProps(workflowDescriptor.backendDescriptor, ioActor, calls, filterJobExecutionsForBackend(calls), workflowOutputs, initializationData.get(backend))
           ).valueOr(errors => throw AggregatedMessageException("Cannot validate backend factories", errors.toList))

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/initialization/WorkflowInitializationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/initialization/WorkflowInitializationActor.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.initialization
 
 import akka.actor.{ActorRef, FSM, Props}
+import common.collections.EnhancedCollections._
 import common.exception.AggregatedMessageException
 import cromwell.backend.BackendLifecycleActor.BackendActorAbortedResponse
 import cromwell.backend.BackendWorkflowInitializationActor._
@@ -85,7 +86,7 @@ case class WorkflowInitializationActor(workflowIdForLogging: WorkflowId,
     case Event(StartInitializationCommand, _) =>
       val backendInitializationActors = Try {
         for {
-          (backend, calls) <- workflowDescriptor.backendAssignments.groupBy(_._2).mapValues(_.keySet)
+          (backend, calls) <- workflowDescriptor.backendAssignments.groupBy(_._2).safeMapValues(_.keySet)
           props <- CromwellBackends.backendLifecycleFactoryActorByName(backend).map(factory =>
             factory.workflowInitializationActorProps(workflowDescriptor.backendDescriptor, ioActor, calls, serviceRegistryActor, restarting)
           ).valueOr(errors => throw AggregatedMessageException("Cannot validate backend factories", errors.toList))

--- a/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
@@ -1,6 +1,7 @@
 package cromwell.webservice
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import common.collections.EnhancedCollections._
 import cromwell.core._
 import cromwell.core.labels.Labels
 import cromwell.services.metadata.MetadataEvent
@@ -26,7 +27,7 @@ object LabelsManagerActor {
   def processLabelsResponse(workflowId: WorkflowId, labels: Map[String, String]): JsObject = {
     JsObject(Map(
       WorkflowMetadataKeys.Id -> JsString(workflowId.toString),
-      WorkflowMetadataKeys.Labels -> JsObject(labels mapValues JsString.apply)
+      WorkflowMetadataKeys.Labels -> JsObject(labels safeMapValues JsString.apply)
     ))
   }
 

--- a/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
@@ -3,6 +3,7 @@ package cromwell.webservice.metadata
 import java.util.UUID
 
 import akka.actor.{ActorRef, LoggingFSM, Props}
+import common.collections.EnhancedCollections._
 import cromwell.webservice.metadata.MetadataComponent._
 import cromwell.core.Dispatcher.ApiDispatcher
 import cromwell.core.ExecutionIndex.ExecutionIndex
@@ -93,7 +94,7 @@ object MetadataBuilderActor {
      *    ...
      * )
      */
-    val callsGroupedByFQNAndIndex = callsGroupedByFQN mapValues { _ groupBy { _.key.jobKey.get.index } }
+    val callsGroupedByFQNAndIndex = callsGroupedByFQN safeMapValues { _ groupBy { _.key.jobKey.get.index } }
     /*
      * Map(
      *    "fqn" -> Map(
@@ -107,12 +108,12 @@ object MetadataBuilderActor {
      *    ...
      * )
      */
-    val callsGroupedByFQNAndIndexAndAttempt = callsGroupedByFQNAndIndex mapValues { _ mapValues { _ groupBy { _.key.jobKey.get.attempt } } }
+    val callsGroupedByFQNAndIndexAndAttempt = callsGroupedByFQNAndIndex safeMapValues { _ safeMapValues { _ groupBy { _.key.jobKey.get.attempt } } }
 
     val eventsToAttemptFunction = Function.tupled(eventsToAttemptMetadata(expandedValues) _)
     val attemptToIndexFunction = (attemptMetadataToIndexMetadata _).tupled
 
-    val callsMap = callsGroupedByFQNAndIndexAndAttempt mapValues { _ mapValues { _ map eventsToAttemptFunction } map attemptToIndexFunction } mapValues { md =>
+    val callsMap = callsGroupedByFQNAndIndexAndAttempt safeMapValues { _ safeMapValues { _ map eventsToAttemptFunction } map attemptToIndexFunction } safeMapValues { md =>
       JsArray(md.toVector.sortBy(_.index) flatMap { _.metadata })
     }
 
@@ -129,7 +130,7 @@ object MetadataBuilderActor {
     * Parse a Seq of MetadataEvent into a full Json metadata response.
     */
   private def parse(events: Seq[MetadataEvent], expandedValues: Map[String, JsValue]): JsObject = {
-    JsObject(events.groupBy(_.key.workflowId.toString) mapValues parseWorkflowEvents(includeCallsIfEmpty = true, expandedValues))
+    JsObject(events.groupBy(_.key.workflowId.toString) safeMapValues parseWorkflowEvents(includeCallsIfEmpty = true, expandedValues))
   }
 
   def uniqueActorName: String = List("MetadataBuilderActor", UUID.randomUUID()).mkString("-")

--- a/engine/src/main/scala/cromwell/webservice/metadata/MetadataComponent.scala
+++ b/engine/src/main/scala/cromwell/webservice/metadata/MetadataComponent.scala
@@ -4,6 +4,7 @@ import cats.instances.list._
 import cats.instances.map._
 import cats.syntax.foldable._
 import cats.{Monoid, Semigroup}
+import common.collections.EnhancedCollections._
 import cromwell.core._
 import cromwell.core.simpleton.WomValueSimpleton._
 import cromwell.services.metadata._
@@ -42,7 +43,7 @@ object MetadataComponent {
 
   implicit val metadataComponentJsonWriter: JsonWriter[MetadataComponent] = JsonWriter.func2Writer[MetadataComponent] {
     case MetadataList(values) => JsArray(values.values.toVector map { _.toJson(this.metadataComponentJsonWriter) })
-    case MetadataObject(values) => JsObject(values.mapValues(_.toJson(this.metadataComponentJsonWriter)))
+    case MetadataObject(values) => JsObject(values.safeMapValues(_.toJson(this.metadataComponentJsonWriter)))
     case primitive: MetadataPrimitive => metadataPrimitiveJsonWriter.write(primitive)
     case MetadataEmptyComponent => JsObject.empty
     case MetadataNullComponent => JsNull

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/nio/OssStorageFileSystemProvider.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/nio/OssStorageFileSystemProvider.scala
@@ -94,7 +94,7 @@ final case class OssStorageFileSystemProvider(config: OssStorageConfiguration) e
       throw new IllegalArgumentException(s"Port is not permitted")
     }
 
-    OssStorageFileSystem(this, bucket, OssStorageConfiguration.parseMap(env.asScala.mapValues(_.asInstanceOf[Any]).toMap))
+    OssStorageFileSystem(this, bucket, OssStorageConfiguration.parseMap(env.asScala.toMap))
   }
 
   override def getFileSystem(uri: URI): OssStorageFileSystem = {

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryParameters.scala
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime
 import cats.data.Validated._
 import cats.syntax.apply._
 import cats.syntax.validated._
+import common.collections.EnhancedCollections._
 import cromwell.core.WorkflowId
 import cromwell.core.labels.Label
 import cromwell.services.metadata.WorkflowQueryKey._
@@ -45,7 +46,7 @@ object WorkflowQueryParameters {
     // The values are the keys capitalized as actually given to the API, which is what will be used in any
     // error messages.
     val keysByCanonicalCapitalization: Map[String, Set[String]] =
-      rawParameters map { _._1 } groupBy { _.toLowerCase.capitalize } mapValues { _.toSet }
+      rawParameters map { _._1 } groupBy { _.toLowerCase.capitalize } safeMapValues { _.toSet }
 
     keysByCanonicalCapitalization.keys.toSet -- WorkflowQueryKey.ValidKeys match {
       case set if set.nonEmpty =>

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -34,6 +34,7 @@ package cromwell.backend.impl.aws
 import java.net.SocketTimeoutException
 
 import cats.data.Validated.Valid
+import common.collections.EnhancedCollections._
 import common.util.StringUtil._
 import common.validation.Validation._
 import cromwell.backend._
@@ -193,7 +194,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     }
 
     // Collect all WomFiles from inputs to the call.
-    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs mapValues {
+    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs safeMapValues {
       womFile =>
         val arrays: Seq[WomArray] = womFile collectAsSeq {
           case womFile: WomFile =>
@@ -206,7 +207,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         arrays.flatMap(_.value).collect {
           case womFile: WomFile => womFile
         }
-    } map identity // <-- unlazy the mapValues
+    }
 
     val callInputInputs = callInputFiles flatMap {
       case (name, files) => inputsFromWomFiles(name, files, files.map(relativeLocalizationPath), jobDescriptor)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
@@ -41,6 +41,7 @@ import wom.transforms.WomWorkflowDefinitionMaker.ops._
 import akka.actor.{ActorRef, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestDuration} // TestProbe
 import software.amazon.awssdk.core.auth.AnonymousCredentialsProvider
+import common.collections.EnhancedCollections._
 // import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobFailedNonRetryableResponse, JobFailedRetryableResponse}
 import cromwell.backend.BackendJobExecutionActor.BackendJobExecutionResponse
 import cromwell.backend._
@@ -442,7 +443,7 @@ class AwsBatchAsyncBackendJobExecutionActorSpec extends TestKitSuite("AwsBatchAs
           WomFileMapper.mapWomFiles(testActorRef.underlyingActor.mapCommandLineWomFile, exceptions = Set.empty)(womValue).get
         }
 
-        val mappedInputs = jobDescriptor.localInputs mapValues pathToLocal
+        val mappedInputs = jobDescriptor.localInputs safeMapValues pathToLocal
 
         mappedInputs(stringKey) match {
           case WomString(v) => assert(v.equalsIgnoreCase(stringVal.value))

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
@@ -32,6 +32,7 @@
 package cromwell.backend.impl.aws
 
 import software.amazon.awssdk.core.auth.AnonymousCredentialsProvider
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
 import cromwell.backend.io.JobPathsSpecHelper._
 // import cromwell.cloudsupport.gcp.auth.AwsBatchAuthModeSpec
@@ -54,7 +55,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
@@ -73,7 +74,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
@@ -96,7 +97,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
@@ -32,6 +32,7 @@
 package cromwell.backend.impl.aws
 
 import software.amazon.awssdk.core.auth.AnonymousCredentialsProvider
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
 // import cromwell.cloudsupport.aws.auth.AwsBatchAuthModeSpec
 import cromwell.core.Tags.AwsTest
@@ -52,7 +53,7 @@ class AwsBatchWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with Matc
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
 

--- a/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsAsyncBackendJobExecutionActor.scala
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException
 import better.files.File.OpenOptions
 import com.aliyuncs.batchcompute.main.v20151111.BatchComputeClient
 import com.aliyuncs.exceptions.{ClientException, ServerException}
+import common.collections.EnhancedCollections._
 import cromwell.backend._
 import cromwell.backend.async.{ExecutionHandle, FailedNonRetryableExecutionHandle, PendingExecutionHandle}
 import cromwell.backend.impl.bcs.RunStatus.{Finished, TerminalRunStatus}
@@ -96,7 +97,7 @@ final class BcsAsyncBackendJobExecutionActor(override val standardParams: Standa
     }
 
     // Collect all WomFiles from inputs to the call.
-    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs mapValues {
+    val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor.fullyQualifiedInputs safeMapValues {
       _.collectAsSeq { case w: WomFile => w }
     }
 

--- a/supportedBackends/bcs/src/test/scala/cromwell/backend/impl/bcs/BcsTestUtilSpec.scala
+++ b/supportedBackends/bcs/src/test/scala/cromwell/backend/impl/bcs/BcsTestUtilSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.impl.bcs
 
 import com.typesafe.config.ConfigFactory
+import common.collections.EnhancedCollections._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptorKey, RuntimeAttributeDefinition}
 import cromwell.backend.BackendSpec.{buildWdlWorkflowDescriptor}
 import cromwell.backend.validation.ContinueOnReturnCodeSet
@@ -122,7 +123,7 @@ trait BcsTestUtilSpec extends TestKitSuite with FlatSpecLike with Matchers with 
   val mockPathBuilders = List(mockPathBuiler)
   lazy val workflowDescriptor =  buildWdlWorkflowDescriptor(
     SampleWdl.HelloWorld.workflowSource(),
-    inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+    inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
   )
   lazy val jobKey = {
     val call = workflowDescriptor.callable.taskCallNodes.head

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
@@ -7,6 +7,7 @@ import _root_.wdl.draft2.model._
 import akka.actor.{ActorRef, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestDuration, TestProbe}
 import com.google.cloud.NoCredentials
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobFailedNonRetryableResponse, JobFailedRetryableResponse}
 import cromwell.backend._
 import cromwell.backend.async.AsyncBackendJobExecutionActor.{Execute, ExecutionMode}
@@ -420,7 +421,7 @@ class PipelinesApiAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsy
           WomFileMapper.mapWomFiles(testActorRef.underlyingActor.mapCommandLineWomFile, Set.empty)(womValue).get
         }
 
-        val mappedInputs = jobDescriptor.localInputs mapValues gcsPathToLocal
+        val mappedInputs = jobDescriptor.localInputs safeMapValues gcsPathToLocal
 
         mappedInputs(stringKey) match {
           case WomString(v) => assert(v.equalsIgnoreCase(stringVal.value))
@@ -874,7 +875,7 @@ class PipelinesApiAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsy
 
     val jesBackend = testActorRef.underlyingActor
 
-    val actual = jesBackend.startMetadataKeyValues.mapValues(_.toString)
+    val actual = jesBackend.startMetadataKeyValues.safeMapValues(_.toString)
     actual should be(
       Map(
         "backendLabels:cromwell-workflow-id" -> s"cromwell-$workflowId",

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.google.pipelines.common
 
 import com.google.cloud.NoCredentials
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
 import cromwell.backend.io.JobPathsSpecHelper._
 import cromwell.cloudsupport.gcp.auth.GoogleAuthModeSpec
@@ -23,7 +24,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
@@ -41,7 +42,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
@@ -63,7 +64,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
     val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.google.pipelines.common
 
 import com.google.cloud.NoCredentials
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
 import cromwell.cloudsupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.TestKitSuite
@@ -21,7 +22,7 @@ class PipelinesApiWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with 
 
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
     workflowPaths.executionRoot.pathAsString should be("gs://my-cromwell-workflows-bucket/")

--- a/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
@@ -5,6 +5,7 @@ import java.net.URL
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
 import com.google.api.services.genomics.Genomics
 import com.google.api.services.genomics.model._
+import common.collections.EnhancedCollections._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.api.{PipelinesApiFactoryInterface, PipelinesApiRequestFactory}
 import cromwell.backend.google.pipelines.common.{PipelinesApiInput, PipelinesApiOutput}
@@ -65,8 +66,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
           ).asJava)
         val rpargs = new RunPipelineArgs().setProjectId(createPipelineParameters.projectId).setServiceAccount(svcAccount).setResources(runtimePipelineResources)
 
-        rpargs.setInputs((inputParameters.mapValues(_.toGoogleRunParameter) ++ literalInputRunParameters).asJava)
-        rpargs.setOutputs(outputParameters.mapValues(_.toGoogleRunParameter).asJava)
+        rpargs.setInputs((inputParameters.safeMapValues(_.toGoogleRunParameter) ++ literalInputRunParameters).asJava)
+        rpargs.setOutputs(outputParameters.safeMapValues(_.toGoogleRunParameter).asJava)
 
         rpargs.setLabels(createPipelineParameters.labels.asJavaMap)
 

--- a/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActorSpec.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActorSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import akka.actor.Props
 import akka.testkit._
 import com.typesafe.config.{Config, ConfigFactory}
+import common.collections.EnhancedCollections._
 import cromwell.backend.google.pipelines.common.PipelinesApiInitializationActorSpec._
 import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.genomicsFactory
 import cromwell.backend.google.pipelines.common.authentication.{GcsLocalizing, PipelinesApiAuthObject}
@@ -89,7 +90,7 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val workflowOptions = WorkflowOptions.fromMap(Map("refresh_token" -> "mytoken")).get
     val workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
-      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint),
       options = workflowOptions
     )
     val calls = workflowDescriptor.callable.taskCallNodes

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -6,6 +6,7 @@ import cats.instances.try_._
 import cats.syntax.functor._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
+import common.collections.EnhancedCollections._
 import cromwell.backend.io.JobPaths
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.path.{DefaultPath, DefaultPathBuilder, Path, PathFactory}
@@ -163,7 +164,7 @@ trait SharedFileSystem extends PathFactory {
    */
   def localizeInputs(inputsRoot: Path, docker: Boolean)(inputs: WomEvaluatedCallInputs): Try[WomEvaluatedCallInputs] = {
     TryUtil.sequenceMap(
-      inputs mapValues WomFileMapper.mapWomFiles(localizeWomFile(inputsRoot, docker), Set.empty),
+      inputs safeMapValues WomFileMapper.mapWomFiles(localizeWomFile(inputsRoot, docker), Set.empty),
       "Failures during localization"
     ) recoverWith {
       case e => Failure(new IOException(e.getMessage) with CromwellFatalExceptionMarker)

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException
 import _root_.wdl.draft2.model.LocallyQualifiedName
 import akka.testkit.{TestDuration, TestProbe}
 import com.typesafe.config.ConfigFactory
+import common.collections.EnhancedCollections._
 import cromwell.backend.BackendJobExecutionActor.{JobAbortedResponse, JobFailedNonRetryableResponse, JobSucceededResponse, RunOnBackend}
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend._
@@ -251,7 +252,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
       // If this is not the case, more context/logic will need to be moved to the backend so it can figure it out by itself
       val symbolMaps: Map[LocallyQualifiedName, WomInteger] = Map("intNumber" -> WomInteger(shard))
 
-      val evaluatedAttributes = call.callable.runtimeAttributes.attributes.mapValues(_.evaluateValue(Map.empty, NoIoFunctionSet).getOrElse(fail("Can't evaluate runtime attribute")))
+      val evaluatedAttributes = call.callable.runtimeAttributes.attributes.safeMapValues(_.evaluateValue(Map.empty, NoIoFunctionSet).getOrElse(fail("Can't evaluate runtime attribute")))
       val runtimeAttributes: Map[LocallyQualifiedName, WomValue] = RuntimeAttributeDefinition.addDefaultsToAttributes(runtimeAttributeDefinitions, WorkflowOptions.empty)(evaluatedAttributes)
 
       val jobDescriptor: BackendJobDescriptor =

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkRuntimeAttributesSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkRuntimeAttributesSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.spark
 
+import common.collections.EnhancedCollections._
 import common.validation.ErrorOr._
 import cromwell.backend.BackendWorkflowDescriptor
 import cromwell.core.labels.Labels
@@ -148,7 +149,7 @@ class SparkRuntimeAttributesSpec extends WordSpecLike with Matchers {
         val staticValues = workflowDescriptor.knownValues.map {
           case (outputPort, resolvedInput) => outputPort.name -> resolvedInput
         }
-        val ra = call.callable.runtimeAttributes.attributes mapValues { _.evaluateValue(staticValues, NoIoFunctionSet) }
+        val ra = call.callable.runtimeAttributes.attributes safeMapValues { _.evaluateValue(staticValues, NoIoFunctionSet) }
         ra.sequence.getOrElse(fail("Failed to evaluate runtime attributes"))
     }
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -1,5 +1,6 @@
 package cromwell.backend.impl.tes
 
+import common.collections.EnhancedCollections._
 import common.util.StringUtil._
 import cromwell.backend.{BackendConfigurationDescriptor, BackendJobDescriptor}
 import cromwell.core.logging.JobLogger
@@ -57,7 +58,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
 
   private val callInputFiles: Map[FullyQualifiedName, Seq[WomFile]] = jobDescriptor
     .fullyQualifiedInputs
-    .mapValues {
+    .safeMapValues {
       _.collectAsSeq { case w: WomFile => w }
     }
 

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlRuntimeAttributes.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlRuntimeAttributes.scala
@@ -1,5 +1,6 @@
 package wdl.draft2.model
 
+import common.collections.EnhancedCollections._
 import wdl.draft2.model.AstTools.{AstNodeName, EnhancedAstNode}
 import wdl.draft2.parser.WdlParser.{Ast, AstList}
 import wom.RuntimeAttributes
@@ -7,7 +8,7 @@ import wom.RuntimeAttributes
 import scala.collection.JavaConverters._
 
 case class WdlRuntimeAttributes(attrs: Map[String, WdlExpression]) {
-  def toWomRuntimeAttributes(task: WdlTask) = RuntimeAttributes(attrs.mapValues(WdlWomExpression(_, task)))
+  def toWomRuntimeAttributes(task: WdlTask) = RuntimeAttributes(attrs.safeMapValues(WdlWomExpression(_, task)))
 }
 
 object WdlRuntimeAttributes {

--- a/wdl/model/draft2/src/test/scala/wdl/values/WdlValueSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/values/WdlValueSpec.scala
@@ -1,5 +1,6 @@
 package wdl.values
 
+import common.collections.EnhancedCollections._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import wdl.SampleWdl
@@ -171,7 +172,7 @@ class WdlValueSpec extends FlatSpec with Matchers {
   private def describe(womValue: WomValue): String = {
     womValue match {
       case WdlCallOutputsObject(call, outputs) =>
-        s"WdlCallOutputsObject(${call.unqualifiedName}, ${outputs.mapValues(_.toWomString)})"
+        s"WdlCallOutputsObject(${call.unqualifiedName}, ${outputs.safeMapValues(_.toWomString)})"
       case _ => womValue.toWomString
     }
   }

--- a/wdl/transforms/biscayne/src/main/scala/wdl/transforms/biscayne/linking/expression/values/BiscayneValueEvaluators.scala
+++ b/wdl/transforms/biscayne/src/main/scala/wdl/transforms/biscayne/linking/expression/values/BiscayneValueEvaluators.scala
@@ -5,6 +5,7 @@ import cats.syntax.validated._
 import cats.syntax.traverse._
 import cats.instances.list._
 import common.validation.ErrorOr._
+import common.collections.EnhancedCollections._
 import wdl.model.draft3.elements.ExpressionElement
 import wdl.model.draft3.elements.ExpressionElement.{AsMap, AsPairs, CollectByKey}
 import wdl.model.draft3.graph.expression.{EvaluatedValue, ForCommandInstantiationOptions, ValueEvaluator}
@@ -71,7 +72,7 @@ object BiscayneValueEvaluators {
             case other => s"Unexpected array element. Expected a Pair[X, Y] but array contained ${other.toWomString}]".invalidNel
           }
           validPairs flatMap { kvpairs =>
-            val grouped: Map[WomValue, WomArray] = kvpairs.groupBy(_._1).mapValues(v => WomArray(v.map(_._2)))
+            val grouped: Map[WomValue, WomArray] = kvpairs.groupBy(_._1).safeMapValues(v => WomArray(v.map(_._2)))
             EvaluatedValue(WomMap(grouped), Seq.empty).validNel
 
           }

--- a/wom/src/main/scala/wom/values/WomValue.scala
+++ b/wom/src/main/scala/wom/values/WomValue.scala
@@ -1,5 +1,6 @@
 package wom.values
 
+import common.collections.EnhancedCollections._
 import wom.expression.ValueAsAnExpression
 import wom.types.WomType
 import wom.{OptionalNotSuppliedException, WomExpressionException}
@@ -62,7 +63,7 @@ trait WomValue {
 
   def computeHash(implicit hasher: FileHasher): SymbolHash = {
     this match {
-      case w: WomObject => symbolHash(w.values mapValues { _.computeHash(hasher) })
+      case w: WomObject => symbolHash(w.values safeMapValues { _.computeHash(hasher) })
       case w: WomMap => symbolHash(w.value map { case (k, v) => k.computeHash(hasher) -> v.computeHash(hasher) })
       case w: WomArray => symbolHash(w.value map { _.computeHash(hasher) } mkString "")
       case w: WomFile => hasher(w)


### PR DESCRIPTION
Jeff had suggested some sort of hook to flag / prevent commits of the original `mapValues` which sounds like a good idea, however there is a Circe `mapValues` for `JsObject`s that we're still using. So not unpossible but more than just a regex.