### PR TITLE
Refactor metadata facing routes into separate trait

### DIFF
--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -8,7 +8,8 @@ import akka.stream.ActorMaterializer
 import common.util.VersionUtil
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.services.instrumentation.CromwellInstrumentationActor
-import cromwell.webservice.{CromwellApiService, SwaggerService}
+import cromwell.webservice.SwaggerService
+import cromwell.webservice.routes.CromwellApiService
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}

--- a/engine/src/main/scala/cromwell/webservice/SwaggerService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerService.scala
@@ -1,5 +1,7 @@
 package cromwell.webservice
 
+import cromwell.webservice.routes.CromwellApiService
+
 trait SwaggerService extends SwaggerUiResourceHttpService {
   override def swaggerServiceName = "cromwell"
 

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -11,7 +11,7 @@ import cromwell.util.JsonFormatting.WomValueJsonFormatter
 import WomValueJsonFormatter._
 import better.files.File
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.{StatusCheckResponse, SubsystemStatus}
-import cromwell.webservice.CromwellApiService.BackendResponse
+import cromwell.webservice.routes.CromwellApiService.BackendResponse
 import cromwell.webservice.metadata.MetadataBuilderActor.BuiltMetadataResponse
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
 

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -31,8 +31,6 @@ import cromwell.services.healthmonitor.HealthMonitorServiceActor.{GetCurrentStat
 import cromwell.services.metadata.MetadataService._
 import cromwell.webservice._
 import cromwell.webservice.WorkflowJsonSupport._
-import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
-import cromwell.webservice.metadata.MetadataBuilderRegulatorActor
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -1,0 +1,188 @@
+package cromwell.webservice.routes
+
+import akka.actor.{ActorRef, ActorRefFactory}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.pattern.{AskTimeoutException, ask}
+import akka.util.Timeout
+import cats.data.NonEmptyList
+import cats.data.Validated.{Invalid, Valid}
+import cromwell.core.Dispatcher.ApiDispatcher
+import cromwell.core.labels.Labels
+import cromwell.core.{WorkflowId, path => _}
+import cromwell.engine.instrumentation.HttpInstrumentation
+import cromwell.server.CromwellShutdown
+import cromwell.services.metadata.MetadataService._
+import cromwell.webservice.LabelsManagerActor
+import cromwell.webservice.LabelsManagerActor._
+import cromwell.webservice.WorkflowJsonSupport._
+import cromwell.webservice.metadata.MetadataBuilderActor
+import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.webservice.routes.CromwellApiService.{EnhancedThrowable, InvalidWorkflowException, UnrecognizedWorkflowException, serviceShuttingDownResponse, validateWorkflowId}
+import cromwell.webservice.routes.MetadataRouteSupport._
+
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.util.{Failure, Success}
+
+
+trait MetadataRouteSupport extends HttpInstrumentation {
+  implicit def actorRefFactory: ActorRefFactory
+  implicit val ec: ExecutionContext
+
+  val serviceRegistryActor: ActorRef
+
+  implicit val timeout: Timeout
+
+  val metadataRoutes = concat(
+    path("workflows" / Segment / Segment / "status") { (_, possibleWorkflowId) =>
+      get {
+        instrumentRequest {
+          metadataLookup(possibleWorkflowId, (w: WorkflowId) => GetStatus(w), serviceRegistryActor)
+        }
+      }
+    },
+    path("workflows" / Segment / Segment / "outputs") { (_, possibleWorkflowId) =>
+      get {
+        instrumentRequest {
+          metadataLookup(possibleWorkflowId, (w: WorkflowId) => WorkflowOutputs(w), serviceRegistryActor)
+        }
+      }
+    },
+    path("workflows" / Segment / Segment / "logs") { (_, possibleWorkflowId) =>
+      get {
+        instrumentRequest {
+          metadataLookup(possibleWorkflowId, (w: WorkflowId) => GetLogs(w), serviceRegistryActor)
+        }
+      }
+    },
+    encodeResponse {
+      path("workflows" / Segment / Segment / "metadata") { (_, possibleWorkflowId) =>
+        instrumentRequest {
+          parameters(('includeKey.*, 'excludeKey.*, 'expandSubWorkflows.as[Boolean].?)) { (includeKeys, excludeKeys, expandSubWorkflowsOption) =>
+            val includeKeysOption = NonEmptyList.fromList(includeKeys.toList)
+            val excludeKeysOption = NonEmptyList.fromList(excludeKeys.toList)
+            val expandSubWorkflows = expandSubWorkflowsOption.getOrElse(false)
+
+            (includeKeysOption, excludeKeysOption) match {
+              case (Some(_), Some(_)) =>
+                val e = new IllegalArgumentException("includeKey and excludeKey may not be specified together")
+                e.failRequest(StatusCodes.BadRequest)
+              case (_, _) =>
+                metadataLookup(possibleWorkflowId,
+                  (w: WorkflowId) => GetSingleWorkflowMetadataAction(w, includeKeysOption, excludeKeysOption, expandSubWorkflows),
+                  serviceRegistryActor)
+            }
+          }
+        }
+      }
+    },
+    path("workflows" / Segment / Segment / "labels") { (_, possibleWorkflowId) =>
+      concat(
+        get {
+          instrumentRequest {
+            metadataLookup(possibleWorkflowId, (w: WorkflowId) => GetLabels(w), serviceRegistryActor)
+          }
+        },
+        patch {
+          entity(as[Map[String, String]]) { parameterMap =>
+            instrumentRequest {
+              Labels.validateMapOfLabels(parameterMap) match {
+                case Valid(labels) =>
+                  val response = validateWorkflowId(possibleWorkflowId, serviceRegistryActor) flatMap { id =>
+                    val lma = actorRefFactory.actorOf(LabelsManagerActor.props(serviceRegistryActor).withDispatcher(ApiDispatcher))
+                    lma.ask(LabelsAddition(LabelsData(id, labels))).mapTo[LabelsManagerActorResponse]
+                  }
+                  onComplete(response) {
+                    case Success(r: BuiltLabelsManagerResponse) => complete(r.response)
+                    case Success(e: FailedLabelsManagerResponse) => e.reason.failRequest(StatusCodes.InternalServerError)
+                    case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)
+                    case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
+
+                  }
+                case Invalid(e) =>
+                  val iae = new IllegalArgumentException(e.toList.mkString(","))
+                  iae.failRequest(StatusCodes.BadRequest)
+              }
+            }
+          }
+        }
+      )
+    },
+    path("workflows" / Segment / "query") { _ =>
+      get {
+        instrumentRequest {
+          parameterSeq { parameters =>
+            queryMetadata(parameters, serviceRegistryActor)
+          }
+        }
+      } ~
+        post {
+          instrumentRequest {
+            entity(as[Seq[Map[String, String]]]) { parameterMap =>
+              queryMetadata(parameterMap.flatMap(_.toSeq), serviceRegistryActor)
+            }
+          }
+        }
+    }
+  )
+}
+
+object MetadataRouteSupport {
+  def metadataLookup(possibleWorkflowId: String,
+                     request: WorkflowId => ReadAction,
+                     serviceRegistryActor: ActorRef)
+                    (implicit actorRefFactory: ActorRefFactory,
+                     timeout: Timeout,
+                     ec: ExecutionContext): Route = {
+    completeMetadataBuilderResponse(metadataBuilderActorRequest(possibleWorkflowId, request, serviceRegistryActor))
+  }
+
+  def queryMetadata(parameters: Seq[(String, String)],
+                    serviceRegistryActor: ActorRef)(implicit timeout: Timeout): Route = {
+    completeMetadataQueryResponse(metadataQueryRequest(parameters, serviceRegistryActor))
+  }
+
+  def metadataBuilderActorRequest(possibleWorkflowId: String,
+                                  request: WorkflowId => ReadAction,
+                                  serviceRegistryActor: ActorRef)
+                                 (implicit actorRefFactory: ActorRefFactory,
+                                  timeout: Timeout,
+                                  ec: ExecutionContext): Future[MetadataBuilderActorResponse] = {
+    import CromwellApiService.validateWorkflowId
+
+    val metadataBuilderActor = actorRefFactory.actorOf(MetadataBuilderActor.props(serviceRegistryActor).withDispatcher(ApiDispatcher), MetadataBuilderActor.uniqueActorName)
+    validateWorkflowId(possibleWorkflowId, serviceRegistryActor) flatMap { w => metadataBuilderActor.ask(request(w)).mapTo[MetadataBuilderActorResponse] }
+  }
+
+  def completeMetadataBuilderResponse(response: Future[MetadataBuilderActorResponse]): Route = {
+    onComplete(response) {
+      case Success(r: BuiltMetadataResponse) => complete(r.response)
+      case Success(r: FailedMetadataResponse) => r.reason.errorRequest(StatusCodes.InternalServerError)
+      case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
+      case Failure(e: UnrecognizedWorkflowException) => e.failRequest(StatusCodes.NotFound)
+      case Failure(e: InvalidWorkflowException) => e.failRequest(StatusCodes.BadRequest)
+      case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)
+      case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
+    }
+  }
+
+  def metadataQueryRequest(parameters: Seq[(String, String)],
+                           serviceRegistryActor: ActorRef)(implicit timeout: Timeout): Future[MetadataQueryResponse] = {
+    serviceRegistryActor.ask(WorkflowQuery(parameters)).mapTo[MetadataQueryResponse]
+  }
+
+  def completeMetadataQueryResponse(response: Future[MetadataQueryResponse]): Route = {
+    import cromwell.webservice.WorkflowJsonSupport.workflowQueryResponse
+
+    onComplete(response) {
+      case Success(w: WorkflowQuerySuccess) => complete(ToResponseMarshallable(w.response))
+      case Success(w: WorkflowQueryFailure) => w.reason.failRequest(StatusCodes.BadRequest)
+      case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
+      case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)
+      case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -19,7 +19,7 @@ import cromwell.services.metadata.MetadataService._
 import cromwell.webservice.LabelsManagerActor
 import cromwell.webservice.LabelsManagerActor._
 import cromwell.webservice.WorkflowJsonSupport._
-import cromwell.webservice.metadata.{MetadataBuilderActor, MetadataBuilderRegulatorActor}
+import cromwell.webservice.metadata.MetadataBuilderRegulatorActor
 import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
 import cromwell.webservice.routes.CromwellApiService.{EnhancedThrowable, InvalidWorkflowException, UnrecognizedWorkflowException, serviceShuttingDownResponse, validateWorkflowId}
 import cromwell.webservice.routes.MetadataRouteSupport._
@@ -152,8 +152,7 @@ object MetadataRouteSupport {
                                   request: WorkflowId => ReadAction,
                                   serviceRegistryActor: ActorRef,
                                   metadataBuilderRegulatorActor: ActorRef)
-                                 (implicit actorRefFactory: ActorRefFactory,
-                                  timeout: Timeout,
+                                 (implicit timeout: Timeout,
                                   ec: ExecutionContext): Future[MetadataBuilderActorResponse] = {
     validateWorkflowId(possibleWorkflowId, serviceRegistryActor) flatMap { w => metadataBuilderRegulatorActor.ask(request(w)).mapTo[MetadataBuilderActorResponse] }
   }

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -137,8 +137,7 @@ object MetadataRouteSupport {
                      request: WorkflowId => ReadAction,
                      serviceRegistryActor: ActorRef,
                      metadataBuilderRegulatorActor: ActorRef)
-                    (implicit actorRefFactory: ActorRefFactory,
-                     timeout: Timeout,
+                    (implicit timeout: Timeout,
                      ec: ExecutionContext): Route = {
     completeMetadataBuilderResponse(metadataBuilderActorRequest(possibleWorkflowId, request, serviceRegistryActor, metadataBuilderRegulatorActor))
   }

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import cromwell.webservice.SwaggerUiHttpServiceSpec._
+import cromwell.webservice.routes.CromwellApiService
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -1,17 +1,13 @@
-package cromwell.webservice
+package cromwell.webservice.routes
 
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
-import akka.http.scaladsl.coding.{Decoder, Gzip}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{HttpEncodings, `Accept-Encoding`}
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.ActorMaterializer
 import common.util.VersionUtil
-import cromwell.core.abort.{WorkflowAbortFailureResponse, WorkflowAbortingResponse}
 import cromwell.core._
+import cromwell.core.abort.{WorkflowAbortFailureResponse, WorkflowAbortingResponse}
 import cromwell.engine.workflow.WorkflowManagerActor
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.{AbortWorkflowCommand, BatchSubmitWorkflows, SubmitWorkflow, WorkflowOnHoldToSubmittedCommand}
@@ -21,6 +17,7 @@ import cromwell.services.healthmonitor.HealthMonitorServiceActor.{GetCurrentStat
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.util.SampleWdl.HelloWorld
+import cromwell.webservice.EngineStatsActor
 import mouse.boolean._
 import org.scalatest.{AsyncFlatSpec, Matchers}
 import spray.json.DefaultJsonProtocol._
@@ -72,47 +69,6 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
         }
   }
 
-    behavior of "REST API /status endpoint"
-    it should "return 200 for get of a known workflow id" in {
-      val workflowId = CromwellApiServiceSpec.ExistingWorkflowId
-
-      Get(s"/workflows/$version/$workflowId/status") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-            status should be(StatusCodes.OK)
-            // Along w/ checking value, ensure it is valid JSON despite the requested content type
-            responseAs[JsObject].fields(WorkflowMetadataKeys.Status) should be(JsString("Submitted"))
-        }
-    }
-
-    it should "return 404 for get of unknown workflow" in {
-      val workflowId = CromwellApiServiceSpec.UnrecognizedWorkflowId
-      Get(s"/workflows/$version/$workflowId/status") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.NotFound) {
-            status
-          }
-        }
-    }
-
-    it should "return 400 for get of a malformed workflow id's status" in {
-      Get(s"/workflows/$version/foobar/status") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.BadRequest) {
-            status
-          }
-          assertResult(
-            """{
-               |  "status": "fail",
-               |  "message": "Invalid workflow ID: 'foobar'."
-               |}""".stripMargin
-          ) {
-            responseAs[String]
-          }
-        }
-    }
 
     behavior of "REST API /abort endpoint"
     it should "return 404 for abort of unknown workflow" in {
@@ -453,139 +409,6 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
         }
     }
 
-    behavior of "REST API /outputs endpoint"
-    it should "return 200 with GET of outputs on successful execution of workflow" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/outputs") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          responseAs[JsObject].fields.keys should contain allOf(WorkflowMetadataKeys.Id, WorkflowMetadataKeys.Outputs)
-        }
-    }
-
-    it should "return 404 with outputs on unknown workflow" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/outputs") ~>
-        akkaHttpService.workflowRoutes ~>
-      check {
-        assertResult(StatusCodes.NotFound) {
-          status
-        }
-      }
-    }
-
-    it should "return 405 with POST of outputs on successful execution of workflow" in {
-      Post(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/outputs") ~>
-        Route.seal(akkaHttpService.workflowRoutes) ~>
-        check {
-          assertResult(StatusCodes.MethodNotAllowed) {
-            status
-          }
-        }
-    }
-
-    behavior of "REST API /logs endpoint"
-    it should "return 200 with paths to stdout/stderr/backend log" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/logs") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-
-          val call = responseAs[JsObject].fields("calls").convertTo[JsObject].fields("mycall").convertTo[Seq[JsObject]].head
-          call.fields("stdout") should be(JsString("stdout.txt"))
-          call.fields("stderr") should be(JsString("stderr.txt"))
-          call.fields("stdout") should be(JsString("stdout.txt"))
-          call.fields("backendLogs").convertTo[JsObject].fields("log") should be (JsString("backend.log"))
-        }
-    }
-
-    it should "return 404 with logs on unknown workflow" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/logs") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.NotFound) {
-            status
-          }
-        }
-    }
-
-    behavior of "REST API /metadata endpoint"
-    it should "return with full metadata from the metadata route" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          val result = responseAs[JsObject]
-          result.fields.keys should contain allOf("testKey1", "testKey2")
-          result.fields.keys shouldNot contain("testKey3")
-          result.fields("testKey1") should be(JsString("myValue1"))
-          result.fields("testKey2") should be(JsString("myValue2"))
-        }
-    }
-
-    it should "return with gzip encoding when requested" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata").addHeader(`Accept-Encoding`(HttpEncodings.gzip)) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          response.headers.find(_.name == "Content-Encoding").get.value should be("gzip")
-        }
-    }
-
-    it should "not return with gzip encoding when not requested" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          response.headers.find(_.name == "Content-Encoding") shouldBe None
-        }
-    }
-
-    it should "return with included metadata from the metadata route" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?includeKey=testKey1&includeKey=testKey2a") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          val result = responseAs[JsObject]
-          result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
-          result.fields.keys should contain noneOf("testKey2b", "testKey3")
-          result.fields("testKey1a") should be(JsString("myValue1a"))
-          result.fields("testKey1b") should be(JsString("myValue1b"))
-          result.fields("testKey2a") should be(JsString("myValue2a"))
-        }
-    }
-
-    it should "return with excluded metadata from the metadata route" in {
-     Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?excludeKey=testKey2b&excludeKey=testKey3") ~>
-       akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          val result = responseAs[JsObject]
-          result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
-          result.fields.keys should contain noneOf("testKey2b", "testKey3")
-          result.fields("testKey1a") should be(JsString("myValue1a"))
-          result.fields("testKey1b") should be(JsString("myValue1b"))
-          result.fields("testKey2a") should be(JsString("myValue2a"))
-        }
-    }
-
-    it should "return an error when included and excluded metadata requested from the metadata route" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?includeKey=testKey1&excludeKey=testKey2") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.BadRequest) {
-            status
-          }
-
-          val decoder: Decoder = Gzip
-          Unmarshal(decoder.decodeMessage(response)).to[String] map { r =>
-            assertResult(
-              s"""{
-                  |  "status": "fail",
-                  |  "message": "includeKey and excludeKey may not be specified together"
-                  |}""".stripMargin
-            ) { r }
-          }
-        }
-    }
-
     behavior of "REST API /timing endpoint"
     it should "return 200 with an HTML document for the timings route" in {
       Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/timing") ~>
@@ -595,143 +418,6 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult("<html>") {
             responseAs[String].substring(0, 6)
           }
-        }
-    }
-
-    behavior of "REST API /query GET endpoint"
-    it should "return good results for a good query" in {
-      Get(s"/workflows/$version/query?status=Succeeded&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          contentType should be(ContentTypes.`application/json`)
-          val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
-          results.head.fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
-          results.head.fields("status") should be(JsString("Succeeded"))
-        }
-    }
-
-    it should "return labels if specified in additionalQueryResultFields param" in {
-      Get(s"/workflows/$version/query?additionalQueryResultFields=labels&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          contentType should be(ContentTypes.`application/json`)
-          val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
-          val fields = results.head.fields
-          fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
-          fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
-          fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key2") should be(JsString("label2"))
-        }
-    }
-
-    it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
-      Get(s"/workflows/$version/query?additionalQueryResultFields=parentWorkflowId&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status should be(StatusCodes.OK)
-          contentType should be(ContentTypes.`application/json`)
-          val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
-          val fields = results.head.fields
-          fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
-          fields(WorkflowMetadataKeys.ParentWorkflowId) should be(JsString("pid"))
-        }
-    }
-
-    behavior of "REST API /query POST endpoint"
-    it should "return good results for a good query map body" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"}]""")) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.OK) {
-            status
-          }
-          assertResult(true) {
-            entityAs[String].contains("\"status\":\"Succeeded\"")
-          }
-        }
-    }
-
-    it should "return labels if specified in additionalQueryResultFields param" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"labels"}]""")) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.OK) {
-            status
-          }
-          val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
-          val fields = results.head.fields
-          fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
-          fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key2") should be(JsString("label2"))
-        }
-    }
-
-    it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"parentWorkflowId"}]""")) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          assertResult(StatusCodes.OK) {
-            status
-          }
-          assertResult(true) {
-            entityAs[String].contains("\"parentWorkflowId\":\"pid\"")
-          }
-        }
-    }
-
-    it should "include totalResultCount in workflow query response" in {
-      Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"}]""")) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          val result = responseAs[JsObject]
-          status should be(StatusCodes.OK)
-          result.fields("totalResultsCount") should be(JsNumber("1"))
-        }
-    }
-
-    behavior of "REST API /labels GET endpoint"
-    it should "return labels for a workflow ID" in {
-      Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/labels") ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          val result = responseAs[JsObject]
-          status should be(StatusCodes.OK)
-          result.fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
-        }
-    }
-
-    behavior of "REST API /labels PATCH endpoint"
-    it should "return successful status response when assigning valid labels to an existing workflow ID" in {
-
-      val validLabelsJson =
-        """
-          |{
-          |  "label-key-1":"label-value-1",
-          |  "label-key-2":"label-value-2"
-          |}
-        """.stripMargin
-
-      val workflowId = CromwellApiServiceSpec.ExistingWorkflowId
-
-      Patch(s"/workflows/$version/$workflowId/labels", HttpEntity(ContentTypes.`application/json`, validLabelsJson)) ~>
-        akkaHttpService.workflowRoutes ~>
-        check {
-          status shouldBe StatusCodes.OK
-          val actualResult = responseAs[JsObject]
-          val expectedResults =
-            s"""
-              |{
-              |  "id": "$workflowId",
-              |  "labels": {
-              |    "key1": "label1",
-              |    "key2": "label2",
-              |    "label-key-1":"label-value-1",
-              |    "label-key-2":"label-value-2"
-              |  }
-              |}
-            """.stripMargin.parseJson
-
-          actualResult shouldBe expectedResults
         }
     }
 }

--- a/engine/src/test/scala/cromwell/webservice/routes/MetadataRouteSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/MetadataRouteSupportSpec.scala
@@ -1,0 +1,347 @@
+package cromwell.webservice.routes
+
+import akka.actor.{ActorSystem, Props}
+import akka.http.scaladsl.coding.{Decoder, Gzip}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.model.headers.{HttpEncodings, `Accept-Encoding`}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import cromwell.core.WorkflowMetadataKeys
+import cromwell.webservice.routes.CromwellApiServiceSpec.MockServiceRegistryActor
+import org.scalatest.{AsyncFlatSpec, Matchers}
+import spray.json.DefaultJsonProtocol._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import cromwell.webservice.routes.MetadataRouteSupportSpec.MockMetadataRouteSupport
+import spray.json._
+
+import scala.concurrent.duration._
+
+class MetadataRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Matchers {
+  val akkaHttpService = new MockMetadataRouteSupport()
+  
+  val version = "v1"
+
+  implicit def routeTestTimeout = RouteTestTimeout(5.seconds)
+
+  behavior of "REST API /status endpoint"
+  it should "return 200 for get of a known workflow id" in {
+    val workflowId = CromwellApiServiceSpec.ExistingWorkflowId
+
+    Get(s"/workflows/$version/$workflowId/status") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        // Along w/ checking value, ensure it is valid JSON despite the requested content type
+        responseAs[JsObject].fields(WorkflowMetadataKeys.Status) should be(JsString("Submitted"))
+      }
+  }
+
+  it should "return 404 for get of unknown workflow" in {
+    val workflowId = CromwellApiServiceSpec.UnrecognizedWorkflowId
+    Get(s"/workflows/$version/$workflowId/status") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  it should "return 400 for get of a malformed workflow id's status" in {
+    Get(s"/workflows/$version/foobar/status") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+        assertResult(
+          """{
+            |  "status": "fail",
+            |  "message": "Invalid workflow ID: 'foobar'."
+            |}""".stripMargin
+        ) {
+          responseAs[String]
+        }
+      }
+  }
+
+  behavior of "REST API /outputs endpoint"
+  it should "return 200 with GET of outputs on successful execution of workflow" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/outputs") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        responseAs[JsObject].fields.keys should contain allOf(WorkflowMetadataKeys.Id, WorkflowMetadataKeys.Outputs)
+      }
+  }
+
+  it should "return 404 with outputs on unknown workflow" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/outputs") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  it should "return 405 with POST of outputs on successful execution of workflow" in {
+    Post(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/outputs") ~>
+      Route.seal(akkaHttpService.metadataRoutes) ~>
+      check {
+        assertResult(StatusCodes.MethodNotAllowed) {
+          status
+        }
+      }
+  }
+
+  behavior of "REST API /logs endpoint"
+  it should "return 200 with paths to stdout/stderr/backend log" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/logs") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+
+        val call = responseAs[JsObject].fields("calls").convertTo[JsObject].fields("mycall").convertTo[Seq[JsObject]].head
+        call.fields("stdout") should be(JsString("stdout.txt"))
+        call.fields("stderr") should be(JsString("stderr.txt"))
+        call.fields("stdout") should be(JsString("stdout.txt"))
+        call.fields("backendLogs").convertTo[JsObject].fields("log") should be (JsString("backend.log"))
+      }
+  }
+
+  it should "return 404 with logs on unknown workflow" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.UnrecognizedWorkflowId}/logs") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  behavior of "REST API /metadata endpoint"
+  it should "return with full metadata from the metadata route" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        val result = responseAs[JsObject]
+        result.fields.keys should contain allOf("testKey1", "testKey2")
+        result.fields.keys shouldNot contain("testKey3")
+        result.fields("testKey1") should be(JsString("myValue1"))
+        result.fields("testKey2") should be(JsString("myValue2"))
+      }
+  }
+
+  it should "return with gzip encoding when requested" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata").addHeader(`Accept-Encoding`(HttpEncodings.gzip)) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        response.headers.find(_.name == "Content-Encoding").get.value should be("gzip")
+      }
+  }
+
+  it should "not return with gzip encoding when not requested" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        response.headers.find(_.name == "Content-Encoding") shouldBe None
+      }
+  }
+
+  it should "return with included metadata from the metadata route" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?includeKey=testKey1&includeKey=testKey2a") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        val result = responseAs[JsObject]
+        result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
+        result.fields.keys should contain noneOf("testKey2b", "testKey3")
+        result.fields("testKey1a") should be(JsString("myValue1a"))
+        result.fields("testKey1b") should be(JsString("myValue1b"))
+        result.fields("testKey2a") should be(JsString("myValue2a"))
+      }
+  }
+
+  it should "return with excluded metadata from the metadata route" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?excludeKey=testKey2b&excludeKey=testKey3") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        val result = responseAs[JsObject]
+        result.fields.keys should contain allOf("testKey1a", "testKey1b", "testKey2a")
+        result.fields.keys should contain noneOf("testKey2b", "testKey3")
+        result.fields("testKey1a") should be(JsString("myValue1a"))
+        result.fields("testKey1b") should be(JsString("myValue1b"))
+        result.fields("testKey2a") should be(JsString("myValue2a"))
+      }
+  }
+
+  it should "return an error when included and excluded metadata requested from the metadata route" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/metadata?includeKey=testKey1&excludeKey=testKey2") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.BadRequest) {
+          status
+        }
+
+        val decoder: Decoder = Gzip
+        Unmarshal(decoder.decodeMessage(response)).to[String] map { r =>
+          assertResult(
+            s"""{
+               |  "status": "fail",
+               |  "message": "includeKey and excludeKey may not be specified together"
+               |}""".stripMargin
+          ) { r }
+        }
+      }
+  }
+
+  behavior of "REST API /query GET endpoint"
+  it should "return good results for a good query" in {
+    Get(s"/workflows/$version/query?status=Succeeded&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/json`)
+        val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
+        results.head.fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
+        results.head.fields("status") should be(JsString("Succeeded"))
+      }
+  }
+
+  it should "return labels if specified in additionalQueryResultFields param" in {
+    Get(s"/workflows/$version/query?additionalQueryResultFields=labels&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/json`)
+        val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
+        val fields = results.head.fields
+        fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
+        fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
+        fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key2") should be(JsString("label2"))
+      }
+  }
+
+  it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
+    Get(s"/workflows/$version/query?additionalQueryResultFields=parentWorkflowId&id=${CromwellApiServiceSpec.ExistingWorkflowId}") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/json`)
+        val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
+        val fields = results.head.fields
+        fields("id") should be(JsString(CromwellApiServiceSpec.ExistingWorkflowId.toString))
+        fields(WorkflowMetadataKeys.ParentWorkflowId) should be(JsString("pid"))
+      }
+  }
+
+  behavior of "REST API /query POST endpoint"
+  it should "return good results for a good query map body" in {
+    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"}]""")) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        assertResult(true) {
+          entityAs[String].contains("\"status\":\"Succeeded\"")
+        }
+      }
+  }
+
+  it should "return labels if specified in additionalQueryResultFields param" in {
+    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"labels"}]""")) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        val results = responseAs[JsObject].fields("results").convertTo[Seq[JsObject]]
+        val fields = results.head.fields
+        fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
+        fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key2") should be(JsString("label2"))
+      }
+  }
+
+  it should "return parentWorkflowId if specified in additionalQueryResultFields param" in {
+    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"additionalQueryResultFields":"parentWorkflowId"}]""")) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        assertResult(StatusCodes.OK) {
+          status
+        }
+        assertResult(true) {
+          entityAs[String].contains("\"parentWorkflowId\":\"pid\"")
+        }
+      }
+  }
+
+  it should "include totalResultCount in workflow query response" in {
+    Post(s"/workflows/$version/query", HttpEntity(ContentTypes.`application/json`, """[{"status":"Succeeded"}]""")) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        val result = responseAs[JsObject]
+        status should be(StatusCodes.OK)
+        result.fields("totalResultsCount") should be(JsNumber("1"))
+      }
+  }
+
+  behavior of "REST API /labels GET endpoint"
+  it should "return labels for a workflow ID" in {
+    Get(s"/workflows/$version/${CromwellApiServiceSpec.ExistingWorkflowId}/labels") ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        val result = responseAs[JsObject]
+        status should be(StatusCodes.OK)
+        result.fields(WorkflowMetadataKeys.Labels).asJsObject.fields("key1") should be(JsString("label1"))
+      }
+  }
+
+  behavior of "REST API /labels PATCH endpoint"
+  it should "return successful status response when assigning valid labels to an existing workflow ID" in {
+
+    val validLabelsJson =
+      """
+        |{
+        |  "label-key-1":"label-value-1",
+        |  "label-key-2":"label-value-2"
+        |}
+      """.stripMargin
+
+    val workflowId = CromwellApiServiceSpec.ExistingWorkflowId
+
+    Patch(s"/workflows/$version/$workflowId/labels", HttpEntity(ContentTypes.`application/json`, validLabelsJson)) ~>
+      akkaHttpService.metadataRoutes ~>
+      check {
+        status shouldBe StatusCodes.OK
+        val actualResult = responseAs[JsObject]
+        val expectedResults =
+          s"""
+             |{
+             |  "id": "$workflowId",
+             |  "labels": {
+             |    "key1": "label1",
+             |    "key2": "label2",
+             |    "label-key-1":"label-value-1",
+             |    "label-key-2":"label-value-2"
+             |  }
+             |}
+            """.stripMargin.parseJson
+
+        actualResult shouldBe expectedResults
+      }
+  }
+}
+
+object MetadataRouteSupportSpec {
+  class MockMetadataRouteSupport()(implicit val system: ActorSystem, routeTestTimeout: RouteTestTimeout) extends MetadataRouteSupport {
+    override def actorRefFactory = system
+    override val ec = system.dispatcher
+    override val timeout = routeTestTimeout.duration
+    override val serviceRegistryActor = actorRefFactory.actorOf(Props(new MockServiceRegistryActor()))
+  }
+}


### PR DESCRIPTION
This is mainly just moving stuff around, pulling the metadata based routes into a separate trait out of CromwellApiService. 

The **meat** of this was peeling out the inner bits of the metadata route logic into separate/composable functions so that I can access them via other incoming work. 

Because @mcovarr are actively poking at the same areas of the code I wanted to get this more basic refactor out ASAP and can follow up with further refactoring at some later point when he's done.