### PR TITLE
Regression test for comments before 'version'

### DIFF
--- a/womtool/src/test/resources/validate/biscayne/valid/pre_version_comments/pre_version_comments.wdl
+++ b/womtool/src/test/resources/validate/biscayne/valid/pre_version_comments/pre_version_comments.wdl
@@ -1,0 +1,15 @@
+#
+##
+###
+# # # # ... We must allow comments before the version statement...
+###
+##
+#
+
+version development
+
+workflow foo {
+  output {
+    Int i = 5
+  }
+}


### PR DESCRIPTION
Allows closing of https://github.com/openwdl/wdl/pull/251 by proving that it's possible to have comments before the `version` statement in WDL files.