### PR TITLE
Only assemble required subprojects for CWL conformance builds

### DIFF
--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -525,7 +525,9 @@ cromwell::private::exists_cromwell_jar() {
 }
 
 cromwell::private::assemble_jars() {
-    CROMWELL_SBT_ASSEMBLY_LOG_LEVEL=error sbt coverage assembly -error
+    # CROMWELL_SBT_ASSEMBLY_COMMAND allows for an override of the default `assembly` command for assembly.
+    # This can be useful to reduce time and memory that might otherwise be spent assembling unused subprojects.
+    CROMWELL_SBT_ASSEMBLY_LOG_LEVEL=error sbt coverage ${CROMWELL_SBT_ASSEMBLY_COMMAND:-assembly} -error
 }
 
 cromwell::private::generate_code_coverage() {

--- a/src/ci/bin/testConformanceLocal.sh
+++ b/src/ci/bin/testConformanceLocal.sh
@@ -9,6 +9,9 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_conformance_environment
 
+# Override of the default sbt assembly command which is just `assembly`.
+# The conformance runs only need these two subprojects so save a couple of minutes and skip the rest.
+CROMWELL_SBT_ASSEMBLY_COMMAND="server/assembly centaurCwlRunner/assembly"
 cromwell::build::assemble_jars
 
 CENTAUR_CWL_RUNNER_MODE="local"

--- a/src/ci/bin/testConformancePapiV2.sh
+++ b/src/ci/bin/testConformancePapiV2.sh
@@ -10,6 +10,9 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_conformance_environment
 
+# Override of the default sbt assembly command which is just `assembly`.
+# The conformance runs only need these two subprojects so save a couple of minutes and skip the rest.
+CROMWELL_SBT_ASSEMBLY_COMMAND="server/assembly centaurCwlRunner/assembly"
 cromwell::build::assemble_jars
 
 CENTAUR_CWL_RUNNER_MODE="papi"


### PR DESCRIPTION
May help to unexplode conformance CI, at the very least it should run faster.