### PR TITLE
Pin cwltool version

### DIFF
--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -279,11 +279,11 @@ cromwell::private::install_cwltool() {
     # TODO: No clue why these are needed for cwltool. If you know please update this comment.
     sudo apt-get install procps || true
     sudo -H pip install 'requests[security]'
-    sudo -H pip install --ignore-installed cwltool==1.0.20180711112827
+    sudo -H pip install --ignore-installed cwltool==1.0.20180809224403
 }
 
 cromwell::private::install_cwltest() {
-    sudo -H pip install cwltest
+    sudo -H pip install cwltest==1.0.20180601100346
 }
 
 cromwell::private::checkout_pinned_cwl() {

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -279,7 +279,7 @@ cromwell::private::install_cwltool() {
     # TODO: No clue why these are needed for cwltool. If you know please update this comment.
     sudo apt-get install procps || true
     sudo -H pip install 'requests[security]'
-    sudo -H pip install --ignore-installed cwltool
+    sudo -H pip install --ignore-installed cwltool==1.0.20180711112827
 }
 
 cromwell::private::install_cwltest() {


### PR DESCRIPTION
Should unblock our CI but may not be necessary if the short-term fix in https://github.com/common-workflow-language/cwltool/pull/865 or the longer-term update in https://github.com/common-workflow-language/cwltool/pull/864 get released soon.

On the other hand, as Peter says re ruamel, having open ended dependencies is a bad idea generally, so maybe pinning to a known good version is a good idea regardless?