### PR TITLE
Update prealign to latest version

### DIFF
--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/main-prealign.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/main-prealign.cwl
@@ -22,8 +22,7 @@ inputs:
 - id: config__algorithm__vcfanno
   type:
     items:
-    - 'null'
-    - items: 'null'
+      items: File
       type: array
     type: array
 - id: resources
@@ -53,12 +52,6 @@ inputs:
   type:
     items: File
     type: array
-- id: genome_resources__variation__train_hapmap
-  secondaryFiles:
-  - .tbi
-  type:
-    items: File
-    type: array
 - id: genome_resources__variation__clinvar
   secondaryFiles:
   - .tbi
@@ -85,11 +78,15 @@ inputs:
     type: array
 - id: config__algorithm__min_allele_fraction
   type:
-    items: long
+    items: double
     type: array
 - id: config__algorithm__nomap_split_targets
   type:
     items: long
+    type: array
+- id: reference__versions
+  type:
+    items: File
     type: array
 - id: vrn_file
   secondaryFiles:
@@ -97,7 +94,9 @@ inputs:
   type:
     items: File
     type: array
-- id: reference__twobit
+- id: genome_resources__variation__train_hapmap
+  secondaryFiles:
+  - .tbi
   type:
     items: File
     type: array
@@ -138,6 +137,12 @@ inputs:
     items: string
     type: array
 - id: genome_resources__variation__exac
+  secondaryFiles:
+  - .tbi
+  type:
+    items: File
+    type: array
+- id: genome_resources__variation__gnomad_exome
   secondaryFiles:
   - .tbi
   type:
@@ -304,6 +309,20 @@ outputs:
     - File
     - 'null'
     type: array
+- id: versions__tools
+  outputSource: multiqc_summary/versions__tools
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__data
+  outputSource: multiqc_summary/versions__data
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
 requirements:
 - class: EnvVarRequirement
   envDef:
@@ -401,8 +420,6 @@ steps:
     source: genome_resources__variation__polyx
   - id: genome_resources__variation__encode_blacklist
     source: genome_resources__variation__encode_blacklist
-  - id: reference__twobit
-    source: reference__twobit
   - id: reference__fasta__base
     source: reference__fasta__base
   - id: resources
@@ -511,8 +528,6 @@ steps:
     source: config__algorithm__tools_off
   - id: reference__fasta__base
     source: reference__fasta__base
-  - id: reference__twobit
-    source: reference__twobit
   - id: reference__rtg
     source: reference__rtg
   - id: reference__genome_context
@@ -527,6 +542,8 @@ steps:
     source: genome_resources__variation__esp
   - id: genome_resources__variation__exac
     source: genome_resources__variation__exac
+  - id: genome_resources__variation__gnomad_exome
+    source: genome_resources__variation__gnomad_exome
   - id: genome_resources__variation__1000g
     source: genome_resources__variation__1000g
   - id: genome_resources__variation__lcr
@@ -583,6 +600,8 @@ steps:
     source: analysis
   - id: reference__fasta__base
     source: reference__fasta__base
+  - id: reference__versions
+    source: reference__versions
   - id: config__algorithm__tools_on
     source: config__algorithm__tools_on
   - id: config__algorithm__tools_off
@@ -593,6 +612,8 @@ steps:
     source: config__algorithm__qc
   - id: metadata__batch
     source: metadata__batch
+  - id: metadata__phenotype
+    source: metadata__phenotype
   - id: config__algorithm__coverage_interval
     source: postprocess_alignment/config__algorithm__coverage_interval
   - id: depth__variant_regions__regions
@@ -646,4 +667,6 @@ steps:
     source: pipeline_summary/qcout_rec
   out:
   - id: summary__multiqc
+  - id: versions__tools
+  - id: versions__data
   run: steps/multiqc_summary.cwl

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/batch_for_variantcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/batch_for_variantcall.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-batch
-- sentinel_outputs=batch_rec:resources;description;reference__fasta__base;metadata__phenotype;config__algorithm__vcfanno;config__algorithm__variantcaller;genome_resources__variation__1000g;config__algorithm__coverage_interval;genome_resources__variation__train_hapmap;genome_resources__variation__clinvar;genome_resources__variation__esp;metadata__batch;genome_resources__variation__lcr;config__algorithm__min_allele_fraction;vrn_file;reference__twobit;reference__genome_context;config__algorithm__validate;reference__snpeff__hg19;config__algorithm__validate_regions;genome_build;genome_resources__variation__exac;genome_resources__aliases__human;config__algorithm__tools_off;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;genome_resources__variation__cosmic;config__algorithm__ensemble;analysis;config__algorithm__tools_on;config__algorithm__effects;config__algorithm__variant_regions;genome_resources__aliases__ensembl;config__algorithm__exclude_regions;reference__rtg;genome_resources__variation__train_indels;genome_resources__aliases__snpeff;align_bam;config__algorithm__variant_regions_merged;regions__sample_callable;config__algorithm__callable_regions
-- sentinel_inputs=analysis:var,genome_build:var,align_bam:var,vrn_file:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__callable_regions:var,regions__sample_callable:var,config__algorithm__variantcaller:var,config__algorithm__ensemble:var,config__algorithm__vcfanno:var,config__algorithm__coverage_interval:var,config__algorithm__effects:var,config__algorithm__min_allele_fraction:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__validate:var,config__algorithm__validate_regions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,reference__fasta__base:var,reference__twobit:var,reference__rtg:var,reference__genome_context:var,genome_resources__variation__clinvar:var,genome_resources__variation__cosmic:var,genome_resources__variation__dbsnp:var,genome_resources__variation__esp:var,genome_resources__variation__exac:var,genome_resources__variation__1000g:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,genome_resources__aliases__ensembl:var,genome_resources__aliases__human:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,genome_resources__variation__train_hapmap:var,genome_resources__variation__train_indels:var,resources:var,description:var
+- sentinel_outputs=batch_rec:resources;description;reference__fasta__base;metadata__phenotype;config__algorithm__vcfanno;config__algorithm__variantcaller;genome_resources__variation__1000g;config__algorithm__coverage_interval;genome_resources__variation__clinvar;genome_resources__variation__esp;metadata__batch;genome_resources__variation__lcr;config__algorithm__min_allele_fraction;vrn_file;genome_resources__variation__train_hapmap;reference__genome_context;config__algorithm__validate;reference__snpeff__hg19;config__algorithm__validate_regions;genome_build;genome_resources__variation__exac;genome_resources__variation__gnomad_exome;genome_resources__aliases__human;config__algorithm__tools_off;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;genome_resources__variation__cosmic;config__algorithm__ensemble;analysis;config__algorithm__tools_on;config__algorithm__effects;config__algorithm__variant_regions;genome_resources__aliases__ensembl;config__algorithm__exclude_regions;reference__rtg;genome_resources__variation__train_indels;genome_resources__aliases__snpeff;align_bam;config__algorithm__variant_regions_merged;regions__sample_callable;config__algorithm__callable_regions
+- sentinel_inputs=analysis:var,genome_build:var,align_bam:var,vrn_file:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__callable_regions:var,regions__sample_callable:var,config__algorithm__variantcaller:var,config__algorithm__ensemble:var,config__algorithm__vcfanno:var,config__algorithm__coverage_interval:var,config__algorithm__effects:var,config__algorithm__min_allele_fraction:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__validate:var,config__algorithm__validate_regions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,reference__fasta__base:var,reference__rtg:var,reference__genome_context:var,genome_resources__variation__clinvar:var,genome_resources__variation__cosmic:var,genome_resources__variation__dbsnp:var,genome_resources__variation__esp:var,genome_resources__variation__exac:var,genome_resources__variation__gnomad_exome:var,genome_resources__variation__1000g:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,genome_resources__aliases__ensembl:var,genome_resources__aliases__human:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,genome_resources__variation__train_hapmap:var,genome_resources__variation__train_indels:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -84,8 +84,7 @@ inputs:
 - id: config__algorithm__vcfanno
   type:
     items:
-    - 'null'
-    - items: 'null'
+      items: File
       type: array
     type: array
 - id: config__algorithm__coverage_interval
@@ -100,7 +99,7 @@ inputs:
     type: array
 - id: config__algorithm__min_allele_fraction
   type:
-    items: long
+    items: double
     type: array
 - id: config__algorithm__exclude_regions
   type:
@@ -153,10 +152,6 @@ inputs:
   type:
     items: File
     type: array
-- id: reference__twobit
-  type:
-    items: File
-    type: array
 - id: reference__rtg
   type:
     items: File
@@ -194,6 +189,12 @@ inputs:
     items: File
     type: array
 - id: genome_resources__variation__exac
+  secondaryFiles:
+  - .tbi
+  type:
+    items: File
+    type: array
+- id: genome_resources__variation__gnomad_exome
   secondaryFiles:
   - .tbi
   type:
@@ -278,8 +279,7 @@ outputs:
           type: string
         - name: config__algorithm__vcfanno
           type:
-          - 'null'
-          - items: 'null'
+            items: File
             type: array
         - name: config__algorithm__variantcaller
           type:
@@ -292,8 +292,6 @@ outputs:
           type:
           - string
           - 'null'
-        - name: genome_resources__variation__train_hapmap
-          type: File
         - name: genome_resources__variation__clinvar
           type: File
         - name: genome_resources__variation__esp
@@ -307,10 +305,10 @@ outputs:
           - 'null'
           - string
         - name: config__algorithm__min_allele_fraction
-          type: long
+          type: double
         - name: vrn_file
           type: File
-        - name: reference__twobit
+        - name: genome_resources__variation__train_hapmap
           type: File
         - name: reference__genome_context
           type:
@@ -329,6 +327,8 @@ outputs:
         - name: genome_build
           type: string
         - name: genome_resources__variation__exac
+          type: File
+        - name: genome_resources__variation__gnomad_exome
           type: File
         - name: genome_resources__aliases__human
           type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/combine_sample_regions.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/combine_sample_regions.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/compare_to_rm.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/compare_to_rm.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1028
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -63,8 +63,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -77,8 +76,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -92,10 +89,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -114,6 +111,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:
@@ -225,8 +224,7 @@ outputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -242,7 +240,7 @@ outputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: reference__genome_context
         type:
           items: File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/concat_batch_variantcalls.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/concat_batch_variantcalls.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -53,8 +53,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -67,8 +66,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -82,10 +79,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -104,6 +101,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/get_parallel_regions.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/get_parallel_regions.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -40,8 +40,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -54,8 +53,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -69,10 +66,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -91,6 +88,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/multiqc_summary.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/multiqc_summary.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=summary__multiqc
+- sentinel_outputs=summary__multiqc,versions__tools,versions__data
 - sentinel_inputs=qcout_rec:record
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -48,6 +48,8 @@ inputs:
         - 'null'
       - name: description
         type: string
+      - name: reference__versions
+        type: File
       - name: genome_build
         type: string
       - name: config__algorithm__tools_off
@@ -68,6 +70,18 @@ inputs:
     type: array
 outputs:
 - id: summary__multiqc
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__tools
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__data
   type:
     items:
     - File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/organize_noalign.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/organize_noalign.cwl
@@ -21,10 +21,10 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1024
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 0
 - class: dx:InputResourceRequirement
-  indirMin: 0
+  indirMin: 4
 inputs:
 - id: files
   type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/pipeline_summary.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/pipeline_summary.cwl
@@ -5,7 +5,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-parallel
-- sentinel_outputs=qcout_rec:summary__qc;summary__metrics;description;genome_build;config__algorithm__tools_off;config__algorithm__qc;config__algorithm__tools_on
+- sentinel_outputs=qcout_rec:summary__qc;summary__metrics;description;reference__versions;genome_build;config__algorithm__tools_off;config__algorithm__qc;config__algorithm__tools_on
 - sentinel_inputs=qc_rec:record
 - run_number=0
 baseCommand:
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -34,9 +34,9 @@ hints:
   - package: bedtools
     specs:
     - https://anaconda.org/bioconda/bedtools
-  - package: fastqc=0.11.7=4
+  - package: fastqc=0.11.7=5
     specs:
-    - https://anaconda.org/bioconda/fastqc=0.11.7=4
+    - https://anaconda.org/bioconda/fastqc=0.11.7=5
   - package: goleft
     specs:
     - https://anaconda.org/bioconda/goleft
@@ -85,6 +85,8 @@ inputs:
       type: string
     - name: reference__fasta__base
       type: File
+    - name: metadata__phenotype
+      type: string
     - name: config__algorithm__coverage_interval
       type:
       - string
@@ -93,6 +95,8 @@ inputs:
       type:
       - 'null'
       - string
+    - name: reference__versions
+      type: File
     - name: genome_build
       type: string
     - name: config__algorithm__coverage
@@ -190,6 +194,8 @@ outputs:
       - 'null'
     - name: description
       type: string
+    - name: reference__versions
+      type: File
     - name: genome_build
       type: string
     - name: config__algorithm__tools_off

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_alignment.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_alignment.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1033
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 5
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -70,8 +70,6 @@ inputs:
       type:
       - 'null'
       - string
-    - name: reference__twobit
-      type: File
     - name: config__algorithm__recalibrate
       type:
       - string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_alignment_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_alignment_to_rec.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=postprocess_alignment_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;genome_resources__variation__lcr;reference__twobit;config__algorithm__recalibrate;config__algorithm__coverage;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__tools_on;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__variant_regions_orig;config__algorithm__coverage_merged;config__algorithm__coverage_orig;config__algorithm__seq2c_bed_ready
-- sentinel_inputs=align_bam:var,config__algorithm__coverage_interval:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__variant_regions_orig:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,config__algorithm__coverage_orig:var,config__algorithm__seq2c_bed_ready:var,config__algorithm__recalibrate:var,config__algorithm__tools_on:var,genome_resources__rnaseq__gene_bed:var,genome_resources__variation__dbsnp:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,reference__twobit:var,reference__fasta__base:var,resources:var,description:var
+- sentinel_outputs=postprocess_alignment_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;genome_resources__variation__lcr;config__algorithm__recalibrate;config__algorithm__coverage;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__tools_on;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__variant_regions_orig;config__algorithm__coverage_merged;config__algorithm__coverage_orig;config__algorithm__seq2c_bed_ready
+- sentinel_inputs=align_bam:var,config__algorithm__coverage_interval:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__variant_regions_orig:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,config__algorithm__coverage_orig:var,config__algorithm__seq2c_bed_ready:var,config__algorithm__recalibrate:var,config__algorithm__tools_on:var,genome_resources__rnaseq__gene_bed:var,genome_resources__variation__dbsnp:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,reference__fasta__base:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -128,10 +128,6 @@ inputs:
     - 'null'
     - string
     type: array
-- id: reference__twobit
-  type:
-    items: File
-    type: array
 - id: reference__fasta__base
   secondaryFiles:
   - .fai
@@ -168,8 +164,6 @@ outputs:
         type:
         - 'null'
         - string
-      - name: reference__twobit
-        type: File
       - name: config__algorithm__recalibrate
         type:
         - string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_variants.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/postprocess_variants.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1025
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -47,8 +47,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -61,8 +60,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -76,10 +73,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -98,6 +95,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/prep_samples.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/prep_samples.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/prep_samples_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/prep_samples_to_rec.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 0

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/qc_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/qc_to_rec.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=qc_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;metadata__batch;genome_build;config__algorithm__coverage;config__algorithm__tools_off;config__algorithm__qc;analysis;config__algorithm__tools_on;config__algorithm__variant_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__coverage_merged;depth__samtools__stats;depth__samtools__idxstats;depth__variant_regions__regions;depth__variant_regions__dist;depth__sv_regions__regions;depth__sv_regions__dist;depth__coverage__regions;depth__coverage__dist;depth__coverage__thresholds;variants__samples
-- sentinel_inputs=align_bam:var,analysis:var,reference__fasta__base:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,genome_build:var,config__algorithm__qc:var,metadata__batch:var,config__algorithm__coverage_interval:var,depth__variant_regions__regions:var,depth__variant_regions__dist:var,depth__samtools__stats:var,depth__samtools__idxstats:var,depth__sv_regions__regions:var,depth__sv_regions__dist:var,depth__coverage__regions:var,depth__coverage__dist:var,depth__coverage__thresholds:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,variants__samples:var,resources:var,description:var
+- sentinel_outputs=qc_rec:resources;description;reference__fasta__base;metadata__phenotype;config__algorithm__coverage_interval;metadata__batch;reference__versions;genome_build;config__algorithm__coverage;config__algorithm__tools_off;config__algorithm__qc;analysis;config__algorithm__tools_on;config__algorithm__variant_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__coverage_merged;depth__samtools__stats;depth__samtools__idxstats;depth__variant_regions__regions;depth__variant_regions__dist;depth__sv_regions__regions;depth__sv_regions__dist;depth__coverage__regions;depth__coverage__dist;depth__coverage__thresholds;variants__samples
+- sentinel_inputs=align_bam:var,analysis:var,reference__fasta__base:var,reference__versions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,genome_build:var,config__algorithm__qc:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__coverage_interval:var,depth__variant_regions__regions:var,depth__variant_regions__dist:var,depth__samtools__stats:var,depth__samtools__idxstats:var,depth__sv_regions__regions:var,depth__sv_regions__dist:var,depth__coverage__regions:var,depth__coverage__dist:var,depth__coverage__thresholds:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,variants__samples:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -42,6 +42,10 @@ inputs:
   secondaryFiles:
   - .fai
   - ^.dict
+  type:
+    items: File
+    type: array
+- id: reference__versions
   type:
     items: File
     type: array
@@ -73,6 +77,10 @@ inputs:
     items:
     - 'null'
     - string
+    type: array
+- id: metadata__phenotype
+  type:
+    items: string
     type: array
 - id: config__algorithm__coverage_interval
   type:
@@ -187,6 +195,8 @@ outputs:
         type: string
       - name: reference__fasta__base
         type: File
+      - name: metadata__phenotype
+        type: string
       - name: config__algorithm__coverage_interval
         type:
         - string
@@ -195,6 +205,8 @@ outputs:
         type:
         - 'null'
         - string
+      - name: reference__versions
+        type: File
       - name: genome_build
         type: string
       - name: config__algorithm__coverage

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/summarize_vc.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/summarize_vc.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -64,8 +64,7 @@ inputs:
           type: string
         - name: config__algorithm__vcfanno
           type:
-          - 'null'
-          - items: 'null'
+            items: File
             type: array
         - name: config__algorithm__variantcaller
           type:
@@ -81,7 +80,7 @@ inputs:
           - 'null'
           - string
         - name: config__algorithm__min_allele_fraction
-          type: long
+          type: double
         - name: reference__genome_context
           type:
             items: File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/variantcall_batch_region.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/steps/variantcall_batch_region.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -86,6 +86,9 @@ hints:
   - package: varscan
     specs:
     - https://anaconda.org/bioconda/varscan
+  - package: moreutils
+    specs:
+    - https://anaconda.org/bioconda/moreutils
   - package: vcfanno
     specs:
     - https://anaconda.org/bioconda/vcfanno
@@ -100,6 +103,9 @@ hints:
     - https://anaconda.org/bioconda/r
     version:
     - 3.4.1
+  - package: r-base=3.4.1=h4fe35fd_8
+    specs:
+    - https://anaconda.org/bioconda/r-base=3.4.1=h4fe35fd_8
   - package: perl
     specs:
     - https://anaconda.org/bioconda/perl
@@ -121,8 +127,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -135,8 +140,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -150,10 +153,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -172,6 +175,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/wf-variantcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/prealign-workflow/wf-variantcall.cwl
@@ -16,8 +16,7 @@ inputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -30,8 +29,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -45,10 +42,10 @@ inputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type: File
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -67,6 +64,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: genome_resources__aliases__human
         type:
@@ -175,8 +174,7 @@ outputs:
         type: string
       - name: config__algorithm__vcfanno
         type:
-        - 'null'
-        - items: 'null'
+          items: File
           type: array
       - name: config__algorithm__variantcaller
         type:
@@ -192,7 +190,7 @@ outputs:
         - 'null'
         - string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: reference__genome_context
         type:
           items: File


### PR DESCRIPTION
Update BCBIO prealign with the latest fix. Will fix the PAPIv2 CRON job.
At this point we should be able to run the workflows without modification. However there seems to be a bug preventing referencing the workflow by http directly, see https://github.com/broadinstitute/cromwell/issues/4235#issuecomment-445825939
If that worked we could point to it directly in the centaur test.
Otherwise we could modify the cron scripts to pull the git repos and submit using the local file.