### PR TITLE
Detect stalled workflows

### DIFF
--- a/core/src/main/scala/cromwell/core/ExecutionStatus.scala
+++ b/core/src/main/scala/cromwell/core/ExecutionStatus.scala
@@ -6,6 +6,7 @@ object ExecutionStatus extends Enumeration {
   val TerminalStatuses = Set(Failed, Done, Aborted, Bypassed, Unstartable)
   val TerminalOrRetryableStatuses = TerminalStatuses + RetryableFailure
   val NonTerminalStatuses = values.diff(TerminalOrRetryableStatuses)
+  val ActiveStatuses = Set(WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting)
 
   implicit val ExecutionStatusOrdering = Ordering.by { status: ExecutionStatus =>
     status match {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -127,4 +127,5 @@ case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescript
   }
 
   def done: Boolean = executionStore.isDone
+  def stalled: Boolean = executionStore.isStalled
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -216,6 +216,12 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     NonTerminalStatuses.map(keysWithStatus).forall(_.isEmpty)
   }
 
+  def isStalled: Boolean = {
+    !isDone && !needsUpdate && ActiveStatuses.map(keysWithStatus).forall(_.isEmpty)
+  }
+
+  def unstarted = keysWithStatus(NotStarted)
+
   def jobStatus(jobKey: JobKey): Option[ExecutionStatus] = statusStore.get(jobKey)
 
   def startedJobs: List[BackendJobDescriptorKey] = {


### PR DESCRIPTION
Resolves (or at least provides resolution to) one class of "my workflow never completes" problems.

We will *hopefully* only ever see this error during development, but it seems like a useful backstop condition to enforce in case it ever does happen to live workflows.