### PR TITLE
increase test timeout on akka http routes for slow CI envs

### DIFF
--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
@@ -1,7 +1,8 @@
 package cromiam.webservice
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.testkit.TestDuration
 import cromiam.server.config.SwaggerOauthConfig
 import io.swagger.models.properties.RefProperty
 import io.swagger.parser.SwaggerParser
@@ -13,11 +14,14 @@ import org.yaml.snakeyaml.nodes.MappingNode
 import org.yaml.snakeyaml.{Yaml => SnakeYaml}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRouteTest with Matchers
   with TableDrivenPropertyChecks {
   def actorRefFactory = system
   override def oauthConfig: SwaggerOauthConfig = SwaggerOauthConfig("clientId", "realm", "appName")
+
+  implicit val timeout = RouteTestTimeout(10.seconds.dilated)
 
   behavior of "SwaggerService"
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
@@ -1,7 +1,8 @@
 package cromwell.webservice
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
+import akka.testkit.TestDuration
 import io.swagger.models.properties.RefProperty
 import io.swagger.parser.SwaggerParser
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -12,10 +13,13 @@ import org.yaml.snakeyaml.nodes.MappingNode
 import org.yaml.snakeyaml.{Yaml => SnakeYaml}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRouteTest with Matchers
   with TableDrivenPropertyChecks {
   def actorRefFactory = system
+
+  implicit val timeout = RouteTestTimeout(10.seconds.dilated)
 
   behavior of "SwaggerService"
 


### PR DESCRIPTION
See https://doc.akka.io/docs/akka-http/current/routing-dsl/testkit.html#increase-timeout