### PR TITLE
Handle invalid inputs parsing error

### DIFF
--- a/centaur/src/main/resources/standardTestCases/empty_inputs_file.test
+++ b/centaur/src/main/resources/standardTestCases/empty_inputs_file.test
@@ -1,0 +1,15 @@
+name: empty_inputs_file
+testFormat: submitfailure
+
+files {
+  workflow: invalid_inputs_json/invalid_inputs_json.wdl
+  inputs: invalid_inputs_json/empty_inputs_file.inputs
+}
+
+submit {
+  statusCode: 400
+  message: """{
+  "status": "fail",
+  "message": "Error(s): Input file is not a valid yaml or json. Inputs data: ''. Error: MatchError: null."
+}"""
+}

--- a/centaur/src/main/resources/standardTestCases/invalid_inputs_json.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_inputs_json.test
@@ -10,6 +10,6 @@ submit {
   statusCode: 400
   message: """{
   "status": "fail",
-  "message": "Error(s): Input file is not valid yaml nor json: while parsing a flow mapping\n in 'reader', line 1, column 1:\n    {\n    ^\nexpected ',' or '}', but got <stream end>\n in 'reader', line 3, column 1:\n    \n    ^\n"
+  "message": "Error(s): Input file is not a valid yaml or json. Inputs data: '{\n  \"intentionally_missing_the_close_brace\": \"oh the humanity\"\n'. Error: ParsingFailure: while parsing a flow mapping\n in 'reader', line 1, column 1:\n    {\n    ^\nexpected ',' or '}', but got <stream end>\n in 'reader', line 3, column 1:\n    \n    ^\n."
 }"""
 }

--- a/centaur/src/main/resources/standardTestCases/invalid_inputs_json/invalid_inputs_json_object.inputs
+++ b/centaur/src/main/resources/standardTestCases/invalid_inputs_json/invalid_inputs_json_object.inputs
@@ -1,0 +1,1 @@
+this_is_not_a_valid_json_object

--- a/centaur/src/main/resources/standardTestCases/invalid_inputs_json_object.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_inputs_json_object.test
@@ -1,0 +1,15 @@
+name: invalid_inputs_json_object
+testFormat: submitfailure
+
+files {
+  workflow: invalid_inputs_json/invalid_inputs_json.wdl
+  inputs: invalid_inputs_json/invalid_inputs_json_object.inputs
+}
+
+submit {
+  statusCode: 400
+  message: """{
+  "status": "fail",
+  "message": "Error(s): Submitted input '\"this_is_not_a_valid_json_object\"' belongs to class spray.json.JsString, which is not a valid json object."
+}"""
+}

--- a/centaur/src/main/resources/standardTestCases/invalid_inputs_json_object.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_inputs_json_object.test
@@ -10,6 +10,6 @@ submit {
   statusCode: 400
   message: """{
   "status": "fail",
-  "message": "Error(s): Submitted input '\"this_is_not_a_valid_json_object\"' belongs to class spray.json.JsString, which is not a valid json object."
+  "message": "Error(s): Submitted input '\"this_is_not_a_valid_json_object\"' of type JsString is not a JSON object."
 }"""
 }

--- a/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
+++ b/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
@@ -268,7 +268,7 @@ object PartialWorkflowSources {
       case Some(input: String) =>  {
         Try(input.parseJson).toErrorOrWithContext(s"parse input: '$input', which is not a valid json. Please check for syntactical errors.") flatMap {
           case JsObject(inputMap) => inputMap.validNel
-          case j: JsValue => s"Submitted input '$input' belongs to ${j.getClass}, which is not a valid json object.".invalidNel
+          case j: JsValue => s"Submitted input '$input' of type ${j.getClass.getSimpleName} is not a JSON object.".invalidNel
         }
       }
       case None => Map.empty[String, JsValue].validNel

--- a/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
+++ b/engine/src/main/scala/cromwell/webservice/PartialWorkflowSources.scala
@@ -172,13 +172,13 @@ object PartialWorkflowSources {
       yaml.parser.parse(data) match {
         // If it's an array, treat each element as an individual input object, otherwise simply toString the whole thing
         case Right(json) => json.asArray.map(_.map(_.toString())).getOrElse(Vector(json.pretty(Printer.noSpaces))).validNel
-        case Left(error) => s"Input file is not a valid yaml or json. Error: ${ExceptionUtils.getMessage(error)}.".invalidNel
+        case Left(error) => s"Input file is not a valid yaml or json. Inputs data: '$data'. Error: ${ExceptionUtils.getMessage(error)}.".invalidNel
       }
     }
 
     parseInputsTry match {
       case Success(v) => v
-      case Failure(error) => s"Input file is not a valid yaml or json. Error: ${ExceptionUtils.getMessage(error)}.".invalidNel
+      case Failure(error) => s"Input file is not a valid yaml or json. Inputs data: '$data'. Error: ${ExceptionUtils.getMessage(error)}.".invalidNel
     }
   }
 

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -223,6 +223,8 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport {
             askSubmit(
               WorkflowStoreActor.BatchSubmitWorkflows(NonEmptyList.fromListUnsafe(workflowSourceFiles.toList)),
               warnings, getWorkflowState(workflowSourceFiles.head.workflowOnHold))
+          case Failure(e: RuntimeException) =>
+            e.failRequest(StatusCodes.NotFound)
           case Failure(t) => t.failRequest(StatusCodes.BadRequest)
         }
       case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -223,8 +223,6 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport {
             askSubmit(
               WorkflowStoreActor.BatchSubmitWorkflows(NonEmptyList.fromListUnsafe(workflowSourceFiles.toList)),
               warnings, getWorkflowState(workflowSourceFiles.head.workflowOnHold))
-          case Failure(e: RuntimeException) =>
-            e.failRequest(StatusCodes.NotFound)
           case Failure(t) => t.failRequest(StatusCodes.BadRequest)
         }
       case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)

--- a/engine/src/test/scala/cromwell/webservice/PartialWorkflowSourcesSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/PartialWorkflowSourcesSpec.scala
@@ -1,17 +1,49 @@
 package cromwell.webservice
 
+import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
-import spray.json._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 class PartialWorkflowSourcesSpec extends FlatSpec with Matchers {
-  it should "succesfully merge and override multiple input files" in {
+
+  behavior of "mergeMaps method"
+  it should "successfully merge and override multiple input files" in {
     val input1 = Map("wf.a1" -> "hello", "wf.a2" -> "world").toJson.toString
     val input2 = Map.empty[String, String].toJson.toString
     val overrideInput1 = Map("wf.a2" -> "universe").toJson.toString
-    val allInputs = PartialWorkflowSources.mergeMaps(Seq(Option(input1), Option(input2), Option(overrideInput1)))
+    val mergedMapsErrorOr = PartialWorkflowSources.mergeMaps(Seq(Option(input1), Option(input2), Option(overrideInput1)))
 
-    allInputs.fields.keys should contain allOf("wf.a1", "wf.a2")
-    allInputs.fields("wf.a2") should be(JsString("universe"))
+    mergedMapsErrorOr.isValid shouldBe true
+
+    mergedMapsErrorOr.map(inputs => {
+      inputs.fields.keys should contain allOf("wf.a1", "wf.a2")
+      inputs.fields("wf.a2") should be(JsString("universe"))
+    })
+  }
+
+  it should "return error when workflow input is not a valid json object" in {
+    val invalidJsonInput = "\"invalidInput\""
+    val mergedMapsErrorOr = PartialWorkflowSources.mergeMaps(Seq(Option(invalidJsonInput)))
+
+    mergedMapsErrorOr.isValid shouldBe false
+
+    mergedMapsErrorOr match {
+      case Valid(_) => "This is unexpected! This test is designed to fail!"
+      case Invalid(error) => error.head shouldBe "Submitted input '\"invalidInput\"' belongs to class spray.json.JsString, which is not a valid json object."
+    }
+  }
+
+  it should "return error when auxiliary workflow input is not a valid json" in {
+    val validInput = "{\"key\":\"value\"}"
+    val invalidAuxJsonInput = "invalidInput"
+    val mergedMapsErrorOr = PartialWorkflowSources.mergeMaps(Seq(Option(validInput), Option(invalidAuxJsonInput)))
+
+    mergedMapsErrorOr.isValid shouldBe false
+
+    mergedMapsErrorOr match {
+      case Valid(_) => "This is unexpected! This test is designed to fail!"
+      case Invalid(error) => error.head shouldBe "Failed to parse input: 'invalidInput', which is not a valid json. Please check for syntactical errors. (reason 1 of 1): Unexpected character 'i' at input index 0 (line 1, position 1), expected JSON Value:\ninvalidInput\n^\n"
+    }
   }
 }


### PR DESCRIPTION
This PR fixes [this](https://github.com/broadinstitute/cromwell/issues/4086) bug. It now handles the cases when empty input file or invalid json (but valid yaml) inputs is passed to Cromwell, and returns better error messages for them.

Closes #4086  