### PR TITLE
Reduce number of logged "unhandled" messages

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -217,9 +217,6 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   whenUnhandled {
     case Event(AbortJobCommand, _) =>
       abort()
-    case Event(unexpected, _) =>
-      log.warning(s"Backend cache hit copying actor received an unexpected message: $unexpected in state $stateName")
-      stay()
   }
 
   def succeedAndStop(returnCode: Option[Int], copiedJobOutputs: CallOutputs, detritusMap: DetritusMap) = {

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -127,9 +127,6 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
     case Event((CurrentState(_, _) | Transition(_, _, _)), _) =>
       // ignore uninteresting current state and transition messages
       stay()
-    case Event(m, d) =>
-      log.warning(s"$Tag: received unexpected message: $m in state ${d.getClass.getSimpleName}")
-      stay()
   }
 
   private def requestMetadataOrIssueReply(newData: TerminalSwraData) = if (metadataOutputPath.isDefined) requestMetadata(newData) else issueReply(newData)

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -266,10 +266,6 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       val sndr = sender()
       context.actorOf(EngineStatsActor.props(data.workflows.values.toList, sndr), s"EngineStatsActor-${sndr.hashCode()}")
       stay()
-    // Anything else certainly IS interesting:
-    case Event(unhandled, _) =>
-      log.warning(s"$tag Unhandled message: $unhandled")
-      stay()
   }
 
   onTransition {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/WorkflowLifecycleActor.scala
@@ -78,12 +78,6 @@ trait WorkflowLifecycleActor[S <: WorkflowLifecycleActorState] extends LoggingFS
     case t => super.supervisorStrategy.decider.applyOrElse(t, (_: Any) => Escalate)
   }
 
-  whenUnhandled {
-    case unhandledMessage =>
-      workflowLogger.warn(s"received an unhandled message: $unhandledMessage")
-      stay
-  }
-
   onTransition {
     case _ -> state if state.terminal =>
       workflowLogger.debug("State is now terminal. Stopping self.")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/preparation/JobPreparationActor.scala
@@ -89,12 +89,6 @@ class JobPreparationActor(workflowDescriptor: EngineWorkflowDescriptor,
       }
   }
 
-  whenUnhandled {
-    case Event(unexpectedMessage, _) =>
-      workflowLogger.warn(s"JobPreparation actor received an unexpected message in state $stateName: $unexpectedMessage")
-      stay()
-  }
-
   private[preparation] lazy val kvStoreKeysToPrefetch: Seq[String] = factory.requestedKeyValueStoreKeys ++ factory.defaultKeyValueStoreKeys
   private[preparation] def scopedKey(key: String) = ScopedKey(workflowDescriptor.id, KvJobKey(jobKey), key)
   private[preparation] def lookupKeyValueEntries(inputs: WomEvaluatedCallInputs,

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -204,9 +204,6 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
   whenUnhandled {
     case Event(EngineLifecycleActorAbortCommand, _) =>
       goto(MaterializationAbortedState)
-    case unhandledMessage =>
-      workflowLogger.warn(s"received an unhandled message $unhandledMessage in state $stateName")
-      stay
   }
 
   private def workflowInitializationFailed(errors: NonEmptyList[String], replyTo: ActorRef) = {

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -2,7 +2,12 @@ akka {
   log-dead-letters = "off"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "cromwell.server.CromwellAkkaLogFilter"
-  actor.guardian-supervisor-strategy = "cromwell.core.CromwellUserGuardianStrategy"
+  actor {
+    debug {
+       unhandled = on
+    }
+    guardian-supervisor-strategy = "cromwell.core.CromwellUserGuardianStrategy"
+  }
 
   http {
     server {

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -288,3 +288,18 @@ class SingleWorkflowRunnerActorFailureSpec extends SingleWorkflowRunnerActorSpec
     }
   }
 }
+
+class SingleWorkflowRunnerActorUnexpectedSpec extends SingleWorkflowRunnerActorSpec {
+  "A SingleWorkflowRunnerActor" should {
+    "successfully warn about unexpected output" in {
+      within(TimeoutDuration) {
+        val runner = createRunnerActor()
+        waitForWarning("unhandled message from Actor") {
+          runner ? RunWorkflow
+          runner ! "expected unexpected"
+        }
+        assert(!system.whenTerminated.isCompleted)
+      }
+    }
+  }
+}

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -288,18 +288,3 @@ class SingleWorkflowRunnerActorFailureSpec extends SingleWorkflowRunnerActorSpec
     }
   }
 }
-
-class SingleWorkflowRunnerActorUnexpectedSpec extends SingleWorkflowRunnerActorSpec {
-  "A SingleWorkflowRunnerActor" should {
-    "successfully warn about unexpected output" in {
-      within(TimeoutDuration) {
-        val runner = createRunnerActor()
-        waitForWarning("SingleWorkflowRunnerActor: received unexpected message: expected unexpected") {
-          runner ? RunWorkflow
-          runner ! "expected unexpected"
-        }
-        assert(!system.whenTerminated.isCompleted)
-      }
-    }
-  }
-}

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -59,10 +59,4 @@ class MetadataSummaryRefreshActor()
     case Event(MetadataSummaryComplete, _) =>
       goto(WaitingForRequest) using SummaryRefreshData
   }
-
-  whenUnhandled {
-    case Event(wut, _) =>
-      log.warning("Unrecognized or unexpected message while in state '{}': {}", stateName, wut)
-      stay()
-  }
 }


### PR DESCRIPTION
If someone wants to see these kinds messages, they can change the configuration of akka (see http://doc.akka.io/docs/akka/current/java/logging.html#Auxiliary_logging_options), instead.

- went through the `whenUnhandled` handlers and removed logging calls that had no or very little info
- removed one test that was associated with one of those logs