### PR TITLE
Remove disabled stats endpoint from swagger

### DIFF
--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -611,19 +611,6 @@ paths:
           description: Successful Request
           schema:
             $ref: '#/definitions/BackendResponse'
-  '/engine/{version}/stats':
-    get:
-      operationId: stats
-      summary: Returns basic statistics from this Cromwell server.
-      parameters:
-        - $ref: '#/parameters/versionParam'
-      tags:
-        - Engine
-      responses:
-        '200':
-          description: Successful Request
-          schema:
-            $ref: '#/definitions/StatsResponse'
   '/engine/{version}/version':
     get:
       operationId: version


### PR DESCRIPTION
The `/stats` endpoint is currently disabled and there is no immediate plan (PR or open issue) to re-enable this feature, so it's best to remove it from the documentation for now.