### PR TITLE
Backport zip import logging to 35_hotfix

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -215,9 +215,9 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       scheduleNextNewWorkflowPoll()
       runningAndNotStartingNewWorkflowsStateFunction(event)
   }
-  
+
   when (Running) (scheduleNextNewWorkflowPollStateFunction.orElse(runningAndNotStartingNewWorkflowsStateFunction))
-  
+
   when (RunningAndNotStartingNewWorkflows) (runningAndNotStartingNewWorkflowsStateFunction)
 
   when (Aborting) {
@@ -289,6 +289,13 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       logger.info(s"$tag Restarting workflow UUID($workflowId) in ${workflow.state.toString} state")
     } else {
       logger.info(s"$tag Starting workflow UUID($workflowId)")
+    }
+
+    // Debugging #4117 - if there are imports present at this point, they were received by Cromwell and written
+    // into the workflow store. (AEN 2018-11-14)
+    workflow.sources.importsZipFileOption match {
+      case Some(zip) => logger.info(s"$tag Found imports zip on workflow $workflowId, size ${zip.length} bytes.")
+      case None => logger.info(s"$tag No imports zip on workflow $workflowId.")
     }
 
     val wfProps = WorkflowActor.props(

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -272,7 +272,7 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
       if (importLocalFilesystem) DirectoryResolver.localFilesystemResolvers(None)
       else List.empty
 
-    val zippedResolverCheck: Parse[Option[ImportResolver]] = fromEither[IO](sourceFiles.importsZipFileOption match {
+    val zippedResolverCheck: Parse[Option[DirectoryResolver]] = fromEither[IO](sourceFiles.importsZipFileOption match {
       case None => None.validNelCheck
       case Some(zipContent) => zippedImportResolver(zipContent).toEither.map(Option.apply)
     })
@@ -282,6 +282,13 @@ class MaterializeWorkflowDescriptorActor(serviceRegistryActor: ActorRef,
     for {
       _ <- publishLabelsToMetadata(id, labels)
       zippedImportResolver <- zippedResolverCheck
+      // Debugging #4117 - make sure we are creating an importable directory out of the zip (AEN 2018-11-14)
+      _ = zippedImportResolver match {
+        case Some(dr: DirectoryResolver) =>
+          workflowLogger.info(s"Importing from unzip directory '${dr.name}' with files [${dr.directory.list.map(_.toFile.getName).mkString(", ")}]")
+        case None =>
+          workflowLogger.info("No zipped import resolver available.")
+      }
       importResolvers = zippedImportResolver.toList ++ localFilesystemResolvers :+ HttpResolver(None, Map.empty)
       sourceAndResolvers <- fromEither[IO](findWorkflowSource(sourceFiles.workflowSource, sourceFiles.workflowUrl, importResolvers))
       _ = if(sourceFiles.workflowUrl.isDefined) publishWorkflowSourceToMetadata(id, sourceAndResolvers._1)

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -128,7 +128,7 @@ object ImportResolver {
     }
   }
 
-  def zippedImportResolver(zippedImports: Array[Byte]): ErrorOr[ImportResolver] = {
+  def zippedImportResolver(zippedImports: Array[Byte]): ErrorOr[DirectoryResolver] = {
     LanguageFactoryUtil.validateImportsDirectory(zippedImports) map { dir =>
       DirectoryResolver(dir, Option(dir.toJava.getCanonicalPath), None)
     }


### PR DESCRIPTION
This extra logging should not merge into mainline `35_hotfix`; rather I'm using the PR as a mechanism for review and approval.

Once approved, I'll work with Mint to deploy `35_hotfix_mint_logging` to their Cromwell.

---

Mint is running `cromwell-35-5f86a05-SNAP.jar`, which refers to [commit `5f86a05`](https://github.com/broadinstitute/cromwell/commit/5f86a055a03bacbe842181783e3ea02bf778d6a6).

As far as I can tell, [`5f86a05`](https://github.com/broadinstitute/cromwell/commit/5f86a055a03bacbe842181783e3ea02bf778d6a6) is the same as [`b05e204`](https://github.com/broadinstitute/cromwell/pull/4091/commits/b05e2045eff34b179deb889f6c492dfd3c73b8b7), which is definitely present in `35_hotfix` (navigate to the [commit list](https://github.com/broadinstitute/cromwell/commits/35_hotfix?after=f3267d30aab008b00d04aeb6fdfcc35800b27c5e+34) and hit "Older" once).

They'll get a few extra commits, but nothing too crazy. I felt this was a more understandable strategy than applying my changes to the (seemingly random) commit they're running.