### PR TITLE
Use prefix hints to filter cache hits, not just base aggregation hashes.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_hit_papi.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_hit_papi.inputs
@@ -1,0 +1,1 @@
+{ "call_cache_hit_prefixes.yo.salutation": "two roots empty hint hit" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_miss_papi.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_miss_papi.inputs
@@ -1,0 +1,1 @@
+{ "call_cache_hit_prefixes.yo.salutation": "two roots empty hint miss" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
@@ -1,1 +1,0 @@
-{ "call_cache_hit_prefixes.yo.salutation": "two roots empty hint" }

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_local.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_local.test
@@ -7,6 +7,8 @@ backends: [Local, LocalNoDocker]
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
   inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs
+  # Because the SFS backend currently does not override the callCacheRootPrefix method, an empty set of prefixes
+  # in workflow options means that no call cache hits will match.
   options: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.options
 }
 

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
@@ -1,7 +1,5 @@
 # A list of call cache hint prefixes is explicitly specified but empty.
 name: call_cache_hit_prefixes_empty_hint_papi
-# Because the SFS backend currently does not override the callCacheRootPrefix method, an empty set of prefixes
-# in workflow options means that no call cache hits will match.
 testFormat: runtwiceexpectingcallcaching
 backends: [Papi]
 

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
@@ -1,0 +1,20 @@
+# In all runs a list of call cache hint prefixes is explicitly specified but empty.
+# The first run has a different "jes_gcs_root" than the second or third so the second and third
+# should not see the first's cache entries.
+name: call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi
+testFormat: runthriceexpectingcallcaching
+backends: [Papi]
+
+files {
+  workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_hit_papi.inputs
+  options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_first.options
+  second-options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
+  third-options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
+}
+
+metadata {
+  workflowName: call_cache_hit_prefixes
+  status: Succeeded
+  "outputs.call_cache_hit_prefixes.sup": "sup two roots empty hint hit?"
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi.test
@@ -1,12 +1,12 @@
 # In both runs a list of call cache hint prefixes is explicitly specified but empty.
 # Each run has different "jes_gcs_root"s so they should not see each other's cache entries.
-name: call_cache_hit_prefixes_two_roots_empty_hint_papi
+name: call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi
 testFormat: runtwiceexpectingnocallcaching
 backends: [Papi]
 
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
-  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi.inputs
+  inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_miss_papi.inputs
   options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_first.options
   second-options: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_papi_second.options
 }
@@ -14,5 +14,5 @@ files {
 metadata {
   workflowName: call_cache_hit_prefixes
   status: Succeeded
-  "outputs.call_cache_hit_prefixes.sup": "sup two roots empty hint?"
+  "outputs.call_cache_hit_prefixes.sup": "sup two roots empty hint miss?"
 }

--- a/centaur/src/main/scala/centaur/test/standard/CentaurTestCase.scala
+++ b/centaur/src/main/scala/centaur/test/standard/CentaurTestCase.scala
@@ -22,6 +22,7 @@ case class CentaurTestCase(workflow: Workflow,
     case WorkflowSuccessTest => TestFormulas.runSuccessfulWorkflowAndVerifyMetadata(workflow)
     case WorkflowFailureTest => TestFormulas.runFailingWorkflowAndVerifyMetadata(workflow)
     case RunTwiceExpectingCallCachingTest => TestFormulas.runWorkflowTwiceExpectingCaching(workflow)
+    case RunThriceExpectingCallCachingTest => TestFormulas.runWorkflowThriceExpectingCaching(workflow)
     case RunTwiceExpectingNoCallCachingTest => TestFormulas.runWorkflowTwiceExpectingNoCaching(workflow)
     case RunFailingTwiceExpectingNoCallCachingTest => TestFormulas.runFailingWorkflowTwiceExpectingNoCaching(workflow)
     case SubmitFailureTest => TestFormulas.submitInvalidWorkflow(workflow, submitResponseOption.get)

--- a/centaur/src/main/scala/centaur/test/standard/CentaurTestFormat.scala
+++ b/centaur/src/main/scala/centaur/test/standard/CentaurTestFormat.scala
@@ -14,6 +14,7 @@ sealed abstract class CentaurTestFormat(val name: String) {
     case WorkflowSuccessTest => "successfully run"
     case WorkflowFailureTest => "fail during execution"
     case RunTwiceExpectingCallCachingTest => "call cache the second run of"
+    case RunThriceExpectingCallCachingTest => "call cache the third run of"
     case RunTwiceExpectingNoCallCachingTest => "NOT call cache the second run of"
     case RunFailingTwiceExpectingNoCallCachingTest => "Fail the first run and NOT call cache the second run of"
     case SubmitFailureTest => "fail to submit"
@@ -37,6 +38,7 @@ object CentaurTestFormat {
   case object WorkflowSuccessTest extends CentaurTestFormat("WorkflowSuccess")
   case object WorkflowFailureTest extends CentaurTestFormat("WorkflowFailure")
   case object RunTwiceExpectingCallCachingTest extends CentaurTestFormat("RunTwiceExpectingCallCaching")
+  case object RunThriceExpectingCallCachingTest extends CentaurTestFormat(name = "RunThriceExpectingCallCaching")
   case object RunTwiceExpectingNoCallCachingTest extends CentaurTestFormat("RunTwiceExpectingNoCallCaching")
   case object RunFailingTwiceExpectingNoCallCachingTest extends CentaurTestFormat("RunFailingTwiceExpectingNoCallCaching")
   case object SubmitFailureTest extends CentaurTestFormat("SubmitFailure")
@@ -92,6 +94,7 @@ object CentaurTestFormat {
       WorkflowSuccessTest,
       WorkflowFailureTest,
       RunTwiceExpectingCallCachingTest,
+      RunThriceExpectingCallCachingTest,
       RunTwiceExpectingNoCallCachingTest,
       RunFailingTwiceExpectingNoCallCachingTest,
       CromwellRestartWithRecover,

--- a/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
@@ -36,6 +36,10 @@ final case class Workflow private(testName: String,
   def secondRun: Workflow = {
     copy(data = data.copy(options = data.secondOptions))
   }
+
+  def thirdRun: Workflow = {
+    copy(data = data.copy(options = data.thirdOptions))
+  }
 }
 
 object Workflow {

--- a/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
@@ -26,7 +26,8 @@ case class WorkflowData(workflowContent: Option[String],
                         options: Option[() => String],
                         labels: List[Label],
                         zippedImports: Option[File],
-                        secondOptions: Option[() => String] = None)
+                        secondOptions: Option[() => String] = None,
+                        thirdOptions: Option[() => String] = None)
 
 object WorkflowData {
   def fromConfig(filesConfig: Config, fullConfig: Config, basePath: File): ErrorOr[WorkflowData] = {
@@ -105,6 +106,7 @@ object WorkflowData {
       inputs = getOptionalFile("inputs") map (file => () => file.contentAsString),
       options = getOptionalFile("options") map (file => () => file.contentAsString),
       secondOptions = getOptionalFile(name = "second-options").orElse(getOptionalFile("options")) map (file => () => file.contentAsString),
+      thirdOptions = getOptionalFile(name = "third-options").orElse(getOptionalFile("options")) map (file => () => file.contentAsString),
       labels = getLabels,
       zippedImports = getImports
     )

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -58,19 +58,23 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
+  case class PrefixAndLength(prefix: String, length: Int)
+
+  private def prefixesAndLengths(prefixes: List[String]): List[PrefixAndLength] = {
+    val doNotMatch = PrefixAndLength("", 1)
+    // `total` is ps.apply as a total function which returns an Option[String] instead of a String.
+    // `total` returns `None` if there is no element at the specified index.
+    val total = prefixes.lift
+    // Take the first three prefixes that have been supplied or fallback values that will intentionally fail to match anything.
+    (0 to 2).toList map { total(_) map { p => PrefixAndLength(p, p.length) } getOrElse doNotMatch }
+  }
+
   override def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCachePrefixes: Option[List[String]] = None)
                                                               (implicit ec: ExecutionContext): Future[Boolean] = {
     val action = callCachePrefixes match {
       case None => dataAccess.existsCallCachingEntriesForBaseAggregationHash(baseAggregationHash).result
       case Some(ps) =>
-        case class PrefixAndLength(prefix: String, length: Int)
-        // Trying to match a prefix of length 1 with an empty string is (intentionally) doomed to fail.
-        val doNotMatch = PrefixAndLength("", 1)
-        // `total` is ps.apply as a total function which returns an Option[String] instead of a String.
-        // `total` returns `None` if there is no element at the specified index.
-        val total = ps.lift
-        // Take the first three prefixes that have been supplied or fallback values that will intentionally fail to match anything.
-        val one :: two :: three :: _ = (0 to 2).toList map { total(_) map { p => PrefixAndLength(p, p.length) } getOrElse doNotMatch }
+        val one :: two :: three :: _ = prefixesAndLengths(ps)
         dataAccess.existsCallCachingEntriesForBaseAggregationHashWithCallCachePrefix(
           (baseAggregationHash,
             one.prefix, one.length,
@@ -80,9 +84,21 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
-  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], hitNumber: Int)
+  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], hitNumber: Int)
                                          (implicit ec: ExecutionContext): Future[Option[Int]] = {
-    val action = dataAccess.callCachingEntriesForAggregatedHashes(baseAggregationHash, inputFilesAggregationHash, hitNumber).result.headOption
+
+    val action = callCachePathPrefixes match {
+      case None =>
+        dataAccess.callCachingEntriesForAggregatedHashes(baseAggregationHash, inputFilesAggregationHash, hitNumber).result.headOption
+      case Some(ps) =>
+        val one :: two :: three :: _ = prefixesAndLengths(ps)
+        dataAccess.callCachingEntriesForAggregatedHashesWithPrefixes(
+          baseAggregationHash, inputFilesAggregationHash,
+          one.prefix, one.length,
+          two.prefix, two.length,
+          three.prefix, three.length,
+          hitNumber).result.headOption
+    }
 
     runTransaction(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -80,4 +80,29 @@ trait CallCachingAggregationEntryComponent {
         (callCachingAggregationEntry.inputFilesAggregation === inputFilesAggregation)
     } yield callCachingAggregationEntry.callCachingEntryId).drop(number - 1).take(1)
   }
+
+  def callCachingEntriesForAggregatedHashesWithPrefixes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]],
+                                                        prefix1: Rep[String], prefix1Length: Rep[Int],
+                                                        prefix2: Rep[String], prefix2Length: Rep[Int],
+                                                        prefix3: Rep[String], prefix3Length: Rep[Int],
+                                                        number: Int) = {
+    (for {
+      callCachingEntry <- callCachingEntries
+      if callCachingEntry.allowResultReuse
+      callCachingAggregationEntry <- callCachingAggregationEntries
+      if callCachingEntry.callCachingEntryId === callCachingAggregationEntry.callCachingEntryId
+      if callCachingAggregationEntry.baseAggregation === baseAggregation
+      if (callCachingAggregationEntry.inputFilesAggregation.isEmpty && inputFilesAggregation.isEmpty) ||
+        (callCachingAggregationEntry.inputFilesAggregation === inputFilesAggregation)
+      detritus <- callCachingDetritusEntries
+      // Pick only one detritus file since this is not an existence check and we don't want to return one row
+      // for each of the (currently 6) types of standard detritus.
+      if detritus.detritusKey === "returnCode"
+      if detritus.callCachingEntryId === callCachingEntry.callCachingEntryId
+      detritusPath = detritus.detritusValue.map { x => x.asColumnOf[String] }
+      if (detritusPath.substring(0, prefix1Length) === prefix1) ||
+        (detritusPath.substring(0, prefix2Length) === prefix2) ||
+        (detritusPath.substring(0, prefix3Length) === prefix3)
+    } yield callCachingAggregationEntry.callCachingEntryId).drop(number - 1).take(1)
+  }
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -9,13 +9,13 @@ import scala.concurrent.{ExecutionContext, Future}
 trait CallCachingSqlDatabase {
   def addCallCaching(joins: Seq[CallCachingJoin], batchSize: Int)(implicit ec: ExecutionContext): Future[Unit]
 
-  def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCacheRootHints: Option[List[String]])
+  def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCachePathPrefixes: Option[List[String]])
                                                      (implicit ec: ExecutionContext): Future[Boolean]
 
   def hasMatchingCallCachingEntriesForHashKeyValues(hashKeyHashValues: NonEmptyList[(String, String)])
                                                    (implicit ec: ExecutionContext): Future[Boolean]
 
-  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], hitNumber: Int)
+  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], hitNumber: Int)
                                 (implicit ec: ExecutionContext): Future[Option[Int]]
 
   def queryResultsForCacheId(callCachingEntryId: Int)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import cats.data.NonEmptyList
+import common.util.StringUtil._
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.backend.BackendJobExecutionActor.{CallCached, JobFailedNonRetryableResponse, JobSucceededResponse}
 import cromwell.core.ExecutionIndex.{ExecutionIndex, IndexEnhancedIndex}
@@ -84,11 +85,12 @@ class CallCache(database: CallCachingSqlDatabase) {
     database.hasMatchingCallCachingEntriesForHashKeyValues(hashKeyValuePairs)
   }
 
-  def callCachingHitForAggregatedHashes(aggregatedCallHashes: AggregatedCallHashes, hitNumber: Int)
+  def callCachingHitForAggregatedHashes(aggregatedCallHashes: AggregatedCallHashes, prefixesHint: Option[CallCachePathPrefixes], hitNumber: Int)
                                        (implicit ec: ExecutionContext): Future[Option[CallCachingEntryId]] = {
     database.findCacheHitForAggregation(
       baseAggregationHash = aggregatedCallHashes.baseAggregatedHash,
       inputFilesAggregationHash = aggregatedCallHashes.inputFilesAggregatedHash,
+      callCachePathPrefixes = prefixesHint.map(_.prefixes),
       hitNumber).map(_ map CallCachingEntryId.apply)
   }
 
@@ -174,6 +176,6 @@ object CallCache {
 
   sealed trait CacheHitHint
   case class CallCachePathPrefixes(callCacheRootPrefix: Option[String], workflowOptionPrefixes: List[String]) extends CacheHitHint {
-    def prefixes: List[String] = callCacheRootPrefix.toList ++ workflowOptionPrefixes
+    lazy val prefixes: List[String] = (callCacheRootPrefix.toList ++ workflowOptionPrefixes) map { _.ensureSlashed }
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -38,8 +38,8 @@ class CallCacheReadActor(cache: CallCache,
           case true => HasMatchingEntries
           case false => NoMatchingEntries
         }
-      case CacheLookupRequest(aggregatedCallHashes, cacheHitNumber) =>
-        cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, cacheHitNumber) map {
+      case CacheLookupRequest(aggregatedCallHashes, cacheHitNumber, prefixesHint) =>
+        cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, prefixesHint, cacheHitNumber) map {
           case Some(nextHit) => CacheLookupNextHit(nextHit)
           case None => CacheLookupNoHit
         }
@@ -83,7 +83,7 @@ object CallCacheReadActor {
   case class AggregatedCallHashes(baseAggregatedHash: String, inputFilesAggregatedHash: Option[String])
 
   sealed trait CallCacheReadActorRequest
-  final case class CacheLookupRequest(aggregatedCallHashes: AggregatedCallHashes, cacheHitNumber: Int) extends CallCacheReadActorRequest
+  final case class CacheLookupRequest(aggregatedCallHashes: AggregatedCallHashes, cacheHitNumber: Int, prefixesHint: Option[CallCachePathPrefixes]) extends CallCacheReadActorRequest
   final case class HasMatchingInitialHashLookup(aggregatedTaskHash: String, cacheHitHints: List[CacheHitHint] = List.empty) extends CallCacheReadActorRequest
   final case class HasMatchingInputFilesHashLookup(fileHashes: NonEmptyList[HashResult]) extends CallCacheReadActorRequest
   final case class CallCacheEntryForCall(workflowId: WorkflowId, jobKey: BackendJobDescriptorKey) extends CallCacheReadActorRequest

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActor.scala
@@ -7,6 +7,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadAct
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, HashError}
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCachePathPrefixes
 
 /**
   * Receives hashes from the CallCacheHashingJobActor and makes requests to the database to determine whether or not there might be a hit
@@ -22,7 +23,7 @@ import cromwell.core.Dispatcher.EngineDispatcher
   * Sends the response to its parent.
   * In case of a CacheHit, stays alive in case using the hit fails and it needs to fetch the next one. Otherwise just dies.
   */
-class CallCacheReadingJobActor(callCacheReadActor: ActorRef) extends LoggingFSM[CallCacheReadingJobActorState, CCRJAData] {
+class CallCacheReadingJobActor(callCacheReadActor: ActorRef, prefixesHint: Option[CallCachePathPrefixes]) extends LoggingFSM[CallCacheReadingJobActorState, CCRJAData] {
   
   startWith(WaitingForInitialHash, CCRJANoData)
   
@@ -45,10 +46,10 @@ class CallCacheReadingJobActor(callCacheReadActor: ActorRef) extends LoggingFSM[
       callCacheReadActor ! HasMatchingInputFilesHashLookup(hashes)
       goto(WaitingForHashCheck)
     case Event(CompleteFileHashingResult(_, aggregatedFileHash), data: CCRJAWithData) =>
-      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(data.initialHash, aggregatedFileHash), data.currentHitNumber)
+      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(data.initialHash, aggregatedFileHash), data.currentHitNumber, prefixesHint)
       goto(WaitingForCacheHitOrMiss) using data.withFileHash(aggregatedFileHash)
     case Event(NoFileHashesResult, data: CCRJAWithData) =>
-      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(data.initialHash, None), data.currentHitNumber)
+      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(data.initialHash, None), data.currentHitNumber, prefixesHint)
       goto(WaitingForCacheHitOrMiss)
   }
   
@@ -59,7 +60,7 @@ class CallCacheReadingJobActor(callCacheReadActor: ActorRef) extends LoggingFSM[
     case Event(CacheLookupNoHit, _) =>
       cacheMiss
     case Event(NextHit, CCRJAWithData(_, aggregatedInitialHash, aggregatedFileHash, currentHitNumber)) =>
-      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, aggregatedFileHash), currentHitNumber)
+      callCacheReadActor ! CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, aggregatedFileHash), currentHitNumber, prefixesHint)
       stay()
   }
   
@@ -81,8 +82,8 @@ class CallCacheReadingJobActor(callCacheReadActor: ActorRef) extends LoggingFSM[
 
 object CallCacheReadingJobActor {
   
-  def props(callCacheReadActor: ActorRef) = {
-    Props(new CallCacheReadingJobActor(callCacheReadActor)).withDispatcher(EngineDispatcher)
+  def props(callCacheReadActor: ActorRef, prefixesHint: Option[CallCachePathPrefixes]) = {
+    Props(new CallCacheReadingJobActor(callCacheReadActor, prefixesHint)).withDispatcher(EngineDispatcher)
   }
   
   sealed trait CallCacheReadingJobActorState

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -7,6 +7,7 @@ import cromwell.core.WorkflowId
 import cromwell.core.callcaching._
 import cromwell.core.logging.JobLogging
 import cromwell.engine.workflow.lifecycle.execution.CallMetadataHelper
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCachePathPrefixes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheHashingJobActor.{CompleteFileHashingResult, FinalFileHashingResult, InitialHashingResult, NoFileHashesResult}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.NextHit
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor._
@@ -27,7 +28,8 @@ class EngineJobHashingActor(receiver: ActorRef,
                             runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition],
                             backendName: String,
                             activity: CallCachingActivity,
-                            callCachingEligible: CallCachingEligible) extends Actor with ActorLogging with JobLogging with CallMetadataHelper {
+                            callCachingEligible: CallCachingEligible,
+                            callCachePathPrefixes: Option[CallCachePathPrefixes]) extends Actor with ActorLogging with JobLogging with CallMetadataHelper {
 
   override val jobTag = jobDescriptor.key.tag
   override val workflowId = jobDescriptor.workflowDescriptor.id
@@ -48,7 +50,8 @@ class EngineJobHashingActor(receiver: ActorRef,
       backendName,
       fileHashingActorProps,
       callCachingEligible,
-      activity
+      activity,
+      callCachePathPrefixes
     ), s"CCHashingJobActor-${workflowId.shortString}-$jobTag")
     super.preStart()
   }
@@ -130,7 +133,8 @@ object EngineJobHashingActor {
             runtimeAttributeDefinitions: Set[RuntimeAttributeDefinition],
             backendName: String,
             activity: CallCachingActivity,
-            callCachingEligible: CallCachingEligible): Props = Props(new EngineJobHashingActor(
+            callCachingEligible: CallCachingEligible,
+            callCachePathPrefixes: Option[CallCachePathPrefixes]): Props = Props(new EngineJobHashingActor(
     receiver = receiver,
     serviceRegistryActor = serviceRegistryActor,
     jobDescriptor = jobDescriptor,
@@ -140,5 +144,6 @@ object EngineJobHashingActor {
     runtimeAttributeDefinitions = runtimeAttributeDefinitions,
     backendName = backendName,
     activity = activity,
-    callCachingEligible = callCachingEligible)).withDispatcher(EngineDispatcher)
+    callCachingEligible = callCachingEligible,
+    callCachePathPrefixes = callCachePathPrefixes)).withDispatcher(EngineDispatcher)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -8,6 +8,7 @@ import cromwell.backend.BackendCacheHitCopyingActor.CopyOutputsCommand
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend._
+import cromwell.backend.standard.StandardInitializationData
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.ExecutionIndex.IndexEnhancedIndex
 import cromwell.core._
@@ -98,6 +99,13 @@ class EngineJobExecutionActor(replyTo: ActorRef,
   private val callCachingAllowReuseMetadataKey = CallCachingKeys.AllowReuseMetadataKey
   private val callCachingHitFailures = CallCachingKeys.HitFailuresKey
   private val callCachingHashes = CallCachingKeys.HashesKey
+
+  val callCachePathPrefixes = for {
+    activity <- Option(effectiveCallCachingMode) collect { case a: CallCachingActivity => a }
+    workflowOptionPrefixes <- activity.options.workflowOptionCallCachePrefixes
+    d <- initializationData collect { case d: StandardInitializationData => d }
+    rootPrefix = d.workflowPaths.callCacheRootPrefix
+  } yield CallCachePathPrefixes(rootPrefix, workflowOptionPrefixes.toList)
 
   implicit val ec: ExecutionContext = context.dispatcher
 
@@ -543,11 +551,12 @@ class EngineJobExecutionActor(replyTo: ActorRef,
           jobDescriptor,
           initializationData,
           fileHashingActorProps,
-          CallCacheReadingJobActor.props(callCacheReadActor),
+          CallCacheReadingJobActor.props(callCacheReadActor, callCachePathPrefixes),
           factory.runtimeAttributeDefinitions(initializationData),
           backendName,
           activity,
-          callCachingEligible
+          callCachingEligible,
+          callCachePathPrefixes
         )
         val ejha = context.actorOf(props, s"ejha_for_$jobDescriptor")
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
@@ -46,7 +46,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       "backedName",
       Props.empty,
       DockerWithHash("ubuntu@sha256:blablablba"),
-      CallCachingActivity(readWriteMode = ReadCache)
+      CallCachingActivity(readWriteMode = ReadCache),
+      callCachePathPrefixes = None
     ), parent.ref)
     watch(testActor)
     expectTerminated(testActor)
@@ -80,7 +81,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       "backedName",
       Props.empty,
       DockerWithHash("ubuntu@sha256:blablablba"),
-      CallCachingActivity(readWriteMode = ReadAndWriteCache)
+      CallCachingActivity(readWriteMode = ReadAndWriteCache),
+      callCachePathPrefixes = None
     ), parent.ref)
     
     val expectedInitialHashes = Set(
@@ -126,7 +128,8 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
       "backend",
       Props.empty,
       DockerWithHash("ubuntu@256:blablabla"),
-      CallCachingActivity(readWriteMode = if (writeToCache) ReadAndWriteCache else ReadCache)
+      CallCachingActivity(readWriteMode = if (writeToCache) ReadAndWriteCache else ReadCache),
+      callCachePathPrefixes = None
     ) {
       override def makeFileHashingActor() = testFileHashingActor
       override def addFileHash(hashResult: HashResult, data: CallCacheHashingJobActorData) = {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
@@ -17,7 +17,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
   it should "try to match initial hashes against DB" in {
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref))
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None))
     actorUnderTest.stateName shouldBe WaitingForInitialHash
 
     // The actual hashes don't matter here, we only care about the aggregated hash
@@ -33,7 +33,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
   it should "ask for file hashes if it found matching entries for initial aggregated hash" in {
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref))
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None))
     actorUnderTest.setState(WaitingForHashCheck, CCRJAWithData(callCacheHashingActor.ref, "AggregatedInitialHash", None, 1))
 
     callCacheReadProbe.send(actorUnderTest, HasMatchingEntries)
@@ -48,7 +48,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheHashingActor = TestProbe()
     val parent = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), parent.ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), parent.ref)
     parent.watch(actorUnderTest)
     
     actorUnderTest.setState(WaitingForHashCheck, CCRJAWithData(callCacheHashingActor.ref, "AggregatedInitialHash", None, 1))
@@ -62,7 +62,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), TestProbe().ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
 
     actorUnderTest.setState(WaitingForFileHashes)
 
@@ -79,7 +79,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), TestProbe().ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
     val aggregatedFileHash: String = "AggregatedFileHash"
@@ -87,7 +87,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
 
     val fileHashes = Set(HashResult(HashKey("f1"), HashValue("h1")), HashResult(HashKey("f2"), HashValue("h2")))
     callCacheHashingActor.send(actorUnderTest, CompleteFileHashingResult(fileHashes, aggregatedFileHash))
-    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, aggregatedFileHash), 1))
+    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, aggregatedFileHash), 1, prefixesHint = None))
 
     eventually {
       actorUnderTest.stateName shouldBe WaitingForCacheHitOrMiss
@@ -99,13 +99,13 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), TestProbe().ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
     actorUnderTest.setState(WaitingForFileHashes, CCRJAWithData(callCacheHashingActor.ref, aggregatedInitialHash, None, 1))
 
     callCacheHashingActor.send(actorUnderTest, NoFileHashesResult)
-    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, None), 1))
+    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, None), 1, prefixesHint = None))
 
     eventually {
       actorUnderTest.stateName shouldBe WaitingForCacheHitOrMiss
@@ -118,7 +118,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheHashingActor = TestProbe()
     val parent = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), parent.ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), parent.ref)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
     actorUnderTest.setState(WaitingForCacheHitOrMiss, CCRJAWithData(callCacheHashingActor.ref, aggregatedInitialHash, None, 1))
@@ -138,7 +138,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheHashingActor = TestProbe()
     val parent = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), parent.ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), parent.ref)
     parent.watch(actorUnderTest)
     
     val aggregatedInitialHash: String = "AggregatedInitialHash"
@@ -154,13 +154,13 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), TestProbe().ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
     actorUnderTest.setState(WaitingForCacheHitOrMiss, CCRJAWithData(callCacheHashingActor.ref, aggregatedInitialHash, None, 2))
 
     actorUnderTest ! NextHit
-    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, None), 2))
+    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, None), 2, prefixesHint = None))
 
     actorUnderTest.stateName shouldBe WaitingForCacheHitOrMiss
   }
@@ -169,14 +169,14 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheReadProbe = TestProbe()
     val callCacheHashingActor = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), TestProbe().ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
     val aggregatedFileHash: String = "AggregatedFileHash"
     actorUnderTest.setState(WaitingForCacheHitOrMiss, CCRJAWithData(callCacheHashingActor.ref, aggregatedInitialHash, Option(aggregatedFileHash), 2))
 
     actorUnderTest ! NextHit
-    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, Option(aggregatedFileHash)), 2))
+    callCacheReadProbe.expectMsg(CacheLookupRequest(AggregatedCallHashes(aggregatedInitialHash, Option(aggregatedFileHash)), 2, prefixesHint = None))
 
     actorUnderTest.stateName shouldBe WaitingForCacheHitOrMiss
   }
@@ -186,7 +186,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheHashingActor = TestProbe()
     val parent = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), parent.ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), parent.ref)
     parent.watch(actorUnderTest)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"
@@ -203,7 +203,7 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     val callCacheHashingActor = TestProbe()
     val parent = TestProbe()
     
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref), parent.ref)
+    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), parent.ref)
     parent.watch(actorUnderTest)
 
     val aggregatedInitialHash: String = "AggregatedInitialHash"

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
@@ -85,7 +85,7 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
           NonEmptyList.of("input: String s1" -> "HASH_S1")
         )
         _ = hasHashPairMatch shouldBe false
-        hit <- dataAccess.findCacheHitForAggregation("BASE_AGGREGATION", Option("FILE_AGGREGATION"), 1)
+        hit <- dataAccess.findCacheHitForAggregation("BASE_AGGREGATION", Option("FILE_AGGREGATION"), callCachePathPrefixes = None, 1)
         _ = hit shouldBe empty
       } yield ()).futureValue
     }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActorSpec.scala
@@ -215,7 +215,8 @@ class EngineJobHashingActorSpec extends TestKitSuite with FlatSpecLike with Matc
     runtimeAttributeDefinitions = runtimeAttributeDefinitions,
     backendName = backendName,
     activity = activity,
-    callCachingEligible = callCachingEligible) {
+    callCachingEligible = callCachingEligible,
+    callCachePathPrefixes = None) {
     // override preStart to nothing to prevent the creation of the CCHJA.
     // This way it doesn't interfere with the tests and we can manually inject the messages we want
     override def preStart() =  ()

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
@@ -20,7 +20,7 @@ object PipelinesApiWorkflowPaths {
   private val AuthFilePathOptionKey = "auth_bucket"
   private val GcsPrefix = "gs://"
 
-  private[common] def callCacheRootHintFromExecutionRoot(executionRoot: String): String = {
+  private[common] def callCachePathPrefixFromExecutionRoot(executionRoot: String): String = {
     // If the root looks like gs://bucket/stuff-under-bucket this should return gs://bucket
     GcsPrefix + executionRoot.substring(GcsPrefix.length).takeWhile(_ != '/')
   }
@@ -35,7 +35,7 @@ case class PipelinesApiWorkflowPaths(workflowDescriptor: BackendWorkflowDescript
   override lazy val executionRootString: String =
     workflowDescriptor.workflowOptions.getOrElse(PipelinesApiWorkflowPaths.GcsRootOptionKey, papiConfiguration.root)
 
-  override lazy val callCacheRootPrefix: Option[String] = Option(callCacheRootHintFromExecutionRoot(executionRootString))
+  override lazy val callCacheRootPrefix: Option[String] = Option(callCachePathPrefixFromExecutionRoot(executionRootString))
 
   private val workflowOptions: WorkflowOptions = workflowDescriptor.workflowOptions
 

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
@@ -37,9 +37,9 @@ class PipelinesApiWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with 
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/${workflowDescriptor.id}_auth.json")
   }
 
-  it should "calculate the call cache root correctly" in {
+  it should "calculate the call cache path prefix from the workflow execution root correctly" in {
     val WorkspaceBucket = "gs://workspace-id"
     val ExecutionRoot = WorkspaceBucket + "/submission-id"
-    PipelinesApiWorkflowPaths.callCacheRootHintFromExecutionRoot(ExecutionRoot) shouldBe WorkspaceBucket
+    PipelinesApiWorkflowPaths.callCachePathPrefixFromExecutionRoot(ExecutionRoot) shouldBe WorkspaceBucket
   }
 }


### PR DESCRIPTION
There's a Centaur test here that's not quite as exacting as I'd like it to be. Really we should make sure Cromwell never even looks at hits from calls with non-matching prefixes. We can TT how best to have automated assertions for this and other perfy sorts of features.