### PR TITLE
Add a test for CWL relative imports by url

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_relative_imports_url.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_relative_imports_url.test
@@ -1,0 +1,18 @@
+name: cwl_relative_imports_zip
+testFormat: workflowsuccess
+
+files {
+  workflowUrl: https://raw.githubusercontent.com/broadinstitute/cromwell/cjl_cwl_relative_imports/centaur/src/main/resources/standardTestCases/cwl_relative_imports/workflow.cwl
+}
+
+metadata {
+  status: Succeeded
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "calls.relative_imports.globSort.outputs.letters": "a b c w x y z"
+  "outputs.relative_imports.letters": "a b c w x y z"
+}
+
+workflowType: CWL
+workflowTypeVersion: v1.0
+workflowRoot: relative_imports

--- a/centaur/src/main/resources/standardTestCases/cwl_relative_imports_url.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_relative_imports_url.test
@@ -1,4 +1,4 @@
-name: cwl_relative_imports_zip
+name: cwl_relative_imports_url
 testFormat: workflowsuccess
 
 files {


### PR DESCRIPTION
The `by_url` edition of #4244 

Before merging:
- [ ] Update github link to point at `develop`