### PR TITLE
set aws default region in integration tests

### DIFF
--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -12,8 +12,8 @@ aws {
     }
   ]
 
-  region = "default" // uses region from ~/.aws/config set by aws configure command,
-                     // or us-east-1 by default
+  region = "us-east-1"
+
 }
 
 engine {

--- a/src/ci/resources/aws_credentials.ctmpl
+++ b/src/ci/resources/aws_credentials.ctmpl
@@ -2,4 +2,5 @@
 [default]
 aws_access_key_id = {{$cromwellAws.Data.access_key}}
 aws_secret_access_key = {{$cromwellAws.Data.secret_key}}
+region = us-east-1
 {{end}}

--- a/src/ci/resources/aws_credentials.ctmpl
+++ b/src/ci/resources/aws_credentials.ctmpl
@@ -2,5 +2,4 @@
 [default]
 aws_access_key_id = {{$cromwellAws.Data.access_key}}
 aws_secret_access_key = {{$cromwellAws.Data.secret_key}}
-region = us-east-1
 {{end}}


### PR DESCRIPTION
Noticed the integration tests were failing. 

After looking into it a little, I'm pretty sure that what happened is that when [this commit](https://github.com/broadinstitute/cromwell/commit/cc636457bf46d6fec001976ee830ad81eaed35b8) un-hardcoded the aws region, the integration tests started trying to submit batches to `batch.default.amazonaws.com` rather than `batch.us-east-1.amazonaws.com`. I think that whatever library is importing the credentials file for use with in AwsAuthMode.scala isn't defaulting to `us-east-1` as advertised. 

I believe this will fix the issue but you might prefer to solve the problem by correcting the default behavior instead; if so feel free to close this.