### PR TITLE
Execution bucket call caching hint support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ that relied upon this cache, the cache is now opt-in and must be turned on expli
 `http` and `https` workflow inputs are now supported for shared filesystem and Google Pipelines API (PAPI) version 2
 backends. Configuration details are described [here](http://cromwell.readthedocs.io/en/develop/filesystems/HTTP).
 
+### Call cache hint support
+
+More efficient cache hit copying in multi-user environments is now supported through the `call_cache_hit_path_prefixes` workflow option.
+Details [here](http://cromwell.readthedocs.io/en/develop/CallCaching/#call-cache-hit-path-prefixes)
+
 ### Bug Fixes
 
 #### API

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
@@ -22,6 +22,13 @@ trait WorkflowPaths extends PathFactory {
   protected lazy val executionRootString: String = config.as[Option[String]]("root").getOrElse("cromwell-executions")
 
   /**
+    * Implementers of this trait might override this to provide an appropriate prefix corresponding to the execution root
+    * of the current workflow. This prefix would be prepended to the list of prefixes provided in workflow options for
+    * searching cache hits.
+    */
+  lazy val callCacheRootPrefix: Option[String] = None
+
+  /**
     * Path of the root directory Cromwell will use for ALL workflows.
     */
   lazy val executionRoot: Path = buildPath(executionRootString).toAbsolutePath

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
@@ -1,0 +1,26 @@
+version 1.0
+
+task yo {
+  input {
+    String salutation
+  }
+  command {
+    echo 'sup ~{salutation}?'
+  }
+
+  runtime {
+    docker: "ubuntu:latest"
+  }
+
+  output {
+    String out = read_string(stdout())
+  }
+}
+
+workflow call_cache_hit_prefixes {
+  call yo
+
+  output {
+    String sup = yo.out
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs
@@ -1,0 +1,1 @@
+{ "call_cache_hit_prefixes.yo.salutation": "empty hint" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.options
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.options
@@ -1,0 +1,3 @@
+{
+  "call_cache_hit_path_prefixes": []
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_no_hint.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_no_hint.inputs
@@ -1,0 +1,1 @@
+{ "call_cache_hit_prefixes.yo.salutation": "no hint" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
@@ -1,0 +1,1 @@
+{ "call_cache_hit_prefixes.yo.salutation": "two roots empty hint" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_first.options
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_first.options
@@ -1,0 +1,4 @@
+{
+   "jes_gcs_root": "gs://cloud-cromwell-dev",
+   "call_cache_hit_path_prefixes": []
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
@@ -1,0 +1,4 @@
+{
+   "jes_gcs_root" : "gs://cloud-cromwell-dev-another",
+   "call_cache_hit_path_prefixes": []
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_local.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_local.test
@@ -1,0 +1,17 @@
+# A list of call cache hint prefixes is explicitly specified but empty.
+name: call_cache_hit_prefixes_empty_hint_local
+testFormat: runtwiceexpectingnocallcaching
+backendsMode: "only"
+backends: [Local, LocalNoDocker]
+
+files {
+  workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs
+  options: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.options
+}
+
+metadata {
+  workflowName: call_cache_hit_prefixes
+  status: Succeeded
+  "outputs.call_cache_hit_prefixes.sup": "sup empty hint?"
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
@@ -1,0 +1,19 @@
+# A list of call cache hint prefixes is explicitly specified but empty.
+name: call_cache_hit_prefixes_empty_hint_papi
+# Because the SFS backend currently does not override the callCacheRootPrefix method, an empty set of prefixes
+# in workflow options means that no call cache hits will match.
+testFormat: runtwiceexpectingcallcaching
+backends: [Papi]
+
+files {
+  workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs
+  options: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.options
+}
+
+metadata {
+  workflowName: call_cache_hit_prefixes
+  status: Succeeded
+  "calls.call_cache_hit_prefixes.yo.callCaching.result": "Cache Hit: <<CACHE_HIT_UUID>>:call_cache_hit_prefixes.yo:-1"
+  "outputs.call_cache_hit_prefixes.sup": "sup empty hint?"
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_no_hint.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_no_hint.test
@@ -1,0 +1,15 @@
+# This is really just a plain call caching test but it's useful for direct comparison to the other prefix hint tests.
+name: call_cache_hit_prefixes_no_hint
+testFormat: runtwiceexpectingcallcaching
+
+files {
+  workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_no_hint.inputs
+}
+
+metadata {
+  workflowName: call_cache_hit_prefixes
+  status: Succeeded
+  "calls.call_cache_hit_prefixes.yo.callCaching.result": "Cache Hit: <<CACHE_HIT_UUID>>:call_cache_hit_prefixes.yo:-1"
+  "outputs.call_cache_hit_prefixes.sup": "sup no hint?"
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_papi.test
@@ -1,0 +1,18 @@
+# In both runs a list of call cache hint prefixes is explicitly specified but empty.
+# Each run has different "jes_gcs_root"s so they should not see each other's cache entries.
+name: call_cache_hit_prefixes_two_roots_empty_hint_papi
+testFormat: runtwiceexpectingnocallcaching
+backends: [Papi]
+
+files {
+  workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
+  options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_first.options
+  second-options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
+}
+
+metadata {
+  workflowName: call_cache_hit_prefixes
+  status: Succeeded
+  "outputs.call_cache_hit_prefixes.sup": "sup two roots empty hint?"
+}

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -43,7 +43,7 @@ object TestFormulas {
   def runWorkflowTwiceExpectingCaching(workflowDefinition: Workflow): Test[SubmitResponse] = {
     for {
       firstWF <- runSuccessfulWorkflow(workflowDefinition)
-      secondWf <- runSuccessfulWorkflow(workflowDefinition)
+      secondWf <- runSuccessfulWorkflow(workflowDefinition.secondRun)
       _ <- printHashDifferential(firstWF, secondWf)
       metadata <- validateMetadata(secondWf, workflowDefinition, Option(firstWF.id.id))
       _ <- validateNoCacheMisses(secondWf, metadata, workflowDefinition)
@@ -54,7 +54,7 @@ object TestFormulas {
   def runWorkflowTwiceExpectingNoCaching(workflowDefinition: Workflow): Test[SubmitResponse] = {
     for {
       _ <- runSuccessfulWorkflow(workflowDefinition) // Build caches
-      testWf <- runSuccessfulWorkflow(workflowDefinition)
+      testWf <- runSuccessfulWorkflow(workflowDefinition.secondRun)
       metadata <- validateMetadata(testWf, workflowDefinition)
       _ <- validateNoCacheHits(testWf, metadata, workflowDefinition)
       _ <- validateDirectoryContentsCounts(workflowDefinition, testWf, metadata)

--- a/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
@@ -32,6 +32,10 @@ final case class Workflow private(testName: String,
     options = CromwellClient.replaceJson(data.options.map(_ ()), "refresh_token", refreshToken),
     labels = Option(data.labels),
     zippedImports = data.zippedImports)
+
+  def secondRun: Workflow = {
+    copy(data = data.copy(options = data.secondOptions))
+  }
 }
 
 object Workflow {

--- a/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
@@ -25,7 +25,8 @@ case class WorkflowData(workflowContent: Option[String],
                         inputs: Option[() => String],
                         options: Option[() => String],
                         labels: List[Label],
-                        zippedImports: Option[File])
+                        zippedImports: Option[File],
+                        secondOptions: Option[() => String] = None)
 
 object WorkflowData {
   def fromConfig(filesConfig: Config, fullConfig: Config, basePath: File): ErrorOr[WorkflowData] = {
@@ -95,7 +96,6 @@ object WorkflowData {
     val workflowTypeVersion = fullConfig.get[Option[String]]("workflowTypeVersion").value
     val workflowRoot = fullConfig.get[Option[String]]("workflowRoot").value
 
-    // TODO: The slurps can throw - not a high priority but see #36
     WorkflowData(
       workflowContent = workflowSource,
       workflowUrl = workflowUrl,
@@ -104,6 +104,7 @@ object WorkflowData {
       workflowTypeVersion = workflowTypeVersion,
       inputs = getOptionalFile("inputs") map (file => () => file.contentAsString),
       options = getOptionalFile("options") map (file => () => file.contentAsString),
+      secondOptions = getOptionalFile(name = "second-options").orElse(getOptionalFile("options")) map (file => () => file.contentAsString),
       labels = getLabels,
       zippedImports = getImports
     )

--- a/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
+++ b/core/src/main/scala/cromwell/core/callcaching/CallCachingMode.scala
@@ -19,7 +19,7 @@ case object CallCachingOff extends CallCachingMode {
   override val withoutWrite = this
 }
 
-case class CallCachingActivity(readWriteMode: ReadWriteMode, options: CallCachingOptions = CallCachingOptions(invalidateBadCacheResults = true)) extends CallCachingMode {
+case class CallCachingActivity(readWriteMode: ReadWriteMode, options: CallCachingOptions = CallCachingOptions()) extends CallCachingMode {
   override val readFromCache = readWriteMode.r
   override val writeToCache = readWriteMode.w
   override lazy val withoutRead: CallCachingMode = if (!writeToCache) CallCachingOff else this.copy(readWriteMode = WriteCache)
@@ -35,4 +35,4 @@ case object ReadCache extends ReadWriteMode { override val w = false }
 case object WriteCache extends ReadWriteMode { override val r = false }
 case object ReadAndWriteCache extends ReadWriteMode
 
-final case class CallCachingOptions(invalidateBadCacheResults: Boolean = true)
+final case class CallCachingOptions(invalidateBadCacheResults: Boolean = true, workflowOptionCallCachePrefixes: Option[Vector[String]] = None)

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -9,7 +9,7 @@ import scala.concurrent.{ExecutionContext, Future}
 trait CallCachingSqlDatabase {
   def addCallCaching(joins: Seq[CallCachingJoin], batchSize: Int)(implicit ec: ExecutionContext): Future[Unit]
 
-  def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String)
+  def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCacheRootHints: Option[List[String]])
                                                      (implicit ec: ExecutionContext): Future[Boolean]
 
   def hasMatchingCallCachingEntriesForHashKeyValues(hashKeyHashValues: NonEmptyList[(String, String)])

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -13,7 +13,7 @@ import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql._
 import cromwell.database.sql.joins.CallCachingJoin
 import cromwell.database.sql.tables._
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCacheHashBundle
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor.AggregatedCallHashes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
 import wom.core._
@@ -72,8 +72,9 @@ class CallCache(database: CallCachingSqlDatabase) {
     CallCachingJoin(callCachingEntry, hashesToInsert.toSeq, aggregatedHashesToInsert, resultToInsert.toSeq, jobDetritusToInsert.toSeq)
   }
 
-  def hasBaseAggregatedHashMatch(baseAggregatedHash: String)(implicit ec: ExecutionContext): Future[Boolean] = {
-    database.hasMatchingCallCachingEntriesForBaseAggregation(baseAggregatedHash)
+  def hasBaseAggregatedHashMatch(baseAggregatedHash: String, hints: List[CacheHitHint])(implicit ec: ExecutionContext): Future[Boolean] = {
+    val ccpp = hints collectFirst { case h: CallCachePathPrefixes => h.prefixes }
+    database.hasMatchingCallCachingEntriesForBaseAggregation(baseAggregatedHash, ccpp)
   }
 
   def hasKeyValuePairHashMatch(hashes: NonEmptyList[HashResult])(implicit ec: ExecutionContext): Future[Boolean] = {
@@ -145,7 +146,7 @@ object CallCache {
                                            callOutputs: CallOutputs,
                                            jobDetritusFiles: Option[Map[String, Path]]
                                          )
-  
+
   implicit class EnhancedCallCachingJoin(val callCachingJoin: CallCachingJoin) extends AnyVal {
     def toJobSuccess(key: BackendJobDescriptorKey, pathBuilders: List[PathBuilder]): JobSucceededResponse = {
       import cromwell.Simpletons._
@@ -156,18 +157,23 @@ object CallCache {
 
       val outputs = if (callCachingJoin.callCachingSimpletonEntries.isEmpty) CallOutputs(Map.empty)
       else WomValueBuilder.toJobOutputs(key.call.outputPorts, callCachingJoin.callCachingSimpletonEntries map toSimpleton)
-      
+
       JobSucceededResponse(key, callCachingJoin.callCachingEntry.returnCode,outputs, Option(detritus), Seq.empty, None, resultGenerationMode = CallCached)
     }
-    
+
     def callCacheHashes: Set[HashResult] = {
       val hashResults = callCachingJoin.callCachingHashEntries.map({
-        case CallCachingHashEntry(k, v, _, _) => HashResult(HashKey.deserialize(k), HashValue(v)) 
+        case CallCachingHashEntry(k, v, _, _) => HashResult(HashKey.deserialize(k), HashValue(v))
       }) ++ callCachingJoin.callCachingAggregationEntry.collect({
         case CallCachingAggregationEntry(k, Some(v), _, _) => HashResult(HashKey.deserialize(k), HashValue(v))
       })
 
       hashResults.toSet
     }
+  }
+
+  sealed trait CacheHitHint
+  case class CallCachePathPrefixes(callCacheRootPrefix: Option[String], workflowOptionPrefixes: List[String]) extends CacheHitHint {
+    def prefixes: List[String] = callCacheRootPrefix.toList ++ workflowOptionPrefixes
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActor.scala
@@ -27,8 +27,8 @@ class CallCacheReadingJobActor(callCacheReadActor: ActorRef) extends LoggingFSM[
   startWith(WaitingForInitialHash, CCRJANoData)
   
   when(WaitingForInitialHash) {
-    case Event(InitialHashingResult(_, aggregatedBaseHash), CCRJANoData) =>
-      callCacheReadActor ! HasMatchingInitialHashLookup(aggregatedBaseHash)
+    case Event(InitialHashingResult(_, aggregatedBaseHash, hints), CCRJANoData) =>
+      callCacheReadActor ! HasMatchingInitialHashLookup(aggregatedBaseHash, hints)
       goto(WaitingForHashCheck) using CCRJAWithData(sender(), aggregatedBaseHash, None, 1)
   }
   

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -47,8 +47,8 @@ class EngineJobHashingActor(receiver: ActorRef,
       runtimeAttributeDefinitions,
       backendName,
       fileHashingActorProps,
-      activity.writeToCache,
-      callCachingEligible
+      callCachingEligible,
+      activity
     ), s"CCHashingJobActor-${workflowId.shortString}-$jobTag")
     super.preStart()
   }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
@@ -45,8 +45,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       Set.empty,
       "backedName",
       Props.empty,
-      false,
-      DockerWithHash("ubuntu@sha256:blablablba")
+      DockerWithHash("ubuntu@sha256:blablablba"),
+      CallCachingActivity(readWriteMode = ReadCache)
     ), parent.ref)
     watch(testActor)
     expectTerminated(testActor)
@@ -79,8 +79,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       runtimeAttributeDefinitions,
       "backedName",
       Props.empty,
-      true,
-      DockerWithHash("ubuntu@sha256:blablablba")
+      DockerWithHash("ubuntu@sha256:blablablba"),
+      CallCachingActivity(readWriteMode = ReadAndWriteCache)
     ), parent.ref)
     
     val expectedInitialHashes = Set(
@@ -125,8 +125,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       Set.empty,
       "backend",
       Props.empty,
-      writeToCache = writeToCache,
-      DockerWithHash("ubuntu@256:blablabla")
+      DockerWithHash("ubuntu@256:blablabla"),
+      CallCachingActivity(readWriteMode = if (writeToCache) ReadAndWriteCache else ReadCache)
     ) {
       override def makeFileHashingActor() = testFileHashingActor
       override def addFileHash(hashResult: HashResult, data: CallCacheHashingJobActorData) = {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
@@ -16,17 +16,17 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
   
   it should "try to match initial hashes against DB" in {
     val callCacheReadProbe = TestProbe()
-    val callCacheHasingActor = TestProbe()
+    val callCacheHashingActor = TestProbe()
     val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref))
     actorUnderTest.stateName shouldBe WaitingForInitialHash
 
     // The actual hashes don't matter here, we only care about the aggregated hash
     val aggregatedInitialhash: String = "AggregatedInitialHash"
-    callCacheHasingActor.send(actorUnderTest, InitialHashingResult(Set.empty, aggregatedInitialhash))
+    callCacheHashingActor.send(actorUnderTest, InitialHashingResult(Set.empty, aggregatedInitialhash))
     callCacheReadProbe.expectMsg(HasMatchingInitialHashLookup(aggregatedInitialhash))
     eventually {
       actorUnderTest.stateName shouldBe WaitingForHashCheck
-      actorUnderTest.stateData shouldBe CCRJAWithData(callCacheHasingActor.ref, aggregatedInitialhash, None, 1)
+      actorUnderTest.stateData shouldBe CCRJAWithData(callCacheHashingActor.ref, aggregatedInitialhash, None, 1)
     }
   }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
@@ -71,7 +71,7 @@ class EngineJobHashingActorSpec extends TestKitSuite with FlatSpecLike with Matc
       (WriteCache, false),
       (ReadAndWriteCache, true)
     )
-    forAll(activities) { case ((readWriteMode, hasCCReadActor)) =>
+    forAll(activities) { case (readWriteMode, hasCCReadActor) =>
       val receiver = TestProbe()
       val actorUnderTest = makeEJHA(receiver.ref, CallCachingActivity(readWriteMode))
       actorUnderTest.underlyingActor.callCacheReadingJobActor.isDefined shouldBe hasCCReadActor

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -110,7 +110,7 @@ class EjeaBackendIsCopyingCachedOutputsSpec extends EngineJobExecutionActorSpec 
           }
 
           s"not invalidate a call for caching if backend coping failed when invalidation is disabled, when it was going to receive $hashComboName, if call caching is $mode" in {
-            val invalidationDisabledOptions = CallCachingOptions(invalidateBadCacheResults = false)
+            val invalidationDisabledOptions = CallCachingOptions(invalidateBadCacheResults = false, workflowOptionCallCachePrefixes = None)
             val cacheInvalidationDisabledMode = mode match {
               case CallCachingActivity(rw, _) => CallCachingActivity(rw, invalidationDisabledOptions)
               case _ => fail(s"Mode $mode not appropriate for cache invalidation tests")

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributesSpec.scala
@@ -14,7 +14,7 @@ class PipelinesApiAttributesSpec extends FlatSpec with Matchers {
 
   behavior of "JesAttributes"
 
-  val googleConfig = GoogleConfiguration(JesGlobalConfig)
+  val googleConfig = GoogleConfiguration(PapiGlobalConfig)
   val runtimeConfig = ConfigFactory.load()
 
   it should "parse correct PAPI config" taggedAs IntegrationTest in {

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
@@ -27,7 +27,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders)
     
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -45,7 +45,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders)
 
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -67,7 +67,7 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders)
 
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationSpec.scala
@@ -117,11 +117,11 @@ class PipelinesApiConfigurationSpec extends FlatSpec with Matchers with TableDri
   }
 
   it should "have correct root" in {
-    new PipelinesApiConfiguration(BackendConfigurationDescriptor(backendConfig, globalConfig), genomicsFactory, googleConfiguration, jesAttributes).root shouldBe "gs://my-cromwell-workflows-bucket"
+    new PipelinesApiConfiguration(BackendConfigurationDescriptor(backendConfig, globalConfig), genomicsFactory, googleConfiguration, papiAttributes).root shouldBe "gs://my-cromwell-workflows-bucket"
   }
 
   it should "have correct docker" in {
-    val dockerConf = new PipelinesApiConfiguration(BackendConfigurationDescriptor(backendConfig, globalConfig), genomicsFactory, googleConfiguration, jesAttributes).dockerCredentials
+    val dockerConf = new PipelinesApiConfiguration(BackendConfigurationDescriptor(backendConfig, globalConfig), genomicsFactory, googleConfiguration, papiAttributes).dockerCredentials
     dockerConf shouldBe defined
     dockerConf.get.token shouldBe "dockerToken"
   }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActorSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.backend.BackendWorkflowInitializationActor.{InitializationFailed, InitializationSuccess, Initialize}
 import cromwell.backend.async.RuntimeAttributeValidationFailures
 import cromwell.backend.google.pipelines.common.PipelinesApiInitializationActorSpec._
-import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.{JesGlobalConfig, genomicsFactory, googleConfiguration, jesAttributes}
+import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.{PapiGlobalConfig, genomicsFactory, googleConfiguration, papiAttributes}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendSpec, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.Dispatcher.BackendDispatcher
@@ -56,7 +56,7 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
   }
 
   private def getJesBackend(workflowDescriptor: BackendWorkflowDescriptor, calls: Set[CommandCallNode], conf: BackendConfigurationDescriptor) = {
-    val props = getJesBackendProps(workflowDescriptor, calls, new PipelinesApiConfiguration(conf, genomicsFactory, googleConfiguration, jesAttributes))
+    val props = getJesBackendProps(workflowDescriptor, calls, new PipelinesApiConfiguration(conf, genomicsFactory, googleConfiguration, papiAttributes))
     system.actorOf(props, "TestableJesInitializationActor-" + UUID.randomUUID)
   }
 
@@ -178,6 +178,6 @@ object PipelinesApiInitializationActorSpec {
       | """.stripMargin))
 
   val defaultBackendConfig = new BackendConfigurationDescriptor(backendConfig, globalConfig) {
-    override private[backend] lazy val cromwellFileSystems = new CromwellFileSystems(JesGlobalConfig)
+    override private[backend] lazy val cromwellFileSystems = new CromwellFileSystems(PapiGlobalConfig)
   }
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.common
 import cats.data.NonEmptyList
 import cromwell.backend.RuntimeAttributeDefinition
 import cromwell.backend.google.pipelines.common.GpuResource.GpuType
-import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.{googleConfiguration, jesAttributes, _}
+import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.{googleConfiguration, papiAttributes, _}
 import cromwell.backend.google.pipelines.common.io.{DiskType, PipelinesApiAttachedDisk, PipelinesApiWorkingDisk}
 import cromwell.backend.validation.{ContinueOnReturnCodeFlag, ContinueOnReturnCodeSet}
 import cromwell.core.WorkflowOptions
@@ -283,7 +283,7 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
                                                            expectedRuntimeAttributes: PipelinesApiRuntimeAttributes,
                                                            workflowOptions: WorkflowOptions = emptyWorkflowOptions,
                                                            defaultZones: NonEmptyList[String] = defaultZones,
-                                                           jesConfiguration: PipelinesApiConfiguration = jesConfiguration): Unit = {
+                                                           jesConfiguration: PipelinesApiConfiguration = papiConfiguration): Unit = {
     try {
       val actualRuntimeAttributes = toJesRuntimeAttributes(runtimeAttributes, workflowOptions, jesConfiguration)
       assert(actualRuntimeAttributes == expectedRuntimeAttributes)
@@ -297,7 +297,7 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
                                                        exMsg: String,
                                                        workflowOptions: WorkflowOptions = emptyWorkflowOptions): Unit = {
     try {
-      toJesRuntimeAttributes(runtimeAttributes, workflowOptions, jesConfiguration)
+      toJesRuntimeAttributes(runtimeAttributes, workflowOptions, papiConfiguration)
       fail(s"A RuntimeException was expected with message: $exMsg")
     } catch {
       case ex: RuntimeException => assert(ex.getMessage.contains(exMsg))
@@ -317,7 +317,7 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
 
   private val emptyWorkflowOptions = WorkflowOptions.fromMap(Map.empty).get
   private val defaultZones = NonEmptyList.of("us-central1-b", "us-central1-a")
-  private val noDefaultsJesConfiguration = new PipelinesApiConfiguration(PipelinesApiTestConfig.NoDefaultsConfigurationDescriptor, genomicsFactory, googleConfiguration, jesAttributes)
+  private val noDefaultsJesConfiguration = new PipelinesApiConfiguration(PipelinesApiTestConfig.NoDefaultsConfigurationDescriptor, genomicsFactory, googleConfiguration, papiAttributes)
   private val staticRuntimeAttributeDefinitions: Set[RuntimeAttributeDefinition] =
-    PipelinesApiRuntimeAttributes.runtimeAttributesBuilder(PipelinesApiTestConfig.jesConfiguration).definitions.toSet
+    PipelinesApiRuntimeAttributes.runtimeAttributesBuilder(PipelinesApiTestConfig.papiConfiguration).definitions.toSet
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiTestConfig.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiTestConfig.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 object PipelinesApiTestConfig {
 
-  private val JesBackendConfigString =
+  private val PapiBackendConfigString =
     """
       |project = "my-cromwell-workflows"
       |root = "gs://my-cromwell-workflows-bucket"
@@ -62,7 +62,7 @@ object PipelinesApiTestConfig {
       |}
       |""".stripMargin
 
-  private val JesGlobalConfigString =
+  private val PapiGlobalConfigString =
     s"""
        |google {
        |  application-name = "cromwell"
@@ -86,7 +86,7 @@ object PipelinesApiTestConfig {
        |    JES {
        |      actor-factory = "cromwell.backend.google.pipelines.common.PipelinesApiBackendLifecycleActorFactory"
        |      config {
-       |      $JesBackendConfigString
+       |      $PapiBackendConfigString
        |      }
        |    }
        |  }
@@ -94,13 +94,13 @@ object PipelinesApiTestConfig {
        |
        |""".stripMargin
 
-  val JesBackendConfig = ConfigFactory.parseString(JesBackendConfigString)
-  val JesGlobalConfig = ConfigFactory.parseString(JesGlobalConfigString)
-  val JesBackendNoDefaultConfig = ConfigFactory.parseString(NoDefaultsConfigString)
-  val JesBackendConfigurationDescriptor = new BackendConfigurationDescriptor(JesBackendConfig, JesGlobalConfig) {
-    override private[backend] lazy val cromwellFileSystems = new CromwellFileSystems(JesGlobalConfig)
+  val PapiBackendConfig = ConfigFactory.parseString(PapiBackendConfigString)
+  val PapiGlobalConfig = ConfigFactory.parseString(PapiGlobalConfigString)
+  val PapiBackendNoDefaultConfig = ConfigFactory.parseString(NoDefaultsConfigString)
+  val PapiBackendConfigurationDescriptor = new BackendConfigurationDescriptor(PapiBackendConfig, PapiGlobalConfig) {
+    override private[backend] lazy val cromwellFileSystems = new CromwellFileSystems(PapiGlobalConfig)
   }
-  val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(JesBackendNoDefaultConfig, JesGlobalConfig)
+  val NoDefaultsConfigurationDescriptor = BackendConfigurationDescriptor(PapiBackendNoDefaultConfig, PapiGlobalConfig)
   val genomicsFactory = new PipelinesApiFactoryInterface {
     override def build(httpRequestInitializer: HttpRequestInitializer) = new PipelinesApiRequestFactory {
       override def cancelRequest(job: StandardAsyncJob) = ???
@@ -109,8 +109,8 @@ object PipelinesApiTestConfig {
     }
     override def usesEncryptedDocker: Boolean = false
   }
-  def pathBuilders()(implicit as: ActorSystem) = Await.result(JesBackendConfigurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
-  val googleConfiguration = GoogleConfiguration(JesGlobalConfig)
-  val jesAttributes = PipelinesApiAttributes(googleConfiguration, JesBackendConfig)
-  val jesConfiguration = new PipelinesApiConfiguration(JesBackendConfigurationDescriptor, genomicsFactory, googleConfiguration, jesAttributes)
+  def pathBuilders()(implicit as: ActorSystem) = Await.result(PapiBackendConfigurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
+  val googleConfiguration = GoogleConfiguration(PapiGlobalConfig)
+  val papiAttributes = PipelinesApiAttributes(googleConfiguration, PapiBackendConfig)
+  val papiConfiguration = new PipelinesApiConfiguration(PapiBackendConfigurationDescriptor, genomicsFactory, googleConfiguration, papiAttributes)
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
@@ -2,7 +2,7 @@ package cromwell.backend.google.pipelines.common
 
 import com.google.cloud.NoCredentials
 import common.collections.EnhancedCollections._
-import cromwell.backend.BackendSpec
+import cromwell.backend.{BackendSpec, BackendWorkflowDescriptor}
 import cromwell.cloudsupport.gcp.auth.GoogleAuthModeSpec
 import cromwell.core.TestKitSuite
 import cromwell.util.SampleWdl
@@ -15,20 +15,31 @@ class PipelinesApiWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with 
   import PipelinesApiTestConfig._
   import cromwell.filesystems.gcs.MockGcsPathBuilder._
 
-  behavior of "JesWorkflowPaths"
+  behavior of "PipelinesApiWorkflowPaths"
 
-  it should "map the correct paths" in {
-    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
+  var workflowDescriptor: BackendWorkflowDescriptor = _
+  var workflowPaths: PipelinesApiWorkflowPaths = _
 
-    val workflowDescriptor = buildWdlWorkflowDescriptor(
+  override def beforeAll: Unit = {
+    workflowDescriptor = buildWdlWorkflowDescriptor(
       SampleWdl.HelloWorld.workflowSource(),
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
     )
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), papiConfiguration, pathBuilders)
+  }
+
+  it should "map the correct paths" in {
+    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
     workflowPaths.executionRoot.pathAsString should be("gs://my-cromwell-workflows-bucket/")
     workflowPaths.workflowRoot.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/")
     workflowPaths.gcsAuthFilePath.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/${workflowDescriptor.id}_auth.json")
+  }
+
+  it should "calculate the call cache root correctly" in {
+    val WorkspaceBucket = "gs://workspace-id"
+    val ExecutionRoot = WorkspaceBucket + "/submission-id"
+    PipelinesApiWorkflowPaths.callCacheRootHintFromExecutionRoot(ExecutionRoot) shouldBe WorkspaceBucket
   }
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
@@ -234,5 +234,5 @@ class MockPipelinesRequestHandler extends PipelinesApiRequestHandler {
 object TestPipelinesApiRequestManager {
   import PipelinesApiTestConfig._
 
-  def props(registryProbe: ActorRef, statusPollers: ActorRef*): Props = Props(new TestPipelinesApiRequestManager(jesConfiguration.qps, jesConfiguration.papiRequestWorkers, registryProbe, statusPollers: _*))
+  def props(registryProbe: ActorRef, statusPollers: ActorRef*): Props = Props(new TestPipelinesApiRequestManager(papiConfiguration.qps, papiConfiguration.papiRequestWorkers, registryProbe, statusPollers: _*))
 }

--- a/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/api/PipelinesApiRequestWorkerV1Spec.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/api/PipelinesApiRequestWorkerV1Spec.scala
@@ -7,7 +7,7 @@ import akka.testkit.{TestActorRef, TestProbe}
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.services.genomics.model.Operation
-import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.jesConfiguration
+import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig.papiConfiguration
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager.PAPIStatusPollRequest
 import cromwell.backend.google.pipelines.common.api.{PipelinesApiRequestManager, PipelinesApiRequestWorkerSpec, TestPipelinesApiBatchHandler, TestPipelinesApiRequestWorker}
 import cromwell.backend.google.pipelines.v1alpha2.api.request.RequestHandler
@@ -22,7 +22,7 @@ class PipelinesApiRequestWorkerV1Spec extends PipelinesApiRequestWorkerSpec[Oper
     managerProbe = TestProbe()
     val registryProbe = TestProbe()
     batchHandler = new TestPipelinesApiBatchHandlerV1(managerProbe.ref)
-    workerActor = TestActorRef(TestPipelinesApiRequestWorker.props(managerProbe.ref, jesConfiguration, registryProbe.ref)(batchHandler), managerProbe.ref)
+    workerActor = TestActorRef(TestPipelinesApiRequestWorker.props(managerProbe.ref, papiConfiguration, registryProbe.ref)(batchHandler), managerProbe.ref)
   }
 }
 


### PR DESCRIPTION
OK slight change of plan: execution bucket call cache hints will be opt-in for now via workflow options with no changes required in Cromwell config. This actually does not have to be  PAPI specific so the proposed nomenclature would be more general:

```json
{
  call_cache_hit_path_prefixes: [ "gs://bucket-full-o-cache-hits", "gs://another-bucket-o-cache-hits" ]
}
```

"opt-in" here means that for now the caller would be responsible for specifying the prefixes by which to filter cache hits. If no prefixes are specified Cromwell will do no cache hit filtering. Backends have the ability to specify a root execution path to prepend to this list. For now this root execution path would only be prepended by PAPI since that's the only backend for which a sensible root could be determined by inspection (i.e. the GCS bucket).

The number of prefixes in this list would be limited, for now I'm arbitrarily choosing 3 total.

@ruchim 
