### PR TITLE
Docker compose for horizontal cromwell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - BUILD_TYPE=checkPublish
     - BUILD_TYPE=conformanceLocal
     - BUILD_TYPE=conformancePapiV2
-    - BUILD_TYPE=dockerDevelop
+    - BUILD_TYPE=dockerScripts
     - BUILD_TYPE=sbt
 script:
   - src/ci/bin/test.sh

--- a/centaur/src/it/scala/centaur/ExternalTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/ExternalTestCaseSpec.scala
@@ -1,0 +1,25 @@
+package centaur
+
+import better.files._
+import cats.data.Validated.{Invalid, Valid}
+import centaur.test.standard.CentaurTestCase
+import com.typesafe.scalalogging.StrictLogging
+
+class ExternalTestCaseSpec(cromwellBackends: List[String]) extends AbstractCentaurTestCaseSpec(cromwellBackends) with StrictLogging {
+
+  def this() = this(CentaurTestSuite.cromwellBackends)
+
+  val testFile = sys.env.get("CENTAUR_TEST_FILE") match {
+    case Some(filePath) => runTestFile(filePath)
+    case _ =>
+      logger.info("No external test to run")
+  }
+
+  def runTestFile(testFile: String) = {
+    CentaurTestCase.fromFile(File(testFile)) match {
+      case Valid(testCase) => executeStandardTest(testCase)
+      case Invalid(error) =>
+        fail(s"Invalid test case: ${error.toList.mkString(", ")}")
+    }
+  }
+}

--- a/scripts/docker-compose-mysql/compose/cromwell/app-config/application.conf
+++ b/scripts/docker-compose-mysql/compose/cromwell/app-config/application.conf
@@ -52,4 +52,5 @@ database {
   db.password = "cromwell"
   db.driver = "com.mysql.jdbc.Driver"
   profile = "slick.jdbc.MySQLProfile$"
+  db.connectionTimeout = 15000
 }

--- a/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
+++ b/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   cromwell:
-    image: "broadinstitute/cromwell:develop"
+    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     working_dir: /cromwell-working-dir
     volumes:
       - ./cromwell-executions:/cromwell-working-dir/cromwell-executions

--- a/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
+++ b/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
@@ -1,0 +1,39 @@
+version: '2.1'
+services:
+  cromwell:
+    image: "broadinstitute/cromwell:develop"
+    working_dir: /cromwell-working-dir
+    volumes:
+      - ./cromwell-executions:/cromwell-working-dir/cromwell-executions
+      - ./compose/cromwell/app-config:/app-config
+    links:
+      - mysql-db
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+    command: ["server"]
+    environment:
+      - JAVA_OPTS=-Dconfig.file=/app-config/application.conf
+  mysql-db:
+    image: "mysql:5.7"
+    environment:
+      - MYSQL_ROOT_PASSWORD=cromwell
+      - MYSQL_DATABASE=cromwell_db
+    volumes:
+      - ./compose/mysql/init:/docker-entrypoint-initdb.d
+      - ./compose/mysql/data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "service", "mysql", "status"]
+      interval: 2s
+      timeout: 30s
+      retries: 15
+    ports:
+      - "3306:3306"
+  lb:
+    image: dockercloud/haproxy
+    links:
+      - cromwell
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8000:80

--- a/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
+++ b/scripts/docker-compose-mysql/docker-compose-cloudwell.yml
@@ -27,8 +27,6 @@ services:
       interval: 2s
       timeout: 30s
       retries: 15
-    ports:
-      - "3306:3306"
   lb:
     image: dockercloud/haproxy
     links:

--- a/scripts/docker-compose-mysql/test/hello.test
+++ b/scripts/docker-compose-mysql/test/hello.test
@@ -1,0 +1,13 @@
+name: hello
+testFormat: workflowsuccess
+
+files {
+  workflow: hello_no_docker.wdl
+}
+
+metadata {
+  workflowName: wf_hello
+  status: Succeeded
+  "calls.wf_hello.hello.executionStatus": Done
+  "outputs.wf_hello.hello.salutation": "Hello you!"
+}

--- a/scripts/docker-compose-mysql/test/hello_no_docker.wdl
+++ b/scripts/docker-compose-mysql/test/hello_no_docker.wdl
@@ -1,0 +1,16 @@
+task hello {
+  String addressee = "you"
+  command {
+    echo "Hello ${addressee}!"
+  }
+  output {
+    String salutation = read_string(stdout())
+  }
+}
+
+workflow wf_hello {
+  call hello
+  output {
+     hello.salutation
+  }
+}

--- a/src/ci/bin/testDockerScripts.sh
+++ b/src/ci/bin/testDockerScripts.sh
@@ -21,7 +21,7 @@ docker run --rm "${docker_tag}" which sbt
 echo "2. Testing sbt assembly"
 docker run --rm -v "${PWD}:${PWD}" -w "${PWD}" "${docker_tag}" sbt assembly
 
-echo "Testing cloudwell docker compose"
+echo "3. Testing cloudwell docker compose"
 
 CROMWELL_TAG=develop
 export CROMWELL_TAG

--- a/src/ci/bin/testDockerScripts.sh
+++ b/src/ci/bin/testDockerScripts.sh
@@ -36,7 +36,7 @@ CENTAUR_TEST_FILE=scripts/docker-compose-mysql/test/hello.test
 export CENTAUR_TEST_FILE
 
 # Call centaur with our custom test case
-sbt clean "centaur/it:testOnly *ExternalTestCaseSpec"
+sudo sbt clean "centaur/it:testOnly *ExternalTestCaseSpec"
 
 # Tear everything down
 docker-compose -f scripts/docker-compose-mysql/docker-compose-cloudwell.yml down

--- a/src/ci/bin/testDockerScripts.sh
+++ b/src/ci/bin/testDockerScripts.sh
@@ -36,7 +36,7 @@ CENTAUR_TEST_FILE=scripts/docker-compose-mysql/test/hello.test
 export CENTAUR_TEST_FILE
 
 # Call centaur with our custom test case
-sbt "project centaur" "it:testOnly *ExternalTestCaseSpec"
+sbt clean "centaur/it:testOnly *ExternalTestCaseSpec"
 
 # Tear everything down
 docker-compose -f scripts/docker-compose-mysql/docker-compose-cloudwell.yml down


### PR DESCRIPTION
Definitely not for prod but could be useful for dev purposes when one wants to spin up a few Cromwells on the same DB. A load balancer in front routes requests to underlying Cromwells talking to a MySQL instance.

For example:

```
$ docker-compose -f scripts/docker-compose-mysql/docker-compose-cloudwell.yml up --scale cromwell=3 -d
Starting docker-compose-mysql_mysql-db_1 ... done
Starting docker-compose-mysql_cromwell_1 ... done
Starting docker-compose-mysql_cromwell_2 ... done
Starting docker-compose-mysql_cromwell_3 ... done
Starting docker-compose-mysql_lb_1       ... done

$ docker ps
CONTAINER ID        IMAGE                             COMMAND                  CREATED             STATUS                    PORTS                                     NAMES
9311d2f053d6        broadinstitute/cromwell:develop   "/bin/bash -c 'java …"   6 minutes ago       Up 15 seconds             8000/tcp                                  docker-compose-mysql_cromwell_3
e040065fe3ba        broadinstitute/cromwell:develop   "/bin/bash -c 'java …"   6 minutes ago       Up 15 seconds             8000/tcp                                  docker-compose-mysql_cromwell_2
aff5007b8d26        dockercloud/haproxy               "/sbin/tini -- docke…"   7 minutes ago       Up 14 seconds             443/tcp, 1936/tcp, 0.0.0.0:8000->80/tcp   docker-compose-mysql_lb_1
b991a7c412a5        broadinstitute/cromwell:develop   "/bin/bash -c 'java …"   7 minutes ago       Up 15 seconds             8000/tcp                                  docker-compose-mysql_cromwell_1
30892dce18b2        mysql:5.7                         "docker-entrypoint.s…"   17 minutes ago      Up 18 seconds (healthy)   0.0.0.0:3306->3306/tcp                    docker-compose-mysql_mysql-db_1
```