### PR TITLE
Remove redirect for stderr on proxy

### DIFF
--- a/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
+++ b/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
@@ -119,7 +119,7 @@ fi
 
 # -i will attach stdin, which effectively makes this a blocking call
 # we redirect to /dev/null so as not to pollute the logs
-docker start -i "${AWS_ECS_PROXY_TARGET_CONTAINER_ID}" > /dev/null 2>&1
+docker start -i "${AWS_ECS_PROXY_TARGET_CONTAINER_ID}" > /dev/null
 rc=$?
 
 # If there are no outputs, there's no reason to go through the dance below.


### PR DESCRIPTION
This PR addresses an issue found during testing of the creation of the custom AMI for the AWS backend. The stderr redirect to /dev/null was put in place to eliminate duplicate logging (proxy and task container). However, redirecting stderr to /dev/null also suppresses some docker error messages; most notably instances where the command executable does not exist in the image.

It is not possible to segregate the docker error messages from stderr output from the task. This PR errs on the side of potential duplicate logging in order to catch docker-based errors.