### PR TITLE
Remove exists query for CC lookup

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -1,6 +1,5 @@
 package cromwell.database.slick
 
-import cats.data.NonEmptyList
 import cats.instances.list._
 import cats.instances.tuple._
 import cats.syntax.apply._
@@ -99,13 +98,6 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
           three.prefix, three.length,
           hitNumber).result.headOption
     }
-
-    runTransaction(action)
-  }
-
-  override def hasMatchingCallCachingEntriesForHashKeyValues(hashKeyHashValues: NonEmptyList[(String, String)])
-                                                            (implicit ec: ExecutionContext): Future[Boolean] = {
-    val action = dataAccess.existsMatchingCachingEntryIdsForHashKeyHashValues(hashKeyHashValues).result
 
     runTransaction(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
@@ -1,6 +1,5 @@
 package cromwell.database.slick.tables
 
-import cats.data.NonEmptyList
 import cromwell.database.sql.tables.CallCachingHashEntry
 
 trait CallCachingHashEntryComponent {
@@ -42,46 +41,4 @@ trait CallCachingHashEntryComponent {
       if callCachingHashEntry.callCachingEntryId === callCachingHashEntryId
     } yield callCachingHashEntry
   )
-
-  /**
-    * Returns true if there exists a row in callCachingHashEntries that matches the parameters.
-    *
-    * @param callCachingEntryId The foreign key.
-    * @param hashKeyHashValue   The hash key and hash value as a tuple.
-    * @return True or false if the row exists.
-    */
-  private def existsCallCachingEntryIdHashKeyHashValue(callCachingEntryId: Rep[Int])
-                                                      (hashKeyHashValue: (String, String)): Rep[Boolean] = {
-    callCachingHashEntries.filter(callCachingHashEntry =>
-      callCachingHashEntry.callCachingEntryId === callCachingEntryId &&
-        callCachingHashEntry.hashKey === hashKeyHashValue._1 &&
-        callCachingHashEntry.hashValue === hashKeyHashValue._2
-    ).exists
-  }
-
-  /**
-    * Returns true if there exists rows for all the hashKeyHashValues.
-    *
-    * @param callCachingEntryId The foreign key.
-    * @param hashKeyHashValues  The hash keys and hash values as tuples.
-    * @return True or false if all the rows exist.
-    */
-  private def existsAllCallCachingEntryIdHashKeyHashValues(callCachingEntryId: Rep[Int],
-                                                           hashKeyHashValues: NonEmptyList[(String, String)]):
-  Rep[Boolean] = {
-    hashKeyHashValues.
-      map(existsCallCachingEntryIdHashKeyHashValue(callCachingEntryId)).
-      toList.reduce(_ && _)
-  }
-
-  /**
-    * Returns whether or not there exists at least one callCachingEntryId for which all the hash keys and hash values match, and are allowed to be reused.
-    */
-  def existsMatchingCachingEntryIdsForHashKeyHashValues(hashKeyHashValues: NonEmptyList[(String, String)]) = {
-    (for {
-      callCachingEntry <- callCachingEntries
-      if existsAllCallCachingEntryIdHashKeyHashValues(
-        callCachingEntry.callCachingEntryId, hashKeyHashValues) && callCachingEntry.allowResultReuse
-    } yield callCachingEntry.callCachingEntryId).exists
-  }
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -1,6 +1,5 @@
 package cromwell.database.sql
 
-import cats.data.NonEmptyList
 import cromwell.database.sql.joins.CallCachingJoin
 import cromwell.database.sql.tables.CallCachingEntry
 
@@ -11,9 +10,6 @@ trait CallCachingSqlDatabase {
 
   def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCachePathPrefixes: Option[List[String]])
                                                      (implicit ec: ExecutionContext): Future[Boolean]
-
-  def hasMatchingCallCachingEntriesForHashKeyValues(hashKeyHashValues: NonEmptyList[(String, String)])
-                                                   (implicit ec: ExecutionContext): Future[Boolean]
 
   def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], hitNumber: Int)
                                 (implicit ec: ExecutionContext): Future[Option[Int]]

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -1,6 +1,5 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
-import cats.data.NonEmptyList
 import common.util.StringUtil._
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.backend.BackendJobExecutionActor.{CallCached, JobFailedNonRetryableResponse, JobSucceededResponse}
@@ -76,13 +75,6 @@ class CallCache(database: CallCachingSqlDatabase) {
   def hasBaseAggregatedHashMatch(baseAggregatedHash: String, hints: List[CacheHitHint])(implicit ec: ExecutionContext): Future[Boolean] = {
     val ccpp = hints collectFirst { case h: CallCachePathPrefixes => h.prefixes }
     database.hasMatchingCallCachingEntriesForBaseAggregation(baseAggregatedHash, ccpp)
-  }
-
-  def hasKeyValuePairHashMatch(hashes: NonEmptyList[HashResult])(implicit ec: ExecutionContext): Future[Boolean] = {
-    val hashKeyValuePairs = hashes map {
-      case HashResult(hashKey, hashValue) => (hashKey.key, hashValue.value)
-    }
-    database.hasMatchingCallCachingEntriesForHashKeyValues(hashKeyValuePairs)
   }
 
   def callCachingHitForAggregatedHashes(aggregatedCallHashes: AggregatedCallHashes, prefixesHint: Option[CallCachePathPrefixes], hitNumber: Int)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActor.scala
@@ -79,10 +79,8 @@ class CallCacheHashingJobActor(jobDescriptor: BackendJobDescriptor,
   when(HashingFiles) {
     case Event(FileHashResponse(result), data) =>
       addFileHash(result, data) match {
-        case (newData, Some(partialHashes: PartialFileHashingResult)) =>
-          sendToCallCacheReadingJobActor(partialHashes, data)
-          // If there is no CCReader, send a message to itself to trigger the next batch
-          if (newData.callCacheReadingJobActor.isEmpty) self ! NextBatchOfFileHashesRequest
+        case (newData, Some(_: PartialFileHashingResult)) =>
+          self ! NextBatchOfFileHashesRequest
           goto(WaitingForHashFileRequest) using newData
         case (newData, Some(finalResult: FinalFileHashingResult)) =>
           sendToCallCacheReadingJobActor(finalResult, newData)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -6,7 +6,6 @@ import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.{LoadConfig, WorkflowId}
 import cromwell.core.actor.BatchActor.CommandAndReplyTo
-import cromwell.core.callcaching.HashResult
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 import cromwell.services.EnhancedThrottlerActor
@@ -33,12 +32,6 @@ class CallCacheReadActor(cache: CallCache,
           case true => HasMatchingEntries
           case false => NoMatchingEntries
         }
-      case HasMatchingInputFilesHashLookup(_) =>
-//        cache.hasKeyValuePairHashMatch(fileHashes) map {
-//          case true => HasMatchingEntries
-//          case false => NoMatchingEntries
-//        }
-        Future.successful(HasMatchingEntries)
       case CacheLookupRequest(aggregatedCallHashes, cacheHitNumber, prefixesHint) =>
         cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, prefixesHint, cacheHitNumber) map {
           case Some(nextHit) => CacheLookupNextHit(nextHit)
@@ -86,7 +79,6 @@ object CallCacheReadActor {
   sealed trait CallCacheReadActorRequest
   final case class CacheLookupRequest(aggregatedCallHashes: AggregatedCallHashes, cacheHitNumber: Int, prefixesHint: Option[CallCachePathPrefixes]) extends CallCacheReadActorRequest
   final case class HasMatchingInitialHashLookup(aggregatedTaskHash: String, cacheHitHints: List[CacheHitHint] = List.empty) extends CallCacheReadActorRequest
-  final case class HasMatchingInputFilesHashLookup(fileHashes: NonEmptyList[HashResult]) extends CallCacheReadActorRequest
   final case class CallCacheEntryForCall(workflowId: WorkflowId, jobKey: BackendJobDescriptorKey) extends CallCacheReadActorRequest
 
   sealed trait CallCacheReadActorResponse

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -33,11 +33,12 @@ class CallCacheReadActor(cache: CallCache,
           case true => HasMatchingEntries
           case false => NoMatchingEntries
         }
-      case HasMatchingInputFilesHashLookup(fileHashes) =>
-        cache.hasKeyValuePairHashMatch(fileHashes) map {
-          case true => HasMatchingEntries
-          case false => NoMatchingEntries
-        }
+      case HasMatchingInputFilesHashLookup(_) =>
+//        cache.hasKeyValuePairHashMatch(fileHashes) map {
+//          case true => HasMatchingEntries
+//          case false => NoMatchingEntries
+//        }
+        Future.successful(HasMatchingEntries)
       case CacheLookupRequest(aggregatedCallHashes, cacheHitNumber, prefixesHint) =>
         cache.callCachingHitForAggregatedHashes(aggregatedCallHashes, prefixesHint, cacheHitNumber) map {
           case Some(nextHit) => CacheLookupNextHit(nextHit)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheHashingJobActorSpec.scala
@@ -179,31 +179,12 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
     parent.expectMsg(NoFileHashesResult)
     parent.expectTerminated(cchja)
   }
-
-  it should "send the PartialFileHashingResult when a batch is complete" in {
-    val callCacheReadProbe = TestProbe()
-    val hashResults = NonEmptyList.of(mock[HashResult])
-    
-    val result: PartialFileHashingResult = PartialFileHashingResult(hashResults)
-    val newData: CallCacheHashingJobActorData = CallCacheHashingJobActorData(List.empty, List.empty, Option(callCacheReadProbe.ref))
-    
-    val cchja = makeCCHJA(Option(callCacheReadProbe.ref), TestProbe().ref, TestProbe().ref, writeToCache = true, Option(newData -> Option(result)))
-
-    cchja.setState(HashingFiles)
-
-    cchja ! FileHashResponse(mock[HashResult])
-
-    callCacheReadProbe.expectMsgClass(classOf[InitialHashingResult])
-    callCacheReadProbe.expectMsg(result)
-    cchja.stateName shouldBe WaitingForHashFileRequest
-    cchja.stateData shouldBe newData
-  }
-
-  it should "send itself a NextBatchOfFileHashesRequest when a batch is complete and there is no CCReader" in {
+  
+  def selfSendNextBacthRequest(ccReader: Option[ActorRef]) = {
     val fileHashingActor = TestProbe()
     val result: PartialFileHashingResult = PartialFileHashingResult(NonEmptyList.of(mock[HashResult]))
     val fileHashRequest = SingleFileHashRequest(null, null, null, null)
-    val newData = CallCacheHashingJobActorData(List(List(fileHashRequest)), List.empty, None)
+    val newData = CallCacheHashingJobActorData(List(List(fileHashRequest)), List.empty, ccReader)
     // still gives a CCReader when instantiating the actor, but not in the data (above)
     // This ensures the check is done with the data and not the actor attribute, as the data will change if the ccreader dies but the actor attribute
     // will stay Some(...)
@@ -216,6 +197,14 @@ class CallCacheHashingJobActorSpec extends TestKitSuite with FlatSpecLike with B
     // This proves that the ccjha keeps hashing files even though there is no ccreader requesting more hashes
     fileHashingActor.expectMsg(fileHashRequest)
     cchja.stateName shouldBe HashingFiles
+  }
+  
+  List(
+    ("send itself a NextBatchOfFileHashesRequest when a batch is complete and there is no CC Reader", None),
+    ("send itself a NextBatchOfFileHashesRequest when a batch is complete and there is a CC Reader", Option(TestProbe().ref))
+  ) foreach {
+    case (description, ccReader) => 
+      it should description in selfSendNextBacthRequest(ccReader)
   }
 
   it should "send FinalFileHashingResult to parent and CCReader and die" in {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
@@ -1,10 +1,9 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.testkit.{TestFSMRef, TestProbe}
-import cats.data.NonEmptyList
 import cromwell.core.TestKitSuite
 import cromwell.core.callcaching.{HashKey, HashResult, HashValue, HashingFailedMessage}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheHashingJobActor.{CompleteFileHashingResult, InitialHashingResult, NextBatchOfFileHashesRequest, NoFileHashesResult, PartialFileHashingResult}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheHashingJobActor.{CompleteFileHashingResult, InitialHashingResult, NextBatchOfFileHashesRequest, NoFileHashesResult}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.{CCRJAWithData, WaitingForCacheHitOrMiss, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, HashError}
@@ -56,23 +55,6 @@ class CallCacheReadingJobActorSpec extends TestKitSuite with FlatSpecLike with M
     callCacheReadProbe.send(actorUnderTest, NoMatchingEntries)
     parent.expectMsg(CacheMiss)
     parent.expectTerminated(actorUnderTest)
-  }
-
-  it should "try to match partial file hashes against DB" in {
-    val callCacheReadProbe = TestProbe()
-    val callCacheHashingActor = TestProbe()
-    
-    val actorUnderTest = TestFSMRef(new CallCacheReadingJobActor(callCacheReadProbe.ref, prefixesHint = None), TestProbe().ref)
-
-    actorUnderTest.setState(WaitingForFileHashes)
-
-    val fileHashes = NonEmptyList.of(HashResult(HashKey("f1"), HashValue("h1")), HashResult(HashKey("f2"), HashValue("h2")))
-    callCacheHashingActor.send(actorUnderTest, PartialFileHashingResult(fileHashes))
-    callCacheReadProbe.expectMsg(HasMatchingInputFilesHashLookup(fileHashes))
-    
-    eventually {
-      actorUnderTest.stateName shouldBe WaitingForHashCheck
-    }
   }
 
   it should "ask for matching cache entries for both aggregated hashes when got both" in {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
@@ -1,10 +1,10 @@
 package cromwell.engine.workflow.lifecycle.execution.callcaching
 
-import cats.data.NonEmptyList
 import com.typesafe.config.ConfigFactory
 import cromwell.core.Tags.DbmsTest
 import cromwell.core.WorkflowId
 import cromwell.database.slick.EngineSlickDatabase
+import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.joins.CallCachingJoin
 import cromwell.database.sql.tables._
 import cromwell.services.EngineServicesStore
@@ -13,7 +13,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.specs2.mock.Mockito
-import cromwell.database.sql.SqlConverters._
 
 import scala.concurrent.ExecutionContext
 
@@ -81,10 +80,6 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
         )
         hasBaseAggregation <- dataAccess.hasMatchingCallCachingEntriesForBaseAggregation("BASE_AGGREGATION")
         _ = hasBaseAggregation shouldBe false
-        hasHashPairMatch <- dataAccess.hasMatchingCallCachingEntriesForHashKeyValues(
-          NonEmptyList.of("input: String s1" -> "HASH_S1")
-        )
-        _ = hasHashPairMatch shouldBe false
         hit <- dataAccess.findCacheHitForAggregation("BASE_AGGREGATION", Option("FILE_AGGREGATION"), callCachePathPrefixes = None, 1)
         _ = hit shouldBe empty
       } yield ()).futureValue


### PR DESCRIPTION
Perf testing has shown that removing this query improves CC time and reduces DB load (see last row in CC google doc)
Unclear if it's worth keeping it as a configurable thing ?
This keeps storing the individual hashes, it just stops using them for "fast" cache miss detection.