### PR TITLE
Only compare the data in StandardAsyncRunStatus that represents the status.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
+++ b/backend/src/main/scala/cromwell/backend/async/ExecutionHandle.scala
@@ -14,12 +14,12 @@ sealed trait ExecutionHandle {
   def result: ExecutionResult
 }
 
-final case class PendingExecutionHandle[BackendJobId <: JobId, BackendRunInfo, BackendRunStatus]
+final case class PendingExecutionHandle[BackendJobId <: JobId, BackendRunInfo, BackendRunState]
 (
   jobDescriptor: BackendJobDescriptor,
   pendingJob: BackendJobId,
   runInfo: Option[BackendRunInfo],
-  previousStatus: Option[BackendRunStatus]
+  previousState: Option[BackendRunState]
 ) extends ExecutionHandle {
   override val isDone = false
   override val result = NonRetryableExecution(new IllegalStateException("PendingExecutionHandle cannot yield a result"))

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -85,10 +85,15 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   type StandardAsyncRunInfo
 
   /** The type of the run status returned during each poll. */
-  type StandardAsyncRunStatus
+  type StandardAsyncRunState
+
+  /** Should return true if the status contained in `thiz` is equivalent to `that`, delta any other data that might be carried around
+    * in the state type.
+    */
+  def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean
 
   /** The pending execution handle for each poll. */
-  type StandardAsyncPendingExecutionHandle = PendingExecutionHandle[StandardAsyncJob, StandardAsyncRunInfo, StandardAsyncRunStatus]
+  type StandardAsyncPendingExecutionHandle = PendingExecutionHandle[StandardAsyncJob, StandardAsyncRunInfo, StandardAsyncRunState]
 
   /** Standard set of parameters passed to the backend. */
   def standardParams: StandardAsyncExecutionActorParams
@@ -144,7 +149,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
 
   // This is a trickery to allow the mapCommandLineWomFile above to call isAdHoc file without creating an
   // infinite recursion. This should really go away when we finally can have a sane implementation
-  // keeping track of the paths cleanly without so many value mappers 
+  // keeping track of the paths cleanly without so many value mappers
   def mapCommandLineJobInputWomFile(womFile: WomFile): WomFile = mapCommandLineWomFile(womFile)
 
   // Allows backends to signal to the StandardAsyncExecutionActor that there's a set of input files which
@@ -345,7 +350,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
         s"""(
            |# add a .file in every empty directory to facilitate directory delocalization on the cloud
            |cd $cwd
-           |find . -type d -empty -print0 | xargs -0 -I % touch %/.file 
+           |find . -type d -empty -print0 | xargs -0 -I % touch %/.file
            |)""".stripMargin)
 
     // The `tee` trickery below is to be able to redirect to known filenames for CWL while also streaming
@@ -670,7 +675,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param handle The handle of the running job.
     * @return The status of the job.
     */
-  def pollStatus(handle: StandardAsyncPendingExecutionHandle): StandardAsyncRunStatus = {
+  def pollStatus(handle: StandardAsyncPendingExecutionHandle): StandardAsyncRunState = {
     throw new NotImplementedError(s"Neither pollStatus nor pollStatusAsync implemented by $getClass")
   }
 
@@ -680,7 +685,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param handle The handle of the running job.
     * @return The status of the job.
     */
-  def pollStatusAsync(handle: StandardAsyncPendingExecutionHandle): Future[StandardAsyncRunStatus] = Future.fromTry(Try(pollStatus(handle)))
+  def pollStatusAsync(handle: StandardAsyncPendingExecutionHandle): Future[StandardAsyncRunState] = Future.fromTry(Try(pollStatus(handle)))
 
   /**
     * Adds custom behavior invoked when polling fails due to some exception. By default adds nothing.
@@ -701,7 +706,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The run status.
     * @return True if the job has completed.
     */
-  def isTerminal(runStatus: StandardAsyncRunStatus): Boolean
+  def isTerminal(runStatus: StandardAsyncRunState): Boolean
 
   /**
     * Returns any events retrieved from the terminal run status.
@@ -709,7 +714,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The terminal run status, as defined by isTerminal.
     * @return The execution events.
     */
-  def getTerminalEvents(runStatus: StandardAsyncRunStatus): Seq[ExecutionEvent] = Seq.empty
+  def getTerminalEvents(runStatus: StandardAsyncRunState): Seq[ExecutionEvent] = Seq.empty
 
   /**
     * Returns true if the status represents a completion.
@@ -717,7 +722,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The run status.
     * @return True if the job is done.
     */
-  def isDone(runStatus: StandardAsyncRunStatus): Boolean = true
+  def isDone(runStatus: StandardAsyncRunState): Boolean = true
 
   /**
     * Returns any custom metadata from the polled status.
@@ -725,7 +730,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The run status.
     * @return The job metadata.
     */
-  def getTerminalMetadata(runStatus: StandardAsyncRunStatus): Map[String, Any] = Map.empty
+  def getTerminalMetadata(runStatus: StandardAsyncRunState): Map[String, Any] = Map.empty
 
   /**
     * Attempts to abort a job when an abort signal is retrieved.
@@ -850,7 +855,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param returnCode The return code.
     * @return The execution handle.
     */
-  def handleExecutionSuccess(runStatus: StandardAsyncRunStatus,
+  def handleExecutionSuccess(runStatus: StandardAsyncRunState,
                              handle: StandardAsyncPendingExecutionHandle,
                              returnCode: Int)(implicit ec: ExecutionContext): Future[ExecutionHandle] = {
     evaluateOutputs() map {
@@ -878,7 +883,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The run status.
     * @return The execution handle.
     */
-  def retryElseFail(runStatus: StandardAsyncRunStatus,
+  def retryElseFail(runStatus: StandardAsyncRunState,
                     backendExecutionStatus: Future[ExecutionHandle]): Future[ExecutionHandle] = {
 
     val retryable = previousFailedRetries < maxRetries
@@ -898,7 +903,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param runStatus The run status.
     * @return The execution handle.
     */
-  def handleExecutionFailure(runStatus: StandardAsyncRunStatus,
+  def handleExecutionFailure(runStatus: StandardAsyncRunState,
                              returnCode: Option[Int]): Future[ExecutionHandle] = {
     val exception = new RuntimeException(s"Task ${jobDescriptor.key.tag} failed for unknown reason: $runStatus")
     Future.successful(FailedNonRetryableExecutionHandle(exception, returnCode))
@@ -949,7 +954,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
 
   private def executeOrRecoverSuccess(executionHandle: ExecutionHandle): Future[ExecutionHandle] = {
     executionHandle match {
-      case handle: PendingExecutionHandle[StandardAsyncJob@unchecked, StandardAsyncRunInfo@unchecked, StandardAsyncRunStatus@unchecked] =>
+      case handle: PendingExecutionHandle[StandardAsyncJob@unchecked, StandardAsyncRunInfo@unchecked, StandardAsyncRunState@unchecked] =>
         tellKvJobId(handle.pendingJob) map { _ =>
           jobLogger.info(s"job id: ${handle.pendingJob.jobId}")
           tellMetadata(Map(CallMetadataKeys.JobId -> handle.pendingJob.jobId))
@@ -969,7 +974,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   override def poll(previous: ExecutionHandle)(implicit ec: ExecutionContext): Future[ExecutionHandle] = {
     previous match {
       case handle: PendingExecutionHandle[
-        StandardAsyncJob@unchecked, StandardAsyncRunInfo@unchecked, StandardAsyncRunStatus@unchecked] =>
+        StandardAsyncJob@unchecked, StandardAsyncRunInfo@unchecked, StandardAsyncRunState@unchecked] =>
 
         jobLogger.debug(s"$tag Polling Job ${handle.pendingJob}")
         pollStatusAsync(handle) flatMap {
@@ -989,29 +994,28 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
   /**
     * Process a poll success.
     *
-    * @param oldHandle The previous execution status.
-    * @param status The updated status.
+    * @param oldHandle The previous execution handle.
+    * @param state The updated run state.
     * @return The updated execution handle.
     */
   def handlePollSuccess(oldHandle: StandardAsyncPendingExecutionHandle,
-                        status: StandardAsyncRunStatus): Future[ExecutionHandle] = {
-    val previousStatus = oldHandle.previousStatus
-    if (!(previousStatus contains status)) {
-      /*
-      If this is the first time checking the status, we log the transition as '-' to 'currentStatus'. Otherwise just use
-      the state names.
-       */
-      val prevStateName = previousStatus.map(_.toString).getOrElse("-")
-      jobLogger.info(s"Status change from $prevStateName to $status")
-      tellMetadata(Map(CallMetadataKeys.BackendStatus -> status))
+                        state: StandardAsyncRunState): Future[ExecutionHandle] = {
+    val previousState = oldHandle.previousState
+    if (!(previousState exists statusEquivalentTo(state))) {
+      // If this is the first time checking the status, we log the transition as '-' to 'currentStatus'. Otherwise just use
+      // the state names.
+      // This logging and metadata publishing assumes that StandardAsyncRunState subtypes `toString` nicely to state names.
+      val prevStatusName = previousState.map(_.toString).getOrElse("-")
+      jobLogger.info(s"Status change from $prevStatusName to $state")
+      tellMetadata(Map(CallMetadataKeys.BackendStatus -> state))
     }
 
-    status match {
-      case _ if isTerminal(status) =>
-        val metadata = getTerminalMetadata(status)
+    state match {
+      case _ if isTerminal(state) =>
+        val metadata = getTerminalMetadata(state)
         tellMetadata(metadata)
-        handleExecutionResult(status, oldHandle)
-      case s => Future.successful(oldHandle.copy(previousStatus = Option(s))) // Copy the current handle with updated previous status.
+        handleExecutionResult(state, oldHandle)
+      case s => Future.successful(oldHandle.copy(previousState = Option(s))) // Copy the current handle with updated previous status.
     }
   }
 
@@ -1052,7 +1056,7 @@ trait StandardAsyncExecutionActor extends AsyncBackendJobExecutionActor with Sta
     * @param oldHandle The previous execution handle.
     * @return The updated execution handle.
     */
-  def handleExecutionResult(status: StandardAsyncRunStatus,
+  def handleExecutionResult(status: StandardAsyncRunState,
                             oldHandle: StandardAsyncPendingExecutionHandle): Future[ExecutionHandle] = {
 
     val stderr = jobPaths.standardPaths.error

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -83,7 +83,9 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
   override type StandardAsyncRunInfo = AwsBatchJob
 
-  override type StandardAsyncRunStatus = RunStatus
+  override type StandardAsyncRunState = RunStatus
+
+  def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean = thiz == that
 
   override lazy val pollBackOff = SimpleExponentialBackoff(1.second, 5.minutes, 1.1)
 
@@ -335,7 +337,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
     for {
       submitJobResponse <- batchJob.submitJob[IO]().run(attributes).unsafeToFuture()
-    } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(submitJobResponse.jobId), Option(batchJob), previousStatus = None)
+    } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(submitJobResponse.jobId), Option(batchJob), previousState = None)
   }
 
   val futureKvJobKey = KvJobKey(jobDescriptor.key.call.fullyQualifiedName, jobDescriptor.key.index, jobDescriptor.key.attempt + 1)

--- a/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/bcs/src/main/scala/cromwell/backend/impl/bcs/BcsAsyncBackendJobExecutionActor.scala
@@ -35,7 +35,9 @@ final class BcsAsyncBackendJobExecutionActor(override val standardParams: Standa
 
   override type StandardAsyncRunInfo = BcsJob
 
-  override type StandardAsyncRunStatus = RunStatus
+  override type StandardAsyncRunState = RunStatus
+
+  def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean = thiz == that
 
   override lazy val pollBackOff = SimpleExponentialBackoff(1.second, 5.minutes, 1.1)
 
@@ -295,7 +297,7 @@ final class BcsAsyncBackendJobExecutionActor(override val standardParams: Standa
 
     for {
       jobId <- Future.fromTry(bcsJob.submit())
-    } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(jobId), Option(bcsJob), previousStatus = None)
+    } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(jobId), Option(bcsJob), previousState = None)
   }
 
   override def recoverAsync(jobId: StandardAsyncJob) = executeAsync()

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -97,7 +97,9 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
 
   override type StandardAsyncRunInfo = Run
 
-  override type StandardAsyncRunStatus = RunStatus
+  override type StandardAsyncRunState = RunStatus
+
+  def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean = thiz == that
 
   override val papiApiActor: ActorRef = jesBackendSingletonActor
 
@@ -436,7 +438,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
 
   private def reconnectToExistingJob(jobForResumption: StandardAsyncJob, forceAbort: Boolean = false) = {
     if (forceAbort) tryAbort(jobForResumption)
-    Future.successful(PendingExecutionHandle(jobDescriptor, jobForResumption, Option(Run(jobForResumption)), previousStatus = None))
+    Future.successful(PendingExecutionHandle(jobDescriptor, jobForResumption, Option(Run(jobForResumption)), previousState = None))
   }
 
   private def createNewJob(): Future[ExecutionHandle] = {
@@ -487,7 +489,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     } yield runId
 
     runPipelineResponse map { runId =>
-      PendingExecutionHandle(jobDescriptor, runId, Option(Run(runId)), previousStatus = None)
+      PendingExecutionHandle(jobDescriptor, runId, Option(Run(runId)), previousState = None)
     } recover {
       case JobAbortedException => AbortedExecutionHandle
     }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -15,12 +15,12 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
-case class SharedFileSystemRunStatus(status: String, date: Calendar) {
+case class SharedFileSystemRunState(status: String, date: Calendar) {
   override def toString: String = status
 }
 
-object SharedFileSystemRunStatus {
-  def apply(status: String): SharedFileSystemRunStatus = SharedFileSystemRunStatus(status, Calendar.getInstance())
+object SharedFileSystemRunState {
+  def apply(status: String): SharedFileSystemRunState = SharedFileSystemRunState(status, Calendar.getInstance())
 }
 
 object SharedFileSystemAsyncJobExecutionActor {
@@ -56,7 +56,12 @@ trait SharedFileSystemAsyncJobExecutionActor
 
   override type StandardAsyncRunInfo = Any
 
-  override type StandardAsyncRunStatus = SharedFileSystemRunStatus
+  override type StandardAsyncRunState = SharedFileSystemRunState
+
+  /** True if the status contained in `thiz` is equivalent to `that`, delta any other data that might be carried around
+    * in the state type.
+    */
+  override def statusEquivalentTo(thiz: StandardAsyncRunState)(that: StandardAsyncRunState): Boolean = thiz.status == that.status
 
   override lazy val pollBackOff = SimpleExponentialBackoff(1.second, 5.minutes, 1.1)
 
@@ -124,7 +129,7 @@ trait SharedFileSystemAsyncJobExecutionActor
   }
 
   override def execute(): ExecutionHandle = {
-    if (isDockerRun) jobPaths.callExecutionRoot.createPermissionedDirectories() 
+    if (isDockerRun) jobPaths.callExecutionRoot.createPermissionedDirectories()
     else jobPaths.callExecutionRoot.createDirectories()
     writeScriptContents().fold(
       identity,
@@ -166,7 +171,7 @@ trait SharedFileSystemAsyncJobExecutionActor
   override def reconnectAsync(job: StandardAsyncJob): Future[ExecutionHandle] = {
     Future.successful(reconnectToExistingJob(job))
   }
-  
+
   override def reconnectToAbortAsync(job: StandardAsyncJob): Future[ExecutionHandle] = {
     Future.successful(reconnectToExistingJob(job, forceAbort = true))
   }
@@ -230,12 +235,12 @@ trait SharedFileSystemAsyncJobExecutionActor
     ()
   }
 
-  override def pollStatus(handle: StandardAsyncPendingExecutionHandle): SharedFileSystemRunStatus = {
-    if (jobPaths.returnCode.exists) SharedFileSystemRunStatus("Done")
-    else SharedFileSystemRunStatus("WaitingForReturnCode")
+  override def pollStatus(handle: StandardAsyncPendingExecutionHandle): SharedFileSystemRunState = {
+    if (jobPaths.returnCode.exists) SharedFileSystemRunState("Done")
+    else SharedFileSystemRunState("WaitingForReturnCode")
   }
 
-  override def isTerminal(runStatus: StandardAsyncRunStatus): Boolean = {
+  override def isTerminal(runStatus: StandardAsyncRunState): Boolean = {
     runStatus.status == "Done"
   }
 


### PR DESCRIPTION
Addresses an issue with recent changes to `SharedFileSystemRunStatus` to include a timestamp. Since the timestamps on two different `SharedFileSystemRunStatus` objects are never the same, two different `SharedFileSystemRunStatus` objects are never the same. This led to Cromwell logging and publishing metadata events for every status poll even if the status hadn't changed.

This is not a great fix since (IMHO) the real problem is the modeling of a status type to include data that does not actually represent the status, but this fix is much narrower than reversing that design change.