### PR TITLE
Fix CWL "failed with null" error message

### DIFF
--- a/cwl/src/main/scala/cwl/CwlDecoder.scala
+++ b/cwl/src/main/scala/cwl/CwlDecoder.scala
@@ -21,7 +21,7 @@ object CwlDecoder {
     val cwlToolResult =
       Try(CwltoolRunner.instance.salad(path))
         .toEither
-        .leftMap(t => NonEmptyList.one(s"running cwltool on file ${path.toString} failed with $t"))
+        .leftMap(t => NonEmptyList.one(s"running cwltool on file $path failed with $t"))
 
     fromEither[IO](cwlToolResult)
   }

--- a/cwl/src/main/scala/cwl/CwlDecoder.scala
+++ b/cwl/src/main/scala/cwl/CwlDecoder.scala
@@ -21,7 +21,7 @@ object CwlDecoder {
     val cwlToolResult =
       Try(CwltoolRunner.instance.salad(path))
         .toEither
-        .leftMap(t => NonEmptyList.one(s"running cwltool on file ${path.toString} failed with ${t.value}"))
+        .leftMap(t => NonEmptyList.one(s"running cwltool on file ${path.toString} failed with $t"))
 
     fromEither[IO](cwlToolResult)
   }

--- a/cwl/src/main/scala/cwl/CwlDecoder.scala
+++ b/cwl/src/main/scala/cwl/CwlDecoder.scala
@@ -21,7 +21,7 @@ object CwlDecoder {
     val cwlToolResult =
       Try(CwltoolRunner.instance.salad(path))
         .toEither
-        .leftMap(t => NonEmptyList.one(s"running cwltool on file ${path.toString} failed with ${t.getMessage}"))
+        .leftMap(t => NonEmptyList.one(s"running cwltool on file ${path.toString} failed with ${t.value}"))
 
     fromEither[IO](cwlToolResult)
   }

--- a/cwl/src/test/scala/cwl/CwlDecoderSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlDecoderSpec.scala
@@ -27,8 +27,8 @@ class CwlDecoderSpec extends FlatSpec with Matchers {
       unsafeRunSync
 
     result.isLeft shouldBe true
-    "Field `run` contains undefined reference to.+wrong.cwl".r.findAllIn(result.left.get.head).size shouldBe 1
-    "Field `run` contains undefined reference to.+wrong2.cwl".r.findAllIn(result.left.get.head).size shouldBe 1
+    "Field `run` contains undefined reference to `file://.+/wrong.cwl`".r.findAllIn(result.left.get.head).size shouldBe 1
+    "Field `run` contains undefined reference to `file://.+/wrong2.cwl`".r.findAllIn(result.left.get.head).size shouldBe 1
   }
 
   it should "fail to parse invalid linked cwl" in {

--- a/cwl/src/test/scala/cwl/CwlDecoderSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlDecoderSpec.scala
@@ -1,5 +1,6 @@
 package cwl
 
+import cats.data.NonEmptyList
 import cwl.CwlDecoder._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -21,10 +22,13 @@ class CwlDecoderSpec extends FlatSpec with Matchers {
   }
 
   it should "fail to parse broken linked cwl" in {
-      decodeCwlFile(rootPath / "brokenlinks.cwl").
-        value.
-        unsafeRunSync.
-        isLeft shouldBe true
+    val result: Either[NonEmptyList[String], Cwl] = decodeCwlFile(rootPath / "brokenlinks.cwl").
+      value.
+      unsafeRunSync
+
+    result.isLeft shouldBe true
+    "Field `run` contains undefined reference to.+wrong.cwl".r.findAllIn(result.left.get.head).size shouldBe 1
+    "Field `run` contains undefined reference to.+wrong2.cwl".r.findAllIn(result.left.get.head).size shouldBe 1
   }
 
   it should "fail to parse invalid linked cwl" in {


### PR DESCRIPTION
Ran into this while working on #4119 

Before:
```
Workflow input processing failed:
running cwltool on file /var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/e0ae0c88-17c0-476b-9b74-bc5562b22ea3.temp.4377309718155227727/e0ae0c88-17c0-476b-9b74-bc5562b22ea3.cwl failed with null
```
After:
```
Workflow input processing failed:
running cwltool on file /var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl failed with Traceback (most recent call last):
  File "/Users/anichols/Library/Caches/Coursier/v1/https/broadinstitute.jfrog.io/broadinstitute/libs-release/org/broadinstitute/heterodon/1.0.0-beta1/heterodon-1.0.0-beta1-single.jar/Lib/heterodon/__init__.py", line 24, in apply
  File "<string>", line 1, in <module>
  File "<string>", line 12, in cwltool_salad
  File "/Users/anichols/Library/Caches/Coursier/v1/https/broadinstitute.jfrog.io/broadinstitute/libs-release/org/broadinstitute/heterodon/1.0.0-beta1/heterodon-1.0.0-beta1-single.jar/Lib/cwltool/load_tool.py", line 279, in validate_document
  File "/Users/anichols/Library/Caches/Coursier/v1/https/broadinstitute.jfrog.io/broadinstitute/libs-release/org/broadinstitute/heterodon/1.0.0-beta1/heterodon-1.0.0-beta1-single.jar/Lib/schema_salad/ref_resolver.py", line 915, in resolve_all
  File "/Users/anichols/Library/Caches/Coursier/v1/https/broadinstitute.jfrog.io/broadinstitute/libs-release/org/broadinstitute/heterodon/1.0.0-beta1/heterodon-1.0.0-beta1-single.jar/Lib/schema_salad/ref_resolver.py", line 1087, in validate_links
schema_salad.validate.ValidationException: ../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl:11:1: checking field `steps`
../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl:19:3:   checking object `../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl#compile`
../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl:20:5:     Field `run` contains undefined reference to `file:///var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/arguments.cwl`
../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl:12:3:   checking object `../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl#untar`
../../../../../var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/c8eb79b9-eee9-4796-b374-4841ff18a27d.cwl:13:5:     Field `run` contains undefined reference to `file:///var/folders/g_/4k204pzx6sg6gcnqc2bqfykxx8k880/T/c8eb79b9-eee9-4796-b374-4841ff18a27d.temp.3969925185320342713/tar-param.cwl`
```
I'm assuming `getMessage` does not work as expected here because the underlying `Throwable` comes from Python.

I did try `t.value.getMessage` to potentially trim down the stack trace, but that's also `null`.