### PR TITLE
Add logs for Papi V2 actions.

### DIFF
--- a/centaur/src/main/resources/standardTestCases/papi_v2_log.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2_log.test
@@ -1,0 +1,44 @@
+name: papi_v2_log
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: papi_v2_log/papi_v2_log.wdl
+}
+
+metadata {
+  workflowName: papi_v2_log
+  status: Succeeded
+
+  # Each array entry matches a `grep -c` in check_log
+
+  "outputs.papi_v2_log.check_write_log.out_counts.0": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.1": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.2": 1
+  # Write localizes /script but not /written.txt
+  "outputs.papi_v2_log.check_write_log.out_counts.3": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.4": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.5": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.6": 1
+  # Write delocalizes /written.txt
+  "outputs.papi_v2_log.check_write_log.out_counts.7": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.8": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.9": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.10": 1
+  "outputs.papi_v2_log.check_write_log.out_counts.11": 1
+
+  "outputs.papi_v2_log.check_read_log.out_counts.0": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.1": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.2": 1
+  # Read localizes /script and /written.txt
+  "outputs.papi_v2_log.check_read_log.out_counts.3": 2
+  "outputs.papi_v2_log.check_read_log.out_counts.4": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.5": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.6": 1
+  # Read doesn't delocalize any outputs
+  "outputs.papi_v2_log.check_read_log.out_counts.7": 0
+  "outputs.papi_v2_log.check_read_log.out_counts.8": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.9": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.10": 1
+  "outputs.papi_v2_log.check_read_log.out_counts.11": 1
+}

--- a/centaur/src/main/resources/standardTestCases/papi_v2_log/papi_v2_log.wdl
+++ b/centaur/src/main/resources/standardTestCases/papi_v2_log/papi_v2_log.wdl
@@ -1,0 +1,64 @@
+version 1.0
+
+workflow papi_v2_log {
+    call write_file
+    call read_file {
+        input: input_file = write_file.written
+    }
+    call check_log as check_write_log {
+        input:
+            out_file_path = write_file.out,
+            log_file_name = "write_file.log"
+    }
+    call check_log as check_read_log {
+        input:
+            out_file_path = read_file.out,
+            log_file_name = "read_file.log"
+    }
+}
+
+task write_file {
+    command { echo "That'll do" > written.txt }
+    output {
+        File out = stdout()
+        File written = "written.txt"
+    }
+    runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+}
+
+task read_file {
+    input { File input_file }
+    command { wc -c ~{input_file} }
+    output { File out = stdout() }
+    runtime { docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950" }
+}
+
+task check_log {
+    input {
+        String out_file_path
+        String log_file_name
+    }
+    String file_log = sub(out_file_path, "/stdout$", "/" + log_file_name)
+    command {
+        set -euo pipefail
+        gsutil cp ~{file_log} log.txt
+        set +e
+        grep -c 'Starting container setup.' log.txt
+        grep -c 'Done container setup.' log.txt
+        grep -c 'Starting localization.' log.txt
+        grep -c 'Localizing input gs://cloud-cromwell-dev/cromwell_execution/travis/papi_v2_log/' log.txt
+        grep -c 'Done localization.' log.txt
+        grep -c 'Running user action: docker run -v /mnt/local-disk:/cromwell_root --entrypoint= ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950 /bin/bash /cromwell_root/script' log.txt
+        grep -c 'Starting delocalization.' log.txt
+        grep -c 'Delocalizing output /cromwell_root/written.txt -> gs://cloud-cromwell-dev/cromwell_execution/travis/papi_v2_log/' log.txt
+        grep -c 'Delocalizing output /cromwell_root/stdout -> gs://cloud-cromwell-dev/cromwell_execution/travis/papi_v2_log/' log.txt
+        grep -c 'Delocalizing output /cromwell_root/stderr -> gs://cloud-cromwell-dev/cromwell_execution/travis/papi_v2_log/' log.txt
+        grep -c 'Delocalizing output /cromwell_root/rc -> gs://cloud-cromwell-dev/cromwell_execution/travis/papi_v2_log/' log.txt
+        grep -c 'Done delocalization.' log.txt
+    }
+    output {
+        File out = stdout()
+        Array[Int] out_counts = read_lines(stdout())
+    }
+    runtime { docker: "google/cloud-sdk" }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -3,11 +3,13 @@ package cromwell.backend.google.pipelines.v2alpha1.api
 import akka.http.scaladsl.model.ContentTypes
 import com.google.api.services.genomics.v2alpha1.model.{Action, Mount, Secret}
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineDockerKeyAndToken
+import cromwell.backend.google.pipelines.common.{PipelinesApiInput, PipelinesApiOutput, PipelinesParameter}
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionFlag.ActionFlag
 import cromwell.docker.DockerImageIdentifier
 import cromwell.docker.registryv2.flows.dockerhub.DockerHub
 import mouse.all._
+import org.apache.commons.text.StringEscapeUtils
 
 import scala.collection.JavaConverters._
 
@@ -21,9 +23,12 @@ object ActionBuilder {
         * Very short description of the action
         */
       val Tag = "tag"
+      val Logging = "logging"
       val InputName = "inputName"
+      val OutputName = "outputName"
     }
     object Value {
+      val ContainerSetup = "ContainerSetup"
       val UserAction = "UserAction"
       val Localization = "Localization"
       val Delocalization = "Delocalization"
@@ -38,6 +43,14 @@ object ActionBuilder {
     def withFlags(flags: List[ActionFlag]): Action = action.setFlags(flags |> javaFlags)
     def withMounts(mounts: List[Mount]): Action = action.setMounts(mounts.asJava)
     def withLabels(labels: Map[String, String]): Action = action.setLabels(labels.asJava)
+
+    def scalaLabels: Map[String, String] = {
+      val list = for {
+        keyValueList <- Option(action.getLabels).toList
+        keyValue <- keyValueList.asScala
+      } yield keyValue
+      list.toMap
+    }
   }
 
   object Gsutil {
@@ -81,4 +94,192 @@ object ActionBuilder {
       .withFlags(flags)
       .withMounts(mounts)
       .withLabels(labels)
+
+  /**
+    * Returns a set of labels for a parameter.
+    *
+    * @param pipelinesParameter Input or output parameter to label.
+    * @return The labels.
+    */
+  def parameterLabels(pipelinesParameter: PipelinesParameter): Map[String, String] = {
+    pipelinesParameter match {
+      case _: PipelinesApiInput =>
+        Map(
+          Key.Tag -> Value.Localization,
+          Key.InputName -> pipelinesParameter.name
+        )
+      case _: PipelinesApiOutput =>
+        Map(
+          Key.Tag -> Value.Delocalization,
+          Key.OutputName -> pipelinesParameter.name
+        )
+    }
+  }
+
+  /**
+    * Surrounds the list of Actions with a pair of starting and done Actions.
+    *
+    * @param description       Description of the list of Actions.
+    * @param loggingLabelValue An entry from Value that describes the list of Actions.
+    * @param isAlwaysRun       If true the pair of starting and done Actions will always be run.
+    * @param actions           The list of Actions to surround.
+    * @return The starting Action, the passed in list, and then a done Action.
+    */
+  def annotateTimestampedActions(description: String, loggingLabelValue: String, isAlwaysRun: Boolean = false)
+                                (actions: List[Action]): List[Action] = {
+    val flags = if (isAlwaysRun) List(ActionFlag.AlwaysRun) else List()
+    val labels = Map(Key.Logging -> loggingLabelValue)
+    val starting = logTimestampedAction(s"Starting $description.", flags, labels)
+    val done = logTimestampedAction(s"Done $description.", flags, labels)
+    starting +: actions :+ done
+  }
+
+  /** Creates an Action that describes the parameter localization or delocalization. */
+  def describeParameter(pipelinesParameter: PipelinesParameter,
+                        actionLabels: Map[String, String]): Action = {
+    pipelinesParameter match {
+      case _: PipelinesApiInput =>
+        val message = "Localizing input %s -> %s".format(
+          quoted(pipelinesParameter.cloudPath),
+          quoted(pipelinesParameter.containerPath),
+        )
+        ActionBuilder.logTimestampedAction(message, List(), actionLabels)
+      case _: PipelinesApiOutput =>
+        val message = "Delocalizing output %s -> %s".format(
+          quoted(pipelinesParameter.containerPath),
+          quoted(pipelinesParameter.cloudPath),
+        )
+        ActionBuilder.logTimestampedAction(message, List(ActionFlag.AlwaysRun), actionLabels)
+    }
+  }
+
+  /** Creates an Action that logs the docker command for the passed in action. */
+  def describeDocker(description: String, action: Action): Action = {
+    ActionBuilder.logTimestampedAction(
+      s"Running $description: ${ActionBuilder.toDockerRun(action)}",
+      Nil,
+      action.scalaLabels
+    )
+  }
+
+  /**
+    * Creates an Action that logs the time as UTC plus prints the message. The original actionLabels will also be
+    * applied to the logged action, except that Key.Tag -> some-value will be replaced with Key.Logging -> some-value.
+    *
+    * @param message      Message to output.
+    * @param actionFlags  Flags from the original Action to also apply to the logging Action.
+    * @param actionLabels Labels from the original Action to modify and apply to the logging Action.
+    * @return A new Action that will log the time and print the message.
+    */
+  private def logTimestampedAction(message: String,
+                                   actionFlags: List[ActionFlag],
+                                   actionLabels: Map[String, String]): Action = {
+    // Uses the cloudSdk image as that image will be used for other operations as well.
+    cloudSdkShellAction(
+      s"""printf '%s %s\\n' "$$(date -u '+%Y/%m/%d %H:%M:%S')" ${quoted(message)}"""
+    )(
+      flags = actionFlags,
+      labels = actionLabels collect {
+        case (key, value) if key == Key.Tag => Key.Logging -> value
+        case (key, value) => key -> value
+      }
+    )
+  }
+
+  /** Converts an Action to a `docker run ...` command runnable in the shell. */
+  private[api] def toDockerRun(action: Action): String = {
+    val commandArgs: String = Option(action.getCommands) match {
+      case Some(commands) =>
+        commands.asScala map {
+          case command if Option(command).isDefined => s" ${quoted(command)}"
+          case _ => ""
+        } mkString ""
+      case None => ""
+    }
+
+    val entrypointArg: String = Option(action.getEntrypoint) match {
+      case Some(entrypoint) => s" --entrypoint=${quoted(entrypoint)}"
+      case None => ""
+    }
+
+    val environmentArgs: String = Option(action.getEnvironment) match {
+      case Some(environment) =>
+        environment.asScala map {
+          case (key, value) if Option(key).isDefined && Option(value).isDefined => s" -e ${quoted(s"$key:$value")}"
+          case (key, _) if Option(key).isDefined => s" -e ${quoted(key)}"
+          case _ => ""
+        } mkString ""
+      case None => ""
+    }
+
+    val imageArg: String = Option(action.getImageUri) match {
+      case None => " <no docker image specified>"
+      case Some(imageUri) => s" ${quoted(imageUri)}"
+    }
+
+    val mountArgs: String = Option(action.getMounts) match {
+      case None => ""
+      case Some(mounts) =>
+        mounts.asScala map {
+          case mount if Option(mount).isEmpty => ""
+          case mount if mount.getReadOnly => s" -v ${quoted(s"/mnt/${mount.getDisk}:${mount.getPath}:ro")}"
+          case mount => s" -v ${quoted(s"/mnt/${mount.getDisk}:${mount.getPath}")}"
+        } mkString ""
+    }
+
+    val nameArg: String = Option(action.getName) match {
+      case None => ""
+      case Some(name) => s" --name ${quoted(name)}"
+    }
+
+    val pidNamespaceArg: String = Option(action.getPidNamespace) match {
+      case Some(pidNamespace) => s" --pid=${quoted(pidNamespace)}"
+      case None => ""
+    }
+
+    val portMappingArgs: String = Option(action.getPortMappings) match {
+      case Some(portMappings) =>
+        portMappings.asScala map {
+          case (key, value) if Option(key).isDefined => s" -p ${quoted(s"$key:$value")}"
+          case (_, value) => s" -p $value"
+        } mkString ""
+      case None => ""
+    }
+
+    val flagsArgs: String = Option(action.getFlags) match {
+      case Some(flags) =>
+        flags.asScala map { arg =>
+          ActionFlag.values.find(_.toString == arg) match {
+            case Some(ActionFlag.PublishExposedPorts) => " -P"
+            case _ => ""
+          }
+        } mkString ""
+      case None => ""
+    }
+
+    Array("docker run",
+      nameArg,
+      mountArgs,
+      environmentArgs,
+      pidNamespaceArg,
+      flagsArgs,
+      portMappingArgs,
+      entrypointArg,
+      imageArg,
+      commandArgs,
+    ).mkString
+  }
+
+  /** Quotes a string such that it's compatible as a string argument in the shell. */
+  private def quoted(any: Any): String = {
+    val str = String.valueOf(any)
+    /*
+    NOTE: escapeXSI is more compact than wrapping in single quotes. Newlines are also stripped by the shell, as they
+    are by escapeXSI. If for some reason escapeXSI doesn't 100% work, say because it ends up stripping some required
+    newlines, then consider adding a check for newlines and then using:
+
+    "'" + str.replace("'", "'\"'\"'") + "'"
+     */
+    StringEscapeUtils.escapeXSI(str)
+  }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -6,7 +6,7 @@ import cromwell.core.path.Path
 import cromwell.filesystems.gcs.GcsPath
 import cromwell.filesystems.gcs.RequesterPaysErrors._
 import mouse.all._
-import org.apache.commons.text.StringEscapeUtils.ESCAPE_XSI
+import org.apache.commons.text.StringEscapeUtils
 
 import scala.concurrent.duration._
 
@@ -25,7 +25,7 @@ object ActionCommands {
   
   implicit class ShellPath(val path: Path) extends AnyVal {
     // The command String runs in Bourne shell so shell metacharacters in filenames must be escaped
-    def escape = ESCAPE_XSI.translate(path.pathAsString)
+    def escape: String = StringEscapeUtils.escapeXSI(path.pathAsString)
   }
   
   private def makeContentTypeFlag(contentType: Option[ContentType]) = contentType.map(ct => s"""-h "Content-Type: $ct"""").getOrElse("")

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ContainerSetup.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ContainerSetup.scala
@@ -1,0 +1,25 @@
+package cromwell.backend.google.pipelines.v2alpha1.api
+
+import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+import cromwell.backend.google.pipelines.common.io.PipelinesApiWorkingDisk
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels.{Key, Value}
+
+import scala.collection.JavaConverters._
+
+trait ContainerSetup {
+  def containerSetupActions(mounts: List[Mount]): List[Action] = {
+    val containerRoot = PipelinesApiWorkingDisk.MountPoint.pathAsString
+
+    // As opposed to V1, the container root does not have a 777 umask, which can cause issues for docker running as non root
+    // Run a first action to create the root and give it the right permissions
+    val containerRootSetup = ActionBuilder
+      .cloudSdkAction
+      .setCommands(
+        List("/bin/bash", "-c", s"mkdir -p $containerRoot && chmod -R a+rwx $containerRoot").asJava
+      )
+      .setMounts(mounts.asJava)
+      .setLabels(Map(Key.Tag -> Value.ContainerSetup).asJava)
+
+    ActionBuilder.annotateTimestampedActions("container setup", Value.ContainerSetup)(List(containerRootSetup))
+  }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
@@ -1,0 +1,20 @@
+package cromwell.backend.google.pipelines.v2alpha1.api
+
+import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
+
+trait UserAction {
+  def userActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Mount]): List[Action] = {
+    val userAction = ActionBuilder.userAction(
+      createPipelineParameters.dockerImage,
+      createPipelineParameters.commandScriptContainerPath.pathAsString,
+      mounts,
+      createPipelineParameters.jobShell,
+      createPipelineParameters.privateDockerKeyAndEncryptedToken
+    )
+
+    val describeAction = ActionBuilder.describeDocker("user action", userAction)
+
+    List(describeAction, userAction)
+  }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilderSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilderSpec.scala
@@ -1,0 +1,54 @@
+package cromwell.backend.google.pipelines.v2alpha1.api
+
+import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+class ActionBuilderSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
+
+  behavior of "ActionBuilder"
+
+  val dockerRunActions = Table(
+    ("description", "action", "command"),
+    ("a cloud sdk action", ActionBuilder.cloudSdkAction, "docker run google/cloud-sdk:slim"),
+    ("a cloud sdk action with args",
+      ActionBuilder.cloudSdkAction.setCommands(List("bash", "-c", "echo hello").asJava),
+      "docker run google/cloud-sdk:slim bash -c echo\\ hello"
+    ),
+    ("a cloud sdk action with quotes in the args",
+      ActionBuilder.cloudSdkAction.setCommands(List("bash", "-c", "echo hello m'lord").asJava),
+      "docker run google/cloud-sdk:slim bash -c echo\\ hello\\ m\\'lord"
+    ),
+    ("a cloud sdk action with a newline in the args",
+      ActionBuilder.cloudSdkAction.setCommands(List("bash", "-c", "echo hello\\\nworld").asJava),
+      "docker run google/cloud-sdk:slim bash -c echo\\ hello\\\\world"
+    ),
+    ("an action with multiple args",
+      new Action()
+        .setImageUri("ubuntu")
+        .setEnvironment(Map("ENV" -> "dev").asJava)
+        .setEntrypoint("")
+        .setCommands(List("bash", "-c", "echo hello").asJava)
+        .setFlags(List(ActionFlag.PublishExposedPorts, ActionFlag.AlwaysRun).map(_.toString).asJava)
+        .setMounts(List(
+          new Mount().setDisk("read-only-disk").setPath("/read/only/container").setReadOnly(true),
+          new Mount().setDisk("read-write-disk").setPath("/read/write/container"),
+        ).asJava)
+        .setName("my_container_name")
+        .setPidNamespace("host")
+        .setPortMappings(Map("8008" -> Int.box(8000)).asJava),
+      "docker run --name my_container_name" +
+        " -v /mnt/read-only-disk:/read/only/container:ro -v /mnt/read-write-disk:/read/write/container" +
+        " -e ENV:dev --pid=host -P -p 8008:8000 --entrypoint= ubuntu bash -c echo\\ hello"
+    ),
+  )
+
+  forAll(dockerRunActions) { (description, action, command) =>
+    it should s"convert $description" in {
+      ActionBuilder.toDockerRun(action) should be(command)
+    }
+  }
+
+}


### PR DESCRIPTION
- Traits with logging for each phase of a Papi V2 Job:
  - Container Setup
  - Localization
  - User Action
  - Delocalization
- More consistent Papi labels for each phase/action.
- Centaur test that checks that logs are generated as expected.