### PR TITLE
Make dockerRoot a configurable value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ backends. Configuration details are described [here](http://cromwell.readthedocs
 More efficient cache hit copying in multi-user environments is now supported through the `call_cache_hit_path_prefixes` workflow option.
 Details [here](http://cromwell.readthedocs.io/en/develop/CallCaching/#call-cache-hit-path-prefixes)
 
+
+### Extra configuration options
+
+The value `dockerRoot` can now be set in a backend configuration. 
+This will set the execution folder in the container (default: `/cromwell-executions`).
+
 ### Bug Fixes
 
 #### API

--- a/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala
@@ -42,7 +42,7 @@ case class JobPathsWithDocker private[io] (override val workflowPaths: WorkflowP
 
   def toDockerPath(path: Path): Path = {
     path.toAbsolutePath match {
-      case p if p.startsWith(WorkflowPathsWithDocker.DockerRoot) => p
+      case p if p.startsWith(workflowPaths.dockerRoot) => p
       case p =>
         /* For example:
           *
@@ -55,7 +55,7 @@ case class JobPathsWithDocker private[io] (override val workflowPaths: WorkflowP
           * TODO: this assumes that p.startsWith(localExecutionRoot)
           */
         val subpath = p.subpath(workflowPaths.executionRoot.getNameCount, p.getNameCount)
-        WorkflowPathsWithDocker.DockerRoot.resolve(subpath)
+        workflowPaths.dockerRoot.resolve(subpath)
     }
   }
 }

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
@@ -10,6 +10,7 @@ import scala.util.Try
 
 object WorkflowPaths {
   val DefaultPathBuilders = List(DefaultPathBuilder)
+  val defaultExecutionRootString: String = "cromwell-executions"
 }
 
 trait WorkflowPaths extends PathFactory {
@@ -19,7 +20,7 @@ trait WorkflowPaths extends PathFactory {
   /**
     * Path (as a String) of the root directory Cromwell should use for ALL workflows.
     */
-  protected lazy val executionRootString: String = config.as[Option[String]]("root").getOrElse("cromwell-executions")
+  protected lazy val executionRootString: String = config.as[Option[String]]("root").getOrElse(WorkflowPaths.defaultExecutionRootString)
 
   /**
     * Implementers of this trait might override this to provide an appropriate prefix corresponding to the execution root

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPaths.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 
 object WorkflowPaths {
   val DefaultPathBuilders = List(DefaultPathBuilder)
-  val defaultExecutionRootString: String = "cromwell-executions"
+  val DefaultExecutionRootString: String = "cromwell-executions"
 }
 
 trait WorkflowPaths extends PathFactory {
@@ -20,7 +20,7 @@ trait WorkflowPaths extends PathFactory {
   /**
     * Path (as a String) of the root directory Cromwell should use for ALL workflows.
     */
-  protected lazy val executionRootString: String = config.as[Option[String]]("root").getOrElse(WorkflowPaths.defaultExecutionRootString)
+  protected lazy val executionRootString: String = config.as[Option[String]]("root").getOrElse(WorkflowPaths.DefaultExecutionRootString)
 
   /**
     * Implementers of this trait might override this to provide an appropriate prefix corresponding to the execution root

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -8,7 +8,7 @@ import net.ceedubs.ficus.Ficus._
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerRoot: Path =
     DefaultPathBuilder.get(
-      config.as[Option[String]]("dockerRoot").getOrElse("/cromwell-executions")
+      config.getOrElse[String]("dockerRoot", "/cromwell-executions")
     )
   val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -3,13 +3,18 @@ package cromwell.backend.io
 import com.typesafe.config.Config
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
+import net.ceedubs.ficus.Ficus._
 
 object WorkflowPathsWithDocker {
   val DockerRoot: Path = DefaultPathBuilder.get("/cromwell-executions")
 }
 
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
-  val dockerWorkflowRoot: Path = workflowPathBuilder(WorkflowPathsWithDocker.DockerRoot)
+  val dockerRoot: Path = config.as[Option[String]]("dockerRoot") match {
+    case Some(pathString) => DefaultPathBuilder.get(pathString)
+    case _ => WorkflowPathsWithDocker.DockerRoot
+  }
+  val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 
   override def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JobPathsWithDocker = {
     new JobPathsWithDocker(workflowPaths.asInstanceOf[WorkflowPathsWithDocker], jobKey)

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -8,7 +8,7 @@ import net.ceedubs.ficus.Ficus._
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerRoot: Path =
     DefaultPathBuilder.get(
-      config.getOrElse[String]("dockerRoot", "/cromwell-executions")
+      config.getOrElse[String]("dockerRoot", WorkflowPathsWithDocker.defaultDockerRoot)
     )
   val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 
@@ -17,4 +17,8 @@ final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDesc
   }
 
   override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
+}
+
+object WorkflowPathsWithDocker {
+  val defaultDockerRoot = "/cromwell-executions"
 }

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -8,7 +8,7 @@ import net.ceedubs.ficus.Ficus._
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerRoot: Path =
     DefaultPathBuilder.get(
-      config.as[Option[String]]("dockerRoot").getOrElse("/cromwell-exections")
+      config.as[Option[String]]("dockerRoot").getOrElse("/cromwell-executions")
     )
   val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -6,13 +6,13 @@ import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 import net.ceedubs.ficus.Ficus._
 
 object WorkflowPathsWithDocker {
-  val defaultDockerRoot = "/cromwell-executions"
+  val DefaultDockerRoot = "/cromwell-executions"
 }
 
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerRoot: Path =
     DefaultPathBuilder.get(
-      config.getOrElse[String]("dockerRoot", WorkflowPathsWithDocker.defaultDockerRoot)
+      config.getOrElse[String]("dockerRoot", WorkflowPathsWithDocker.DefaultDockerRoot)
     )
   val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -5,15 +5,11 @@ import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 import net.ceedubs.ficus.Ficus._
 
-object WorkflowPathsWithDocker {
-  val DockerRoot: Path = DefaultPathBuilder.get("/cromwell-executions")
-}
-
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
-  val dockerRoot: Path = config.as[Option[String]]("dockerRoot") match {
-    case Some(pathString) => DefaultPathBuilder.get(pathString)
-    case _ => WorkflowPathsWithDocker.DockerRoot
-  }
+  val dockerRoot: Path =
+    DefaultPathBuilder.get(
+      config.as[Option[String]]("dockerRoot").getOrElse("/cromwell-exections")
+    )
   val dockerWorkflowRoot: Path = workflowPathBuilder(dockerRoot)
 
   override def toJobPaths(workflowPaths: WorkflowPaths, jobKey: BackendJobDescriptorKey): JobPathsWithDocker = {

--- a/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
+++ b/backend/src/main/scala/cromwell/backend/io/WorkflowPathsWithDocker.scala
@@ -5,6 +5,10 @@ import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder}
 import net.ceedubs.ficus.Ficus._
 
+object WorkflowPathsWithDocker {
+  val defaultDockerRoot = "/cromwell-executions"
+}
+
 final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDescriptor, config: Config, pathBuilders: List[PathBuilder] = WorkflowPaths.DefaultPathBuilders) extends WorkflowPaths {
   val dockerRoot: Path =
     DefaultPathBuilder.get(
@@ -17,8 +21,4 @@ final case class WorkflowPathsWithDocker(workflowDescriptor: BackendWorkflowDesc
   }
 
   override protected def withDescriptor(workflowDescriptor: BackendWorkflowDescriptor): WorkflowPaths = this.copy(workflowDescriptor = workflowDescriptor)
-}
-
-object WorkflowPathsWithDocker {
-  val defaultDockerRoot = "/cromwell-executions"
 }

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -11,11 +11,28 @@ import wom.graph.WomIdentifier
 
 class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
-  val backendConfig = mock[Config]
+  def createBackendConfig(values: Map[String, String]): Config = {
+    val backendConfig = mock[Config]
+    values.foreach {
+      case (key: String, value: String) => {
+        when(backendConfig.hasPath(key)).thenReturn(true)
+        when(backendConfig.getString(key)).thenReturn(value)
+      }
+    }
+    backendConfig
+  }
+
+  def rootConfig(root: Option[String], dockerRoot: Option[String]) = {
+    val values: Map[String,String] = root.map("root" -> _).toMap ++ dockerRoot.map("dockerRoot" -> _).toMap
+    createBackendConfig(values)
+  }
+
+  def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]): Unit = {
+
+  }
 
   "WorkflowPaths" should "provide correct paths for a workflow" in {
-    when(backendConfig.hasPath("root")).thenReturn(true)
-    when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
+    val backendConfig = createBackendConfig(Map("root" -> "local-cromwell-executions"))
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val id = wd.id
@@ -26,6 +43,7 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
   }
 
   "WorkflowPaths" should "provide correct paths for a sub workflow" in {
+    val backendConfig = createBackendConfig(Map("root" -> "local-cromwell-executions"))
     when(backendConfig.hasPath("root")).thenReturn(true)
     when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
     val rootWd = mock[BackendWorkflowDescriptor]

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -14,9 +14,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
   val backendConfig = mock[Config]
 
   "WorkflowPaths" should "provide correct paths for a workflow" in {
-    when(backendConfig.hasPath(any[String])).thenReturn(true)
+    when(backendConfig.hasPath("root")).thenReturn(true)
     when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
-    when(backendConfig.getAnyRef("dockerRoot")).thenReturn(None)
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val id = wd.id
@@ -27,9 +26,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
   }
 
   "WorkflowPaths" should "provide correct paths for a sub workflow" in {
-    when(backendConfig.hasPath(any[String])).thenReturn(true)
+    when(backendConfig.hasPath("root")).thenReturn(true)
     when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
-    when(backendConfig.getAnyRef("dockerRoot")).thenReturn(None)
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")
     val rootWorkflowId = WorkflowId.randomId()

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -14,10 +14,9 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
   def createConfig(values: Map[String, String]): Config = {
     val config = mock[Config]
     values.foreach {
-      case (key: String, value: String) => {
+      case (key: String, value: String) =>
         when(config.hasPath(key)).thenReturn(true)
         when(config.getString(key)).thenReturn(value)
-      }
     }
     config
   }
@@ -35,7 +34,7 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     TestConfig(Some("local-cromwell-executions"), Some("/dockerRootExecutions")) // Testing with both defined.
   )
 
-  def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]): Unit = {
+  def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]) = {
     val backendConfig = rootConfig(root, dockerRoot)
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
@@ -43,12 +42,12 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val expectedRoot = root.getOrElse(WorkflowPaths.defaultExecutionRootString)
     val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.defaultDockerRoot)
     workflowPaths.workflowRoot.pathAsString shouldBe
-      DefaultPathBuilder.get(s"${expectedRoot}/wf_hello/$id").toAbsolutePath.pathAsString
+      DefaultPathBuilder.get(s"$expectedRoot/wf_hello/$id").toAbsolutePath.pathAsString
     workflowPaths.dockerWorkflowRoot.pathAsString shouldBe
       s"$expectedDockerRoot/wf_hello/$id"
   }
 
-  def testSubWorkflowPaths(root: Option[String], dockerRoot: Option[String]): Unit = {
+  def testSubWorkflowPaths(root: Option[String], dockerRoot: Option[String]) = {
     val backendConfig = rootConfig(root, dockerRoot)
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -29,9 +29,9 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
   case class TestConfig(root: Option[String], dockerRoot: Option[String])
   val testConfigs: List[TestConfig] = List(
     TestConfig(None, None), // Defaults testing
-    TestConfig(Some("local-cromwell-executions"), None), // Testing only with defined root
-    TestConfig(None, Some("/dockerRootExecutions")), // Testing only with defined dockerRoot
-    TestConfig(Some("local-cromwell-executions"), Some("/dockerRootExecutions")) // Testing with both defined.
+    TestConfig(Some("local-cromwell-executions"), None),
+    TestConfig(None, Some("/dockerRootExecutions")),
+    TestConfig(Some("local-cromwell-executions"), Some("/dockerRootExecutions"))
   )
 
   def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]) = {

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -11,41 +11,45 @@ import wom.graph.WomIdentifier
 
 class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
-  def createBackendConfig(values: Map[String, String]): Config = {
-    val backendConfig = mock[Config]
+  def createConfig(values: Map[String, String]): Config = {
+    val config = mock[Config]
     values.foreach {
       case (key: String, value: String) => {
-        when(backendConfig.hasPath(key)).thenReturn(true)
-        when(backendConfig.getString(key)).thenReturn(value)
+        when(config.hasPath(key)).thenReturn(true)
+        when(config.getString(key)).thenReturn(value)
       }
     }
-    backendConfig
+    config
   }
 
   def rootConfig(root: Option[String], dockerRoot: Option[String]) = {
     val values: Map[String,String] = root.map("root" -> _).toMap ++ dockerRoot.map("dockerRoot" -> _).toMap
-    createBackendConfig(values)
+    createConfig(values)
   }
+
+  case class TestConfig(root: Option[String], dockerRoot: Option[String])
+  val testConfigs: List[TestConfig] = List(
+    TestConfig(None, None), // Defaults testing
+    TestConfig(Some("local-cromwell-executions"), None), // Testing only with defined root
+    TestConfig(None, Some("/dockerRootExecutions")), // Testing only with defined dockerRoot
+    TestConfig(Some("local-cromwell-executions"), Some("/dockerRootExecutions")) // Testing with both defined.
+  )
 
   def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]): Unit = {
-
-  }
-
-  "WorkflowPaths" should "provide correct paths for a workflow" in {
-    val backendConfig = createBackendConfig(Map("root" -> "local-cromwell-executions"))
+    val backendConfig = rootConfig(root, dockerRoot)
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val id = wd.id
+    val expectedRoot = root.getOrElse(WorkflowPaths.defaultExecutionRootString)
+    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.defaultDockerRoot)
     workflowPaths.workflowRoot.pathAsString shouldBe
-      DefaultPathBuilder.get(s"local-cromwell-executions/wf_hello/$id").toAbsolutePath.pathAsString
+      DefaultPathBuilder.get(s"${expectedRoot}/wf_hello/$id").toAbsolutePath.pathAsString
     workflowPaths.dockerWorkflowRoot.pathAsString shouldBe
-      s"/cromwell-executions/wf_hello/$id"
+      s"$expectedDockerRoot/wf_hello/$id"
   }
 
-  "WorkflowPaths" should "provide correct paths for a sub workflow" in {
-    val backendConfig = createBackendConfig(Map("root" -> "local-cromwell-executions"))
-    when(backendConfig.hasPath("root")).thenReturn(true)
-    when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
+  def testSubWorkflowPaths(root: Option[String], dockerRoot: Option[String]): Unit = {
+    val backendConfig = rootConfig(root, dockerRoot)
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")
     val rootWorkflowId = WorkflowId.randomId()
@@ -57,9 +61,9 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val subWorkflowId = WorkflowId.randomId()
     subWd.callable returns subWorkflow
     subWd.id returns subWorkflowId
-    
+
     val call1 = WomMocks.mockTaskCall(WomIdentifier("call1"))
-    
+
     val jobKey = new JobKey {
       override def node = call1
       override def tag: String = "tag1"
@@ -69,12 +73,23 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
     subWd.breadCrumbs returns List(BackendJobBreadCrumb(rootWorkflow, rootWorkflowId, jobKey))
     subWd.id returns subWorkflowId
-    
+
     val workflowPaths = new WorkflowPathsWithDocker(subWd, backendConfig)
+    val expectedRoot = root.getOrElse(WorkflowPaths.defaultExecutionRootString)
+    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.defaultDockerRoot)
+
     workflowPaths.workflowRoot.pathAsString shouldBe
       DefaultPathBuilder.get(
-        s"local-cromwell-executions/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
+        s"$expectedRoot/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
       ).toAbsolutePath.pathAsString
-    workflowPaths.dockerWorkflowRoot.pathAsString shouldBe s"/cromwell-executions/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
+    workflowPaths.dockerWorkflowRoot.pathAsString shouldBe s"$expectedDockerRoot/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
+  }
+
+  "WorkflowPaths" should "provide correct paths for a workflow" in {
+    testConfigs.foreach(config => testWorkflowPaths(config.root, config.dockerRoot))
+  }
+
+  "WorkflowPaths" should "provide correct paths for a sub workflow" in {
+    testConfigs.foreach(config => testSubWorkflowPaths(config.root, config.dockerRoot))
   }
 }

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -15,7 +15,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
   "WorkflowPaths" should "provide correct paths for a workflow" in {
     when(backendConfig.hasPath(any[String])).thenReturn(true)
-    when(backendConfig.getString(any[String])).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
+    when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
+    when(backendConfig.getAnyRef("dockerRoot")).thenReturn(None)
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val id = wd.id
@@ -27,8 +28,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
 
   "WorkflowPaths" should "provide correct paths for a sub workflow" in {
     when(backendConfig.hasPath(any[String])).thenReturn(true)
-    when(backendConfig.getString(any[String])).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
-    
+    when(backendConfig.getString("root")).thenReturn("local-cromwell-executions") // This is the folder defined in the config as the execution root dir
+    when(backendConfig.getAnyRef("dockerRoot")).thenReturn(None)
     val rootWd = mock[BackendWorkflowDescriptor]
     val rootWorkflow = WomMocks.mockWorkflowDefinition("rootWorkflow")
     val rootWorkflowId = WorkflowId.randomId()

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -39,8 +39,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     val wd = buildWdlWorkflowDescriptor(TestWorkflows.HelloWorld)
     val workflowPaths = new WorkflowPathsWithDocker(wd, backendConfig)
     val id = wd.id
-    val expectedRoot = root.getOrElse(WorkflowPaths.defaultExecutionRootString)
-    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.defaultDockerRoot)
+    val expectedRoot = root.getOrElse(WorkflowPaths.DefaultExecutionRootString)
+    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.DefaultDockerRoot)
     workflowPaths.workflowRoot.pathAsString shouldBe
       DefaultPathBuilder.get(s"$expectedRoot/wf_hello/$id").toAbsolutePath.pathAsString
     workflowPaths.dockerWorkflowRoot.pathAsString shouldBe
@@ -74,8 +74,8 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     subWd.id returns subWorkflowId
 
     val workflowPaths = new WorkflowPathsWithDocker(subWd, backendConfig)
-    val expectedRoot = root.getOrElse(WorkflowPaths.defaultExecutionRootString)
-    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.defaultDockerRoot)
+    val expectedRoot = root.getOrElse(WorkflowPaths.DefaultExecutionRootString)
+    val expectedDockerRoot = dockerRoot.getOrElse(WorkflowPathsWithDocker.DefaultDockerRoot)
 
     workflowPaths.workflowRoot.pathAsString shouldBe
       DefaultPathBuilder.get(

--- a/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/WorkflowPathsSpec.scala
@@ -26,12 +26,12 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     createConfig(values)
   }
 
-  case class TestConfig(root: Option[String], dockerRoot: Option[String])
+  case class TestConfig(name: String, root: Option[String], dockerRoot: Option[String])
   val testConfigs: List[TestConfig] = List(
-    TestConfig(None, None), // Defaults testing
-    TestConfig(Some("local-cromwell-executions"), None),
-    TestConfig(None, Some("/dockerRootExecutions")),
-    TestConfig(Some("local-cromwell-executions"), Some("/dockerRootExecutions"))
+    TestConfig("defaults", None, None), // Defaults testing
+    TestConfig("custom root defined", Some("local-cromwell-executions"), None),
+    TestConfig("custom dockerRoot defined", None, Some("/dockerRootExecutions")),
+    TestConfig("both root and dockerRoot defined", Some("local-cromwell-executions"), Some("/dockerRootExecutions"))
   )
 
   def testWorkflowPaths(root: Option[String], dockerRoot: Option[String]) = {
@@ -84,11 +84,14 @@ class WorkflowPathsSpec extends FlatSpec with Matchers with BackendSpec {
     workflowPaths.dockerWorkflowRoot.pathAsString shouldBe s"$expectedDockerRoot/rootWorkflow/$rootWorkflowId/call-call1/shard-1/attempt-2/subWorkflow/$subWorkflowId"
   }
 
-  "WorkflowPaths" should "provide correct paths for a workflow" in {
-    testConfigs.foreach(config => testWorkflowPaths(config.root, config.dockerRoot))
+  testConfigs.foreach { config =>
+    "WorkflowPaths" should s"provide correct paths for a workflow with ${config.name}" in {
+      testWorkflowPaths(config.root, config.dockerRoot)
+    }
   }
-
-  "WorkflowPaths" should "provide correct paths for a sub workflow" in {
-    testConfigs.foreach(config => testSubWorkflowPaths(config.root, config.dockerRoot))
+  testConfigs.foreach { config =>
+    "WorkflowPaths" should s"provide correct paths for a sub workflow with ${config.name}" in {
+      testSubWorkflowPaths(config.root, config.dockerRoot)
+    }
   }
 }

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -327,6 +327,12 @@ backend {
         # launches.
         root = "cromwell-executions"
 
+        # Root directory where Cromwell writes job results in the container. This value
+        # can be used to specify where the execution folder is mounted in the container.
+        # it is used for the construction of the docker_cwd string in the submit-docker
+        # value above.
+        dockerRoot = "/cromwell-executions"
+
         # File system configuration.
         filesystems {
 


### PR DESCRIPTION
Fixes #4084 
For singularity users it is nice that `dockerRoot` can be set, as they do not have control over which paths are available in the image and `/cromwell-executions` cannot be automatically created. Other paths could be used, BioContainers for example have a `/data` folder meant specifically for these use cases. But this requires dockerRoot to be configurable.

The fallback value is still `/cromwell-executions` so nothing changes if the value is not specified in the config.