### PR TITLE
Cache output copy failures

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendCacheHitCopyingActor.scala
@@ -1,7 +1,10 @@
 package cromwell.backend
 
+import cromwell.core.JobKey
 import cromwell.core.simpleton.WomValueSimpleton
 
 object BackendCacheHitCopyingActor {
   final case class CopyOutputsCommand(womValueSimpletons: Seq[WomValueSimpleton], jobDetritusFiles: Map[String, String], returnCode: Option[Int])
+
+  final case class CopyingOutputsFailedResponse(jobKey: JobKey, cacheCopyAttempt: Int, failure: Throwable)
 }

--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -84,7 +84,7 @@ trait BackendLifecycleActorFactory {
     *
     * Simples!
     */
-  def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef) => Props] = None
+  def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int) => Props] = None
 
   /* ****************************** */
   /*              Misc.             */

--- a/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardLifecycleActorFactory.scala
@@ -131,7 +131,7 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
   }
 
   override def cacheHitCopyingActorProps:
-  Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef) => Props] = {
+  Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int) => Props] = {
     cacheHitCopyingActorClassOption map {
       standardCacheHitCopyingActor => cacheHitCopyingActorInner(standardCacheHitCopyingActor) _
     }
@@ -141,17 +141,19 @@ trait StandardLifecycleActorFactory extends BackendLifecycleActorFactory {
                                (jobDescriptor: BackendJobDescriptor,
                                 initializationDataOption: Option[BackendInitializationData],
                                 serviceRegistryActor: ActorRef,
-                                ioActor: ActorRef): Props = {
-    val params = cacheHitCopyingActorParams(jobDescriptor, initializationDataOption, serviceRegistryActor, ioActor)
+                                ioActor: ActorRef,
+                                cacheCopyAttempt: Int): Props = {
+    val params = cacheHitCopyingActorParams(jobDescriptor, initializationDataOption, serviceRegistryActor, ioActor, cacheCopyAttempt)
     Props(standardCacheHitCopyingActor, params).withDispatcher(BackendDispatcher)
   }
 
   def cacheHitCopyingActorParams(jobDescriptor: BackendJobDescriptor,
                                  initializationDataOption: Option[BackendInitializationData],
                                  serviceRegistryActor: ActorRef,
-                                 ioActor: ActorRef): StandardCacheHitCopyingActorParams = {
+                                 ioActor: ActorRef,
+                                 cacheCopyAttempt: Int): StandardCacheHitCopyingActorParams = {
     DefaultStandardCacheHitCopyingActorParams(
-      jobDescriptor, initializationDataOption, serviceRegistryActor, ioActor, configurationDescriptor)
+      jobDescriptor, initializationDataOption, serviceRegistryActor, ioActor, configurationDescriptor, cacheCopyAttempt)
   }
 
   override def workflowFinalizationActorProps(workflowDescriptor: BackendWorkflowDescriptor, ioActor: ActorRef, calls: Set[CommandCallNode],

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -7,7 +7,7 @@ import cats.instances.list._
 import cats.instances.set._
 import cats.instances.tuple._
 import cats.syntax.foldable._
-import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
+import cromwell.backend.BackendCacheHitCopyingActor.{CopyOutputsCommand, CopyingOutputsFailedResponse}
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend.io.JobPaths
@@ -36,6 +36,11 @@ trait StandardCacheHitCopyingActorParams {
   def ioActor: ActorRef
 
   def configurationDescriptor: BackendConfigurationDescriptor
+
+  /**
+    * The number of this copy attempt (so that listeners can ignore "timeout"s from previous attempts)
+    */
+  def cacheCopyAttempt: Int
 }
 
 /** A default implementation of the cache hit copying params. */
@@ -45,7 +50,8 @@ case class DefaultStandardCacheHitCopyingActorParams
   override val backendInitializationDataOption: Option[BackendInitializationData],
   override val serviceRegistryActor: ActorRef,
   override val ioActor: ActorRef,
-  override val configurationDescriptor: BackendConfigurationDescriptor
+  override val configurationDescriptor: BackendConfigurationDescriptor,
+  override val cacheCopyAttempt: Int
 ) extends StandardCacheHitCopyingActorParams
 
 object StandardCacheHitCopyingActor {
@@ -178,12 +184,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
           stay() using Option(newData)
       }
     case Event(IoFailure(command: IoCommand[_], failure), Some(data)) =>
-      // We can get extra I/O timeout messages from previous cache copy attempt. This is due to the fact that if one file fails to copy,
-      // we immediately cache miss and try the next potential hit, but don't cancel previous copy requests.
-      // (any other failure is fatal)
-      if (!failure.isInstanceOf[TimeoutException]) {
-        context.parent ! JobFailedNonRetryableResponse(jobDescriptor.key, failure, None)
-      }
+      context.parent ! CopyingOutputsFailedResponse(jobDescriptor.key, standardParams.cacheCopyAttempt, failure)
 
       val (newData, commandState) = data.commandComplete(command)
 
@@ -230,7 +231,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   }
 
   def failAndStop(failure: Throwable) = {
-    context.parent ! JobFailedNonRetryableResponse(jobDescriptor.key, failure, None)
+    context.parent ! CopyingOutputsFailedResponse(jobDescriptor.key, standardParams.cacheCopyAttempt, failure)
     context stop self
     stay()
   }

--- a/build.sbt
+++ b/build.sbt
@@ -333,6 +333,7 @@ lazy val server = project
   .dependsOn(wdlBiscayneLanguageFactory)
   .dependsOn(cwlV1_0LanguageFactory)
   .dependsOn(engine % "test->test")
+  .dependsOn(common % "test->test")
 
 lazy val root = (project in file("."))
   .withRootSettings()

--- a/common/src/test/scala/common/assertion/CaseClassAssertions.scala
+++ b/common/src/test/scala/common/assertion/CaseClassAssertions.scala
@@ -1,0 +1,14 @@
+package common.assertion
+
+import org.scalatest.Matchers
+
+object CaseClassAssertions extends Matchers {
+  implicit class ComparableCaseClass[A <: Product](actualA: A) {
+    // Assumes that expectedA and actualA are the same type. If we don't subtype case classes, that should hold...
+    def shouldEqualFieldwise(expectedA: A): Unit = {
+      (0 until actualA.productArity) foreach { i =>
+        actualA.productElement(i) should be(expectedA.productElement(i))
+      }
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -1,7 +1,5 @@
 package cromwell.engine.workflow.lifecycle.execution.job
 
-import java.util.concurrent.TimeoutException
-
 import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor.{ActorInitializationException, ActorRef, LoggingFSM, OneForOneStrategy, Props}
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -406,10 +406,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       }
     case Event(EngineLifecycleActorAbortCommand, _) =>
       forwardAndStop(JobAbortedResponse(jobDescriptorKey))
-    // We can get extra I/O timeout messages from previous cache copy attempt. This is due to the fact that if one file fails to copy,
-    // we immediately cache miss and try the next potential hit, but don't cancel previous copy requests.
-    case Event(JobFailedNonRetryableResponse(_, _: TimeoutException, _), _) =>
-      stay()
     case Event(msg, _) =>
       log.error("Bad message from {} to EngineJobExecutionActor in state {}(with data {}): {}", sender, stateName, stateData, msg)
       stay

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -2,7 +2,7 @@ package cromwell.engine.workflow.lifecycle.execution.job
 
 import akka.actor.SupervisorStrategy.{Escalate, Stop}
 import akka.actor.{ActorInitializationException, ActorRef, LoggingFSM, OneForOneStrategy, Props}
-import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
+import cromwell.backend.BackendCacheHitCopyingActor.{CopyOutputsCommand, CopyingOutputsFailedResponse}
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend._
@@ -206,18 +206,21 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   }
 
   when(FetchingCachedOutputsFromDatabase) {
-    case Event(CachedOutputLookupSucceeded(womValueSimpletons, jobDetritus, returnCode, cacheResultId, cacheHitDetails), data: ResponsePendingData) =>
-      writeToMetadata(Map(
-        callCachingHitResultMetadataKey -> true,
-        callCachingReadResultMetadataKey -> s"Cache Hit: $cacheHitDetails"))
-      log.debug("Cache hit for {}! Fetching cached result {}", jobTag, cacheResultId)
-      makeBackendCopyCacheHit(womValueSimpletons, jobDetritus, returnCode, data, cacheResultId) using data.withCacheDetails(cacheHitDetails)
+    case Event(CachedOutputLookupSucceeded(womValueSimpletons, jobDetritus, returnCode, cacheResultId, cacheHitDetails), data @ ResponsePendingData(_, _, _, _, Some(ejeaCacheHit), _)) =>
+      if (cacheResultId != ejeaCacheHit.hit.cacheResultId) {
+        // Sanity check: was this the right set of results (a false here is a BAD thing!):
+        log.error(s"Received incorrect call cache results from FetchCachedResultsActor. Expected ${ejeaCacheHit.hit} but got $cacheResultId. Running job")
+        // Treat this like the "CachedOutputLookupFailed" event:
+        runJob(data)
+      } else {
+        writeToMetadata(Map(
+          callCachingHitResultMetadataKey -> true,
+          callCachingReadResultMetadataKey -> s"Cache Hit: $cacheHitDetails"))
+        log.debug("Cache hit for {}! Fetching cached result {}", jobTag, cacheResultId)
+        makeBackendCopyCacheHit(womValueSimpletons, jobDetritus, returnCode, data, cacheResultId, ejeaCacheHit.hitNumber) using data.withCacheDetails(cacheHitDetails)
+      }
     case Event(CachedOutputLookupFailed(_, error), data: ResponsePendingData) =>
-      log.warning("Can't make a copy of the cached job outputs for {} due to {}. Running job.", jobTag, error)
-      runJob(data)
-    case Event(JobFailedNonRetryableResponse(_, error, _), data: ResponsePendingData) =>
-      // Similar to CachedOutputLookupFailed, some BackendCacheHitCopyingActors send this message when a copy fails:
-      log.warning("Can't make a copy of the cached job outputs for {} due to {}. Running job.", jobTag, error)
+      log.warning("Can't fetch a list of cached outputs to copy for {} due to {}. Running job.", jobTag, error)
       runJob(data)
     case Event(hashes: CallCacheHashes, data: ResponsePendingData) =>
       addHashesAndStay(data, hashes)
@@ -236,11 +239,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       stay using data.withSuccessResponse(response)
     case Event(response: JobSucceededResponse, data: ResponsePendingData) => // bad hashes or cache write off
       saveJobCompletionToJobStore(data.withSuccessResponse(response))
-    case Event(response: BackendJobExecutionResponse, data @ ResponsePendingData(_, _, _, _, Some(cacheHit), _)) =>
-      response match {
-        case f: BackendJobFailedResponse => invalidateCacheHitAndTransition(cacheHit, data, f.throwable)
-        case _ => runJob(data)
-      }
+    case Event(CopyingOutputsFailedResponse(_, cacheCopyAttempt, throwable), data @ ResponsePendingData(_, _, _, _, Some(cacheHit), _)) if cacheCopyAttempt == cacheHit.hitNumber =>
+      invalidateCacheHitAndTransition(cacheHit, data, throwable)
 
     // Hashes arrive:
     case Event(hashes: CallCacheHashes, data: SucceededResponseData) =>
@@ -404,6 +404,11 @@ class EngineJobExecutionActor(replyTo: ActorRef,
       }
     case Event(EngineLifecycleActorAbortCommand, _) =>
       forwardAndStop(JobAbortedResponse(jobDescriptorKey))
+    case Event(_: CopyingOutputsFailedResponse, _) =>
+      // Normally these are caught in when(BackendIsCopyingCachedOutputs) { ... }
+      // But sometimes, we get failed responses long after we've moved on from a particular cache hit (usually
+      // due to timeouts). That's ok, we just ignore this message in any other situation:
+      stay()
     case Event(msg, _) =>
       log.error("Bad message from {} to EngineJobExecutionActor in state {}(with data {}): {}", sender, stateName, stateData, msg)
       stay
@@ -556,10 +561,15 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     goto(FetchingCachedOutputsFromDatabase) using data
   }
 
-  private def makeBackendCopyCacheHit(womValueSimpletons: Seq[WomValueSimpleton], jobDetritusFiles: Map[String,String], returnCode: Option[Int], data: ResponsePendingData, cacheResultId: CallCachingEntryId) = {
+  private def makeBackendCopyCacheHit(womValueSimpletons: Seq[WomValueSimpleton],
+                                      jobDetritusFiles: Map[String,String],
+                                      returnCode: Option[Int],
+                                      data: ResponsePendingData,
+                                      cacheResultId: CallCachingEntryId,
+                                      cacheCopyAttempt: Int) = {
     factory.cacheHitCopyingActorProps match {
       case Some(propsMaker) =>
-        val backendCacheHitCopyingActorProps = propsMaker(data.jobDescriptor, initializationData, serviceRegistryActor, ioActor)
+        val backendCacheHitCopyingActorProps = propsMaker(data.jobDescriptor, initializationData, serviceRegistryActor, ioActor, cacheCopyAttempt)
         val cacheHitCopyActor = context.actorOf(backendCacheHitCopyingActorProps, buildCacheHitCopyingActorName(data.jobDescriptor, cacheResultId))
         cacheHitCopyActor ! CopyOutputsCommand(womValueSimpletons, jobDetritusFiles, returnCode)
         replyTo ! JobRunning(data.jobDescriptor.key, data.jobDescriptor.evaluatedTaskInputs)

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
@@ -1,17 +1,18 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
 import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
-import cromwell.backend.BackendJobExecutionActor.JobFailedNonRetryableResponse
 import cromwell.core.WorkflowId
 import cromwell.core.callcaching.{CallCachingActivity, ReadAndWriteCache}
 import cromwell.core.simpleton.WomValueSimpleton
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
-import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.HashError
+import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, HashError}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
 import wom.values.WomString
+
+import common.assertion.CaseClassAssertions._
 
 import scala.util.{Failure, Success}
 
@@ -30,59 +31,70 @@ class EjeaFetchingCachedOutputsFromDatabaseSpec extends EngineJobExecutionActorS
       s"Correctly receive $name then begin the backend-specific output copying actor when it gets a result-fetch success" in {
         ejea = ejeaInFetchingCachedOutputsFromDatabaseState()
         // Send the response from the EJHA (if there was one!):
-        ejhaResponse foreach { ejea ! _ }
+        ejhaResponse foreach {
+          ejea ! _
+        }
 
         // Send the response from the "Fetch" actor
         val cachedSimpletons = Seq(WomValueSimpleton("a", WomString("hullo")), WomValueSimpleton("b", WomString("cheerio")))
         val detritusMap = Map("stdout" -> "//somePath")
         val cachedReturnCode = Some(17)
-        val sourceCacheDetails = s"${WorkflowId.randomId}:call-someTask:1"
-        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, CallCachingEntryId(75), sourceCacheDetails)
+        val sourceCacheDetails = s"${WorkflowId.randomId()}:call-someTask:1"
+        ejea ! CachedOutputLookupSucceeded(cachedSimpletons, detritusMap, cachedReturnCode, callCachingEntryId, sourceCacheDetails)
         helper.callCacheHitCopyingProbe.expectMsg(CopyOutputsCommand(cachedSimpletons, detritusMap, cachedReturnCode))
 
         // Check we end up in the right state:
         ejea.stateName should be(BackendIsCopyingCachedOutputs)
         // Check we end up with the right data:
-        val expectedData = initialData.copy(hashes = ejhaResponse map {
-          case SuccessfulCallCacheHashes => Success(SuccessfulCallCacheHashes)
-          case HashError(t) => Failure(t)
-          case _ => fail(s"Bad test wiring. We didn't expect $ejhaResponse here")
-        })
-        ejea.stateData should be(expectedData)
+        val expectedData = initialData.copy(
+          hashes = ejhaResponse map {
+            case SuccessfulCallCacheHashes => Success(SuccessfulCallCacheHashes)
+            case HashError(t) => Failure(t)
+            case _ => fail(s"Bad test wiring. We didn't expect $ejhaResponse here")
+          },
+          // NB: the "callCachingEntryId" is verified when the EJEA gets the fetch result (and so not changed).
+          // Similarly, hit number is not incremented by the FetchingCachedOutputs state (because it was already done):
+          // But, we should check that the details are correctly updated:
+          ejeaCacheHit = initialData.ejeaCacheHit.map(oldHit => oldHit.copy(details = Some(sourceCacheDetails)))
+        )
+
+        ejea.stateData.asInstanceOf[ResponsePendingData] shouldEqualFieldwise expectedData
       }
 
       RestartOrExecuteCommandTuples foreach { case RestartOrExecuteCommandTuple(operationName, restarting, expectedMessage) =>
         // Send the response from the "Fetch" actor
         val failureReason = new Exception("You can't handle the truth!")
-        List(CachedOutputLookupFailed(CallCachingEntryId(90210), failureReason), JobFailedNonRetryableResponse(null, failureReason, None)) foreach { msg =>
-          s"Correctly receive $name then $operationName the job when it gets a ${msg.getClass.getSimpleName} result-fetch failure" in {
-            ejea = ejeaInFetchingCachedOutputsFromDatabaseState(restarting)
-            // Send the response from the EJHA (if there was one!):
-            ejhaResponse foreach {
-              ejea ! _
-            }
+        val lookupFailedMsg = CachedOutputLookupFailed(CallCachingEntryId(90210), failureReason)
 
-            ejea ! msg
+        s"Correctly receive $name then $operationName the job when it gets a ${lookupFailedMsg.getClass.getSimpleName} result-fetch failure" in {
+          ejea = ejeaInFetchingCachedOutputsFromDatabaseState(restarting)
+          // Send the response from the EJHA (if there was one!):
+          ejhaResponse foreach {
+            ejea ! _
+          }
 
-            helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
+          ejea ! lookupFailedMsg
 
-            // Check we end up in the right state:
-            ejea.stateName should be(RunningJob)
-            // Check we end up with the right data:
-            val expectedData = initialData.copy(hashes = ejhaResponse map {
+          helper.bjeaProbe.expectMsg(awaitTimeout, expectedMessage)
+
+          // Check we end up in the right state:
+          ejea.stateName should be(RunningJob)
+          // Check we end up with the right data:
+          val expectedData = initialData.copy(
+            hashes = ejhaResponse map {
               case SuccessfulCallCacheHashes => Success(SuccessfulCallCacheHashes)
               case HashError(t) => Failure(t)
               case _ => fail(s"Bad test wiring. We didn't expect $ejhaResponse here")
             },
-              backendJobActor = Option(helper.bjeaProbe.ref)
-            )
-            ejea.stateData should be(expectedData)
-          }
+            backendJobActor = Option(helper.bjeaProbe.ref)
+          )
+          ejea.stateData should be(expectedData)
         }
       }
     }
   }
 
-  def initialData = ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None)
+  val callCachingEntryId = CallCachingEntryId(75)
+  def initialData = ResponsePendingData(helper.backendJobDescriptor, helper.bjeaProps, None, None, Some(EJEACacheHit(CacheHit(callCachingEntryId), 2, None)), None)
   def ejeaInFetchingCachedOutputsFromDatabaseState(restarting: Boolean = false) = helper.buildEJEA(restarting = restarting, callCachingMode = CallCachingActivity(ReadAndWriteCache)).setStateInline(data = initialData)
 }

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.workflow.lifecycle.execution.ejea
 
+import cromwell.backend.BackendCacheHitCopyingActor.CopyingOutputsFailedResponse
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.callcaching._
@@ -106,9 +107,15 @@ private[ejea] object HasJobSuccessResponse {
 
 private[ejea] trait HasJobFailureResponses { self: EngineJobExecutionActorSpec =>
   val failedRc = Option(12)
-  val failureReason = new Exception("The sixth sheik's sheep is sick!")
+  val failureReason = new Exception("Deliberate failure for test case: job run failed!")
   // Need to delay making the response because job descriptors come from the per-test "helper", which is null outside tests!
   def failureRetryableResponse = JobFailedRetryableResponse(helper.jobDescriptorKey, failureReason, failedRc)
   def failureNonRetryableResponse = JobFailedNonRetryableResponse(helper.jobDescriptorKey, failureReason, Option(12))
   def abortedResponse = JobAbortedResponse(helper.jobDescriptorKey)
+}
+
+private[ejea] trait HasCopyFailureResponses { self: EngineJobExecutionActorSpec =>
+  val copyFailureReason = new Exception("Deliberate failure for test case: failed to copy cache outputs!")
+  // Need to delay making the response because job descriptors come from the per-test "helper", which is null outside tests!
+  def failedToCopyResponse(attemptNumber: Int) = CopyingOutputsFailedResponse(helper.jobDescriptorKey, attemptNumber, copyFailureReason)
 }

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -84,7 +84,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
                                         ioActor: ActorRef,
                                         backendSingletonActor: Option[ActorRef]): Props = bjeaProps
 
-    override def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef) => Props] = Option((_, _, _, _) => callCacheHitCopyingProbe.props)
+    override def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int) => Props] = Option((_, _, _, _, _) => callCacheHitCopyingProbe.props)
 
     override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                              jobKey: BackendJobDescriptorKey,


### PR DESCRIPTION
Part II of the "unexpected `JobFailedNonRetryable` during cache output copying" saga.

- Stop using the confusing `JobFailedNonRetryable` response when an output copy fails (it's not like `JobSucceeded` which correctly tells us that the job has already succeeded)
- Update the tests to reflect this
- Add some sanity checks to the EJEA's handlers (specifically - did we copy the right outputs, and did we fetch the right outputs from the database)