### PR TITLE
Caching actor: Don't emit fatal timeout messages that must be ignored

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -1,7 +1,5 @@
 package cromwell.engine.workflow.lifecycle.execution.job
 
-import java.util.concurrent.TimeoutException
-
 import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor.{ActorInitializationException, ActorRef, LoggingFSM, OneForOneStrategy, Props}
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -406,10 +406,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       }
     case Event(EngineLifecycleActorAbortCommand, _) =>
       forwardAndStop(JobAbortedResponse(jobDescriptorKey))
-    // We can get extra I/O timeout messages from previous cache copy attempt. This is due to the fact that if one file fails to copy,
-    // we immediately cache miss and try the next potential hit, but don't cancel previous copy requests.
-    case Event(JobFailedNonRetryableResponse(_, _: TimeoutException, _), _) =>
-      stay()
     case Event(msg, _) =>
       log.error("Bad message from {} to EngineJobExecutionActor in state {}(with data {}): {}", sender, stateName, stateData, msg)
       stay


### PR DESCRIPTION
@Horneth I think this was originally added by you (but git blame might be lying...), could you sanity check this?