### PR TITLE
Added engine upgrade test for call caching.

### DIFF
--- a/centaur/src/it/scala/centaur/reporting/BigQueryReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/BigQueryReporter.scala
@@ -1,5 +1,6 @@
 package centaur.reporting
 
+import java.time.OffsetDateTime
 import java.util
 
 import cats.effect.IO
@@ -153,6 +154,7 @@ class BigQueryReporter(override val params: ErrorReporterParams) extends ErrorRe
       "test_message" -> Option(centaurTestException.message),
       "test_name" -> Option(testEnvironment.name),
       "test_stack_trace" -> centaurTestException.causeOption.map(ExceptionUtils.getStackTrace),
+      "test_timestamp" -> Option(OffsetDateTime.now.toString),
       "test_workflow_id" -> centaurTestException.workflowIdOption,
     ).collect {
       case (key, Some(value)) => (key, value)

--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha.wdl
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha.wdl
@@ -1,0 +1,526 @@
+version 1.0
+
+workflow call_cache_cha_cha {
+    input {
+        Boolean modify_file_using_cloud
+        String modify_file_command_prefix
+        String modify_file_docker
+    }
+
+    # Make some files:
+    call make_files { input: ready = true }
+    # Call cache the made files, creating some copies:
+    call make_files as make_files_cached { input: ready = make_files.done }
+
+    # Make sure read_files is in the call cache:
+    call read_files { input: ready = true, a = make_files.enganadora, b = make_files.alardoso }
+
+    # Modify that file! Oh so crafty!
+    if (modify_file_using_cloud) {
+        call modify_file_cloud {
+            input: ready = read_files.done,
+                file_path_raw = make_files.enganadora,
+                modify_file_command_prefix = modify_file_command_prefix,
+                modify_file_docker = modify_file_docker
+        }
+    }
+    if (!modify_file_using_cloud) {
+        call modify_file_local {
+            input: ready = read_files.done,
+                file_path_raw = make_files.enganadora,
+                modify_file_command_prefix = modify_file_command_prefix
+        }
+    }
+
+    Boolean modify_file_done = select_first([modify_file_cloud.done, modify_file_local.done])
+
+    # The file inputs are different., shouldn't hit the call cache.
+    call read_files as read_files_after_modify {
+        input: ready = modify_file_done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Give the last call a chance to be writen to the call caching DB
+    call sleep as sleep_before_restart { input: duration = 5, ready = read_files_after_modify.done }
+
+    call sleep as sleep_during_restart { input: duration = 60, ready = sleep_before_restart.done }
+
+    call sleep as sleep_after_restart { input: duration = 5, ready = sleep_during_restart.done }
+
+    # Using the copied files after modification, even if the task name is different, should still call cache to read_files:
+    # ** Should call cache to read_files **
+    call read_copied_files {
+        input: ready = sleep_after_restart.done,
+            a = make_files_cached.enganadora,
+            b = make_files_cached.alardoso
+    }
+
+    # Task with inputs in the other order. Should not call cache:
+    call read_files_swapped {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Extra whitespace and rearranged task definition.
+    # Should call cache to read_files_after_modify:
+    call read_files_whitespace {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Different command? Don't call cache!
+    call read_files_new_command {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Different output expressions? Don't call cache!
+    call read_files_new_output_expressions {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Different output names? Can't call cache (yet, at least)!
+    call read_files_new_output_names {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Different non-File input? Can't call cache!
+    call read_files as read_files_non_file_input_switcheroo {
+        input: ready = !sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+
+    # Different input names? Don't call cache!
+    call read_files_inputs_renamed {
+        input: ready = sleep_after_restart.done,
+            c = make_files.enganadora,
+            d = make_files.alardoso
+    }
+
+    # Like read_files but with 2 Array[File] instead of File
+    call read_array_files {
+        input: ready = sleep_after_restart.done,
+            a = [make_files.enganadora],
+            b = [make_files.alardoso]
+    }
+
+    # Give the last call a chance to be writen to the call caching DB
+    call sleep as sleep_some_more { input: duration = 5, ready = read_array_files.done }
+
+    # Same as read_array_files except a is empty and b contains both, in the same order. Don't call cache!
+    call read_array_files as read_array_files_rearranged {
+        input: ready = sleep_some_more.done,
+            a = [],
+            b = [make_files.enganadora,
+            make_files.alardoso]
+    }
+
+    # Local runtime attributes:
+    call read_files_different_docker {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_different_continueOnReturnCode {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_different_continueOnReturnCode_2 {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_without_continueOnReturnCode {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_different_failOnStderr {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_without_failOnStderr {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+    call read_files_failOnStderr_expression {
+        input: ready = sleep_after_restart.done,
+            a = make_files.enganadora,
+            b = make_files.alardoso
+    }
+}
+
+task make_files {
+    input {
+        Boolean ready
+    }
+    command {
+        echo enganadora > enganadora.txt
+        chmod go+w enganadora.txt
+        echo alardoso > alardoso.txt
+    }
+    output {
+        Boolean done = true
+        File enganadora = "enganadora.txt"
+        File alardoso = "alardoso.txt" }
+    runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+}
+
+task modify_file_local {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        String file_path_raw
+        String modify_file_command_prefix
+        # Remove if this task works without it:
+        # String file_path = sub(file_path_raw, "file://", "")
+    }
+    command {
+        ~{modify_file_command_prefix} ~{file_path_raw}
+    }
+    output { Boolean done = true }
+    runtime {
+        # No docker, we need this to run against the same FS as Cromwell so it can modify the right file!
+        # docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        backend: "Local"
+    }
+}
+
+task modify_file_cloud {
+    input {
+        Boolean ready
+        String file_path_raw
+        String modify_file_command_prefix
+        String modify_file_docker
+    }
+    command {
+        ~{modify_file_command_prefix} ~{file_path_raw}
+    }
+    output {
+        Boolean done = true }
+    runtime {
+        docker: modify_file_docker
+    }
+}
+
+task read_files {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task sleep {
+    input {
+        Int duration
+        Boolean ready
+    }
+    command { sleep ~{duration} }
+    output { Boolean done = true }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+# Identical to read_files, apart from the name...
+task read_copied_files {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_swapped {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{b} ~{a} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_whitespace {
+    input {
+        # Just like read_files, but with additional whitespace!
+        Boolean   ready
+
+        File b
+        File a
+    }
+    command {
+
+                cat ~{a} ~{b} > out
+    }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_new_command {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command {
+      for i in ~{a} ~{b}
+      do
+        cat $i >> out
+      done
+    }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_new_output_expressions {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") + "_suffix" }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_new_output_names {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean dunn = true
+        String ess = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_inputs_renamed {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File c
+        File d
+    }
+    command { cat ~{c} ~{d} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_different_docker {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+        continueOnReturnCode: 0
+        failOnStderr: false
+    }
+}
+
+task read_files_different_continueOnReturnCode {
+    input {
+         # 'ready' is ignored, but useful for flow-control
+         Boolean ready
+         File a
+         File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: false
+        failOnStderr: false
+    }
+}
+
+task read_files_different_continueOnReturnCode_2 {
+    input {
+         # 'ready' is ignored, but useful for flow-control
+         Boolean ready
+         File a
+         File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: [ 0 ]
+        failOnStderr: false
+    }
+}
+
+task read_files_without_continueOnReturnCode {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        failOnStderr: false
+    }
+}
+
+task read_files_different_failOnStderr {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: true
+    }
+}
+
+task read_files_without_failOnStderr {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+    }
+}
+
+task read_files_failOnStderr_expression {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        File a
+        File b
+    }
+    command { cat ~{a} ~{b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: !ready
+    }
+}
+
+task read_array_files {
+    input {
+        # 'ready' is ignored, but useful for flow-control
+        Boolean ready
+        Array[File] a
+        Array[File] b
+    }
+    command { cat ~{sep = " " a} ~{sep = " " b} > out }
+    output {
+        Boolean done = true
+        String s = read_string("out") }
+    runtime {
+        docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+        continueOnReturnCode: 0
+        failOnStderr: !ready
+    }
+}

--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha_local.inputs.json
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha_local.inputs.json
@@ -1,0 +1,5 @@
+{
+  "call_cache_cha_cha.modify_file_command_prefix": "echo \"ginga\" >",
+  "call_cache_cha_cha.modify_file_using_cloud": false,
+  "call_cache_cha_cha.modify_file_docker": "notused"
+}

--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha_papi.inputs.json
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha_papi.inputs.json
@@ -1,0 +1,5 @@
+{
+  "call_cache_cha_cha.modify_file_command_prefix": "echo \"override\" | gsutil cp -",
+  "call_cache_cha_cha.modify_file_using_cloud": true,
+  "call_cache_cha_cha.modify_file_docker": "google/cloud-sdk"
+}

--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha_local.test
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha_local.test
@@ -1,0 +1,54 @@
+name: call_cache_cha_cha_local
+testFormat: CromwellRestartWithRecover
+callMark: call_cache_cha_cha.sleep_during_restart
+backends: [Local]
+tags: [engine_upgrade, localdockertest]
+retryTestFailures: false
+
+files {
+  workflow: call_cache_cha_cha/call_cache_cha_cha.wdl
+  inputs: call_cache_cha_cha/call_cache_cha_cha_local.inputs.json
+}
+
+metadata {
+  workflowName: call_cache_cha_cha
+  status: Succeeded
+  "calls.call_cache_cha_cha.make_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.make_files_cached.callCaching.result": "Cache Hit: <<UUID>>:call_cache_cha_cha.make_files:-1"
+
+  "calls.call_cache_cha_cha.read_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.modify_file_local.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_after_modify.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_copied_files.callCaching.result": "Cache Hit: <<UUID>>:call_cache_cha_cha.read_files:-1"
+  "calls.call_cache_cha_cha.read_files_swapped.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_command.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_output_expressions.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_output_names.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_non_file_input_switcheroo.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_inputs_renamed.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_docker.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_continueOnReturnCode.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_continueOnReturnCode_2.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_failOnStderr.callCaching.hit": false
+
+  "calls.call_cache_cha_cha.read_files_whitespace.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_without_continueOnReturnCode.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_without_failOnStderr.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_failOnStderr_expression.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_array_files_rearranged.callCaching.hit": false
+
+  // Check that hashes are published to metadata
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output count": "C81E728D9D4C2F636F067F89CC14862C"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.docker": "09F611634147800124391D34D57A3A9F"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.failOnStderr": "68934A3E9455FA72420237EB05902327"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.File b.0": "5bbc090a49179c69c72354bce371e152"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.File a.0": "0e4a079e970c7802de92f5151e0dc2b9"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.backend name": "509820290D57F333403F490DDE7316F4"
+}

--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha_papi.test
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha_papi.test
@@ -1,0 +1,54 @@
+name: call_cache_cha_cha_papi
+testFormat: CromwellRestartWithRecover
+callMark: call_cache_cha_cha.sleep_during_restart
+backends: [Papi]
+tags: [engine_upgrade]
+retryTestFailures: false
+
+files {
+  workflow: call_cache_cha_cha/call_cache_cha_cha.wdl
+  inputs: call_cache_cha_cha/call_cache_cha_cha_papi.inputs.json
+}
+
+metadata {
+  workflowName: call_cache_cha_cha
+  status: Succeeded
+  "calls.call_cache_cha_cha.make_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.make_files_cached.callCaching.result": "Cache Hit: <<UUID>>:call_cache_cha_cha.make_files:-1"
+
+  "calls.call_cache_cha_cha.read_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.modify_file_cloud.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_after_modify.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_copied_files.callCaching.result": "Cache Hit: <<UUID>>:call_cache_cha_cha.read_files:-1"
+  "calls.call_cache_cha_cha.read_files_swapped.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_command.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_output_expressions.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_new_output_names.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_non_file_input_switcheroo.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_inputs_renamed.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_docker.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_continueOnReturnCode.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_continueOnReturnCode_2.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_files_different_failOnStderr.callCaching.hit": false
+
+  "calls.call_cache_cha_cha.read_files_whitespace.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_without_continueOnReturnCode.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_without_failOnStderr.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_files_failOnStderr_expression.callCaching.hit": true
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hit": false
+  "calls.call_cache_cha_cha.read_array_files_rearranged.callCaching.hit": false
+
+  // Check that hashes are published to metadata
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output count": "C81E728D9D4C2F636F067F89CC14862C"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.docker": "09F611634147800124391D34D57A3A9F"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.runtime attribute.failOnStderr": "68934A3E9455FA72420237EB05902327"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output expression.Boolean done": "B326B5062B2F0E69046810717534CB09"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.output expression.String s": "A865407608C706C3A061C106080F8497"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input count": "ECCBC87E4B5CE2FE28308FD9F2A7BAF3"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.command template": "854640FC8C6DFD8DA6DA3898FC160D02"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.Boolean ready": "B326B5062B2F0E69046810717534CB09"
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.File b.0": "UGbNrg=="
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.input.File a.0": "T53tZg=="
+  "calls.call_cache_cha_cha.read_array_files.callCaching.hashes.backend name": "36EF4A8AB268D1A1C74D8108C93D48ED"
+}

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
@@ -1,6 +1,7 @@
 name: call_cache_capoeira_jes
 testFormat: workflowsuccess
 backends: [Papi, Local]
+retryTestFailures: false
 
 files {
   workflow: call_cache_capoeira/call_cache_capoeira_jes.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira_local.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira_local.test
@@ -2,6 +2,7 @@ name: call_cache_capoeira_local
 testFormat: workflowsuccess
 backends: [Local]
 tags: [localdockertest]
+retryTestFailures: false
 
 files {
   workflow: call_cache_capoeira/call_cache_capoeira_local.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira_tes.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira_tes.test
@@ -2,6 +2,7 @@ name: call_cache_capoeira_tes
 testFormat: workflowsuccess
 backends: [TES]
 tags: [localdockertest]
+retryTestFailures: false
 
 files {
   workflow: call_cache_capoeira/call_cache_capoeira_tes.wdl

--- a/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunner.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/CentaurCwlRunner.scala
@@ -165,7 +165,15 @@ object CentaurCwlRunner extends StrictLogging {
       labels,
       zippedImports
     )
-    val workflow = Workflow(testName, workflowData, workflowMetadata, notInMetadata, directoryContentCounts, backends)
+    val workflow = Workflow(
+      testName,
+      workflowData,
+      workflowMetadata,
+      notInMetadata,
+      directoryContentCounts,
+      backends,
+      retryTestFailures = false
+    )
     val testCase = CentaurTestCase(workflow, testFormat, testOptions, submitResponseOption)
 
     if (!args.quiet) {

--- a/src/ci/bin/testCentaurEngineUpgradePapiV2.sh
+++ b/src/ci/bin/testCentaurEngineUpgradePapiV2.sh
@@ -13,4 +13,5 @@ cromwell::build::setup_centaur_environment
 cromwell::build::assemble_jars
 
 cromwell::build::run_centaur \
-    -s "centaur.EngineUpgradeTestCaseSpec"
+    -s "centaur.EngineUpgradeTestCaseSpec" \
+    -e localdockertest \


### PR DESCRIPTION
Related:
- Allow centaur tests to disable retries.
- Add the `test_timestamp` to bigquery reports.