### PR TITLE
Implement recover in TES and improve abort

### DIFF
--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
@@ -15,6 +15,7 @@ metadata {
   status: Aborted
   "calls.scheduled_abort.let_me_run.executionStatus": "Done"
   "calls.scheduled_abort.aborted.executionStatus": "Aborted"
+  "calls.scheduled_abort.aborted.backendStatus": "Cancelled"
 }
 
 absent-metadata-keys: ["calls.scheduled_abort.lost_in_space.status"]

--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_tes.test
@@ -14,7 +14,7 @@ metadata {
   workflowName: scheduled_abort
   status: Aborted
   "calls.scheduled_abort.let_me_run.executionStatus": "Done"
-  "calls.scheduled_abort.aborted.executionStatus": "Failed"
+  "calls.scheduled_abort.aborted.executionStatus": "Aborted"
 }
 
 absent-metadata-keys: ["calls.scheduled_abort.lost_in_space.status"]

--- a/centaur/src/main/resources/standardTestCases/restart.restart_tes_without_recover.test
+++ b/centaur/src/main/resources/standardTestCases/restart.restart_tes_without_recover.test
@@ -1,5 +1,5 @@
 name: restart_tes_without_recover
-testFormat: CromwellRestartWithoutRecover
+testFormat: CromwellRestartWithRecover
 callMark: cromwell_restart.cromwell_killer
 backends: [TES]
 tags: [localdockertest]

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -167,7 +167,17 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(ctr.id), None, previousStatus = None)
   }
 
-  override def recoverAsync(jobId: StandardAsyncJob) = executeAsync()
+  override def reconnectAsync(jobId: StandardAsyncJob) = {
+    val handle = PendingExecutionHandle[StandardAsyncJob, StandardAsyncRunInfo, StandardAsyncRunStatus](jobDescriptor, jobId, None, previousStatus = None)
+    Future.successful(handle)
+  }
+
+  override def recoverAsync(jobId: StandardAsyncJob) = reconnectAsync(jobId)
+
+  override def reconnectToAbortAsync(jobId: StandardAsyncJob) = {
+    tryAbort(jobId)
+    reconnectAsync(jobId)
+  }
 
   override def tryAbort(job: StandardAsyncJob): Unit = {
 


### PR DESCRIPTION
This should also fix transient failures of the `abort a workflow mid run and restart immediately abort.restart_abort_tes` centaur test