### PR TITLE
Add tabs to one Centaur case

### DIFF
--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/struct_output/struct_output.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/struct_output/struct_output.wdl
@@ -1,15 +1,18 @@
 version 1.0
 
+# This workflow has been arbitrarily selected to test that tabs work as whitespace.
+# Be very careful while editing, as many editors automatically convert spaces to tabs.
+
 struct FooStruct {
-  Int simple
-  Pair[Array[Int], Map[String, Boolean]] complex
+	Int simple
+	Pair[Array[Int], Map[String, Boolean]] complex
 }
 
 workflow struct_output {
-  output {
-    FooStruct myFoo = object {
-      simple: 5,
-      complex: ([5], { "t": true })
-    }
-  }
+	output {
+		FooStruct myFoo = object {
+			simple: 5,
+			complex: ([5], { "t": true })
+		}
+	}
 }


### PR DESCRIPTION
Related to (but does not close) https://github.com/broadinstitute/cromwell/issues/4051

In the issue above, doubt was raised whether we correctly support tabs. I wanted to test whether we do and add a test, and this change does both.