### PR TITLE
Retry ontology parsing

### DIFF
--- a/common/src/main/scala/common/util/Backoff.scala
+++ b/common/src/main/scala/common/util/Backoff.scala
@@ -1,0 +1,19 @@
+package common.util
+
+import scala.concurrent.duration.FiniteDuration
+
+trait Backoff {
+  /** Next interval in millis */
+  def backoffMillis: Long
+  /** Get the next instance of backoff. This should be called after every call to backoffMillis */
+  def next: Backoff
+}
+
+object Backoff {
+  def staticBackoff(time: FiniteDuration) = StaticBackoff(time)
+}
+
+case class StaticBackoff(time: FiniteDuration) extends Backoff {
+  override def backoffMillis = time.toMillis
+  override def next = this
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -397,12 +397,15 @@ languages {
   }
 }
 
-# Uncomment to enable caching of ontologies. Improves performance when loading ontologies from remote IRIs.
-#ontology {
-#  cache {
-#    max-size = 20
-#  }
-#}
+ontology {
+  # Uncomment to enable caching of ontologies. Improves performance when loading ontologies from remote IRIs.
+  #cache {
+  #  max-size = 20
+  #}
+  retries = 3
+  pool-size = 3
+  backoff-time = 2 seconds
+}
 
 
 # Other backend examples are in cromwell.examples.conf

--- a/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/actor/RobustClientHelper.scala
@@ -1,9 +1,10 @@
 package cromwell.core.actor
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable}
+import common.util.Backoff
 import cromwell.core.actor.RobustClientHelper._
 import cromwell.core.actor.StreamIntegration._
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.language.postfixOps

--- a/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
+++ b/core/src/main/scala/cromwell/core/io/IoClientHelper.scala
@@ -2,8 +2,9 @@ package cromwell.core.io
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import com.typesafe.config.{Config, ConfigFactory}
+import common.util.Backoff
 import cromwell.core.actor.RobustClientHelper
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 
 import scala.concurrent.duration._
 import net.ceedubs.ficus.Ficus._

--- a/core/src/main/scala/cromwell/core/path/CustomRetryParams.scala
+++ b/core/src/main/scala/cromwell/core/path/CustomRetryParams.scala
@@ -1,6 +1,7 @@
 package cromwell.core.path
 
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import common.util.Backoff
+import cromwell.core.retry.SimpleExponentialBackoff
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._

--- a/core/src/main/scala/cromwell/core/retry/GoogleBackoff.scala
+++ b/core/src/main/scala/cromwell/core/retry/GoogleBackoff.scala
@@ -2,16 +2,10 @@ package cromwell.core.retry
 
 import com.google.api.client.util.ExponentialBackOff
 import com.typesafe.config.Config
+import common.util.Backoff
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
-
-trait Backoff {
-  /** Next interval in millis */
-  def backoffMillis: Long
-  /** Get the next instance of backoff. This should be called after every call to backoffMillis */
-  def next: Backoff
-}
 
 object InitialGapBackoff {
   def apply(initialGap: FiniteDuration, initialInterval: FiniteDuration, maxInterval: FiniteDuration, multiplier: Double) = {

--- a/core/src/main/scala/cromwell/core/retry/Retry.scala
+++ b/core/src/main/scala/cromwell/core/retry/Retry.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.concurrent.{ExecutionContext, Future}
 import akka.pattern.after
+import common.util.Backoff
 
 object Retry {
   /**

--- a/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/actor/RobustClientHelperSpec.scala
@@ -2,9 +2,10 @@ package cromwell.core.actor
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
+import common.util.Backoff
 import cromwell.core.TestKitSuite
 import cromwell.core.actor.StreamIntegration.BackPressure
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import org.scalatest.{FlatSpecLike, Matchers}
 
 import scala.concurrent.duration._

--- a/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoClientHelperSpec.scala
@@ -2,10 +2,11 @@ package cromwell.core.io
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
 import akka.testkit.{TestActorRef, TestProbe}
+import common.util.Backoff
 import cromwell.core.TestKitSuite
 import cromwell.core.io.DefaultIoCommand.DefaultIoSizeCommand
 import cromwell.core.path.Path
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpecLike, Matchers}
 

--- a/cwl/src/main/scala/cwl/ontology/OntologyConfiguration.scala
+++ b/cwl/src/main/scala/cwl/ontology/OntologyConfiguration.scala
@@ -1,0 +1,27 @@
+package cwl.ontology
+
+import cats.syntax.apply._
+import com.typesafe.config.Config
+import common.util.Backoff
+import common.validation.ErrorOr.ErrorOr
+import common.validation.Validation._
+import net.ceedubs.ficus.Ficus._
+
+import scala.concurrent.duration.FiniteDuration
+
+case class OntologyConfiguration(retries: Option[Int], backoff: Backoff, poolSize: Int)
+
+object OntologyConfiguration {
+  def apply(config: Config): OntologyConfiguration = {
+    val retries = validate { Option(config.as[Int]("retries")) }
+    val backoff = validate {
+      Backoff.staticBackoff(
+        config.as[FiniteDuration]("backoff-time")
+      )
+    }
+    val poolSize = validate { config.as[Int]("pool-size") }
+
+    val validated: ErrorOr[OntologyConfiguration] = (retries, backoff, poolSize).mapN(OntologyConfiguration.apply)
+    validated.unsafe("Ontology configuration")
+  }
+}

--- a/cwl/src/main/scala/cwl/ontology/Schema.scala
+++ b/cwl/src/main/scala/cwl/ontology/Schema.scala
@@ -8,8 +8,8 @@ import cats.syntax.traverse._
 import com.google.common.cache.{Cache, CacheBuilder}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
+import common.util.IORetry
 import common.util.IORetry.StatefulIoError
-import common.util.{Backoff, IORetry}
 import common.validation.ErrorOr._
 import common.validation.Validation._
 import cwl.ontology.Schema._
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{FiniteDuration, _}
 import scala.util.Try
 
 /**
@@ -110,19 +109,15 @@ case class Schema(schemaIris: Seq[String],
 object Schema {
   // Extending StrictLogging creates a circular dependency here for some reason, so making the logger ourselves
   private val logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
-  private [ontology] val ontologyConfig = ConfigFactory.load.getAs[Config]("ontology")
-  private [ontology] val cacheConfig = ontologyConfig.flatMap(_.getAs[Config]("cache"))
+  private [ontology] val ontologyConfig = ConfigFactory.load.as[Config]("ontology")
+  private val ontologyConfiguration = OntologyConfiguration(ontologyConfig)
+  private [ontology] val cacheConfig = ontologyConfig.getAs[Config]("cache")
 
   // Simple cache to avoid reloading the same ontologies too often
   private val ontologyCache = cacheConfig.map(makeOntologyCache)
 
-  // Loading the ontology can fail transiently, so retry 3 times by default
-  // See https://github.com/protegeproject/webprotege/issues/298
-  private val retries = ontologyConfig.flatMap(_.getAs[Int]("retries")).getOrElse(3)
-  private val backoffTime = ontologyConfig.flatMap(_.getAs[FiniteDuration]("backoff")).getOrElse(1.second)
-  private val backoff = Backoff.staticBackoff(backoffTime)
   private implicit val statefulIoError = StatefulIoError.noop[Unit]
-  private implicit val timer = cats.effect.IO.timer(ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()))
+  private implicit val timer = cats.effect.IO.timer(ExecutionContext.fromExecutor(Executors.newFixedThreadPool(ontologyConfiguration.poolSize)))
 
   private [ontology] def makeOntologyCache(config: Config): Cache[IRI, OWLOntology] = {
     val cacheConfig = CacheConfiguration(config)
@@ -148,16 +143,17 @@ object Schema {
           ontologyManager.copyOntology(ontology, OntologyCopy.DEEP)
         case _ =>
           logger.info(s"Loading ${iri.toURI.toString}")
-          val ontology =loadOntologyFromIri(ontologyManager, iri)
+          val ontology = loadOntologyFromIri(ontologyManager, iri)
           cache.foreach(_.put(iri, ontology))
           ontology
       }
     }
   }
 
+  // Loading the ontology can fail transiently, so put retires around it. See https://github.com/protegeproject/webprotege/issues/298
   private [ontology] def loadOntologyFromIri(ontologyManager: OWLOntologyManager, iri: IRI): OWLOntology = {
     val load = IO { ontologyManager.loadOntologyFromOntologyDocument(iri) }
-    IORetry.withRetry[OWLOntology, Unit](load, (), Option(retries), backoff).unsafeRunSync()
+    IORetry.withRetry[OWLOntology, Unit](load, (), ontologyConfiguration.retries, ontologyConfiguration.backoff).unsafeRunSync()
   }
 
   /**

--- a/cwl/src/test/resources/application.conf
+++ b/cwl/src/test/resources/application.conf
@@ -2,3 +2,13 @@ akka {
   log-dead-letters = "off"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
+
+ontology {
+  # Uncomment to enable caching of ontologies. Improves performance when loading ontologies from remote IRIs.
+  #cache {
+  #  max-size = 20
+  #}
+  retries = 3
+  pool-size = 3
+  backoff-time = 2 seconds
+}

--- a/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/HttpFlowWithRetry.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/registryv2/flows/HttpFlowWithRetry.scala
@@ -6,9 +6,10 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.{ActorMaterializer, FanOutShape2}
 import akka.stream.javadsl.MergePreferred
 import akka.stream.scaladsl.{Flow, GraphDSL, Partition}
+import common.util.Backoff
 import cromwell.docker.registryv2.flows.FlowUtils._
 import cromwell.docker.registryv2.flows.HttpFlowWithRetry._
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration._

--- a/engine/src/main/scala/cromwell/engine/io/IoAttempts.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoAttempts.scala
@@ -1,8 +1,8 @@
 package cromwell.engine.io
 
 import cats.Show
+import common.util.IORetry.StatefulIoError
 import cromwell.core.CromwellFatalExceptionMarker
-import cromwell.core.retry.IORetry.StatefulIoError
 import org.apache.commons.lang3.exception.ExceptionUtils
 
 object IoAttempts {

--- a/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchCommandContext.scala
+++ b/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchCommandContext.scala
@@ -9,8 +9,9 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.google.api.client.util.ExponentialBackOff
 import com.google.cloud.storage.StorageException
+import common.util.Backoff
 import cromwell.core.io.SingleFileIoCommand
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.engine.io.IoActor.IoResult
 import cromwell.engine.io.gcs.GcsBatchCommandContext.BatchResponse
 import cromwell.engine.io.{IoActor, IoCommandContext}

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -6,9 +6,9 @@ import java.nio.charset.StandardCharsets
 import akka.actor.Scheduler
 import akka.stream.scaladsl.Flow
 import cats.effect.IO
+import common.util.IORetry
 import cromwell.core.io._
 import cromwell.core.path.Path
-import cromwell.core.retry.IORetry
 import cromwell.engine.io.IoActor._
 import cromwell.engine.io.{IoAttempts, IoCommandContext}
 import cromwell.filesystems.gcs.GcsPath

--- a/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/WorkflowDockerLookupActorSpec.scala
@@ -3,8 +3,9 @@ package cromwell.engine.workflow
 import akka.actor.{ActorRef, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
+import common.util.Backoff
 import cromwell.core.actor.StreamIntegration.BackPressure
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{TestKitSuite, WorkflowId}
 import cromwell.database.slick.EngineSlickDatabase
 import cromwell.database.sql.tables.DockerHashStoreEntry

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/nio/OssStorageRetry.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/nio/OssStorageRetry.scala
@@ -1,7 +1,8 @@
 package cromwell.filesystems.oss.nio
 
 import com.aliyun.oss.{ClientException, OSSException}
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import common.util.Backoff
+import cromwell.core.retry.SimpleExponentialBackoff
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
@@ -8,13 +8,14 @@ import akka.dispatch.ControlMessage
 import cats.data.NonEmptyList
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.{HttpHeaders, HttpRequest}
+import common.util.Backoff
 import cromwell.backend.BackendSingletonActorAbortWorkflow
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiRunCreationClient.JobAbortedException
 import cromwell.backend.google.pipelines.common.PapiInstrumentation
 import cromwell.backend.standard.StandardAsyncJob
 import cromwell.core.Dispatcher.BackendDispatcher
-import cromwell.core.retry.{Backoff, SimpleExponentialBackoff}
+import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{CromwellFatalExceptionMarker, LoadConfig, Mailbox, WorkflowId}
 import cromwell.services.instrumentation.{CromwellInstrumentation, CromwellInstrumentationScheduler}
 import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}


### PR DESCRIPTION
There is a bug in the owl library where ontology parsing can sometimes fail, causing tests to fail.
See https://github.com/protegeproject/webprotege/issues/298

For now retry parsing a few times. Should fix the `cwl_format***` transient centaur failures.