### PR TITLE
Bump file read timeout to maybe reduce test failures

### DIFF
--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -50,7 +50,7 @@ object EngineFunctionEvaluators {
       EvaluatedValue(WomSingleFile(ioFunctionSet.pathFunctions.stderr), Seq.empty).validNel
   }
 
-  private val ReadWaitTimeout = 10.seconds
+  private val ReadWaitTimeout = 60.seconds
   private def readFile(fileToRead: WomSingleFile, ioFunctionSet: IoFunctionSet, sizeLimit: Int) = {
     Try(Await.result(ioFunctionSet.readFile(fileToRead.value, Option(sizeLimit), failOnOverflow = true), ReadWaitTimeout))
   }


### PR DESCRIPTION
We've seen a few times the IO error `Failed to evaluate job outputs [...] Futures timed out after [10 seconds]` in tests.

I hypothesize that file read times from buckets may suffer from occasional outliers due to 🌩

I know this is the right timeout to change thanks to [this branch](https://github.com/broadinstitute/cromwell/compare/aen_make_it_timeout?expand=1) where I induced error `Failed to evaluate job outputs [...] Futures timed out after [10 microseconds]`