### PR TITLE
Centaur/Sentry updates ahead of BigQuery.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ scripts/docker-compose-mysql/compose/mysql/data
 # Vault rendered resources
 artifactory_credentials.properties
 bcs_application.conf
-centaur_application_sentry_config.inc.conf
+centaur_secure.inc.conf
 cromwell-centaur-requester-pays-service-account.json
 cromwell-centaur-service-account.json
 cromwell-service-account.json

--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,7 @@ lazy val centaur = project
   .dependsOn(wdlTransformsDraft2)
   .dependsOn(wdlTransformsDraft3)
   .dependsOn(womtool)
+  .dependsOn(databaseSql % "it->compile")
 
 lazy val services = project
   .withLibrarySettings("cromwell-services")

--- a/centaur/src/it/scala/centaur/reporting/CiEnvironment.scala
+++ b/centaur/src/it/scala/centaur/reporting/CiEnvironment.scala
@@ -9,7 +9,6 @@ case class CiEnvironment
 (
   isCi: Option[Boolean],
   isCron: Option[Boolean],
-  isSecure: Option[Boolean],
   `type`: Option[String],
   branch: Option[String],
   event: Option[String],
@@ -17,8 +16,7 @@ case class CiEnvironment
   number: Option[String],
   provider: Option[String],
   url: Option[String],
-  os: Option[String],
-  requiresSecure: Option[Boolean]
+  os: Option[String]
 )
 
 object CiEnvironment {
@@ -26,7 +24,6 @@ object CiEnvironment {
     new CiEnvironment(
       isCi = sys.env.get("CROMWELL_BUILD_IS_CI").flatMap(tryToBoolean),
       isCron = sys.env.get("CROMWELL_BUILD_IS_CRON").flatMap(tryToBoolean),
-      isSecure = sys.env.get("CROMWELL_BUILD_IS_SECURE").flatMap(tryToBoolean),
       `type` = sys.env.get("CROMWELL_BUILD_TYPE"),
       branch = sys.env.get("CROMWELL_BUILD_BRANCH"),
       event = sys.env.get("CROMWELL_BUILD_EVENT"),
@@ -35,7 +32,6 @@ object CiEnvironment {
       provider = sys.env.get("CROMWELL_BUILD_PROVIDER"),
       os = sys.env.get("CROMWELL_BUILD_OS"),
       url = sys.env.get("CROMWELL_BUILD_URL"),
-      requiresSecure = sys.env.get("CROMWELL_BUILD_REQUIRES_SECURE").flatMap(tryToBoolean)
     )
   }
 

--- a/centaur/src/it/scala/centaur/reporting/CromwellDatabase.scala
+++ b/centaur/src/it/scala/centaur/reporting/CromwellDatabase.scala
@@ -1,0 +1,37 @@
+package centaur.reporting
+
+import cats.effect.IO
+import cromwell.database.sql.tables.{JobKeyValueEntry, MetadataEntry}
+import cromwell.database.sql.{EngineSqlDatabase, MetadataSqlDatabase}
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Wraps connections to a cromwell database. The database connections are not initialized until first use.
+  */
+class CromwellDatabase(engineDatabaseThunk: => EngineSqlDatabase, metadataDatabaseThunk: => MetadataSqlDatabase) {
+
+  private lazy val engineDatabase: EngineSqlDatabase = engineDatabaseThunk
+  private lazy val metadataDatabase: MetadataSqlDatabase = metadataDatabaseThunk
+
+  def jobKeyValueEntriesIo(workflowExecutionUuidOption: Option[String])
+                          (implicit executionContext: ExecutionContext): IO[Seq[JobKeyValueEntry]] = {
+    workflowExecutionUuidOption.map(jobKeyValueEntriesIo).getOrElse(IO.pure(Seq.empty))
+  }
+
+  def jobKeyValueEntriesIo(workflowExecutionUuid: String)
+                          (implicit executionContext: ExecutionContext): IO[Seq[JobKeyValueEntry]] = {
+    IO.fromFuture(IO(engineDatabase.queryJobKeyValueEntries(workflowExecutionUuid)))
+  }
+
+  def metadataEntriesIo(workflowExecutionUuidOption: Option[String])
+                       (implicit executionContext: ExecutionContext): IO[Seq[MetadataEntry]] = {
+    workflowExecutionUuidOption.map(metadataEntriesIo).getOrElse(IO.pure(Seq.empty))
+  }
+
+  def metadataEntriesIo(workflowExecutionUuid: String)
+                       (implicit executionContext: ExecutionContext): IO[Seq[MetadataEntry]] = {
+    IO.fromFuture(IO(metadataDatabase.queryMetadataEntries(workflowExecutionUuid)))
+  }
+
+}

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporter.scala
@@ -3,12 +3,14 @@ package centaur.reporting
 import cats.effect.IO
 import centaur.test.CentaurTestException
 
+import scala.concurrent.ExecutionContext
+
 /**
   * Reports errors during testing.
   */
 trait ErrorReporter {
-  /** The name of this reporter. */
-  def name: String
+  /** The various parameters for this reporter. */
+  def params: ErrorReporterParams
 
   /** A description of where the reporter is sending the errors. */
   def destination: String
@@ -16,5 +18,6 @@ trait ErrorReporter {
   /** Send a report of a centaur failure. */
   def logCentaurFailure(testEnvironment: TestEnvironment,
                         ciEnvironment: CiEnvironment,
-                        centaurTestException: CentaurTestException): IO[Unit]
+                        centaurTestException: CentaurTestException)
+                       (implicit executionContext: ExecutionContext): IO[Unit]
 }

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporterParams.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporterParams.scala
@@ -1,0 +1,14 @@
+package centaur.reporting
+
+import com.typesafe.config.Config
+
+/**
+  * Collects all of the parameters to pass to a new ErrorReporter.
+  */
+case class ErrorReporterParams
+(
+  name: String,
+  rootConfig: Config,
+  reporterConfig: Config,
+  cromwellDatabase: CromwellDatabase
+)

--- a/centaur/src/it/scala/centaur/reporting/SentryReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/SentryReporter.scala
@@ -3,13 +3,18 @@ package centaur.reporting
 import cats.effect.IO
 import centaur.reporting.SentryReporter._
 import centaur.test.CentaurTestException
+import centaur.test.metadata.CallAttemptFailure
 import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.typesafe.config.Config
+import cromwell.core.WorkflowMetadataKeys
 import io.sentry.dsn.Dsn
 import io.sentry.event.helper.ContextBuilderHelper
+import io.sentry.event.interfaces.ExceptionInterface
+import io.sentry.event.{Event, EventBuilder}
 import io.sentry.{DefaultSentryClientFactory, SentryClient}
 
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 /**
@@ -17,9 +22,9 @@ import scala.util.Try
   *
   * The dsn is NOT loaded using normal sentry lookup procedures.
   */
-class SentryReporter(override val name: String, config: Config) extends ErrorReporter {
+class SentryReporter(override val params: ErrorReporterParams) extends ErrorReporter {
 
-  val dsn: Dsn = new Dsn(config.getString("dsn"))
+  val dsn: Dsn = new Dsn(params.reporterConfig.getString("dsn"))
 
   override lazy val destination: String = {
     val portInfo: String = {
@@ -35,12 +40,34 @@ class SentryReporter(override val name: String, config: Config) extends ErrorRep
 
   override def logCentaurFailure(testEnvironment: TestEnvironment,
                                  ciEnvironment: CiEnvironment,
-                                 centaurTestException: CentaurTestException): IO[Unit] = {
+                                 centaurTestException: CentaurTestException)
+                                (implicit executionContext: ExecutionContext): IO[Unit] = {
+    for {
+      callAttemptFailures <- CallAttemptFailure.buildFailures(centaurTestException.metadataJsonOption)
+      _ <- sendSentryFailure(testEnvironment, ciEnvironment, centaurTestException, callAttemptFailures)
+    } yield ()
+  }
+
+  private def sendSentryFailure(testEnvironment: TestEnvironment,
+                                ciEnvironment: CiEnvironment,
+                                centaurTestException: CentaurTestException,
+                                callAttemptFailures: Vector[CallAttemptFailure]): IO[Unit] = {
     withSentryClient { sentryClient =>
       addTestEnvironment(sentryClient, testEnvironment)
       addCiEnvironment(sentryClient, ciEnvironment)
       addCentaurTestException(sentryClient, centaurTestException)
-      sentryClient.sendException(centaurTestException)
+      addCallAttemptFailures(sentryClient, callAttemptFailures)
+
+      // Updated version of
+      // https://github.com/getsentry/sentry-java/blob/v1.7.5/sentry/src/main/java/io/sentry/SentryClient.java#L200-L203
+      val eventBuilder = new EventBuilder()
+        .withMessage(centaurTestException.getMessage)
+        .withLevel(Event.Level.ERROR)
+        .withSentryInterface(new ExceptionInterface(centaurTestException))
+        // https://docs.sentry.io/learn/rollups/#custom-grouping
+        .withFingerprint("{{ default }}", providerOrDefault(ciEnvironment))
+
+      sentryClient.sendEvent(eventBuilder)
     }
   }
 
@@ -63,19 +90,42 @@ class SentryReporter(override val name: String, config: Config) extends ErrorRep
 
 object SentryReporter {
   private val CiEnvironmentPrefix = "ci_env_"
+  private val CiDefaultProvider = "unknown"
+
+  private val HighlightedMetadataKeys = List(
+    WorkflowMetadataKeys.SubmissionTime,
+    WorkflowMetadataKeys.StartTime,
+    WorkflowMetadataKeys.EndTime,
+    WorkflowMetadataKeys.Status
+  )
+
+  private val HighlightedSubmissionKeys = List(
+    WorkflowMetadataKeys.SubmissionSection_Workflow,
+    WorkflowMetadataKeys.SubmissionSection_WorkflowUrl,
+    WorkflowMetadataKeys.SubmissionSection_Root,
+    WorkflowMetadataKeys.SubmissionSection_Inputs,
+    WorkflowMetadataKeys.SubmissionSection_Options,
+    WorkflowMetadataKeys.SubmissionSection_Imports,
+    WorkflowMetadataKeys.SubmissionSection_WorkflowType,
+    WorkflowMetadataKeys.SubmissionSection_Labels,
+    WorkflowMetadataKeys.SubmissionSection_WorkflowTypeVersion
+  )
+
+  private def providerOrDefault(ciEnvironment: CiEnvironment): String = {
+    ciEnvironment.provider.getOrElse(CiDefaultProvider)
+  }
 
   /** Adds relevant tags for the test environment. */
   private def addTestEnvironment(sentryClient: SentryClient, testEnvironment: TestEnvironment): Unit = {
-    sentryClient.addTag(CiEnvironmentPrefix + "test_name", testEnvironment.testName)
-    sentryClient.addTag(CiEnvironmentPrefix + "attempt", String.valueOf(testEnvironment.attempt + 1))
+    sentryClient.addTag(CiEnvironmentPrefix + "test_name", testEnvironment.name)
+    sentryClient.addTag(CiEnvironmentPrefix + "test_attempt", String.valueOf(testEnvironment.attempt + 1))
   }
 
   /** Adds relevant tags for the CI environment, when present. */
   private def addCiEnvironment(sentryClient: SentryClient, ciEnvironment: CiEnvironment): Unit = {
-    sentryClient.setEnvironment(ciEnvironment.provider.getOrElse("unknown"))
+    sentryClient.setEnvironment(providerOrDefault(ciEnvironment))
     addEnvironmentTag(sentryClient, "is_ci", ciEnvironment.isCi)
     addEnvironmentTag(sentryClient, "is_cron", ciEnvironment.isCron)
-    addEnvironmentTag(sentryClient, "is_secure", ciEnvironment.isSecure)
     addEnvironmentTag(sentryClient, "type", ciEnvironment.`type`)
     addEnvironmentTag(sentryClient, "branch", ciEnvironment.branch)
     addEnvironmentTag(sentryClient, "event", ciEnvironment.event)
@@ -104,7 +154,42 @@ object SentryReporter {
       val mapper = new ObjectMapper()
       // Convert the metadata to a java.util.Map compatible with sentry's addExtra
       val metadataMap = mapper.readValue[java.util.Map[String, AnyRef]](metadataJson, mapTypeReference)
+      // Note: Metadata will be truncated in Sentry.
+      // https://github.com/getsentry/sentry-java/blob/v1.7.5/sentry/src/main/java/io/sentry/marshaller/json/SentryJsonGenerator.java#L27-L30
       sentryClient.addExtra("metadata", metadataMap)
+
+      metadataMap.asScala foreach {
+        case (key, value) if HighlightedMetadataKeys.contains(key) =>
+          sentryClient.addExtra(key, value)
+        case (WorkflowMetadataKeys.SubmissionSection, value) =>
+          value.asInstanceOf[java.util.Map[String, AnyRef]].asScala foreach {
+            case (submissionKey, submissionValue) if HighlightedSubmissionKeys.contains(submissionKey) =>
+              sentryClient.addExtra(WorkflowMetadataKeys.SubmissionSection + "." + submissionKey, submissionValue)
+          }
+        case _ => /* ignore */
+      }
+    }
+  }
+
+  private def addCallAttemptFailures(sentryClient: SentryClient,
+                                     callAttemptFailures: Vector[CallAttemptFailure]): Unit = {
+    if (callAttemptFailures.nonEmpty) {
+      val failures = callAttemptFailures map { failure =>
+        Map(
+          "call_fully_qualified_name" -> Option(failure.callFullyQualifiedName),
+          "job_index" -> Option(failure.jobIndex),
+          "job_attempt" -> Option(failure.jobAttempt),
+          "message" -> Option(failure.message),
+          "start" -> failure.startOption,
+          "end" -> failure.endOption,
+          "stdout" -> failure.stdoutOption,
+          "stderr" -> failure.stderrOption,
+          "call_root" -> failure.callRootOption,
+        ) collect {
+          case (key, Some(value)) => (key, value)
+        }
+      }
+      sentryClient.addExtra(s"call_failures", failures.map(_.asJava).toArray)
     }
   }
 

--- a/centaur/src/it/scala/centaur/reporting/TestEnvironment.scala
+++ b/centaur/src/it/scala/centaur/reporting/TestEnvironment.scala
@@ -3,8 +3,8 @@ package centaur.reporting
 /**
   * Information about a test.
   *
-  * @param testName The test name.
+  * @param name The test name.
   * @param retries The total number of retries.
   * @param attempt The zero based attempt.
   */
-case class TestEnvironment(testName: String, retries: Int, attempt: Int)
+case class TestEnvironment(name: String, retries: Int, attempt: Int)

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -9,13 +9,12 @@ import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshaller.UnsupportedContentTypeException
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, BufferOverflowException, StreamTcpException}
 import cats.effect.IO
-import centaur.test.metadata.WorkflowMetadata
 import centaur.test.workflow.Workflow
 import centaur.{CentaurConfig, CromwellManager}
 import com.typesafe.config.ConfigFactory
 import cromwell.api.CromwellClient
 import cromwell.api.CromwellClient.UnsuccessfulRequestException
-import cromwell.api.model.{CallCacheDiff, CromwellBackends, ShardIndex, SubmittedWorkflow, WorkflowId, WorkflowOutputs, WorkflowStatus}
+import cromwell.api.model.{CallCacheDiff, CromwellBackends, ShardIndex, SubmittedWorkflow, WorkflowId, WorkflowMetadata, WorkflowOutputs, WorkflowStatus}
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent._
@@ -69,9 +68,7 @@ object CentaurCromwellClient {
   def metadata(workflow: SubmittedWorkflow): IO[WorkflowMetadata] = metadata(workflow.id)
 
   def metadata(id: WorkflowId): IO[WorkflowMetadata] = {
-    sendReceiveFutureCompletion(() => cromwellClient.metadata(id)) map { m =>
-      WorkflowMetadata.fromMetadataJson(m.value).toOption.get
-    }
+    sendReceiveFutureCompletion(() => cromwellClient.metadata(id))
   }
 
   lazy val backends: Try[CromwellBackends] = Try(Await.result(cromwellClient.backends, CromwellManager.timeout * 2))

--- a/centaur/src/main/scala/centaur/test/CentaurTestException.scala
+++ b/centaur/src/main/scala/centaur/test/CentaurTestException.scala
@@ -1,10 +1,7 @@
 package centaur.test
 
-import centaur.test.metadata.WorkflowMetadata
 import centaur.test.workflow.Workflow
-import cromwell.api.model.SubmittedWorkflow
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import cromwell.api.model.{SubmittedWorkflow, WorkflowMetadata}
 
 /**
   * An exception with information about a centaur test failure.
@@ -33,7 +30,7 @@ object CentaurTestException {
       message,
       workflowDefinition.testName,
       Option(submittedWorkflow.id.toString),
-      Option(actualMetadata.value.toJson.compactPrint),
+      Option(actualMetadata.value),
       None
     )
   }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -6,10 +6,11 @@ import cats.Monad
 import cats.effect.IO
 import cats.instances.list._
 import cats.syntax.traverse._
+import centaur.test.metadata.WorkflowFlatMetadata._
 import centaur._
 import centaur.api.CentaurCromwellClient
 import centaur.api.CentaurCromwellClient.LogFailures
-import centaur.test.metadata.WorkflowMetadata
+import centaur.test.metadata.WorkflowFlatMetadata
 import centaur.test.submit.SubmitHttpResponse
 import centaur.test.workflow.Workflow
 import com.google.api.services.genomics.Genomics
@@ -21,7 +22,7 @@ import com.typesafe.config.Config
 import common.validation.Validation._
 import configs.syntax._
 import cromwell.api.CromwellClient.UnsuccessfulRequestException
-import cromwell.api.model.{CallCacheDiff, Failed, SubmittedWorkflow, TerminalStatus, WorkflowId, WorkflowStatus}
+import cromwell.api.model.{CallCacheDiff, Failed, SubmittedWorkflow, TerminalStatus, WorkflowId, WorkflowMetadata, WorkflowStatus}
 import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import spray.json.JsString
@@ -205,7 +206,7 @@ object Operations {
                         formerJobId: String): Test[Unit] = {
     new Test[Unit] {
       override def run: IO[Unit] = CentaurCromwellClient.metadata(workflow) flatMap { s =>
-        s.value.get(s"calls.$callFqn.jobId") match {
+        s.asFlat.value.get(s"calls.$callFqn.jobId") match {
           case Some(newJobId) if newJobId.asInstanceOf[JsString].value == formerJobId => IO.unit
           case Some(newJobId) =>
             val message = s"Pre-restart job ID $formerJobId did not match post restart job ID $newJobId"
@@ -252,16 +253,16 @@ object Operations {
         metadata <- CentaurCromwellClient
           .metadata(WorkflowId.fromString(subWorkflowId))
           .redeem(_ => None, Option.apply)
-        jobId <- IO.pure(metadata.flatMap(_.value.get("calls.inner_abort.aborted.jobId")))
+        jobId <- IO.pure(metadata.flatMap(_.asFlat.value.get("calls.inner_abort.aborted.jobId")))
       } yield jobId.map(_.asInstanceOf[JsString].value)
     }
 
     def valueAsString(key: String, metadata: WorkflowMetadata) = {
-      metadata.value.get(key).map(_.asInstanceOf[JsString].value)
+      metadata.asFlat.value.get(key).map(_.asInstanceOf[JsString].value)
     }
 
     def findCallStatus(metadata: WorkflowMetadata): IO[Option[(String, String)]] = {
-      val status = metadata.value.get(s"calls.$callFqn.executionStatus")
+      val status = metadata.asFlat.value.get(s"calls.$callFqn.executionStatus")
       val statusString = status.map(_.asInstanceOf[JsString].value)
 
       for {
@@ -312,7 +313,7 @@ object Operations {
 
       for {
         md <- CentaurCromwellClient.metadata(workflowB)
-        calls = md.value.keySet.flatMap({
+        calls = md.asFlat.value.keySet.flatMap({
           case callNameRegexp(name) => Option(name)
           case _ => None
         })
@@ -338,7 +339,8 @@ object Operations {
                        workflowSpec: Workflow,
                        cacheHitUUID: Option[UUID] = None): Test[WorkflowMetadata] = {
     new Test[WorkflowMetadata] {
-      def eventuallyMetadata(workflow: SubmittedWorkflow, expectedMetadata: WorkflowMetadata): IO[WorkflowMetadata] = {
+      def eventuallyMetadata(workflow: SubmittedWorkflow,
+                             expectedMetadata: WorkflowFlatMetadata): IO[WorkflowMetadata] = {
         validateMetadata(workflow, expectedMetadata).handleErrorWith({ _ =>
           for {
             _ <- IO.sleep(2.seconds)
@@ -348,7 +350,8 @@ object Operations {
         })
       }
 
-      def validateMetadata(workflow: SubmittedWorkflow, expectedMetadata: WorkflowMetadata): IO[WorkflowMetadata] = {
+      def validateMetadata(workflow: SubmittedWorkflow,
+                           expectedMetadata: WorkflowFlatMetadata): IO[WorkflowMetadata] = {
         def checkDiff(diffs: Iterable[String], actualMetadata: WorkflowMetadata): IO[Unit] = {
           if (diffs.nonEmpty) {
             val message = s"Invalid metadata response:\n -${diffs.mkString("\n -")}\n"
@@ -361,7 +364,7 @@ object Operations {
         def validateUnwantedMetadata(actualMetadata: WorkflowMetadata): IO[Unit] = {
           if (workflowSpec.notInMetadata.nonEmpty) {
             // Check that none of the "notInMetadata" keys are in the actual metadata
-            val absentMdIntersect = workflowSpec.notInMetadata.toSet.intersect(actualMetadata.value.keySet)
+            val absentMdIntersect = workflowSpec.notInMetadata.toSet.intersect(actualMetadata.asFlat.value.keySet)
             if (absentMdIntersect.nonEmpty) {
               val message = s"Found unwanted keys in metadata: ${absentMdIntersect.mkString(", ")}"
               IO.raiseError(CentaurTestException(message, workflowSpec, workflow, actualMetadata))
@@ -377,7 +380,7 @@ object Operations {
         for {
           actualMetadata <- CentaurCromwellClient.metadata(workflow)
           _ <- validateUnwantedMetadata(actualMetadata)
-          diffs = expectedMetadata.diff(actualMetadata, workflow.id.id, cacheHitUUID)
+          diffs = expectedMetadata.diff(actualMetadata.asFlat, workflow.id.id, cacheHitUUID)
           _ <- checkDiff(diffs, actualMetadata)
         } yield actualMetadata
       }
@@ -401,7 +404,7 @@ object Operations {
                                blacklistedValue: String): Test[Unit] = {
     new Test[Unit] {
       override def run: IO[Unit] = {
-        val badCacheResults = metadata.value collect {
+        val badCacheResults = metadata.asFlat.value collect {
           case (k, JsString(v)) if k.contains("callCaching.result") && v.contains(blacklistedValue) => s"$k: $v"
         }
 

--- a/centaur/src/main/scala/centaur/test/metadata/CallAttemptFailure.scala
+++ b/centaur/src/main/scala/centaur/test/metadata/CallAttemptFailure.scala
@@ -1,0 +1,86 @@
+package centaur.test.metadata
+
+import java.time.OffsetDateTime
+
+import cats.effect._
+import cats.instances.either._
+import cats.instances.option._
+import cats.instances.vector._
+import cats.syntax.apply._
+import cats.syntax.traverse._
+import io.circe._
+import io.circe.parser._
+
+/**
+  * The first failure message of a call. Based on the JMUI FailureMessage:
+  *
+  * https://github.com/DataBiosphere/job-manager/blob/f83e4284e2419389b7e515720c9d960d2eb81a29/servers/cromwell/jobs/controllers/jobs_controller.py#L155-L162
+  */
+case class CallAttemptFailure
+(
+  workflowId: String,
+  callFullyQualifiedName: String,
+  jobIndex: Int,
+  jobAttempt: Int,
+  message: String,
+  startOption: Option[OffsetDateTime],
+  endOption: Option[OffsetDateTime],
+  stdoutOption: Option[String],
+  stderrOption: Option[String],
+  callRootOption: Option[String]
+)
+
+object CallAttemptFailure {
+  def buildFailures(jsonOption: Option[String]): IO[Vector[CallAttemptFailure]] = {
+    jsonOption.map(buildFailures).getOrElse(IO.pure(Vector.empty))
+  }
+
+  def buildFailures(json: String): IO[Vector[CallAttemptFailure]] = {
+    IO.fromEither(decode[Vector[CallAttemptFailure]](json))
+  }
+
+  private implicit val decodeOffsetDateTime: Decoder[OffsetDateTime] = Decoder.decodeString.map(OffsetDateTime.parse)
+  private implicit val decodeFailures: Decoder[Vector[CallAttemptFailure]] = {
+    Decoder.instance { c =>
+      for {
+        workflowId <- c.get[String]("id")
+        calls <- c.get[Map[String, Json]]("calls").map(_.toVector)
+        callAttemptFailures <- calls.flatTraverse[Decoder.Result, CallAttemptFailure] {
+          case (callName, callJson) =>
+            val decoderCallAttempt = decodeFromCallAttempt(workflowId, callName)
+            callJson.as[Vector[Option[CallAttemptFailure]]](Decoder.decodeVector(decoderCallAttempt)).map(_.flatten)
+        }
+      } yield callAttemptFailures
+    } or Decoder.const(Vector.empty)
+  }
+
+  private def decodeFromCallAttempt(workflowId: String, callName: String): Decoder[Option[CallAttemptFailure]] = {
+    Decoder.instance { c =>
+      for {
+        shardIndexOption <- c.get[Option[Int]]("shardIndex")
+        attemptOption <- c.get[Option[Int]]("attempt")
+        messageOption <- c.downField("failures").downArray.get[Option[String]]("message")
+        startOption <- c.get[Option[OffsetDateTime]]("start")
+        endOption <- c.get[Option[OffsetDateTime]]("end")
+        stdoutOption <- c.get[Option[String]]("stdout")
+        stderrOption <- c.get[Option[String]]("stderr")
+        callRootOption <- c.get[Option[String]]("callRoot")
+        callAttemptFailureOption = (shardIndexOption, attemptOption, messageOption) mapN {
+          (shardIndex, attempt, message) =>
+            new CallAttemptFailure(
+              workflowId = workflowId,
+              callFullyQualifiedName = callName,
+              jobIndex = shardIndex,
+              jobAttempt = attempt,
+              message = message,
+              startOption = startOption,
+              endOption = endOption,
+              stdoutOption = stdoutOption,
+              stderrOption = stderrOption,
+              callRootOption = callRootOption
+            )
+        }
+      } yield callAttemptFailureOption
+    } or Decoder.const(None)
+  }
+}

--- a/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
@@ -6,7 +6,7 @@ import better.files._
 import cats.data.Validated._
 import cats.syntax.apply._
 import cats.syntax.validated._
-import centaur.test.metadata.WorkflowMetadata
+import centaur.test.metadata.WorkflowFlatMetadata
 import com.typesafe.config.{Config, ConfigFactory}
 import common.validation.ErrorOr.ErrorOr
 import configs.Result
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try}
 
 final case class Workflow private(testName: String,
                                   data: WorkflowData,
-                                  metadata: Option[WorkflowMetadata],
+                                  metadata: Option[WorkflowFlatMetadata],
                                   notInMetadata: List[String],
                                   directoryContentCounts: Option[DirectoryContentCountCheck],
                                   backends: BackendsRequirement) {
@@ -54,8 +54,8 @@ object Workflow {
         val backendsRequirement = BackendsRequirement.fromConfig(conf.get[String]("backendsMode").map(_.toLowerCase).valueOrElse("all"), conf.get[List[String]]("backends").valueOrElse(List.empty[String]).map(_.toLowerCase))
         // If basePath is provided it'll be used as basis for finding other files, otherwise use the dir the config was in
         val basePath = conf.get[Option[Path]]("basePath") valueOrElse None map (File(_)) getOrElse configFile
-        val metadata: ErrorOr[Option[WorkflowMetadata]] = conf.get[Config]("metadata") match {
-          case Result.Success(md) => WorkflowMetadata.fromConfig(md) map Option.apply
+        val metadata: ErrorOr[Option[WorkflowFlatMetadata]] = conf.get[Config]("metadata") match {
+          case Result.Success(md) => WorkflowFlatMetadata.fromConfig(md) map Option.apply
           case Result.Failure(_) => None.validNel
         }
         val absentMetadata = conf.get[List[String]]("absent-metadata-keys") match {

--- a/centaur/src/test/resources/centaur/test/metadata/failingInSeveralWaysMetadata.json
+++ b/centaur/src/test/resources/centaur/test/metadata/failingInSeveralWaysMetadata.json
@@ -1,0 +1,3208 @@
+{
+  "workflowName": "FailingInSeveralWays",
+  "actualWorkflowLanguageVersion": "draft-2",
+  "submittedFiles": {
+    "workflow": "workflow FailingInSeveralWays {\n\n\tcall WriteGreeting {\n\t  input:\n\t    greeting = \"I like modifying strings\"\n\t}\n\n\tcall ReadItBackToMe {\n\t\tinput:\n\t\t\toriginal_greeting = WriteGreeting.out\n\t}\n\n\tcall WillFail {\n\t  input:\n\t    argument = ReadItBackToMe.outfile\n\t}\n\n  scatter(idx in range(50)) {\n    call ScatterJobThatWillFailSometimes {\n      input:\n        idx = idx\n    }\n  }\n\n\toutput {\n\t\tFile outfile = ReadItBackToMe.outfile\n\t}\n}\n\ntask WriteGreeting {\n\n\tString greeting\n\n\tcommand {\n\t\techo \"${greeting}\"\n\t}\n\toutput {\n\t\tString out = read_string(stdout())\n\t}\n}\n\ntask ReadItBackToMe {\n\n\tString original_greeting\n\n\tcommand {\n\t\techo \"${original_greeting} to you too\"\n\t}\n\toutput {\n\t\tFile outfile = read_string(stdout())\n\t}\n}\n\ntask WillFail {\n  String argument\n\n\tcommand {\n    exit 0;\n\t}\n}\ntask ScatterJobThatWillFailSometimes {\n  Int idx\n\n  command {\n    if [ \"${idx}\" -gt \"40\" ]; then\n      exit 1;\n    fi\n\n    if [ \"${idx}\" -lt \"20\" ]; then\n      exit 0;\n    fi\n  }\n}\n",
+    "workflowType": "WDL",
+    "root": "None",
+    "options": "{\n\n}",
+    "inputs": "{\"HelloWorld.WriteGreeting.greeting\":\"I like modifying files\"}",
+    "labels": "{}"
+  },
+  "calls": {
+    "FailingInSeveralWays.ScatterJobThatWillFailSometimes": [
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-0/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 0,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 0
+        },
+        "returnCode": 0,
+        "jobId": "10147",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.813-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-0/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-0",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.148-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.042-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.793-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.530-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.148-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.042-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.530-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.793-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-1/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 1,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 1
+        },
+        "returnCode": 0,
+        "jobId": "10040",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-1/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-1",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.992-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.852-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.992-04:00"
+          },
+          {
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00",
+            "startTime": "2018-07-26T17:18:58.852-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.800-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.800-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-2/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 2,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 2
+        },
+        "returnCode": 0,
+        "jobId": "10033",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.812-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-2/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-2",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.006-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.011-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.006-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.011-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.796-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-3/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 3,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 3
+        },
+        "returnCode": 0,
+        "jobId": "9928",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-3/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-3",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.727-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.727-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.796-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-4/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 4,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 4
+        },
+        "returnCode": 0,
+        "jobId": "9722",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-4/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-4",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.521-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.791-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.551-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.521-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.551-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.791-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-5/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 5,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 5
+        },
+        "returnCode": 0,
+        "jobId": "9705",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-5/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-5",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.791-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.521-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.544-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.852-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.521-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.544-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.852-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.791-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-6/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 6,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 6
+        },
+        "returnCode": 0,
+        "jobId": "9748",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-6/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-6",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.795-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.569-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.853-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.569-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.853-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.794-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-7/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 7,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 7
+        },
+        "returnCode": 0,
+        "jobId": "10034",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-7/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-7",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.007-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.795-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.007-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.131-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.131-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-8/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 8,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 8
+        },
+        "returnCode": 0,
+        "jobId": "10128",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-8/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-8",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:19:00.230-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.529-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.529-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.138-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.793-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.138-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.230-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.792-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-9/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 9,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 9
+        },
+        "returnCode": 0,
+        "jobId": "10035",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-9/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-9",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.794-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.160-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.002-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.002-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.160-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.794-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-10/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 10,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 10
+        },
+        "returnCode": 0,
+        "jobId": "10250",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-10/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-10",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.529-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.122-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.122-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.053-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.053-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.529-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.793-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.793-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-11/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 11,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 11
+        },
+        "returnCode": 0,
+        "jobId": "10052",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-11/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-11",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:56.027-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.528-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.825-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.794-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.528-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.027-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.793-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-12/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 12,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 12
+        },
+        "returnCode": 0,
+        "jobId": "9835",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-12/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-12",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.702-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.702-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-13/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 13,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 13
+        },
+        "returnCode": 0,
+        "jobId": "10092",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-13/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-13",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.797-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.729-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.853-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.729-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.853-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-14/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 14,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 14
+        },
+        "returnCode": 0,
+        "jobId": "9982",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-14/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-14",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.853-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.882-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.853-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.799-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.882-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.798-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-15/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 15,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 15
+        },
+        "returnCode": 0,
+        "jobId": "10266",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.805-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-15/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-15",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:19:01.120-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.792-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.530-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.311-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.311-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.120-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.521-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.521-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.530-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.792-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-16/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 16,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 16
+        },
+        "returnCode": 0,
+        "jobId": "10229",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.804-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-16/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-16",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.934-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.291-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:01.291-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.799-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.934-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.799-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-17/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 17,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 17
+        },
+        "returnCode": 0,
+        "jobId": "10253",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-17/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-17",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.529-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.122-04:00"
+          },
+          {
+            "endTime": "2018-07-26T17:19:00.812-04:00",
+            "startTime": "2018-07-26T17:19:00.279-04:00",
+            "description": "UpdatingJobStore"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.122-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.279-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.793-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.529-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.793-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-18/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 18,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 18
+        },
+        "returnCode": 0,
+        "jobId": "10195",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.815-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-18/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-18",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:19:00.219-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.797-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.730-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.730-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.219-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-19/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 19,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 19
+        },
+        "returnCode": 0,
+        "jobId": "9718",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-19/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-19",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.557-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.557-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.830-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.793-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.793-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.830-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.793-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-20/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 20,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 20
+        },
+        "returnCode": 0,
+        "jobId": "9910",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.829-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-20/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-20",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.847-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.798-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.755-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.755-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.847-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-21/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 21,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 21
+        },
+        "returnCode": 0,
+        "jobId": "9985",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-21/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-21",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.872-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.825-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.798-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.872-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.798-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-22/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 22,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 22
+        },
+        "returnCode": 0,
+        "jobId": "10320",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.805-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-22/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-22",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.800-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.978-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.978-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.419-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:01.419-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.800-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-23/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 23,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 23
+        },
+        "returnCode": 0,
+        "jobId": "10039",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-23/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-23",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.799-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.984-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "endTime": "2018-07-26T17:18:58.844-04:00",
+            "startTime": "2018-07-26T17:18:55.984-04:00",
+            "description": "RunningJob"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.799-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-24/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 24,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 24
+        },
+        "returnCode": 0,
+        "jobId": "9834",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-24/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-24",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.652-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.652-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.795-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-25/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 25,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 25
+        },
+        "returnCode": 0,
+        "jobId": "10246",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.813-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-25/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-25",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.981-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.800-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.981-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.123-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.123-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.799-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-26/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 26,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 26
+        },
+        "returnCode": 0,
+        "jobId": "9756",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-26/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-26",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.852-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.795-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.586-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.586-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.852-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-27/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 27,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 27
+        },
+        "returnCode": 0,
+        "jobId": "9991",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-27/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-27",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.901-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.799-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.901-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.799-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-28/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 28,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 28
+        },
+        "returnCode": 0,
+        "jobId": "9865",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-28/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-28",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.798-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.750-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.750-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.798-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-29/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 29,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 29
+        },
+        "returnCode": 0,
+        "jobId": "9880",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.828-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-29/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-29",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.771-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.798-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.771-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.798-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-30/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 30,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 30
+        },
+        "returnCode": 0,
+        "jobId": "9860",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.829-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-30/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-30",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.847-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.740-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.847-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.740-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.797-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-31/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 31,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 31
+        },
+        "returnCode": 0,
+        "jobId": "9929",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-31/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-31",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.711-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.711-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.796-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-32/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 32,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 32
+        },
+        "returnCode": 0,
+        "jobId": "10259",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.804-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-32/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-32",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:19:01.239-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.974-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.799-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.974-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.239-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.799-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.799-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-33/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 33,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 33
+        },
+        "returnCode": 0,
+        "jobId": "10049",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-33/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-33",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:59.800-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.716-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.716-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:59.800-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.796-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-34/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 34,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 34
+        },
+        "returnCode": 0,
+        "jobId": "9696",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-34/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-34",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.790-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.791-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.853-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.532-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.532-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.853-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.790-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-35/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 35,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 35
+        },
+        "returnCode": 0,
+        "jobId": "9695",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-35/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-35",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.792-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.521-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.536-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.536-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.852-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.521-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.852-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.791-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-36/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 36,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 36
+        },
+        "returnCode": 0,
+        "jobId": "9927",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.829-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-36/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-36",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.697-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.697-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.846-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.846-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-37/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 37,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 37
+        },
+        "returnCode": 0,
+        "jobId": "9693",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-37/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-37",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.531-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.531-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.791-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.791-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-38/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 38,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 38
+        },
+        "returnCode": 0,
+        "jobId": "10041",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.822-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-38/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-38",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:56.016-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.828-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.794-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.828-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.528-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.528-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.016-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.794-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-39/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 39,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 39
+        },
+        "returnCode": 0,
+        "jobId": "9782",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.830-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-39/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-39",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.851-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.605-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.795-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.605-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.851-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.795-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.795-04:00"
+      },
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-40/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 40,
+        "outputs": {},
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 40
+        },
+        "returnCode": 0,
+        "jobId": "9866",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.831-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-40/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-40",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.733-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.853-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.823-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.733-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.853-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.797-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-41/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 41,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "effectiveCallCachingMode": "CallCachingOff",
+          "allowResultReuse": false
+        },
+        "inputs": {
+          "idx": 41
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:41:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "10032",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.813-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-41/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-41",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.800-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.992-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:59.901-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.992-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:59.901-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.800-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-42/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 42,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 42
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:42:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "9710",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.822-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-42/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-42",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.792-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.522-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.554-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.522-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.554-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.792-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-43/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 43,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 43
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:43:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "10038",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.829-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-43/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-43",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.527-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.985-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.848-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.848-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.527-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.985-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.800-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.800-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.800-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-44/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 44,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 44
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:44:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "10117",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.814-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-44/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-44",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.526-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.883-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.201-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.798-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.798-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.526-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.883-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.201-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.798-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-45/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 45,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 45
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:45:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "10050",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:00.816-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-45/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-45",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.528-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.016-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.528-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:00.242-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:00.812-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.016-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:00.242-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.794-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.794-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.794-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-46/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 46,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 46
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:46:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "9970",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.827-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-46/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-46",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.796-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.796-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.725-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.725-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.796-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-47/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 47,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 47
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:47:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "9830",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.828-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-47/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-47",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.523-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.625-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.521-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.844-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.792-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.792-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.625-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.844-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.521-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.792-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-48/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 48,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 48
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:48:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "10244",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.804-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-48/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-48",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.525-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:56.002-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.524-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.525-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.524-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.002-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.072-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:19:01.072-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.797-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.797-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.797-04:00"
+      },
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-49/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": 49,
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "idx": 49
+        },
+        "returnCode": 1,
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:49:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "jobId": "9697",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:59.829-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-49/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ScatterJobThatWillFailSometimes/shard-49",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:55.534-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:58.848-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:54.791-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:54.791-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:55.534-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:58.848-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:59.822-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:55.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:55.520-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:54.791-04:00"
+      }
+    ],
+    "FailingInSeveralWays.ReadItBackToMe": [
+      {
+        "retryableFailure": false,
+        "executionStatus": "Failed",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ReadItBackToMe/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": -1,
+        "runtimeAttributes": {
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0",
+          "maxRetries": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "original_greeting": "I like modifying strings"
+        },
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Could not process output, file not found: /Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ReadItBackToMe/execution/I like modifying strings to you too"
+          }
+        ],
+        "jobId": "10356",
+        "backend": "Local",
+        "end": "2018-07-26T17:19:01.805-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ReadItBackToMe/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ReadItBackToMe",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:19:01.763-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:19:01.804-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:57.523-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:19:01.763-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.873-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:57.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:56.873-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:56.873-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:57.520-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:57.520-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:57.520-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:57.523-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:56.873-04:00"
+      }
+    ],
+    "FailingInSeveralWays.WriteGreeting": [
+      {
+        "executionStatus": "Done",
+        "stdout": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-WriteGreeting/execution/stdout",
+        "backendStatus": "Done",
+        "shardIndex": -1,
+        "outputs": {
+          "out": "I like modifying strings"
+        },
+        "runtimeAttributes": {
+          "maxRetries": "0",
+          "failOnStderr": "false",
+          "continueOnReturnCode": "0"
+        },
+        "callCaching": {
+          "allowResultReuse": false,
+          "effectiveCallCachingMode": "CallCachingOff"
+        },
+        "inputs": {
+          "greeting": "I like modifying strings"
+        },
+        "returnCode": 0,
+        "jobId": "9675",
+        "backend": "Local",
+        "end": "2018-07-26T17:18:54.803-04:00",
+        "stderr": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-WriteGreeting/execution/stderr",
+        "callRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-WriteGreeting",
+        "attempt": 1,
+        "executionEvents": [
+          {
+            "startTime": "2018-07-26T17:18:53.518-04:00",
+            "description": "WaitingForValueStore",
+            "endTime": "2018-07-26T17:18:53.518-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:53.521-04:00",
+            "description": "RunningJob",
+            "endTime": "2018-07-26T17:18:53.808-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:52.731-04:00",
+            "description": "RequestingExecutionToken",
+            "endTime": "2018-07-26T17:18:53.518-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:53.808-04:00",
+            "description": "UpdatingJobStore",
+            "endTime": "2018-07-26T17:18:54.803-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:52.731-04:00",
+            "description": "Pending",
+            "endTime": "2018-07-26T17:18:52.731-04:00"
+          },
+          {
+            "startTime": "2018-07-26T17:18:53.518-04:00",
+            "description": "PreparingJob",
+            "endTime": "2018-07-26T17:18:53.521-04:00"
+          }
+        ],
+        "start": "2018-07-26T17:18:52.730-04:00"
+      }
+    ]
+  },
+  "outputs": {},
+  "workflowRoot": "/Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845",
+  "actualWorkflowLanguage": "WDL",
+  "id": "9e83cb0d-0347-431e-8ee6-48f535060845",
+  "inputs": {},
+  "labels": {
+    "cromwell-workflow-id": "cromwell-9e83cb0d-0347-431e-8ee6-48f535060845"
+  },
+  "submission": "2018-07-26T17:18:38.108-04:00",
+  "status": "Failed",
+  "failures": [
+    {
+      "message": "Workflow failed",
+      "causedBy": [
+        {
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:49:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details.",
+          "causedBy": []
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:42:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:47:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:45:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Could not process output, file not found: /Users/rasch/p/cromwell/cromwell-executions/FailingInSeveralWays/9e83cb0d-0347-431e-8ee6-48f535060845/call-ReadItBackToMe/execution/I like modifying strings to you too"
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:46:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:48:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:44:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:43:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        },
+        {
+          "causedBy": [],
+          "message": "Job FailingInSeveralWays.ScatterJobThatWillFailSometimes:41:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+        }
+      ]
+    }
+  ],
+  "end": "2018-07-26T17:19:01.972-04:00",
+  "start": "2018-07-26T17:18:50.664-04:00"
+}

--- a/centaur/src/test/scala/centaur/test/metadata/CallAttemptFailureSpec.scala
+++ b/centaur/src/test/scala/centaur/test/metadata/CallAttemptFailureSpec.scala
@@ -1,0 +1,41 @@
+package centaur.test.metadata
+
+import centaur.test.metadata.CallAttemptFailureSpec._
+import io.circe.ParsingFailure
+import org.scalatest.{FlatSpec, Matchers}
+
+class CallAttemptFailureSpec extends FlatSpec with Matchers {
+
+  behavior of "CallAttemptFailure"
+
+  it should "parse metadata" in {
+    val res = CallAttemptFailure.buildFailures(failingInSeveralWaysMetadataJson).unsafeRunSync()
+    res.size should be(10)
+    val firsts = res.take(9)
+    val last = res.drop(9).head
+    firsts.map(_.callFullyQualifiedName).distinct should contain theSameElementsAs
+      Vector("FailingInSeveralWays.ScatterJobThatWillFailSometimes")
+    firsts.map(_.jobIndex) should contain theSameElementsInOrderAs (41 to 49)
+    last.callFullyQualifiedName should be("FailingInSeveralWays.ReadItBackToMe")
+    last.workflowId should be("9e83cb0d-0347-431e-8ee6-48f535060845")
+  }
+
+  it should "parse empty json as an empty vector" in {
+    val res = CallAttemptFailure.buildFailures("{}").unsafeRunSync()
+    res should be(empty)
+  }
+
+  it should "not parse malformed json" in {
+    val theException: Exception = the[ParsingFailure] thrownBy CallAttemptFailure.buildFailures("{").unsafeRunSync()
+    theException should have message "exhausted input"
+  }
+
+}
+
+object CallAttemptFailureSpec {
+  private val failingInSeveralWaysMetadataJson = {
+    val resource = classOf[CallAttemptFailureSpec].getResource("failingInSeveralWaysMetadata.json")
+    val path = resource.getPath
+    better.files.File(path).contentAsString
+  }
+}

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/Outputs.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/Outputs.scala
@@ -1,22 +1,23 @@
 package centaur.cwl
 
 import centaur.api.CentaurCromwellClient
+import centaur.test.metadata.WorkflowFlatMetadata._
+import common.validation.Parse._
 import cromwell.api.model.SubmittedWorkflow
 import cromwell.core.path.PathBuilder
-import common.validation.Parse._
 import cwl.ontology.Schema
 import cwl.{Cwl, CwlDecoder, MyriadOutputType}
 import io.circe.Json
 import io.circe.syntax._
+import scalaz.syntax.std.map._
 import shapeless.Poly1
 import spray.json.{JsObject, JsString, JsValue}
-import scalaz.syntax.std.map._
 
 object Outputs {
 
   //When the string returned is not valid JSON, it is effectively an exception as CWL runner expects JSON to be returned
   def handleOutput(submittedWorkflow: SubmittedWorkflow, pathBuilder: PathBuilder): String = {
-    val metadata: Map[String, JsValue] = CentaurCromwellClient.metadata(submittedWorkflow).unsafeRunSync().value
+    val metadata: Map[String, JsValue] = CentaurCromwellClient.metadata(submittedWorkflow).unsafeRunSync().asFlat.value
 
     // Wrapper function to provide the right signature for `intersectWith` below.
     def outputResolver(schemaOption: Option[Schema])(jsValue: JsValue, mot: MyriadOutputType): Json = {

--- a/database/sql/src/main/scala/cromwell/database/slick/EngineSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/EngineSlickDatabase.scala
@@ -1,8 +1,15 @@
 package cromwell.database.slick
 
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.database.slick.tables.EngineDataAccessComponent
 import cromwell.database.sql.EngineSqlDatabase
+
+object EngineSlickDatabase {
+  def fromParentConfig(parentConfig: Config = ConfigFactory.load): EngineSlickDatabase = {
+    val databaseConfig = SlickDatabase.getDatabaseConfig("engine", parentConfig)
+    new EngineSlickDatabase(databaseConfig)
+  }
+}
 
 class EngineSlickDatabase(originalDatabaseConfig: Config)
   extends SlickDatabase(originalDatabaseConfig)

--- a/database/sql/src/main/scala/cromwell/database/slick/JobKeyValueSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/JobKeyValueSlickDatabase.scala
@@ -48,6 +48,12 @@ trait JobKeyValueSlickDatabase extends JobKeyValueSqlDatabase {
     runTransaction(action).void
   }
 
+  override def queryJobKeyValueEntries(workflowExecutionUuid: String)
+                                      (implicit ec: ExecutionContext): Future[Seq[JobKeyValueEntry]] = {
+    val action = dataAccess.jobKeyValueEntriesForWorkflowExecutionUuid(workflowExecutionUuid).result
+    runTransaction(action)
+  }
+
   override def queryStoreValue(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int,
                                jobRetryAttempt: Int, storeKey: String)
                               (implicit ec: ExecutionContext): Future[Option[String]] = {

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -3,7 +3,7 @@ package cromwell.database.slick
 import java.sql.Timestamp
 
 import cats.data.NonEmptyList
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.database.slick.tables.MetadataDataAccessComponent
 import cromwell.database.sql.MetadataSqlDatabase
 import cromwell.database.sql.SqlConverters._
@@ -11,6 +11,13 @@ import cromwell.database.sql.joins.{CallOrWorkflowQuery, CallQuery, MetadataJobQ
 import cromwell.database.sql.tables.{CustomLabelEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 
 import scala.concurrent.{ExecutionContext, Future}
+
+object MetadataSlickDatabase {
+  def fromParentConfig(parentConfig: Config = ConfigFactory.load): MetadataSlickDatabase = {
+    val databaseConfig = SlickDatabase.getDatabaseConfig("metadata", parentConfig)
+    new MetadataSlickDatabase(databaseConfig)
+  }
+}
 
 class MetadataSlickDatabase(originalDatabaseConfig: Config)
   extends SlickDatabase(originalDatabaseConfig)

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -42,6 +42,11 @@ object SlickDatabase {
       Await.result(slickDatabase.database.run(slickDatabase.dataAccess.schema.create), Duration.Inf)
     }
   }
+
+  def getDatabaseConfig(name: String, parentConfig: Config): Config = {
+    val rootDatabaseConfig = parentConfig.getConfig("database")
+    rootDatabaseConfig.getOrElse(name, rootDatabaseConfig)
+  }
 }
 
 /**

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/JobKeyValueEntryComponent.scala
@@ -35,6 +35,12 @@ trait JobKeyValueEntryComponent {
 
   val jobKeyValueEntryIdsAutoInc = jobKeyValueEntries returning jobKeyValueEntries.map(_.jobKeyValueEntryId)
 
+  val jobKeyValueEntriesForWorkflowExecutionUuid = Compiled((workflowExecutionUuid: Rep[String]) => for {
+      jobKeyValueEntry <- jobKeyValueEntries
+      if jobKeyValueEntry.workflowExecutionUuid === workflowExecutionUuid
+    } yield jobKeyValueEntry
+  )
+
   val storeValuesForJobKeyAndStoreKey = Compiled(
     (workflowExecutionUuid: Rep[String], callFullyQualifiedName: Rep[String], jobIndex: Rep[Int], jobAttempt: Rep[Int],
      storeKey: Rep[String]) => for {

--- a/database/sql/src/main/scala/cromwell/database/sql/JobKeyValueSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/JobKeyValueSqlDatabase.scala
@@ -13,6 +13,9 @@ trait JobKeyValueSqlDatabase {
   def addJobKeyValueEntries(jobKeyValueEntries: Iterable[JobKeyValueEntry])
                            (implicit ec: ExecutionContext): Future[Unit]
 
+  def queryJobKeyValueEntries(workflowExecutionUuid: String)
+                             (implicit ec: ExecutionContext): Future[Seq[JobKeyValueEntry]]
+
   def queryStoreValue(workflowExecutionUuid: String, callFqn: String, jobScatterIndex: Int,
                       jobRetryAttempt: Int, storeKey: String)
                      (implicit ec: ExecutionContext): Future[Option[String]]

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -8,8 +8,7 @@ import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait MetadataSqlDatabase {
-  this: SqlDatabase =>
+trait MetadataSqlDatabase extends SqlDatabase {
 
   /*
   The following section relates to:

--- a/services/src/main/scala/cromwell/services/EngineServicesStore.scala
+++ b/services/src/main/scala/cromwell/services/EngineServicesStore.scala
@@ -7,11 +7,8 @@ import cromwell.database.sql.EngineSqlDatabase
 object EngineServicesStore {
   val EngineLiquibaseSettings = LiquibaseSettings("changelog.xml")
 
-  private val engineDatabaseConfig = ServicesStore.getDatabaseConfig("engine")
-
   import ServicesStore.EnhancedSqlDatabase
 
   val engineDatabaseInterface: EngineSqlDatabase =
-    new EngineSlickDatabase(engineDatabaseConfig)
-      .initialized(EngineServicesStore.EngineLiquibaseSettings)
+    EngineSlickDatabase.fromParentConfig().initialized(EngineServicesStore.EngineLiquibaseSettings)
 }

--- a/services/src/main/scala/cromwell/services/MetadataServicesStore.scala
+++ b/services/src/main/scala/cromwell/services/MetadataServicesStore.scala
@@ -16,12 +16,10 @@ object MetadataServicesStore {
     "SQLMETADATA" + Database.databaseChangeLogTableName
   )
 
-  private val metadataDatabaseConfig = ServicesStore.getDatabaseConfig("metadata")
-
   import ServicesStore.EnhancedSqlDatabase
 
   // Mix in AutoCloseable for shutdown purposes.
   // This whole MetadataSqlDatabase interface will likely change to a more abstract MetadataDAO in the future.
-  val metadataDatabaseInterface: MetadataSqlDatabase with AutoCloseable =
-    new MetadataSlickDatabase(metadataDatabaseConfig).initialized(MetadataServicesStore.MetadataLiquibaseSettings)
+  val metadataDatabaseInterface: MetadataSqlDatabase =
+    MetadataSlickDatabase.fromParentConfig().initialized(MetadataServicesStore.MetadataLiquibaseSettings)
 }

--- a/services/src/main/scala/cromwell/services/ServicesStore.scala
+++ b/services/src/main/scala/cromwell/services/ServicesStore.scala
@@ -1,60 +1,13 @@
 package cromwell.services
 
-import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.database.migration.liquibase.{LiquibaseSettings, LiquibaseUtils}
 import cromwell.database.sql.SqlDatabase
 import net.ceedubs.ficus.Ficus._
 
 object ServicesStore {
-
-  def getDatabaseConfig(name: String): Config = {
-    val rootDatabaseConfig = ConfigFactory.load.getConfig("database")
-    val databaseConfig = rootDatabaseConfig.getOrElse(name, rootDatabaseConfig)
-    if (databaseConfig.hasPath("config")) {
-      val msg =
-        """|
-           |*******************************
-           |***** DEPRECATION MESSAGE *****
-           |*******************************
-           |
-           |Use of configuration path 'database.config' has been deprecated.
-           |
-           |Move the configuration directly under the 'database' element, and remove the key 'database.config'.
-           |
-           |""".stripMargin
-      throw new Exception(msg)
-    } else if (databaseConfig.hasPath("driver")) {
-      val msg =
-        """|
-           |*******************************
-           |***** DEPRECATION MESSAGE *****
-           |*******************************
-           |
-           |Use of configuration path 'database.driver' has been deprecated. Replace with a "profile" element instead, e.g:
-           |
-           |database {
-           |  #driver = "slick.driver.MySQLDriver$" #old
-           |  profile = "slick.jdbc.MySQLProfile$"  #new
-           |  db {
-           |    driver = "com.mysql.jdbc.Driver"
-           |    url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
-           |    user = "user"
-           |    password = "pass"
-           |    connectionTimeout = 5000
-           |  }
-           |}
-           |
-           |Cromwell thanks you.
-           |""".stripMargin
-      throw
-        new RuntimeException(msg)
-    }
-    databaseConfig
-  }
-
   implicit class EnhancedSqlDatabase[A <: SqlDatabase](val sqlDatabase: A) extends AnyVal {
     def initialized(settings: LiquibaseSettings): A = {
-      if (sqlDatabase.databaseConfig.as[Option[Boolean]]("liquibase.updateSchema").getOrElse(true)) {
+      if (sqlDatabase.databaseConfig.getOrElse("liquibase.updateSchema", true)) {
         sqlDatabase withConnection LiquibaseUtils.updateSchema(settings)
       }
       sqlDatabase

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -22,20 +22,4 @@ system {
   }
 }
 
-database {
-  db {
-    hostname = localhost
-    hostname = ${?CROMWELL_BUILD_MYSQL_HOSTNAME}
-    port = 3306
-    port = ${?CROMWELL_BUILD_MYSQL_PORT}
-    schema = cromwell_test
-    schema = ${?CROMWELL_BUILD_MYSQL_SCHEMA}
-    url = "jdbc:mysql://"${database.db.hostname}":"${database.db.port}"/"${database.db.schema}"?useSSL=false&rewriteBatchedStatements=true"
-    user = root
-    user = ${?CROMWELL_BUILD_MYSQL_USERNAME}
-    password = ""
-    password = ${?CROMWELL_BUILD_MYSQL_PASSWORD}
-    driver = "com.mysql.jdbc.Driver"
-  }
-  profile = "slick.jdbc.MySQLProfile$"
-}
+include "cromwell_database.inc.conf"

--- a/src/ci/resources/centaur_application.conf
+++ b/src/ci/resources/centaur_application.conf
@@ -14,9 +14,13 @@ centaur {
         class: "centaur.reporting.SentryReporter"
         config {
           dsn: "noop://localhost?async=false&stacktrace.app.packages=quieted_with_any_value_because_empty_was_not_working"
-          include "centaur_application_sentry_config.inc.conf"
         }
       }
     }
   }
+
+  cromwell {
+    include "cromwell_database.inc.conf"
+  }
+  include "centaur_secure.inc.conf"
 }

--- a/src/ci/resources/centaur_application_sentry_config.inc.conf.ctmpl
+++ b/src/ci/resources/centaur_application_sentry_config.inc.conf.ctmpl
@@ -1,3 +1,0 @@
-{{with $centaurSentry := vault (printf "secret/dsde/cromwell/common/centaur-sentry")}}
-dsn: "{{$centaurSentry.Data.error_reporter_dsn}}"
-{{end}}

--- a/src/ci/resources/centaur_secure.inc.conf.ctmpl
+++ b/src/ci/resources/centaur_secure.inc.conf.ctmpl
@@ -1,0 +1,12 @@
+{{with $centaurSentry := vault (printf "secret/dsde/cromwell/common/centaur-sentry")}}
+error-reporter {
+  providers {
+    sentry {
+      class: "centaur.reporting.SentryReporter"
+      config {
+        dsn: "{{$centaurSentry.Data.error_reporter_dsn}}"
+      }
+    }
+  }
+}
+{{end}}

--- a/src/ci/resources/cromwell_database.inc.conf
+++ b/src/ci/resources/cromwell_database.inc.conf
@@ -1,0 +1,17 @@
+database {
+  db {
+    hostname = localhost
+    hostname = ${?CROMWELL_BUILD_MYSQL_HOSTNAME}
+    port = 3306
+    port = ${?CROMWELL_BUILD_MYSQL_PORT}
+    schema = cromwell_test
+    schema = ${?CROMWELL_BUILD_MYSQL_SCHEMA}
+    url = "jdbc:mysql://"${database.db.hostname}":"${database.db.port}"/"${database.db.schema}"?useSSL=false&rewriteBatchedStatements=true"
+    user = root
+    user = ${?CROMWELL_BUILD_MYSQL_USERNAME}
+    password = ""
+    password = ${?CROMWELL_BUILD_MYSQL_PASSWORD}
+    driver = "com.mysql.jdbc.Driver"
+  }
+  profile = "slick.jdbc.MySQLProfile$"
+}


### PR DESCRIPTION
Sending JMUI style call failures to Sentry.
Wired in the ability for Centaur integration tests to get data directly from the Cromwell database.
Added a `queryJobKeyValueEntries` to return all job key/values for a workflow.
Removed deprecation exception for old database config syntax.
Flatten metadata only during comparison, passing the original internally.
Removed secure env variables that were always true in Sentry.
Refactored centaur secure config rendering.