### PR TITLE
Backstop Resources: TotalMaxJobsPerRootWf and MaxScatterWidth

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -136,7 +136,7 @@ system {
     # the quota availble on the GCS API
     number-of-requests = 100000
     per = 100 seconds
-a
+
     # Number of times an I/O operation should be attempted before giving up and failing it.
     number-of-attempts = 5
     

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -128,7 +128,7 @@ system {
 
   # Total max. jobs that can be created per root workflow. If it goes beyond N, Cromwell will fail the workflow by:
   # - no longer creating new jobs
-  # - let jobs that are currently finish, and then fail the workflow
+  # - let the jobs that have already been started finish, and then fail the workflow
   total-max-jobs-per-root-workflow = 1000000
 
   io {
@@ -136,7 +136,7 @@ system {
     # the quota availble on the GCS API
     number-of-requests = 100000
     per = 100 seconds
-
+a
     # Number of times an I/O operation should be attempted before giving up and failing it.
     number-of-attempts = 5
     

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -124,12 +124,12 @@ system {
   number-of-cache-read-workers = 25
 
   # Maximum scatter width per scatter node. Cromwell will fail the workflow if the scatter width goes beyond N
-  max-scatter-width-per-scatter = 5
+  max-scatter-width-per-scatter = 100000
 
   # Total max. jobs that can be created per root workflow. If it goes beyond N, Cromwell will fail the workflow by:
   # - no longer creating new jobs
   # - let jobs that are currently finish, and then fail the workflow
-  total-max-jobs-per-root-workflow = 10
+  total-max-jobs-per-root-workflow = 1000000
 
   io {
     # Global Throttling - This is mostly useful for GCS and can be adjusted to match

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -123,6 +123,14 @@ system {
   # Default number of cache read workers
   number-of-cache-read-workers = 25
 
+  # Maximum scatter width per scatter node. Cromwell will fail the workflow if the scatter width goes beyond N
+  max-scatter-width-per-scatter = 5
+
+  # Total max. jobs that can be created per root workflow. If it goes beyond N, Cromwell will fail the workflow by:
+  # - no longer creating new jobs
+  # - let jobs that are currently finish, and then fail the workflow
+  total-max-jobs-per-root-workflow = 10
+
   io {
     # Global Throttling - This is mostly useful for GCS and can be adjusted to match
     # the quota availble on the GCS API

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -124,7 +124,7 @@ system {
   number-of-cache-read-workers = 25
 
   # Maximum scatter width per scatter node. Cromwell will fail the workflow if the scatter width goes beyond N
-  max-scatter-width-per-scatter = 100000
+  max-scatter-width-per-scatter = 1000000
 
   # Total max. jobs that can be created per root workflow. If it goes beyond N, Cromwell will fail the workflow by:
   # - no longer creating new jobs

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -292,6 +292,7 @@ class WorkflowActor(val workflowId: WorkflowId,
         backendSingletonCollection,
         initializationData,
         startState = data.effectiveStartableState,
+        rootConfig = conf,
         totalJobsByRootWf = totalJobsByRootWf), name = s"WorkflowExecutionActor-$workflowId")
 
       executionActor ! ExecuteWorkflowCommand

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -1,5 +1,7 @@
 package cromwell.engine.workflow
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor._
 import com.typesafe.config.Config
@@ -158,7 +160,8 @@ object WorkflowActor {
             workflowStoreActor: ActorRef,
             backendSingletonCollection: BackendSingletonCollection,
             serverMode: Boolean,
-            workflowHeartbeatConfig: WorkflowHeartbeatConfig): Props = {
+            workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+            totalJobsByRootWf: AtomicInteger): Props = {
     Props(
       new WorkflowActor(
         workflowId = workflowId,
@@ -177,7 +180,8 @@ object WorkflowActor {
         workflowStoreActor = workflowStoreActor,
         backendSingletonCollection = backendSingletonCollection,
         serverMode = serverMode,
-        workflowHeartbeatConfig = workflowHeartbeatConfig)).withDispatcher(EngineDispatcher)
+        workflowHeartbeatConfig = workflowHeartbeatConfig,
+        totalJobsByRootWf = totalJobsByRootWf)).withDispatcher(EngineDispatcher)
   }
 }
 
@@ -200,7 +204,8 @@ class WorkflowActor(val workflowId: WorkflowId,
                     workflowStoreActor: ActorRef,
                     backendSingletonCollection: BackendSingletonCollection,
                     serverMode: Boolean,
-                    workflowHeartbeatConfig: WorkflowHeartbeatConfig)
+                    workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+                    totalJobsByRootWf: AtomicInteger)
   extends LoggingFSM[WorkflowActorState, WorkflowActorData] with WorkflowLogging with WorkflowMetadataHelper
   with WorkflowInstrumentation with Timers {
 
@@ -286,7 +291,8 @@ class WorkflowActor(val workflowId: WorkflowId,
         jobTokenDispenserActor = jobTokenDispenserActor,
         backendSingletonCollection,
         initializationData,
-        startState = data.effectiveStartableState), name = s"WorkflowExecutionActor-$workflowId")
+        startState = data.effectiveStartableState,
+        totalJobsByRootWf = totalJobsByRootWf), name = s"WorkflowExecutionActor-$workflowId")
 
       executionActor ! ExecuteWorkflowCommand
       

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -1,5 +1,7 @@
 package cromwell.engine.workflow
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor._
 import akka.event.Logging
@@ -292,7 +294,8 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       workflowStoreActor = params.workflowStore,
       backendSingletonCollection = params.backendSingletonCollection,
       serverMode = params.serverMode,
-      workflowHeartbeatConfig = params.workflowHeartbeatConfig)
+      workflowHeartbeatConfig = params.workflowHeartbeatConfig,
+      totalJobsByRootWf = new AtomicInteger())
     val wfActor = context.actorOf(wfProps, name = s"WorkflowActor-$workflowId")
 
     wfActor ! SubscribeTransitionCallBack(self)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor.{ActorRef, FSM, LoggingFSM, OneForOneStrategy, Props, SupervisorStrategy}
+import com.typesafe.config.Config
 import cromwell.backend.{AllBackendInitializationData, BackendLifecycleActorFactory, BackendWorkflowDescriptor}
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core._
@@ -40,6 +41,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
                                 backendSingletonCollection: BackendSingletonCollection,
                                 initializationData: AllBackendInitializationData,
                                 startState: StartableState,
+                                rootConfig: Config,
                                 totalJobsByRootWf: AtomicInteger) extends LoggingFSM[SubWorkflowExecutionActorState, SubWorkflowExecutionActorData] with JobLogging with WorkflowMetadataHelper with CallMetadataHelper {
 
   override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() { case _ => Escalate }
@@ -194,6 +196,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
         backendSingletonCollection,
         initializationData,
         startState,
+        rootConfig,
         totalJobsByRootWf
       ),
       s"${subWorkflowEngineDescriptor.id}-SubWorkflowActor-${key.tag}"
@@ -305,6 +308,7 @@ object SubWorkflowExecutionActor {
             backendSingletonCollection: BackendSingletonCollection,
             initializationData: AllBackendInitializationData,
             startState: StartableState,
+            rootConfig: Config,
             totalJobsByRootWf: AtomicInteger) = {
     Props(new SubWorkflowExecutionActor(
       key,
@@ -322,6 +326,7 @@ object SubWorkflowExecutionActor {
       backendSingletonCollection,
       initializationData,
       startState,
+      rootConfig,
       totalJobsByRootWf)
     ).withDispatcher(EngineDispatcher)
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -58,7 +58,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
   private val restarting = params.startState.restarted
   private val tag = s"WorkflowExecutionActor [UUID(${workflowDescriptor.id.shortString})]"
 
-  private val DefaultTotalMaxJobsPerRootWf = 10000
+  private val DefaultTotalMaxJobsPerRootWf = 1000000
   private val TotalMaxJobsPerRootWf = ConfigFactory.load.getConfig("system").as[Option[Int]]("total-max-jobs-per-root-workflow").getOrElse(DefaultTotalMaxJobsPerRootWf)
 
   private val backendFactories: Map[String, BackendLifecycleActorFactory] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
@@ -21,7 +21,7 @@ import wom.values.WomValue
 import scala.language.postfixOps
 
 private [execution] case class ScatterKey(node: ScatterNode) extends JobKey {
-  private val DefaultMaxScatterSize = 100000
+  private val DefaultMaxScatterSize = 1000000
   private val MaxScatterWidth = ConfigFactory.load.getConfig("system").as[Option[Int]]("max-scatter-width-per-scatter").getOrElse(DefaultMaxScatterSize)
 
   // When scatters are nested, this might become Some(_)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/keys/ScatterKey.scala
@@ -21,7 +21,7 @@ import wom.values.WomValue
 import scala.language.postfixOps
 
 private [execution] case class ScatterKey(node: ScatterNode) extends JobKey {
-  private val DefaultMaxScatterSize = 10000
+  private val DefaultMaxScatterSize = 100000
   private val MaxScatterWidth = ConfigFactory.load.getConfig("system").as[Option[Int]]("max-scatter-width-per-scatter").getOrElse(DefaultMaxScatterSize)
 
   // When scatters are nested, this might become Some(_)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -101,6 +101,7 @@ object ExecutionStore {
     val notStartedBackendJobs = notStartedKeys.collect { case key: BackendJobDescriptorKey => key }
     val notStartedBackendJobsCt = notStartedBackendJobs.size
 
+    // this limits the total max jobs that can be created by a root workflow
     if (totalJobsByRootWf.addAndGet(notStartedBackendJobsCt) > TotalMaxJobsPerRootWf)
       s"Root workflow tried creating ${totalJobsByRootWf.get} jobs, which is more than $TotalMaxJobsPerRootWf, the max cumulative jobs allowed per root workflow.".invalidNel
     else {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -21,9 +21,8 @@ import wom.graph.expression.ExpressionNodeLike
 import net.ceedubs.ficus.Ficus._
 
 object ExecutionStore {
-  private val DefaultTotalMaxJobsPerRootWf = 10000
-  private val config = ConfigFactory.load
-  private val TotalMaxJobsPerRootWf = config.getConfig("system").as[Option[Int]]("total-max-jobs-per-root-workflow").getOrElse(DefaultTotalMaxJobsPerRootWf)
+  private val DefaultTotalMaxJobsPerRootWf = 1000000
+  private val TotalMaxJobsPerRootWf = ConfigFactory.load.getConfig("system").as[Option[Int]]("total-max-jobs-per-root-workflow").getOrElse(DefaultTotalMaxJobsPerRootWf)
 
   type StatusTable = Table[GraphNode, ExecutionIndex.ExecutionIndex, JobKey]
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -1,7 +1,12 @@
 package cromwell.engine.workflow.lifecycle.execution.stores
 
-import common.collections.Table
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.syntax.validated._
+import com.typesafe.config.ConfigFactory
 import common.collections.EnhancedCollections._
+import common.collections.Table
+import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import cromwell.core.ExecutionStatus._
@@ -13,8 +18,13 @@ import wom.callable.ExecutableCallable
 import wom.graph.GraphNodePort.{ConditionalOutputPort, OutputPort, ScatterGathererPort}
 import wom.graph._
 import wom.graph.expression.ExpressionNodeLike
+import net.ceedubs.ficus.Ficus._
 
 object ExecutionStore {
+  private val DefaultTotalMaxJobsPerRootWf = 10000
+  private val config = ConfigFactory.load
+  private val TotalMaxJobsPerRootWf = config.getConfig("system").as[Option[Int]]("total-max-jobs-per-root-workflow").getOrElse(DefaultTotalMaxJobsPerRootWf)
+
   type StatusTable = Table[GraphNode, ExecutionIndex.ExecutionIndex, JobKey]
 
   val MaxJobsToStartPerTick = 1000
@@ -78,7 +88,7 @@ object ExecutionStore {
 
   def empty = ActiveExecutionStore(Map.empty[JobKey, ExecutionStatus], needsUpdate = false)
 
-  def apply(callable: ExecutableCallable) = {
+  def apply(callable: ExecutableCallable, totalJobsByRootWf: AtomicInteger): ErrorOr[ActiveExecutionStore] = {
     // Keys that are added in a NotStarted Status
     val notStartedKeys = callable.graph.nodes collect {
       case call: CommandCallNode => BackendJobDescriptorKey(call, None, 1)
@@ -88,13 +98,19 @@ object ExecutionStore {
       case subworkflow: WorkflowCallNode => SubWorkflowKey(subworkflow, None, 1)
     }
 
-    // There are potentially resolved workflow inputs that are default WomExpressions.
-    // For now assume that those are call inputs that will be evaluated in the CallPreparation.
-    // If they are actually workflow declarations then we would need to add them to the ExecutionStore so they can be evaluated.
-    // In that case we would want InstantiatedExpressions so we can create an InstantiatedExpressionNode and add a DeclarationKey
-    ActiveExecutionStore(notStartedKeys.map(_ -> NotStarted).toMap, notStartedKeys.nonEmpty)
-  }
+    val notStartedBackendJobs = notStartedKeys.collect { case key: BackendJobDescriptorKey => key }
+    val notStartedBackendJobsCt = notStartedBackendJobs.size
 
+    if (notStartedBackendJobsCt > TotalMaxJobsPerRootWf || totalJobsByRootWf.addAndGet(notStartedBackendJobsCt) > TotalMaxJobsPerRootWf)
+      s"Root workflow tried creating ${totalJobsByRootWf.get} jobs, which is more than $TotalMaxJobsPerRootWf, the max cumulative jobs allowed per root workflow.".invalidNel
+    else {
+      // There are potentially resolved workflow inputs that are default WomExpressions.
+      // For now assume that those are call inputs that will be evaluated in the CallPreparation.
+      // If they are actually workflow declarations then we would need to add them to the ExecutionStore so they can be evaluated.
+      // In that case we would want InstantiatedExpressions so we can create an InstantiatedExpressionNode and add a DeclarationKey
+      ActiveExecutionStore(notStartedKeys.map(_ -> NotStarted).toMap, notStartedKeys.nonEmpty).validNel
+    }
+  }
 }
 
 /**

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -101,7 +101,7 @@ object ExecutionStore {
     val notStartedBackendJobs = notStartedKeys.collect { case key: BackendJobDescriptorKey => key }
     val notStartedBackendJobsCt = notStartedBackendJobs.size
 
-    if (notStartedBackendJobsCt > TotalMaxJobsPerRootWf || totalJobsByRootWf.addAndGet(notStartedBackendJobsCt) > TotalMaxJobsPerRootWf)
+    if (totalJobsByRootWf.addAndGet(notStartedBackendJobsCt) > TotalMaxJobsPerRootWf)
       s"Root workflow tried creating ${totalJobsByRootWf.get} jobs, which is more than $TotalMaxJobsPerRootWf, the max cumulative jobs allowed per root workflow.".invalidNel
     else {
       // There are potentially resolved workflow inputs that are default WomExpressions.

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.Props
 import akka.testkit.{TestFSMRef, TestProbe}
+import com.typesafe.config.ConfigFactory
 import cromwell.backend.{AllBackendInitializationData, BackendWorkflowDescriptor, JobExecutionMap}
 import cromwell.core._
 import cromwell.core.callcaching.CallCachingOff
@@ -61,7 +62,8 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with FlatSpecLike with 
   val subWorkflow = WomMocks.mockWorkflowDefinition("sub_wf")
   val subWorkflowCall = WomMocks.mockWorkflowCall(WomIdentifier("workflow"), definition = subWorkflow)
   val subKey: SubWorkflowKey = SubWorkflowKey(subWorkflowCall, None, 1)
-  
+  val rootConfig = ConfigFactory.load
+
   val awaitTimeout: FiniteDuration = 10 seconds
 
   def buildEWEA(startState: StartableState = Submitted) = {
@@ -82,6 +84,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with FlatSpecLike with 
         BackendSingletonCollection(Map.empty),
         AllBackendInitializationData(Map.empty),
         startState,
+        rootConfig,
         new AtomicInteger()
       ) {
         override def createSubWorkflowPreparationActor(subWorkflowId: WorkflowId) = preparationActor.ref

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution
 
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.Props
 import akka.testkit.{TestFSMRef, TestProbe}
@@ -80,7 +81,8 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with FlatSpecLike with 
         jobTokenDispenserProbe.ref,
         BackendSingletonCollection(Map.empty),
         AllBackendInitializationData(Map.empty),
-        startState
+        startState,
+        new AtomicInteger()
       ) {
         override def createSubWorkflowPreparationActor(subWorkflowId: WorkflowId) = preparationActor.ref
         override def createSubWorkflowActor(createSubWorkflowActor: EngineWorkflowDescriptor) = subWorkflowActor.ref

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -1,6 +1,7 @@
 package cromwell
 
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.Props
 import akka.testkit._
@@ -17,6 +18,7 @@ import cromwell.engine.workflow.workflowstore.{Submitted, WorkflowHeartbeatConfi
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.HelloWorld.Addressee
 import org.scalatest.BeforeAndAfter
+
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Promise}
 
@@ -65,7 +67,8 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
         backendSingletonCollection = BackendSingletonCollection(Map("Local" -> None)),
         serverMode = true,
         workflowStoreActor = system.actorOf(Props.empty),
-        workflowHeartbeatConfig = WorkflowHeartbeatConfig(config)),
+        workflowHeartbeatConfig = WorkflowHeartbeatConfig(config),
+        totalJobsByRootWf = new AtomicInteger()),
       supervisor = supervisor.ref,
       name = s"workflow-actor-$workflowId"
     )

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
@@ -40,6 +40,8 @@ class WorkflowExecutionActorSpec extends CromwellTestKitSpec with FlatSpecLike w
 
   val serviceRegistry = TestProbe().ref
 
+  val rootConfig = ConfigFactory.load
+
   val runtimeSection =
     """
       |runtime {
@@ -79,7 +81,7 @@ class WorkflowExecutionActorSpec extends CromwellTestKitSpec with FlatSpecLike w
     val weaSupervisor = TestProbe()
     val workflowExecutionActor = TestActorRef(
       props = WorkflowExecutionActor.props(engineWorkflowDescriptor, ioActor, serviceRegistryActor, jobStoreActor, subWorkflowStoreActor,
-        callCacheReadActor.ref, callCacheWriteActor.ref, dockerHashActor.ref, jobTokenDispenserActor, MockBackendSingletonCollection, AllBackendInitializationData.empty, startState = Submitted, new AtomicInteger()),
+        callCacheReadActor.ref, callCacheWriteActor.ref, dockerHashActor.ref, jobTokenDispenserActor, MockBackendSingletonCollection, AllBackendInitializationData.empty, startState = Submitted, rootConfig, new AtomicInteger()),
       name = "WorkflowExecutionActor",
       supervisor = weaSupervisor.ref)
 

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
@@ -1,5 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import akka.actor.{Actor, Props}
 import akka.testkit.{EventFilter, TestActorRef, TestDuration, TestProbe}
 import com.typesafe.config.ConfigFactory
@@ -77,7 +79,7 @@ class WorkflowExecutionActorSpec extends CromwellTestKitSpec with FlatSpecLike w
     val weaSupervisor = TestProbe()
     val workflowExecutionActor = TestActorRef(
       props = WorkflowExecutionActor.props(engineWorkflowDescriptor, ioActor, serviceRegistryActor, jobStoreActor, subWorkflowStoreActor,
-        callCacheReadActor.ref, callCacheWriteActor.ref, dockerHashActor.ref, jobTokenDispenserActor, MockBackendSingletonCollection, AllBackendInitializationData.empty, startState = Submitted),
+        callCacheReadActor.ref, callCacheWriteActor.ref, dockerHashActor.ref, jobTokenDispenserActor, MockBackendSingletonCollection, AllBackendInitializationData.empty, startState = Submitted, new AtomicInteger()),
       name = "WorkflowExecutionActor",
       supervisor = weaSupervisor.ref)
 


### PR DESCRIPTION
This PR introduces two new config settings: `max-scatter-width-per-scatter` and `total-max-jobs-per-root-workflow`. Their purpose is:

- max-scatter-width-per-scatter: Maximum scatter width per scatter node. If a workflow has a scatter width more than this number, Cromwell will fail the workflow
- total-max-jobs-per-root-workflow: Total max. jobs that can be created per root workflow. If workflow tries to create jobs more than this number, Cromwell will fail the workflow by: no longer creating new jobs and let the jobs that have already been started finish, and then fail the workflow

Remaining: Update the default values of these two configurations in `reference.conf` based on threshold determined from Performance Tests.
