### PR TITLE
[Test Reliability] Better message around StatsDInstrumentationSpec failures

### DIFF
--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -83,7 +83,7 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
         expectedExactPackets foreach { packet => if (!received.contains(packet)) {
           val prefix = packet.split(":").head
           received.find(_.startsWith(prefix)) match {
-            case Some(sharedPrefix) => fail(s"Missing packet: $packet, but found: $sharedPrefix")
+            case Some(sharedPrefix) => fail(s"Missing packet: $packet, but found: $sharedPrefix. Should this be a fuzzy packet?")
             case None => fail(s"Missing packet: $packet, and no packets received with prefix $prefix")
           }
         }}

--- a/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/instrumentation/impl/statsd/StatsDInstrumentationServiceActorSpec.scala
@@ -80,7 +80,13 @@ class StatsDInstrumentationServiceActorSpec extends TestKitSuite with FlatSpecLi
           case Udp.Received(data, _) => data.utf8String
         }
 
-        expectedExactPackets foreach { packet => if (!received.contains(packet)) fail(s"Missing packet: $packet") }
+        expectedExactPackets foreach { packet => if (!received.contains(packet)) {
+          val prefix = packet.split(":").head
+          received.find(_.startsWith(prefix)) match {
+            case Some(sharedPrefix) => fail(s"Missing packet: $packet, but found: $sharedPrefix")
+            case None => fail(s"Missing packet: $packet, and no packets received with prefix $prefix")
+          }
+        }}
         expectedFuzzyPackets foreach { packet => if (!received.exists(_.contains(packet))) fail(s"Missing fuzzy packet: $packet") }
       }
   }


### PR DESCRIPTION
Should help with debugging occasional failures like this in travis by replacing "not found" with "this looks similar":

```
StatsDInstrumentationServiceActorSpec:
StatsDInstrumentationServiceActor
- should increment counters (1 second, 193 milliseconds)
- should add count (1 second, 9 milliseconds)
- should set gauges (1 second, 10 milliseconds)
info- should set timings *** FAILED *** (3 seconds, 701 milliseconds)
info  Missing packet: prefix_value.cromwell.test_prefix.test.metric.bucket.timing.stddev:0.00|g (StatsDInstrumentationServiceActorSpec.scala:83)
info  org.scalatest.exceptions.TestFailedException:
info  ...[0m[0m
info  at cromwell.services.instrumentation.impl.statsd.StatsDInstrumentationServiceActorSpec.$anonfun$new$4(StatsDInstrumentationServiceActorSpec.scala:83)
info  at cromwell.services.instrumentation.impl.statsd.StatsDInstrumentationServiceActorSpec.$anonfun$new$4$adapted(StatsDInstrumentationServiceActorSpec.scala:83)
info  at scala.collection.immutable.Set$Set4.foreach(Set.scala:206)
info  at cromwell.services.instrumentation.impl.statsd.StatsDInstrumentationServiceActorSpec.$anonfun$new$2(StatsDInstrumentationServiceActorSpec.scala:83)
info  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
info  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
info  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
info  ...
```