### PR TITLE
Task monitoring action for PAPIv2

### DIFF
--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -21,6 +21,6 @@ Keys | Possible Values | Description
   "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com"
   "auth_bucket": "gs://my-auth-bucket/private",
   "monitoring_script": "gs://bucket/script.sh",
-  "monitoring_image": "gcr.io/my_google_project/my-monitoring-image"
+  "monitoring_image": "quay.io/broadinstitute/cromwell-monitor"
 }
 ```

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -10,6 +10,7 @@ Keys | Possible Values | Description
 `refresh_token` |`string` |   Only used if `localizeWithRefreshToken` is specified in the [Configuration](../Configuring).
 `auth_bucket` |`string` |     A GCS URL that only Cromwell can write to.  The Cromwell account is determined by the `google.authScheme` (and the corresponding `google.userAuth` and `google.serviceAuth`). Defaults to the the value in [jes_gcs_root](#jes_gcs_root).
 `monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
+`monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
 
 # Example
 ```json
@@ -19,6 +20,7 @@ Keys | Possible Values | Description
   "refresh_token": "1/Fjf8gfJr5fdfNf9dk26fdn23FDm4x",
   "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com"
   "auth_bucket": "gs://my-auth-bucket/private",
-  "monitoring_script": "gs://bucket/script.sh"
+  "monitoring_script": "gs://bucket/script.sh",
+  "monitoring_image": "gcr.io/my_google_project/my-monitoring-image"
 }
 ```

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
@@ -2,6 +2,7 @@ package cromwell.backend.google.pipelines.common
 
 object WorkflowOptionKeys {
   val MonitoringScript = "monitoring_script"
+  val MonitoringImage = "monitoring_image"
   val GoogleProject = "google_project"
   val GoogleComputeServiceAccount = "google_compute_service_account"
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/.dockerignore
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/.dockerignore
@@ -1,0 +1,4 @@
+/**/*
+
+!/requirements.txt
+!/monitor.py

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/Dockerfile
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:alpine
+
+WORKDIR /opt
+
+ADD requirements.txt ./
+
+RUN apk add --no-cache \
+      build-base \
+      libstdc++ \
+      linux-headers \
+    && \
+    pip install -r requirements.txt && \
+    apk del \
+      build-base \
+      linux-headers
+
+ADD monitor.py ./
+
+ENTRYPOINT ["./monitor.py"]

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/README.md
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/README.md
@@ -1,0 +1,33 @@
+# Stackdriver task monitor*
+
+This folder contains code for monitoring resource utilization in PAPIv2 tasks
+through [Stackdriver Monitoring](https://cloud.google.com/monitoring).
+
+[monitor.py](monitor.py) script
+is intended to be used as a Docker image, via a background "monitoring action" in PAPIv2.
+The image can be specified through `monitoring_image` workflow option.
+
+It uses [psutil](https://psutil.readthedocs.io) to
+continuously measure CPU, memory and disk space utilization
+and disk IOPS, and periodically report them
+as distinct metrics to Stackdriver Monitoring API.
+
+The labels for each time point contain
+- Cromwell-specific values, such as workflow ID, task call name, index and attempt.
+- GCP instance values such as instance name, zone, number of CPU cores, total memory and disk size.
+
+This approach enables:
+
+1)  Users to easily plot real-time resource usage statistics across all tasks in
+    a workflow, or for a single task call across many workflow runs,
+    etc.
+
+    This can be very powerful to quickly determine the outlier tasks
+    that could use optimization, without the need for any configuration
+    or code.
+
+2)  Scripts to easily get aggregate statistics
+    on resource utilization and to produce suggestions
+    based on those.
+
+[*] Detailed discussion: [PR 4510](https://github.com/broadinstitute/cromwell/pull/4510).

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/monitor.py
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/monitor.py
@@ -6,7 +6,7 @@ from google.cloud.monitoring_v3.types import LabelDescriptor, MetricDescriptor, 
 from os import environ
 import psutil as ps
 import requests
-from signal import signal, SIGINT, SIGTERM
+from signal import signal, SIGTERM
 from sys import stderr
 from time import sleep, time
 
@@ -193,7 +193,6 @@ def signal_handler(signum, frame):
   running = False
 
 running = True
-signal(SIGINT, signal_handler)
 signal(SIGTERM, signal_handler)
 
 ### Main loop
@@ -203,7 +202,7 @@ signal(SIGTERM, signal_handler)
 #
 # However, if it detects a container termination signal,
 # it *should* report the final metric
-# right after the current measurement, and then exit.
+# right after the current measurement, and then exit normally.
 
 reset()
 while running:
@@ -211,3 +210,4 @@ while running:
   if not running or report_time >= REPORT_TIME_SEC:
     report()
     reset()
+exit(0)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/monitor.py
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/monitor.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+
+from functools import reduce
+from google.cloud.monitoring_v3 import MetricServiceClient
+from google.cloud.monitoring_v3.types import LabelDescriptor, MetricDescriptor, TimeSeries
+from os import environ
+import psutil as ps
+import requests
+from signal import signal, SIGINT, SIGTERM
+from sys import stderr
+from time import sleep, time
+
+def get_metadata(key):
+  return requests.get(
+    'http://metadata.google.internal/computeMetadata/v1/instance/' + key,
+    headers={'Metadata-Flavor': 'Google'}
+  ).text
+
+def reset():
+  global memory_used, disk_used, disk_reads, disk_writes, report_time
+
+  # Explicitly reset the CPU counter, because the first call of this method always reports 0
+  ps.cpu_percent()
+
+  memory_used = 0
+
+  disk_used = 0
+  disk_reads = disk_io('read_count')
+  disk_writes = disk_io('write_count')
+
+  report_time = 0
+
+def measure():
+  global memory_used, disk_used, report_time
+
+  memory_used = max(memory_used, MEMORY_SIZE - mem_usage('available'))
+  disk_used = max(disk_used, disk_usage('used'))
+
+  report_time += MEASUREMENT_TIME_SEC
+  sleep(MEASUREMENT_TIME_SEC)
+
+def mem_usage(param):
+  return getattr(ps.virtual_memory(), param)
+
+def disk_usage(param):
+  return reduce(
+    lambda usage, mount: usage + getattr(ps.disk_usage(mount), param),
+    DISK_MOUNTS, 0,
+  )
+
+def disk_io(param):
+  return getattr(ps.disk_io_counters(), param)
+
+def format_gb(value_bytes):
+  return '%.1f' % round(value_bytes / 2**30, 1)
+
+def get_metric(key, value_type, unit, description):
+  return client.create_metric_descriptor(PROJECT_NAME, MetricDescriptor(
+    type='/'.join(['custom.googleapis.com', METRIC_ROOT, key]),
+    description=description,
+    metric_kind='GAUGE',
+    value_type=value_type,
+    unit=unit,
+    labels=LABEL_DESCRIPTORS,
+  ))
+
+def create_time_series(series):
+  client.create_time_series(PROJECT_NAME, series)
+
+def get_time_series(metric_descriptor, value):
+  series = TimeSeries()
+
+  series.metric.type = metric_descriptor.type
+  labels = series.metric.labels
+  labels['workflow_id'] = WORKFLOW_ID
+  labels['task_call_name'] = TASK_CALL_NAME
+  labels['task_call_index'] = TASK_CALL_INDEX
+  labels['task_call_attempt'] = TASK_CALL_ATTEMPT
+  labels['cpu_count'] = CPU_COUNT_LABEL
+  labels['mem_size'] = MEMORY_SIZE_LABEL
+  labels['disk_size'] = DISK_SIZE_LABEL
+
+  series.resource.type = 'gce_instance'
+  series.resource.labels['zone'] = ZONE
+  series.resource.labels['instance_id'] = INSTANCE
+
+  point = series.points.add(value=value)
+  point.interval.end_time.seconds = int(time())
+
+  return series
+
+def report():
+  create_time_series([
+    get_time_series(CPU_UTILIZATION_METRIC, { 'double_value': ps.cpu_percent() }),
+    get_time_series(MEMORY_UTILIZATION_METRIC, { 'double_value': memory_used / MEMORY_SIZE * 100 }),
+    get_time_series(DISK_UTILIZATION_METRIC, { 'double_value': disk_used / DISK_SIZE * 100 }),
+    get_time_series(DISK_READS_METRIC, { 'double_value': (disk_io('read_count') - disk_reads) / report_time }),
+    get_time_series(DISK_WRITES_METRIC, { 'double_value': (disk_io('write_count') - disk_writes) / report_time }),
+  ])
+
+### Define constants
+
+# Cromwell variables passed to the container
+# through environmental variables
+WORKFLOW_ID = environ['WORKFLOW_ID']
+TASK_CALL_NAME = environ['TASK_CALL_NAME']
+TASK_CALL_INDEX = environ['TASK_CALL_INDEX']
+TASK_CALL_ATTEMPT = environ['TASK_CALL_ATTEMPT']
+DISK_MOUNTS = environ['DISK_MOUNTS'].split()
+
+# GCP instance name, zone and project
+# from instance introspection API
+INSTANCE = get_metadata('name')
+_, PROJECT, _, ZONE = get_metadata('zone').split('/')
+
+client = MetricServiceClient()
+PROJECT_NAME = client.project_path(PROJECT)
+
+METRIC_ROOT = 'wdl_task'
+
+MEASUREMENT_TIME_SEC = 1
+REPORT_TIME_SEC = 60
+
+LABEL_DESCRIPTORS = [
+  LabelDescriptor(
+    key='workflow_id',
+    description='Cromwell workflow ID',
+  ),
+  LabelDescriptor(
+    key='task_call_name',
+    description='Cromwell task call name',
+  ),
+  LabelDescriptor(
+    key='task_call_index',
+    description='Cromwell task call index',
+  ),
+  LabelDescriptor(
+    key='task_call_attempt',
+    description='Cromwell task call attempt',
+  ),
+  LabelDescriptor(
+    key='cpu_count',
+    description='Number of virtual cores',
+  ),
+  LabelDescriptor(
+    key='mem_size',
+    description='Total memory size, GB',
+  ),
+  LabelDescriptor(
+    key='disk_size',
+    description='Total disk size, GB',
+  ),
+]
+
+CPU_COUNT = ps.cpu_count()
+CPU_COUNT_LABEL = str(CPU_COUNT)
+
+MEMORY_SIZE = mem_usage('total')
+MEMORY_SIZE_LABEL = format_gb(MEMORY_SIZE)
+
+DISK_SIZE = disk_usage('total')
+DISK_SIZE_LABEL = format_gb(DISK_SIZE)
+
+CPU_UTILIZATION_METRIC = get_metric(
+  'cpu_utilization', 'DOUBLE', '%',
+  '% of CPU utilized in a Cromwell task call',
+)
+
+MEMORY_UTILIZATION_METRIC = get_metric(
+  'mem_utilization', 'DOUBLE', '%',
+  '% of memory utilized in a Cromwell task call',
+)
+
+DISK_UTILIZATION_METRIC = get_metric(
+  'disk_utilization', 'DOUBLE', '%',
+  '% of disk utilized in a Cromwell task call',
+)
+
+DISK_READS_METRIC = get_metric(
+  'disk_reads', 'DOUBLE', '{reads}/s',
+  'Disk read IOPS in a Cromwell task call',
+)
+
+DISK_WRITES_METRIC = get_metric(
+  'disk_writes', 'DOUBLE', '{writes}/s',
+  'Disk write IOPS in a Cromwell task call',
+)
+
+### Detect container termination
+
+def signal_handler(signum, frame):
+  global running
+  running = False
+
+running = True
+signal(SIGINT, signal_handler)
+signal(SIGTERM, signal_handler)
+
+### Main loop
+#
+# It continuously measures runtime metrics every MEASUREMENT_TIME_SEC,
+# and reports them to Stackdriver Monitoring API every REPORT_TIME_SEC.
+#
+# However, if it detects a container termination signal,
+# it *should* report the final metric
+# right after the current measurement, and then exit.
+
+reset()
+while running:
+  measure()
+  if not running or report_time >= REPORT_TIME_SEC:
+    report()
+    reset()

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/requirements.txt
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/cromwell-monitor/requirements.txt
@@ -1,0 +1,3 @@
+google-cloud-monitoring
+psutil
+requests

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 
 case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, endpointUrl: URL)(implicit localizationConfiguration: LocalizationConfiguration) extends PipelinesApiFactoryInterface
   with ContainerSetup
+  with MonitoringAction
   with Localization
   with UserAction
   with Delocalization {
@@ -53,10 +54,11 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       val mounts = createPipelineParameters |> toMounts
 
       val containerSetup: List[Action] = containerSetupActions(mounts)
+      val monitoring: List[Action] = monitoringActions(mounts)
       val localization: List[Action] = localizeActions(createPipelineParameters, mounts)
       val userAction: List[Action] = userActions(createPipelineParameters, mounts)
       val deLocalization: List[Action] = deLocalizeActions(createPipelineParameters, mounts)
-      val allActions = containerSetup ++ localization ++ userAction ++ deLocalization
+      val allActions = containerSetup ++ monitoring ++ localization ++ userAction ++ deLocalization
 
       val environment = Map.empty[String, String].asJava
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -78,8 +78,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
             // Profile and Email scopes are requirements for interacting with Martha v2
             Oauth2Scopes.USERINFO_EMAIL,
             Oauth2Scopes.USERINFO_PROFILE,
-            // Monitoring Scopes as POC
-            "https://www.googleapis.com/auth/monitoring.write"
+            // Monitoring scope as POC
+            GenomicsFactory.MonitoringWrite,
           ).asJava
         )
 
@@ -156,4 +156,12 @@ object GenomicsFactory {
     * For some reason this scope isn't listed as a constant under CloudKMSScopes.
     */
   val KmsScope = "https://www.googleapis.com/auth/cloudkms"
+
+  /**
+    * Scope to write metrics to Stackdriver Monitoring API.
+    * Used by the monitoring action.
+    *
+    * For some reason we couldn't find this scope within Google libraries
+    */
+  val MonitoringWrite = "https://www.googleapis.com/auth/monitoring.write"
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -54,11 +54,11 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       val mounts = createPipelineParameters |> toMounts
 
       val containerSetup: List[Action] = containerSetupActions(mounts)
-      val monitoring: List[Action] = monitoringActions(createPipelineParameters, mounts)
       val localization: List[Action] = localizeActions(createPipelineParameters, mounts)
       val userAction: List[Action] = userActions(createPipelineParameters, mounts)
       val deLocalization: List[Action] = deLocalizeActions(createPipelineParameters, mounts)
-      val allActions = containerSetup ++ monitoring ++ localization ++ userAction ++ deLocalization
+      val monitoring: List[Action] = monitoringActions(createPipelineParameters, mounts)
+      val allActions = containerSetup ++ localization ++ userAction ++ deLocalization ++ monitoring
 
       val environment = Map.empty[String, String].asJava
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -54,7 +54,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       val mounts = createPipelineParameters |> toMounts
 
       val containerSetup: List[Action] = containerSetupActions(mounts)
-      val monitoring: List[Action] = monitoringActions(mounts)
+      val monitoring: List[Action] = monitoringActions(createPipelineParameters, mounts)
       val localization: List[Action] = localizeActions(createPipelineParameters, mounts)
       val userAction: List[Action] = userActions(createPipelineParameters, mounts)
       val deLocalization: List[Action] = deLocalizeActions(createPipelineParameters, mounts)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -64,19 +64,9 @@ object ActionBuilder {
   def withImage(image: String) = new Action()
     .setImageUri(image)
 
-  /**
-    * The Docker image to report runtime metrics to Stackdriver Monitoring API.
-    * It is currently hard-coded, with the assumption that if folks use PAPI v2,
-    * they would want to get monitoring over a Google service as well.
-    *
-    * However, it could be made into a configuration option overridable
-    * at the workflow and/or Cromwell config levels, at the cost
-    * of additional complexity in configuration.
-    */
-  val monitoringImage = "quay.io/broadinstitute/cromwell-monitor"
-  def monitoringAction(environment: Map[String, String], mounts: List[Mount] = List.empty): Action =
+  def monitoringAction(image: String, environment: Map[String, String], mounts: List[Mount] = List.empty): Action =
     new Action()
-      .setImageUri(monitoringImage)
+      .setImageUri(image)
       .withFlags(List(ActionFlag.RunInBackground))
       .withMounts(mounts)
       .setEnvironment(environment.asJava)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -64,6 +64,15 @@ object ActionBuilder {
   def withImage(image: String) = new Action()
     .setImageUri(image)
 
+  /**
+    * The Docker image to report runtime metrics to Stackdriver Monitoring API.
+    * It is currently hard-coded, with the assumption that if folks use PAPI v2,
+    * they would want to get monitoring over a Google service as well.
+    *
+    * However, it could be made into a configuration option overridable
+    * at the workflow and/or Cromwell config levels, at the cost
+    * of additional complexity in configuration.
+    */
   val monitoringImage = "quay.io/broadinstitute/cromwell-monitor"
   def monitoringAction(environment: Map[String, String], mounts: List[Mount] = List.empty): Action =
     new Action()

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -64,6 +64,13 @@ object ActionBuilder {
   def withImage(image: String) = new Action()
     .setImageUri(image)
 
+  val monitoringImage = "quay.io/broadinstitute/cromwell-monitor"
+  def monitoringAction(mounts: List[Mount] = List.empty): Action =
+    new Action()
+      .setImageUri(monitoringImage)
+      .withFlags(List(ActionFlag.RunInBackground))
+      .withMounts(mounts)
+
   def userAction(docker: String,
                  scriptContainerPath: String,
                  mounts: List[Mount],

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -65,11 +65,12 @@ object ActionBuilder {
     .setImageUri(image)
 
   val monitoringImage = "quay.io/broadinstitute/cromwell-monitor"
-  def monitoringAction(mounts: List[Mount] = List.empty): Action =
+  def monitoringAction(environment: Map[String, String], mounts: List[Mount] = List.empty): Action =
     new Action()
       .setImageUri(monitoringImage)
       .withFlags(List(ActionFlag.RunInBackground))
       .withMounts(mounts)
+      .setEnvironment(environment.asJava)
 
   def userAction(docker: String,
                  scriptContainerPath: String,

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -10,6 +10,8 @@ trait MonitoringAction {
       */
     val WorkflowId = "WORKFLOW_ID"
     val TaskCallName = "TASK_CALL_NAME"
+    val TaskCallIndex = "TASK_CALL_INDEX"
+    val TaskCallAttempt = "TASK_CALL_ATTEMPT"
     val DiskMounts = "DISK_MOUNTS"
   }
 
@@ -19,6 +21,8 @@ trait MonitoringAction {
     val environment = Map(
       Env.WorkflowId -> job.workflowDescriptor.id.toString,
       Env.TaskCallName -> job.taskCall.localName,
+      Env.TaskCallIndex -> (job.key.index map { _.toString } getOrElse "NA"),
+      Env.TaskCallAttempt -> job.key.attempt.toString,
       Env.DiskMounts -> mounts.map(_.getPath).mkString(" "),
     )
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -3,6 +3,7 @@ package cromwell.backend.google.pipelines.v2alpha1.api
 import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
 import cromwell.backend.google.pipelines.common.WorkflowOptionKeys
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
+import scala.collection.JavaConverters._
 
 trait MonitoringAction {
   object Env {
@@ -30,8 +31,11 @@ trait MonitoringAction {
     val monitoringAction = ActionBuilder.monitoringAction(image, environment, mounts)
 
     val describeAction = ActionBuilder.describeDocker("monitoring action", monitoringAction)
+      .setFlags(List(ActionFlag.RunInBackground.toString).asJava)
 
-    List(describeAction, monitoringAction)
+    val terminationAction = ActionBuilder.monitoringTerminationAction()
+
+    List(describeAction, monitoringAction, terminationAction)
   }
 
   def monitoringActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Mount]): List[Action] = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -10,6 +10,7 @@ trait MonitoringAction {
       */
     val WorkflowId = "WORKFLOW_ID"
     val TaskCallName = "TASK_CALL_NAME"
+    val DiskMounts = "DISK_MOUNTS"
   }
 
   def monitoringActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Mount]): List[Action] = {
@@ -18,6 +19,7 @@ trait MonitoringAction {
     val environment = Map(
       Env.WorkflowId -> job.workflowDescriptor.id.toString,
       Env.TaskCallName -> job.taskCall.localName,
+      Env.DiskMounts -> mounts.map(_.getPath).mkString(" "),
     )
 
     val monitoringAction = ActionBuilder.monitoringAction(environment, mounts)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -1,0 +1,13 @@
+package cromwell.backend.google.pipelines.v2alpha1.api
+
+import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+
+trait MonitoringAction {
+  def monitoringActions(mounts: List[Mount]): List[Action] = {
+    val monitoringAction = ActionBuilder.monitoringAction(mounts)
+
+    val describeAction = ActionBuilder.describeDocker("monitoring action", monitoringAction)
+
+    List(describeAction, monitoringAction)
+  }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -1,10 +1,26 @@
 package cromwell.backend.google.pipelines.v2alpha1.api
 
 import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 
 trait MonitoringAction {
-  def monitoringActions(mounts: List[Mount]): List[Action] = {
-    val monitoringAction = ActionBuilder.monitoringAction(mounts)
+  object Env {
+    /**
+      * Name of an environmental variable
+      */
+    val WorkflowId = "WORKFLOW_ID"
+    val TaskCallName = "TASK_CALL_NAME"
+  }
+
+  def monitoringActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Mount]): List[Action] = {
+    val job = createPipelineParameters.jobDescriptor
+
+    val environment = Map(
+      Env.WorkflowId -> job.workflowDescriptor.id.toString,
+      Env.TaskCallName -> job.taskCall.localName,
+    )
+
+    val monitoringAction = ActionBuilder.monitoringAction(environment, mounts)
 
     val describeAction = ActionBuilder.describeDocker("monitoring action", monitoringAction)
 


### PR DESCRIPTION
Hi all,

As discussed with @TimothyTickle, @ruchim, @benjamincarlin, @gsaksena, @abaumann, @kshakir, @geoffjentry, and others at the Broad retreat and DSP holiday hackathon, we're putting a proposal for a new feature that reports task call resource utilization metrics to Stackdriver Monitoring API.

This serves 2 important goals:

1) Users can easily plot real-time resource usage statistics across all tasks in a workflow, or for a single task call across many workflow runs, etc.

    This can be very powerful to quickly determine outlier tasks that could use optimization, without the need for any configuration or code (or any changes to the workflow). It's also much easier than the current state-of-the-art, i.e. parsing task-level monitoring logs.

2) Scripts can easily get aggregate statistics on resource utilization and could produce suggestions based on those.

    This could provide a path towards automatic runtime configuration based on the models trained with historical data. One could also detect situations like out-of-memory calls and automatically adjust resources according to those.

It would also be pretty easy to add logic for estimation of task call-level cost based on the pricing of associated resources. This could provide a long-sought feature of real-time cost monitoring/control (thanks to @TimothyTickle for the suggestion).

Monitoring is done using the new "monitoring action" for PAPIv2, which currently uses the hard-coded [quay.io/broadinstitute/cromwell-monitor](https://quay.io/repository/broadinstitute/cromwell-monitor) image, built from https://github.com/broadinstitute/cromwell-monitor (I wasn't sure if that code belonged here or in a separate repo). This is advantageous to just using it as a _monitoring_script_, because it removes all assumptions on the "user" Docker image (for the task itself). For example, we don't have to assume a particular distribution or presence of Python and its libraries. So it should work exactly the same for any task.

Per @geoffjentry's suggestion, we've [consulted](https://groups.google.com/forum/#!topic/google-genomics-discuss/caYM7oHbfx0) with the Google Genomics team, and they don't see any apparent issues with the concept.

We could expose this as a workflow option like `monitoring_image`, and allow configuring it at the Cromwell level, so e.g. any user of Terra (or any other hosted Cromwell with PAPIv2 backend) could get usage reports without having to configure anything. The metrics are reported in their GCP project, so a user gets automatic access to them as long as they're a viewer.

We could also easily expose a link to workflow- and task-level reports in Job Manager UI, so they will be literally point-and-click away.

Each timepoint is designed to be self-sufficient, as it is labeled with:
- Cromwell-specific values, such as workflow ID, task call name, index and attempt.
- GCP instance values such as instance name, zone, number of CPU cores, total memory and disk size.

Here's an example graph of cpu/memory/disk utilization for one of our production workflows, as it is running right now - one can already see we could probably save ~40% of the cost:
<img width="1869" alt="screen shot 2019-01-02 at 4 43 20 pm" src="https://user-images.githubusercontent.com/137337/50614108-c0e6e800-0ead-11e9-9ef4-02029725a44c.png">

Reporting itself costs very little if anything at all, because Stackdriver provides a generous free tier worth ~65K instance-hours each month, and ~$0.0006 per instance-hour after that (at the current rate of 5 metric points reported each minute).

@kshakir suggested using a "vendor-neutral" reporting library such as [Micrometer.io](http://micrometer.io/), although I have reservations around that - mostly because that may require additional setup and we want this to "just work"; but also because the implementation is currently PAPIv2-specific anyway, so it is already non-vendor agnostic. Likewise, one could export metrics from Stackdriver monitoring if they wanted to. But we're open to the idea.

Finally, I haven't added any tests yet, as it's unclear in which shape or form (if at all) you'd like to integrate this code.

Thanks in advance for any feedback!
~[@broadinstitute/wintergreen](https://github.com/orgs/broadinstitute/teams/wintergreen) team.

