### PR TITLE
Horizontal Cromwell Deadlock Fix

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
@@ -116,7 +116,8 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
         dataAccess.heartbeatForWorkflowStoreEntry(workflowExecutionUuid).update(heartbeatTimestampOption)
       })
     } yield counts.sum
-    runTransaction(action)
+    // Auto-commit mode, so each statement is individually committed to avoid deadlocks
+    runAction(action)
   }
 
   override def releaseWorkflowStoreEntries(cromwellId: String)(implicit ec: ExecutionContext): Future[Unit] = {

--- a/scripts/docker-compose-mysql/compose/cromwell/app-config/test-deadlock-norefresh.conf
+++ b/scripts/docker-compose-mysql/compose/cromwell/app-config/test-deadlock-norefresh.conf
@@ -13,43 +13,12 @@
 # WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 # WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
 
-include required("cromwell-application")
-
-# Disable docker on the local backend so that the jobs actually run.
-backend {
-  providers {
-    Local {
-      config {
-        runtime-attributes = ""
-        submit-docker = null
-      }
-    }
-  }
-}
-
-# Enable dangerous settings for debugging purposes
-danger.debug.only {
-  minimum-heartbeat-ttl = 1ns
-  exit-on-rollback-exception-with-status-code = 43
-}
-
-# Custom settings to debug database deadlocks
-system {
-  max-concurrent-workflows = 50
-  max-workflow-launch-count = 10
-  new-workflow-poll-rate = 1
-  coordinated-workflow-store-access = false
-	workflow-restart = false
-  workflow-heartbeats {
-    heartbeat-interval = 1s
-    write-batch-size = 10
-  }
-}
+include required("test-deadlock")
 
 services {
   MetadataService {
     config {
-      metadata-summary-refresh-interval = "2 seconds"
+      metadata-summary-refresh-interval = "Inf"
     }
   }
 }

--- a/scripts/docker-compose-mysql/compose/cromwell/bin/get_cromwell_hosts.py
+++ b/scripts/docker-compose-mysql/compose/cromwell/bin/get_cromwell_hosts.py
@@ -16,14 +16,13 @@ our_container = \
 project_name = our_container['Labels']['com.docker.compose.project']
 service_name = 'cromwell'
 filters = [
-  'com.docker.compose.project={}'.format(project_name),
-  'com.docker.compose.service={}'.format(service_name)
+  'com.docker.compose.project={}'.format(project_name)
 ]
 
 containers = cli.containers(filters={'label': filters})
 
 hostname_list = []
-for container in containers:
+for container in [x for x in containers if x['Labels']['com.docker.compose.service'].startswith(service_name)]:
   project = container['Labels']['com.docker.compose.project']
   service = container['Labels']['com.docker.compose.service']
   number = container['Labels']['com.docker.compose.container-number']

--- a/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
+++ b/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
@@ -22,10 +22,10 @@ done
 # Submit batches of workflows to the load balancer.
 BATCHES_TO_RUN=100
 WF_PER_BATCH=10
-TOTAL_WFS=$(( $BATCHES_TO_RUN * $WF_PER_BATCH ))
+TOTAL_WFS=$(( BATCHES_TO_RUN * WF_PER_BATCH ))
 for _ in $(seq $BATCHES_TO_RUN); do
-  echo `date`
-	curl \
+  echo $(date)
+  curl \
     -s -X POST \
     "http://lb:80/api/workflows/v1/batch" \
     -H 'Content-Type: multipart/form-data' \

--- a/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
+++ b/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
@@ -23,6 +23,7 @@ done
 BATCHES_TO_RUN=100
 WF_PER_BATCH=10
 TOTAL_WFS=$(( BATCHES_TO_RUN * WF_PER_BATCH ))
+inputs=$(for ((i=1; i <= $WF_PER_BATCH; i++)); do echo -n ',{}'; done | cut -c2-)
 for _ in $(seq $BATCHES_TO_RUN); do
   echo $(date)
   curl \
@@ -30,7 +31,7 @@ for _ in $(seq $BATCHES_TO_RUN); do
     "http://lb:80/api/workflows/v1/batch" \
     -H 'Content-Type: multipart/form-data' \
     -F 'workflowSource=workflow w {call t} task t { command{echo "hello"} }' \
-    -F 'workflowInputs=[{},{},{},{},{},{},{},{},{},{}]'
+    -F "workflowInputs=[$inputs]"
   echo
 done
 

--- a/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
+++ b/scripts/docker-compose-mysql/compose/cromwell/bin/test-deadlock.sh
@@ -20,17 +20,30 @@ for host in "${cromwell_hosts[@]}"; do
 done
 
 # Submit batches of workflows to the load balancer.
-for _ in $(seq 50); do
-  curl \
-    -X POST \
+BATCHES_TO_RUN=100
+WF_PER_BATCH=10
+TOTAL_WFS=$(( $BATCHES_TO_RUN * $WF_PER_BATCH ))
+for _ in $(seq $BATCHES_TO_RUN); do
+  echo `date`
+	curl \
+    -s -X POST \
     "http://lb:80/api/workflows/v1/batch" \
     -H 'Content-Type: multipart/form-data' \
     -F 'workflowSource=workflow w {call t} task t { command{echo "hello"} }' \
     -F 'workflowInputs=[{},{},{},{},{},{},{},{},{},{}]'
+  echo
 done
 
-echo "Sleeping five minutes to let workflows run..."
-sleep 300
+echo "Sleeping up to ten minutes to let workflows run..."
+n=0
+until [ $n -ge 20 ]
+do
+    sleep 30
+    success=$(curl -s -X GET "http://lb:80/api/workflows/v1/query?status=Succeeded" -H "accept: application/json" | grep -Po "totalResultsCount\":([0-9]*)" | cut -d":" -f2)
+    echo "Found $success successful workflows so far"
+    [ $success -ge $TOTAL_WFS ] && break
+    n=$[$n+1]
+done
 
 # Check if all of the hosts are still up.
 for host in "${cromwell_hosts[@]}"; do

--- a/scripts/docker-compose-mysql/docker-compose-deadlock.yml
+++ b/scripts/docker-compose-mysql/docker-compose-deadlock.yml
@@ -37,7 +37,7 @@
 # ```
 version: '2.1'
 services:
-  cromwell:
+  cromwell_master:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     working_dir: /cromwell-working-dir
     volumes:
@@ -51,8 +51,30 @@ services:
     command: ["server"]
     environment:
       - JAVA_OPTS=-Dconfig.file=/app-config/test-deadlock.conf
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 2s
+      timeout: 30s
+      retries: 60
+  cromwell_norefresh:
+    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    working_dir: /cromwell-working-dir
+    volumes:
+      - ./cromwell-executions:/cromwell-working-dir/cromwell-executions
+      - ./compose/cromwell/app-config:/app-config
+    links:
+      - mysql-db
+    depends_on:
+      mysql-db:
+        condition: service_healthy
+      cromwell_master:
+        condition: service_healthy
+    command: ["server"]
+    environment:
+      - JAVA_OPTS=-Dconfig.file=/app-config/test-deadlock-norefresh.conf
   mysql-db:
     image: "mysql:5.7"
+    command: --general_log=1 --general-log-file=/var/log/mysql/cromwell_mysql.general.log
     environment:
       - MYSQL_ROOT_PASSWORD=cromwell
       - MYSQL_DATABASE=cromwell_db
@@ -67,7 +89,8 @@ services:
   lb:
     image: dockercloud/haproxy
     links:
-      - cromwell
+      - cromwell_master
+      - cromwell_norefresh
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
@@ -75,7 +98,8 @@ services:
   deadlocker:
     image: python:3.7
     links:
-      - cromwell
+      - cromwell_master
+      - cromwell_norefresh
       - lb
     volumes:
       - ./compose/cromwell/bin:/cromwell/bin

--- a/src/ci/bin/testDockerDeadlock.sh
+++ b/src/ci/bin/testDockerDeadlock.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+#clean up local mysql database
+rm -rf scripts/docker-compose-mysql/compose/mysql/data
+
 set -o errexit -o nounset -o pipefail
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
@@ -28,7 +31,7 @@ CROMWELL_TAG="${TEST_CROMWELL_TAG}" \
 docker-compose \
   -f scripts/docker-compose-mysql/docker-compose-deadlock.yml \
   up \
-  --scale cromwell=3 \
+  --scale cromwell_norefresh=2 \
   --exit-code-from deadlocker
 
 exit_code=$?
@@ -36,8 +39,12 @@ set -o errexit
 
 echo "docker-compose exit code was ${exit_code}"
 
-# Tear everything down
+# Tear everything down, but dump out the logs first
 CROMWELL_TAG="${TEST_CROMWELL_TAG}" \
+docker-compose \
+  -f scripts/docker-compose-mysql/docker-compose-deadlock.yml \
+  logs --no-color > deadlock.logs \
+
 docker-compose \
   -f scripts/docker-compose-mysql/docker-compose-deadlock.yml \
   down \

--- a/src/ci/bin/testDockerDeadlock.sh
+++ b/src/ci/bin/testDockerDeadlock.sh
@@ -54,7 +54,4 @@ docker-compose \
 # - scripts/docker-compose-mysql/compose/mysql/data
 # - scripts/docker-compose-mysql/cromwell-executions
 
-if [[ "${exit_code}" == "0" ]]; then
-  echo "Expected a failure. At least a deadlock should have occurred." >&2
-  exit 1
-fi
+exit ${exit_code}


### PR DESCRIPTION
Things Changed
- added a cromwell-master, which refreshes status metadata.  There can be only one.
- created a pool of cromwell_norefresh, which has status refresh turned off, these can scale
- found race condition when multiple cromwells try to create the liquibase lock table at once, configured to have master go first
- updated scripts/compose to handle the above two kinds of cromwell
- increased to 100 batches of 10 workflow each
- changed timeout script to show number of completed workflows and break when done
- delete database at start of run, so the above works
- ran heartbeats in auto-commit mode rather than in a single transaction
- dump out logs at end of run for debugging

Things I'd like to share
 - Lock Ordering in SELECT...FOR UPDATE no es bueno, there are great feature in MYSQL v8 (SKIP LOCKED) but we can't use those yet
 - how to configure mysql for query logging, and what it shows
 - heartbeat batches were never a batched update, just a big transaction
 - slick terminology can give give the wrong intuition
 - impact of cleaning db before each run
 - No deadlocks!