### PR TITLE
Allow FetchCachedResultsActor to complete if post-processing fails

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -27,23 +27,25 @@ class FetchCachedResultsActor(cacheResultId: CallCachingEntryId, replyTo: ActorR
   {
     implicit val ec: ExecutionContext = context.dispatcher
 
-    callCache.fetchCachedResult(cacheResultId) onComplete {
-      case Success(Some(result)) =>
+    callCache.fetchCachedResult(cacheResultId) map {
+      case Some(result) =>
         val simpletons = result.callCachingSimpletonEntries map toSimpleton
         val jobDetritusFiles = result.callCachingDetritusEntries map { jobDetritusEntry =>
           jobDetritusEntry.detritusKey -> jobDetritusEntry.detritusValue.toRawString
         }
 
         val sourceCacheDetails = Seq(result.callCachingEntry.workflowExecutionUuid,
-                                    result.callCachingEntry.callFullyQualifiedName,
-                                    result.callCachingEntry.jobIndex).mkString(":")
+          result.callCachingEntry.callFullyQualifiedName,
+          result.callCachingEntry.jobIndex).mkString(":")
 
-        replyTo ! CachedOutputLookupSucceeded(simpletons, jobDetritusFiles.toMap,
-                                              result.callCachingEntry.returnCode,
-                                              cacheResultId, sourceCacheDetails)
-      case Success(None) =>
+        CachedOutputLookupSucceeded(simpletons, jobDetritusFiles.toMap,
+          result.callCachingEntry.returnCode,
+          cacheResultId, sourceCacheDetails)
+      case None =>
         val reason = new RuntimeException(s"Cache hit vanished between discovery and retrieval: $cacheResultId")
-        replyTo ! CachedOutputLookupFailed(cacheResultId, reason)
+        CachedOutputLookupFailed(cacheResultId, reason)
+    } onComplete {
+      case Success(sendMe) => replyTo ! sendMe
       case Failure(t) => replyTo ! CachedOutputLookupFailed(cacheResultId, t)
     }
   }


### PR DESCRIPTION
Note: this is a tactical fix to allow the cache-fetch post-processing to fail and the workflow to continue.
It does nothing to prevent the errors from happening in the first place - for that issue see #3979 