### PR TITLE
Maybe fix deadlock on horizontal Cromwell

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -97,6 +97,11 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
     database.run(action.transactionally)
   }
 
+  // Run in a single session for efficiency, but without transaction semantics
+  protected[this] def runInSession[R](action: DBIO[R]): Future[R] = {
+    database.run(action.withPinnedSession)
+  }
+
   /*
     * Upsert the provided values in batch.
     * Fails the query if one or more upsert failed.

--- a/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
@@ -78,10 +78,10 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
     // List if any of those workflows completed and their workflow store entries were removed.
 
     val transactions = workflowExecutionUuids.toList map { i: String =>
-      runTransaction(dataAccess.heartbeatForWorkflowStoreEntry(i).update(optionNow))
+      dataAccess.heartbeatForWorkflowStoreEntry(i).update(optionNow)
     }
 
-    Future.sequence(transactions).map(_.sum)
+    database.run(DBIO.sequence(transactions).withPinnedSession).map(_.sum)
   }
 
   override def releaseWorkflowStoreEntries(cromwellId: String)(implicit ec: ExecutionContext): Future[Unit] = {


### PR DESCRIPTION
This change attempts to fix the deadlock between [starting workflows](https://github.com/broadinstitute/cromwell/blob/develop/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala#L65) and [writing heartbeats](https://github.com/broadinstitute/cromwell/blob/develop/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala#L75) by removing transaction semantics from the heartbeat write query. This way, the second query no longer locks multiple rows at once.

I am using Slick's [`withPinnedSession`](http://slick.lightbend.com/doc/3.2.0/dbio.html#transactions-and-pinned-sessions) to preserve the efficiency gain of having all the queries in a single session.

Generated SQL statements logged on my local Cromwell show that `transactionally` and `withPinnedSession` both cause queries to execute in a single session, as evidenced by the setting of session variable `autocommit`:

- `database.run(action.transactionally)`:
```
Query SET autocommit=0
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'c8482924-ef9e-4b3f-930c-ab5f023eeb78'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'e79a1ee7-dd21-4a55-b52d-03f50031b75e'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'f0bae536-32c2-4f15-93af-f03515668faf'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '9892d137-40b5-420c-94b4-88481c8ad249'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '4447f78f-85d2-4c27-8d2f-ea230ca130c1'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:43:00.194' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '3a43b3bf-2cd5-4470-8131-05ff8016ccbb'
Query commit
```
- `database.run(action.withPinnedSession)`:
```
Query SET autocommit=1
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:55:47.844' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '9fa0610c-6345-4abc-9240-883d1bb10f34'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:55:47.844' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '6df0ea00-027e-4fb7-9bbe-67bbed69f966'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:55:47.844' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'd5748deb-5a28-4678-92c0-cc03aaeb689d'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:55:47.844' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '5e423c7e-7857-4884-814f-787b98c54491'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:55:47.844' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'db449c5a-5138-42ec-992a-d88f29a78693'
Query SET autocommit=0
```
- `database.run(action)`:
```
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '6a68865c-13ea-410e-a774-9b5e58f45523'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '669f97ea-1256-4732-a4ac-a565ff749e41'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'c3994549-e8e1-4478-9bf3-ef46cc16f505'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '8d535b7f-4832-429c-9144-c3c39eeb7006'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = 'd89fe8c2-3803-407d-99c6-3b77443ff20b'
Query update `WORKFLOW_STORE_ENTRY` set `HEARTBEAT_TIMESTAMP` = '2018-08-20 15:32:10.097' where `WORKFLOW_STORE_ENTRY`.`WORKFLOW_EXECUTION_UUID` = '768dfe30-7072-4430-bb31-355499ca1443'
```