### PR TITLE
Handle multiline HPC submission stdout with job-id-regex

### DIFF
--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActorSpec.scala
@@ -1,0 +1,24 @@
+package cromwell.backend.impl.sfs.config
+
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class ConfigAsyncJobExecutionActorSpec extends FlatSpec with Matchers {
+
+  behavior of "getJobRegex"
+
+  val successfulTestCases = Map(
+    ("Job <03957>... blah blah blah", "Job <(\\d+)>.*") -> "03957",
+
+    ("""mxq_group_id=...
+      |mxq_group_name=...
+      |mxq_job_id=16988030
+      |""".stripMargin, "mxq_job_id=(\\d+)") -> "16988030"
+  )
+
+  successfulTestCases foreach { case ((fileContent, jobIdRegex), expectedJobId) =>
+    it should s"find the right job ID $expectedJobId using the regex $jobIdRegex" in {
+      DispatchedConfigAsyncJobExecutionActor.getJob(fileContent, null, jobIdRegex).jobId should be(expectedJobId)
+    }
+  }
+}


### PR DESCRIPTION
Closes #4436 which was made for [this forum post](https://gatkforums.broadinstitute.org/wdl/discussion/13716/could-not-find-job-id-from-stdout-file-cromwell-with-an-unusual-backend#latest).

A majority of this PR is just me shuffling content around in ConfigAsyncJobExecutionActor.scala to allow me to test the `getJob` function easily.