### PR TITLE
Prints out the gsutil failures when (de)localizing

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -90,7 +90,7 @@ object ActionBuilder {
 
   def cloudSdkShellAction(shellCommand: String)(mounts: List[Mount] = List.empty, flags: List[ActionFlag] = List.empty, labels: Map[String, String] = Map.empty): Action =
     cloudSdkAction
-      .withCommand("/bin/sh", "-c", shellCommand)
+      .withCommand("/bin/sh", "-c", if (shellCommand.contains("\n")) shellCommand |> ActionCommands.multiLineCommand else shellCommand)
       .withFlags(flags)
       .withMounts(mounts)
       .withLabels(labels)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -126,11 +126,7 @@ object ActionCommands {
        |  cat gsutil_output.txt 1>&2
        |  
        |  # Check if it matches the BucketIsRequesterPaysErrorMessage
-       |  grep "$BucketIsRequesterPaysErrorMessage" gsutil_output.txt
-       |  
-       |  # If it does, grep will return 0
-       |  IS_RP_FAILURE=$$?
-       |  if [ "$$IS_RP_FAILURE" = "0" ]; then
+       |  if grep -q "$BucketIsRequesterPaysErrorMessage" gsutil_output.txt; then
        |    echo "Retrying with user project"
        |    ${withProject |> f}
        |  else

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -147,8 +147,7 @@ object ActionCommands {
     val base64EncodedScript = Base64.encodeBase64String(withBashShebang.getBytes)
     val scriptPath = s"/tmp/$randomUuid.sh"
 
-    s"apt-get install --assume-yes coreutils && " +
-      s"echo $base64EncodedScript | base64 --decode > $scriptPath && " +
+      s"""python -c 'import base64; print(base64.b64decode("$base64EncodedScript"));' > $scriptPath && """ +
       s"chmod u+x $scriptPath && " +
       s"sh $scriptPath"
   }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -80,7 +80,8 @@ object ActionCommands {
        |done""".stripMargin
 
   def retry(f: => String)(implicit localizationConfiguration: LocalizationConfiguration, wait: FiniteDuration) = {
-    s"""for i in `seq ${localizationConfiguration.localizationAttempts}`; do
+    s"""for i in $$(seq ${localizationConfiguration.localizationAttempts}); do
+       |  echo "Attempt $$i"
        |  (
        |    $f
        |  )

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -1,4 +1,6 @@
 package cromwell.backend.google.pipelines.v2alpha1.api
+import java.util.UUID
+
 import akka.http.scaladsl.model.ContentType
 import common.util.StringUtil._
 import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.LocalizationConfiguration
@@ -6,6 +8,7 @@ import cromwell.core.path.Path
 import cromwell.filesystems.gcs.GcsPath
 import cromwell.filesystems.gcs.RequesterPaysErrors._
 import mouse.all._
+import org.apache.commons.codec.binary.Base64
 import org.apache.commons.text.StringEscapeUtils
 
 import scala.concurrent.duration._
@@ -68,14 +71,34 @@ object ActionCommands {
 
   def ifExist(containerPath: Path)(f: => String) = s"if [ -e ${containerPath.escape} ]; then $f; fi"
 
-  def every(duration: FiniteDuration)(f: => String) = s"while true; do $f 2> /dev/null || true; sleep ${duration.toSeconds}; done"
+  def every(duration: FiniteDuration)(f: => String) =
+    s"""while true; do
+       |  (
+       |    $f
+       |  ) 2> /dev/null
+       |  sleep ${duration.toSeconds}
+       |done""".stripMargin
 
   def retry(f: => String)(implicit localizationConfiguration: LocalizationConfiguration, wait: FiniteDuration) = {
-    s"""retry() { for i in `seq ${localizationConfiguration.localizationAttempts}`; do $f; RC=$$?; if [ "$$RC" = "0" ]; then break; fi; sleep ${wait.toSeconds}; done; return "$$RC"; }; retry"""
+    s"""for i in `seq ${localizationConfiguration.localizationAttempts}`; do
+       |  (
+       |    $f
+       |  )
+       |  RC=$$?
+       |  if [ "$$RC" = "0" ]; then
+       |    break
+       |  fi
+       |  sleep ${wait.toSeconds}
+       |done
+       |exit "$$RC"""".stripMargin
   }
 
   def delocalizeFileOrDirectory(containerPath: Path, cloudPath: Path, contentType: Option[ContentType])(implicit localizationConfiguration: LocalizationConfiguration) = {
-    s"if [ -d ${containerPath.escape} ]; then ${delocalizeDirectory(containerPath, cloudPath, contentType)}; else ${delocalizeFile(containerPath, cloudPath, contentType)}; fi"
+    s"""if [ -d ${containerPath.escape} ]; then
+       |  ${delocalizeDirectory(containerPath, cloudPath, contentType)}
+       |else 
+       |  ${delocalizeFile(containerPath, cloudPath, contentType)}
+       |fi""".stripMargin
   }
 
   def localizeDirectory(cloudPath: Path, containerPath: Path)(implicit localizationConfiguration: LocalizationConfiguration) = retry {
@@ -94,7 +117,39 @@ object ActionCommands {
     val withoutProject = ""
     val withProject = s"-u ${path.projectId}"
 
-    s"""${f(withoutProject)} 2> gsutil_output.txt; RC_GSUTIL=$$?; if [ "$$RC_GSUTIL" = "1" ]; then
-       | grep "$BucketIsRequesterPaysErrorMessage" gsutil_output.txt && echo "Retrying with user project"; ${f(withProject)}; fi """.stripMargin
+    s"""${withoutProject |> f} 2> gsutil_output.txt
+       |# Record the exit code of the gsutil command without project flag
+       |RC_GSUTIL=$$?
+       |if [ "$$RC_GSUTIL" != "0" ]; then
+       |  echo "gsutil command failed"
+       |  # Print the reason of the failure to stderr
+       |  cat gsutil_output.txt 1>&2
+       |  
+       |  # Check if it matches the BucketIsRequesterPaysErrorMessage
+       |  grep "$BucketIsRequesterPaysErrorMessage" gsutil_output.txt
+       |  
+       |  # If it does, grep will return 0
+       |  IS_RP_FAILURE=$$?
+       |  if [ "$$IS_RP_FAILURE" = "0" ]; then
+       |    echo "Retrying with user project"
+       |    ${withProject |> f}
+       |  else
+       |    exit "$$RC_GSUTIL"
+       |  fi
+       |else
+       |  exit 0
+       |fi""".stripMargin
+  }
+
+  def multiLineCommand(commandString: String) = {
+    val randomUuid = UUID.randomUUID().toString
+    val withBashShebang = s"#!/bin/bash\n\n$commandString"
+    val base64EncodedScript = Base64.encodeBase64String(withBashShebang.getBytes)
+    val scriptPath = s"/tmp/$randomUuid.sh"
+
+    s"apt-get install --assume-yes coreutils && " +
+      s"echo $base64EncodedScript | base64 --decode > $scriptPath && " +
+      s"chmod u+x $scriptPath && " +
+      s"sh $scriptPath"
   }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -15,7 +15,6 @@ import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder._
 import cromwell.backend.google.pipelines.v2alpha1.api.ActionCommands._
 import cromwell.backend.google.pipelines.v2alpha1.api.Delocalization._
 import cromwell.core.path.{DefaultPathBuilder, Path}
-import org.apache.commons.codec.binary.Base64
 import wom.runtime.WomOutputRuntimeExtractor
 
 import scala.collection.JavaConverters._
@@ -102,17 +101,6 @@ trait Delocalization {
   }
 
   private def delocalizeRuntimeOutputsAction(cloudCallRoot: Path, inputFile: String, workflowRoot: Path, mounts: List[Mount]): Action = {
-    def multiLineCommand(commandString: String) = {
-      val randomUuid = UUID.randomUUID().toString
-      val base64EncodedScript = Base64.encodeBase64String(commandString.getBytes)
-      val scriptPath = s"/tmp/$randomUuid.sh"
-
-      s"apt-get install --assume-yes coreutils && " +
-        s"echo $base64EncodedScript | base64 --decode > $scriptPath && " +
-        s"chmod u+x $scriptPath && " +
-        s"sh $scriptPath"
-    }
-    
     val command = multiLineCommand(delocalizeRuntimeOutputsScript(inputFile, workflowRoot, cloudCallRoot))
     ActionBuilder.cloudSdkShellAction(command)(mounts, flags = List(ActionFlag.DisableImagePrefetch), labels = Map(Key.Tag -> Value.Delocalization))
   }

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
@@ -23,8 +23,8 @@ class ActionCommandsSpec extends FlatSpec with Matchers with Mockito {
                          |RC_GSUTIL=$?
                          |if [ "$RC_GSUTIL" != "0" ]; then
                          |  echo "gsutil command failed"
-                         |  # Print the reason of the failure
-                         |  cat gsutil_output.txt
+                         |  # Print the reason of the failure to stderr
+                         |  cat gsutil_output.txt 1>&2
                          |  
                          |  # Check if it matches the BucketIsRequesterPaysErrorMessage
                          |  grep "Bucket is requester pays bucket but no user project provided." gsutil_output.txt

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
@@ -27,11 +27,7 @@ class ActionCommandsSpec extends FlatSpec with Matchers with Mockito {
                          |  cat gsutil_output.txt 1>&2
                          |  
                          |  # Check if it matches the BucketIsRequesterPaysErrorMessage
-                         |  grep "Bucket is requester pays bucket but no user project provided." gsutil_output.txt
-                         |  
-                         |  # If it does, grep will return 0
-                         |  IS_RP_FAILURE=$?
-                         |  if [ "$IS_RP_FAILURE" = "0" ]; then
+                         |  if grep -q "Bucket is requester pays bucket but no user project provided." gsutil_output.txt; then
                          |    echo "Retrying with user project"
                          |    flag is -u my-project
                          |  else
@@ -44,7 +40,8 @@ class ActionCommandsSpec extends FlatSpec with Matchers with Mockito {
   
   it should "use LocalizationConfiguration to set the number of localization retries" in {
     implicit val localizationConfiguration = LocalizationConfiguration(refineMV(31380))
-    retry("I'm very flaky") shouldBe """for i in `seq 31380`; do
+    retry("I'm very flaky") shouldBe """for i in $(seq 31380); do
+                                       |  echo "Attempt $i"
                                        |  (
                                        |    I'm very flaky
                                        |  )

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommandsSpec.scala
@@ -18,11 +18,42 @@ class ActionCommandsSpec extends FlatSpec with Matchers with Mockito {
       s"flag is $flag"
     }
     
-    recovered shouldBe "flag is  2> gsutil_output.txt; RC_GSUTIL=$?; if [ \"$RC_GSUTIL\" = \"1\" ]; then\n grep \"Bucket is requester pays bucket but no user project provided.\" gsutil_output.txt && echo \"Retrying with user project\"; flag is -u my-project; fi "
+    recovered shouldBe """flag is  2> gsutil_output.txt
+                         |# Record the exit code of the gsutil command without project flag
+                         |RC_GSUTIL=$?
+                         |if [ "$RC_GSUTIL" != "0" ]; then
+                         |  echo "gsutil command failed"
+                         |  # Print the reason of the failure
+                         |  cat gsutil_output.txt
+                         |  
+                         |  # Check if it matches the BucketIsRequesterPaysErrorMessage
+                         |  grep "Bucket is requester pays bucket but no user project provided." gsutil_output.txt
+                         |  
+                         |  # If it does, grep will return 0
+                         |  IS_RP_FAILURE=$?
+                         |  if [ "$IS_RP_FAILURE" = "0" ]; then
+                         |    echo "Retrying with user project"
+                         |    flag is -u my-project
+                         |  else
+                         |    exit "$RC_GSUTIL"
+                         |  fi
+                         |else
+                         |  exit 0
+                         |fi""".stripMargin
   }
   
   it should "use LocalizationConfiguration to set the number of localization retries" in {
     implicit val localizationConfiguration = LocalizationConfiguration(refineMV(31380))
-    retry("I'm very flaky") shouldBe "retry() { for i in `seq 31380`; do I'm very flaky; RC=$?; if [ \"$RC\" = \"0\" ]; then break; fi; sleep 5; done; return \"$RC\"; }; retry"
+    retry("I'm very flaky") shouldBe """for i in `seq 31380`; do
+                                       |  (
+                                       |    I'm very flaky
+                                       |  )
+                                       |  RC=$?
+                                       |  if [ "$RC" = "0" ]; then
+                                       |    break
+                                       |  fi
+                                       |  sleep 5
+                                       |done
+                                       |exit "$RC"""".stripMargin
   }
 }


### PR DESCRIPTION
Feel free to 🐦 this
I recently used the base64 trick to do the delocalization of `cwl.output.json`, which makes writing/reading (multiline) scripts a lot easier but it also adds some overhead.
In any case the real change is [here](https://github.com/broadinstitute/cromwell/pull/4396/files#diff-bc6317d6a6b6aea749b55e1d713a75dcR126)
This is to help debug this issue: https://github.com/broadinstitute/cromwell/issues/4336