### PR TITLE
Fix lowestCommonSubtype order within complex types

### DIFF
--- a/cwl/src/test/scala/cwl/WorkflowStepInputSpec.scala
+++ b/cwl/src/test/scala/cwl/WorkflowStepInputSpec.scala
@@ -72,7 +72,7 @@ object WorkflowStepInputSpec extends Properties("WorkflowStepInput") {
     WorkflowStepInput.determineMergeType(Map("s#in" -> WomBooleanType, "s#in2" -> WomIntegerType),
       Option(LinkMergeMethod.MergeFlattened),
       None, hasDefault = false
-    ) == Right(WomAnyType)
+    ) == Right(WomStringType)
   }
 }
 

--- a/wdl/model/draft2/src/test/scala/wdl/expression/ValueEvaluatorSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/expression/ValueEvaluatorSpec.scala
@@ -2,6 +2,7 @@ package wdl.expression
 
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{FlatSpec, Matchers}
+import wdl.draft2.model
 import wdl.draft2.model.WdlExpression
 import wdl.draft2.model.expression.{NoFunctions, WdlStandardLibraryFunctions, WdlStandardLibraryFunctionsType}
 import wdl.shared.FileSizeLimitationConfig
@@ -570,5 +571,24 @@ class ValueEvaluatorSpec extends FlatSpec with Matchers {
     val evaluated = exp.evaluate(lookup, NoFunctions)
     evaluated.isSuccess shouldBe true
     evaluated.get.womType shouldBe WomMapType(WomStringType, WomOptionalType(WomStringType))
+  }
+
+  it should "evaluate a map literal with values of String? and Int? into a Map[String, String?]" in {
+    val str = """ { "i": i_in, "s": s_in } """
+    val lookup = Map(
+      "i_in" -> WomOptionalValue(WomIntegerType, Some(WomInteger(1))),
+      "s_in" -> WomOptionalValue(WomStringType, Some(WomString("two")))
+    )
+    val exp = model.WdlExpression.fromString(str)
+
+    val expectedMap: WomMap = WomMap(WomMapType(WomStringType, WomOptionalType(WomStringType)), Map (
+      WomString("i") -> WomOptionalValue(WomStringType, Some(WomString("1"))),
+      WomString("s") -> WomOptionalValue(WomStringType, Some(WomString("two")))
+    ))
+
+    val evaluated = exp.evaluate(lookup, NoFunctions)
+
+    evaluated.isSuccess should be(true)
+    evaluated.get should be(expectedMap)
   }
 }

--- a/wom/src/main/scala/wom/types/WomPrimitiveType.scala
+++ b/wom/src/main/scala/wom/types/WomPrimitiveType.scala
@@ -1,6 +1,7 @@
 package wom.types
 
 trait WomPrimitiveType extends WomType {
+
   lazy val coercionMap: Map[WomType, Seq[WomType]] = Map(
     // From type -> To type
     WomAnyType -> Seq(WomStringType, WomIntegerType, WomFloatType, WomSingleFileType, WomBooleanType),

--- a/wom/src/main/scala/wom/types/WomType.scala
+++ b/wom/src/main/scala/wom/types/WomType.scala
@@ -115,13 +115,19 @@ object WomType {
         firstCommonPrimitive(types)
       } else None
     }
+
+    val coercePriority = List(
+      WomStringType, WomSingleFileType, WomUnlistedDirectoryType, WomFloatType, WomIntegerType, WomBooleanType, WomObjectType
+    )
+
     private def firstCommonPrimitive(types: Iterable[WomType]): Option[WomType] = {
-      // See if any of the types are a good candidate:
-      val options = types.filter(t => types.forall(_.isCoerceableFrom(t)))
-      womTypeCoercionOrder.collectFirst {
-        // Primitives:
-        case p: WomPrimitiveType if options.toList.contains(p) => p
-      }
+      // Types in the incoming list which everything could coerce to:
+      val suppliedOptions = types.filter(t => types.forall(t.isCoerceableFrom))
+
+      // A type not in the incoming list but which everything could coerce to nonetheless:
+      lazy val unsuppliedOption: Option[WomType] = coercePriority.find(p => types.forall(p.isCoerceableFrom))
+
+      coercePriority.find { p => suppliedOptions.toList.contains(p) } orElse { unsuppliedOption }
     }
   }
 

--- a/wom/src/main/scala/wom/values/WomMap.scala
+++ b/wom/src/main/scala/wom/values/WomMap.scala
@@ -40,11 +40,11 @@ object WomMap {
   def apply(m: Map[WomValue, WomValue]): WomMap = {
     val keyType = WomType.lowestCommonSubtype(m.keys.map(_.womType))
     val valueType = WomType.lowestCommonSubtype(m.values.map(_.womType))
-    WomMap(WomMapType(keyType, valueType), m)
+    coerceMap(m, WomMapType(keyType, valueType))
   }
 }
 
-case class WomMap(womType: WomMapType, value: Map[WomValue, WomValue]) extends WomValue with WomArrayLike with TsvSerializable {
+final case class WomMap private(womType: WomMapType, value: Map[WomValue, WomValue]) extends WomValue with WomArrayLike with TsvSerializable {
   val typesUsedInKey = value.map { case (k, _) => k.womType }.toSet
 
   if (typesUsedInKey.size == 1 && typesUsedInKey.head != womType.keyType)
@@ -73,7 +73,7 @@ case class WomMap(womType: WomMapType, value: Map[WomValue, WomValue]) extends W
     }
   }
 
-  def map(f: PartialFunction[((WomValue, WomValue)), (WomValue, WomValue)]): WomMap = {
+  def map(f: PartialFunction[(WomValue, WomValue), (WomValue, WomValue)]): WomMap = {
     value map f match {
       case m: Map[WomValue, WomValue] if m.nonEmpty => WomMap(WomMapType(m.head._1.womType, m.head._2.womType), m)
       case _ => this

--- a/wom/src/test/scala/wom/types/WomTypeSpec.scala
+++ b/wom/src/test/scala/wom/types/WomTypeSpec.scala
@@ -156,4 +156,59 @@ class WomTypeSpec extends FlatSpec with Matchers {
     ("Pair[Int, String]", WomPairType(WomIntegerType, WomStringType)),
     ("Pair[Array[Int], String]", WomPairType(WomArrayType(WomIntegerType), WomStringType))
   )
+
+  behavior of "lowestCommonSubtype"
+
+  it should "choose correctly between two primitives" in {
+    WomType.lowestCommonSubtype(Seq(WomStringType, WomIntegerType)) should be(WomStringType)
+  }
+
+  it should "choose a good pair type" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomPairType(WomStringType, WomIntegerType),
+      WomPairType(WomIntegerType, WomStringType)
+    )) should be(WomPairType(WomStringType, WomStringType))
+  }
+
+  it should "choose a good optional type" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomOptionalType(WomIntegerType),
+      WomOptionalType(WomStringType)
+    )) should be(WomOptionalType(WomStringType))
+  }
+
+  it should "support boxing into an optional type" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomOptionalType(WomIntegerType),
+      WomStringType
+    )) should be(WomOptionalType(WomStringType))
+  }
+
+  it should "choose a good array type" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomArrayType(WomOptionalType(WomIntegerType)),
+      WomArrayType(WomOptionalType(WomStringType))
+    )) should be(WomArrayType(WomOptionalType(WomStringType)))
+  }
+
+  it should "choose a good map type" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomOptionalType(WomMapType(WomIntegerType, WomStringType)),
+      WomOptionalType(WomMapType(WomStringType, WomIntegerType)),
+    )) should be(WomOptionalType(WomMapType(WomStringType, WomStringType)))
+  }
+
+  it should "choose 'object' for lists of objects" in {
+    WomType.lowestCommonSubtype(Seq(
+      WomCompositeType(Map(
+        "i" -> WomIntegerType,
+        "s" -> WomStringType
+      )),
+      WomCompositeType(Map(
+        "a" -> WomStringType,
+        "b" -> WomIntegerType
+      ))
+    )) should be(WomObjectType)
+  }
+
 }


### PR DESCRIPTION
Superficially fixes #4131 since there was a genuine problem, but see the comment on the issue about preferring `object { }` when creating objects (especially when they have non-homogeneous fields).