### PR TITLE
Add profile and email scopes to PAPI jobs

### DIFF
--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
@@ -9,6 +9,8 @@ object PipelinesApiFactoryInterface {
   val GenomicsScope = "https://www.googleapis.com/auth/genomics"
   val ComputeScope = "https://www.googleapis.com/auth/compute"
   val StorageFullControlScope = "https://www.googleapis.com/auth/devstorage.full_control"
+  val EmailScope =   "https://www.googleapis.com/auth/userinfo.email"
+  val ProfileScope =  "https://www.googleapis.com/auth/userinfo.profile"
   val KmsScope = "https://www.googleapis.com/auth/cloudkms"
 }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -71,7 +71,9 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
             PipelinesApiFactoryInterface.GenomicsScope,
             PipelinesApiFactoryInterface.ComputeScope,
             PipelinesApiFactoryInterface.StorageFullControlScope,
-            PipelinesApiFactoryInterface.KmsScope
+            PipelinesApiFactoryInterface.KmsScope,
+            PipelinesApiFactoryInterface.EmailScope,
+            PipelinesApiFactoryInterface.ProfileScope
           ).asJava
         )
 


### PR DESCRIPTION
These scopes are needed to make requests to Martha v2 