### PR TITLE
When all you have is a hammer

### DIFF
--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -306,7 +306,7 @@ cromwell::private::export_conformance_variables() {
     CROMWELL_BUILD_CWL_TEST_WDL="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.wdl"
     CROMWELL_BUILD_CWL_TEST_INPUTS="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.inputs.json"
     CROMWELL_BUILD_CWL_TEST_OUTPUT="${CROMWELL_BUILD_LOG_DIRECTORY}/cwl_conformance_test.out.txt"
-    CROMWELL_BUILD_CWL_TEST_PARALLELISM=10 # Set too high will cause false negatives due to cromwell server timeouts.
+    CROMWELL_BUILD_CWL_TEST_PARALLELISM=8 # Set too high will cause false negatives due to cromwell server timeouts.
 
     export CROMWELL_BUILD_CWL_TOOL_VERSION
     export CROMWELL_BUILD_CWL_TEST_VERSION
@@ -398,7 +398,7 @@ cromwell::private::write_cwl_test_inputs() {
     "cwl_conformance_test.centaur_cwl_runner": "${CROMWELL_BUILD_CWL_TEST_RUNNER}",
     "cwl_conformance_test.conformance_expected_failures":
         "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_BUILD_BACKEND_TYPE}_conformance_expected_failures.txt",
-    "cwl_conformance_test.timeout": 600
+    "cwl_conformance_test.timeout": 720
 }
 JSON
 }

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -306,7 +306,7 @@ cromwell::private::export_conformance_variables() {
     CROMWELL_BUILD_CWL_TEST_WDL="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.wdl"
     CROMWELL_BUILD_CWL_TEST_INPUTS="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.inputs.json"
     CROMWELL_BUILD_CWL_TEST_OUTPUT="${CROMWELL_BUILD_LOG_DIRECTORY}/cwl_conformance_test.out.txt"
-    CROMWELL_BUILD_CWL_TEST_PARALLELISM=8 # Set too high will cause false negatives due to cromwell server timeouts.
+    CROMWELL_BUILD_CWL_TEST_PARALLELISM=15 # Set too high will cause false negatives due to cromwell server timeouts.
 
     export CROMWELL_BUILD_CWL_TOOL_VERSION
     export CROMWELL_BUILD_CWL_TEST_VERSION
@@ -398,7 +398,7 @@ cromwell::private::write_cwl_test_inputs() {
     "cwl_conformance_test.centaur_cwl_runner": "${CROMWELL_BUILD_CWL_TEST_RUNNER}",
     "cwl_conformance_test.conformance_expected_failures":
         "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_BUILD_BACKEND_TYPE}_conformance_expected_failures.txt",
-    "cwl_conformance_test.timeout": 720
+    "cwl_conformance_test.timeout": 900
 }
 JSON
 }

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -306,7 +306,7 @@ cromwell::private::export_conformance_variables() {
     CROMWELL_BUILD_CWL_TEST_WDL="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.wdl"
     CROMWELL_BUILD_CWL_TEST_INPUTS="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.inputs.json"
     CROMWELL_BUILD_CWL_TEST_OUTPUT="${CROMWELL_BUILD_LOG_DIRECTORY}/cwl_conformance_test.out.txt"
-    CROMWELL_BUILD_CWL_TEST_PARALLELISM=15 # Set too high will cause false negatives due to cromwell server timeouts.
+    CROMWELL_BUILD_CWL_TEST_PARALLELISM=10 # Set too high will cause false negatives due to cromwell server timeouts.
 
     export CROMWELL_BUILD_CWL_TOOL_VERSION
     export CROMWELL_BUILD_CWL_TEST_VERSION
@@ -398,7 +398,7 @@ cromwell::private::write_cwl_test_inputs() {
     "cwl_conformance_test.centaur_cwl_runner": "${CROMWELL_BUILD_CWL_TEST_RUNNER}",
     "cwl_conformance_test.conformance_expected_failures":
         "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_BUILD_BACKEND_TYPE}_conformance_expected_failures.txt",
-    "cwl_conformance_test.timeout": 900
+    "cwl_conformance_test.timeout": 1200
 }
 JSON
 }


### PR DESCRIPTION
The failure rate was getting unreasonable so I figured someone should do something.

It might take a bit longer, but at least it'll more likely return green.

---

Once build activity died down after everyone went home, I was able to isolate the imapct of  conformance PapiV2 by running it on its own: virtually none (my run started at 7:10).

<img width="898" alt="screen shot 2018-10-12 at 7 39 48 pm" src="https://user-images.githubusercontent.com/1087943/46898326-a37a2300-ce56-11e8-9c0a-ff5f33ade931.png">

It's still possible that other jobs suck up quota which in turn affects conformance PapiV2 even if it uses very little itself.

I asked for more quota again, because my first request didn't give us enough breathing room (screenshot _after_ first increase):
<img width="976" alt="screen shot 2018-10-12 at 6 24 21 pm" src="https://user-images.githubusercontent.com/1087943/46898377-15526c80-ce57-11e8-8af6-f7844e84b843.png">