### PR TITLE
adding circleci config stuffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,11 +98,10 @@ dockerdeploy: &dockerdeploy
             docker push ${CONTAINER_NAME}:latest
       fi
 
-
 dockerbuild: &dockerbuild
     name: Build cromwell development Docker container
     command: |
-      docker build --cache-from=${CONTAINER_BUILD_NAME} -t ${CONTAINER_NAME}:${DOCKER_TAG} .
+      docker build --cache-from=${CONTAINER_BUILD_NAME} -f scripts/docker-develop/Dockerfile -t ${CONTAINER_NAME}:${DOCKER_TAG} .
 
 
 
@@ -134,8 +133,12 @@ jobs:
           name: Run tests
           command: |
             echo "What tests would you like, my dear McMuffins?"
+            echo "1. Testing for install of sbt and scala"
             docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
+            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version
             docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
+            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} sbt --version
+            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ jobs:
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
             echo "1. Testing sbt assembly"
-            echo "docker run -it -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
-            docker run -it -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
+            echo "docker run -v /tmp/src:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
+            docker run -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,8 @@ dockerdeploy: &dockerdeploy
 dockerbuild: &dockerbuild
     name: Build cromwell development Docker container
     command: |
-      docker build --cache-from=${CONTAINER_BUILD_NAME} -f scripts/docker-develop/Dockerfile -t ${CONTAINER_NAME}:${DOCKER_TAG} .
+      source ${BASH_ENV}
+      docker build -f scripts/docker-develop/Dockerfile -t ${CONTAINER_NAME}:${DOCKER_TAG} .
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,11 @@ jobs:
           command: |
             echo "What tests would you like, my dear McMuffins?"
             echo "1. Testing for install of sbt and scala"
-            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
-            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version
-            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
-            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} sbt --version
+            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
+            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version
+            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
+            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt --version
+            echo "1. Testing sbt assembly for scala"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,178 @@
+# This is a continuous build CircleCI configuration for cromwell,
+# intended to bulid on CircleCI to spread out testing over Travis/Cricle.
+# The container is built and pushed to the CONTAINER_NAME variable
+# defined here or within the CircleCI settings. The following environment
+# variables are acceptable here or in these settings (for sensitive information)
+#
+# CONTAINER_NAME if not set, will use Github repo and organization name 
+# DOCKER_USER
+# DOCKER_EMAIL
+
+################################################################################
+# Functions
+################################################################################
+
+# Defaults
+
+defaults: &defaults
+  docker:
+    - image: docker:18.01.0-ce-git
+  working_directory: /tmp/src
+
+# Installation
+install: &install
+    name: Install parallel gzip, gettext, python3, and jq
+    command: apk add --no-cache pigz python3 gettext jq
+
+# Environment
+sourceenv: &sourceenv
+    name: Source environment variables from the BASH_ENV
+    command: source $BASH_ENV 
+
+
+# Docker
+
+dockerenv: &dockerenv
+    name: Define container and Docker names
+    command: |
+        # If not set, define DOCKER_TAG
+        if [ ! -n "${DOCKER_TAG:-}" ]; then
+            DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
+        fi
+        # If not set, define CONTAINER_NAME
+        if [ ! -n "${CONTAINER_NAME:-}" ]; then
+            CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+        fi
+        echo "Container name is ${CONTAINER_NAME}"
+        # If not set, define REPO_NAME
+        if [ ! -n "${REPO_NAME:-}" ]; then
+            LOCAL_REPO="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            REPO_NAME=/tmp/src
+            echo "Repository name (REPO_NAME) is not defined, will build ${LOCAL_REPO} in ${REPO_NAME}"
+        else
+            echo "Repository name found defined for build: ${REPO_NAME}"
+        fi
+        # export to bash environment
+        echo "export CONTAINER_NAME=${CONTAINER_NAME}" >> ${BASH_ENV}
+        echo "export DOCKER_TAG=${DOCKER_TAG}" >> ${BASH_ENV}
+        echo "export REPO_NAME=${REPO_NAME}" >> ${BASH_ENV}
+        cat ${BASH_ENV}
+
+
+dockerload: &dockerload
+    name: Load Docker container Image
+    no_output_timeout: 30m
+    command: | 
+      echo "Working directory is ${PWD}"
+      docker info
+      set +o pipefail
+      if [ -f /tmp/cache/container.tar.gz ]; then
+          apk update && apk add --no-cache pigz curl curl-dev
+          pigz -d --stdout /tmp/cache/container.tar.gz | docker load
+          docker images
+      fi
+
+
+dockersave: &dockersave
+    name: Docker Save
+    no_output_timeout: 40m
+    command: |
+        source ${BASH_ENV}
+        echo "Saving ${CONTAINER_NAME}:${DOCKER_TAG} to container.tar.gz"
+        mkdir -p /tmp/cache
+        docker save ${CONTAINER_NAME}:${DOCKER_TAG} \
+          | pigz -2 -p 3 > /tmp/cache/container.tar.gz
+
+
+dockerdeploy: &dockerdeploy
+    name: Deploy to Docker Hub
+    no_output_timeout: 40m
+    command: |
+      source ${BASH_ENV}
+      echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
+      if [[ -n "$DOCKER_PASS" ]]; then
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker push ${CONTAINER_NAME}:${DOCKER_TAG}
+            echo "Tagging latest image..."
+            docker tag ${CONTAINER_NAME}:${DOCKER_TAG} ${CONTAINER_NAME}:latest
+            docker push ${CONTAINER_NAME}:latest
+      fi
+
+
+dockerbuild: &dockerbuild
+    name: Build cromwell development Docker container
+    command: |
+      docker build --cache-from=${CONTAINER_BUILD_NAME} -t ${CONTAINER_NAME}:${DOCKER_TAG} .
+
+
+
+
+################################################################################
+# Jobs
+################################################################################
+
+
+version: 2
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - docker-v1-{{ .Branch }}
+          paths:
+            - /tmp/cache/container.tar.gz
+      - restore_cache:
+          key: dependency-cache
+      - setup_remote_docker
+      - run: *dockerenv
+      - run: *install
+      - run: *dockerload
+      - run: *dockerbuild
+      - run:
+          name: Run tests
+          command: |
+            echo "What tests would you like, my dear McMuffins?"
+            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
+            docker run --it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
+      - run: *dockersave
+
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - setup_remote_docker
+      - run: *dockerenv
+      - run: *dockerload
+      - run: *dockerdeploy
+
+
+################################################################################
+# Workflows
+################################################################################
+
+
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: 
+                - gh-pages
+                - /docs?/.*/
+            tags:
+              only: /.*/
+
+      # Upload the container to Docker Hub
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ jobs:
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
             echo "1. Testing sbt assembly"
-            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
-            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
+            echo "docker run -it -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
+            docker run -it -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,13 +133,19 @@ jobs:
       - run:
           name: Run tests
           command: |
+            source ${BASH_ENV}
             echo "What tests would you like, my dear McMuffins?"
             echo "1. Testing for install of sbt and scala"
+            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which scala"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
+            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version
+            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
+            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt version"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt --version
             echo "1. Testing sbt assembly for scala"
+            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,9 +138,7 @@ jobs:
             echo "1. Testing for install of sbt"
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
-            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt version"
-            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt --version
-            echo "1. Testing sbt assembly for scala"
+            echo "1. Testing sbt assembly"
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,11 +135,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo "What tests would you like, my dear McMuffins?"
-            echo "1. Testing for install of sbt and scala"
-            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which scala"
-            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which scala
-            echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version"
-            docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} scala --version
+            echo "1. Testing for install of sbt"
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} sbt version"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ jobs:
             echo "docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt"
             docker run -it ${CONTAINER_NAME}:${DOCKER_TAG} which sbt
             echo "1. Testing sbt assembly"
-            echo "docker run -v /tmp/src:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
-            docker run -v $PWD:/code ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
+            echo "docker run ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly"
+            docker run ${CONTAINER_NAME}:${DOCKER_TAG} sbt assembly
       - run: *dockersave
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/broadinstitute/cromwell.svg?branch=develop)](https://travis-ci.org/broadinstitute/cromwell?branch=develop)
 [![codecov](https://codecov.io/gh/broadinstitute/cromwell/branch/develop/graph/badge.svg)](https://codecov.io/gh/broadinstitute/cromwell)
+[![CircleCI](https://circleci.com/gh/vsoch/cromwell.svg?style=svg)](https://circleci.com/gh/vsoch/cromwell)
 
 ## Welcome to Cromwell
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/broadinstitute/cromwell.svg?branch=develop)](https://travis-ci.org/broadinstitute/cromwell?branch=develop)
 [![codecov](https://codecov.io/gh/broadinstitute/cromwell/branch/develop/graph/badge.svg)](https://codecov.io/gh/broadinstitute/cromwell)
-[![CircleCI](https://circleci.com/gh/vsoch/cromwell.svg?style=svg)](https://circleci.com/gh/vsoch/cromwell)
+[![CircleCI](https://circleci.com/gh/broadinstitute/cromwell.svg?style=svg)](https://circleci.com/gh/broadinstitute/cromwell)
 
 ## Welcome to Cromwell
 

--- a/scripts/docker-develop/Dockerfile
+++ b/scripts/docker-develop/Dockerfile
@@ -41,3 +41,4 @@ RUN useradd pigman && \
     mkdir -p /code
 
 WORKDIR /code
+ADD . /code/


### PR DESCRIPTION
This pull request will trigger CI to run for the newly added configuration. 

## What does it do?
Specifically, this test builds and deploys a docker development container with sbt and scala to build cromwell. 

## How is it tested?
The user is instructed to bind the source code with "sbt assembly" in the `/code` directory in the container after binding the root of this repository to `/code`. Since we cannot have volumes in circle, we instead just test the added code to the container, also located at `/code`. Since the purpose of this container is to be a clean slate with sbt, scala to build cromwell, the primary test that is important is ensuring that `sbt assembly` runs successfully without a hitch. Any other "docker" tests for the actual cromwell (not building it) would not belong here, but with Docker containers meant to deploy cromwell proper.

# Where does it deploy?
The container will deploy to the `CONTAINER_NAME` defined in the circle environment settings (or in the circle config at `.circleci/config.yml`. By default, it will be tagged with the commit first 10 characters, and then latest, and you can change this behavior by defining `DOCKER_TAG` either in the config or circle environment (I don't see a reason to do this). Note that deploy is ONLY set up to happen on pushes to master (and you can change this to also be develop, if you choose, or to be both and then to deploy to tags `<branch>-<commit>` or something like that.

## Background
This was first done at the repo [vsoch/cromwell](https://github.com/vsoch/cromwell/pull/1) to test since I can't set it up for the broadinstitute. The (finally) working test is at [https://circleci.com/gh/vsoch/cromwell/11](https://circleci.com/gh/vsoch/cromwell/11). I forgot that I can't have volumes, so it took me many tries to remember this, derp :P 

When adding to the repository here, the following additional work will be needed for setup:

 - Turn on the repository to build at circleci. The first build, since there is no `.circici/config.yml` will probably just yell at you for having "Version 1.0" or not finding a config.
 - You will want to turn on building forked pull requests in the settings
 - Under environment variables, define the following:
    - `DOCKER_USER` should be the user to authenticate pushing
    - `DOCKER_PASS` password for that user (**important** do not turn on also testing of forked pull requests on their branch (different setting from above) as this could compromise these credentials.
    - `CONTAINER_NAME` should be something like `broadinstiutute/cromwell-dev`

 - The tag will always build the commit id, and then latest. If you want to change this behavior, define `DOCKER_TAG`.
 - ensure the branch logic (when things are triggered) is to your liking.
 - update the repo badge to be cromwell here and not on vsoch (after you connect the two!)

I noticed that there is no sbt version set (in some config file) - would this make sense to do?

```bash
[warn] No sbt.version set in project/build.properties, base directory: /
[info] Set current project to root (in build file:/)
[info] 1.2.1
```
