### PR TITLE
[34_hotfix] Publish metadata matching PAPI v1 standard stream filenames.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_stdout_expression_papi.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_stdout_expression_papi.test
@@ -3,7 +3,7 @@ testFormat: workflowsuccess
 workflowType: CWL
 workflowTypeVersion: v1.0
 workflowRoot: cwl_stdout_expression
-backends: [Papi]
+backends: [Papi2]
 
 files {
   workflow: cwl_stdout_expression/cwl_stdout_expression.cwl

--- a/centaur/src/main/resources/standardTestCases/papiv1_streams.test
+++ b/centaur/src/main/resources/standardTestCases/papiv1_streams.test
@@ -1,0 +1,18 @@
+name: papiv1_streams
+testFormat: workflowsuccess
+backends: [Papi1]
+
+files {
+  workflow: papiv1_streams/papiv1_streams.wdl
+}
+
+metadata {
+  workflowName: papiv1_streams
+  status: Succeeded
+
+  "calls.papiv1_streams.sup.executionStatus": Done
+  "calls.papiv1_streams.sup.stdout": "<<WORKFLOW_ROOT>>call-sup/sup-stdout.log"
+  "calls.papiv1_streams.sup.stderr": "<<WORKFLOW_ROOT>>call-sup/sup-stderr.log"
+
+  # Ideally there would be a test for the shards of a scatter but the proper keys were elusive.
+}

--- a/centaur/src/main/resources/standardTestCases/papiv1_streams/papiv1_streams.wdl
+++ b/centaur/src/main/resources/standardTestCases/papiv1_streams/papiv1_streams.wdl
@@ -1,0 +1,20 @@
+version 1.0
+
+task sup {
+  input {
+    Int i
+  }
+  command {
+    echo sup ~{i}
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}
+
+workflow papiv1_streams {
+  call sup { input: i = 0 }
+  scatter (i in range(3)) {
+    call sup as scatsup { input: i = i }
+  }
+}

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
@@ -105,7 +105,8 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     gcsCred <- gcsCredentials
     genomicsCred <- genomicsCredentials
     validatedPathBuilders <- pathBuilders
-  } yield new PipelinesApiWorkflowPaths(workflowDescriptor, gcsCred, genomicsCred, pipelinesConfiguration, validatedPathBuilders)(ioEc)
+  } yield new PipelinesApiWorkflowPaths(
+    workflowDescriptor, gcsCred, genomicsCred, pipelinesConfiguration, validatedPathBuilders, standardStreamNameToFileNameMetadataMapper)(ioEc)
 
   override lazy val initializationData: Future[PipelinesApiBackendInitializationData] = for {
     jesWorkflowPaths <- workflowPaths
@@ -128,5 +129,13 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     } yield Option(data)
   }
 
+  def standardStreamNameToFileNameMetadataMapper(pipelinesApiJobPaths: PipelinesApiJobPaths, streamName: String): String =
+    PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper(pipelinesApiJobPaths, streamName)
+
   override lazy val ioCommandBuilder = GcsBatchCommandBuilder
+}
+
+object PipelinesApiInitializationActor {
+  // For metadata publishing purposes default to using the name of a standard stream as the stream's filename.
+  def defaultStandardStreamNameToFileNameMetadataMapper(pipelinesApiJobPaths: PipelinesApiJobPaths, streamName: String): String = streamName
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
@@ -43,4 +43,11 @@ final case class PipelinesApiJobPaths(override val workflowPaths: PipelinesApiWo
   override lazy val customLogPaths: Map[String, Path] = Map(
     PipelinesApiJobPaths.JesLogPathKey -> jesLogPath
   )
+
+  override def standardOutputAndErrorPaths: Map[String, Path] = {
+    super.standardOutputAndErrorPaths map { case (k, v) =>
+      val updated = workflowPaths.standardStreamNameToFileNameMetadataMapper(this, k)
+      k -> v.parent.resolve(updated)
+    }
+  }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
@@ -23,7 +23,12 @@ case class PipelinesApiWorkflowPaths(workflowDescriptor: BackendWorkflowDescript
                                      gcsCredentials: Credentials,
                                      genomicsCredentials: Credentials,
                                      papiConfiguration: PipelinesApiConfiguration,
-                                     override val pathBuilders: PathBuilders)(implicit ec: ExecutionContext) extends WorkflowPaths {
+                                     override val pathBuilders: PathBuilders,
+                                     // This allows for the adjustment of the standard stream file names in PAPI v1 to match the
+                                     // combined controller + job standard output and error files. PAPI v1 controls the periodic
+                                     // delocalization of these files so the metadata Cromwell publishes for these files needs
+                                     // to match the PAPI v1 names.
+                                     standardStreamNameToFileNameMetadataMapper: (PipelinesApiJobPaths, String) => String)(implicit ec: ExecutionContext) extends WorkflowPaths {
   override lazy val executionRootString: String =
     workflowDescriptor.workflowOptions.getOrElse(PipelinesApiWorkflowPaths.GcsRootOptionKey, papiConfiguration.root)
 

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
@@ -101,7 +101,8 @@ class PipelinesApiAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsy
 
   private def buildInitializationData(jobDescriptor: BackendJobDescriptor, configuration: PipelinesApiConfiguration) = {
     val pathBuilders = Await.result(configuration.configurationDescriptor.pathBuilders(WorkflowOptions.empty), 5.seconds)
-    val workflowPaths = PipelinesApiWorkflowPaths(jobDescriptor.workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), configuration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(
+      jobDescriptor.workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), configuration, pathBuilders, PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
     val runtimeAttributesBuilder = PipelinesApiRuntimeAttributes.runtimeAttributesBuilder(configuration)
     val requestFactory = new PipelinesApiRequestFactory {
       override def cancelRequest(job: StandardAsyncJob) = null

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiCallPathsSpec.scala
@@ -26,7 +26,8 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(
+      workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders, PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
     
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -44,7 +45,8 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(
+      workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders, PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
 
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     
@@ -66,7 +68,8 @@ class PipelinesApiCallPathsSpec extends TestKitSuite with FlatSpecLike with Matc
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
     )
     val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(
+      workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders, PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
 
     val callPaths = PipelinesApiJobPaths(workflowPaths, jobDescriptorKey)
     

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPathsSpec.scala
@@ -23,7 +23,7 @@ class PipelinesApiWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with 
       SampleWdl.HelloWorld.workflowSource(),
       inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.mapValues(JsString.apply)).compactPrint)
     )
-    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders)
+    val workflowPaths = PipelinesApiWorkflowPaths(workflowDescriptor, NoCredentials.getInstance(), NoCredentials.getInstance(), jesConfiguration, pathBuilders, PipelinesApiInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper)
     workflowPaths.executionRoot.pathAsString should be("gs://my-cromwell-workflows-bucket/")
     workflowPaths.workflowRoot.pathAsString should
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/")

--- a/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/PipelinesApiInitializationActor.scala
@@ -3,8 +3,8 @@ package cromwell.backend.google.pipelines.v1alpha2
 import java.io.IOException
 
 import com.google.cloud.storage.contrib.nio.CloudStorageOptions
-import cromwell.backend.google.pipelines.common.authentication.{GcsLocalizing, PipelinesApiDockerCredentials, PipelinesApiAuthObject}
-import cromwell.backend.google.pipelines.common.{PipelinesApiInitializationActorParams, PipelinesApiWorkflowPaths}
+import cromwell.backend.google.pipelines.common.authentication.{GcsLocalizing, PipelinesApiAuthObject, PipelinesApiDockerCredentials}
+import cromwell.backend.google.pipelines.common.{PipelinesApiInitializationActorParams, PipelinesApiJobPaths, PipelinesApiWorkflowPaths}
 import cromwell.backend.google.pipelines.v1alpha2.PipelinesApiInitializationActor.AuthFileAlreadyExistsException
 import cromwell.cloudsupport.gcp.auth.{ClientSecrets, GoogleAuthMode}
 import cromwell.core.path.Path
@@ -74,6 +74,11 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     if (jsonMap.nonEmpty) Option(JsObject(jsonMap).prettyPrint)
     else None
   }
+
+  /** Overridden for v1 to account for the way the PAPI v1 controller names these files. PAPI v1 completely manages the periodic
+    * delocalization of these files including their naming. */
+  override def standardStreamNameToFileNameMetadataMapper(pipelinesApiJobPaths: PipelinesApiJobPaths, streamName: String): String =
+    s"${pipelinesApiJobPaths.jesLogBasename}-$streamName.log"
 }
 
 object PipelinesApiInitializationActor {


### PR DESCRIPTION
The PAPI v1 standard stream files that are periodically delocalized are named by the PAPI v1 controller and don't have the regular `stdout` and `stderr` names. So while Cromwell was teeing this data to the standard streams correctly and the PAPI v1 controller was delocalizing correctly, the paths Cromwell published to metadata corresponded to the `stdout` and `stderr` files that are only delocalized when the job completes. `stdout` and `stderr` are arguably more correct than the files periodically delocalized by PAPI v1 since they won't contain output from the wrapper script, but the expectations for FC are that these paths in metadata should point to the files that are periodically delocalized.