### PR TITLE
Match on IoFailAck and not specifically IoFailure.

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/RootWorkflowFileHashCacheActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/RootWorkflowFileHashCacheActor.scala
@@ -59,7 +59,7 @@ class RootWorkflowFileHashCacheActor private(override val ioActor: ActorRef) ext
         cache.put(hashContext.file, FileHashSuccess(value))
       }
     // Hash Failure
-    case (hashContext: FileHashContext, failure: IoFailure[_]) =>
+    case (hashContext: FileHashContext, failure: IoFailAck[_]) =>
       handleHashResult(failure, hashContext) { requesters =>
         requesters.toList foreach { case FileHashRequester(replyTo, fileHashContext, ioCommand) =>
           replyTo ! Tuple2(fileHashContext, IoFailure(ioCommand, failure.failure))

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -198,10 +198,10 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
         path = f.forbiddenPath,
         andThen = failAndAwaitPendingResponses(f.failure, f.command, data)
       )
-    case Event(IoFailure(command: IoCommand[_], failure), Some(data)) =>
+    case Event(IoFailAck(command: IoCommand[_], failure), Some(data)) =>
       failAndAwaitPendingResponses(failure, command, data)
     // Should not be possible
-    case Event(IoFailure(_: IoCommand[_], failure), None) => failAndStop(failure)
+    case Event(IoFailAck(_: IoCommand[_], failure), None) => failAndStop(failure)
   }
 
   when(FailedState) {

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardFileHashingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardFileHashingActor.scala
@@ -91,7 +91,7 @@ abstract class StandardFileHashingActor(standardParams: StandardFileHashingActor
       context.parent ! FileHashResponse(HashResult(fileHashRequest.hashKey, HashValue(result)))
 
     // Hash Failure
-    case (fileHashRequest: FileHashContext, IoFailure(_, failure: Throwable)) =>
+    case (fileHashRequest: FileHashContext, IoFailAck(_, failure: Throwable)) =>
       context.parent ! HashingFailedMessage(fileHashRequest.file, failure)
 
     case other =>

--- a/core/src/main/scala/cromwell/core/io/IoAck.scala
+++ b/core/src/main/scala/cromwell/core/io/IoAck.scala
@@ -19,6 +19,16 @@ case class IoSuccess[T](command: IoCommand[T], result: T) extends IoAck[T] {
   override def toTry = Success(result)
 }
 
+object IoFailAck {
+  def unapply(any: Any): Option[(IoCommand[_], Throwable)] = {
+    any match {
+      case f: IoFailAck[_] =>
+        Option((f.command, f.failure))
+      case _ => None
+    }
+  }
+}
+
 trait IoFailAck[T] extends IoAck[T] {
   val failure: Throwable
   override def toTry = Failure(failure)

--- a/core/src/test/scala/cromwell/core/io/IoAckSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoAckSpec.scala
@@ -1,0 +1,28 @@
+package cromwell.core.io
+
+import java.nio.file.Paths
+
+import cromwell.core.io.DefaultIoCommand.DefaultIoCopyCommand
+import cromwell.core.path.DefaultPathBuilder
+import org.scalatest.{FlatSpecLike, Matchers}
+
+class IoAckSpec extends FlatSpecLike with Matchers {
+
+  "IoFailAck pattern matching" should "work for both IoFailure and IoReadForbiddenFailure" in {
+    import DefaultPathBuilder._
+    val command = DefaultIoCopyCommand(build(Paths.get("foo")), build(Paths.get("bar")), overwrite = false)
+
+    val ioFailure = IoFailure(command, new RuntimeException("blah"))
+    val ioReadForbiddenFailure = IoFailure(command, new RuntimeException("blah"))
+
+    ioFailure match {
+      case IoFailAck(_: IoCommand[_], _: Throwable) => ()
+      case _ => fail("IoFailure did not unapply")
+    }
+
+    ioReadForbiddenFailure match {
+      case IoFailAck(_: IoCommand[_], _: Throwable) => ()
+      case _ => fail("IoReadForbiddenFailure did not unapply")
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -146,7 +146,7 @@ trait IoCommandContext[T] extends StreamContext {
   def request: IoCommand[T]
   def replyTo: ActorRef
   def fail(failure: Throwable): IoResult = (request.fail(failure), this)
-  def failForbidden(failure: Throwable, forbiddenPath: String): IoResult = (request.failReadForbidden(failure, forbiddenPath), this)
+  def failReadForbidden(failure: Throwable, forbiddenPath: String): IoResult = (request.failReadForbidden(failure, forbiddenPath), this)
   def success(value: T): IoResult = (request.success(value), this)
 }
 

--- a/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
@@ -178,7 +178,7 @@ class GcsBatchFlow(batchSize: Int, scheduler: Scheduler, onRetry: IoCommandConte
   private def failReadForbidden(context: GcsBatchCommandContext[_, _], failure: Throwable, forbiddenPath: String) = {
     Future.successful(
       GcsBatchTerminal(
-        context.failForbidden(EnhancedCromwellIoException(IoAttempts(context.currentAttempt), failure), forbiddenPath)
+        context.failReadForbidden(EnhancedCromwellIoException(IoAttempts(context.currentAttempt), failure), forbiddenPath)
       )
     )
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
@@ -74,14 +74,14 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
       updateLogsPathInMetadata(workflowId, copy.destination)
       deleteLog(copy.source)
       
-    case (workflowId: WorkflowId, IoFailure(copy: IoCopyCommand, failure)) =>
+    case (workflowId: WorkflowId, IoFailAck(copy: IoCopyCommand, failure)) =>
       pushWorkflowFailures(workflowId, List(new IOException("Could not copy workflow logs", failure)))
       log.error(failure, s"Failed to copy workflow logs from ${copy.source.pathAsString} to ${copy.destination.pathAsString}")
       deleteLog(copy.source)
       
     case IoSuccess(_: IoDeleteCommand, _) => removeWork()
       
-    case IoFailure(delete: IoDeleteCommand, failure) =>
+    case IoFailAck(delete: IoDeleteCommand, failure) =>
       removeWork()
       log.error(failure, s"Failed to delete workflow logs from ${delete.file.pathAsString}")
 


### PR DESCRIPTION
The code was previously pattern matching on `IoFailure` when it also needed to be able to handle `IoReadForbiddenFailure`. This adds an `unapply` to a trait implemented by both of those case classes to pattern match both types.