### PR TITLE
correct typo in Slurm configuration

### DIFF
--- a/docs/backends/SLURM.md
+++ b/docs/backends/SLURM.md
@@ -13,7 +13,7 @@ SLURM {
 
     submit = """
         sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
-        ${"-n " + cpus} \
+        ${"-c " + cpus} \
         --mem-per-cpu=${requested_memory_mb_per_core} \
         --wrap "/bin/bash ${script}"
     """


### PR DESCRIPTION
The number of cpus per task should be designated with the `-c` flag. The `-n` flag is for the number of tasks. Due to the nature of cromwell the number of tasks is always 1. So we need to adjust the number of cpus by setting `--cpus-per-task=` or `-c `.