### PR TITLE
Added another latch plus patience to EnhancedRhinoSandboxSpec.

### DIFF
--- a/cwl/src/test/scala/cwl/internal/EnhancedRhinoSandboxSpec.scala
+++ b/cwl/src/test/scala/cwl/internal/EnhancedRhinoSandboxSpec.scala
@@ -5,9 +5,11 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import cwl.internal.EnhancedRhinoSandboxSpec.CachedClassLoader
 import org.apache.commons.io.IOUtils
 import org.mozilla.javascript.ContextFactory
+import org.scalatest.concurrent.ScaledTimeSpans
 import org.scalatest.{FlatSpec, Matchers}
+import scala.concurrent.duration._
 
-class EnhancedRhinoSandboxSpec extends FlatSpec with Matchers {
+class EnhancedRhinoSandboxSpec extends FlatSpec with Matchers with ScaledTimeSpans {
 
   behavior of "EnhancedRhinoSandbox"
 
@@ -15,39 +17,56 @@ class EnhancedRhinoSandboxSpec extends FlatSpec with Matchers {
     // Initialize the context factory here to be sure that our loaded runner is actually using a fresh ContextFactory
     new EnhancedRhinoSandbox(true).assertContextFactory()
 
+    val threadCount = 10
+
     // A custom loader that will contain our fresh static ContextFactory
     val cachedClassLoader = new CachedClassLoader
+    // A latch that lets this test know the threads are ready
+    val threadReadyLatch = new CountDownLatch(threadCount)
     // A latch to ensure that all threads try to run at the same time
-    val countDownLatch = new CountDownLatch(1)
+    val threadGoLatch = new CountDownLatch(1)
 
     class Runner(name: String) extends Thread {
       var success = false
 
       override def run(): Unit = {
-        EnhancedRhinoSandboxSpec.runClassLoaded(cachedClassLoader, countDownLatch)
+        EnhancedRhinoSandboxSpec.runClassLoaded(
+          cachedClassLoader,
+          threadReadyLatch = threadReadyLatch,
+          threadGoLatch = threadGoLatch
+        )
         success = true
       }
     }
 
-    val threads = (0 until 10).map(i => new Runner(i.toString))
+    val threads = (0 until threadCount).map(i => new Runner(i.toString))
+    // move all the threads to the starting line...
     threads.foreach(_.start())
-    countDownLatch.countDown()
-    threads.foreach(_.join(1000L))
+    // Wait for threads to say they're ready
+    threadReadyLatch.await(scaled(10.seconds).toMillis, TimeUnit.MILLISECONDS)
+    // go!
+    threadGoLatch.countDown()
+    // Maximum time to wait for each runner to finish
+    threads.foreach(_.join(scaled(10.seconds).toMillis))
+
     withClue("all threads did not complete successfully:") {
       threads.map(_.success) should contain only true
     }
   }
 }
 
-object EnhancedRhinoSandboxSpec {
+object EnhancedRhinoSandboxSpec extends ScaledTimeSpans {
   /**
     * Runs a runner loaded from a custom class loader.
     */
   private def runClassLoaded(ecmaScriptUtilClassLoader: CachedClassLoader,
-                             countDownLatch: CountDownLatch): Unit = {
+                             threadReadyLatch: CountDownLatch,
+                             threadGoLatch: CountDownLatch): Unit = {
     val cls = ecmaScriptUtilClassLoader.loadClass(classOf[LatchedRunner].getName)
     val obj = cls.newInstance
-    cls.getMethod("run", classOf[CountDownLatch]).invoke(obj, countDownLatch)
+    cls
+      .getMethod("run", classOf[CountDownLatch], classOf[CountDownLatch])
+      .invoke(obj, threadReadyLatch, threadGoLatch)
     ()
   }
 
@@ -58,9 +77,12 @@ object EnhancedRhinoSandboxSpec {
     * Inspired by: https://stackoverflow.com/questions/13263079/run-two-thread-at-the-same-time-in-java#13263273
     */
   class LatchedRunner {
-    def run(countDownLatch: CountDownLatch): Unit = {
+    def run(threadReadyLatch: CountDownLatch, threadGoLatch: CountDownLatch): Unit = {
       require(!ContextFactory.hasExplicitGlobal, "The ContextFactory within this classloader is already initialized")
-      countDownLatch.await(5, TimeUnit.SECONDS)
+      // Notify the test we're at the starting line.
+      threadReadyLatch.countDown()
+      // This await is for the time between all the threads `start()`-ing up, and the `countDownLatch.countDown()`
+      threadGoLatch.await(scaled(5.seconds).toMillis, TimeUnit.MILLISECONDS)
       new EnhancedRhinoSandbox(true).assertContextFactory()
       ()
     }

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -76,7 +76,7 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
     TestableWorkflowActorAndMetadataPromise(workflowActor, supervisor, promise)
   }
 
-  implicit val TestExecutionTimeout = 10.seconds.dilated
+  implicit val TestExecutionTimeout = 30.seconds.dilated
   val AwaitAlmostNothing = 100.milliseconds.dilated
   var workflowId: WorkflowId = _
   before {


### PR DESCRIPTION
Bonus: Increase timeout on SimpleWorkflowActorSpec that sometimes takes longer than 10s from call-start to end-of-workflow.