### PR TITLE
Bumped dependencies.

### DIFF
--- a/CromIAM/src/main/scala/cromiam/sam/SamClient.scala
+++ b/CromIAM/src/main/scala/cromiam/sam/SamClient.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
-import com.softwaremill.sttp._
+import com.softwaremill.sttp.{StatusCodes => _, _}
 import cromiam.auth.{Collection, User}
 import cromiam.sam.SamClient._
 import cromiam.sam.SamResourceJsonSupport._

--- a/centaur/src/main/resources/standardTestCases/invalid_inputs_json.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_inputs_json.test
@@ -10,6 +10,6 @@ submit {
   statusCode: 400
   message: """{
   "status": "fail",
-  "message": "Error(s): Input file is not valid yaml nor json: while parsing a flow mapping\n in 'reader', line 1, column 1:\n    {\n    ^\nexpected ',' or '}', but got StreamEnd\n in 'reader', line 3, column 1:\n    \n    ^\n"
+  "message": "Error(s): Input file is not valid yaml nor json: while parsing a flow mapping\n in 'reader', line 1, column 1:\n    {\n    ^\nexpected ',' or '}', but got <stream end>\n in 'reader', line 3, column 1:\n    \n    ^\n"
 }"""
 }

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -73,6 +73,9 @@ object CentaurCromwellClient {
 
   lazy val backends: Try[CromwellBackends] = Try(Await.result(cromwellClient.backends, CromwellManager.timeout * 2))
 
+  implicit private val timer = IO.timer(blockingEc)
+  implicit private val contextShift = IO.contextShift(blockingEc)
+
   def retryRequest[T](x: () => Future[T], timeout: FiniteDuration): IO[T] = {
     // If Cromwell is known not to be ready, delay the request to avoid requests bound to fail 
     val ioDelay = if (!CromwellManager.isReady) IO.sleep(10.seconds) else IO.unit

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -161,6 +161,9 @@ object Operations {
     }
   }
 
+  implicit private val timer = IO.timer(global)
+  implicit private val contextShift = IO.contextShift(global)
+
   def waitFor(duration: FiniteDuration) = {
     new Test[Unit] {
       override def run = IO.sleep(duration)

--- a/centaurCwlRunner/src/main/resources/logback.xml
+++ b/centaurCwlRunner/src/main/resources/logback.xml
@@ -18,4 +18,13 @@
     https://github.com/akka/akka-http/blob/v10.0.10/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolMasterActor.scala#L117
     -->
     <logger name="akka.http.impl.engine.client.PoolMasterActor" level="off" additivity="false"/>
+
+    <!--
+    Silence Injector warning logging of:
+    06:36:48.095 [main] WARN  org.semanticweb.owlapi.utilities.Injector - No files found for META-INF/services/org.semanticweb.owlapi.model.OWLOntologyIRIMapper
+
+    via:
+    https://github.com/owlcs/owlapi/blob/owlapi-parent-5.1.7/api/src/main/java/org/semanticweb/owlapi/utilities/Injector.java#L383
+    -->
+    <logger name="org.semanticweb.owlapi.utilities.Injector" level="error" additivity="false"/>
 </configuration>

--- a/common/src/main/scala/common/validation/Validation.scala
+++ b/common/src/main/scala/common/validation/Validation.scala
@@ -1,7 +1,6 @@
 package common.validation
 
 import java.io.{PrintWriter, StringWriter}
-import java.net.{URI, URL}
 
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, Validated, ValidatedNel}
@@ -11,7 +10,6 @@ import common.Checked
 import common.exception.AggregatedMessageException
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Parse.Parse
-import net.ceedubs.ficus.readers.{StringReader, ValueReader}
 import org.slf4j.Logger
 
 import scala.concurrent.Future
@@ -24,8 +22,6 @@ object Validation {
       logger.warn(s"Unrecognized configuration key(s) for $context: ${unrecognizedKeys.mkString(", ")}")
     }
   }
-  
-  implicit val urlReader: ValueReader[URL] = StringReader.stringValueReader.map { URI.create(_).toURL }
   
   def validate[A](block: => A): ErrorOr[A] = Try(block) match {
     case Success(result) => result.validNel

--- a/common/src/test/scala/common/validation/ValidationSpec.scala
+++ b/common/src/test/scala/common/validation/ValidationSpec.scala
@@ -1,14 +1,10 @@
 package common.validation
 
-import java.net.URL
-
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{NonEmptyList, ValidatedNel}
 import cats.syntax.validated._
-import com.typesafe.config.ConfigFactory
 import common.exception.AggregatedMessageException
 import common.validation.Validation._
-import net.ceedubs.ficus.Ficus._
 import org.scalatest.{FlatSpec, Matchers}
 import org.slf4j.Logger
 import org.specs2.mock.Mockito
@@ -39,14 +35,6 @@ class ValidationSpec extends FlatSpec with Matchers with Mockito {
     val context = "warnings"
     warnNotRecognized(keys, reference, context, mockLogger)
     warnings should be(empty)
-  }
-
-  it should "read config URLs with urlReader" in {
-    val config = ConfigFactory.parseString("""url: "http://hello/world"""")
-    val url = config.as[URL]("url")
-    url.getProtocol should be ("http")
-    url.getHost should be("hello")
-    url.getPath should be("/world")
   }
 
   it should "convert a valid to a successful future" in {

--- a/core/src/test/scala/cromwell/core/logging/LoggerWrapperSpec.scala
+++ b/core/src/test/scala/cromwell/core/logging/LoggerWrapperSpec.scala
@@ -258,9 +258,28 @@ class LoggerWrapperSpec extends FlatSpec with Matchers with Mockito with TableDr
 
       def toList(arguments: Any): List[Any] = {
         arguments match {
-          case array: Array[_] => array.toList
+          case array: Array[_] => toLastFlattened(array)
           case seq: Seq[_] => seq.toList
           case any => List(any)
+        }
+      }
+
+      /*
+        * Flatten the last element of the array if the last element is itself an array.
+        *
+        * org.mockito.ArgumentMatchers#anyVararg() is deprecated, but works, sending in an empty array in the tail
+        * position. If we tried to use org.mockito.ArgumentMatchers#any(), it ends up mocking the wrong overloaded
+        * method. At each logging level there are two methods with very similar signatures:
+        *
+        * cromwell.core.logging.LoggerWrapper.error(pattern: String, arguments: AnyRef*)
+        * cromwell.core.logging.LoggerWrapper.error(pattern: String, arg: Any)
+        *
+        * As is, the Any vs. AnyRef overloads are barely dodging the issue https://issues.scala-lang.org/browse/SI-2991.
+        */
+      def toLastFlattened(array: Array[_]): List[Any] = {
+        array.toList.reverse match {
+          case (array: Array[_]) :: tail => tail.reverse ++ array.toList
+          case other => other.reverse
         }
       }
 
@@ -275,34 +294,34 @@ class LoggerWrapperSpec extends FlatSpec with Matchers with Mockito with TableDr
       val mockLogger = mock[Logger]
 
       mockLogger.error(anyString).answers(updateSlf4jMessages(Level.ERROR, _))
-      mockLogger.error(anyString, any[Any]).answers(updateSlf4jMessages(Level.ERROR, _))
-      mockLogger.error(anyString, any[Any], any[Any]).answers(updateSlf4jMessages(Level.ERROR, _))
+      mockLogger.error(anyString, any[Any]()).answers(updateSlf4jMessages(Level.ERROR, _))
+      mockLogger.error(anyString, any[Any](), any[Any]()).answers(updateSlf4jMessages(Level.ERROR, _))
       mockLogger.error(anyString, anyVarArg[AnyRef]).answers(updateSlf4jMessages(Level.ERROR, _))
-      mockLogger.error(anyString, any[Throwable]).answers(updateSlf4jMessages(Level.ERROR, _))
+      mockLogger.error(anyString, any[Throwable]()).answers(updateSlf4jMessages(Level.ERROR, _))
 
       mockLogger.warn(anyString).answers(updateSlf4jMessages(Level.WARN, _))
-      mockLogger.warn(anyString, any[Any]).answers(updateSlf4jMessages(Level.WARN, _))
-      mockLogger.warn(anyString, any[Any], any[Any]).answers(updateSlf4jMessages(Level.WARN, _))
+      mockLogger.warn(anyString, any[Any]()).answers(updateSlf4jMessages(Level.WARN, _))
+      mockLogger.warn(anyString, any[Any](), any[Any]()).answers(updateSlf4jMessages(Level.WARN, _))
       mockLogger.warn(anyString, anyVarArg[AnyRef]).answers(updateSlf4jMessages(Level.WARN, _))
-      mockLogger.warn(anyString, any[Throwable]).answers(updateSlf4jMessages(Level.WARN, _))
+      mockLogger.warn(anyString, any[Throwable]()).answers(updateSlf4jMessages(Level.WARN, _))
 
       mockLogger.info(anyString).answers(updateSlf4jMessages(Level.INFO, _))
-      mockLogger.info(anyString, any[Any]).answers(updateSlf4jMessages(Level.INFO, _))
-      mockLogger.info(anyString, any[Any], any[Any]).answers(updateSlf4jMessages(Level.INFO, _))
+      mockLogger.info(anyString, any[Any]()).answers(updateSlf4jMessages(Level.INFO, _))
+      mockLogger.info(anyString, any[Any](), any[Any]()).answers(updateSlf4jMessages(Level.INFO, _))
       mockLogger.info(anyString, anyVarArg[AnyRef]).answers(updateSlf4jMessages(Level.INFO, _))
-      mockLogger.info(anyString, any[Throwable]).answers(updateSlf4jMessages(Level.INFO, _))
+      mockLogger.info(anyString, any[Throwable]()).answers(updateSlf4jMessages(Level.INFO, _))
 
       mockLogger.debug(anyString).answers(updateSlf4jMessages(Level.DEBUG, _))
-      mockLogger.debug(anyString, any[Any]).answers(updateSlf4jMessages(Level.DEBUG, _))
-      mockLogger.debug(anyString, any[Any], any[Any]).answers(updateSlf4jMessages(Level.DEBUG, _))
+      mockLogger.debug(anyString, any[Any]()).answers(updateSlf4jMessages(Level.DEBUG, _))
+      mockLogger.debug(anyString, any[Any](), any[Any]()).answers(updateSlf4jMessages(Level.DEBUG, _))
       mockLogger.debug(anyString, anyVarArg[AnyRef]).answers(updateSlf4jMessages(Level.DEBUG, _))
-      mockLogger.debug(anyString, any[Throwable]).answers(updateSlf4jMessages(Level.DEBUG, _))
+      mockLogger.debug(anyString, any[Throwable]()).answers(updateSlf4jMessages(Level.DEBUG, _))
 
       mockLogger.trace(anyString).answers(updateSlf4jMessages(Level.TRACE, _))
-      mockLogger.trace(anyString, any[Any]).answers(updateSlf4jMessages(Level.TRACE, _))
-      mockLogger.trace(anyString, any[Any], any[Any]).answers(updateSlf4jMessages(Level.TRACE, _))
+      mockLogger.trace(anyString, any[Any]()).answers(updateSlf4jMessages(Level.TRACE, _))
+      mockLogger.trace(anyString, any[Any](), any[Any]()).answers(updateSlf4jMessages(Level.TRACE, _))
       mockLogger.trace(anyString, anyVarArg[AnyRef]).answers(updateSlf4jMessages(Level.TRACE, _))
-      mockLogger.trace(anyString, any[Throwable]).answers(updateSlf4jMessages(Level.TRACE, _))
+      mockLogger.trace(anyString, any[Throwable]()).answers(updateSlf4jMessages(Level.TRACE, _))
 
       val mockLoggingAdapter: LoggingAdapter = new LoggingAdapter {
         override val isErrorEnabled: Boolean = true

--- a/core/src/test/scala/cromwell/util/WomValueJsonFormatterSpec.scala
+++ b/core/src/test/scala/cromwell/util/WomValueJsonFormatterSpec.scala
@@ -2,7 +2,7 @@ package cromwell.util
 
 import cromwell.util.JsonFormatting.WomValueJsonFormatter.WomValueJsonFormat
 import org.scalatest.{FlatSpec, Matchers}
-import spray.json.{JsObject, pimpString}
+import spray.json.{JsObject, enrichString}
 import wom.types._
 import wom.values._
 

--- a/cwl/src/main/scala/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/cwl/CwlCodecs.scala
@@ -3,7 +3,6 @@ package cwl
 import cats.data.NonEmptyList
 import io.circe._
 import io.circe.generic.auto._
-import eu.timepit.refined.string._
 import io.circe.refined._
 import io.circe.literal._
 import common.Checked

--- a/filesystems/oss/src/test/scala/cromwell/filesystems/oss/nio/OssStorageFileAttributesViewSpec.scala
+++ b/filesystems/oss/src/test/scala/cromwell/filesystems/oss/nio/OssStorageFileAttributesViewSpec.scala
@@ -3,7 +3,7 @@ package cromwell.filesystems.oss.nio
 import com.aliyun.oss.OSSClient
 import com.aliyun.oss.model.GenericRequest
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 
 class OssStorageFileAttributesViewSpec extends OssNioUtilSpec {

--- a/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/WdlWorkflowHttpImportSpec.scala
+++ b/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/WdlWorkflowHttpImportSpec.scala
@@ -39,7 +39,7 @@ class WdlWorkflowHttpImportSpec extends FlatSpec with BeforeAndAfterAll with Mat
 
   override def beforeAll() = {
     mockServer = startClientAndServer(PortFactory.findFreePort())
-    host = "http://localhost:" + mockServer.getPort
+    host = "http://localhost:" + mockServer.getLocalPort
 
     mockServer.when(
       request().withPath("/hello.wdl")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,98 +1,96 @@
 import sbt._
 
 object Dependencies {
-  private val apacheCommonNetV = "3.6"
-  private val akkaHttpV = "10.1.3"
-  private val akkaV = "2.5.13"
+  private val akkaHttpV = "10.1.5"
+  private val akkaV = "2.5.16"
+  private val alibabaCloudBcsV = "5.3.2"
   private val alibabaCloudCoreV = "3.6.0"
   private val alibabaCloudOssV = "3.1.0"
-  private val alibabaCloudBcsV = "5.3.2"
-  private val ammoniteOpsV = "1.0.1"
-  private val apacheHttpClientV = "4.5.3"
+  private val ammoniteOpsV = "1.2.0"
+  private val apacheCommonNetV = "3.6"
+  private val apacheHttpClientV = "4.5.6"
   private val apacheHttpCoreV = "4.4.6"
   private val awsSdkV = "2.0.0-preview-9"
-  private val s3fsV = "1.0.1"
   private val betterFilesV = "2.17.1"
-  private val catsEffectV = "1.0.0-RC2"
-  private val catsV = "1.0.1"
+  private val catsEffectV = "1.0.0"
+  private val catsV = "1.3.1"
   private val circeV = "0.9.3"
-  private val circeYamlV = "0.7.0"
-  private val commonsCodecV = "1.10"
-  private val commonsIoV = "2.5"
-  private val commonsLang3V = "3.5"
+  private val circeYamlV = "0.8.0"
+  private val commonsCodecV = "1.11"
+  private val commonsIoV = "2.6"
+  private val commonsLang3V = "3.8"
   private val commonsLoggingV = "1.2"
-  private val commonsTextV = "1.1"
+  private val commonsTextV = "1.4"
   private val configsV = "0.4.4"
-  private val delightRhinoSandboxV = "0.0.8"
+  private val delightRhinoSandboxV = "0.0.9"
   private val errorProneAnnotationsV = "2.0.19"
-  private val ficusV = "1.4.1"
-  private val fs2V = "0.10.2"
+  private val ficusV = "1.4.3"
+  private val fs2V = "0.10.6"
   private val ftpFsV = "1.2.1"
   private val gaxV = "1.28.0"
-  private val googleApiClientV = "1.23.0"
-  private val googleCloudCoreV = "1.34.0"
-  private val googleCloudKmsV = "v1-rev26-1.23.0"
-  private val googleCloudNioV = "0.52.0-alpha"
+  private val googleApiClientV = "1.25.0"
+  private val googleCloudCoreV = "1.43.0"
+  private val googleCloudKmsV = "v1-rev63-1.25.0"
+  private val googleCloudNioV = "0.61.0-alpha"
   private val googleCredentialsV = "0.8.0"
-  private val googleGenomicsServicesV2ApiV = "v2alpha1-rev15-1.23.0"
   private val googleGenomicsServicesV1ApiV = "v1alpha2-rev495-1.23.0"
-  private val googleHttpClientV = googleApiClientV
-  private val googleOauth2V = "0.8.0"
-  private val googleOauthClientV = googleApiClientV
-  private val grpcV = "1.12.0"
+  private val googleGenomicsServicesV2ApiV = "v2alpha1-rev31-1.25.0"
+  private val googleOauth2V = "0.11.0"
+  private val grpcV = "1.15.0"
   private val guavaV = "26.0-jre"
   private val heterodonV = "1.0.0-beta1"
-  private val hsqldbV = "2.3.4"
+  private val hsqldbV = "2.4.1"
   private val jacksonV = "2.9.6"
-  private val janinoV = "3.0.7"
+  private val janinoV = "3.0.9"
   private val jodaTimeV = "2.9.4"
   private val jsr305V = "3.0.0"
-  private val kindProjectorV = "0.9.4"
-  private val kittensV = "1.0.0-RC3"
+  private val kindProjectorV = "0.9.7"
+  private val kittensV = "1.2.0"
   private val liquibaseSlf4jV = "2.0.0"
   private val liquibaseV = "3.5.5"
   private val logbackV = "1.2.3"
   private val metrics3StatsdV = "4.2.0"
-  private val metricsScalaV = "3.5.6"
+  private val metricsScalaV = "4.0.0"
   private val mockFtpServerV = "2.7.1"
-  private val mockserverNettyV = "3.10.2"
+  private val mockserverNettyV = "5.4.1"
   private val mongoJavaDriverV = "3.8.1"
-  private val mouseV = "0.10-MF"
-  private val mysqlV = "5.1.46"
+  private val mouseV = "0.18"
+  private val mysqlV = "5.1.47"
   private val nettyHandlerV = "4.1.22.Final"
-  private val owlApiV = "5.1.4"
-  private val paradiseV = "2.1.0"
+  private val owlApiV = "5.1.7"
+  private val paradiseV = "2.1.1"
   private val pegdownV = "1.6.0"
   private val protoGoogleCommonProtosV = "0.1.21"
   private val protoGoogleIamV1V = "0.1.21"
   private val protobufJavaV = "3.3.1"
   private val reactiveStreamsV = "1.0.1"
-  private val refinedV = "0.8.3"
-  private val rhinoV = "1.7.8"
-  private val scalaGraphV = "1.12.0"
-  private val scalaLoggingV = "3.7.1"
+  private val refinedV = "0.9.2"
+  private val rhinoV = "1.7.10"
+  private val s3fsV = "1.0.1"
+  private val scalaGraphV = "1.12.5"
+  private val scalaLoggingV = "3.9.0"
   private val scalaPoolV = "0.4.1"
   private val scalaXmlV = "1.0.6"
-  private val scalacheckV = "1.13.4"
-  private val scalacticV = "3.0.1"
-  private val scalameterV = "0.8.2"
-  private val scalamockV = "4.0.0"
-  private val scalatestV = "3.0.2"
-  private val scalazV = "7.2.17"
-  private val scoptV = "3.6.0"
-  private val sentryLogbackV = "1.7.5"
+  private val scalacheckV = "1.14.0"
+  private val scalacticV = "3.0.5"
+  private val scalameterV = "0.10.1"
+  private val scalamockV = "4.1.0"
+  private val scalatestV = "3.0.5"
+  private val scalazV = "7.2.26"
+  private val scoptV = "3.7.0"
+  private val sentryLogbackV = "1.7.8"
   private val shapelessV = "2.3.3"
-  private val simulacrumV = "0.12.0"
-  private val slf4jV = "1.7.24"
+  private val simulacrumV = "0.13.0"
+  private val slf4jV = "1.7.25"
+  private val slickCatsV = "0.7.1.1"
   private val slickV = "3.2.3"
-  private val slickCatsV = "0.7.1"
-  private val snakeyamlV = "1.17"
-  private val specs2MockV = "3.8.9" // 3.9.X doesn't enjoy the spark backend or refined
-  private val sprayJsonV = "1.3.3"
-  private val sttpV = "1.1.12"
-  private val swaggerParserV = "1.0.22"
+  private val snakeyamlV = "1.23"
+  private val specs2MockV = "4.3.4"
+  private val sprayJsonV = "1.3.4"
+  private val sttpV = "1.3.3"
+  private val swaggerParserV = "1.0.38"
   private val swaggerUiV = "3.2.2"
-  private val typesafeConfigV = "1.3.1"
+  private val typesafeConfigV = "1.3.3"
   private val workbenchGoogleV = "0.15-2fc79a3"
   private val workbenchModelV = "0.10-6800f3a"
   private val workbenchUtilV = "0.3-f3ce961"
@@ -124,11 +122,11 @@ object Dependencies {
     "com.google.errorprone" % "error_prone_annotations" % errorProneAnnotationsV,
     "com.google.guava" % "guava" % guavaV,
     "com.google.guava-gwt" % "guava" % guavaV,
-    "com.google.http-client" % "google-http-client" % googleHttpClientV,
-    "com.google.http-client" % "google-http-client-appengine" % googleHttpClientV,
-    "com.google.http-client" % "google-http-client-jackson" % googleHttpClientV,
-    "com.google.http-client" % "google-http-client-jackson2" % googleHttpClientV,
-    "com.google.oauth-client" % "google-oauth-client" % googleOauthClientV,
+    "com.google.http-client" % "google-http-client" % googleApiClientV,
+    "com.google.http-client" % "google-http-client-appengine" % googleApiClientV,
+    "com.google.http-client" % "google-http-client-jackson" % googleApiClientV,
+    "com.google.http-client" % "google-http-client-jackson2" % googleApiClientV,
+    "com.google.oauth-client" % "google-oauth-client" % googleApiClientV,
     "com.google.protobuf" % "protobuf-java" % protobufJavaV,
     "com.google.protobuf" % "protobuf-java-util" % protobufJavaV,
     "com.typesafe" % "config" % typesafeConfigV,
@@ -183,7 +181,7 @@ object Dependencies {
     "io.github.andrebeat" %% "scala-pool" % scalaPoolV,
     "com.google.guava" % "guava" % guavaV,
     "org.scalamock" %% "scalamock" % scalamockV % Test,
-    "org.mockftpserver" % "MockFtpServer" % mockFtpServerV
+    "org.mockftpserver" % "MockFtpServer" % mockFtpServerV % Test
   )
 
   // Internal collections of dependencies
@@ -195,7 +193,7 @@ object Dependencies {
   private val catsDependencies = List(
     "org.typelevel" %% "cats-core" % catsV,
     "org.typelevel" %% "alleycats-core" % catsV,
-    "com.github.benhutchison" %% "mouse" % mouseV,
+    "org.typelevel" %% "mouse" % mouseV,
     "org.typelevel" %% "kittens" % kittensV
   )
 
@@ -283,6 +281,9 @@ object Dependencies {
     "com.aliyun.oss" % "aliyun-sdk-oss" % alibabaCloudOssV
       // stax is included twice by oss 3.1.0 and cause assembly merge conflicts via stax vs. javax.xml.stream
       exclude("stax", "stax-api")
+      // javax.activation:activation has been replaced. https://stackoverflow.com/a/46493809
+      // The old version was causing an assembly merge conflict.
+      exclude("javax.activation", "activation")
   )
 
   private val aliyunBatchComputeDependencies = List(
@@ -344,7 +345,7 @@ object Dependencies {
     "org.typelevel" %% "cats-effect" % catsEffectV,
     "org.apache.commons" % "commons-lang3" % commonsLang3V
   ) ++ catsDependencies ++ configDependencies
-  
+
   val womDependencies = List(
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
     "io.spray" %% "spray-json" % sprayJsonV,

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -178,7 +178,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
         }
       }
 
-      schemaMetadata.indexMetadata.groupBy(getIndexName) foreach {
+      schemaMetadata.indexMetadata.filterNot(isForeignKeyIndex).groupBy(getIndexName) foreach {
         case (indexName, indexColumns) =>
           val index = indexColumns.head
           val prefix = if (index.nonUnique) "IX" else "UC"
@@ -297,7 +297,6 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
     it should "fail to store and retrieve empty blobs" taggedAs DbmsTest in {
       // See notes in BytesToBlobOption
       import eu.timepit.refined.auto._
-      import eu.timepit.refined.collection._
       val clob = "".toClob(default = "{}")
       val clobOption = "{}".toClobOption
       val emptyBlob = new SerialBlob(Array.empty[Byte])
@@ -374,7 +373,6 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
     it should "store and retrieve empty blobs" taggedAs DbmsTest in {
       // See notes in BytesToBlobOption
       import eu.timepit.refined.auto._
-      import eu.timepit.refined.collection._
 
       val submittedWorkflowState = WorkflowStoreState.Submitted
       val clob = "".toClob(default = "{}")
@@ -587,6 +585,8 @@ object ServicesStoreSpec {
     s"cromwell.database.slick.tables.${tableName}Component$$${tableName.replace("Entry", "Entries")}"
 
   private def getIndexName(index: MIndexInfo) = index.indexName.get.replaceAll("(^SYS_IDX_|_\\d+$)", "")
+
+  private def isForeignKeyIndex(index: MIndexInfo) = getIndexName(index).startsWith("FK_")
 
   case class TableClass(tableName: String) {
     private def getClass(name: String): Try[Class[_]] = Try(Class.forName(name))

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributes.scala
@@ -1,6 +1,6 @@
 package cromwell.backend.google.pipelines.common
 
-import java.net.{URI, URL}
+import java.net.URL
 
 import cats.data.Validated._
 import cats.syntax.apply._
@@ -17,11 +17,10 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.{refineMV, refineV}
 import net.ceedubs.ficus.Ficus._
-import net.ceedubs.ficus.readers.{StringReader, ValueReader}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration._
 
 case class PipelinesApiAttributes(project: String,
                                   computeServiceAccount: String,
@@ -86,8 +85,6 @@ object PipelinesApiAttributes {
   )
 
   private val context = "Jes"
-
-  implicit val urlReader: ValueReader[URL] = StringReader.stringValueReader.map { URI.create(_).toURL }
 
   def apply(googleConfig: GoogleConfiguration, backendConfig: Config): PipelinesApiAttributes = {
     val configKeys = backendConfig.entrySet().asScala.toSet map { entry: java.util.Map.Entry[String, ConfigValue] => entry.getKey }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
@@ -30,8 +30,6 @@ class PipelinesApiConfiguration(val configurationDescriptor: BackendConfiguratio
   val dockerToken: Option[String] = dockerCredentials map { _.token }
 
   val needAuthFileUpload = jesAuths.gcs.requiresAuthFile || dockerCredentials.isDefined || jesAttributes.restrictMetadataAccess
-  val qps = jesAttributes.qps
-  val papiRequestWorkers = jesAttributes.requestWorkers
   val jobShell = configurationDescriptor.backendConfig.as[Option[String]]("job-shell").getOrElse(
     configurationDescriptor.globalConfig.getOrElse("system.job-shell", "/bin/bash"))
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
@@ -234,5 +234,12 @@ class MockPipelinesRequestHandler extends PipelinesApiRequestHandler {
 object TestPipelinesApiRequestManager {
   import PipelinesApiTestConfig._
 
-  def props(registryProbe: ActorRef, statusPollers: ActorRef*): Props = Props(new TestPipelinesApiRequestManager(papiConfiguration.qps, papiConfiguration.papiRequestWorkers, registryProbe, statusPollers: _*))
+  def props(registryProbe: ActorRef, statusPollers: ActorRef*): Props = {
+    Props(new TestPipelinesApiRequestManager(
+      papiConfiguration.jesAttributes.qps,
+      papiConfiguration.jesAttributes.requestWorkers,
+      registryProbe,
+      statusPollers: _*)
+    )
+  }
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorkerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorkerSpec.scala
@@ -136,8 +136,13 @@ abstract class TestPipelinesApiBatchHandler[O >: Null] extends PipelinesApiReque
 
 object TestPipelinesApiRequestWorker {
   def props(manager: ActorRef, jesConfiguration: PipelinesApiConfiguration, registryProbe: ActorRef)
-              (implicit batchHandler: TestPipelinesApiBatchHandler[_]) = 
-    Props(new TestPipelinesApiRequestWorker(manager, jesConfiguration.qps, registryProbe))
+           (implicit batchHandler: TestPipelinesApiBatchHandler[_]): Props = {
+    Props(new TestPipelinesApiRequestWorker(
+      manager,
+      jesConfiguration.jesAttributes.qps,
+      registryProbe
+    ))
+  }
   
   sealed trait PipelinesApiBatchCallbackResponse
   case object CallbackSuccess extends PipelinesApiBatchCallbackResponse

--- a/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiLifecycleActorFactory.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiLifecycleActorFactory.scala
@@ -12,7 +12,11 @@ class PipelinesApiLifecycleActorFactory(name: String, configurationDescriptor: B
   override protected val jesConfiguration = new PipelinesApiConfiguration(configurationDescriptor, genomicsFactory, googleConfig, papiAttributes)
   override def requiredBackendSingletonActor(serviceRegistryActor: ActorRef) = {
     implicit val batchHandler = new RequestHandler(googleConfig.applicationName, papiAttributes.endpointUrl)
-    PipelinesApiBackendSingletonActor.props(jesConfiguration.qps, jesConfiguration.papiRequestWorkers, serviceRegistryActor)
+    PipelinesApiBackendSingletonActor.props(
+      jesConfiguration.jesAttributes.qps,
+      jesConfiguration.jesAttributes.requestWorkers,
+      serviceRegistryActor
+    )
   }
 
   override lazy val initializationActorClass: Class[_ <: StandardInitializationActor] =

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiLifecycleActorFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiLifecycleActorFactory.scala
@@ -12,7 +12,11 @@ class PipelinesApiLifecycleActorFactory(name: String, configurationDescriptor: B
   override protected val jesConfiguration = new PipelinesApiConfiguration(configurationDescriptor, genomicsFactory, googleConfig, papiAttributes)
   override def requiredBackendSingletonActor(serviceRegistryActor: ActorRef) = {
     implicit val batchHandler = new RequestHandler(googleConfig.applicationName, papiAttributes.endpointUrl)
-    PipelinesApiBackendSingletonActor.props(jesConfiguration.qps, jesConfiguration.papiRequestWorkers, serviceRegistryActor)
+    PipelinesApiBackendSingletonActor.props(
+      jesConfiguration.jesAttributes.qps,
+      jesConfiguration.jesAttributes.requestWorkers,
+      serviceRegistryActor
+    )
   }
   override lazy val asyncExecutionActorClass: Class[_ <: StandardAsyncExecutionActor] =
     classOf[PipelinesApiAsyncBackendJobExecutionActor]

--- a/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkClusterProcessSpec.scala
+++ b/supportedBackends/spark/src/test/scala/cromwell/backend/impl/spark/SparkClusterProcessSpec.scala
@@ -7,7 +7,7 @@ import cromwell.backend.impl.spark.SparkClusterProcess._
 import cromwell.core.TestKitSuite
 import cromwell.core.path.Obsolete._
 import cromwell.core.path.Path
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito
 import org.mockito.Mockito._
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -78,11 +78,16 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
   private val mockFailedHttpResponse = HttpResponse(StatusCodes.OK, entity = HttpEntity(ContentTypes.`application/json`, mockFailedClusterResponse.toJson.toString))
   private val mockBadHttpResponse = HttpResponse(StatusCodes.BadRequest)
 
+  // https://stackoverflow.com/a/41337557 & https://stackoverflow.com/a/13361530
+  private val Workaround_SI_2991: Seq[Future[HttpResponse]] = Nil
+
   "SparkCluster process" should {
     "return finished status when Spray rest client return successful http response" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.successful(mockSuccessHttpResponse)).when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
+      doReturn(Future.successful(mockSuccessHttpResponse), Workaround_SI_2991: _*)
+        .when(sparkClusterProcess)
+        .makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe Finished
         verify(sparkClusterProcess, times(1)).startMonitoringSparkClusterJob(testRoot.path, jsonFileName)
@@ -95,7 +100,9 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
     "return failed status when Spray rest client return unsuccessful http response" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.successful(mockFailedHttpResponse)).when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
+      doReturn(Future.successful(mockFailedHttpResponse), Workaround_SI_2991: _*)
+        .when(sparkClusterProcess)
+        .makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe a[Failed]
         assert(response.asInstanceOf[Failed].error.getMessage.contains("Spark Driver returned failed status"))
@@ -109,7 +116,9 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
     "return failed status when Spray rest client return bad http response" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.successful(mockBadHttpResponse)).when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
+      doReturn(Future.successful(mockBadHttpResponse), Workaround_SI_2991: _*)
+        .when(sparkClusterProcess)
+        .makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe a[Failed]
         assert(response.asInstanceOf[Failed].error.getMessage.contains("Spark Driver returned failed status"))
@@ -123,7 +132,9 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
     "return failed status when makeHttpRequest throws exception" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.failed(new IllegalStateException("request timed out"))).when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
+      doReturn(Future.failed(new IllegalStateException("request timed out")), Workaround_SI_2991: _*)
+        .when(sparkClusterProcess)
+        .makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe a[Failed]
         assert(response.asInstanceOf[Failed].error.getMessage.contains("Spark Driver returned failed status"))
@@ -148,7 +159,9 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
     "return failed status when Spray rest client return unknown response" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.successful(mockUnknownResponse)).when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
+      doReturn(Future.successful(mockUnknownResponse), Workaround_SI_2991: _*)
+        .when(sparkClusterProcess)
+        .makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe a[Failed]
         assert(response.asInstanceOf[Failed].error.getMessage.contains("Spark Driver returned failed status"))
@@ -162,7 +175,8 @@ class SparkClusterProcessSpec extends TestKitSuite("SparkClusterProcess")
     "return finished status when Spray rest client return running and then finished response" in {
       val sparkClusterProcess = Mockito.spy(new SparkClusterProcess()(system))
       jsonFile write sampleSubmissionResponse
-      doReturn(Future.successful(mockRunningHttpResponse)).doReturn(Future.successful(mockSuccessHttpResponse))
+      doReturn(Future.successful(mockRunningHttpResponse), Workaround_SI_2991: _*)
+        .doReturn(Future.successful(mockSuccessHttpResponse), Workaround_SI_2991: _*)
         .when(sparkClusterProcess).makeHttpRequest(any[HttpRequest])
       whenReady(sparkClusterProcess.startMonitoringSparkClusterJob(testRoot.path, jsonFileName), timeout) { response =>
         response shouldBe Finished


### PR DESCRIPTION
Bypass Mockito error "Cannot cast to primitive type" on classes also modified due to use of Refined.
Dependencies still reported out of date via `sbt dependencyUpdates`:
- com.aliyun:aliyun-java-sdk-core : 3.6.0 -> 3.7.1 -> 4.0.8
  Waiting for https://github.com/aliyun/aliyun-openapi-java-sdk/issues/54
- com.github.pathikrit:better-files : 2.17.1 -> 3.6.0
  Unstable API would probably require multiple changes
- com.google.apis:google-api-services-cloudkms : v1-rev63-1.25.0 -> InvalidVersion(v1beta1-rev6-1.22.0)
  False positive due to version not being SemVer
- com.google.apis:google-api-services-genomics : v2alpha1-rev31-1.25.0 -> InvalidVersion(v2alpha1-rev9-1.23.0)
  False positive due to version not being SemVer
- mysql:mysql-connector-java : 5.1.47 -> 8.0.12
  See notes in Dependencies.scala on changes that would be required by users.
- org.broadinstitute.dsde.workbench:workbench-google : 0.15-2fc79a3 -> 0.15-ff73de5-SNAP -> 0.100-f9bd914-SNAP -> 1.0-e8e6ff0-SNAP
  Need more research to know what changed
- org.broadinstitute.dsde.workbench:workbench-model : 0.10-6800f3a -> 0.10-ff73de5-SNAP -> 0.12-e24d5a6-SNAP
  Need more research to know what changed
- org.broadinstitute.dsde.workbench:workbench-util : 0.3-f3ce961 -> 0.3-ff937c4-SNAP
  Need more research to know what changed
- org.liquibase:liquibase-core : 3.5.5 -> 3.6.2
  Waiting for https://liquibase.jira.com/browse/CORE-3311
- org.webjars:swagger-ui : 3.2.2 -> 3.18.2
  Unstable API would probably require multiple changes
- software.amazon.awssdk:aws-sdk-java : 2.0.0-preview-9 -> 2.0.1
  Waiting for https://github.com/broadinstitute/cromwell/issues/3909