### PR TITLE
Extra logging around imports zip

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -294,6 +294,13 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       logger.info(s"$tag Starting workflow UUID($workflowId)")
     }
 
+    // Debugging #4117 - if there are imports present at this point, they were received by Cromwell and written
+    // into the workflow store. (AEN 2018-11-14)
+    workflow.sources.importsZipFileOption match {
+      case Some(zip) => logger.info(s"$tag Found imports zip on workflow $workflowId, size ${zip.length} bytes.")
+      case None => logger.info(s"$tag No imports zip on workflow $workflowId.")
+    }
+
     val fileHashCacheActor: Option[ActorRef] =
       if (fileHashCacheEnabled) Option(context.system.actorOf(RootWorkflowFileHashCacheActor.props(params.ioActor))) else None
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -306,7 +306,16 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
       validatedNamespace <- buildValidatedNamespace(factory, sourceAndResolvers._1, sourceAndResolvers._2)
       _ = pushNamespaceMetadata(validatedNamespace)
       ewd <- fromEither[IO](buildWorkflowDescriptor(id, validatedNamespace, workflowOptions, labels, conf, pathBuilders, outputRuntimeExtractor).toEither)
-    } yield ewd
+    } yield {
+
+      // Debugging #4117 - make sure we are creating an importable directory out of the zip (AEN 2018-11-14)
+      zippedImportResolver match {
+        case Some(zir) => workflowLogger.info(s"Using zip import resolver '${zir.name}')")
+        case None => workflowLogger.info("No zipped import resolver available.")
+      }
+
+      ewd
+    }
   }
 
   private def publishWorkflowSourceToMetadata(id: WorkflowId, workflowSource: WorkflowSource): Unit = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -301,7 +301,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
       // Debugging #4117 - make sure we are creating an importable directory out of the zip (AEN 2018-11-14)
       _ = zippedImportResolver match {
         case Some(dr: DirectoryResolver) =>
-          workflowLogger.info(s"Importing from unzip directory '${dr.name}' with files [${dr.directory.list.map(_.pathAsString).mkString(", ")}]")
+          workflowLogger.info(s"Importing from unzip directory '${dr.name}' with files [${dr.directory.list.map(_.toFile.getName).mkString(", ")}]")
         case None =>
           workflowLogger.info("No zipped import resolver available.")
       }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -310,7 +310,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
 
       // Debugging #4117 - make sure we are creating an importable directory out of the zip (AEN 2018-11-14)
       zippedImportResolver match {
-        case Some(zir) => workflowLogger.info(s"Using zip import resolver '${zir.name}')")
+        case Some(zir) => workflowLogger.info(s"Using zip import resolver '${zir.name}'")
         case None => workflowLogger.info("No zipped import resolver available.")
       }
 

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -130,7 +130,7 @@ object ImportResolver {
   }
 
   def zippedImportResolver(zippedImports: Array[Byte], workflowId: WorkflowId): ErrorOr[ImportResolver] = {
-    LanguageFactoryUtil.createImportsDirectory(zippedImports, workflowId = Option(workflowId)) map { dir =>
+    LanguageFactoryUtil.createImportsDirectory(zippedImports, workflowId) map { dir =>
       DirectoryResolver(dir, Option(dir.toJava.getCanonicalPath), None)
     }
   }

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -129,7 +129,7 @@ object ImportResolver {
     }
   }
 
-  def zippedImportResolver(zippedImports: Array[Byte], workflowId: WorkflowId): ErrorOr[ImportResolver] = {
+  def zippedImportResolver(zippedImports: Array[Byte], workflowId: WorkflowId): ErrorOr[DirectoryResolver] = {
     LanguageFactoryUtil.createImportsDirectory(zippedImports, workflowId) map { dir =>
       DirectoryResolver(dir, Option(dir.toJava.getCanonicalPath), None)
     }

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -18,6 +18,7 @@ import common.validation.Validation._
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import java.nio.file.{Path => NioPath}
 
+import cromwell.core.WorkflowId
 import wom.core.WorkflowSource
 
 import scala.concurrent.duration._
@@ -128,8 +129,8 @@ object ImportResolver {
     }
   }
 
-  def zippedImportResolver(zippedImports: Array[Byte]): ErrorOr[ImportResolver] = {
-    LanguageFactoryUtil.validateImportsDirectory(zippedImports) map { dir =>
+  def zippedImportResolver(zippedImports: Array[Byte], workflowId: WorkflowId): ErrorOr[ImportResolver] = {
+    LanguageFactoryUtil.createImportsDirectory(zippedImports, workflowId = Option(workflowId)) map { dir =>
       DirectoryResolver(dir, Option(dir.toJava.getCanonicalPath), None)
     }
   }

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -5,6 +5,7 @@ import cats.syntax.validated._
 import common.Checked
 import common.validation.ErrorOr.ErrorOr
 import cromwell.core.CromwellGraphNode.CromwellEnhancedOutputPort
+import cromwell.core.WorkflowId
 import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import cromwell.languages.ValidatedWomNamespace
@@ -24,10 +25,15 @@ object LanguageFactoryUtil {
     * @param parentPath if specified, where to unzip to. Otherwise it'll end up somewhere random
     * @return where the imports were unzipped to
     */
-  def validateImportsDirectory(zipContents: Array[Byte], parentPath: Option[Path] = None): ErrorOr[Path] = {
+  def createImportsDirectory(zipContents: Array[Byte], parentPath: Option[Path] = None, workflowId: Option[WorkflowId] = None): ErrorOr[Path] = {
 
     def makeZipFile: Try[Path] = Try {
-      DefaultPathBuilder.createTempFile("", ".zip", parentPath).writeByteArray(zipContents)(OpenOptions.default)
+      val prefix = workflowId match {
+        case Some(id) => s"imports_workflow_${id}_"
+        case None => "imports_"
+      }
+
+      DefaultPathBuilder.createTempFile(prefix, ".zip", parentPath).writeByteArray(zipContents)(OpenOptions.default)
     }
 
     def unZipFile(f: Path) = Try(f.unzipTo(parentPath))

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -22,21 +22,15 @@ object LanguageFactoryUtil {
   /**
     * Unzip the imports.zip and validate that it was good.
     * @param zipContents the zip contents
-    * @param parentPath if specified, where to unzip to. Otherwise it'll end up somewhere random
     * @return where the imports were unzipped to
     */
-  def createImportsDirectory(zipContents: Array[Byte], parentPath: Option[Path] = None, workflowId: Option[WorkflowId] = None): ErrorOr[Path] = {
+  def createImportsDirectory(zipContents: Array[Byte], workflowId: WorkflowId): ErrorOr[Path] = {
 
     def makeZipFile: Try[Path] = Try {
-      val prefix = workflowId match {
-        case Some(id) => s"imports_workflow_${id}_"
-        case None => "imports_"
-      }
-
-      DefaultPathBuilder.createTempFile(prefix, ".zip", parentPath).writeByteArray(zipContents)(OpenOptions.default)
+     DefaultPathBuilder.createTempFile(s"imports_workflow_${workflowId}_", ".zip").writeByteArray(zipContents)(OpenOptions.default)
     }
 
-    def unZipFile(f: Path) = Try(f.unzipTo(parentPath))
+    def unZipFile(f: Path) = Try(f.unzip)
 
     val importsFile = for {
       zipFile <- makeZipFile

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -27,7 +27,7 @@ object LanguageFactoryUtil {
   def createImportsDirectory(zipContents: Array[Byte], workflowId: WorkflowId): ErrorOr[Path] = {
 
     def makeZipFile: Try[Path] = Try {
-     DefaultPathBuilder.createTempFile(s"imports_workflow_${workflowId}_", ".zip").writeByteArray(zipContents)(OpenOptions.default)
+      DefaultPathBuilder.createTempFile(s"imports_workflow_${workflowId}_", ".zip").writeByteArray(zipContents)(OpenOptions.default)
     }
 
     def unZipFile(f: Path) = Try(f.unzip)

--- a/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
+++ b/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
@@ -72,7 +72,7 @@ class WdlDraft2LanguageFactory(override val config: Config) extends LanguageFact
       def call: ErrorOr[WdlNamespaceWithWorkflow] = source match {
         case w: WorkflowSourceFilesWithDependenciesZip =>
           for {
-            importsDir <- LanguageFactoryUtil.validateImportsDirectory(w.importsZip)
+            importsDir <- LanguageFactoryUtil.createImportsDirectory(w.importsZip)
             wf <- WdlNamespaceWithWorkflow.load(workflowSource, importResolvers map resolverConverter).toErrorOr
             _ = importsDir.delete(swallowIOExceptions = true)
           } yield wf

--- a/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
+++ b/languageFactories/wdl-draft2/src/main/scala/languages/wdl/draft2/WdlDraft2LanguageFactory.scala
@@ -69,16 +69,7 @@ class WdlDraft2LanguageFactory(override val config: Config) extends LanguageFact
     }
 
     def validationCallable = new Callable[ErrorOr[WdlNamespaceWithWorkflow]] {
-      def call: ErrorOr[WdlNamespaceWithWorkflow] = source match {
-        case w: WorkflowSourceFilesWithDependenciesZip =>
-          for {
-            importsDir <- LanguageFactoryUtil.createImportsDirectory(w.importsZip)
-            wf <- WdlNamespaceWithWorkflow.load(workflowSource, importResolvers map resolverConverter).toErrorOr
-            _ = importsDir.delete(swallowIOExceptions = true)
-          } yield wf
-        case _: WorkflowSourceFilesWithoutImports =>
-          WdlNamespaceWithWorkflow.load(workflowSource, importResolvers map resolverConverter).toErrorOr
-      }
+      def call: ErrorOr[WdlNamespaceWithWorkflow] = WdlNamespaceWithWorkflow.load(workflowSource, importResolvers map resolverConverter).toErrorOr
     }
 
     lazy val wdlNamespaceValidation: ErrorOr[WdlNamespaceWithWorkflow] = namespaceCache.map(_.get(workflowHashKey, validationCallable)).getOrElse(validationCallable.call)


### PR DESCRIPTION
In support of #4117.

I picked two strategic places to dump some info about a workflow's imports zip (if present):
- Right as the workflow is submitted
  - Did we receive the zip and correctly write it to the workflow store table?
- Immediately before we attempt to instantiate the workflow
  - Did we unzip the zip and create a viable `DirectoryResolver` from it?
  - Based on this log output, we can SSH into the server and look at the actual directory created, in the pattern `/tmp/99104084175675660.zip2922990665093481334`

No tests specifically for this, but you can see the new log statements in the CI output. (That's where you'll find this pudding's proof.)