### PR TITLE
Fix metadata, call caching issues for CWL Long type

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows/cwl_cache_between_workflows.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows/cwl_cache_between_workflows.cwl
@@ -36,11 +36,11 @@ $graph:
 
   outputs:
     trapezoidalArea:
-      type: float
+      type: long
       outputBinding:
         glob: stdout.txt
         loadContents: true
-        outputEval: $(parseFloat(self[0].contents))
+        outputEval: $(parseLong(self[0].contents))
 
   arguments:
   - valueFrom: "echo $(inputs.baseAverage * inputs.height)"
@@ -63,7 +63,7 @@ $graph:
       type: float
       outputSource: step-average/baseAverage
     trapezoidalArea:
-      type: float
+      type: long
       outputSource: step-product/trapezoidalArea
 
   steps:

--- a/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows/cwl_cache_between_workflows.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows/cwl_cache_between_workflows.cwl
@@ -40,7 +40,7 @@ $graph:
       outputBinding:
         glob: stdout.txt
         loadContents: true
-        outputEval: $(parseLong(self[0].contents))
+        outputEval: $(parseFloat(self[0].contents))
 
   arguments:
   - valueFrom: "echo $(inputs.baseAverage * inputs.height)"

--- a/engine/src/main/scala/cromwell/Simpletons.scala
+++ b/engine/src/main/scala/cromwell/Simpletons.scala
@@ -3,7 +3,7 @@ package cromwell
 import cromwell.core.simpleton.WomValueSimpleton
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.tables.{CallCachingSimpletonEntry, JobStoreSimpletonEntry}
-import wom.types.{WomBooleanType, WomFloatType, WomIntegerType, WomStringType}
+import wom.types.{WomBooleanType, WomFloatType, WomIntegerType, WomLongType, WomStringType}
 import wom.values.{WomPrimitive, WomSingleFile, WomValue}
 
 import scala.util.Try
@@ -25,6 +25,7 @@ object Simpletons {
       case "String" => WomStringType.coerceRawValue
       case "Int" => WomIntegerType.coerceRawValue
       case "Float" => WomFloatType.coerceRawValue
+      case "Long" => WomLongType.coerceRawValue
       case "Boolean" => WomBooleanType.coerceRawValue
       case "File" => s => Try(WomSingleFile(s))
       case _ => throw new RuntimeException(s"unrecognized simpleton WOM type: $womType")

--- a/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
@@ -54,6 +54,7 @@ object MetadataValue {
     Option(value).getOrElse("") match {
       case WomInteger(i) => new MetadataValue(i.toString, MetadataInt)
       case WomFloat(f) => new MetadataValue(f.toString, MetadataNumber)
+      case WomLong(f) => new MetadataValue(f.toString, MetadataNumber)
       case WomBoolean(b) => new MetadataValue(b.toString, MetadataBoolean)
       case WomOptionalValue(_, Some(o)) => apply(o)
       case WomOptionalValue(_, None) => new MetadataValue("", MetadataNull)


### PR DESCRIPTION
Closes #4023 

I hijacked one of the steps in `cwl_cache_between_workflows.cwl` to test `Long` alongside `Float` - the second commit [fails](https://api.travis-ci.org/v3/job/419242749/log.txt) with the error the user saw.