### PR TITLE
Better message for bad path

### DIFF
--- a/core/src/main/scala/cromwell/core/path/PathFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathFactory.scala
@@ -58,7 +58,7 @@ object PathFactory {
     path.map(postMapping) getOrElse {
       val pathBuilderNames: String = pathBuilders map { _.name } mkString ", "
       throw PathParsingException(
-        s"""Could not build the path "$string". It may refer to a filesystem not supported by this instance of Cromwell - see messages below for details.""" +
+        s"""Could not build the path "$string". It may refer to a filesystem not supported by this instance of Cromwell.""" +
           s" Supported filesystems are: $pathBuilderNames." +
           s" Failures: $failuresMessage" +
           s" Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems"

--- a/core/src/main/scala/cromwell/core/path/PathFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathFactory.scala
@@ -58,7 +58,7 @@ object PathFactory {
     path.map(postMapping) getOrElse {
       val pathBuilderNames: String = pathBuilders map { _.name } mkString ", "
       throw PathParsingException(
-        s"""Either the path "$string" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it.""" +
+        s"""Could not build the path "$string". It may refer to a filesystem not supported by this instance of Cromwell - see messages below for details.""" +
           s" Supported filesystems are: $pathBuilderNames." +
           s" Failures: $failuresMessage" +
           s" Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems"

--- a/core/src/main/scala/cromwell/core/path/PathFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathFactory.scala
@@ -58,7 +58,7 @@ object PathFactory {
     path.map(postMapping) getOrElse {
       val pathBuilderNames: String = pathBuilders map { _.name } mkString ", "
       throw PathParsingException(
-        s"Either $string exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it." +
+        s"Either the path \"$string\" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it." +
           s" Supported filesystems are: $pathBuilderNames." +
           s" Failures: $failuresMessage" +
           s" Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems"

--- a/core/src/main/scala/cromwell/core/path/PathFactory.scala
+++ b/core/src/main/scala/cromwell/core/path/PathFactory.scala
@@ -58,7 +58,7 @@ object PathFactory {
     path.map(postMapping) getOrElse {
       val pathBuilderNames: String = pathBuilders map { _.name } mkString ", "
       throw PathParsingException(
-        s"Either the path \"$string\" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it." +
+        s"""Either the path "$string" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it.""" +
           s" Supported filesystems are: $pathBuilderNames." +
           s" Failures: $failuresMessage" +
           s" Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems"

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -160,7 +160,7 @@ class GcsPathBuilder(apiStorage: com.google.api.services.storage.Storage,
           val cloudStoragePath = fileSystem.getPath(path)
           GcsPath(cloudStoragePath, apiStorage, cloudStorage, projectId)
         }
-      case PossiblyValidRelativeGcsPath => Failure(new IllegalArgumentException(s"$string does not have a gcs scheme"))
+      case PossiblyValidRelativeGcsPath => Failure(new IllegalArgumentException(s"""Path "$string" does not have a gcs scheme"""))
       case invalid: InvalidGcsPath => Failure(new IllegalArgumentException(invalid.errorMessage))
     }
   }

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/GcsPathBuilderSpec.scala
@@ -275,15 +275,15 @@ class GcsPathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wi
   )
 
   private def badPaths = Seq(
-    BadPath("an empty path", "", " does not have a gcs scheme"),
+    BadPath("an empty path", "", "Path \"\" does not have a gcs scheme"),
     BadPath("an bucketless path", "gs://", "The specified GCS path 'gs://' does not parse as a URI.\nExpected authority at index 5: gs://"),
     BadPath("a bucket named .", "gs://./hello/world", "The path 'gs://./hello/world' does not seem to be a valid GCS path. Please check that it starts with gs:// and that the bucket and object follow GCS naming guidelines at https://cloud.google.com/storage/docs/naming."),
     BadPath("a non ascii bucket name", "gs://nonasciibucket£€/hello/world",
       "The path 'gs://nonasciibucket£€/hello/world' does not seem to be a valid GCS path. Please check that it starts with gs:// and that the bucket and object follow GCS naming guidelines at https://cloud.google.com/storage/docs/naming."),
     BadPath("a https path", "https://hello/world", "Cloud Storage URIs must have 'gs' scheme: https://hello/world"),
     BadPath("a file uri path", "file:///hello/world", "Cloud Storage URIs must have 'gs' scheme: file:///hello/world"),
-    BadPath("a relative file path", "hello/world", "hello/world does not have a gcs scheme"),
-    BadPath("an absolute file path", "/hello/world", "/hello/world does not have a gcs scheme")
+    BadPath("a relative file path", "hello/world", "Path \"hello/world\" does not have a gcs scheme"),
+    BadPath("an absolute file path", "/hello/world", "Path \"/hello/world\" does not have a gcs scheme")
   )
 
   private lazy val pathBuilder = {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -59,7 +59,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
   I'm merging this in the interest of time.
 
   It throws the following exception:
-  Cause: java.lang.IllegalArgumentException: Either s3://my-cromwell-workflows-bucket exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it. Supported filesystems are: s3. Failures: s3: AWS region not provided (SdkClientException) Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems
+  Cause: java.lang.IllegalArgumentException: Either the path "s3://my-cromwell-workflows-bucket" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it. Supported filesystems are: s3. Failures: s3: AWS region not provided (SdkClientException) Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems
 [info]   at cromwell.core.path.PathParsingException.<init>(PathParsingException.scala:5)
 [info]   at cromwell.core.path.PathFactory$.$anonfun$buildPath$4(PathFactory.scala:64)
 [info]   at scala.Option.getOrElse(Option.scala:121)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -59,7 +59,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
   I'm merging this in the interest of time.
 
   It throws the following exception:
-  Cause: java.lang.IllegalArgumentException: Either the path "s3://my-cromwell-workflows-bucket" exists on a filesystem not supported by this instance of Cromwell, or a failure occurred while building an actionable path from it. Supported filesystems are: s3. Failures: s3: AWS region not provided (SdkClientException) Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems
+  Cause: java.lang.IllegalArgumentException: Could not build the path "s3://my-cromwell-workflows-bucket". It may refer to a filesystem not supported by this instance of Cromwell. Supported filesystems are: s3. Failures: s3: AWS region not provided (SdkClientException) Please refer to the documentation for more information on how to configure filesystems: http://cromwell.readthedocs.io/en/develop/backends/HPC/#filesystems
 [info]   at cromwell.core.path.PathParsingException.<init>(PathParsingException.scala:5)
 [info]   at cromwell.core.path.PathFactory$.$anonfun$buildPath$4(PathFactory.scala:64)
 [info]   at scala.Option.getOrElse(Option.scala:121)


### PR DESCRIPTION
It's a bit of a pet peeve of mine when error messages don't put quotes around raw values. This leads to  unnecessarily confusing scenarios like
```
Your input  did not meet our requirements.
```
for an input of `""`.