### PR TITLE
Prevent attempt to create symlinks across partitions in flaky SharedFileSystemJobExecutionActorSpec

### DIFF
--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -134,7 +134,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
 
       val jobPaths = JobPathsWithDocker(jobDescriptor.key, workflowDescriptor, conf.backendConfig)
 
-      whenReady(backend.execute/*, Timeout.apply()*/) { executionResponse =>
+      whenReady(backend.execute) { executionResponse =>
         assertResponse(executionResponse, expectedResponse)
         val localizedJsonInputFile = DefaultPathBuilder.get(jobPaths.callInputsRoot.pathAsString, jsonInputFile.parent.pathAsString.hashCode.toString + "/" + jsonInputFile.name)
         val localizedCallInputFile = DefaultPathBuilder.get(jobPaths.callInputsRoot.pathAsString, callInputFile.parent.pathAsString.hashCode.toString + "/" + callInputFile.name)


### PR DESCRIPTION
Flaky test was throwing `**Invalid cross-device link**` which enforces that symlinks aren't created from one partition to another.

This PR sets the base path for paths in the spec to be `.` , i.e. the path in which the spec is running.