### PR TITLE
Don't really glob when evaluating files

### DIFF
--- a/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
@@ -10,8 +10,8 @@ import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.io.DirectoryFunctions.listFiles
 import cromwell.core.io.AsyncIoFunctions
 import cromwell.core.path.{Path, PathFactory}
-import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.expression.IoFunctionSet.{IoDirectory, IoElement, IoFile}
+import wom.expression.{IoFunctionSet, IoFunctionSetAdapter}
 import wom.graph.CommandCallNode
 import wom.values.{WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomSingleFile, WomUnlistedDirectory}
 
@@ -20,10 +20,12 @@ import scala.util.Try
 
 trait DirectoryFunctions extends IoFunctionSet with PathFactory with AsyncIoFunctions {
 
+  private lazy val evaluateFileFunctions = new IoFunctionSetAdapter(this) with FileEvaluationIoFunctionSet
+
   def findDirectoryOutputs(call: CommandCallNode,
                            jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomUnlistedDirectory]] = {
     call.callable.outputs.flatTraverse[ErrorOr, WomUnlistedDirectory] { outputDefinition =>
-      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, NoIoFunctionSet, outputDefinition.womType) map {
+      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, evaluateFileFunctions, outputDefinition.womType) map {
         _.toList.flatMap(_.file.flattenFiles) collect { case unlistedDirectory: WomUnlistedDirectory => unlistedDirectory }
       }
     }

--- a/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/DirectoryFunctions.scala
@@ -10,7 +10,7 @@ import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.io.DirectoryFunctions.listFiles
 import cromwell.core.io.AsyncIoFunctions
 import cromwell.core.path.{Path, PathFactory}
-import wom.expression.IoFunctionSet
+import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.expression.IoFunctionSet.{IoDirectory, IoElement, IoFile}
 import wom.graph.CommandCallNode
 import wom.values.{WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomSingleFile, WomUnlistedDirectory}
@@ -23,7 +23,7 @@ trait DirectoryFunctions extends IoFunctionSet with PathFactory with AsyncIoFunc
   def findDirectoryOutputs(call: CommandCallNode,
                            jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomUnlistedDirectory]] = {
     call.callable.outputs.flatTraverse[ErrorOr, WomUnlistedDirectory] { outputDefinition =>
-      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, this, outputDefinition.womType) map {
+      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, NoIoFunctionSet, outputDefinition.womType) map {
         _.toList.flatMap(_.file.flattenFiles) collect { case unlistedDirectory: WomUnlistedDirectory => unlistedDirectory }
       }
     }

--- a/backend/src/main/scala/cromwell/backend/io/FileEvaluationIoFunctionSet.scala
+++ b/backend/src/main/scala/cromwell/backend/io/FileEvaluationIoFunctionSet.scala
@@ -1,0 +1,9 @@
+package cromwell.backend.io
+
+import wom.expression.IoFunctionSet
+
+import scala.concurrent.Future
+
+trait FileEvaluationIoFunctionSet { this: IoFunctionSet =>
+  override def glob(pattern: String) = Future.failed(new IllegalStateException("Cannot perform globing while evaluating files"))
+}

--- a/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
@@ -6,7 +6,7 @@ import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.BackendJobDescriptor
 import cromwell.core.CallContext
 import cromwell.core.io.AsyncIoFunctions
-import wom.expression.IoFunctionSet
+import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.graph.CommandCallNode
 import wom.values._
 
@@ -18,7 +18,7 @@ trait GlobFunctions extends IoFunctionSet with AsyncIoFunctions {
 
   def findGlobOutputs(call: CommandCallNode, jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomGlobFile]] = {
     def fromOutputs = call.callable.outputs.flatTraverse[ErrorOr, WomGlobFile] { outputDefinition =>
-      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, this, outputDefinition.womType) map {
+      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, NoIoFunctionSet, outputDefinition.womType) map {
         _.toList.flatMap(_.file.flattenFiles) collect { case glob: WomGlobFile => glob }
       }
     }

--- a/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/io/GlobFunctions.scala
@@ -6,7 +6,7 @@ import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.BackendJobDescriptor
 import cromwell.core.CallContext
 import cromwell.core.io.AsyncIoFunctions
-import wom.expression.{IoFunctionSet, NoIoFunctionSet}
+import wom.expression.{IoFunctionSet, IoFunctionSetAdapter}
 import wom.graph.CommandCallNode
 import wom.values._
 
@@ -14,11 +14,13 @@ import scala.concurrent.Future
 
 trait GlobFunctions extends IoFunctionSet with AsyncIoFunctions {
 
+  private lazy val evaluateFileFunctions = new IoFunctionSetAdapter(this) with FileEvaluationIoFunctionSet
+
   def callContext: CallContext
 
   def findGlobOutputs(call: CommandCallNode, jobDescriptor: BackendJobDescriptor): ErrorOr[List[WomGlobFile]] = {
     def fromOutputs = call.callable.outputs.flatTraverse[ErrorOr, WomGlobFile] { outputDefinition =>
-      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, NoIoFunctionSet, outputDefinition.womType) map {
+      outputDefinition.expression.evaluateFiles(jobDescriptor.localInputs, evaluateFileFunctions, outputDefinition.womType) map {
         _.toList.flatMap(_.file.flattenFiles) collect { case glob: WomGlobFile => glob }
       }
     }

--- a/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
+++ b/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
@@ -1,0 +1,15 @@
+package wom.expression
+
+class IoFunctionSetAdapter(delegate: IoFunctionSet) extends IoFunctionSet {
+  override def pathFunctions = delegate.pathFunctions
+  override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean) = delegate.readFile(path, maxBytes, failOnOverflow)
+  override def writeFile(path: String, content: String) = delegate.writeFile(path, content)
+  override def createTemporaryDirectory(name: Option[String]) = delegate.createTemporaryDirectory(name)
+  override def copyFile(source: String, destination: String) = delegate.copyFile(source, destination)
+  override def glob(pattern: String) = delegate.glob(pattern)
+  override def listAllFilesUnderDirectory(dirPath: String) = delegate.listAllFilesUnderDirectory(dirPath)
+  override def listDirectory(path: String)(visited: Vector[String]) = delegate.listDirectory(path)(visited)
+  override def isDirectory(path: String) = delegate.isDirectory(path)
+  override def size(path: String) = delegate.size(path)
+  override implicit def ec  = delegate.ec
+}


### PR DESCRIPTION
The `evaluateFiles` method is used to figure out what files are going to be produced or are referenced by an expression, before the task has been run.
In this context it doesn't make sense to do the work of evaluating `glob` which will fail since the task hasn't run.
Instead, fail immediately. When that happens, we fallback to a second algorithm to evaluate the files ([draft-2](https://github.com/broadinstitute/cromwell/blob/541636734705b7d93321a31ac5817f96b275eb0f/wdl/model/draft2/src/main/scala/wdl/draft2/model/expression/FileEvaluator.scala#L52), [draft-3](https://github.com/broadinstitute/cromwell/blob/541636734705b7d93321a31ac5817f96b275eb0f/wdl/model/draft3/src/main/scala/wdl/model/draft3/graph/expression/FileEvaluator.scala#L25))

This should fix the `dontglobinputs` transient centaur failures. With the caveat that the real underlying issue is this: https://github.com/broadinstitute/cromwell/issues/4209