### PR TITLE
Adding Dockerfile for sbt/scala development build

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -8,6 +8,13 @@ features or fixes, the following are required to build Cromwell from source:
 * [Java 8](http://www.oracle.com/technetwork/java/javase/overview/java8-2100321.html)
 * [Git](https://git-scm.com/)
 
+You can also use the [development image](https://github.com/broadinstitute/cromwell/tree/develop/scripts/docker-develop), and build a development container to work inside:
+
+```bash
+$ docker build -t cromwell-dev Dockerfile
+$ docker run -it cromwell-dev bash
+```
+
 First start by cloning the Cromwell repository from GitHub:
 
 ```bash

--- a/scripts/docker-develop/Dockerfile
+++ b/scripts/docker-develop/Dockerfile
@@ -1,0 +1,43 @@
+FROM openjdk:8u171
+
+# docker build -t vanessa/cromwell-dev .
+
+# Development environment for Cromwell that includes:
+#
+#   Scala 2.12
+#   SBT 1.x
+#   Java 8
+#   Git
+
+# Env variables
+ENV SCALA_VERSION 2.12.6
+ENV SBT_VERSION 1.2.1
+
+# Scala expects this file
+RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
+
+#
+## Scala
+#
+
+RUN mkdir -p /home/pigman && \
+    curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /opt/ && \
+    echo >> /home/pigman/.bashrc && \
+    echo "export PATH=/opt/scala-$SCALA_VERSION/bin:$PATH" >> /home/pigman/.bashrc
+
+#
+## sbt
+#
+
+RUN curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+  dpkg -i sbt-$SBT_VERSION.deb && \
+  rm sbt-$SBT_VERSION.deb && \
+  apt-get update && \
+  apt-get install sbt && \
+  sbt sbtVersion
+
+# Instruct user to add code here during development
+RUN useradd pigman && \
+    mkdir -p /code
+
+WORKDIR /code

--- a/scripts/docker-develop/README.md
+++ b/scripts/docker-develop/README.md
@@ -1,0 +1,60 @@
+# Cromwell Docker Development
+
+This is a container intended to help with development of Cromwell, in the
+case that you don't want to install the dependencies on your host. It
+includes the required software mentioned in [the developer docs](http://cromwell.readthedocs.io/en/develop/Building/) but with additional instructions to interact with the repository.
+
+As with the build instructions, first start by cloning the Cromwell repository from GitHub:
+
+```bash
+$ git clone git@github.com:broadinstitute/cromwell.git
+```
+
+And change into this directory:
+
+```bash
+$ cd cromwell/scripts/docker-develop
+```
+
+This is where this README.md sits with a [Dockerfile](Dockerfile)
+
+## Step 1. Build the Container
+From this folder with the Dockerfile, build the container. In the command below
+we are calling it `cromwell-dev` and you can choose to change this name if you want.
+
+```bash
+$ docker build -t cromwell-dev Dockerfile
+```
+
+and change back to the root of the repository
+
+```bash
+cd ../../
+```
+
+## Step 2. Shell into Working Environment
+If you require a specific version of Cromwell as a starting point, do the appropriate `git checkout` now. 
+
+You are next going to want to bind the cromwell
+source code to be somewhere in the container. Actually, we have a `/code` directory
+ready for you to make this easy. Run this command from the base of the repository:
+
+```bash
+$ docker run -v $PWD/:/code -it cromwell-dev bash
+```
+
+## Step 4. The Development Steps
+
+You are going to use the command `sbt assembly` to create a runnable Cromwell JAR. The output
+will be `server/target`. Remember, here we are inside the container with scala and sbt:
+
+
+```bash
+$ sbt assembly
+```
+
+`sbt assembly` will build the runnable Cromwell JAR in `server/target/scala-2.12/` with a name like `cromwell-<VERSION>.jar`.
+
+You can then interact with it in the container, or on your host if you like. Remember that
+you have Java already in the container, so it makes sense to develop there.
+


### PR DESCRIPTION
This is a quick PR to add a Dockerfile (and instructions) so that scala/sbt don't need to be installed on the user system. This is a nice step to have, and I decided to do before working on the issues addressed in https://github.com/broadinstitute/cromwell/issues/2177#issuecomment-412505720

@geoffjentry could you point me to the udocker example you mentioned? If there isn't a clear documentation for it, what I'm generally interested in to develop the singularity bit is:

 - where is the entrypoint for the scala application (when the user interacts to do something with docker, for example)
 - what is the general flow
 - is what we want to do for singularity comparable to the udocker example, so mirroring that code would do the trick?

Here are some quick links, if they are helpful!

 - https://hub.docker.com/r/vanessa/cromwell-dev/
 - https://github.com/vsoch/cromwell/tree/add/singularity/scripts/docker-develop

For the first, the container is still pushing... on my insanely great crappy wireless :) 