### PR TITLE
Refactor Google Credentials ahead of adding BigQuery.

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -85,7 +85,9 @@ object Operations {
   lazy val googleConf: Config = CentaurConfig.conf.getConfig("google")
   lazy val authName: String = googleConf.getString("auth")
   lazy val genomicsEndpointUrl: String = googleConf.getString("genomics.endpoint-url")
-  lazy val credentials: Credentials = configuration.auth(authName).toTry.get.credential(Map.empty)
+  lazy val credentials: Credentials = configuration.auth(authName)
+    .unsafe
+    .pipelinesApiCredentials(GoogleAuthMode.NoOptionLookup)
   lazy val credentialsProjectOption: Option[String] = {
     Option(credentials) collect {
       case serviceAccountCredentials: ServiceAccountCredentials => serviceAccountCredentials.getProjectId

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/gcp/auth/GoogleAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/gcp/auth/GoogleAuthMode.scala
@@ -10,6 +10,8 @@ import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudkms.v1.CloudKMS
+import com.google.api.services.compute.ComputeScopes
+import com.google.api.services.genomics.v2alpha1.GenomicsScopes
 import com.google.api.services.storage.StorageScopes
 import com.google.auth.Credentials
 import com.google.auth.http.HttpTransportFactory
@@ -25,6 +27,21 @@ import scala.util.{Failure, Success, Try}
 object GoogleAuthMode {
 
   type OptionLookup = String => String
+  val NoOptionLookup = noOptionLookup _
+
+  /**
+    * Enables swapping out credential validation for various testing purposes ONLY.
+    *
+    * All traits in this file are sealed, all classes final, meaning things like Mockito or other java/scala overrides
+    * cannot work.
+    */
+  type CredentialsValidation = Credentials => Unit
+  private[auth] val NoCredentialsValidation = mouse.ignore _
+
+  private def noOptionLookup(string: String): Nothing = {
+    throw new UnsupportedOperationException(s"cannot lookup $string")
+  }
+
   lazy val jsonFactory = JacksonFactory.getDefaultInstance
   lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   lazy val HttpTransportFactory = new HttpTransportFactory {
@@ -38,10 +55,12 @@ object GoogleAuthMode {
   val DockerCredentialsEncryptionKeyNameKey = "docker_credentials_key_name"
   val DockerCredentialsTokenKey = "docker_credentials_token"
 
-  val GcsScopes = List(
+  private val PipelinesApiScopes = List(
     StorageScopes.DEVSTORAGE_FULL_CONTROL,
-    StorageScopes.DEVSTORAGE_READ_WRITE
-  ).asJava
+    StorageScopes.DEVSTORAGE_READ_WRITE,
+    GenomicsScopes.GENOMICS,
+    ComputeScopes.COMPUTE
+  )
 
   def checkReadable(file: File) = {
     if (!file.isReadable) throw new FileNotFoundException(s"File $file does not exist or is not readable")
@@ -83,23 +102,47 @@ object GoogleAuthMode {
     val response = kms.projects.locations.keyRings.cryptoKeys.encrypt(keyName, request).execute
     response.getCiphertext
   }
+
+  /** Used for both checking that the credential is valid and creating a fresh credential. */
+  private def refreshCredentials(credentials: Credentials): Unit = {
+    credentials.refresh()
+  }
 }
 
 
 sealed trait GoogleAuthMode {
   protected lazy val log = LoggerFactory.getLogger(getClass.getSimpleName)
 
-  /**
-    * Validate the auth mode against provided options
-    */
-  def validate(options: OptionLookup): Unit = {
-    ()
-  }
-
   def name: String
 
   // Create a Credential object from the google.api.client.auth library (https://github.com/google/google-api-java-client)
-  def credential(options: OptionLookup): Credentials
+  private[auth] def credentials(options: OptionLookup, scopes: java.util.Collection[String]): Credentials
+
+  /**
+    * Create a credential object suitable for use with Pipelines API.
+    *
+    * @param options A lookup for external credential information.
+    * @return Credentials with scopes compatible with the Genomics API compute and storage.
+    */
+  def pipelinesApiCredentials(options: OptionLookup): Credentials = {
+    credentials(options, PipelinesApiScopes.asJavaCollection)
+  }
+
+  /**
+    * Alias for credentials(GoogleAuthMode.NoOptionLookup, Set.empty).
+    * Only valid for credentials that are NOT externally provided and do not need scopes, such as ApplicationDefault.
+    */
+  private[auth] def credentials(): Credentials = {
+    credentials(GoogleAuthMode.NoOptionLookup, java.util.Collections.emptySet[String])
+  }
+
+  /**
+    * Alias for credentials(options, Set.empty).
+    * Only valid for credentials that are NOT externally provided and do not need scopes, such as ApplicationDefault.
+    */
+  private[auth] def credentials(options: OptionLookup): Credentials = {
+    credentials(options, java.util.Collections.emptySet[String])
+  }
 
   def requiresAuthFile: Boolean = false
 
@@ -109,10 +152,10 @@ sealed trait GoogleAuthMode {
     * All traits in this file are sealed, all classes final, meaning things like Mockito or other java/scala overrides
     * cannot work.
     */
-  private[auth] var credentialValidation: Credentials => Unit = credentials => credentials.refresh()
+  private[auth] var credentialsValidation: CredentialsValidation = refreshCredentials
 
-  protected def validateCredential(credential: Credentials) = {
-    Try(credentialValidation(credential)) match {
+  protected def validateCredentials[A <: Credentials](credential: A): credential.type = {
+    Try(credentialsValidation(credential)) match {
       case Failure(ex) => throw new RuntimeException(s"Google credentials are invalid: ${ex.getMessage}", ex)
       case Success(_) => credential
     }
@@ -124,9 +167,13 @@ sealed trait GoogleAuthMode {
 case object MockAuthMode extends GoogleAuthMode {
   override val name = "no_auth"
 
-  override def credential(options: OptionLookup): Credentials = NoCredentials.getInstance
+  override def credentials(unusedOptions: OptionLookup, unusedScopes: java.util.Collection[String]): NoCredentials = {
+    NoCredentials.getInstance
+  }
 
-  override def apiClientGoogleCredential(options: OptionLookup) = Option(new MockGoogleCredential.Builder().build())
+  override def apiClientGoogleCredential(options: OptionLookup): Option[MockGoogleCredential] = {
+    Option(new MockGoogleCredential.Builder().build())
+  }
 }
 
 object ServiceAccountMode {
@@ -148,48 +195,43 @@ trait HasApiClientGoogleCredentialStream { self: GoogleAuthMode =>
 }
 
 final case class ServiceAccountMode(override val name: String,
-                                    fileFormat: CredentialFileFormat,
-                                    scopes: java.util.List[String]) extends GoogleAuthMode with HasApiClientGoogleCredentialStream {
+                                    fileFormat: CredentialFileFormat)
+  extends GoogleAuthMode with HasApiClientGoogleCredentialStream {
   private val credentialsFile = File(fileFormat.file)
   checkReadable(credentialsFile)
 
   override protected def credentialStream(options: OptionLookup): InputStream = credentialsFile.newInputStream
 
-  private lazy val _credential: Credentials = {
-    val serviceAccount = fileFormat match {
+  private lazy val serviceAccountCredentials: ServiceAccountCredentials = {
+    fileFormat match {
       case PemFileFormat(accountId, _) =>
         log.warn("The PEM file format will be deprecated in the upcoming Cromwell version. Please use JSON instead.")
-        ServiceAccountCredentials.fromPkcs8(accountId, accountId, credentialsFile.contentAsString, null, scopes)
-      case _: JsonFileFormat => ServiceAccountCredentials.fromStream(credentialsFile.newInputStream).createScoped(scopes)
+        ServiceAccountCredentials.fromPkcs8(accountId, accountId, credentialsFile.contentAsString, null, null)
+      case _: JsonFileFormat => ServiceAccountCredentials.fromStream(credentialsFile.newInputStream)
     }
-
-    // Validate credentials synchronously here, without retry.
-    // It's very unlikely to fail as it should not happen more than a few times
-    // (one for the engine and for each backend using it) per Cromwell instance.
-    validateCredential(serviceAccount)
   }
 
-  override def credential(options: OptionLookup): Credentials = _credential
+  override def credentials(unusedOptions: OptionLookup,
+                           scopes: java.util.Collection[String]): GoogleCredentials = {
+    val scopedCredentials = serviceAccountCredentials.createScoped(scopes)
+    validateCredentials(scopedCredentials)
+  }
 }
 
-final case class UserServiceAccountMode(override val name: String, scopes: java.util.List[String]) extends GoogleAuthMode with HasApiClientGoogleCredentialStream {
+final case class UserServiceAccountMode(override val name: String)
+  extends GoogleAuthMode with HasApiClientGoogleCredentialStream {
   private def extractServiceAccount(options: OptionLookup): String = {
     extract(options, UserServiceAccountKey)
-  }
-
-  override def validate(options: OptionLookup): Unit = {
-    extractServiceAccount(options)
-    ()
   }
 
   override protected def credentialStream(options: OptionLookup): InputStream = {
     new ByteArrayInputStream(extractServiceAccount(options).getBytes("UTF-8"))
   }
 
-  override def credential(options: OptionLookup): Credentials = {
-    ServiceAccountCredentials
-      .fromStream(credentialStream(options))
-      .createScoped(scopes)
+  override def credentials(options: OptionLookup, scopes: java.util.Collection[String]): GoogleCredentials = {
+    val newCredentials = ServiceAccountCredentials.fromStream(credentialStream(options))
+    val scopedCredentials: GoogleCredentials = newCredentials.createScoped(scopes)
+    validateCredentials(scopedCredentials)
   }
 }
 
@@ -197,8 +239,7 @@ final case class UserServiceAccountMode(override val name: String, scopes: java.
 final case class UserMode(override val name: String,
                           user: String,
                           secretsPath: String,
-                          datastoreDir: String,
-                          scopes: java.util.List[String]) extends GoogleAuthMode {
+                          datastoreDir: String) extends GoogleAuthMode {
 
   private lazy val secretsStream = {
     val secretsFile = File(secretsPath)
@@ -206,27 +247,31 @@ final case class UserMode(override val name: String,
     secretsFile.newInputStream
   }
 
-  private lazy val _credential: Credentials = {
-    validateCredential(UserCredentials.fromStream(secretsStream))
+  private lazy val userCredentials: UserCredentials = {
+    validateCredentials(UserCredentials.fromStream(secretsStream))
   }
 
-  override def credential(options: OptionLookup): Credentials = _credential
+  override def credentials(unusedOptions: OptionLookup, unusedScopes: java.util.Collection[String]): Credentials = {
+    userCredentials
+  }
 }
 
 object ApplicationDefaultMode {
-  private lazy val _credential: Credentials = GoogleCredentials.getApplicationDefault
+  private lazy val applicationDefaultCredentials: GoogleCredentials = GoogleCredentials.getApplicationDefault
 }
 
 final case class ApplicationDefaultMode(name: String) extends GoogleAuthMode {
-  override def credential(options: OptionLookup): Credentials = ApplicationDefaultMode._credential
+  override def credentials(unusedOptions: OptionLookup,
+                           unusedScopes: java.util.Collection[String]): GoogleCredentials = {
+    ApplicationDefaultMode.applicationDefaultCredentials
+  }
 
   override def apiClientGoogleCredential(unused: OptionLookup): Option[GoogleCredential] = Option(GoogleCredential.getApplicationDefault(httpTransport, jsonFactory))
 }
 
 final case class RefreshTokenMode(name: String,
                                   clientId: String,
-                                  clientSecret: String,
-                                  scopes: java.util.List[String]) extends GoogleAuthMode with ClientSecrets {
+                                  clientSecret: String) extends GoogleAuthMode with ClientSecrets {
 
   import GoogleAuthMode._
 
@@ -236,22 +281,16 @@ final case class RefreshTokenMode(name: String,
     extract(options, RefreshTokenOptionKey)
   }
 
-  override def validate(options: OptionLookup) = {
-    extractRefreshToken(options)
-    ()
-  }
-
-  override def credential(options: OptionLookup): Credentials = {
+  override def credentials(options: OptionLookup, unusedScopes: java.util.Collection[String]): UserCredentials = {
     val refreshToken = extractRefreshToken(options)
-    validateCredential(
-      UserCredentials
-        .newBuilder()
-        .setClientId(clientId)
-        .setClientSecret(clientSecret)
-        .setRefreshToken(refreshToken)
-        .setHttpTransportFactory(GoogleAuthMode.HttpTransportFactory)
-        .build()
-    )
+    val newCredentials: UserCredentials = UserCredentials
+      .newBuilder()
+      .setClientId(clientId)
+      .setClientSecret(clientSecret)
+      .setRefreshToken(refreshToken)
+      .setHttpTransportFactory(GoogleAuthMode.HttpTransportFactory)
+      .build()
+    validateCredentials(newCredentials)
   }
 }
 

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ApplicationDefaultModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ApplicationDefaultModeSpec.scala
@@ -9,16 +9,8 @@ class ApplicationDefaultModeSpec extends FlatSpec with Matchers {
   it should "generate a credential" in {
     GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
     val applicationDefaultMode = new ApplicationDefaultMode("application-default")
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val credentials = applicationDefaultMode.credential(workflowOptions)
+    val credentials = applicationDefaultMode.credentials()
     credentials.getAuthenticationType should be("OAuth2")
-  }
-
-  it should "validate" in {
-    GoogleAuthModeSpec.assumeHasApplicationDefaultCredentials()
-    val applicationDefaultMode = new ApplicationDefaultMode("application-default")
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    applicationDefaultMode.validate(workflowOptions)
   }
 
   it should "requiresAuthFile" in {

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/GoogleAuthModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/GoogleAuthModeSpec.scala
@@ -113,5 +113,4 @@ object GoogleAuthModeSpec {
 
   lazy val refreshTokenOptions: OptionLookup = Map("refresh_token" -> "the_refresh_token")
   lazy val userServiceAccountOptions: OptionLookup = Map("user_service_account_json" -> serviceAccountJsonContents)
-  lazy val emptyOptions: OptionLookup = Map.empty
 }

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/MockAuthModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/MockAuthModeSpec.scala
@@ -8,15 +8,8 @@ class MockAuthModeSpec extends FlatSpec with Matchers {
 
   it should "generate a credential" in {
     val mockAuthMode = MockAuthMode
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val credentials = mockAuthMode.credential(workflowOptions)
+    val credentials = mockAuthMode.credentials()
     credentials.getAuthenticationType should be("OAuth2")
-  }
-
-  it should "validate" in {
-    val mockAuthMode = MockAuthMode
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    mockAuthMode.validate(workflowOptions)
   }
 
   it should "requiresAuthFile" in {

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/RefreshTokenModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/RefreshTokenModeSpec.scala
@@ -1,6 +1,5 @@
 package cromwell.cloudsupport.gcp.auth
 
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class RefreshTokenModeSpec extends FlatSpec with Matchers {
@@ -11,10 +10,10 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret"
+    )
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
-    val exception = intercept[RuntimeException](refreshTokenMode.credential(workflowOptions))
+    val exception = intercept[RuntimeException](refreshTokenMode.credentials(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
   }
 
@@ -22,11 +21,11 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret"
+    )
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
-    refreshTokenMode.credentialValidation = _ => throw new IllegalArgumentException("no worries! this is expected")
-    val exception = intercept[RuntimeException](refreshTokenMode.credential(workflowOptions))
+    refreshTokenMode.credentialsValidation = _ => throw new IllegalArgumentException("no worries! this is expected")
+    val exception = intercept[RuntimeException](refreshTokenMode.credentials(workflowOptions))
     exception.getMessage should startWith("Google credentials are invalid: ")
   }
 
@@ -34,32 +33,21 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
-    refreshTokenMode.credentialValidation = _ => ()
+      "secret_secret"
+    )
+    refreshTokenMode.credentialsValidation = GoogleAuthMode.NoCredentialsValidation
     val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
-    val credentials = refreshTokenMode.credential(workflowOptions)
+    val credentials = refreshTokenMode.credentials(workflowOptions)
     credentials.getAuthenticationType should be("OAuth2")
   }
 
-  it should "validate with a refresh_token workflow option" in {
+  it should "fail to generate without a refresh_token workflow option" in {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.refreshTokenOptions
-    refreshTokenMode.validate(workflowOptions)
-  }
-
-  it should "fail validate without a refresh_token workflow option" in {
-    val refreshTokenMode = RefreshTokenMode(
-      "user-via-refresh",
-      "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[OptionLookupException](refreshTokenMode.validate(workflowOptions))
+      "secret_secret"
+    )
+    val exception = intercept[OptionLookupException](refreshTokenMode.credentials())
     exception.getMessage should be("refresh_token")
   }
 
@@ -67,8 +55,8 @@ class RefreshTokenModeSpec extends FlatSpec with Matchers {
     val refreshTokenMode = RefreshTokenMode(
       "user-via-refresh",
       "secret_id",
-      "secret_secret",
-      GoogleConfiguration.GoogleScopes)
+      "secret_secret"
+    )
     refreshTokenMode.requiresAuthFile should be(true)
   }
 

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ServiceAccountModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/ServiceAccountModeSpec.scala
@@ -3,7 +3,6 @@ package cromwell.cloudsupport.gcp.auth
 import java.io.FileNotFoundException
 
 import better.files.File
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class ServiceAccountModeSpec extends FlatSpec with Matchers {
@@ -16,10 +15,9 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       .write(GoogleAuthModeSpec.serviceAccountJsonContents)
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
-      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[RuntimeException](serviceAccountMode.credential(workflowOptions))
+      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString)
+    )
+    val exception = intercept[RuntimeException](serviceAccountMode.credentials())
     exception.getMessage should startWith("Google credentials are invalid: ")
     jsonMockFile.delete(true)
   }
@@ -31,9 +29,8 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[RuntimeException](serviceAccountMode.credential(workflowOptions))
+    )
+    val exception = intercept[RuntimeException](serviceAccountMode.credentials())
     exception.getMessage should startWith("Google credentials are invalid: ")
     pemMockFile.delete(true)
   }
@@ -43,8 +40,8 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val exception = intercept[FileNotFoundException] {
       ServiceAccountMode(
         "service-account",
-        ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-        GoogleConfiguration.GoogleScopes)
+        ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString)
+      )
     }
     exception.getMessage should fullyMatch regex "File .*/service-account..*.json does not exist or is not readable"
   }
@@ -55,7 +52,7 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       ServiceAccountMode(
         "service-account",
         ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-        GoogleConfiguration.GoogleScopes)
+      )
     }
     exception.getMessage should fullyMatch regex "File .*/service-account..*.pem does not exist or is not readable"
   }
@@ -66,11 +63,10 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       .write(GoogleAuthModeSpec.serviceAccountJsonContents)
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
-      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    serviceAccountMode.credentialValidation = _ => ()
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val credentials = serviceAccountMode.credential(workflowOptions)
+      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString)
+    )
+    serviceAccountMode.credentialsValidation = GoogleAuthMode.NoCredentialsValidation
+    val credentials = serviceAccountMode.credentials()
     credentials.getAuthenticationType should be("OAuth2")
     jsonMockFile.delete(true)
   }
@@ -82,37 +78,10 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
       ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    serviceAccountMode.credentialValidation = _ => ()
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val credentials = serviceAccountMode.credential(workflowOptions)
+    )
+    serviceAccountMode.credentialsValidation = GoogleAuthMode.NoCredentialsValidation
+    val credentials = serviceAccountMode.credentials()
     credentials.getAuthenticationType should be("OAuth2")
-    pemMockFile.delete(true)
-  }
-
-  it should "pass validate with a refresh_token workflow option from json" in {
-    val jsonMockFile = File
-      .newTemporaryFile("service-account.", ".json")
-      .write(GoogleAuthModeSpec.serviceAccountJsonContents)
-    val serviceAccountMode = ServiceAccountMode(
-      "service-account",
-      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    serviceAccountMode.validate(workflowOptions)
-    jsonMockFile.delete(true)
-  }
-
-  it should "pass validate with a refresh_token workflow option from a pem" in {
-    val pemMockFile = File
-      .newTemporaryFile("service-account.", ".pem")
-      .write(GoogleAuthModeSpec.serviceAccountPemContents)
-    val serviceAccountMode = ServiceAccountMode(
-      "service-account",
-      ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    serviceAccountMode.validate(workflowOptions)
     pemMockFile.delete(true)
   }
 
@@ -122,8 +91,8 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       .write(GoogleAuthModeSpec.serviceAccountJsonContents)
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
-      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      ServiceAccountMode.JsonFileFormat(jsonMockFile.pathAsString)
+    )
     serviceAccountMode.requiresAuthFile should be(false)
     jsonMockFile.delete(true)
   }
@@ -134,8 +103,8 @@ class ServiceAccountModeSpec extends FlatSpec with Matchers {
       .write(GoogleAuthModeSpec.serviceAccountPemContents)
     val serviceAccountMode = ServiceAccountMode(
       "service-account",
-      ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString),
-      GoogleConfiguration.GoogleScopes)
+      ServiceAccountMode.PemFileFormat("the_account_id", pemMockFile.pathAsString)
+    )
     serviceAccountMode.requiresAuthFile should be(false)
     pemMockFile.delete(true)
   }

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserModeSpec.scala
@@ -3,7 +3,6 @@ package cromwell.cloudsupport.gcp.auth
 import java.io.FileNotFoundException
 
 import better.files.File
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class UserModeSpec extends FlatSpec with Matchers {
@@ -17,11 +16,9 @@ class UserModeSpec extends FlatSpec with Matchers {
       "user",
       "alice",
       secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      dataStoreMockDir.pathAsString
     )
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[RuntimeException](userMode.credential(workflowOptions))
+    val exception = intercept[RuntimeException](userMode.credentials())
     exception.getMessage should startWith("Google credentials are invalid: ")
     secretsMockFile.delete(true)
     dataStoreMockDir.delete(true)
@@ -34,11 +31,9 @@ class UserModeSpec extends FlatSpec with Matchers {
       "user",
       "alice",
       secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      dataStoreMockDir.pathAsString
     )
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[FileNotFoundException](userMode.credential(workflowOptions))
+    val exception = intercept[FileNotFoundException](userMode.credentials())
     exception.getMessage should fullyMatch regex "File .*/secrets..*.json does not exist or is not readable"
     dataStoreMockDir.delete(true)
   }
@@ -50,29 +45,11 @@ class UserModeSpec extends FlatSpec with Matchers {
       "user",
       "alice",
       secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      dataStoreMockDir.pathAsString
     )
-    userMode.credentialValidation = _ => ()
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val credentials = userMode.credential(workflowOptions)
+    userMode.credentialsValidation = GoogleAuthMode.NoCredentialsValidation
+    val credentials = userMode.credentials()
     credentials.getAuthenticationType should be("OAuth2")
-    secretsMockFile.delete(true)
-    dataStoreMockDir.delete(true)
-  }
-
-  it should "validate" in {
-    val secretsMockFile = File.newTemporaryFile("secrets.", ".json").write(GoogleAuthModeSpec.userCredentialsContents)
-    val dataStoreMockDir = File.newTemporaryDirectory("dataStore.")
-    val userMode = UserMode(
-      "user",
-      "alice",
-      secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
-    )
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    userMode.validate(workflowOptions)
     secretsMockFile.delete(true)
     dataStoreMockDir.delete(true)
   }
@@ -84,8 +61,7 @@ class UserModeSpec extends FlatSpec with Matchers {
       "user",
       "alice",
       secretsMockFile.pathAsString,
-      dataStoreMockDir.pathAsString,
-      GoogleConfiguration.GoogleScopes
+      dataStoreMockDir.pathAsString
     )
     userMode.requiresAuthFile should be(false)
     secretsMockFile.delete(true)

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserServiceAccountModeSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/gcp/auth/UserServiceAccountModeSpec.scala
@@ -1,42 +1,27 @@
 package cromwell.cloudsupport.gcp.auth
 
-import cromwell.cloudsupport.gcp.GoogleConfiguration
 import org.scalatest.{FlatSpec, Matchers}
 
 class UserServiceAccountModeSpec extends FlatSpec with Matchers {
 
   behavior of "UserServiceAccountMode"
 
-  it should "generate a credential" in {
-    val userServiceAccountMode = UserServiceAccountMode(
-      "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+  it should "generate a non-validated credential" in {
+    val userServiceAccountMode = UserServiceAccountMode("user-service-account")
     val workflowOptions = GoogleAuthModeSpec.userServiceAccountOptions
-    val credentials = userServiceAccountMode.credential(workflowOptions)
+    userServiceAccountMode.credentialsValidation = GoogleAuthMode.NoCredentialsValidation
+    val credentials = userServiceAccountMode.credentials(workflowOptions)
     credentials.getAuthenticationType should be("OAuth2")
   }
 
-  it should "validate with a user_service_account_json workflow option" in {
-    val userServiceAccountMode = UserServiceAccountMode(
-      "user-service-account",
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.userServiceAccountOptions
-    userServiceAccountMode.validate(workflowOptions)
-  }
-
-  it should "fail validate without a user_service_account_json workflow option" in {
-    val userServiceAccountMode = UserServiceAccountMode(
-      "user-service-account",
-      GoogleConfiguration.GoogleScopes)
-    val workflowOptions = GoogleAuthModeSpec.emptyOptions
-    val exception = intercept[OptionLookupException](userServiceAccountMode.validate(workflowOptions))
+  it should "fail to generate credentials without a user_service_account_json workflow option" in {
+    val userServiceAccountMode = UserServiceAccountMode("user-service-account")
+    val exception = intercept[OptionLookupException](userServiceAccountMode.credentials())
     exception.getMessage should be("user_service_account_json")
   }
 
   it should "requiresAuthFile" in {
-    val userServiceAccountMode = UserServiceAccountMode(
-      "user-service-account",
-      GoogleConfiguration.GoogleScopes)
+    val userServiceAccountMode = UserServiceAccountMode("user-service-account")
     userServiceAccountMode.requiresAuthFile should be(false)
   }
 

--- a/common/src/main/scala/common/validation/Validation.scala
+++ b/common/src/main/scala/common/validation/Validation.scala
@@ -38,7 +38,7 @@ object Validation {
       v fold(
         //Use f to turn the failure list into a Throwable, then fail a future with it.
         //Function composition lets us ignore the actual argument of the error list
-        (Future.failed _) compose f,
+        Future.failed _ compose f,
         Future.successful
       )
   }
@@ -71,7 +71,9 @@ object Validation {
       case Valid(options) => Success(options)
       case Invalid(err) => Failure(AggregatedMessageException(context, err.toList))
     }
-    
+
+    def unsafe: A = unsafe("Errors(s)")
+
     def unsafe(context: String): A = e.valueOr(errors => throw AggregatedMessageException(context, errors.toList))
   }
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -100,7 +100,7 @@ object GcsPathBuilder {
                    cloudStorageConfiguration: CloudStorageConfiguration,
                    options: WorkflowOptions,
                    defaultProject: Option[String])(implicit as: ActorSystem, ec: ExecutionContext): Future[GcsPathBuilder] = {
-    authMode.retryCredential(options) map { credentials =>
+    authMode.retryPipelinesApiCredentials(options) map { credentials =>
       fromCredentials(credentials,
         applicationName,
         retrySettings,

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
@@ -24,13 +24,13 @@ object GoogleUtil {
 
   implicit class EnhancedGoogleAuthMode(val googleAuthMode: GoogleAuthMode) extends AnyVal {
     /**
-      * Retries getting the credentials three times.
+      * Retries getting the pipelines API credentials three times.
       */
-    def retryCredential(options: WorkflowOptions)
-                       (implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials] = {
+    def retryPipelinesApiCredentials(options: WorkflowOptions)
+                                    (implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials] = {
       def credential(): Credentials = {
         try {
-          googleAuthMode.credential((key: String) => options.get(key).get)
+          googleAuthMode.pipelinesApiCredentials((key: String) => options.get(key).get)
         } catch {
           case exception: OptionLookupException =>
             throw new IllegalArgumentException(s"Missing parameters in workflow options: ${exception.key}", exception)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
@@ -5,8 +5,8 @@ import com.google.auth.Credentials
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory
 import cromwell.backend.standard.{StandardInitializationActor, StandardInitializationActorParams, StandardValidatedRuntimeAttributesBuilder}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
-import cromwell.core.Dispatcher
 import cromwell.cloudsupport.gcp.auth.{GoogleAuthMode, UserServiceAccountMode}
+import cromwell.core.Dispatcher
 import cromwell.core.io.AsyncIoActorClient
 import cromwell.filesystems.gcs.GoogleUtil._
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
@@ -41,11 +41,11 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
 
   // Credentials object for the GCS API
   private lazy val gcsCredentials: Future[Credentials] =
-    pipelinesConfiguration.jesAttributes.auths.gcs.retryCredential(workflowOptions)
+    pipelinesConfiguration.jesAttributes.auths.gcs.retryPipelinesApiCredentials(workflowOptions)
 
   // Credentials object for the Genomics API
   private lazy val genomicsCredentials: Future[Credentials] =
-    pipelinesConfiguration.jesAttributes.auths.genomics.retryCredential(workflowOptions)
+    pipelinesConfiguration.jesAttributes.auths.genomics.retryPipelinesApiCredentials(workflowOptions)
 
   // Genomics object to access the Genomics API
   private lazy val genomics: Future[PipelinesApiRequestFactory] = {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
@@ -5,15 +5,6 @@ import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
 import mouse.all._
 
-object PipelinesApiFactoryInterface {
-  val GenomicsScope = "https://www.googleapis.com/auth/genomics"
-  val ComputeScope = "https://www.googleapis.com/auth/compute"
-  val StorageFullControlScope = "https://www.googleapis.com/auth/devstorage.full_control"
-  val KmsScope = "https://www.googleapis.com/auth/cloudkms"
-  val EmailScope = "https://www.googleapis.com/auth/userinfo.email"
-  val ProfileScope = "https://www.googleapis.com/auth/userinfo.profile"
-}
-
 /**
   * The interface provides a single method to build a PipelinesApiRequestFactory
   * There should be one PipelinesApiRequestFactory created per workflow.

--- a/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
@@ -3,7 +3,8 @@ package cromwell.backend.google.pipelines.v1alpha2
 import java.net.URL
 
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
-import com.google.api.services.genomics.Genomics
+import com.google.api.services.compute.ComputeScopes
+import com.google.api.services.genomics.{Genomics, GenomicsScopes}
 import com.google.api.services.genomics.model._
 import common.collections.EnhancedCollections._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
@@ -61,8 +62,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
 
         val svcAccount = new ServiceAccount().setEmail(createPipelineParameters.computeServiceAccount)
           .setScopes(List(
-            PipelinesApiFactoryInterface.GenomicsScope,
-            PipelinesApiFactoryInterface.ComputeScope
+            GenomicsScopes.GENOMICS,
+            ComputeScopes.COMPUTE
           ).asJava)
         val rpargs = new RunPipelineArgs().setProjectId(createPipelineParameters.projectId).setServiceAccount(svcAccount).setResources(runtimePipelineResources)
 

--- a/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActorSpec.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActorSpec.scala
@@ -110,7 +110,9 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
 
     val TestingBits(actorRef, _) = buildJesInitializationTestingBits(refreshTokenConfig)
     val actor = actorRef.underlyingActor
-    actor.refreshTokenAuth should be(Some(GcsLocalizing(RefreshTokenMode("user-via-refresh", "secret_id", "secret_secret", GoogleConfiguration.GoogleScopes),  "mytoken")))
+    val expectedAuthMode = RefreshTokenMode("user-via-refresh", "secret_id", "secret_secret")
+    val expectedAuth = GcsLocalizing(expectedAuthMode,  "mytoken")
+    actor.refreshTokenAuth should be(Option(expectedAuth))
   }
 
   it should "generate the correct json content for no docker token and no refresh token" in {
@@ -119,9 +121,9 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val TestingBits(actorRef, _) = buildJesInitializationTestingBits()
     val actor = actorRef.underlyingActor
 
-    actor.generateAuthJson(flattenAuthOptions(None, None), false) should be(empty)
+    actor.generateAuthJson(flattenAuthOptions(None, None), restrictMetadataAccess = false) should be(empty)
 
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, None), false)
+    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, None), restrictMetadataAccess = false)
     authJsonOption should be(empty)
 
     actorRef.stop()
@@ -133,7 +135,10 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val TestingBits(actorRef, jesConfiguration) = buildJesInitializationTestingBits()
     val actor = actorRef.underlyingActor
 
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(jesConfiguration.dockerCredentials, None), false)
+    val authJsonOption = actor.generateAuthJson(
+      flattenAuthOptions(jesConfiguration.dockerCredentials, None),
+      restrictMetadataAccess = false
+    )
     authJsonOption shouldNot be(empty)
     // dXNlcm5hbWU6cGFzc3dvcmQ= is base64-encoded username:password
     authJsonOption.get should be(
@@ -159,7 +164,7 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val actor = actorRef.underlyingActor
 
     val gcsUserAuth = Option(GcsLocalizing(SimpleClientSecrets("myclientid", "myclientsecret"), "mytoken"))
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, gcsUserAuth), false)
+    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, gcsUserAuth), restrictMetadataAccess = false)
     authJsonOption shouldNot be(empty)
     authJsonOption.get should be(
       normalize(
@@ -186,7 +191,10 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val actor = actorRef.underlyingActor
 
     val gcsUserAuth = Option(GcsLocalizing(SimpleClientSecrets("myclientid", "myclientsecret"), "mytoken"))
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(jesConfiguration.dockerCredentials, gcsUserAuth), false)
+    val authJsonOption = actor.generateAuthJson(
+      flattenAuthOptions(jesConfiguration.dockerCredentials, gcsUserAuth),
+      restrictMetadataAccess = false
+    )
     authJsonOption shouldNot be(empty)
     authJsonOption.get should be(
       normalize(
@@ -216,7 +224,10 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val actor = actorRef.underlyingActor
 
     val gcsUserAuth = Option(GcsLocalizing(SimpleClientSecrets("myclientid", "myclientsecret"), "mytoken"))
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(jesConfiguration.dockerCredentials, gcsUserAuth), true)
+    val authJsonOption = actor.generateAuthJson(
+      flattenAuthOptions(jesConfiguration.dockerCredentials, gcsUserAuth),
+      restrictMetadataAccess = true
+    )
     authJsonOption shouldNot be(empty)
     authJsonOption.get should be(
       normalize(
@@ -246,7 +257,7 @@ class PipelinesApiInitializationActorSpec extends TestKitSuite("PipelinesApiInit
     val TestingBits(actorRef, _) = buildJesInitializationTestingBits()
     val actor = actorRef.underlyingActor
 
-    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, None), true)
+    val authJsonOption = actor.generateAuthJson(flattenAuthOptions(None, None), restrictMetadataAccess = true)
     authJsonOption shouldNot be(empty)
     authJsonOption.get should be(
       normalize(

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -3,8 +3,11 @@ package cromwell.backend.google.pipelines.v2alpha1
 import java.net.URL
 
 import com.google.api.client.http.HttpRequestInitializer
-import com.google.api.services.genomics.v2alpha1.Genomics
+import com.google.api.services.compute.ComputeScopes
+import com.google.api.services.genomics.v2alpha1.{Genomics, GenomicsScopes}
 import com.google.api.services.genomics.v2alpha1.model._
+import com.google.api.services.oauth2.Oauth2Scopes
+import com.google.api.services.storage.StorageScopes
 import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.LocalizationConfiguration
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.api.{PipelinesApiFactoryInterface, PipelinesApiRequestFactory}
@@ -68,13 +71,13 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         .setEmail(createPipelineParameters.computeServiceAccount)
         .setScopes(
           List(
-            PipelinesApiFactoryInterface.GenomicsScope,
-            PipelinesApiFactoryInterface.ComputeScope,
-            PipelinesApiFactoryInterface.StorageFullControlScope,
-            PipelinesApiFactoryInterface.KmsScope,
+            GenomicsScopes.GENOMICS,
+            ComputeScopes.COMPUTE,
+            StorageScopes.DEVSTORAGE_FULL_CONTROL,
+            GenomicsFactory.KmsScope,
             // Profile and Email scopes are requirements for interacting with Martha v2
-            PipelinesApiFactoryInterface.EmailScope,
-            PipelinesApiFactoryInterface.ProfileScope
+            Oauth2Scopes.USERINFO_EMAIL,
+            Oauth2Scopes.USERINFO_PROFILE
           ).asJava
         )
 
@@ -124,4 +127,16 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
   }
 
   override def usesEncryptedDocker: Boolean = true
+}
+
+object GenomicsFactory {
+  /**
+    * More restricted version of com.google.api.services.cloudkms.v1.CloudKMSScopes.CLOUD_PLATFORM
+    * Could use that scope to keep things simple, but docs say to use a more restricted scope:
+    *
+    *   https://cloud.google.com/kms/docs/accessing-the-api#google_compute_engine
+    *
+    * For some reason this scope isn't listed as a constant under CloudKMSScopes.
+    */
+  val KmsScope = "https://www.googleapis.com/auth/cloudkms"
 }


### PR DESCRIPTION
"Pipeline" Scopes are added only for "Pipeline" Credentials.
Otherwise scopes must be requested when asking for credentials.
`Credential` generator (vs. `Credentials`, the former an older API) still returns an unscoped Credential.
Renamed methods returning Credentials from `credential` to `credentials`.
Now also validating USA Credentials before returning.
Credentials lookups from workflow options are only done for "Pipeline" creds and tests.
Removed a `validate(WorkflowOptions)` that wasn't in use since commit 6fbeadc.
Removed scope declarations no longer in use.
Using scope-constants as-much-as-possible from the Google SDKs.
Added an `unsafe` to replace `toTry.get`.