### PR TITLE
Perf metrics- Handle GCS metadata file input

### DIFF
--- a/perf/src/main/scala/cromwell/perf/CompareMetadata.scala
+++ b/perf/src/main/scala/cromwell/perf/CompareMetadata.scala
@@ -37,7 +37,7 @@ object CompareMetadata extends App with StrictLogging{
     val credentials = GoogleCredentials.fromStream(new FileInputStream(pathToServiceAccount))
     val storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService
     val blob = storage.get(gcsBucket, fileToBeLocalized)
-    val metadataFileContent = new String(blob.getContent())
+    val metadataFileContent = blob.getContent().map(_.toChar).mkString
 
     decode[Metadata](metadataFileContent)
   }

--- a/perf/src/main/scala/cromwell/perf/CompareMetadata.scala
+++ b/perf/src/main/scala/cromwell/perf/CompareMetadata.scala
@@ -31,8 +31,7 @@ object CompareMetadata extends App with StrictLogging{
 
   def parseMetadataFromGcsFile(gcsUrl: String, pathToServiceAccount: String): Either[circe.Error, Metadata] = {
     val gcsUrlArray = gcsUrl.replace("gs://", "").split("/", 2)
-    val fileToBeLocalized = gcsUrlArray(1)
-    val gcsBucket = gcsUrlArray(0)
+    val Array(gcsBucket, fileToBeLocalized) = gcsUrlArray
 
     val credentials = GoogleCredentials.fromStream(new FileInputStream(pathToServiceAccount))
     val storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -520,5 +520,5 @@ object Dependencies {
 
   val perfDependencies = List(
     "io.circe" %% "circe-java8" % circeV
-  ) ++ circeDependencies ++ betterFilesDependencies ++ commonDependencies
+  ) ++ circeDependencies ++ betterFilesDependencies ++ commonDependencies ++ googleApiClientDependencies ++ googleCloudDependencies
 }

--- a/src/ci/resources/cromwell-perf-service-account.json.ctmpl
+++ b/src/ci/resources/cromwell-perf-service-account.json.ctmpl
@@ -1,4 +1,4 @@
-{{with $cromwellPerfServiceAccount := vault (printf "secret/dsp/cromwell/perf/service-account-deployer.json")}}
+{{with $cromwellPerfServiceAccount := vault (printf "secret/dsde/cromwell/common/cromwell-perf-service-account.json")}}
 
 {{$cromwellPerfServiceAccount.Data | toJSONPretty}}
 

--- a/src/ci/resources/cromwell-perf-service-account.json.ctmpl
+++ b/src/ci/resources/cromwell-perf-service-account.json.ctmpl
@@ -1,0 +1,5 @@
+{{with $cromwellPerfServiceAccount := vault (printf "secret/dsp/cromwell/perf/service-account-deployer.json")}}
+
+{{$cromwellPerfServiceAccount.Data | toJSONPretty}}
+
+{{end}}


### PR DESCRIPTION
Perf project can now handle GCS metadata.json file inputs. This is helpful for comparing metadata through Jenkins job.

Closes #4211 