### PR TITLE
Only execute isAlive once per timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Cromwell Change Log
 
+## 37 Release Notes
+
+### Changing configuration options
+
+When the value `exit-code-timeout-seconds` is set, `isAlive` is only called only each interval instead on each poll.
+
+
 ## 36 Release Notes
 
 ### Extra configuration options
 
 The value `exit-code-timeout-seconds` can now set in a backend configuration.
-Details [here](https://cromwell.readthedocs.io/en/develop/backends/HPC/#Exit-code-timeout)
+Details [here](https://cromwell.readthedocs.io/en/develop/backends/HPC/#exit-code-timeout)
 
 ### [AWS S3 file transfers are now encrypted](https://github.com/broadinstitute/cromwell/pull/4264)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changing configuration options
 
-When the value `exit-code-timeout-seconds` is set, `isAlive` is only called only each interval instead on each poll.
+When the value `exit-code-timeout-seconds` is set, `check-alive` command is now only called once every timeout interval instead of each poll.
 
 
 ## 36 Release Notes

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -1006,8 +1006,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
       // the state names.
       // This logging and metadata publishing assumes that StandardAsyncRunState subtypes `toString` nicely to state names.
       val prevStatusName = previousState.map(_.toString).getOrElse("-")
-      if (prevStatusName == state.toString) jobLogger.debug(s"Status change from $prevStatusName to $state")
-      else jobLogger.info(s"Status change from $prevStatusName to $state")
+      jobLogger.info(s"Status change from $prevStatusName to $state")
       tellMetadata(Map(CallMetadataKeys.BackendStatus -> state))
     }
 

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -1002,7 +1002,8 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
       the state names.
        */
       val prevStateName = previousStatus.map(_.toString).getOrElse("-")
-      jobLogger.info(s"Status change from $prevStateName to $status")
+      if (prevStateName == status.toString) jobLogger.debug(s"Status change from $prevStateName to $status")
+      else jobLogger.info(s"Status change from $prevStateName to $status")
       tellMetadata(Map(CallMetadataKeys.BackendStatus -> status))
     }
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.sfs
 
 import java.nio.file.FileAlreadyExistsException
+import java.time.{LocalDateTime, ZoneId}
 import java.util.Calendar
 
 import cromwell.backend._
@@ -18,10 +19,11 @@ import scala.util.{Failure, Success, Try}
 case class SharedFileSystemRunStatus(status: String, date: Calendar) {
   override def toString: String = status
 
-  def experired(timeoutSeconds: Int): Boolean = {
-    val currentDate = Calendar.getInstance()
-    currentDate.add(Calendar.SECOND, -timeoutSeconds)
-    this.date.after(currentDate)
+  def expired(timeoutInSeconds: Long): Boolean = {
+    LocalDateTime
+      .ofInstant(date.toInstant, ZoneId.systemDefault())
+      .plusSeconds(timeoutInSeconds)
+      .isBefore(LocalDateTime.now())
   }
 }
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -17,6 +17,12 @@ import scala.util.{Failure, Success, Try}
 
 case class SharedFileSystemRunStatus(status: String, date: Calendar) {
   override def toString: String = status
+
+  def experired(timeoutSeconds: Int): Boolean = {
+    val currentDate = Calendar.getInstance()
+    currentDate.add(Calendar.SECOND, -timeoutSeconds)
+    this.date.after(currentDate)
+  }
 }
 
 object SharedFileSystemRunStatus {


### PR DESCRIPTION
Follow up on https://github.com/broadinstitute/cromwell/pull/4112

This will reduce the load on the JVM a lot

 I did indeed a stress test on our system with 50.000 async qsub/qstat jobs but this was outside the jvm. Inside the jvm this ends up in blocking threads to cromwell.

When the timeout is set to 120 seconds, `isAlive` will only run once each 120 seconds.