### PR TITLE
Add a test for CWL relative imports using zips

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_relative_imports/cwl_glob_sort.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_relative_imports/cwl_glob_sort.cwl
@@ -1,0 +1,16 @@
+cwlVersion: v1.0
+class: CommandLineTool
+requirements:
+  - class: InlineJavascriptRequirement
+hints:
+  DockerRequirement:
+    dockerPull: "debian:stretch-slim"
+inputs: []
+baseCommand: [touch, z, y, x, w, c, b, a]
+outputs:
+  letters:
+    type: string
+    outputBinding:
+      glob: '?'
+      outputEval: |
+        ${ return self.sort(function(a,b) { return a.location > b.location ? 1 : (a.location < b.location ? -1 : 0) }).map(f => f.basename).join(" ") }

--- a/centaur/src/main/resources/standardTestCases/cwl_relative_imports/workflow.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_relative_imports/workflow.cwl
@@ -1,0 +1,16 @@
+cwlVersion: v1.0
+$graph:
+- id: relative_imports
+  class: Workflow
+
+  inputs: []
+  outputs:
+    letters:
+      type: string
+      outputSource: globSort/letters
+
+  steps:
+    globSort:
+      in: []
+      run: cwl_glob_sort.cwl
+      out: [letters]

--- a/centaur/src/main/resources/standardTestCases/cwl_relative_imports_zip.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_relative_imports_zip.test
@@ -1,0 +1,21 @@
+name: cwl_relative_imports_zip
+testFormat: workflowsuccess
+
+files {
+  workflow: cwl_relative_imports/workflow.cwl
+  imports: [
+    cwl_relative_imports/cwl_glob_sort.cwl
+  ]
+}
+
+metadata {
+  status: Succeeded
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "calls.relative_imports.globSort.outputs.letters": "a b c w x y z"
+  "outputs.relative_imports.letters": "a b c w x y z"
+}
+
+workflowType: CWL
+workflowTypeVersion: v1.0
+workflowRoot: relative_imports

--- a/cwl/src/main/scala/cwl/CwlDecoder.scala
+++ b/cwl/src/main/scala/cwl/CwlDecoder.scala
@@ -8,6 +8,7 @@ import cats.syntax.either._
 import cats.{Applicative, Monad}
 import common.validation.ErrorOr._
 import common.validation.Parse._
+import common.validation.Validation.ValidationChecked
 import cwl.preprocessor.CwlPreProcessor
 import io.circe.Json
 
@@ -38,7 +39,7 @@ object CwlDecoder {
     }
   }
 
-  def parseJson(json: Json, file: BFile): Parse[Cwl] = fromEither[IO](CwlCodecs.decodeCwl(json).leftMap(_.prepend(s"error when parsing file $file")))
+  def parseJson(json: Json, file: BFile): Parse[Cwl] = fromEither[IO](CwlCodecs.decodeCwl(json).contextualizeErrors(s"parse '$file'"))
 
   /**
     * Notice it gives you one instance of Cwl.  This has transformed all embedded files into scala object state


### PR DESCRIPTION
Should pass without any dev changes, but this will:
- highlight regressions
- host the files in github for a `by_url` test to find and use