### PR TITLE
Move import tests back to 'develop'

### DIFF
--- a/centaur/src/main/resources/standardTestCases/wdl_biscayne/biscayne_http_relative_imports/biscayne_http_relative_imports.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_biscayne/biscayne_http_relative_imports/biscayne_http_relative_imports.wdl
@@ -1,7 +1,7 @@
 version development
 
 # Is there a better way to test this?
-import "https://raw.githubusercontent.com/broadinstitute/cromwell/aen_3990/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
+import "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
 
 workflow biscayne_http_relative_imports {
   call foo.foo_wf

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_http_imports/draft3_http_imports.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_http_imports/draft3_http_imports.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-import "https://raw.githubusercontent.com/broadinstitute/cromwell/aen_3990/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_infer_version/draft3_infer_version.wdl" as infered
+import "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/centaur/src/main/resources/standardTestCases/wdl_draft3/draft3_infer_version/draft3_infer_version.wdl" as infered
 
 workflow draft3_http_imports {
   call infered.draft3_infer_version

--- a/centaur/src/main/resources/standardTestCases/workflow_url_biscayne_sub_wfs.test
+++ b/centaur/src/main/resources/standardTestCases/workflow_url_biscayne_sub_wfs.test
@@ -2,7 +2,7 @@ name: workflow_url_biscayne_sub_wfs
 testFormat: workflowsuccess
 
 files {
-  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/aen_3990/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
+  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/workflow_url_http_relative_imports.test
+++ b/centaur/src/main/resources/standardTestCases/workflow_url_http_relative_imports.test
@@ -3,7 +3,7 @@ testFormat: workflowsuccess
 tags: ["wdl_biscayne"]
 
 files {
-  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/aen_3990/centaur/src/main/resources/standardTestCases/wdl_biscayne/biscayne_http_relative_imports/biscayne_http_relative_imports.wdl"
+  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/centaur/src/main/resources/standardTestCases/wdl_biscayne/biscayne_http_relative_imports/biscayne_http_relative_imports.wdl"
 }
 
 metadata {

--- a/womtool/src/test/resources/validate/biscayne/valid/http_relative_imports/http_relative_imports.wdl
+++ b/womtool/src/test/resources/validate/biscayne/valid/http_relative_imports/http_relative_imports.wdl
@@ -1,7 +1,7 @@
 version development
 
 # Is there a better way to test this?
-import "https://raw.githubusercontent.com/broadinstitute/cromwell/aen_3990/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
+import "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl"
 
 workflow http_relative_imports {
   call foo.foo_wf


### PR DESCRIPTION
Now that the version strings are correct in develop, we don't need `aen_3990` anymore