### PR TITLE
Provides WES status and abort endpoints directly to the Cromwell server.

### DIFF
--- a/core/src/main/scala/cromwell/core/abort/AbortResponse.scala
+++ b/core/src/main/scala/cromwell/core/abort/AbortResponse.scala
@@ -2,7 +2,12 @@ package cromwell.core.abort
 
 import cromwell.core.WorkflowId
 
-sealed trait AbortResponse
-case class WorkflowAbortedResponse(workflowId: WorkflowId) extends AbortResponse
-case class WorkflowAbortRequestedResponse(workflowId: WorkflowId) extends AbortResponse
-case class WorkflowAbortFailureResponse(workflowId: WorkflowId, failure: Throwable) extends AbortResponse
+sealed trait AbortResponse {
+  val workflowId: WorkflowId
+}
+
+final case class WorkflowAbortFailureResponse(workflowId: WorkflowId, failure: Throwable) extends AbortResponse
+
+sealed trait SuccesfulAbortResponse extends AbortResponse
+final case class WorkflowAbortedResponse(workflowId: WorkflowId) extends SuccesfulAbortResponse
+final case class WorkflowAbortRequestedResponse(workflowId: WorkflowId) extends SuccesfulAbortResponse

--- a/core/src/main/scala/cromwell/core/abort/AbortResponse.scala
+++ b/core/src/main/scala/cromwell/core/abort/AbortResponse.scala
@@ -8,6 +8,6 @@ sealed trait AbortResponse {
 
 final case class WorkflowAbortFailureResponse(workflowId: WorkflowId, failure: Throwable) extends AbortResponse
 
-sealed trait SuccesfulAbortResponse extends AbortResponse
-final case class WorkflowAbortedResponse(workflowId: WorkflowId) extends SuccesfulAbortResponse
-final case class WorkflowAbortRequestedResponse(workflowId: WorkflowId) extends SuccesfulAbortResponse
+sealed trait SuccessfulAbortResponse extends AbortResponse
+final case class WorkflowAbortedResponse(workflowId: WorkflowId) extends SuccessfulAbortResponse
+final case class WorkflowAbortRequestedResponse(workflowId: WorkflowId) extends SuccessfulAbortResponse

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -10,6 +10,7 @@ import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.services.instrumentation.CromwellInstrumentationActor
 import cromwell.webservice.SwaggerService
 import cromwell.webservice.routes.CromwellApiService
+import cromwell.webservice.routes.wes.WesRouteSupport
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
@@ -26,7 +27,9 @@ object CromwellServer {
 
 class CromwellServerActor(cromwellSystem: CromwellSystem, gracefulShutdown: Boolean, abortJobsOnTerminate: Boolean)(override implicit val materializer: ActorMaterializer)
   extends CromwellRootActor(gracefulShutdown, abortJobsOnTerminate, serverMode = true)
-    with CromwellApiService with CromwellInstrumentationActor
+    with CromwellApiService
+    with CromwellInstrumentationActor
+    with WesRouteSupport
     with SwaggerService
     with ActorLogging {
   implicit val actorSystem = context.system
@@ -43,7 +46,7 @@ class CromwellServerActor(cromwellSystem: CromwellSystem, gracefulShutdown: Bool
     * actual cromwell+swagger+oauth+/api support is needed.
     */
   val apiRoutes: Route = pathPrefix("api")(concat(workflowRoutes))
-  val nonApiRoutes: Route = concat(engineRoutes, swaggerUiResourceRoute)
+  val nonApiRoutes: Route = concat(engineRoutes, swaggerUiResourceRoute, wesRoutes)
   val allRoutes: Route = concat(apiRoutes, nonApiRoutes)
 
   val serverBinding = Http().bindAndHandle(allRoutes, interface, port)

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -285,6 +285,11 @@ object CromwellApiService {
     */
   private def standardAbortErrorHandler: PartialFunction[Throwable, Route] = {
     case e: InvalidWorkflowException => e.failRequest(StatusCodes.BadRequest)
+    /*
+       FIXME:
+       Note that the following condition is currently impossible to reach. There's a test for this condition however,
+       so will remove in a subsequent PR as it's topically different than this PR
+     */
     case e: IllegalStateException => e.errorRequest(StatusCodes.Forbidden)
     case e: WorkflowNotFoundException => e.errorRequest(StatusCodes.NotFound)
     case _: AskTimeoutException if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallabl
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.pattern.{AskTimeoutException, ask}
 import akka.stream.ActorMaterializer
 import akka.util.{ByteString, Timeout}
@@ -17,7 +17,7 @@ import cats.data.Validated.{Invalid, Valid}
 import com.typesafe.config.ConfigFactory
 import common.exception.AggregatedMessageException
 import common.util.VersionUtil
-import cromwell.core.abort.{AbortResponse, WorkflowAbortFailureResponse, WorkflowAbortedResponse, WorkflowAbortRequestedResponse}
+import cromwell.core.abort._
 import cromwell.core.{path => _, _}
 import cromwell.engine.backend.BackendConfiguration
 import cromwell.engine.instrumentation.HttpInstrumentation
@@ -29,6 +29,7 @@ import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStore
 import cromwell.server.CromwellShutdown
 import cromwell.services.healthmonitor.HealthMonitorServiceActor.{GetCurrentStatus, StatusCheckResponse}
 import cromwell.services.metadata.MetadataService._
+import cromwell.webservice._
 import cromwell.webservice.WorkflowJsonSupport._
 import cromwell.webservice._
 import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
@@ -39,7 +40,8 @@ import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport {
+trait CromwellApiService extends HttpInstrumentation
+  with MetadataRouteSupport {
   import CromwellApiService._
 
   implicit def actorRefFactory: ActorRefFactory
@@ -114,32 +116,7 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport {
     path("workflows" / Segment / Segment / "abort") { (_, possibleWorkflowId) =>
       post {
         instrumentRequest {
-          def sendAbort(workflowId: WorkflowId): Route = {
-            val response = workflowStoreActor.ask(WorkflowStoreActor.AbortWorkflowCommand(workflowId)).mapTo[AbortResponse]
-
-            onComplete(response) {
-              case Success(WorkflowAbortedResponse(id)) =>
-                complete(ToResponseMarshallable(WorkflowAbortResponse(id.toString, WorkflowAborted.toString)))
-              case Success(WorkflowAbortRequestedResponse(id)) =>
-                complete(ToResponseMarshallable(WorkflowAbortResponse(id.toString, WorkflowAborting.toString)))
-              case Success(WorkflowAbortFailureResponse(_, e: IllegalStateException)) =>
-                /*
-                  Note that this is currently impossible to reach but was left as-is during the transition to akka http.
-                  When aborts get fixed, this should be looked at.
-                */
-                e.errorRequest(StatusCodes.Forbidden)
-              case Success(WorkflowAbortFailureResponse(_, e: WorkflowNotFoundException)) => e.errorRequest(StatusCodes.NotFound)
-              case Success(WorkflowAbortFailureResponse(_, e)) => e.errorRequest(StatusCodes.InternalServerError)
-              case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
-              case Failure(e: TimeoutException) => e.failRequest(StatusCodes.ServiceUnavailable)
-              case Failure(e) => e.errorRequest(StatusCodes.InternalServerError)
-            }
-          }
-
-          Try(WorkflowId.fromString(possibleWorkflowId)) match {
-            case Success(workflowId) => sendAbort(workflowId)
-            case Failure(_) => InvalidWorkflowException(possibleWorkflowId).failRequest(StatusCodes.BadRequest)
-          }
+          abortWorkflow(possibleWorkflowId, workflowStoreActor, workflowManagerActor)
         }
       }
     } ~
@@ -269,6 +246,50 @@ object CromwellApiService {
     def errorRequest(statusCode: StatusCode, warnings: Seq[String] = Vector.empty): Route = {
       completeResponse(statusCode, APIResponse.error(e).toJson.prettyPrint, warnings)
     }
+  }
+
+  /**
+    * Sends a request to abort the workflow. Provides configurable success & error handlers to allow
+    * for different API endpoints to provide different effects in the appropriate situations, e.g. HTTP codes
+    * and error messages
+    */
+  def abortWorkflow(possibleWorkflowId: String,
+                    workflowStoreActor: ActorRef,
+                    workflowManagerActor: ActorRef,
+                    successHandler: WorkflowId => Route = standardAbortSuccessHandler,
+                    errorHandler: PartialFunction[Throwable, Route] = standardAbortErrorHandler)
+                   (implicit timeout: Timeout): Route = {
+    handleExceptions(ExceptionHandler(errorHandler)) {
+      Try(WorkflowId.fromString(possibleWorkflowId)) match {
+        case Success(workflowId) =>
+          val response = workflowStoreActor.ask(WorkflowStoreActor.AbortWorkflowCommand(workflowId)).mapTo[AbortResponse]
+          onComplete(response) {
+            case Success(x: SuccesfulAbortResponse) => successHandler(x.workflowId)
+            case Success(x: WorkflowAbortFailureResponse) => throw x.failure
+            case Failure(e) => throw e
+          }
+        case Failure(_) => throw InvalidWorkflowException(possibleWorkflowId)
+      }
+    }
+  }
+
+  /**
+    * The abort success handler for typical cases, i.e. cromwell's API.
+    */
+  private def standardAbortSuccessHandler(workflowId: WorkflowId): Route = {
+    complete(ToResponseMarshallable(WorkflowAbortResponse(workflowId.toString, WorkflowAborting.toString)))
+  }
+
+  /**
+    * The abort error handler for typical cases, i.e. cromwell's API
+    */
+  private def standardAbortErrorHandler: PartialFunction[Throwable, Route] = {
+    case e: InvalidWorkflowException => e.failRequest(StatusCodes.BadRequest)
+    case e: IllegalStateException => e.errorRequest(StatusCodes.Forbidden)
+    case e: WorkflowNotFoundException => e.errorRequest(StatusCodes.NotFound)
+    case _: AskTimeoutException if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
+    case e: TimeoutException => e.failRequest(StatusCodes.ServiceUnavailable)
+    case e: Exception => e.errorRequest(StatusCodes.InternalServerError)
   }
 
   def validateWorkflowId(possibleWorkflowId: String,

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -40,8 +40,7 @@ import scala.concurrent.{ExecutionContext, Future, TimeoutException}
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
-trait CromwellApiService extends HttpInstrumentation
-  with MetadataRouteSupport {
+trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport {
   import CromwellApiService._
 
   implicit def actorRefFactory: ActorRefFactory

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesResponse.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesResponse.scala
@@ -1,0 +1,32 @@
+package cromwell.webservice.routes.wes
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import cromwell.webservice.routes.wes.WesState.WesState
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+
+sealed trait WesResponse extends Product with Serializable
+final case class WesErrorResponse(msg: String, status_code: Int) extends WesResponse
+final case class WesRunId(run_id: String) extends WesResponse
+final case class WesRunStatus(run_id: String, state: WesState) extends WesResponse
+
+object WesResponseJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  import WesStateJsonSupport._
+
+  implicit val WesResponseErrorFormat = jsonFormat2(WesErrorResponse)
+  implicit val WesResponseRunIdFormat = jsonFormat1(WesRunId)
+  implicit val WesResponseStatusFormat = jsonFormat2(WesRunStatus)
+
+  implicit object WesResponseFormat extends RootJsonFormat[WesResponse] {
+    import spray.json._
+
+    def write(r: WesResponse) = {
+      r match {
+        case r: WesRunId => r.toJson
+        case s: WesRunStatus => s.toJson
+        case e: WesErrorResponse => e.toJson
+      }
+    }
+
+    def read(value: JsValue) = throw new UnsupportedOperationException("Reading WesResponse objects from JSON is not supported")
+  }
+}

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -15,7 +15,7 @@ import WesResponseJsonSupport._
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.server.directives.RouteDirectives.complete
 import WesRouteSupport._
-import cromwell.core.WorkflowId
+import cromwell.core.abort.SuccessfulAbortResponse
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.server.CromwellShutdown
 import cromwell.webservice.routes.CromwellApiService
@@ -80,8 +80,8 @@ trait WesRouteSupport extends HttpInstrumentation {
 object WesRouteSupport {
   val NotFoundError = WesErrorResponse("The requested workflow run wasn't found", StatusCodes.NotFound.intValue)
 
-  def WesAbortSuccessHandler(workflowId: WorkflowId): Route = {
-    complete(WesRunId(workflowId.toString))
+  def WesAbortSuccessHandler: PartialFunction[SuccessfulAbortResponse, Route] = {
+    case response => complete(WesRunId(response.workflowId.toString))
   }
 
   def WesAbortErrorHandler: PartialFunction[Throwable, Route] = {

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -1,0 +1,89 @@
+package cromwell.webservice.routes.wes
+
+import akka.actor.ActorRef
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import akka.pattern.{AskTimeoutException, ask}
+import akka.util.Timeout
+import cromwell.engine.instrumentation.HttpInstrumentation
+import cromwell.services.metadata.MetadataService.{GetStatus, MetadataServiceResponse, StatusLookupFailed, StatusLookupResponse}
+import cromwell.webservice.routes.CromwellApiService.{EnhancedThrowable, UnrecognizedWorkflowException, validateWorkflowId}
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+import WesResponseJsonSupport._
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.server.directives.RouteDirectives.complete
+import WesRouteSupport._
+import cromwell.core.WorkflowId
+import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
+import cromwell.server.CromwellShutdown
+import cromwell.webservice.routes.CromwellApiService
+
+trait WesRouteSupport extends HttpInstrumentation {
+  val serviceRegistryActor: ActorRef
+  val workflowManagerActor: ActorRef
+  val workflowStoreActor: ActorRef
+
+  implicit val ec: ExecutionContext
+  implicit val timeout: Timeout
+
+  /*
+    These routes are not currently going through the MetadataBuilderRegulator/MetadataBuilder. This is for two reasons:
+      - It'd require a fairly substantial refactor of the MetadataBuilderActor to be more general
+      - It's expected that for now the usage of these endpoints will not be extensive, so the protections of the regulator
+         should not be necessary
+    */
+  val wesRoutes: Route =
+    instrumentRequest {
+      concat(
+        pathPrefix("ga4gh" / "wes" / "v1" / "runs") {
+          concat(
+            path(Segment / "status") { possibleWorkflowId =>
+              val response  = validateWorkflowId(possibleWorkflowId, serviceRegistryActor).flatMap(w => serviceRegistryActor.ask(GetStatus(w)).mapTo[MetadataServiceResponse])
+              // WES can also return a 401 or a 403 but that requires user auth knowledge which Cromwell doesn't currently have
+              onComplete(response) {
+                case Success(s: StatusLookupResponse) =>
+                  val wesState = WesState.fromCromwellStatus(s.status)
+                  complete(WesRunStatus(s.workflowId.toString, wesState))
+                case Success(r: StatusLookupFailed) => r.reason.errorRequest(StatusCodes.InternalServerError)
+                case Success(m: MetadataServiceResponse) =>
+                  // This should never happen, but ....
+                  val error = new IllegalStateException("Unexpected response from Metadata service: " + m)
+                  error.errorRequest(StatusCodes.InternalServerError)
+                case Failure(_: UnrecognizedWorkflowException) => complete(NotFoundError)
+                case Failure(e) => complete(WesErrorResponse(e.getMessage, StatusCodes.InternalServerError.intValue))
+              }
+            },
+            path(Segment / "cancel") { possibleWorkflowId =>
+              CromwellApiService.abortWorkflow(possibleWorkflowId,
+                workflowStoreActor,
+                workflowManagerActor,
+                successHandler = WesAbortSuccessHandler,
+                errorHandler = WesAbortErrorHandler)
+            }
+          )
+        }
+      )
+    }
+}
+
+object WesRouteSupport {
+  val NotFoundError = WesErrorResponse("The requested workflow run wasn't found", StatusCodes.NotFound.intValue)
+
+  def WesAbortSuccessHandler(workflowId: WorkflowId): Route = {
+    complete(WesRunId(workflowId.toString))
+  }
+
+  def WesAbortErrorHandler: PartialFunction[Throwable, Route] = {
+    // There are also some auth situations which should be handled, but at the moment Cromwell doesn't allow for those
+    case e: IllegalStateException => respondWithWesError(e.getLocalizedMessage, StatusCodes.Forbidden)
+    case e: WorkflowNotFoundException => respondWithWesError(e.getLocalizedMessage, StatusCodes.NotFound)
+    case _: AskTimeoutException if CromwellShutdown.shutdownInProgress() => respondWithWesError("Cromwell service is shutting down", StatusCodes.InternalServerError)
+    case e: Exception => respondWithWesError(e.getLocalizedMessage, StatusCodes.InternalServerError)
+  }
+
+  private def respondWithWesError(errorMsg: String, status: StatusCode): Route = {
+    complete((status, WesErrorResponse(errorMsg, status.intValue)))
+  }
+}

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -29,6 +29,13 @@ trait WesRouteSupport extends HttpInstrumentation {
   implicit val timeout: Timeout
 
   /*
+    Defines routes intended to sit alongside the primary Cromwell REST endpoints. For instance, we'll now have:
+    GET /api/workflows/v1/ID/status
+    GET /ga4gh/wes/v1/runs/ID
+
+    POST /api/workflows/v1/ID/abort
+    POST /ga4gh/wes/v1/runs/ID/cancel
+
     These routes are not currently going through the MetadataBuilderRegulator/MetadataBuilder. This is for two reasons:
       - It'd require a fairly substantial refactor of the MetadataBuilderActor to be more general
       - It's expected that for now the usage of these endpoints will not be extensive, so the protections of the regulator
@@ -56,11 +63,13 @@ trait WesRouteSupport extends HttpInstrumentation {
               }
             },
             path(Segment / "cancel") { possibleWorkflowId =>
-              CromwellApiService.abortWorkflow(possibleWorkflowId,
-                workflowStoreActor,
-                workflowManagerActor,
-                successHandler = WesAbortSuccessHandler,
-                errorHandler = WesAbortErrorHandler)
+              post {
+                  CromwellApiService.abortWorkflow(possibleWorkflowId,
+                    workflowStoreActor,
+                    workflowManagerActor,
+                    successHandler = WesAbortSuccessHandler,
+                    errorHandler = WesAbortErrorHandler)
+              }
             }
           )
         }

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
@@ -1,0 +1,54 @@
+package cromwell.webservice.routes.wes
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import cromwell.core._
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
+
+object WesState {
+  sealed trait WesState extends Product with Serializable
+  case object UNKNOWN extends WesState
+  case object QUEUED extends WesState
+  case object INITIALIZING extends WesState
+  case object RUNNING extends WesState
+  case object PAUSED extends WesState
+  case object COMPLETE extends WesState
+  case object EXECUTOR_ERROR extends WesState
+  case object SYSTEM_ERROR extends WesState
+  case object CANCELED extends WesState
+  case object CANCELING extends WesState // Before any shorebirds worry about the spelling, it really is CANCELING
+
+  def fromCromwellStatus(cromwellStatus: WorkflowState): WesState = {
+    cromwellStatus match {
+      case WorkflowOnHold => PAUSED
+      case WorkflowSubmitted => QUEUED
+      case WorkflowRunning => RUNNING
+      case WorkflowAborting => CANCELING
+      case WorkflowAborted => CANCELED
+      case WorkflowSucceeded => COMPLETE
+      case WorkflowFailed => EXECUTOR_ERROR
+      case _ => UNKNOWN
+    }
+  }
+}
+
+object WesStateJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  import WesState._
+
+  implicit object WesStateFormat extends RootJsonFormat[WesState] {
+    def write(obj: WesState): JsValue = JsString(obj.toString)
+
+    def read(json: JsValue): WesState = json match {
+      case JsString(string) if string == "UNKNOWN" => UNKNOWN
+      case JsString(string) if string == "QUEUED" => QUEUED
+      case JsString(string) if string == "INITIALIZING" => INITIALIZING
+      case JsString(string) if string == "RUNNING" => RUNNING
+      case JsString(string) if string == "PAUSED" => PAUSED
+      case JsString(string) if string == "COMPLETE" => COMPLETE
+      case JsString(string) if string == "EXECUTOR_ERROR" => EXECUTOR_ERROR
+      case JsString(string) if string == "SYSTEM_ERROR" => SYSTEM_ERROR
+      case JsString(string) if string == "CANCELED" => CANCELED
+      case JsString(string) if string == "CANCELING" => CANCELING
+      case other => throw new UnsupportedOperationException(s"Cannot deserialize $other into a WesState")
+    }
+  }
+}

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
@@ -5,28 +5,44 @@ import cromwell.core._
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
 
 object WesState {
-  sealed trait WesState extends Product with Serializable
-  case object UNKNOWN extends WesState
-  case object QUEUED extends WesState
-  case object INITIALIZING extends WesState
-  case object RUNNING extends WesState
-  case object PAUSED extends WesState
-  case object COMPLETE extends WesState
-  case object EXECUTOR_ERROR extends WesState
-  case object SYSTEM_ERROR extends WesState
-  case object CANCELED extends WesState
-  case object CANCELING extends WesState // Before any shorebirds worry about the spelling, it really is CANCELING
+  sealed trait WesState extends Product with Serializable { val name: String }
+  case object Unknown extends WesState { override val name = "UNKNOWN"}
+  case object Queued extends WesState { override val name = "QUEUED"}
+  case object Initializing extends WesState { override val name = "INITIALIZING"}
+  case object Running extends WesState { override val name = "RUNNING"}
+  case object Paused extends WesState { override val name = "PAUSED"}
+  case object Complete extends WesState { override val name = "COMPLETE"}
+  case object ExecutorError extends WesState { override val name = "EXECUTOR_ERROR"}
+  case object SystemError extends WesState { override val name = "SYSTEM_ERROR"}
+  case object Canceled extends WesState { override val name = "CANCELED"}
+  case object Canceling extends WesState { override val name = "CANCELING"}
 
   def fromCromwellStatus(cromwellStatus: WorkflowState): WesState = {
     cromwellStatus match {
-      case WorkflowOnHold => PAUSED
-      case WorkflowSubmitted => QUEUED
-      case WorkflowRunning => RUNNING
-      case WorkflowAborting => CANCELING
-      case WorkflowAborted => CANCELED
-      case WorkflowSucceeded => COMPLETE
-      case WorkflowFailed => EXECUTOR_ERROR
-      case _ => UNKNOWN
+      case WorkflowOnHold => Paused
+      case WorkflowSubmitted => Queued
+      case WorkflowRunning => Running
+      case WorkflowAborting => Canceling
+      case WorkflowAborted => Canceled
+      case WorkflowSucceeded => Complete
+      case WorkflowFailed => ExecutorError
+      case _ => Unknown
+    }
+  }
+
+  def fromString(status: String): WesState = {
+    status match {
+      case Unknown.name => Unknown
+      case Queued.name => Queued
+      case Initializing.name => Initializing
+      case Running.name => Running
+      case Paused.name => Paused
+      case Complete.name => Complete
+      case ExecutorError.name => ExecutorError
+      case SystemError.name => SystemError
+      case Canceled.name => Canceled
+      case Canceling.name => Canceling
+      case doh => throw new IllegalArgumentException(s"Invalid status attempting to be coerced to WesState: $doh")
     }
   }
 }
@@ -35,19 +51,11 @@ object WesStateJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   import WesState._
 
   implicit object WesStateFormat extends RootJsonFormat[WesState] {
-    def write(obj: WesState): JsValue = JsString(obj.toString)
+    def write(obj: WesState): JsValue = JsString(obj.name)
 
-    def read(json: JsValue): WesState = json match {
-      case JsString(string) if string == "UNKNOWN" => UNKNOWN
-      case JsString(string) if string == "QUEUED" => QUEUED
-      case JsString(string) if string == "INITIALIZING" => INITIALIZING
-      case JsString(string) if string == "RUNNING" => RUNNING
-      case JsString(string) if string == "PAUSED" => PAUSED
-      case JsString(string) if string == "COMPLETE" => COMPLETE
-      case JsString(string) if string == "EXECUTOR_ERROR" => EXECUTOR_ERROR
-      case JsString(string) if string == "SYSTEM_ERROR" => SYSTEM_ERROR
-      case JsString(string) if string == "CANCELED" => CANCELED
-      case JsString(string) if string == "CANCELING" => CANCELING
+    def read(json: JsValue): WesState =
+      json match {
+      case JsString(string) => WesState.fromString(string)
       case other => throw new UnsupportedOperationException(s"Cannot deserialize $other into a WesState")
     }
   }

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -465,7 +465,12 @@ object CromwellApiServiceSpec {
   val ExistingWorkflowId = WorkflowId.fromString("c4c6339c-8cc9-47fb-acc5-b5cb8d2809f5")
   val AbortedWorkflowId = WorkflowId.fromString("0574111c-c7d3-4145-8190-7a7ed8e8324a")
   val UnrecognizedWorkflowId = WorkflowId.fromString("2bdd06cc-e794-46c8-a897-4c86cedb6a06")
-  val RecognizedWorkflowIds = Set(ExistingWorkflowId)
+  val OnHoldWorkflowId = WorkflowId.fromString("fe6dbaf6-e15c-4438-813c-479b35867142")
+  val RunningWorkflowId = WorkflowId.fromString("dcfea0ab-9a3e-4bc0-ab82-794a37c4d484")
+  val AbortingWorkflowId = WorkflowId.fromString("2e3503f5-24f5-4a01-a4d1-bb1088bb5c1e")
+  val SucceededWorkflowId = WorkflowId.fromString("0cb43b8c-0259-4a19-b7fe-921ced326738")
+  val FailedWorkflowId = WorkflowId.fromString("df501790-cef5-4df7-9b48-8760533e3136")
+  val RecognizedWorkflowIds = Set(ExistingWorkflowId, AbortedWorkflowId, OnHoldWorkflowId, RunningWorkflowId, AbortingWorkflowId, SucceededWorkflowId, FailedWorkflowId)
 
   class MockApiService()(implicit val system: ActorSystem) extends CromwellApiService {
     override def actorRefFactory = system
@@ -521,6 +526,12 @@ object CromwellApiServiceSpec {
           ok = true,
           systems = Map(
             "Engine Database" -> SubsystemStatus(ok = true, messages = None)))
+      case GetStatus(id) if id == OnHoldWorkflowId => sender ! StatusLookupResponse(id, WorkflowOnHold)
+      case GetStatus(id) if id == RunningWorkflowId => sender ! StatusLookupResponse(id, WorkflowRunning)
+      case GetStatus(id) if id == AbortingWorkflowId => sender ! StatusLookupResponse(id, WorkflowAborting)
+      case GetStatus(id) if id == AbortedWorkflowId => sender ! StatusLookupResponse(id, WorkflowAborted)
+      case GetStatus(id) if id == SucceededWorkflowId => sender ! StatusLookupResponse(id, WorkflowSucceeded)
+      case GetStatus(id) if id == FailedWorkflowId => sender ! StatusLookupResponse(id, WorkflowFailed)
       case GetStatus(id) => sender ! StatusLookupResponse(id, WorkflowSubmitted)
       case GetLabels(id) => sender ! LabelLookupResponse(id, Map("key1" -> "label1", "key2" -> "label2"))
       case WorkflowOutputs(id) =>

--- a/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
@@ -1,0 +1,129 @@
+package cromwell.webservice.routes.wes
+
+import akka.actor.Props
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cromwell.webservice.routes.CromwellApiServiceSpec
+
+import scala.concurrent.duration._
+import cromwell.webservice.routes.CromwellApiServiceSpec.{MockServiceRegistryActor, MockWorkflowManagerActor, MockWorkflowStoreActor}
+import org.scalatest.{AsyncFlatSpec, Matchers}
+import WesResponseJsonSupport._
+
+class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Matchers with WesRouteSupport {
+  val actorRefFactory = system
+  override implicit val ec = system.dispatcher
+  override implicit val timeout = 5.seconds
+
+  override val workflowStoreActor = actorRefFactory.actorOf(Props(new MockWorkflowStoreActor()))
+  override val serviceRegistryActor = actorRefFactory.actorOf(Props(new MockServiceRegistryActor()))
+  override val workflowManagerActor = actorRefFactory.actorOf(Props(new MockWorkflowManagerActor()))
+
+  val version = "v1"
+
+  behavior of "WES API /status endpoint"
+  it should "return PAUSED when on hold" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.OnHoldWorkflowId}/status") ~>
+      wesRoutes ~>
+        check {
+          responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.OnHoldWorkflowId.toString, WesState.PAUSED)
+        }
+  }
+
+  it should "return QUEUED when submitted" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.ExistingWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.ExistingWorkflowId.toString, WesState.QUEUED)
+      }
+  }
+
+  it should "return RUNNING when running" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.RunningWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.RunningWorkflowId.toString, WesState.RUNNING)
+      }
+  }
+
+  it should "return CANCELING when aborting" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.AbortingWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortingWorkflowId.toString, WesState.CANCELING)
+      }
+  }
+
+  it should "return CANCELED when on hold" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.AbortedWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortedWorkflowId.toString, WesState.CANCELED)
+      }
+  }
+
+  it should "return COMPLETE when successful" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.SucceededWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.SucceededWorkflowId.toString, WesState.COMPLETE)
+      }
+  }
+
+  it should "return EXECUTOR_ERROR when a workflow fails" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.FailedWorkflowId}/status") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.FailedWorkflowId.toString, WesState.EXECUTOR_ERROR)
+      }
+  }
+
+  behavior of "WES API /cancel endpoint"
+  it should "return 404 for abort of unknown workflow" in {
+    val workflowId = CromwellApiServiceSpec.UnrecognizedWorkflowId
+
+    Post(s"/ga4gh/wes/$version/runs/$workflowId/cancel") ~>
+      wesRoutes ~>
+      check {
+        assertResult(StatusCodes.NotFound) {
+          status
+        }
+      }
+  }
+
+  it should "return 400 for abort of a malformed workflow id" in {
+    Post(s"/ga4gh/wes/$version/runs/foobar/cancel") ~>
+      wesRoutes ~>
+      check {
+        assertResult(StatusCodes.InternalServerError) {
+          status
+        }
+
+        responseAs[WesErrorResponse] shouldEqual WesErrorResponse("Invalid workflow ID: 'foobar'.", StatusCodes.InternalServerError.intValue)
+      }
+  }
+
+  it should "return 403 for abort of a workflow in a terminal state" in {
+    Post(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.AbortedWorkflowId}/cancel") ~>
+      wesRoutes ~>
+      check {
+        assertResult(StatusCodes.Forbidden) {
+          status
+        }
+
+        responseAs[WesErrorResponse] shouldEqual WesErrorResponse(s"Workflow ID '${CromwellApiServiceSpec.AbortedWorkflowId}' is in terminal state 'Aborted' and cannot be aborted.", StatusCodes.Forbidden.intValue)
+      }
+  }
+
+  it should "return 200 for abort of a known workflow id" in {
+    Post(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.ExistingWorkflowId}/cancel") ~>
+      wesRoutes ~>
+      check {
+        responseAs[WesRunId] shouldEqual WesRunId(CromwellApiServiceSpec.ExistingWorkflowId.toString)
+
+        assertResult(StatusCodes.OK) {
+          status
+        }
+      }
+  }
+}

--- a/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
@@ -2,6 +2,7 @@ package cromwell.webservice.routes.wes
 
 import akka.actor.Props
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromwell.webservice.routes.CromwellApiServiceSpec
 
@@ -9,6 +10,7 @@ import scala.concurrent.duration._
 import cromwell.webservice.routes.CromwellApiServiceSpec.{MockServiceRegistryActor, MockWorkflowManagerActor, MockWorkflowStoreActor}
 import org.scalatest.{AsyncFlatSpec, Matchers}
 import WesResponseJsonSupport._
+import akka.http.scaladsl.server.MethodRejection
 
 class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Matchers with WesRouteSupport {
   val actorRefFactory = system
@@ -124,6 +126,14 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
         assertResult(StatusCodes.OK) {
           status
         }
+      }
+  }
+
+  it should "fail if you submit via GET" in {
+    Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.ExistingWorkflowId}/cancel") ~>
+      wesRoutes ~>
+      check {
+        rejection shouldEqual MethodRejection(POST)
       }
   }
 }

--- a/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/wes/WesRouteSupportSpec.scala
@@ -28,7 +28,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.OnHoldWorkflowId}/status") ~>
       wesRoutes ~>
         check {
-          responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.OnHoldWorkflowId.toString, WesState.PAUSED)
+          responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.OnHoldWorkflowId.toString, WesState.Paused)
         }
   }
 
@@ -36,7 +36,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.ExistingWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.ExistingWorkflowId.toString, WesState.QUEUED)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.ExistingWorkflowId.toString, WesState.Queued)
       }
   }
 
@@ -44,7 +44,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.RunningWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.RunningWorkflowId.toString, WesState.RUNNING)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.RunningWorkflowId.toString, WesState.Running)
       }
   }
 
@@ -52,7 +52,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.AbortingWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortingWorkflowId.toString, WesState.CANCELING)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortingWorkflowId.toString, WesState.Canceling)
       }
   }
 
@@ -60,7 +60,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.AbortedWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortedWorkflowId.toString, WesState.CANCELED)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.AbortedWorkflowId.toString, WesState.Canceled)
       }
   }
 
@@ -68,7 +68,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.SucceededWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.SucceededWorkflowId.toString, WesState.COMPLETE)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.SucceededWorkflowId.toString, WesState.Complete)
       }
   }
 
@@ -76,7 +76,7 @@ class WesRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest with Mat
     Get(s"/ga4gh/wes/$version/runs/${CromwellApiServiceSpec.FailedWorkflowId}/status") ~>
       wesRoutes ~>
       check {
-        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.FailedWorkflowId.toString, WesState.EXECUTOR_ERROR)
+        responseAs[WesRunStatus] shouldEqual WesRunStatus(CromwellApiServiceSpec.FailedWorkflowId.toString, WesState.ExecutorError)
       }
   }
 


### PR DESCRIPTION
A partial implementation of the WES 1.0 standard directly embedded in the Cromwell server (modulo auth, but that's another story altogether).

Why partial? Because I wanted to keep PR sizes down and didn't want to be rebasing every 3 days. Also this lays the basic infrastructure, so might as well get commentary on that. It's not hurting anything to have a partial implementation.

Why status & abort? Because they were the easiest to do.