### PR TITLE
CI updates for Travis/Jenkins/Sentry.

### DIFF
--- a/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
@@ -24,7 +24,8 @@ class Slf4jReporter(override val name: String, config: Config) extends ErrorRepo
           centaurTestException.workflowIdOption.map("with workflow id '" + _ + "' ").getOrElse("") +
           s"failed on attempt ${testEnvironment.attempt + 1} " +
           s"of ${testEnvironment.retries + 1}"
-      logger.error(message, centaurTestException)
+      val metadata = centaurTestException.metadataJsonOption.map(" with metadata:\n" + _).getOrElse("")
+      logger.error(message + metadata, centaurTestException)
     }
   }
 }

--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
@@ -6,6 +6,8 @@ backends: [Papi]
 
 files {
   workflow: abort/scheduled_abort.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: abort/scheduled_abort.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_local.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_local.test
@@ -8,6 +8,8 @@ tags: [localdockertest]
 
 files {
   workflow: abort/scheduled_abort.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: abort/scheduled_abort.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
@@ -6,6 +6,8 @@ backends: [TES]
 
 files {
   workflow: abort/scheduled_abort.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: abort/scheduled_abort.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/abort.scheduled_abort.test
+++ b/centaur/src/main/resources/standardTestCases/abort.scheduled_abort.test
@@ -5,6 +5,8 @@ callMark: scheduled_abort.aborted
 
 files {
   workflow: abort/scheduled_abort.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: abort/scheduled_abort.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/abort.sub_workflow_abort.test
+++ b/centaur/src/main/resources/standardTestCases/abort.sub_workflow_abort.test
@@ -8,6 +8,8 @@ files {
   imports: [
     abort/sub_workflow_aborted_import.wdl
   ]
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: abort/scheduled_abort.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/abort/scheduled_abort.options
+++ b/centaur/src/main/resources/standardTestCases/abort/scheduled_abort.options
@@ -1,0 +1,3 @@
+{
+    "read_from_cache": false
+}

--- a/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_jes.test
+++ b/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_jes.test
@@ -5,6 +5,8 @@ backends: [Papi]
 
 files {
   workflow: failures/restart_while_failing/restart_while_failing.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: failures/restart_while_failing/restart_while_failing.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_local.test
+++ b/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_local.test
@@ -7,6 +7,8 @@ tags: [localdockertest]
 
 files {
   workflow: failures/restart_while_failing/restart_while_failing.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: failures/restart_while_failing/restart_while_failing.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_tes.test
+++ b/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_tes.test
@@ -6,6 +6,8 @@ tags: [localdockertest]
 
 files {
   workflow: failures/restart_while_failing/restart_while_failing.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
+  options: failures/restart_while_failing/restart_while_failing.options
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.options
+++ b/centaur/src/main/resources/standardTestCases/failures/restart_while_failing/restart_while_failing.options
@@ -1,0 +1,3 @@
+{
+    "read_from_cache": false
+}

--- a/centaur/src/main/resources/standardTestCases/no_new_calls.test
+++ b/centaur/src/main/resources/standardTestCases/no_new_calls.test
@@ -3,6 +3,7 @@ testFormat: workflowfailure
 
 files {
   workflow: no_new_calls/no_new_calls.wdl
+  # https://github.com/broadinstitute/cromwell/issues/4014
   options: no_new_calls/no_new_calls.options
 }
 

--- a/centaur/src/main/resources/standardTestCases/no_new_calls/no_new_calls.options
+++ b/centaur/src/main/resources/standardTestCases/no_new_calls/no_new_calls.options
@@ -1,3 +1,4 @@
 {
+  "read_from_cache": false,
   "workflowFailureMode": "NoNewCalls"
 }

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -75,7 +75,7 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_IS_CRON=false
             CROMWELL_BUILD_IS_SECURE="${TRAVIS_SECURE_ENV_VARS}"
             CROMWELL_BUILD_TYPE="${BUILD_TYPE}"
-            CROMWELL_BUILD_BRANCH="${TRAVIS_BRANCH}"
+            CROMWELL_BUILD_BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}"
             CROMWELL_BUILD_EVENT="${TRAVIS_EVENT_TYPE}"
             CROMWELL_BUILD_TAG="${TRAVIS_TAG}"
             CROMWELL_BUILD_NUMBER="${TRAVIS_JOB_NUMBER}"
@@ -91,11 +91,12 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             ;;
         "${CROMWELL_BUILD_PROVIDER_JENKINS}")
+            # External variables must be passed through in the ENVIRONMENT of src/ci/docker-compose/docker-compose.yml
             CROMWELL_BUILD_IS_CI=true
             CROMWELL_BUILD_IS_CRON=true
             CROMWELL_BUILD_IS_SECURE=true
             CROMWELL_BUILD_TYPE="${JENKINS_BUILD_TYPE}"
-            CROMWELL_BUILD_BRANCH="${GIT_BRANCH}"
+            CROMWELL_BUILD_BRANCH="${GIT_BRANCH#origin/}"
             CROMWELL_BUILD_EVENT=""
             CROMWELL_BUILD_TAG=""
             CROMWELL_BUILD_NUMBER="${BUILD_NUMBER}"

--- a/src/ci/bin/testConformancePapiV2.sh
+++ b/src/ci/bin/testConformancePapiV2.sh
@@ -57,7 +57,7 @@ cat <<JSON >"${CROMWELL_BUILD_CWL_TEST_INPUTS}"
     "cwl_conformance_test.centaur_cwl_runner": "${CROMWELL_BUILD_CWL_TEST_RUNNER}",
     "cwl_conformance_test.conformance_expected_failures":
         "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/papi_conformance_expected_failures.txt",
-    "cwl_conformance_test.timeout": 900
+    "cwl_conformance_test.timeout": 1200
 }
 JSON
 

--- a/src/ci/docker-compose/docker-compose.yml
+++ b/src/ci/docker-compose/docker-compose.yml
@@ -5,6 +5,10 @@ services:
       context: cromwell-test
     command: src/ci/bin/test.sh
     environment:
+      - BUILD_NUMBER
+      - BUILD_URL
+      - CI
+      - GIT_BRANCH
       - JENKINS
       - JENKINS_BUILD_TYPE
     working_dir: ${PWD}


### PR DESCRIPTION
- As sentry may drop some metadata, print the metadata to slf4j.
- For centaur-restarting-cromwell, remember if cromwell was alive, and log more of the connection status.
- Pass more jenkins variables through docker.
- Increase papi v2 cwl conformance test timeout due to problematic test 55.
- Use pr branch name during pr builds.