### PR TITLE
Tweaks to test timeouts.

### DIFF
--- a/dockerHashing/src/test/scala/cromwell/docker/local/DockerCliFlowSpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/local/DockerCliFlowSpec.scala
@@ -36,20 +36,20 @@ class DockerCliFlowSpec extends DockerFlowSpec("DockerCliFlowSpec") with FlatSpe
     val notFound = makeRequest("ubuntu:nonexistingtag")
     dockerActor ! notFound
 
-    expectMsgClass(5.seconds, classOf[DockerHashNotFound])
+    expectMsgClass(30.seconds, classOf[DockerHashNotFound])
   }
 
   it should "send image not found if the user doesn't have permission on this image" taggedAs IntegrationTest in {
     val unauthorized = makeRequest("tjeandet/sinatra:v1")
     dockerActor ! unauthorized
 
-    expectMsgClass(5.seconds, classOf[DockerHashNotFound])
+    expectMsgClass(30.seconds, classOf[DockerHashNotFound])
   }
 
   it should "send image not found for an unrecognized host" taggedAs IntegrationTest in {
     val unauthorized = makeRequest("unknown.io/image:v1")
     dockerActor ! unauthorized
 
-    expectMsgClass(5.seconds, classOf[DockerHashNotFound])
+    expectMsgClass(30.seconds, classOf[DockerHashNotFound])
   }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedWriteActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedWriteActorSpec.scala
@@ -23,7 +23,7 @@ class WorkflowStoreCoordinatedWriteActorSpec extends TestKitSuite("WorkflowStore
   override implicit def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   def sleepAndThrow: Nothing = {
-    Thread.sleep(5 * 1000L)
+    Thread.sleep(30.seconds.dilated.toMillis)
     throw new RuntimeException("test should have timed out")
   }
 
@@ -132,7 +132,8 @@ class WorkflowStoreCoordinatedWriteActorSpec extends TestKitSuite("WorkflowStore
         }
       }
       val actor = TestActorRef(new WorkflowStoreCoordinatedWriteActor(workflowStore))
-      val request = FetchStartableWorkflows(1, s"test $description fetchStartableWorkflows", 1.second)
+      val heartbeatTtlNotReallyUsed = 1.second
+      val request = FetchStartableWorkflows(1, s"test $description fetchStartableWorkflows", heartbeatTtlNotReallyUsed)
       implicit val timeout: Timeout = Timeout(2.seconds.dilated)
       actor.ask(request).failed map { actual =>
         actual.getMessage should startWith(expectedMessagePrefix)

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -18,22 +18,20 @@ import spray.json._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSpecLike with Matchers with Mockito
   with TableDrivenPropertyChecks with ImplicitSender {
 
-  behavior of "MetadataParser"
+  behavior of "MetadataBuilderActor"
 
-  val defaultTimeout = 200 millis
+  val defaultTimeout: FiniteDuration = 1.second.dilated
   implicit val timeout: Timeout = defaultTimeout
-
-  val mockServiceRegistry = TestProbe()
 
   def assertMetadataResponse(action: MetadataServiceAction,
                              queryReply: MetadataQuery,
                              events: Seq[MetadataEvent],
                              expectedRes: String): Future[Assertion] = {
+    val mockServiceRegistry = TestProbe()
     val mba = system.actorOf(MetadataBuilderActor.props(mockServiceRegistry.ref))
     val response = mba.ask(action).mapTo[MetadataBuilderActorResponse]
     mockServiceRegistry.expectMsg(defaultTimeout, action)
@@ -462,6 +460,8 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     val subQueryAction = GetMetadataQueryAction(subQuery)
     
     val parentProbe = TestProbe()
+    val mockServiceRegistry = TestProbe()
+
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(mockServiceRegistry.ref), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
     val response = metadataBuilder.ask(mainQueryAction).mapTo[MetadataBuilderActorResponse]
     mockServiceRegistry.expectMsg(defaultTimeout, mainQueryAction)
@@ -506,6 +506,8 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     val queryNoExpandAction = GetMetadataQueryAction(queryNoExpand)
     
     val parentProbe = TestProbe()
+    val mockServiceRegistry = TestProbe()
+
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(mockServiceRegistry.ref), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
     val response = metadataBuilder.ask(queryNoExpandAction).mapTo[MetadataBuilderActorResponse]
     mockServiceRegistry.expectMsg(defaultTimeout, queryNoExpandAction)

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -3,7 +3,6 @@ package cromwell.services
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.sql.Connection
 import java.time.OffsetDateTime
-import javax.sql.rowset.serial.{SerialBlob, SerialClob, SerialException}
 
 import better.files._
 import com.typesafe.config.ConfigFactory
@@ -15,6 +14,7 @@ import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.joins.JobStoreJoin
 import cromwell.database.sql.tables.WorkflowStoreEntry.WorkflowStoreState
 import cromwell.database.sql.tables.{JobStoreEntry, JobStoreSimpletonEntry, WorkflowStoreEntry}
+import javax.sql.rowset.serial.{SerialBlob, SerialClob, SerialException}
 import liquibase.diff.DiffResult
 import liquibase.diff.output.DiffOutputControl
 import liquibase.diff.output.changelog.DiffToChangeLog
@@ -22,7 +22,6 @@ import org.hsqldb.persist.HsqlDatabaseProperties
 import org.scalactic.StringNormalizations
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 import slick.jdbc.JdbcProfile
 import slick.jdbc.meta._
@@ -38,7 +37,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 
   implicit val ec = ExecutionContext.global
 
-  implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Millis))
+  implicit val defaultPatience = PatienceConfig(timeout = scaled(5.seconds), interval = scaled(100.millis))
 
   behavior of "ServicesStore"
 
@@ -71,7 +70,7 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
           _ = queried.get.jobStoreEntry.workflowExecutionUuid should be(workflowUuid)
         } yield ()
       }
-      Future.sequence(futures).futureValue(Timeout(10.seconds))
+      Future.sequence(futures).futureValue(Timeout(scaled(30.seconds)))
     }
   }
 

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -71,6 +71,12 @@ class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with 
   it should "fail if any subsystems fail but correctly bin them" in {
     val hm = TestActorRef(new TestHealthMonitorActor {
       override def subsystems: Set[MonitoredSubsystem] = Set(SuccessSubsystem, FailureSubsystem)
+      /*
+      Unlike success-statuses, failure-statuses retry a number of times before storing their values.
+      While the failures-status is retrying, the success-status ends up becoming "stale", and flips to "unknown".
+      So, increase the timeout for marking the success-status as stale.
+       */
+      override lazy val staleThreshold = scaled(10.seconds)
     })
     eventualStatus(hm, ok = false, (SuccessSubsystem, OkStatus), (FailureSubsystem, FailedStatus))
   }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAttributesSpec.scala
@@ -82,7 +82,7 @@ class PipelinesApiAttributesSpec extends FlatSpec with Matchers {
     errorsList should contain("No configuration setting found for key 'root'")
     errorsList should contain("No configuration setting found for key 'genomics.auth'")
     errorsList should contain("No configuration setting found for key 'filesystems'")
-    errorsList should contain("URI is not absolute")
+    errorsList should contain("String: 2: genomics.endpoint-url has type String rather than java.net.URL")
   }
 
   def configString(preemptible: String = "", genomics: String = ""): String =


### PR DESCRIPTION
Also: Stop using global probes in the MetadataBuilderActorSpec.