### PR TITLE
Add new hash path strategy with last modified time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 37 Release Notes
 
+### Added new call cache path+modtime hashing strategy.
+
+Call caching hashes with this new strategy are based on the path and the last modified time of the file.
+
 ### Call cache blacklisting
 
 The Google Pipelines API (PAPI) version 1 and 2 backends now offer the option of call cache blacklisting on a per-bucket basis.

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -371,6 +371,7 @@ backend {
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+              # Default: file
               hashing-strategy: "file"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -386,7 +386,7 @@ backend {
                 "hard-link", "soft-link", "copy"
               ]
 
-              # Possible values: file, path
+              # Possible values: file, path, path+modtime
               # "file" will compute an md5 hash of the file content.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -369,8 +369,8 @@ backend {
               # Possible values: file, path
               # "file" will compute an md5 hash of the file content.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
-              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
               # in order to allow for the original file path to be hashed.
+              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
               hashing-strategy: "file"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -369,6 +369,7 @@ backend {
               # Possible values: file, path
               # "file" will compute an md5 hash of the file content.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
+              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
               # in order to allow for the original file path to be hashed.
               hashing-strategy: "file"
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -318,18 +318,15 @@ When running a job on the Config (Shared Filesystem) backend, Cromwell provides 
 
 ```HOCON
       config {
-        #...
         filesystems {
-          #...
           local {
-            #...
             caching {
               # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
               duplication-strategy: [
                 "hard-link", "soft-link", "copy"
               ]
 
-              # Possible values: file, path
+              # Possible values: file, path, path+modtime
               # "file" will compute an md5 hash of the file content.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -308,6 +308,7 @@ When running a job on the Config (Shared Filesystem) backend, Cromwell provides 
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+              # Default: file
               hashing-strategy: "file"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -290,13 +290,13 @@ Cromwell also accepts [Workflow Options](wf_options/Overview#call-caching-option
 
 When running a job on the Config (Shared Filesystem) backend, Cromwell provides some additional options in the backend's config section:
 
-```
+```HOCON
       config {
-        ...
+        #...
         filesystems {
-          ...
+          #...
           local {
-            ...
+            #...
             caching {
               # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
               duplication-strategy: [
@@ -307,7 +307,7 @@ When running a job on the Config (Shared Filesystem) backend, Cromwell provides 
               # "file" will compute an md5 hash of the file content.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
-              # Default: file
+              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
               hashing-strategy: "file"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -77,6 +77,15 @@ final case class HashPathStrategy(checkSiblingMd5: Boolean) extends ConfigHashin
   override val description = "hash file path"
 }
 
+final case class HashPathModTimeStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
+  override def hash(file: Path): Try[String] = {
+    // Add the last modified date here to make sure these are the files we are looking for.
+    Try(DigestUtils.md5Hex(file.toAbsolutePath.pathAsString + file.lastModifiedTime.toString))
+  }
+
+  override val description = "hash file path and last modified time"
+}
+
 final case class HashFileStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
   override protected def hash(file: Path): Try[String] = {
     tryWithResource(() => file.newInputStream) { DigestUtils.md5Hex }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -24,6 +24,7 @@ object ConfigHashingStrategy {
       hashingConfig.as[Option[String]]("hashing-strategy").getOrElse("file") match {
         case "path" => HashPathStrategy(checkSiblingMd5)
         case "file" => HashFileStrategy(checkSiblingMd5)
+        case "path+modtime" => HashPathModTimeStrategy(checkSiblingMd5)
         case what =>
           logger.warn(s"Unrecognized hashing strategy $what.")
           HashPathStrategy(checkSiblingMd5)


### PR DESCRIPTION
Dear developers,

During testing I ran into the problem that the `HashPathStrategy` does not include the last modified date of the file. It assumes: "if the path is there, it is the same file". This is not necessarily the case. Files can be modified or replaced.Therefore the current `HashPathStrategy` is a big liability when trying to get reproducible results.

By adding a "last modified date" to the `HashPathStrategy` this will ensure that nothing has  happened to the file from the user or system side. This of course is not as safe as the `HashFileStrategy` since it does not protect against filesystem or hardware errors, but it provides a lot more safety compared to the current `HashPathStrategy`.  
This is also how Snakemake checks if files are the same and it works quite well.

Alternatively there could be an option in the Configfile that allows you to set this behaviour. Please let me know what you think of this.