### PR TITLE
Reduce hash cost of WdlSyntaxErrorFormatter

### DIFF
--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -13,6 +13,14 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   // To approximate, just use Java's case-class-ignorant implementation (hash functions are allowed to be imperfect)
   override def hashCode(): Int = System.identityHashCode(this)
 
+  override def equals(other: Any): Boolean = {
+    other match {
+      case otherFormatter: WdlSyntaxErrorFormatter =>
+        this.terminalMap == otherFormatter.terminalMap
+      case _ => false
+    }
+  }
+
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
   private def getTerminal(t: Terminal) = t match {
     case interpolated: InterpolatedTerminal => terminalMap.get(interpolated.rootTerminal)

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -13,6 +13,8 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   // To approximate, just use Java's case-class-ignorant implementation (hash functions are allowed to be imperfect)
   override def hashCode(): Int = System.identityHashCode(this)
 
+  override def equals(obj: Any): Boolean = this eq obj.asInstanceOf[AnyRef]
+
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
   private def getTerminal(t: Terminal) = t match {
     case interpolated: InterpolatedTerminal => terminalMap.get(interpolated.rootTerminal)

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -9,6 +9,11 @@ import scala.collection.JavaConverters._
 
 case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) extends SyntaxErrorFormatter {
 
+  // Hashing the terminalMap is very expensive, because we are re-hashing the entire workflow for every terminal in it (exponential with size of workflow)
+  // Hashes are used to find potentially equal objects in an efficient manner, so a quick proxy for that is the number of terminals, i.e. the size of the map.
+  // ( Explanation stolen from Jon Skeet, https://stackoverflow.com/a/14735277/818054 )
+  override def hashCode(): Int = terminalMap.size
+
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
   private def getTerminal(t: Terminal) = t match {
     case interpolated: InterpolatedTerminal => terminalMap.get(interpolated.rootTerminal)

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -9,9 +9,8 @@ import scala.collection.JavaConverters._
 
 case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) extends SyntaxErrorFormatter {
 
-  // Hashing the terminalMap is very expensive, because we are re-hashing the entire workflow for every terminal in it (exponential with size of workflow)
-  // Hashes are used to find potentially equal objects in an efficient manner, so a quick proxy for that is the number of terminals, i.e. the size of the map.
-  // ( Explanation stolen from Jon Skeet, https://stackoverflow.com/a/14735277/818054 )
+  // Hashing the terminalMap is very expensive because we re-hash the entire workflow once for every terminal in it (exponential with size of workflow)
+  // To approximate, let's just say that two workflows with the same number of terminals are likely identical (hash functions are allowed to be imperfect)
   override def hashCode(): Int = terminalMap.size
 
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -10,8 +10,8 @@ import scala.collection.JavaConverters._
 case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) extends SyntaxErrorFormatter {
 
   // Hashing the terminalMap is very expensive because we re-hash the entire workflow once for every terminal in it (exponential with size of workflow)
-  // To approximate, let's just say that two workflows with the same number of terminals are likely identical (hash functions are allowed to be imperfect)
-  override def hashCode(): Int = terminalMap.size
+  // To approximate, just use Java's case-class-ignorant implementation (hash functions are allowed to be imperfect)
+  override def hashCode(): Int = System.identityHashCode(this)
 
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
   private def getTerminal(t: Terminal) = t match {

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlSyntaxErrorFormatter.scala
@@ -13,14 +13,6 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WorkflowSource]) e
   // To approximate, just use Java's case-class-ignorant implementation (hash functions are allowed to be imperfect)
   override def hashCode(): Int = System.identityHashCode(this)
 
-  override def equals(other: Any): Boolean = {
-    other match {
-      case otherFormatter: WdlSyntaxErrorFormatter =>
-        this.terminalMap == otherFormatter.terminalMap
-      case _ => false
-    }
-  }
-
   private def pointToSource(t: Terminal): String = s"${line(t)}\n${" " * (t.getColumn - 1)}^"
   private def getTerminal(t: Terminal) = t match {
     case interpolated: InterpolatedTerminal => terminalMap.get(interpolated.rootTerminal)


### PR DESCRIPTION
I don't have numbers for this yet, but it seems to run way faster.