### PR TITLE
BCBIO improvements part 1

### DIFF
--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -14,6 +14,7 @@ import cromwell.services.keyvalue.KeyValueServiceActor.KvResponse
 import wom.callable.{ExecutableCallable, MetaValueElement}
 import wom.graph.CommandCallNode
 import wom.graph.GraphNodePort.OutputPort
+import wom.runtime.WomOutputRuntimeExtractor
 import wom.values.WomArray.WomArrayLike
 import wom.values._
 
@@ -67,8 +68,9 @@ object BackendWorkflowDescriptor {
             callable: ExecutableCallable,
             knownValues: Map[OutputPort, WomValue],
             workflowOptions: WorkflowOptions,
-            customLabels: Labels) = {
-    new BackendWorkflowDescriptor(id, callable, knownValues, workflowOptions, customLabels, List.empty)
+            customLabels: Labels,
+            outputRuntimeExtractor: Option[WomOutputRuntimeExtractor] = None) = {
+    new BackendWorkflowDescriptor(id, callable, knownValues, workflowOptions, customLabels, List.empty, outputRuntimeExtractor)
   }
 }
 
@@ -80,7 +82,8 @@ case class BackendWorkflowDescriptor(id: WorkflowId,
                                      knownValues: Map[OutputPort, WomValue],
                                      workflowOptions: WorkflowOptions,
                                      customLabels: Labels,
-                                     breadCrumbs: List[BackendJobBreadCrumb]) {
+                                     breadCrumbs: List[BackendJobBreadCrumb],
+                                     outputRuntimeExtractor: Option[WomOutputRuntimeExtractor]) {
 
   val rootWorkflow = breadCrumbs.headOption.map(_.callable).getOrElse(callable)
   val possiblyNotRootWorkflowId = id.toPossiblyNotRoot

--- a/backend/src/main/scala/cromwell/backend/validation/InformationValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/InformationValidation.scala
@@ -25,16 +25,16 @@ import scala.util.{Failure, Success}
   * `withDefault` can be used to create a validation that defaults to a particular size.
   */
 object InformationValidation {
-  def instance(attributeName: String = RuntimeAttributesKeys.MemoryKey, defaultUnit: MemoryUnit): RuntimeAttributesValidation[MemorySize] =
-    new InformationValidation(attributeName, defaultUnit)
-  def optional(attributeName: String = RuntimeAttributesKeys.MemoryKey, defaultUnit: MemoryUnit): OptionalRuntimeAttributesValidation[MemorySize] =
-    instance(attributeName, defaultUnit).optional
-  def configDefaultString(attributeName: String = RuntimeAttributesKeys.MemoryKey, config: Option[Config], defaultUnit: MemoryUnit): Option[String] =
-    instance(attributeName, defaultUnit).configDefaultValue(config)
-  def withDefaultMemory(attributeName: String = RuntimeAttributesKeys.MemoryKey, memorySize: String, defaultUnit: MemoryUnit): RuntimeAttributesValidation[MemorySize] = {
+  def instance(attributeName: String = RuntimeAttributesKeys.MemoryKey, defaultUnit: MemoryUnit, allowZero: Boolean = false): RuntimeAttributesValidation[MemorySize] =
+    new InformationValidation(attributeName, defaultUnit, allowZero)
+  def optional(attributeName: String = RuntimeAttributesKeys.MemoryKey, defaultUnit: MemoryUnit, allowZero: Boolean = false): OptionalRuntimeAttributesValidation[MemorySize] =
+    instance(attributeName, defaultUnit, allowZero).optional
+  def configDefaultString(attributeName: String = RuntimeAttributesKeys.MemoryKey, config: Option[Config], defaultUnit: MemoryUnit, allowZero: Boolean = false): Option[String] =
+    instance(attributeName, defaultUnit, allowZero).configDefaultValue(config)
+  def withDefaultMemory(attributeName: String = RuntimeAttributesKeys.MemoryKey, memorySize: String, defaultUnit: MemoryUnit, allowZero: Boolean = false): RuntimeAttributesValidation[MemorySize] = {
     MemorySize.parse(memorySize) match {
-      case Success(memory) => instance(attributeName, defaultUnit).withDefault(WomInteger(memory.bytes.toInt))
-      case Failure(_) => instance(attributeName, defaultUnit).withDefault(BadDefaultAttribute(WomString(memorySize.toString)))
+      case Success(memory) => instance(attributeName, defaultUnit, allowZero).withDefault(WomInteger(memory.bytes.toInt))
+      case Failure(_) => instance(attributeName, defaultUnit, allowZero).withDefault(BadDefaultAttribute(WomString(memorySize.toString)))
     }
   }
 
@@ -44,12 +44,12 @@ object InformationValidation {
     "Expecting %s runtime attribute to be an Integer or String with format '8 GB'." +
       " Exception: %s"
 
-  private[validation] def validateString(attributeName: String, wdlString: WomString): ErrorOr[MemorySize] =
-    validateString(attributeName, wdlString.value)
+  private[validation] def validateString(attributeName: String, wdlString: WomString, allowZero: Boolean): ErrorOr[MemorySize] =
+    validateString(attributeName, wdlString.value, allowZero)
 
-  private[validation] def validateString(attributeName: String, value: String): ErrorOr[MemorySize] = {
+  private[validation] def validateString(attributeName: String, value: String, allowZero: Boolean): ErrorOr[MemorySize] = {
     MemorySize.parse(value) match {
-      case scala.util.Success(memorySize: MemorySize) if memorySize.amount > 0 =>
+      case scala.util.Success(memorySize: MemorySize) if memorySize.amount > 0 || (memorySize.amount == 0 && allowZero) =>
         memorySize.to(MemoryUnit.GB).validNel
       case scala.util.Success(memorySize: MemorySize) =>
         wrongAmountFormat.format(attributeName, memorySize.amount).invalidNel
@@ -58,25 +58,25 @@ object InformationValidation {
     }
   }
 
-  private[validation] def validateInteger(attributeName: String, wdlInteger: WomInteger, defaultUnit: MemoryUnit): ErrorOr[MemorySize] =
-    validateInteger(attributeName, wdlInteger.value, defaultUnit)
+  private[validation] def validateInteger(attributeName: String, wdlInteger: WomInteger, defaultUnit: MemoryUnit, allowZero: Boolean): ErrorOr[MemorySize] =
+    validateInteger(attributeName, wdlInteger.value, defaultUnit, allowZero)
 
-  private[validation] def validateInteger(attributeName: String, value: Int, defaultUnit: MemoryUnit): ErrorOr[MemorySize] = {
-    if (value <= 0)
+  private[validation] def validateInteger(attributeName: String, value: Int, defaultUnit: MemoryUnit, allowZero: Boolean): ErrorOr[MemorySize] = {
+    if (value <= 0 && !allowZero)
       wrongAmountFormat.format(attributeName, value).invalidNel
     else
       MemorySize(value.toDouble, defaultUnit).to(MemoryUnit.GB).validNel
   }
 
-  def validateLong(attributeName: String, value: Long, defaultUnit: MemoryUnit): ErrorOr[MemorySize] = {
-    if (value <= 0)
+  def validateLong(attributeName: String, value: Long, defaultUnit: MemoryUnit, allowZero: Boolean): ErrorOr[MemorySize] = {
+    if (value <= 0 && !allowZero)
       wrongAmountFormat.format(attributeName, value).invalidNel
     else
       MemorySize(value.toDouble, defaultUnit).to(MemoryUnit.GB).validNel
   }
 }
 
-class InformationValidation(attributeName: String, defaultUnit: MemoryUnit) extends RuntimeAttributesValidation[MemorySize] {
+class InformationValidation(attributeName: String, defaultUnit: MemoryUnit, allowZero: Boolean = false) extends RuntimeAttributesValidation[MemorySize] {
 
   import InformationValidation._
 
@@ -85,9 +85,9 @@ class InformationValidation(attributeName: String, defaultUnit: MemoryUnit) exte
   override def coercion = Seq(WomIntegerType, WomLongType, WomStringType)
 
   override protected def validateValue: PartialFunction[WomValue, ErrorOr[MemorySize]] = {
-    case WomLong(value) => InformationValidation.validateLong(key, value, defaultUnit)
-    case WomInteger(value) => InformationValidation.validateInteger(key, value, defaultUnit)
-    case WomString(value) => InformationValidation.validateString(key, value)
+    case WomLong(value) => InformationValidation.validateLong(key, value, defaultUnit, allowZero)
+    case WomInteger(value) => InformationValidation.validateInteger(key, value, defaultUnit, allowZero)
+    case WomString(value) => InformationValidation.validateString(key, value, allowZero)
   }
 
   override def missingValueMessage: String = wrongTypeFormat.format(key, "Not supported WDL type value")

--- a/backend/src/main/scala/cromwell/backend/validation/InformationValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/InformationValidation.scala
@@ -62,14 +62,14 @@ object InformationValidation {
     validateInteger(attributeName, wdlInteger.value, defaultUnit, allowZero)
 
   private[validation] def validateInteger(attributeName: String, value: Int, defaultUnit: MemoryUnit, allowZero: Boolean): ErrorOr[MemorySize] = {
-    if (value <= 0 && !allowZero)
+    if (value < 0 || (value == 0 && !allowZero))
       wrongAmountFormat.format(attributeName, value).invalidNel
     else
       MemorySize(value.toDouble, defaultUnit).to(MemoryUnit.GB).validNel
   }
 
   def validateLong(attributeName: String, value: Long, defaultUnit: MemoryUnit, allowZero: Boolean): ErrorOr[MemorySize] = {
-    if (value <= 0 && !allowZero)
+    if (value < 0 || (value == 0 && !allowZero))
       wrongAmountFormat.format(attributeName, value).invalidNel
     else
       MemorySize(value.toDouble, defaultUnit).to(MemoryUnit.GB).validNel

--- a/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/RuntimeAttributesValidation.scala
@@ -76,7 +76,7 @@ object RuntimeAttributesValidation {
   }
 
   def parseMemoryString(k: String, s: WomString): ErrorOr[MemorySize] = {
-    InformationValidation.validateString(k, s)
+    InformationValidation.validateString(k, s, allowZero = false)
   }
 
   def withDefault[ValidatedType](validation: RuntimeAttributesValidation[ValidatedType],

--- a/common/src/main/scala/common/util/StringUtil.scala
+++ b/common/src/main/scala/common/util/StringUtil.scala
@@ -2,12 +2,47 @@ package common.util
 
 import mouse.all._
 import org.apache.commons.lang3.StringUtils
+import org.apache.commons.text.StringEscapeUtils
 
 object StringUtil {
   implicit class EnhancedString(val string: String) extends AnyVal {
 
+    /**
+      * Ensure string ends with a /
+      */
     def ensureSlashed: String = StringUtils.appendIfMissing(string, "/")
 
+    /**
+      * Ensure string does not end with a /
+      */
     def ensureUnslashed: String = string.ensureSlashed |> StringUtils.chop
+
+    /**
+      * Ensure string does not start with a /
+      */
+    def ensureNoSlashPrefix: String = string.stripPrefix("/")
+
+    /**
+      * Escape for shell use
+      */
+    def shellEscaped: String = StringEscapeUtils.escapeXSI(string)
+
+    /**
+      * Escape / with \/
+      */
+    def slashEscaped: String = string.replaceAll("/", "\\\\/")
+
+    /**
+      * Escape the string for use in shell and also escape slashes so it can be used in a sed expression while keeping
+      * / as a sed separator
+      */
+    def sedEscaped: String = string.shellEscaped.slashEscaped
+
+    /**
+      * Makes the string look like a relative directory.
+      * i.e no slash prefix and a slash suffix
+      * e.g: /root/some/dir -> root/some/dir/
+      */
+    def relativeDirectory = string.ensureNoSlashPrefix.ensureSlashed
   }
 }

--- a/common/src/main/scala/common/util/StringUtil.scala
+++ b/common/src/main/scala/common/util/StringUtil.scala
@@ -20,29 +20,29 @@ object StringUtil {
     /**
       * Ensure string does not start with a /
       */
-    def ensureNoSlashPrefix: String = string.stripPrefix("/")
+    def ensureNoLeadingSlash: String = string.stripPrefix("/")
 
     /**
       * Escape for shell use
       */
-    def shellEscaped: String = StringEscapeUtils.escapeXSI(string)
+    def ensureShellEscaped: String = StringEscapeUtils.escapeXSI(string)
 
     /**
       * Escape / with \/
       */
-    def slashEscaped: String = string.replaceAll("/", "\\\\/")
+    def ensureSlashEscaped: String = string.replaceAll("/", "\\\\/")
 
     /**
       * Escape the string for use in shell and also escape slashes so it can be used in a sed expression while keeping
       * / as a sed separator
       */
-    def sedEscaped: String = string.shellEscaped.slashEscaped
+    def ensureSedEscaped: String = string.ensureShellEscaped.ensureSlashEscaped
 
     /**
       * Makes the string look like a relative directory.
       * i.e no slash prefix and a slash suffix
       * e.g: /root/some/dir -> root/some/dir/
       */
-    def relativeDirectory = string.ensureNoSlashPrefix.ensureSlashed
+    def relativeDirectory = string.ensureNoLeadingSlash.ensureSlashed
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -391,6 +391,17 @@ languages {
         config {
           strict-validation: false
           enabled: true
+
+          # Optional section to define a command returning paths to output files that
+          # can only be known after the user's command has been run
+          output-runtime-extractor {
+            # Optional docker image on which the command should be run - Must have bash if provided
+            docker-image = "stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09"
+            # Single line command executed after the tool has run.
+            # It should write to stdout the file paths that are referenced in the cwl.output.json (or any other file path
+            # not already defined in the outputs of the tool and therefore unknown when the tool is run)
+            command = "cat cwl.output.json 2>/dev/null | jq -r '.. | .path? // .location? // empty'" 
+          }
         }
       }
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -246,7 +246,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
         case (None, None) => "Either workflow source or url has to be supplied".invalidNelCheck
       }
     }
-    
+
     def findFactory(workflowSource: WorkflowSource): ErrorOr[LanguageFactory] = {
       def chooseFactory(factories: List[LanguageFactory]): Option[LanguageFactory] = factories.find(_.looksParsable(workflowSource))
 

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
@@ -9,6 +9,7 @@ import cromwell.languages.util.ImportResolver.ImportResolver
 import wom.core._
 import wom.executable.WomBundle
 import wom.expression.IoFunctionSet
+import wom.runtime.WomOutputRuntimeExtractor
 
 trait LanguageFactory {
 
@@ -26,6 +27,11 @@ trait LanguageFactory {
 
 
   lazy val strictValidation: Boolean = !config.as[Option[Boolean]]("strict-validation").contains(false)
+
+  lazy val womOutputRuntimeExtractor: Checked[Option[WomOutputRuntimeExtractor]] = config.getAs[Config]("output-runtime-extractor") match {
+    case Some(c) => WomOutputRuntimeExtractor.fromConfig(c).map(Option.apply).toEither
+    case _ => None.validNelCheck
+  }
 
   def getWomBundle(workflowSource: WorkflowSource,
                    workflowOptionsJson: WorkflowOptionsJson,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   private val commonsIoV = "2.6"
   private val commonsLang3V = "3.8"
   private val commonsLoggingV = "1.2"
-  private val commonsTextV = "1.4"
+  private val commonsTextV = "1.6"
   private val configsV = "0.4.4"
   private val delightRhinoSandboxV = "0.0.9"
   private val errorProneAnnotationsV = "2.0.19"
@@ -142,6 +142,7 @@ object Dependencies {
     "io.spray" %% "spray-json" % sprayJsonV,
     "joda-time" % "joda-time" % jodaTimeV,
     "org.apache.commons" % "commons-lang3" % commonsLang3V,
+    "org.apache.commons" % "commons-text" % commonsTextV,
     "org.apache.httpcomponents" % "httpclient" % apacheHttpClientV,
     "org.apache.httpcomponents" % "httpcore" % apacheHttpCoreV,
     "org.mongodb" % "mongo-java-driver" % mongoJavaDriverV,
@@ -341,6 +342,7 @@ object Dependencies {
     "org.slf4j" % "slf4j-api" % slf4jV,
     "org.typelevel" %% "cats-effect" % catsEffectV,
     "org.apache.commons" % "commons-lang3" % commonsLang3V,
+    "org.apache.commons" % "commons-text" % commonsTextV,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
     "ch.qos.logback" % "logback-classic" % logbackV,
     "ch.qos.logback" % "logback-access" % logbackV
@@ -378,7 +380,6 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
     "io.spray" %% "spray-json" % sprayJsonV,
     "org.scalacheck" %% "scalacheck" % scalacheckV % Test,
-    "org.apache.commons" % "commons-text" % commonsTextV,
     "com.github.mpilquist" %% "simulacrum" % simulacrumV,
     "commons-codec" % "commons-codec" % commonsCodecV,
     "eu.timepit" %% "refined" % refinedV

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -413,7 +413,8 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           backendLabels,
           preemptible,
           pipelinesConfiguration.jobShell,
-          dockerKeyAndToken
+          dockerKeyAndToken,
+          jobDescriptor.workflowDescriptor.outputRuntimeExtractor
         )
       case Some(other) =>
         throw new RuntimeException(s"Unexpected initialization data: $other")

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -8,6 +8,7 @@ import cromwell.backend.standard.StandardAsyncJob
 import cromwell.core.labels.Labels
 import cromwell.core.logging.JobLogger
 import cromwell.core.path.Path
+import wom.runtime.WomOutputRuntimeExtractor
 
 /**
   * The PipelinesApiRequestFactory defines the HttpRequests needed to run jobs
@@ -71,7 +72,8 @@ object PipelinesApiRequestFactory {
                                       labels: Labels,
                                       preemptible: Boolean,
                                       jobShell: String,
-                                      privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken]) {
+                                      privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
+                                      womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor]) {
     def literalInputs = inputOutputParameters.literalInputParameters
     def inputParameters = inputOutputParameters.fileInputParameters
     def outputParameters = inputOutputParameters.fileOutputParameters

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -73,6 +73,22 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
       } getOrElse {
         GcsPathBuilder.validateGcsPath(path) match {
           case _: ValidFullGcsPath => path
+
+          /*
+            * Strip the prefixes in RuntimeOutputMapping.prefixFilters from the path, one at a time.
+            * For instance
+            * file:///cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt will progressively become
+            *
+            * /cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+            * bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+            * call-A/file.txt
+            *
+            * This code is called as part of a path mapper that will be applied to the WOMified cwl.output.json.
+            * The cwl.output.json when it's being read by Cromwell from the bucket still contains local paths 
+            * (as they were created by the cwl tool).
+            * In order to keep things working we need to map those local paths to where they were actually delocalized,
+            * which is determined in cromwell.backend.google.pipelines.v2alpha1.api.Delocalization.
+            */
           case _ => (callRootPath / 
             RuntimeOutputMapping
                 .prefixFilters(workflowPaths.workflowRoot)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -73,7 +73,13 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
       } getOrElse {
         GcsPathBuilder.validateGcsPath(path) match {
           case _: ValidFullGcsPath => path
-          case _ => (callRootPath / path.stripPrefix("file://").stripPrefix("/")).pathAsString
+          case _ => (callRootPath / 
+            RuntimeOutputMapping
+                .prefixFilters(workflowPaths.workflowRoot)
+                .foldLeft(path)({
+                  case (newPath, prefix) => newPath.stripPrefix(prefix)
+                })
+            ).pathAsString
         }
       }
     }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/RuntimeOutputMapping.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/RuntimeOutputMapping.scala
@@ -14,7 +14,7 @@ object RuntimeOutputMapping {
     * 
     * For instance:
     * 
-    * file:////cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+    * file:///cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
     *  ->
     * call-A/file.txt
     * 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/RuntimeOutputMapping.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/RuntimeOutputMapping.scala
@@ -1,0 +1,32 @@
+package cromwell.backend.google.pipelines.v2alpha1
+
+import common.util.StringUtil._
+import cromwell.backend.google.pipelines.common.io.PipelinesApiWorkingDisk
+import cromwell.core.path.Path
+
+object RuntimeOutputMapping {
+
+  /**
+    * List of prefixes to be stripped away from runtime output paths before
+    * appending them to the cloud call root to generate the delocalization path.
+    * The goal is to reduce unnecessary long paths which keep repeating the workflow root
+    * as the workflow progresses
+    * 
+    * For instance:
+    * 
+    * file:////cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+    *  ->
+    * call-A/file.txt
+    * 
+    * Which will be delocalized to
+    * gs://bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-B/call-A/file.txt
+    *  instead of
+    * gs://bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-B/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+    */
+  def prefixFilters(workflowRoot: Path): List[String] = List(
+    "file://",
+    "/",
+    PipelinesApiWorkingDisk.MountPoint.pathAsString.relativeDirectory,
+    workflowRoot.pathWithoutScheme.relativeDirectory
+  )
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -58,7 +58,7 @@ object ActionBuilder {
     val ContentTypeTextHeader = s"Content-Type: $contentTypeText"
   }
 
-  private val cloudSdkImage = "google/cloud-sdk:slim"
+  val cloudSdkImage = "google/cloud-sdk:slim"
   def cloudSdkAction: Action = new Action().setImageUri(cloudSdkImage)
 
   def withImage(image: String) = new Action()

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -8,12 +8,15 @@ import common.util.StringUtil._
 import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.LocalizationConfiguration
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.v2alpha1.PipelinesConversions._
+import cromwell.backend.google.pipelines.v2alpha1.RuntimeOutputMapping
 import cromwell.backend.google.pipelines.v2alpha1.ToParameter.ops._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels.Value
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionCommands._
 import cromwell.backend.google.pipelines.v2alpha1.api.Delocalization._
 import cromwell.core.path.{DefaultPathBuilder, Path}
+import org.apache.commons.codec.binary.Base64
+import wom.runtime.WomOutputRuntimeExtractor
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -47,45 +50,72 @@ trait Delocalization {
     )(flags = List(ActionFlag.RunInBackground))
   }
 
-  private def parseOutputJsonAction(containerCallRoot: String, outputDirectory: String, outputFile: String, mounts: List[Mount]): Action = {
+  private def runtimeOutputExtractorAction(containerCallRoot: String,
+                                    outputFile: String,
+                                    mounts: List[Mount],
+                                    womOutputRuntimeExtractor: WomOutputRuntimeExtractor): Action = {
     val commands = List(
       "-c",
-      // Create the directory where the output of jq will be written
-      s"mkdir -p $outputDirectory &&" +
-      // Read the content of cwl.output.json - redirect stderr to /dev/null so it doesn't fail if there's no cwl.output.json
-      s" cat ${containerCallRoot.ensureSlashed}cwl.output.json 2>/dev/null" +
-        // Pipe the result to jq. Parse the json and traverse it looking for "path" or "location" values,
-        // stripping any fully qualified file:// URLs.
-      """ | jq -r '.. | .path? // .location? // empty | gsub("file://"; "")' """ +
-      // Redirect the result to a file that can be used in the next action to delocalize the extracted files / directories
-      s" > $outputFile"
+      // Create the directory where the fofn will be written
+      s"mkdir -p $$(dirname $outputFile) && " +
+      s"cd $containerCallRoot && " +
+      s"${womOutputRuntimeExtractor.command} > $outputFile"
     )
 
     ActionBuilder
-      .withImage("stedolan/jq@sha256:a61ed0bca213081b64be94c5e1b402ea58bc549f457c2682a86704dd55231e09")
+      .withImage(womOutputRuntimeExtractor.dockerImage.getOrElse(cloudSdkImage))
       .setCommands(commands.asJava)
       .withMounts(mounts)
       .setEntrypoint("/bin/bash")
       // Saves us some time if something else fails before we get to run this action
       .withFlags(List(ActionFlag.DisableImagePrefetch))
   }
+  
+  private def delocalizeRuntimeOutputsScript(fofnPath: String, workflowRoot: Path, cloudCallRoot: Path) = {
+    val gsutilCommand: String => String = { flag =>
+      s"""gsutil -m $flag cp -r $$line "${cloudCallRoot.pathAsString.ensureSlashed}$$gcs_path""""
+    }
+    
+    def sedStripPrefix(prefix: String) = s"""sed -e "s/^${prefix.sedEscaped}//""""
+    
+    // See RuntimeOutputMapping.prefixFilters for more info on why this is needed
+    val prefixFilters = RuntimeOutputMapping
+      .prefixFilters(workflowRoot)
+      .map(sedStripPrefix)
+      .mkString(" | ")
 
-  private def delocalizeOutputJsonFilesAction(cloudCallRoot: Path, inputFile: String, workflowRoot: String, mounts: List[Mount]): Action = {
-    val sedStripSlashPrefix = "s/^\\///"
-    val gsutilCommand: String => String = flag => s"""gsutil -m $flag cp -r % ${cloudCallRoot.pathAsString.ensureSlashed}$$(echo % | sed -e "$sedStripSlashPrefix")"""
-    val command =
-        // Read the file containing files to delocalize
-        s"cat $inputFile 2>/dev/null" +
-        /*
-         * Pipe the result to xargs and execute a gsutil cp command, appending the path to the cloudCallRoot
-         * Use a subshell so that we can strip the potential leading slash from the local path and avoid double slashes in the cloud path
-         * It also seems that the gsutil fails without sub shelling
-         * We can't use the gsutil -I flag here because it would lose the directory structure once it gets copied to the bucket
-         * sh -c 'gsutil cp % $(echo % | sed -e "s/^\///")'
-         */
-        s""" | xargs -I % sh -c '${recoverRequesterPaysError(cloudCallRoot)(gsutilCommand)}'"""
+    /*
+     * Delocalize all the files returned by the runtime output extractor
+     */
+    s"""
+       |#! /bin/bash
+       |
+       |set -x
+       |
+       |if [ -f $fofnPath ]; then
+       |  while IFS= read line
+       |  do
+       |    gcs_path=$$(echo $$line | $prefixFilters)
+       |    ${recoverRequesterPaysError(cloudCallRoot)(gsutilCommand)}
+       |  done  <$fofnPath
+       |fi
+     """.stripMargin
+  }
 
-    ActionBuilder.cloudSdkShellAction(command)(mounts)
+  private def delocalizeRuntimeOutputsAction(cloudCallRoot: Path, inputFile: String, workflowRoot: Path, mounts: List[Mount]): Action = {
+    def multiLineCommand(commandString: String) = {
+      val randomUuid = UUID.randomUUID().toString
+      val base64EncodedScript = Base64.encodeBase64String(commandString.getBytes)
+      val scriptPath = s"/tmp/$randomUuid.sh"
+
+      s"apt-get install --assume-yes coreutils && " +
+        s"echo $base64EncodedScript | base64 --decode > $scriptPath && " +
+        s"chmod u+x $scriptPath && " +
+        s"sh $scriptPath"
+    }
+    
+    val command = multiLineCommand(delocalizeRuntimeOutputsScript(inputFile, workflowRoot, cloudCallRoot))
+    ActionBuilder.cloudSdkShellAction(command)(mounts, flags = List(ActionFlag.DisableImagePrefetch))
   }
 
   def deLocalizeActions(createPipelineParameters: CreatePipelineParameters,
@@ -103,12 +133,17 @@ trait Delocalization {
      */
     val temporaryFofnDirectoryForCwlOutputJson = callExecutionContainerRoot.pathAsString.ensureSlashed + UUID.randomUUID().toString.split("-")(0)
     val temporaryFofnForCwlOutputJson = temporaryFofnDirectoryForCwlOutputJson + "/cwl_output_json_references.txt"
-    val parseAction = parseOutputJsonAction(callExecutionContainerRoot.pathAsString, temporaryFofnDirectoryForCwlOutputJson, temporaryFofnForCwlOutputJson, mounts)
-    val delocalizeAction = delocalizeOutputJsonFilesAction(cloudCallRoot, temporaryFofnForCwlOutputJson, createPipelineParameters.cloudWorkflowRoot.pathAsString, mounts)
+
+    val runtimeExtractionActions = createPipelineParameters.womOutputRuntimeExtractor.toList flatMap { extractor =>
+      List (
+        runtimeOutputExtractorAction(callExecutionContainerRoot.pathAsString, temporaryFofnForCwlOutputJson, mounts, extractor),
+        delocalizeRuntimeOutputsAction(cloudCallRoot, temporaryFofnForCwlOutputJson, createPipelineParameters.cloudWorkflowRoot, mounts)
+      )
+    }
 
     ActionBuilder.annotateTimestampedActions("delocalization", Value.Delocalization)(
       createPipelineParameters.outputParameters.flatMap(_.toActions(mounts).toList) ++
-        List(parseAction, delocalizeAction)
+        runtimeExtractionActions
     ) :+
       copyAggregatedLogToLegacyPath(callExecutionContainerRoot, gcsLegacyLogPath) :+
       copyAggregatedLogToLegacyPathPeriodic(callExecutionContainerRoot, createPipelineParameters.logGcsPath) :+

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -76,7 +76,7 @@ trait Delocalization {
       s"""gsutil -m $flag cp -r $$line "${cloudCallRoot.pathAsString.ensureSlashed}$$gcs_path""""
     }
     
-    def sedStripPrefix(prefix: String) = s"""sed -e "s/^${prefix.sedEscaped}//""""
+    def sedStripPrefix(prefix: String) = s"""sed -e "s/^${prefix.ensureSedEscaped}//""""
     
     // See RuntimeOutputMapping.prefixFilters for more info on why this is needed
     val prefixFilters = RuntimeOutputMapping

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -87,19 +87,17 @@ trait Delocalization {
     /*
      * Delocalize all the files returned by the runtime output extractor
      */
-    s"""
-       |#! /bin/bash
-       |
-       |set -x
-       |
-       |if [ -f $fofnPath ]; then
-       |  while IFS= read line
-       |  do
-       |    gcs_path=$$(echo $$line | $prefixFilters)
-       |    ${recoverRequesterPaysError(cloudCallRoot)(gsutilCommand)}
-       |  done  <$fofnPath
-       |fi
-     """.stripMargin
+    s"""|#!/bin/bash
+        |
+        |set -x
+        |
+        |if [ -f $fofnPath ]; then
+        |  while IFS= read line
+        |  do
+        |    gcs_path=$$(echo $$line | $prefixFilters)
+        |    ${recoverRequesterPaysError(cloudCallRoot)(gsutilCommand)}
+        |  done  <$fofnPath
+        |fi""".stripMargin
   }
 
   private def delocalizeRuntimeOutputsAction(cloudCallRoot: Path, inputFile: String, workflowRoot: Path, mounts: List[Mount]): Action = {

--- a/wom/src/main/scala/wom/runtime/WomOutputRuntimeExtractor.scala
+++ b/wom/src/main/scala/wom/runtime/WomOutputRuntimeExtractor.scala
@@ -1,0 +1,17 @@
+package wom.runtime
+
+import cats.syntax.apply._
+import com.typesafe.config.Config
+import common.validation.Validation._
+import net.ceedubs.ficus.Ficus._
+
+object WomOutputRuntimeExtractor {
+  def fromConfig(config: Config) = {
+    val dockerImage = validate { config.getAs[String]("docker-image") }
+    val command = validate { config.as[String]("command") }
+
+    (dockerImage, command).mapN(WomOutputRuntimeExtractor.apply)
+  }
+}
+
+case class WomOutputRuntimeExtractor(dockerImage: Option[String], command: String)


### PR DESCRIPTION
- Allow a `0` value for CWL `outDirMin` and `tmpDirMin` resource attributes
- Adds an optional section to the language factory to define a command to run after the user's action that will return output files that can only be known at runtime
  - Only defined for CWL for now, which will remove unnecessary pull of jq for WDL tasks on PAPI2
  - Docker image and command can both be changed in the configuration
- The PAPI2 logic that handles delocalization of those file strips away some redundant pieces in the delocalized paths to reduce the overall length of the path
