### PR TITLE
Fix flakiness of StatsD test in Jenkins QA

### DIFF
--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -48,7 +48,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
   }
 
   // Fuzzy packets are metrics which we expect to see but for which cannot determine the exact values for asynchronous reasons
-  final case class StatsDTestBit(description: String, metric: CromwellMetric, expectedExactPackets: Set[String], expectedFuzzyPackets: Set[String] = Set.empty)
+  case class StatsDTestBit(description: String, metric: CromwellMetric, expectedExactPackets: Set[String], expectedFuzzyPackets: Set[String] = Set.empty)
   
   // Note: The current StatsD implementation sends everything as StatsD gauges so we expect all packets to be "...|g"
   List(

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -48,7 +48,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
   }
 
   // Fuzzy packets are metrics which we expect to see but for which cannot determine the exact values for asynchronous reasons
-  case class StatsDTestBit(description: String, metric: CromwellMetric, expectedExactPackets: Set[String], expectedFuzzyPackets: Set[String] = Set.empty)
+  final case class StatsDTestBit(description: String, metric: CromwellMetric, expectedExactPackets: Set[String], expectedFuzzyPackets: Set[String] = Set.empty)
   
   // Note: The current StatsD implementation sends everything as StatsD gauges so we expect all packets to be "...|g"
   List(


### PR DESCRIPTION
Passed in this jenkins run https://fc-jenkins.dsp-techops.broadinstitute.org/job/cromwell-test-runner/740 (which still failed from other tests, hopefully fixed by https://github.com/broadinstitute/cromwell/pull/4296)