### PR TITLE
Switch tests back to develop

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_format/cwl_format_url.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_format/cwl_format_url.cwl
@@ -6,7 +6,7 @@ $schemas:
   # Relative path:
   - ../../../../../../cwl/src/test/resources/cwl/ontology/EDAM.owl
   # Absolute (remote) path:
-  - https://raw.githubusercontent.com/broadinstitute/cromwell/cjl_cwl_relative_imports/cwl/src/test/resources/cwl/ontology/gx_edam.ttl
+  - https://raw.githubusercontent.com/broadinstitute/cromwell/develop/cwl/src/test/resources/cwl/ontology/gx_edam.ttl
 $graph:
 - id: main
   class: CommandLineTool

--- a/centaur/src/main/resources/standardTestCases/cwl_format_valid_with_workflow_url.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_format_valid_with_workflow_url.test
@@ -8,7 +8,7 @@ backends: [Local, LocalNoDocker]
 tags: [localdockertest]
 
 files {
-  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/cjl_cwl_relative_imports/centaur/src/main/resources/standardTestCases/cwl_format/cwl_format_url.cwl"
+  workflowUrl: "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/centaur/src/main/resources/standardTestCases/cwl_format/cwl_format_url.cwl"
   inputs: cwl_format/cwl_format_valid.yaml
   options: cwl_format/cwl_format.options
 }


### PR DESCRIPTION
Now that #4308 has merged, point the test URLs back to the develop branch.

- [ ] And then delete branch `cjl_cwl_relative_imports`