### PR TITLE
Ignore refresh token tests

### DIFF
--- a/centaur/src/main/resources/standardTestCases/refresh_token.test
+++ b/centaur/src/main/resources/standardTestCases/refresh_token.test
@@ -1,3 +1,5 @@
+ignore: true
+
 name: refresh_token
 testFormat: workflowsuccess
 backends: [Papi-Refresh]

--- a/centaur/src/main/resources/standardTestCases/refresh_token_no_auth_bucket.test
+++ b/centaur/src/main/resources/standardTestCases/refresh_token_no_auth_bucket.test
@@ -1,3 +1,5 @@
+ignore: true
+
 name: refresh_token_no_auth_bucket
 testFormat: workflowfailure
 backends: [Papi-Refresh]

--- a/centaur/src/main/resources/standardTestCases/refresh_token_sub_workflow.test
+++ b/centaur/src/main/resources/standardTestCases/refresh_token_sub_workflow.test
@@ -1,3 +1,5 @@
+ignore: true
+
 name: refresh_token_sub_workflow
 testFormat: workflowsuccess
 backends: [Papi-Refresh]


### PR DESCRIPTION
I am under the impression that this feature is EOL and we should not bother fixing the tests.

~Next stop, delete the code and tests, but that's more than I can take on today.~

Let the 👍/👎 's decide!