### PR TITLE
Apply exponential backoff when retrying from backpressure IO

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -132,6 +132,18 @@ system {
     # Number of times an I/O operation should be attempted before giving up and failing it.
     number-of-attempts = 5
     
+    # configures exponential backoff of io requests
+    backpressure-backoff {
+      # starting point
+      min = 10 seconds
+      # maximum waiting time between attempts
+      max = 5 minutes
+      # how much longer to wait between each attempt
+      multiplier = 2
+      # randomizes wait times to avoid large spikes. Must be between 0 and 1.
+      randomization-factor = 0.9
+    }
+    
     # Amount of time after which an I/O operation will timeout if no response has been received.
     # Note that a timeout may result in a workflow failure so be careful not to set a timeout too low.
     # Unless you start experiencing timeouts under very heavy load there should be no reason to change the default values.

--- a/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
@@ -1,14 +1,21 @@
 package cromwell.core.io
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
+import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.actor.RobustClientHelper
+import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import net.ceedubs.ficus.Ficus._
 
 trait IoClientHelper extends RobustClientHelper { this: Actor with ActorLogging =>
   def ioActor: ActorRef
 
   lazy val defaultIoTimeout = RobustClientHelper.DefaultRequestLostTimeout
+  
+  protected def config = ConfigFactory.load().as[Config]("system.io.backpressure-backoff")
+  
+  override protected def initialBackoff(): Backoff = SimpleExponentialBackoff(config)
 
   protected def ioResponseReceive: Receive = {
     case ack: IoAck[_] if hasTimeout(ack.command) =>

--- a/core/src/main/scala/cromwell/core/retry/Backoff.scala
+++ b/core/src/main/scala/cromwell/core/retry/Backoff.scala
@@ -1,6 +1,8 @@
 package cromwell.core.retry
 
 import com.google.api.client.util.ExponentialBackOff
+import com.typesafe.config.Config
+import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -31,13 +33,23 @@ case class InitialGapBackoff(initialGapMillis: FiniteDuration, googleBackoff: Ex
 }
 
 object SimpleExponentialBackoff {
-  def apply(initialInterval: FiniteDuration, maxInterval: FiniteDuration, multiplier: Double) = {
+  def apply(initialInterval: FiniteDuration, maxInterval: FiniteDuration, multiplier: Double, randomizationFactor: Double = ExponentialBackOff.DEFAULT_RANDOMIZATION_FACTOR) = {
     new SimpleExponentialBackoff(new ExponentialBackOff.Builder()
       .setInitialIntervalMillis(initialInterval.toMillis.toInt)
       .setMaxIntervalMillis(maxInterval.toMillis.toInt)
       .setMultiplier(multiplier)
       .setMaxElapsedTimeMillis(Int.MaxValue)
+      .setRandomizationFactor(randomizationFactor)
       .build())
+  }
+  
+  def apply(config: Config): SimpleExponentialBackoff = {
+    SimpleExponentialBackoff(
+      config.as[FiniteDuration]("min"),
+      config.as[FiniteDuration]("max"),
+      config.as[Double]("multiplier"),
+      config.as[Double]("randomization-factor")
+    )
   }
 }
 

--- a/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
@@ -5,6 +5,7 @@ import akka.testkit.{TestActorRef, TestProbe}
 import cromwell.core.TestKitSuite
 import cromwell.core.io.DefaultIoCommand.DefaultIoSizeCommand
 import cromwell.core.path.Path
+import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpecLike, Matchers}
 
@@ -18,10 +19,10 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   it should "intercept IoAcks and cancel timers" in {
     val ioActorProbe = TestProbe()
     val delegateProbe = TestProbe()
-    val backpressureTimeout = 1 second
+    val backoff = SimpleExponentialBackoff(100 seconds, 10.hours, 2D, 0D)
     val noResponseTimeout = 3 seconds
     
-    val testActor = TestActorRef(new IoClientHelperTestActor(ioActorProbe.ref, delegateProbe.ref, backpressureTimeout, noResponseTimeout)) 
+    val testActor = TestActorRef(new IoClientHelperTestActor(ioActorProbe.ref, delegateProbe.ref, backoff, noResponseTimeout)) 
     
     val command = DefaultIoSizeCommand(mock[Path])
     val response = IoSuccess(command, 5)
@@ -48,10 +49,10 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   it should "intercept IoAcks and cancel timers for a command with context" in {
     val ioActorProbe = TestProbe()
     val delegateProbe = TestProbe()
-    val backpressureTimeout = 1 second
+    val backoff = SimpleExponentialBackoff(100 seconds, 10.hours, 2D, 0D)
     val noResponseTimeout = 3 seconds
 
-    val testActor = TestActorRef(new IoClientHelperTestActor(ioActorProbe.ref, delegateProbe.ref, backpressureTimeout, noResponseTimeout))
+    val testActor = TestActorRef(new IoClientHelperTestActor(ioActorProbe.ref, delegateProbe.ref, backoff, noResponseTimeout))
 
     val commandContext = "context"
     val command = DefaultIoSizeCommand(mock[Path])
@@ -82,10 +83,12 @@ class IoClientHelperSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   
   private class IoClientHelperTestActor(override val ioActor: ActorRef,
                                 delegateTo: ActorRef,
-                                override val backpressureTimeout: FiniteDuration,
+                                backoff: Backoff,
                                 noResponseTimeout: FiniteDuration) extends Actor with ActorLogging with IoClientHelper {
 
     implicit val ioCommandBuilder = DefaultIoCommandBuilder
+
+    override protected def initialBackoff = backoff
     
     context.become(ioReceive orElse receive)
 

--- a/core/src/test/scala/cromwell/core/retry/BackoffSpec.scala
+++ b/core/src/test/scala/cromwell/core/retry/BackoffSpec.scala
@@ -1,8 +1,9 @@
 package cromwell.core.retry
 
 import com.google.api.client.util.ExponentialBackOff.Builder
+import com.typesafe.config.ConfigFactory
 import org.scalatest.{FlatSpec, Matchers}
-
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class BackoffSpec extends FlatSpec with Matchers {
@@ -46,6 +47,23 @@ class BackoffSpec extends FlatSpec with Matchers {
           .build()
       )
     }
+  }
+
+  it should "parse config" in {
+    val config = ConfigFactory.parseMap(
+      Map(
+        "min" -> "5 seconds",
+        "max" -> "30 seconds",
+        "multiplier" -> 6D,
+        "randomization-factor" -> 0D
+      ).asJava
+    )
+    
+    val backoff = SimpleExponentialBackoff(config)
+    backoff.googleBackoff.getCurrentIntervalMillis shouldBe 5.seconds.toMillis.toInt
+    backoff.googleBackoff.getMaxIntervalMillis shouldBe 30.seconds.toMillis.toInt
+    backoff.googleBackoff.getMultiplier shouldBe 6D
+    backoff.googleBackoff.getRandomizationFactor shouldBe 0D
   }
 
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowDockerLookupActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowDockerLookupActor.scala
@@ -11,8 +11,6 @@ import cromwell.engine.workflow.WorkflowDockerLookupActor._
 import cromwell.services.EngineServicesStore
 import common.util.TryUtil
 
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.{Failure, Success}
 
 /**
@@ -43,12 +41,6 @@ class WorkflowDockerLookupActor private[workflow](workflowId: WorkflowId,
   extends LoggingFSM[WorkflowDockerLookupActorState, WorkflowDockerLookupActorData] with DockerClientHelper {
 
   implicit val ec = context.system.dispatchers.lookup(Dispatcher.EngineDispatcher)
-
-  // Amount of time after which the docker request should be considered lost and sent again.
-  override protected def backpressureTimeout: FiniteDuration = 10 seconds
-  // A multiplier for the amount of time to wait when we get a Backpressure response before sending the request again.
-  // This effectively bounds the jitter.
-  override protected def backpressureRandomizerFactor: Double = 0.5D
 
   context.become(dockerReceive orElse receive)
 


### PR DESCRIPTION
I know the I/O actor is not very trendy these days, but even if it ends up going away I thought this was a small change that could help with handling IO pressure in a better way.
Currently if an actor receives a backpressure message it waits more or less 5 seconds and retries. This uses configurable exponential backoff instead with a higher randomization of waiting times to avoid spikes as much as possible.