### PR TITLE
Global ftp config + doc

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -213,7 +213,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     globFiles map globScript mkString "\n"
 
   /**
-    * Returns the shell scripting for linking a glob results.
+    * Returns the shell scripting for linking a glob results file.
     *
     * @param globFile The glob.
     * @return The shell scripting.

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
@@ -1,6 +1,7 @@
 package centaur.cwl
 
 import better.files.File
+import cloud.nio.impl.ftp.FtpFileSystems
 import com.typesafe.config.Config
 import common.validation.Parse.{Parse, _}
 import cromwell.core.path.Obsolete.Paths
@@ -83,7 +84,8 @@ case class TeskRunMode(conf: Config) extends CentaurCwlRunnerRunMode {
   override lazy val description: String = "tesk"
 
   override lazy val pathBuilderFactory: PathBuilderFactory = {
-    new FtpPathBuilderFactory(conf, ftpConfig, CromwellFtpFileSystems.Default)
+    val fileSystemsConfiguration = FtpFileSystems.DefaultConfig.copy(capacity = 1)
+    new FtpPathBuilderFactory(conf, ftpConfig, new CromwellFtpFileSystems(new FtpFileSystems(fileSystemsConfiguration)))
   }
 
   override def preProcessWorkflow(workflow: String): String = preprocessor.preProcessWorkflow(workflow)

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
@@ -84,7 +84,7 @@ case class TeskRunMode(conf: Config) extends CentaurCwlRunnerRunMode {
   override lazy val description: String = "tesk"
 
   override lazy val pathBuilderFactory: PathBuilderFactory = {
-    val fileSystemsConfiguration = FtpFileSystems.DefaultConfig.copy(capacity = 1)
+    val fileSystemsConfiguration = FtpFileSystems.DefaultConfig.copy(capacity = 2)
     new FtpPathBuilderFactory(conf, ftpConfig, new CromwellFtpFileSystems(new FtpFileSystems(fileSystemsConfiguration)))
   }
 

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunnerRunMode.scala
@@ -5,8 +5,8 @@ import com.typesafe.config.Config
 import common.validation.Parse.{Parse, _}
 import cromwell.core.path.Obsolete.Paths
 import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilderFactory}
+import cromwell.filesystems.ftp.{CromwellFtpFileSystems, FtpPathBuilderFactory}
 import cromwell.filesystems.gcs.GcsPathBuilderFactory
-import cromwell.filesystems.ftp.FtpPathBuilderFactory
 import cwl.preprocessor.CwlPreProcessor
 
 sealed trait CentaurCwlRunnerRunMode {
@@ -80,10 +80,10 @@ case class TeskRunMode(conf: Config) extends CentaurCwlRunnerRunMode {
   private lazy val ftpConfig = conf.getConfig("ftp")
   private lazy val preprocessor = new CloudPreprocessor(conf, "tesk.default-input-ftp-prefix")
 
-  override lazy val description: String = s"tesk"
+  override lazy val description: String = "tesk"
 
   override lazy val pathBuilderFactory: PathBuilderFactory = {
-    new FtpPathBuilderFactory(conf, ftpConfig)
+    new FtpPathBuilderFactory(conf, ftpConfig, CromwellFtpFileSystems.Default)
   }
 
   override def preProcessWorkflow(workflow: String): String = preprocessor.preProcessWorkflow(workflow)

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpClientPool.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpClientPool.scala
@@ -25,7 +25,10 @@ class FtpClientPool(capacity: Int, maxIdleTime: FiniteDuration, factory: () => F
   maxIdleTime = maxIdleTime,
   referenceType = ReferenceType.Strong,
   _factory = factory,
+  // Reset is called every time a client is added or released back to the pool. We don't want to actually reset the connection here
+  // otherwise we'd need to login again and reconfigure the connection every time
   _reset = Function.const(()),
   _dispose = FtpClientPool.dispose,
+  // Could not find a good health check at the moment (isAvailable and isConnected on the socket seem to both return false sometimes even if the client is fine)
   _healthCheck = Function.const(true)
 )

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystem.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystem.scala
@@ -1,13 +1,12 @@
 package cloud.nio.impl.ftp
 
+import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.{Active, Passive}
 import cloud.nio.spi.CloudNioFileSystem
 import com.typesafe.scalalogging.StrictLogging
-import net.ceedubs.ficus.Ficus._
 import org.apache.commons.net.ftp.FTPClient
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.TimeoutException
-import scala.concurrent.duration._
 
 object FtpCloudNioFileSystem {
   val logger = LoggerFactory.getLogger("FtpFileSystem")
@@ -15,33 +14,25 @@ object FtpCloudNioFileSystem {
 
 class FtpCloudNioFileSystem(provider: FtpCloudNioFileSystemProvider, host: String) extends CloudNioFileSystem(provider, host) with StrictLogging {
   private val credentials = provider.credentials
-  private val leaseTimeout = provider.config.getAs[FiniteDuration]("acquire-connection-timeout")
-  // Cannot be less than 2, otherwise we can't copy files as we need 2 connections to copy a file (one for downstream and one for upstream)
-  private val capacity = Math.max(provider.config.getAs[Int]("connection-count-per-user").getOrElse(2), 2)
-  private val idleConnectionTimeout = provider.config.getAs[FiniteDuration]("idle-connection-timeout").getOrElse(10.minutes)
-  private val connectionPort = provider.config.getAs[Int]("connection-port").getOrElse(21)
-  private val connectionModeFunction: FTPClient => Unit = provider.config.getAs[String]("connection-mode").getOrElse("passive") match {
-    case "passive" => client: FTPClient => client.enterLocalPassiveMode() 
-    case "active" => client: FTPClient => client.enterLocalActiveMode()
-    case other => client: FTPClient => {
-      logger.warn(s"Unrecognized connection mode $other, defaulting to passive mode")
-      client.enterLocalPassiveMode()
-    }
+  private val ftpConfig = provider.ftpConfig
+  private val connectionModeFunction: FTPClient => Unit = ftpConfig.connectionMode match {
+    case Passive => client: FTPClient => client.enterLocalPassiveMode()
+    case Active => client: FTPClient => client.enterLocalActiveMode()
   }
-  
+
   private [ftp] lazy val clientFactory = () => {
     val client = new FTPClient()
-    client.setDefaultPort(connectionPort)
+    client.setDefaultPort(ftpConfig.connectionPort)
     client.connect(host)
     // Calling connect RESETS the mode, so make sure to call enterLocalPassiveMode AFTER connecting !!
     connectionModeFunction(client)
     credentials.login(client)
     client
   }
-  
-  private val clientPool = new FtpClientPool(capacity, idleConnectionTimeout, clientFactory)
-  
-  def leaseClient = leaseTimeout match {
+
+  private val clientPool = new FtpClientPool(ftpConfig.capacity, ftpConfig.idleConnectionTimeout, clientFactory)
+
+  def leaseClient = ftpConfig.leaseTimeout match {
     case Some(timeout) => clientPool.tryAcquire(timeout).getOrElse(throw new TimeoutException("Timed out waiting for an available connection, try again later."))
     case _ => clientPool.acquire()
   }
@@ -56,4 +47,3 @@ class FtpCloudNioFileSystem(provider: FtpCloudNioFileSystemProvider, host: Strin
     super.close()
   }
 }
-

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProvider.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProvider.scala
@@ -11,7 +11,9 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.util.{Failure, Success, Try}
 
-class FtpCloudNioFileSystemProvider(override val config: Config, val credentials: FtpCredentials) extends CloudNioFileSystemProvider with StrictLogging {
+class FtpCloudNioFileSystemProvider(override val config: Config, val credentials: FtpCredentials, ftpFileSystems: FtpFileSystems) extends CloudNioFileSystemProvider with StrictLogging {
+  val ftpConfig = ftpFileSystems.config
+
   override def fileProvider = new FtpCloudNioFileProvider(this)
 
   override def isFatal(exception: Exception) = exception match {
@@ -57,6 +59,6 @@ class FtpCloudNioFileSystemProvider(override val config: Config, val credentials
   }
   
   def newCloudNioFileSystemFromHost(host: String) = {
-    FtpFileSystems.getFileSystem(host, this)
+    ftpFileSystems.getFileSystem(host, this)
   }
 }

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProvider.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProvider.scala
@@ -2,7 +2,7 @@ package cloud.nio.impl.ftp
 
 import java.io.IOException
 import java.nio.file.attribute.FileAttribute
-import java.nio.file.{FileAlreadyExistsException, Path}
+import java.nio.file.{FileAlreadyExistsException, NoSuchFileException, Path}
 
 import cloud.nio.impl.ftp.FtpUtil.FtpIoException
 import cloud.nio.spi.{CloudNioFileSystemProvider, CloudNioPath, CloudNioReadChannel, CloudNioRetry}
@@ -44,6 +44,7 @@ class FtpCloudNioFileSystemProvider(override val config: Config, val credentials
     } match {
       case Success(_) =>
       case Failure(f: FileAlreadyExistsException) => throw f
+      case Failure(f: NoSuchFileException) => throw f
       // java.nio.files.Files.createDirectories swallows IOException, that are not FileAlreadyExistsException, so log them here so we can now what happened
       case Failure(f: IOException) =>
         logger.error(s"Failed to create directory at $dir", f)

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpFileSystems.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpFileSystems.scala
@@ -1,13 +1,25 @@
 package cloud.nio.impl.ftp
 
+import cloud.nio.impl.ftp.FtpFileSystems.FtpCacheKey
+import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.Passive
 import com.google.common.cache._
 
 import scala.concurrent.duration._
 
 object FtpFileSystems {
-  private case class FtpCacheKey(host: String, ftpProvider: FtpCloudNioFileSystemProvider)
-  
-  private val fileSystemTTL = 1.day
+  val DefaultConfig = FtpFileSystemsConfiguration(1.day, Option(1.hour), 5, 1.hour, 21, Passive)
+  val Default = new FtpFileSystems(DefaultConfig)
+  private [ftp] case class FtpCacheKey(host: String, ftpProvider: FtpCloudNioFileSystemProvider)
+}
+
+/**
+  * Holds all FTP filesystems in a cache. There should be only one filesystem per ftp server per user in the cache
+  * A single instance of this class should be created per JVM instance, the goal is to be able to control how many connections
+  * to an ftp server are being opened from the IP address running this program.
+  */
+class FtpFileSystems(val config: FtpFileSystemsConfiguration) {
+
+  private val fileSystemTTL = config.cacheTTL
 
   private val fileSystemsCache: LoadingCache[FtpCacheKey, FtpCloudNioFileSystem] = CacheBuilder.newBuilder()
     .expireAfterAccess(fileSystemTTL.length, fileSystemTTL.unit)
@@ -15,10 +27,10 @@ object FtpFileSystems {
       notification.getValue.close()
     })
     .build[FtpCacheKey, FtpCloudNioFileSystem](new CacheLoader[FtpCacheKey, FtpCloudNioFileSystem] {
-      override def load(key: FtpCacheKey) = {
-        new FtpCloudNioFileSystem(key.ftpProvider, key.host)
-      }
+      override def load(key: FtpCacheKey) = createFileSystem(key)
     })
+  
+  private [ftp] def createFileSystem(key: FtpCacheKey) = new FtpCloudNioFileSystem(key.ftpProvider, key.host)
 
   def getFileSystem(host: String, ftpCloudNioFileProvider: FtpCloudNioFileSystemProvider) = {
     fileSystemsCache.get(FtpCacheKey(host, ftpCloudNioFileProvider))

--- a/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpFileSystemsConfiguration.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/main/scala/cloud/nio/impl/ftp/FtpFileSystemsConfiguration.scala
@@ -1,0 +1,18 @@
+package cloud.nio.impl.ftp
+
+import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.ConnectionMode
+
+import scala.concurrent.duration.FiniteDuration
+
+case class FtpFileSystemsConfiguration(cacheTTL: FiniteDuration,
+                                       leaseTimeout: Option[FiniteDuration],
+                                       capacity: Int,
+                                       idleConnectionTimeout: FiniteDuration,
+                                       connectionPort: Int,
+                                       connectionMode: ConnectionMode)
+
+object FtpFileSystemsConfiguration {
+  sealed trait ConnectionMode
+  case object Passive extends ConnectionMode
+  case object Active extends ConnectionMode
+}

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileProviderSpec.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileProviderSpec.scala
@@ -140,7 +140,7 @@ class FtpCloudNioFileProviderSpec extends FlatSpec with Matchers with MockFtpFil
     attributes.lastModifiedTime() should not be null
   }
 
-  it should "craete a directory" in {
+  it should "create a directory" in {
     val root = "/root/directory"
     val directory = s"$root/directory"
     fakeUnixFileSystem.add(new DirectoryEntry(root))

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProviderSpec.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemProviderSpec.scala
@@ -41,7 +41,7 @@ class FtpCloudNioFileSystemProviderSpec extends FlatSpec with Matchers with Mock
 
   it should "pre compute the size before opening a read channel to avoid deadlocks" in {
     val mockSizeFunction = mockFunction[Long]
-    val provider = new FtpCloudNioFileSystemProvider(ConfigFactory.empty(), FtpAnonymousCredentials) {
+    val provider = new FtpCloudNioFileSystemProvider(ConfigFactory.empty(), FtpAnonymousCredentials, ftpFileSystems) {
 
       override def fileProvider = new FtpCloudNioFileProvider(this) {
         override def fileAttributes(cloudHost: String, cloudPath: String) =

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemSpec.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpCloudNioFileSystemSpec.scala
@@ -17,12 +17,8 @@ class FtpCloudNioFileSystemSpec extends FlatSpec with Matchers with Eventually {
   implicit val patience = patienceConfig
 
   it should "lease the number of clients configured, not more, not less" in {
-    val config = ConfigFactory.parseString(
-      """
-        |acquire-connection-timeout = 1 second
-        |connection-count-per-user = 3
-      """.stripMargin)
-    val provider = new FtpCloudNioFileSystemProvider(config, FtpAnonymousCredentials)
+    val fileSystems = new FtpFileSystems(FtpFileSystems.DefaultConfig.copy(leaseTimeout = Option(1.second), capacity = 3))
+    val provider = new FtpCloudNioFileSystemProvider(ConfigFactory.empty, FtpAnonymousCredentials, fileSystems)
     val fileSystem = new FtpCloudNioFileSystem(provider, "ftp.example.com") {
       // Override so we don't try to connect to anything
       override private[ftp] lazy val clientFactory = () => { new FTPClient() }
@@ -43,11 +39,8 @@ class FtpCloudNioFileSystemSpec extends FlatSpec with Matchers with Eventually {
   }
 
   it should "lease a pair of clients atomically" in {
-    val config = ConfigFactory.parseString(
-      """
-        |connection-count-per-user = 2
-      """.stripMargin)
-    val provider = new FtpCloudNioFileSystemProvider(config, FtpAnonymousCredentials)
+    val fileSystems = new FtpFileSystems(FtpFileSystems.DefaultConfig.copy(capacity = 2))
+    val provider = new FtpCloudNioFileSystemProvider(ConfigFactory.empty, FtpAnonymousCredentials, fileSystems)
     val fileSystem = new FtpCloudNioFileSystem(provider, "ftp.example.com") {
       // Override so we don't try to connect to anything
       override private[ftp] lazy val clientFactory = () => { new FTPClient() }

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpFileSystemsSpec.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpFileSystemsSpec.scala
@@ -1,0 +1,39 @@
+package cloud.nio.impl.ftp
+
+import cloud.nio.impl.ftp.FtpFileSystems.FtpCacheKey
+import com.typesafe.config.ConfigFactory
+import org.scalamock.function.MockFunction1
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, Matchers}
+
+class FtpFileSystemsSpec extends FlatSpec with Matchers with MockFactory {
+
+  behavior of "FtpFileSystemsSpec"
+
+  val emptyConfig = ConfigFactory.empty
+  
+  it should "cache file systems per server per user" in {
+    val mockCreateFunction = mockFunction[FtpCacheKey, FtpCloudNioFileSystem]
+    val ftpFileSystems = new MockFtpFileSystems(FtpFileSystems.DefaultConfig, mockCreateFunction)
+    
+    val authenticatedCredentials1 = FtpAuthenticatedCredentials("user1", "password", None)
+    
+    val provider = new FtpCloudNioFileSystemProvider(emptyConfig, authenticatedCredentials1, ftpFileSystems)
+    // Same as provider1, just other instance
+    val providerClone = new FtpCloudNioFileSystemProvider(emptyConfig, authenticatedCredentials1, ftpFileSystems)
+    
+    // Expects the creation function to only be called once, since the 2 providers have the same credentials, even though they're
+    // different instances
+    mockCreateFunction.expects(FtpCacheKey("host1.com", provider))
+      .returns(new FtpCloudNioFileSystem(provider, "host1.com"))
+      .once()
+
+    provider.newCloudNioFileSystemFromHost("host1.com")
+    providerClone.newCloudNioFileSystemFromHost("host1.com")
+  }
+  
+  class MockFtpFileSystems(conf: FtpFileSystemsConfiguration, mockCreateFunction: MockFunction1[FtpCacheKey, FtpCloudNioFileSystem]) extends FtpFileSystems(conf) {
+    override private[ftp] def createFileSystem(key: FtpCacheKey) = mockCreateFunction(key)
+  }
+
+}

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpUtilSpec.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/FtpUtilSpec.scala
@@ -51,5 +51,4 @@ class FtpUtilSpec extends FlatSpec with Matchers with Mockito {
     an[IllegalStateException] shouldBe thrownBy(lease.get())
     clientPool.live() shouldBe 0
   }
-
 }

--- a/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/MockFtpFileSystem.scala
+++ b/cloud-nio/cloud-nio-impl-ftp/src/test/scala/cloud/nio/impl/ftp/MockFtpFileSystem.scala
@@ -5,8 +5,6 @@ import org.mockftpserver.fake.filesystem.{DirectoryEntry, UnixFakeFileSystem}
 import org.mockftpserver.fake.{FakeFtpServer, UserAccount}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
-import scala.collection.JavaConverters._
-
 trait MockFtpFileSystem extends BeforeAndAfterAll { this: Suite =>
   private var connectionPort: Option[Int] = None
   
@@ -28,9 +26,11 @@ trait MockFtpFileSystem extends BeforeAndAfterAll { this: Suite =>
     fakeFtpServer.stop()
   }
   
+  lazy val ftpFileSystemsConfiguration = FtpFileSystems.DefaultConfig.copy(connectionPort = connectionPort.getOrElse(throw new RuntimeException("Fake FTP server has not been started")))
+  lazy val ftpFileSystems = new FtpFileSystems(ftpFileSystemsConfiguration)
+  
   // Do not call this before starting the server
   lazy val mockProvider = {
-    val config = ConfigFactory.parseMap(Map("connection-port" -> connectionPort.getOrElse(throw new RuntimeException("Fake FTP server has not been started"))).asJava)
-    new FtpCloudNioFileSystemProvider(config, FtpAuthenticatedCredentials("test_user", "test_password", None))
+    new FtpCloudNioFileSystemProvider(ConfigFactory.empty, FtpAuthenticatedCredentials("test_user", "test_password", None), ftpFileSystems)
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -273,7 +273,31 @@ filesystems {
     class = "cromwell.filesystems.http.HttpPathBuilderFactory"
   }
   ftp {
+    # When the global configuration is used, the factory constructor needs to have a third argument of the type of the global configuration
     class = "cromwell.filesystems.ftp.FtpPathBuilderFactory"
+    # Use to share a unique global object across all instances of the factory
+    global {
+      # Class to instantiate and propagate to all factories. Takes a single typesafe config argument
+      class = "cromwell.filesystems.ftp.CromwellFtpFileSystems"
+      # Configuration to be passed
+      config {
+        # All instances of FTP filesystems are being cached and re-used across a single Cromwell instance.
+        # This allows control over how many connections are being established to a host for a specific user at any given time.
+        # Cached filesystems are removed from the cache (and their associated connections closed) when they haven't been used for the
+        # time configured below. This value should be sufficiently high to cover for the duration of the longest expected I/O operation.
+        cache-ttl = 1 day
+        # How long to wait trying to obtain a connection from the pool before giving up. Don't specify for no timeout
+        # obtain-connection-timeout = 1 hour
+        # Maximum number of connections that will be established per user per host. This is across the entire Cromwell instance
+        max-connection-per-server-per-user = 30
+        # Time after which a connection will be closed if idle
+        idle-connection-timeout = 1 hour
+        # FTP connection port to use
+        connection-port: 21
+        # FTP connection mode
+        connection-mode = "passive"
+      }
+    }
   }
 }
 

--- a/docs/backends/TES.md
+++ b/docs/backends/TES.md
@@ -63,3 +63,11 @@ This backend supports CPU, memory and disk size configuration through the use of
     * Type: String (ex: "1 GB" or "1024 MB")
 
 If they are not set, the TES backend may use default values.
+
+**TESK**
+
+[TESK](https://github.com/EMBL-EBI-TSI/TESK) is an implementation of the TES interface that uses Kubernetes and FTP.
+When running Cromwell with a TESK backend, you will want to customize the way Cromwell process globs, as kubernetes will not work well with hard links in a lot of cases which is the default behavior in Cromwell.
+By adding this to the `config` section of the TES backend in Cromwell, Cromwell will use symlinks instead.  
+
+`glob-link-command = "ls -L GLOB_PATTERN 2> /dev/null | xargs -I ? ln -s ? GLOB_DIRECTORY"`

--- a/docs/filesystems/FileTransferProtocol.md
+++ b/docs/filesystems/FileTransferProtocol.md
@@ -1,0 +1,121 @@
+# File Transfer Protocol (FTP)
+
+Cromwell supports communication with basic FTP servers (not FTPS, and not SFTP either).
+Please read the [#Filesystems](Filesystems.md) section before to get an explanation of how filesystems can be configured in general.
+For a full example of FTP configuration see [here](#Example)
+
+**Note**: Be aware that FTP is in many cases very inefficient, not secure and generally doesn't scale well. If possible, consider using an alternate file system.
+
+## Overview
+
+Cromwell handles FTP connections as follows:
+
+- Cromwell maintains one FTP FileSystem per FTP server per user
+- An FTP FileSystem maintains a pool of connections with a fixed size (see `max-connection-per-server-per-user` configuration below) to that server, for that user
+- When an FTP FileSystem hasn't been used in a certain amount of time (see `cache-ttl` configuration below), the associated connections are closed and it is destroyed
+- In a given pool, when a connection has been idle for a certain amount of time (see `idle-connection-timeout` configuration below), it is closed
+
+```
+ Cromwell
++---------------------------------------------------------------------------------------------------+
+|                                                                                                   |
+|  FileSystem 1                     FileSystem 2                     FileSystem 3                   |
+| +-----------------------------+  +-----------------------------+  +-----------------------------+ |
+| |                             |  |                             |  |                             | |
+| | ftp://user1@server1.com     |  | ftp://user2@server1.com     |  | ftp://user1@server2.com     | |
+| |                             |  |                             |  |                             | |
+| |  Connection Pool            |  |  Connection Pool            |  |  Connection Pool            | |
+| | +-------------------------+ |  | +-------------------------+ |  | +-------------------------+ | |
+| | |                         | |  | |                         | |  | |                         | | |
+| | |  - Connection 1         | |  | |  - Connection 1         | |  | |  - Connection 1         | | |
+| | |                         | |  | |                         | |  | |                         | | |
+| | |  - Connection 2         | |  | |  - Connection 2         | |  | |  - Connection 2         | | |
+| | |                         | |  | |                         | |  | |                         | | |
+| | |  - Connection 3         | |  | |  - Connection 3         | |  | |  - Connection 3         | | |
+| | |                         | |  | |                         | |  | |                         | | |
+| | +-------------------------+ |  | +-------------------------+ |  | +-------------------------+ | |
+| |                             |  |                             |  |                             | |
+| +-----------------------------+  +-----------------------------+  +-----------------------------+ |
++---------------------------------------------------------------------------------------------------+
+```
+
+
+## Global Configuration
+
+The FTP filesystem supports a global configuration. The goal is to configure values that will apply Cromwell-wide, as opposed to other configuration that could be backend (or engine) specific (see below).
+
+Default configuration:
+
+```hocon
+filesystems.ftp.global.config = {
+    # This value should be sufficiently high to cover for the duration of the longest expected I/O operation.
+    # It is a time to live value after which a filesystem (unique per user per server) will be closed and evicted from the cache if unused for the specified duration.
+    cache-ttl = 1 day
+    
+    # How long to wait trying to obtain a connection from the pool before giving up. Don't specify for no timeout
+    # obtain-connection-timeout = 1 hour
+    
+    # Maximum number of connections that will be established per user per ftp server. This is across the entire Cromwell instance.
+    # Setting this number allows to workaround FTP server restrictions for the number of connections for a single user per IP address.
+    # Has to be >= 2 to allow copying (Copying and FTP file requires downloading and uploading it)
+    max-connection-per-server-per-user = 30
+    
+    # Time after which a connection will be closed if idle. This is to try to free connections from a filesystem when it's not heavily used.
+    idle-connection-timeout = 1 hour
+    
+    # FTP connection port to use
+    connection-port: 21
+    
+    # FTP connection mode
+    connection-mode = "passive"
+}
+
+```
+
+Note that this configuration being global, it applies the same way regardless of the FTP server. There is currently no good way to make this configuration dependent on the server.
+
+## Instance Configuration
+
+Configuration that can be applied to a backend or engine filesystem stanza:
+
+```hocon
+ftp {
+  # optional
+  auth {
+    username = "username"
+    password = "password"
+    # Optional
+    account = "account"
+  }
+}
+```
+
+A default authentication can be provided in the configuration. It can be overridden using the following workflow options: `ftp-username`, `ftp-password`, `ftp-account`
+If authentication is omitted the connection is established as an anonymous user.
+
+## Example
+
+Example of configuration mixing the above two sections:
+
+```hocon
+filesystems.ftp.global.config {
+    # We only override what changes from the default
+    max-connection-per-server-per-user = 20
+}
+
+# Configure the default auth for the engine
+engine.filesystems.ftp {
+  auth {
+    username = "me"
+    password = "my_password"
+  }
+}
+
+# Configure the default auth for the local backend
+backend.providers.Local.config.filesystems.ftp {
+  auth {
+    username = "me"
+    password = "my_password"
+  }
+}
+```

--- a/docs/filesystems/Filesystems.md
+++ b/docs/filesystems/Filesystems.md
@@ -123,3 +123,5 @@ The filesystem configuration used will be the one in the `config` section of the
 -  Object Storage Service (OSS) - [Alibaba Cloud Doc](https://www.alibabacloud.com/product/oss)
 
 -  HTTP - support for `http` or `https` URLs for [workflow inputs only](http://cromwell.readthedocs.io/en/develop/filesystems/HTTP)
+
+- File Transfer Protocol (FTP) - [Cromwell Doc](FileTransferProtocol.md)

--- a/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/CromwellFtpFileSystems.scala
+++ b/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/CromwellFtpFileSystems.scala
@@ -1,0 +1,52 @@
+package cromwell.filesystems.ftp
+
+import cats.syntax.apply._
+import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.{Active, ConnectionMode, Passive}
+import cloud.nio.impl.ftp.{FtpFileSystems, FtpFileSystemsConfiguration}
+import com.typesafe.config.ConfigException.{BadValue, Missing}
+import com.typesafe.config.{Config, ConfigFactory}
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import cromwell.filesystems.ftp.CromwellFtpFileSystems._
+import net.ceedubs.ficus.Ficus._
+import net.ceedubs.ficus.readers.ValueReader
+
+import scala.concurrent.duration.FiniteDuration
+
+object CromwellFtpFileSystems {
+  implicit val connectionModeReader = new ValueReader[ConnectionMode] {
+    override def read(config: Config, path: String) = if (config.hasPath(path)) {
+      config.as[String](path) match {
+        case "passive" => Passive
+        case "active" => Active
+        case other => throw new BadValue(path, s"Unrecognized connection mode: $other")
+      }
+    } else throw new Missing(path)
+  }
+
+  def parseConfig(config: Config): FtpFileSystemsConfiguration = {
+    val cacheTTL = validate[FiniteDuration] { config.as[FiniteDuration]("cache-ttl") }
+    val leaseTimeout = validate[Option[FiniteDuration]] { config.getAs[FiniteDuration]("obtain-connection-timeout") }
+    // Cannot be less than 2, otherwise we can't copy files as we need 2 connections to copy a file (one for downstream and one for upstream)
+    val capacity: ErrorOr[Int] = validate[Int] { config.as[Int]("max-connection-per-server-per-user") } map { c => Math.max(2, c) }
+    val idleConnectionTimeout = validate[FiniteDuration] { config.as[FiniteDuration]("idle-connection-timeout") }
+    val connectionPort = validate[Int] { config.as[Int]("connection-port") }
+    val connectionMode = validate[ConnectionMode] { config.as[ConnectionMode]("connection-mode") }
+
+    (cacheTTL, leaseTimeout, capacity, idleConnectionTimeout, connectionPort, connectionMode)
+      .mapN(FtpFileSystemsConfiguration.apply)
+      .unsafe("Failed to parse FTP configuration")
+  }
+  
+  val Default = new CromwellFtpFileSystems(ConfigFactory.empty()) {
+    override lazy val ftpFileSystems = FtpFileSystems.Default
+  }
+}
+
+/**
+  * Cromwell Wrapper around an FtpFileSystems instance to handle parsing and validation of the configuration.
+  * This is the class used as the global configuration class in the ftp filesystem configuration
+  */
+class CromwellFtpFileSystems(private val config: Config) {
+  lazy val ftpFileSystems = new FtpFileSystems(parseConfig(config))
+}

--- a/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/CromwellFtpFileSystems.scala
+++ b/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/CromwellFtpFileSystems.scala
@@ -3,8 +3,8 @@ package cromwell.filesystems.ftp
 import cats.syntax.apply._
 import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.{Active, ConnectionMode, Passive}
 import cloud.nio.impl.ftp.{FtpFileSystems, FtpFileSystemsConfiguration}
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigException.{BadValue, Missing}
-import com.typesafe.config.{Config, ConfigFactory}
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
 import cromwell.filesystems.ftp.CromwellFtpFileSystems._
@@ -38,15 +38,13 @@ object CromwellFtpFileSystems {
       .unsafe("Failed to parse FTP configuration")
   }
   
-  val Default = new CromwellFtpFileSystems(ConfigFactory.empty()) {
-    override lazy val ftpFileSystems = FtpFileSystems.Default
-  }
+  val Default = new CromwellFtpFileSystems(FtpFileSystems.Default)
 }
 
 /**
   * Cromwell Wrapper around an FtpFileSystems instance to handle parsing and validation of the configuration.
   * This is the class used as the global configuration class in the ftp filesystem configuration
   */
-class CromwellFtpFileSystems(private val config: Config) {
-  lazy val ftpFileSystems = new FtpFileSystems(parseConfig(config))
+class CromwellFtpFileSystems(val ftpFileSystems: FtpFileSystems) {
+  def this(config: Config) = this(new FtpFileSystems(parseConfig(config)))
 }

--- a/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/FtpPathBuilderFactory.scala
+++ b/filesystems/ftp/src/main/scala/cromwell/filesystems/ftp/FtpPathBuilderFactory.scala
@@ -10,28 +10,33 @@ import cromwell.filesystems.ftp.FtpPathBuilderFactory._
 import scala.concurrent.{ExecutionContext, Future}
 
 object FtpPathBuilderFactory {
-  case class FileSystemKey(host: String, configuration: FtpConfiguration)
-  def credentialsFromWorkflowOptions(workflowOptions: WorkflowOptions) = {
-    def getValue(key: String) = workflowOptions.get("ftp-username").toOption
+  object WorkflowOptions {
+    val FtpUsername = "ftp-username"
+    val FtpPassword = "ftp-password"
+    val FtpAccount = "ftp-account"
+  }
 
-    (getValue("ftp-username"), getValue("ftp-password"), getValue("ftp-account")) match {
+  def credentialsFromWorkflowOptions(workflowOptions: WorkflowOptions) = {
+    def getValue(key: String) = workflowOptions.get(key).toOption
+
+    (getValue(WorkflowOptions.FtpUsername), getValue(WorkflowOptions.FtpPassword), getValue(WorkflowOptions.FtpAccount)) match {
       case (Some(username), Some(password), account) => Option(FtpAuthenticatedCredentials(username, password, account))
       case _ => None
     }
   }
 }
 
-class FtpPathBuilderFactory(globalConfig: Config, instanceConfig: Config) extends PathBuilderFactory {
-  private [ftp] lazy val configFtpConfiguration = FtpConfiguration(instanceConfig)
-  private lazy val defaultFtpProvider = new FtpCloudNioFileSystemProvider(instanceConfig, configFtpConfiguration.ftpCredentials)
+class FtpPathBuilderFactory(globalConfig: Config, instanceConfig: Config, cromwellFtpFileSystems: CromwellFtpFileSystems) extends PathBuilderFactory {
+  private [ftp] lazy val configFtpConfiguration = FtpInstanceConfiguration(instanceConfig)
+  private lazy val defaultFtpProvider = new FtpCloudNioFileSystemProvider(instanceConfig, configFtpConfiguration.ftpCredentials, cromwellFtpFileSystems.ftpFileSystems)
 
   override def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext) = Future.successful {
     val provider = credentialsFromWorkflowOptions(options) match {
       case Some(overriddenCredentials) =>
-        new FtpCloudNioFileSystemProvider(instanceConfig, overriddenCredentials)
+        new FtpCloudNioFileSystemProvider(instanceConfig, overriddenCredentials, cromwellFtpFileSystems.ftpFileSystems)
       case _ => defaultFtpProvider
     }
-    
+
     FtpPathBuilder(provider)
   }
 }

--- a/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/CromwellFtpFileSystemsSpec.scala
+++ b/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/CromwellFtpFileSystemsSpec.scala
@@ -1,0 +1,31 @@
+package cromwell.filesystems.ftp
+
+import cloud.nio.impl.ftp.FtpFileSystemsConfiguration.Active
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
+
+class CromwellFtpFileSystemsSpec extends FlatSpec with Matchers {
+
+  behavior of "CromwellFtpFileSystemsSpec"
+
+  it should "parse configuration" in {
+    val config = ConfigFactory.parseString(
+      """cache-ttl = 10 days
+        |obtain-connection-timeout = 12 hours
+        |max-connection-per-server-per-user = 1
+        |idle-connection-timeout = 14 hours
+        |connection-port: 212
+        |connection-mode = "active" """.stripMargin)
+    
+    val fs = new CromwellFtpFileSystems(config)
+    fs.ftpFileSystems.config.cacheTTL shouldBe 10.days
+    fs.ftpFileSystems.config.leaseTimeout shouldBe Some(12.hours)
+    // 1 should be upped to 2
+    fs.ftpFileSystems.config.capacity shouldBe 2
+    fs.ftpFileSystems.config.idleConnectionTimeout shouldBe 14.hours
+    fs.ftpFileSystems.config.connectionPort shouldBe 212
+    fs.ftpFileSystems.config.connectionMode shouldBe Active
+  }
+
+}

--- a/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/FtpInstanceConfigurationSpec.scala
+++ b/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/FtpInstanceConfigurationSpec.scala
@@ -4,16 +4,16 @@ import cloud.nio.impl.ftp.{FtpAnonymousCredentials, FtpAuthenticatedCredentials}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{FlatSpec, Matchers}
 
-class FtpConfigurationSpec extends FlatSpec with Matchers {
+class FtpInstanceConfigurationSpec extends FlatSpec with Matchers {
 
   behavior of "FtpConfigurationSpec"
 
   it should "parse anonymous credentials" in {
-    FtpConfiguration(ConfigFactory.empty()).ftpCredentials shouldBe FtpAnonymousCredentials
+    FtpInstanceConfiguration(ConfigFactory.empty()).ftpCredentials shouldBe FtpAnonymousCredentials
   }
 
   it should "parse authenticated credentials" in {
-    FtpConfiguration(ConfigFactory.parseString(
+    FtpInstanceConfiguration(ConfigFactory.parseString(
       """
         |auth {
         |  username = "me"
@@ -21,7 +21,7 @@ class FtpConfigurationSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin)).ftpCredentials shouldBe FtpAuthenticatedCredentials("me", "mot de passe", None)
 
-    FtpConfiguration(ConfigFactory.parseString(
+    FtpInstanceConfiguration(ConfigFactory.parseString(
       """
         |auth {
         |  username = "me"

--- a/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/FtpPathSpec.scala
+++ b/filesystems/ftp/src/test/scala/cromwell/filesystems/ftp/FtpPathSpec.scala
@@ -14,8 +14,8 @@ class FtpPathSpec extends FlatSpec with Matchers with PathBuilderSpecUtils {
 
   behavior of "FtpPathSpec"
 
-  val pathBuilderFactory = new FtpPathBuilderFactory(ConfigFactory.empty(), ConfigFactory.empty()) {
-    override private [ftp] lazy val configFtpConfiguration = new FtpConfiguration(FtpAnonymousCredentials, 1.hour)
+  val pathBuilderFactory = new FtpPathBuilderFactory(ConfigFactory.empty(), ConfigFactory.empty(), CromwellFtpFileSystems.Default) {
+    override private [ftp] lazy val configFtpConfiguration = new FtpInstanceConfiguration(FtpAnonymousCredentials)
   }
 
   val pathBuilder =

--- a/src/ci/bin/testConformanceTesk.sh
+++ b/src/ci/bin/testConformanceTesk.sh
@@ -61,7 +61,7 @@ cat <<JSON >"${CROMWELL_BUILD_CWL_TEST_INPUTS}"
     "cwl_conformance_test.centaur_cwl_runner": "${CROMWELL_BUILD_CWL_TEST_RUNNER}",
     "cwl_conformance_test.conformance_expected_failures":
         "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/tesk_conformance_expected_failures.txt",
-    "cwl_conformance_test.timeout": 5000
+    "cwl_conformance_test.timeout": 600
 }
 JSON
 

--- a/src/ci/resources/tesk_application_ftp.conf.ctmpl
+++ b/src/ci/resources/tesk_application_ftp.conf.ctmpl
@@ -1,6 +1,6 @@
 {{with $cromwellFtp := vault (printf "secret/dsde/cromwell/common/cromwell-ftp")}}
 filesystems {
-   ftp.global.config.max-connection-per-server-per-user = 7
+   ftp.global.config.max-connection-per-server-per-user = 5
 }
 
 engine {

--- a/src/ci/resources/tesk_application_ftp.conf.ctmpl
+++ b/src/ci/resources/tesk_application_ftp.conf.ctmpl
@@ -1,6 +1,6 @@
 {{with $cromwellFtp := vault (printf "secret/dsde/cromwell/common/cromwell-ftp")}}
 filesystems {
-   ftp.global.config.max-connection-per-server-per-user = 8
+   ftp.global.config.max-connection-per-server-per-user = 7
 }
 
 engine {

--- a/src/ci/resources/tesk_application_ftp.conf.ctmpl
+++ b/src/ci/resources/tesk_application_ftp.conf.ctmpl
@@ -1,4 +1,8 @@
 {{with $cromwellFtp := vault (printf "secret/dsde/cromwell/common/cromwell-ftp")}}
+filesystems {
+   ftp.global.config.max-connection-per-server-per-user = 8
+}
+
 engine {
   filesystems {
     ftp {
@@ -6,7 +10,6 @@ engine {
         username = {{$cromwellFtp.Data.username}}
         password = {{$cromwellFtp.Data.password}}
       }
-      connection-count-per-user = 4
     }
   }
 }
@@ -21,7 +24,6 @@ backend {
               username = {{$cromwellFtp.Data.username}}
               password = {{$cromwellFtp.Data.password}}
             }
-            connection-count-per-user = 4
           }
         }
       }


### PR DESCRIPTION
This is a PR to the already existing TESK PR to add some docs and a "global filesystem config for ftp". The reason is this:

- FTP servers can decide to limit how many connections they allow per IP address per user
- Cromwell Filesystems are defined as "PathBuilderFactories". A factory is configurable at the backend level and the engine level. Meaning there will be one instance of the factory per backend that chooses to enable a given filesystem, + one for the engine if the engine wants to support it too.
- However since we need to manage a pool of connections to the FTP server over the entire Cromwell instance, we can't create a new pool per factory.
- This introduces a "global" or "singleton" configuration object that can be defined in the root filesystem configuration (as java class path) and will be shared among all factories.
- A factory can choose to use it or not, if not then everything is as it was. If yes, a single instance of this singleton object will be created and passed to the factories when they're instantiated