### PR TITLE
Fix bcbio test bcbio_svcall

### DIFF
--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/main-svcall-samples.json
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/main-svcall-samples.json
@@ -40,8 +40,8 @@
         "True"
     ],
     "config__algorithm__min_allele_fraction": [
-        10,
-        10
+        10.0,
+        10.0
     ],
     "config__algorithm__nomap_split_size": [
         250,
@@ -75,19 +75,25 @@
     ],
     "config__algorithm__svcaller": [
         [
-            "manta",
-            "lumpy",
             "cnvkit",
-            "delly",
-            "titancna"
+            "manta",
+            "lumpy"
         ],
         [
-            "manta",
-            "lumpy",
             "cnvkit",
-            "delly",
-            "titancna"
+            "manta",
+            "lumpy"
         ]
+    ],
+    "config__algorithm__svprioritize": [
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/automated/variant_regions-bam.bed"
+        },
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/automated/variant_regions-bam.bed"
+        }
     ],
     "config__algorithm__svvalidate": [
         {
@@ -132,12 +138,10 @@
     ],
     "config__algorithm__variantcaller": [
         [
-            "vardict",
-            "mutect2"
+            "vardict"
         ],
         [
-            "vardict",
-            "mutect2"
+            "vardict"
         ]
     ],
     "config__algorithm__vcfanno": [
@@ -358,6 +362,42 @@
             ]
         }
     ],
+    "genome_resources__variation__gc_profile": [
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/coverage/gc/GC_profile.1000bp.cnp"
+        },
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/coverage/gc/GC_profile.1000bp.cnp"
+        }
+    ],
+    "genome_resources__variation__germline_het_pon": [
+        null,
+        null
+    ],
+    "genome_resources__variation__gnomad_exome": [
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/variation/gnomad_exome.vcf.gz",
+            "secondaryFiles": [
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/variation/gnomad_exome.vcf.gz.tbi"
+                }
+            ]
+        },
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/variation/gnomad_exome.vcf.gz",
+            "secondaryFiles": [
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/variation/gnomad_exome.vcf.gz.tbi"
+                }
+            ]
+        }
+    ],
     "genome_resources__variation__lcr": [
         null,
         null
@@ -560,14 +600,76 @@
             "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/snpeff--hg19-wf.tar.gz"
         }
     ],
-    "reference__twobit": [
+    "reference__versions": [
         {
             "class": "File",
-            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/ucsc/hg19.2bit"
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/versions.csv"
         },
         {
             "class": "File",
-            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/ucsc/hg19.2bit"
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/versions.csv"
+        }
+    ],
+    "reference__viral": [
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa",
+            "secondaryFiles": [
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.pac"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.amb"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.sa"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.dict"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.ann"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.bwt"
+                }
+            ]
+        },
+        {
+            "class": "File",
+            "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa",
+            "secondaryFiles": [
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.pac"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.amb"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.sa"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.dict"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.ann"
+                },
+                {
+                    "class": "File",
+                    "path": "gs://bcbiodata/test_bcbio_cwl/testdata/genomes/hg19/viral/gdc-viral.fa.bwt"
+                }
+            ]
         }
     ],
     "resources": [

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/main-svcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/main-svcall.cwl
@@ -36,6 +36,10 @@ inputs:
       items: File
       type: array
     type: array
+- id: config__algorithm__svprioritize
+  type:
+    items: File
+    type: array
 - id: resources
   type:
     items: string
@@ -69,9 +73,7 @@ inputs:
   type:
     items: File
     type: array
-- id: genome_resources__variation__train_hapmap
-  secondaryFiles:
-  - .tbi
+- id: genome_resources__variation__gc_profile
   type:
     items: File
     type: array
@@ -119,11 +121,15 @@ inputs:
     type: array
 - id: config__algorithm__min_allele_fraction
   type:
-    items: long
+    items: double
     type: array
 - id: config__algorithm__nomap_split_targets
   type:
     items: long
+    type: array
+- id: reference__versions
+  type:
+    items: File
     type: array
 - id: reference__bwa__indexes
   secondaryFiles:
@@ -140,7 +146,9 @@ inputs:
     - 'null'
     - string
     type: array
-- id: reference__twobit
+- id: genome_resources__variation__train_hapmap
+  secondaryFiles:
+  - .tbi
   type:
     items: File
     type: array
@@ -199,7 +207,19 @@ inputs:
   type:
     items: string
     type: array
+- id: genome_resources__variation__germline_het_pon
+  type:
+    items:
+    - 'null'
+    - string
+    type: array
 - id: genome_resources__variation__exac
+  secondaryFiles:
+  - .tbi
+  type:
+    items: File
+    type: array
+- id: genome_resources__variation__gnomad_exome
   secondaryFiles:
   - .tbi
   type:
@@ -254,6 +274,17 @@ inputs:
     items:
     - 'null'
     - string
+    type: array
+- id: reference__viral
+  secondaryFiles:
+  - .amb
+  - .ann
+  - .sa
+  - .pac
+  - ^.dict
+  - .bwt
+  type:
+    items: File
     type: array
 - id: genome_resources__variation__cosmic
   secondaryFiles:
@@ -396,8 +427,48 @@ outputs:
     - File
     - 'null'
     type: array
+- id: sv__prioritize__tsv
+  outputSource: summarize_sv/sv__prioritize__tsv
+  type:
+    items:
+      items:
+      - File
+      - 'null'
+      type: array
+    type: array
+- id: sv__prioritize__raw
+  outputSource: summarize_sv/sv__prioritize__raw
+  type:
+    items:
+      items:
+      - File
+      - 'null'
+      type: array
+    type: array
+- id: sv__supplemental
+  outputSource: summarize_sv/sv__supplemental
+  type:
+    items:
+      items:
+      - File
+      type: array
+    type: array
 - id: summary__multiqc
   outputSource: multiqc_summary/summary__multiqc
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__tools
+  outputSource: multiqc_summary/versions__tools
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__data
+  outputSource: multiqc_summary/versions__data
   type:
     items:
     - File
@@ -443,6 +514,8 @@ steps:
     source: config__algorithm__adapters
   - id: config__algorithm__bam_clean
     source: config__algorithm__bam_clean
+  - id: config__algorithm__variant_regions
+    source: config__algorithm__variant_regions
   - id: config__algorithm__mark_duplicates
     source: config__algorithm__mark_duplicates
   - id: resources
@@ -533,8 +606,6 @@ steps:
     source: genome_resources__variation__polyx
   - id: genome_resources__variation__encode_blacklist
     source: genome_resources__variation__encode_blacklist
-  - id: reference__twobit
-    source: reference__twobit
   - id: reference__fasta__base
     source: reference__fasta__base
   - id: resources
@@ -643,8 +714,6 @@ steps:
     source: config__algorithm__tools_off
   - id: reference__fasta__base
     source: reference__fasta__base
-  - id: reference__twobit
-    source: reference__twobit
   - id: reference__rtg
     source: reference__rtg
   - id: reference__genome_context
@@ -659,6 +728,8 @@ steps:
     source: genome_resources__variation__esp
   - id: genome_resources__variation__exac
     source: genome_resources__variation__exac
+  - id: genome_resources__variation__gnomad_exome
+    source: genome_resources__variation__gnomad_exome
   - id: genome_resources__variation__1000g
     source: genome_resources__variation__1000g
   - id: genome_resources__variation__lcr
@@ -779,10 +850,16 @@ steps:
     source: config__algorithm__tools_on
   - id: config__algorithm__tools_off
     source: config__algorithm__tools_off
+  - id: config__algorithm__svprioritize
+    source: config__algorithm__svprioritize
   - id: config__algorithm__svvalidate
     source: config__algorithm__svvalidate
   - id: regions__sample_callable
     source: postprocess_alignment/regions__sample_callable
+  - id: genome_resources__variation__gc_profile
+    source: genome_resources__variation__gc_profile
+  - id: genome_resources__variation__germline_het_pon
+    source: genome_resources__variation__germline_het_pon
   - id: genome_resources__aliases__snpeff
     source: genome_resources__aliases__snpeff
   - id: reference__snpeff__hg19
@@ -810,6 +887,9 @@ steps:
     source: svcall/sv_rec
   out:
   - id: sv__calls
+  - id: sv__supplemental
+  - id: sv__prioritize__tsv
+  - id: sv__prioritize__raw
   - id: svvalidate__grading_summary
   - id: svvalidate__grading_plots
   run: steps/summarize_sv.cwl
@@ -821,6 +901,8 @@ steps:
     source: analysis
   - id: reference__fasta__base
     source: reference__fasta__base
+  - id: reference__versions
+    source: reference__versions
   - id: config__algorithm__tools_on
     source: config__algorithm__tools_on
   - id: config__algorithm__tools_off
@@ -831,6 +913,8 @@ steps:
     source: config__algorithm__qc
   - id: metadata__batch
     source: metadata__batch
+  - id: metadata__phenotype
+    source: metadata__phenotype
   - id: config__algorithm__coverage_interval
     source: postprocess_alignment/config__algorithm__coverage_interval
   - id: depth__variant_regions__regions
@@ -861,6 +945,8 @@ steps:
     source: postprocess_alignment/config__algorithm__coverage_merged
   - id: variants__samples
     source: summarize_vc/variants__samples
+  - id: reference__viral
+    source: reference__viral
   - id: resources
     source: resources
   - id: description
@@ -884,4 +970,6 @@ steps:
     source: pipeline_summary/qcout_rec
   out:
   - id: summary__multiqc
+  - id: versions__tools
+  - id: versions__data
   run: steps/multiqc_summary.cwl

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/alignment_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/alignment_to_rec.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=alignment_rec:resources;description;config__algorithm__align_split_size;files;config__algorithm__trim_reads;reference__fasta__base;config__algorithm__adapters;rgnames__lb;rgnames__rg;rgnames__lane;reference__bwa__indexes;config__algorithm__bam_clean;config__algorithm__aligner;rgnames__pl;rgnames__pu;config__algorithm__mark_duplicates;analysis;rgnames__sample
-- sentinel_inputs=files:var,analysis:var,config__algorithm__align_split_size:var,reference__fasta__base:var,rgnames__pl:var,rgnames__sample:var,rgnames__pu:var,rgnames__lane:var,rgnames__rg:var,rgnames__lb:var,reference__bwa__indexes:var,config__algorithm__aligner:var,config__algorithm__trim_reads:var,config__algorithm__adapters:var,config__algorithm__bam_clean:var,config__algorithm__mark_duplicates:var,resources:var,description:var
+- sentinel_outputs=alignment_rec:resources;description;config__algorithm__align_split_size;files;config__algorithm__trim_reads;reference__fasta__base;config__algorithm__adapters;rgnames__lb;rgnames__rg;rgnames__lane;reference__bwa__indexes;config__algorithm__bam_clean;config__algorithm__aligner;rgnames__pl;rgnames__pu;config__algorithm__mark_duplicates;analysis;rgnames__sample;config__algorithm__variant_regions
+- sentinel_inputs=files:var,analysis:var,config__algorithm__align_split_size:var,reference__fasta__base:var,rgnames__pl:var,rgnames__sample:var,rgnames__pu:var,rgnames__lane:var,rgnames__rg:var,rgnames__lb:var,reference__bwa__indexes:var,config__algorithm__aligner:var,config__algorithm__trim_reads:var,config__algorithm__adapters:var,config__algorithm__bam_clean:var,config__algorithm__variant_regions:var,config__algorithm__mark_duplicates:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -111,6 +111,12 @@ inputs:
     - 'null'
     - boolean
     type: array
+- id: config__algorithm__variant_regions
+  type:
+    items:
+    - 'null'
+    - string
+    type: array
 - id: config__algorithm__mark_duplicates
   type:
     items:
@@ -185,6 +191,10 @@ outputs:
         type: string
       - name: rgnames__sample
         type: string
+      - name: config__algorithm__variant_regions
+        type:
+        - 'null'
+        - string
       name: alignment_rec
       type: record
     type: array

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/batch_for_sv.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/batch_for_sv.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-batch
-- sentinel_outputs=sv_batch_rec:resources;description;reference__snpeff__hg19;genome_build;config__algorithm__tools_off;analysis;config__algorithm__tools_on;config__algorithm__svvalidate;genome_resources__aliases__snpeff;work_bam_plus__disc;work_bam_plus__sr;regions__sample_callable;variants__samples;depth__bins__normalized;depth__bins__background;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
-- sentinel_inputs=analysis:var,genome_build:var,work_bam_plus__disc:var,work_bam_plus__sr:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,config__algorithm__svvalidate:var,regions__sample_callable:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,sv_coverage_rec:record,variants__samples:var
+- sentinel_outputs=sv_batch_rec:resources;description;config__algorithm__svprioritize;genome_resources__variation__gc_profile;reference__snpeff__hg19;genome_build;genome_resources__variation__germline_het_pon;config__algorithm__tools_off;analysis;config__algorithm__tools_on;config__algorithm__svvalidate;genome_resources__aliases__snpeff;work_bam_plus__disc;work_bam_plus__sr;regions__sample_callable;variants__samples;depth__bins__normalized;depth__bins__background;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__gcannotated;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
+- sentinel_inputs=analysis:var,genome_build:var,work_bam_plus__disc:var,work_bam_plus__sr:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,config__algorithm__svprioritize:var,config__algorithm__svvalidate:var,regions__sample_callable:var,genome_resources__variation__gc_profile:var,genome_resources__variation__germline_het_pon:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,sv_coverage_rec:record,variants__samples:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1024
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 0
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -63,6 +63,10 @@ inputs:
     - items: 'null'
       type: array
     type: array
+- id: config__algorithm__svprioritize
+  type:
+    items: File
+    type: array
 - id: config__algorithm__svvalidate
   secondaryFiles:
   - .tbi
@@ -76,6 +80,16 @@ inputs:
     items:
     - File
     - 'null'
+    type: array
+- id: genome_resources__variation__gc_profile
+  type:
+    items: File
+    type: array
+- id: genome_resources__variation__germline_het_pon
+  type:
+    items:
+    - 'null'
+    - string
     type: array
 - id: genome_resources__aliases__snpeff
   type:
@@ -114,6 +128,10 @@ inputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'
@@ -197,10 +215,18 @@ outputs:
           type: string
         - name: description
           type: string
+        - name: config__algorithm__svprioritize
+          type: File
+        - name: genome_resources__variation__gc_profile
+          type: File
         - name: reference__snpeff__hg19
           type: File
         - name: genome_build
           type: string
+        - name: genome_resources__variation__germline_het_pon
+          type:
+          - 'null'
+          - string
         - name: config__algorithm__tools_off
           type:
           - 'null'
@@ -259,6 +285,10 @@ outputs:
           - File
           - 'null'
         - name: regions__bins__antitarget
+          type:
+          - File
+          - 'null'
+        - name: regions__bins__gcannotated
           type:
           - File
           - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/batch_for_variantcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/batch_for_variantcall.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-batch
-- sentinel_outputs=batch_rec:resources;description;reference__fasta__base;config__algorithm__vcfanno;config__algorithm__variantcaller;config__algorithm__coverage_interval;genome_resources__variation__train_hapmap;genome_resources__variation__clinvar;genome_resources__variation__esp;metadata__batch;genome_resources__variation__lcr;genome_resources__variation__1000g;config__algorithm__min_allele_fraction;vrn_file;reference__twobit;reference__genome_context;config__algorithm__validate;reference__snpeff__hg19;config__algorithm__validate_regions;genome_build;genome_resources__variation__exac;metadata__phenotype;genome_resources__aliases__human;config__algorithm__tools_off;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;genome_resources__variation__cosmic;config__algorithm__ensemble;analysis;config__algorithm__tools_on;config__algorithm__effects;config__algorithm__variant_regions;genome_resources__aliases__ensembl;config__algorithm__exclude_regions;reference__rtg;genome_resources__variation__train_indels;genome_resources__aliases__snpeff;align_bam;config__algorithm__variant_regions_merged;regions__sample_callable;config__algorithm__callable_regions
-- sentinel_inputs=analysis:var,genome_build:var,align_bam:var,vrn_file:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__callable_regions:var,regions__sample_callable:var,config__algorithm__variantcaller:var,config__algorithm__ensemble:var,config__algorithm__vcfanno:var,config__algorithm__coverage_interval:var,config__algorithm__effects:var,config__algorithm__min_allele_fraction:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__validate:var,config__algorithm__validate_regions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,reference__fasta__base:var,reference__twobit:var,reference__rtg:var,reference__genome_context:var,genome_resources__variation__clinvar:var,genome_resources__variation__cosmic:var,genome_resources__variation__dbsnp:var,genome_resources__variation__esp:var,genome_resources__variation__exac:var,genome_resources__variation__1000g:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,genome_resources__aliases__ensembl:var,genome_resources__aliases__human:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,genome_resources__variation__train_hapmap:var,genome_resources__variation__train_indels:var,resources:var,description:var
+- sentinel_outputs=batch_rec:resources;description;reference__fasta__base;config__algorithm__vcfanno;config__algorithm__variantcaller;config__algorithm__coverage_interval;genome_resources__variation__clinvar;genome_resources__variation__esp;metadata__batch;genome_resources__variation__lcr;genome_resources__variation__1000g;config__algorithm__min_allele_fraction;vrn_file;genome_resources__variation__train_hapmap;reference__genome_context;config__algorithm__validate;reference__snpeff__hg19;config__algorithm__validate_regions;genome_build;genome_resources__variation__exac;genome_resources__variation__gnomad_exome;metadata__phenotype;genome_resources__aliases__human;config__algorithm__tools_off;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;genome_resources__variation__cosmic;config__algorithm__ensemble;analysis;config__algorithm__tools_on;config__algorithm__effects;config__algorithm__variant_regions;genome_resources__aliases__ensembl;config__algorithm__exclude_regions;reference__rtg;genome_resources__variation__train_indels;genome_resources__aliases__snpeff;align_bam;config__algorithm__variant_regions_merged;regions__sample_callable;config__algorithm__callable_regions
+- sentinel_inputs=analysis:var,genome_build:var,align_bam:var,vrn_file:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__callable_regions:var,regions__sample_callable:var,config__algorithm__variantcaller:var,config__algorithm__ensemble:var,config__algorithm__vcfanno:var,config__algorithm__coverage_interval:var,config__algorithm__effects:var,config__algorithm__min_allele_fraction:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__validate:var,config__algorithm__validate_regions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,reference__fasta__base:var,reference__rtg:var,reference__genome_context:var,genome_resources__variation__clinvar:var,genome_resources__variation__cosmic:var,genome_resources__variation__dbsnp:var,genome_resources__variation__esp:var,genome_resources__variation__exac:var,genome_resources__variation__gnomad_exome:var,genome_resources__variation__1000g:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,genome_resources__aliases__ensembl:var,genome_resources__aliases__human:var,genome_resources__aliases__snpeff:var,reference__snpeff__hg19:var,genome_resources__variation__train_hapmap:var,genome_resources__variation__train_indels:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -96,7 +96,7 @@ inputs:
     type: array
 - id: config__algorithm__min_allele_fraction
   type:
-    items: long
+    items: double
     type: array
 - id: config__algorithm__exclude_regions
   type:
@@ -149,10 +149,6 @@ inputs:
   type:
     items: File
     type: array
-- id: reference__twobit
-  type:
-    items: File
-    type: array
 - id: reference__rtg
   type:
     items: File
@@ -190,6 +186,12 @@ inputs:
     items: File
     type: array
 - id: genome_resources__variation__exac
+  secondaryFiles:
+  - .tbi
+  type:
+    items: File
+    type: array
+- id: genome_resources__variation__gnomad_exome
   secondaryFiles:
   - .tbi
   type:
@@ -280,8 +282,6 @@ outputs:
           type:
           - string
           - 'null'
-        - name: genome_resources__variation__train_hapmap
-          type: File
         - name: genome_resources__variation__clinvar
           type: File
         - name: genome_resources__variation__esp
@@ -295,12 +295,12 @@ outputs:
         - name: genome_resources__variation__1000g
           type: File
         - name: config__algorithm__min_allele_fraction
-          type: long
+          type: double
         - name: vrn_file
           type:
           - 'null'
           - string
-        - name: reference__twobit
+        - name: genome_resources__variation__train_hapmap
           type: File
         - name: reference__genome_context
           type:
@@ -319,6 +319,8 @@ outputs:
         - name: genome_build
           type: string
         - name: genome_resources__variation__exac
+          type: File
+        - name: genome_resources__variation__gnomad_exome
           type: File
         - name: metadata__phenotype
           type: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/calculate_sv_bins.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/calculate_sv_bins.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=sv_bin_rec:regions__bins__target;regions__bins__antitarget;regions__bins__group;resources;description;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
+- sentinel_outputs=sv_bin_rec:regions__bins__target;regions__bins__antitarget;regions__bins__gcannotated;regions__bins__group;resources;description;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
 - sentinel_inputs=align_bam:var,reference__fasta__base:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__callable_regions:var,config__algorithm__coverage_interval:var,config__algorithm__exclude_regions:var,config__algorithm__sv_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__svcaller:var,depth__variant_regions__regions:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,genome_resources__rnaseq__gene_bed:var,resources:var,description:var
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -142,6 +142,10 @@ outputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/calculate_sv_coverage.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/calculate_sv_coverage.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-parallel
-- sentinel_outputs=sv_rawcoverage_rec:depth__bins__target;depth__bins__antitarget;resources;description;regions__bins__target;regions__bins__antitarget;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
+- sentinel_outputs=sv_rawcoverage_rec:depth__bins__target;depth__bins__antitarget;resources;description;regions__bins__target;regions__bins__antitarget;regions__bins__gcannotated;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
 - sentinel_inputs=sv_bin_rec:record
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1028
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -42,6 +42,10 @@ inputs:
       - File
       - 'null'
     - name: regions__bins__antitarget
+      type:
+      - File
+      - 'null'
+    - name: regions__bins__gcannotated
       type:
       - File
       - 'null'
@@ -129,6 +133,10 @@ outputs:
       - File
       - 'null'
     - name: regions__bins__antitarget
+      type:
+      - File
+      - 'null'
+    - name: regions__bins__gcannotated
       type:
       - File
       - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/combine_sample_regions.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/combine_sample_regions.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/compare_to_rm.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/compare_to_rm.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1028
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -69,8 +69,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -84,12 +82,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -108,6 +106,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string
@@ -230,7 +230,7 @@ outputs:
       - name: metadata__batch
         type: string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: reference__genome_context
         type:
           items: File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/concat_batch_variantcalls.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/concat_batch_variantcalls.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -59,8 +59,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -74,12 +72,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -98,6 +96,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/detect_sv.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/detect_sv.cwl
@@ -5,7 +5,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=batch-single
-- sentinel_outputs=sv_rec:sv__variantcaller;sv__vrn_file;svvalidate__summary;resources;description;genome_build;config__algorithm__tools_off;analysis;config__algorithm__tools_on;config__algorithm__svvalidate;genome_resources__aliases__snpeff;regions__sample_callable;variants__samples;depth__bins__normalized;depth__bins__background;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
+- sentinel_outputs=sv_rec:sv__variantcaller;sv__vrn_file;sv__supplemental;svvalidate__summary;resources;description;config__algorithm__svprioritize;genome_resources__variation__gc_profile;genome_build;genome_resources__variation__germline_het_pon;config__algorithm__tools_off;analysis;config__algorithm__tools_on;config__algorithm__svvalidate;genome_resources__aliases__snpeff;regions__sample_callable;variants__samples;depth__bins__normalized;depth__bins__background;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__gcannotated;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
 - sentinel_inputs=sv_batch_rec:record
 - run_number=0
 baseCommand:
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 8192
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -37,6 +37,9 @@ hints:
   - package: delly
     specs:
     - https://anaconda.org/bioconda/delly
+  - package: duphold
+    specs:
+    - https://anaconda.org/bioconda/duphold
   - package: extract-sv-reads
     specs:
     - https://anaconda.org/bioconda/extract-sv-reads
@@ -83,6 +86,12 @@ hints:
     - https://anaconda.org/bioconda/r
     version:
     - 3.4.1
+  - package: r-base=3.4.1=h4fe35fd_8
+    specs:
+    - https://anaconda.org/bioconda/r-base=3.4.1=h4fe35fd_8
+  - package: xorg-libxt
+    specs:
+    - https://anaconda.org/bioconda/xorg-libxt
   - package: vawk
     specs:
     - https://anaconda.org/bioconda/vawk
@@ -97,10 +106,18 @@ inputs:
         type: string
       - name: description
         type: string
+      - name: config__algorithm__svprioritize
+        type: File
+      - name: genome_resources__variation__gc_profile
+        type: File
       - name: reference__snpeff__hg19
         type: File
       - name: genome_build
         type: string
+      - name: genome_resources__variation__germline_het_pon
+        type:
+        - 'null'
+        - string
       - name: config__algorithm__tools_off
         type:
         - 'null'
@@ -159,6 +176,10 @@ inputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'
@@ -233,6 +254,11 @@ outputs:
         type:
         - File
         - 'null'
+      - name: sv__supplemental
+        type:
+          items:
+          - File
+          type: array
       - name: svvalidate__summary
         type:
         - File
@@ -241,8 +267,16 @@ outputs:
         type: string
       - name: description
         type: string
+      - name: config__algorithm__svprioritize
+        type: File
+      - name: genome_resources__variation__gc_profile
+        type: File
       - name: genome_build
         type: string
+      - name: genome_resources__variation__germline_het_pon
+        type:
+        - 'null'
+        - string
       - name: config__algorithm__tools_off
         type:
         - 'null'
@@ -293,6 +327,10 @@ outputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/get_parallel_regions.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/get_parallel_regions.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -46,8 +46,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -61,12 +59,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -85,6 +83,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/merge_split_alignments.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/merge_split_alignments.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1035
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 6
 - class: dx:InputResourceRequirement
   indirMin: 4
@@ -94,6 +94,10 @@ inputs:
       type: string
     - name: rgnames__sample
       type: string
+    - name: config__algorithm__variant_regions
+      type:
+      - 'null'
+      - string
     name: alignment_rec
     type: record
 - id: work_bam

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/multiqc_summary.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/multiqc_summary.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=summary__multiqc
+- sentinel_outputs=summary__multiqc,versions__tools,versions__data
 - sentinel_inputs=qcout_rec:record
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1030
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -48,6 +48,8 @@ inputs:
         - 'null'
       - name: description
         type: string
+      - name: reference__versions
+        type: File
       - name: genome_build
         type: string
       - name: config__algorithm__tools_off
@@ -68,6 +70,18 @@ inputs:
     type: array
 outputs:
 - id: summary__multiqc
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__tools
+  type:
+    items:
+    - File
+    - 'null'
+    type: array
+- id: versions__data
   type:
     items:
     - File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/normalize_sv_coverage.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/normalize_sv_coverage.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=sv_coverage_rec:depth__bins__normalized;depth__bins__background;resources;description;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
+- sentinel_outputs=sv_coverage_rec:depth__bins__normalized;depth__bins__background;resources;description;depth__bins__target;depth__bins__antitarget;regions__bins__target;regions__bins__antitarget;regions__bins__gcannotated;regions__bins__group;reference__fasta__base;config__algorithm__svcaller;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;metadata__batch;genome_resources__variation__lcr;metadata__phenotype;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__sv_regions;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;depth__variant_regions__regions;config__algorithm__callable_regions
 - sentinel_inputs=sv_rawcoverage_rec:record
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1028
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -52,6 +52,10 @@ inputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'
@@ -145,6 +149,10 @@ outputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/pipeline_summary.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/pipeline_summary.cwl
@@ -5,7 +5,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-parallel
-- sentinel_outputs=qcout_rec:summary__qc;summary__metrics;description;genome_build;config__algorithm__tools_off;config__algorithm__qc;config__algorithm__tools_on
+- sentinel_outputs=qcout_rec:summary__qc;summary__metrics;description;reference__versions;genome_build;config__algorithm__tools_off;config__algorithm__qc;config__algorithm__tools_on
 - sentinel_inputs=qc_rec:record
 - run_number=0
 baseCommand:
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -34,9 +34,9 @@ hints:
   - package: bedtools
     specs:
     - https://anaconda.org/bioconda/bedtools
-  - package: fastqc=0.11.7=4
+  - package: fastqc=0.11.7=5
     specs:
-    - https://anaconda.org/bioconda/fastqc=0.11.7=4
+    - https://anaconda.org/bioconda/fastqc=0.11.7=5
   - package: goleft
     specs:
     - https://anaconda.org/bioconda/goleft
@@ -91,13 +91,19 @@ inputs:
       - 'null'
     - name: metadata__batch
       type: string
+    - name: reference__versions
+      type: File
     - name: genome_build
+      type: string
+    - name: metadata__phenotype
       type: string
     - name: config__algorithm__tools_off
       type:
       - 'null'
       - items: 'null'
         type: array
+    - name: reference__viral
+      type: File
     - name: config__algorithm__qc
       type:
         items: string
@@ -188,6 +194,8 @@ outputs:
       - 'null'
     - name: description
       type: string
+    - name: reference__versions
+      type: File
     - name: genome_build
       type: string
     - name: config__algorithm__tools_off

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_alignment.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_alignment.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1033
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 5
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -70,8 +70,6 @@ inputs:
       type:
       - 'null'
       - string
-    - name: reference__twobit
-      type: File
     - name: config__algorithm__recalibrate
       type:
       - string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_alignment_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_alignment_to_rec.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=postprocess_alignment_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;genome_resources__variation__lcr;reference__twobit;config__algorithm__recalibrate;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__tools_on;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__variant_regions_orig;config__algorithm__coverage;config__algorithm__coverage_merged;config__algorithm__coverage_orig;config__algorithm__seq2c_bed_ready
-- sentinel_inputs=align_bam:var,config__algorithm__coverage_interval:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__variant_regions_orig:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,config__algorithm__coverage_orig:var,config__algorithm__seq2c_bed_ready:var,config__algorithm__recalibrate:var,config__algorithm__tools_on:var,genome_resources__rnaseq__gene_bed:var,genome_resources__variation__dbsnp:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,reference__twobit:var,reference__fasta__base:var,resources:var,description:var
+- sentinel_outputs=postprocess_alignment_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;genome_resources__rnaseq__gene_bed;genome_resources__variation__lcr;config__algorithm__recalibrate;genome_resources__variation__dbsnp;genome_resources__variation__polyx;genome_resources__variation__encode_blacklist;config__algorithm__tools_on;config__algorithm__variant_regions;config__algorithm__exclude_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__variant_regions_orig;config__algorithm__coverage;config__algorithm__coverage_merged;config__algorithm__coverage_orig;config__algorithm__seq2c_bed_ready
+- sentinel_inputs=align_bam:var,config__algorithm__coverage_interval:var,config__algorithm__exclude_regions:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__variant_regions_orig:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,config__algorithm__coverage_orig:var,config__algorithm__seq2c_bed_ready:var,config__algorithm__recalibrate:var,config__algorithm__tools_on:var,genome_resources__rnaseq__gene_bed:var,genome_resources__variation__dbsnp:var,genome_resources__variation__lcr:var,genome_resources__variation__polyx:var,genome_resources__variation__encode_blacklist:var,reference__fasta__base:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -130,10 +130,6 @@ inputs:
     - 'null'
     - string
     type: array
-- id: reference__twobit
-  type:
-    items: File
-    type: array
 - id: reference__fasta__base
   secondaryFiles:
   - .fai
@@ -170,8 +166,6 @@ outputs:
         type:
         - 'null'
         - string
-      - name: reference__twobit
-        type: File
       - name: config__algorithm__recalibrate
         type:
         - string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_variants.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/postprocess_variants.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1025
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -53,8 +53,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -68,12 +66,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -92,6 +90,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_align_inputs.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_align_inputs.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1028
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 4
@@ -110,6 +110,10 @@ inputs:
       type: string
     - name: rgnames__sample
       type: string
+    - name: config__algorithm__variant_regions
+      type:
+      - 'null'
+      - string
     name: alignment_rec
     type: record
 outputs:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_samples.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_samples.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_samples_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/prep_samples_to_rec.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 0

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/process_alignment.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/process_alignment.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 7
@@ -139,6 +139,10 @@ inputs:
       type: string
     - name: rgnames__sample
       type: string
+    - name: config__algorithm__variant_regions
+      type:
+      - 'null'
+      - string
     name: alignment_rec
     type: record
 - id: process_alignment_rec

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/qc_to_rec.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/qc_to_rec.cwl
@@ -4,8 +4,8 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=qc_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;metadata__batch;genome_build;config__algorithm__tools_off;config__algorithm__qc;analysis;config__algorithm__tools_on;config__algorithm__variant_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__coverage;config__algorithm__coverage_merged;depth__samtools__stats;depth__samtools__idxstats;depth__variant_regions__regions;depth__variant_regions__dist;depth__sv_regions__regions;depth__sv_regions__dist;depth__coverage__regions;depth__coverage__dist;depth__coverage__thresholds;variants__samples
-- sentinel_inputs=align_bam:var,analysis:var,reference__fasta__base:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,genome_build:var,config__algorithm__qc:var,metadata__batch:var,config__algorithm__coverage_interval:var,depth__variant_regions__regions:var,depth__variant_regions__dist:var,depth__samtools__stats:var,depth__samtools__idxstats:var,depth__sv_regions__regions:var,depth__sv_regions__dist:var,depth__coverage__regions:var,depth__coverage__dist:var,depth__coverage__thresholds:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,variants__samples:var,resources:var,description:var
+- sentinel_outputs=qc_rec:resources;description;reference__fasta__base;config__algorithm__coverage_interval;metadata__batch;reference__versions;genome_build;metadata__phenotype;config__algorithm__tools_off;reference__viral;config__algorithm__qc;analysis;config__algorithm__tools_on;config__algorithm__variant_regions;align_bam;config__algorithm__variant_regions_merged;config__algorithm__coverage;config__algorithm__coverage_merged;depth__samtools__stats;depth__samtools__idxstats;depth__variant_regions__regions;depth__variant_regions__dist;depth__sv_regions__regions;depth__sv_regions__dist;depth__coverage__regions;depth__coverage__dist;depth__coverage__thresholds;variants__samples
+- sentinel_inputs=align_bam:var,analysis:var,reference__fasta__base:var,reference__versions:var,config__algorithm__tools_on:var,config__algorithm__tools_off:var,genome_build:var,config__algorithm__qc:var,metadata__batch:var,metadata__phenotype:var,config__algorithm__coverage_interval:var,depth__variant_regions__regions:var,depth__variant_regions__dist:var,depth__samtools__stats:var,depth__samtools__idxstats:var,depth__sv_regions__regions:var,depth__sv_regions__dist:var,depth__coverage__regions:var,depth__coverage__dist:var,depth__coverage__thresholds:var,config__algorithm__variant_regions:var,config__algorithm__variant_regions_merged:var,config__algorithm__coverage:var,config__algorithm__coverage_merged:var,variants__samples:var,reference__viral:var,resources:var,description:var
 - run_number=0
 baseCommand:
 - bcbio_nextgen.py
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1028
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 0
@@ -42,6 +42,10 @@ inputs:
   secondaryFiles:
   - .fai
   - ^.dict
+  type:
+    items: File
+    type: array
+- id: reference__versions
   type:
     items: File
     type: array
@@ -69,6 +73,10 @@ inputs:
       type: array
     type: array
 - id: metadata__batch
+  type:
+    items: string
+    type: array
+- id: metadata__phenotype
   type:
     items: string
     type: array
@@ -166,6 +174,17 @@ inputs:
         type: array
       type: array
     type: array
+- id: reference__viral
+  secondaryFiles:
+  - .amb
+  - .ann
+  - .sa
+  - .pac
+  - ^.dict
+  - .bwt
+  type:
+    items: File
+    type: array
 - id: resources
   type:
     items: string
@@ -191,13 +210,19 @@ outputs:
         - 'null'
       - name: metadata__batch
         type: string
+      - name: reference__versions
+        type: File
       - name: genome_build
+        type: string
+      - name: metadata__phenotype
         type: string
       - name: config__algorithm__tools_off
         type:
         - 'null'
         - items: 'null'
           type: array
+      - name: reference__viral
+        type: File
       - name: config__algorithm__qc
         type:
           items: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/summarize_sv.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/summarize_sv.cwl
@@ -4,7 +4,7 @@ arguments:
 - position: 0
   valueFrom: sentinel_runtime=cores,$(runtime['cores']),ram,$(runtime['ram'])
 - sentinel_parallel=multi-combined
-- sentinel_outputs=sv__calls,svvalidate__grading_summary,svvalidate__grading_plots
+- sentinel_outputs=sv__calls,sv__supplemental,sv__prioritize__tsv,sv__prioritize__raw,svvalidate__grading_summary,svvalidate__grading_plots
 - sentinel_inputs=sv_rec:record
 - run_number=0
 baseCommand:
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1027
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 2
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -39,6 +39,11 @@ inputs:
           type:
           - File
           - 'null'
+        - name: sv__supplemental
+          type:
+            items:
+            - File
+            type: array
         - name: svvalidate__summary
           type:
           - File
@@ -47,8 +52,16 @@ inputs:
           type: string
         - name: description
           type: string
+        - name: config__algorithm__svprioritize
+          type: File
+        - name: genome_resources__variation__gc_profile
+          type: File
         - name: genome_build
           type: string
+        - name: genome_resources__variation__germline_het_pon
+          type:
+          - 'null'
+          - string
         - name: config__algorithm__tools_off
           type:
           - 'null'
@@ -99,6 +112,10 @@ inputs:
           - File
           - 'null'
         - name: regions__bins__antitarget
+          type:
+          - File
+          - 'null'
+        - name: regions__bins__gcannotated
           type:
           - File
           - 'null'
@@ -159,6 +176,29 @@ inputs:
     type: array
 outputs:
 - id: sv__calls
+  type:
+    items:
+      items:
+      - File
+      - 'null'
+      type: array
+    type: array
+- id: sv__supplemental
+  type:
+    items:
+      items:
+      - File
+      type: array
+    type: array
+- id: sv__prioritize__tsv
+  type:
+    items:
+      items:
+      - File
+      - 'null'
+      type: array
+    type: array
+- id: sv__prioritize__raw
   type:
     items:
       items:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/summarize_vc.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/summarize_vc.cwl
@@ -21,7 +21,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 1
   outdirMin: 1025
-  ramMin: 2048
+  ramMin: 3072
   tmpdirMin: 1
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -73,7 +73,7 @@ inputs:
         - name: metadata__batch
           type: string
         - name: config__algorithm__min_allele_fraction
-          type: long
+          type: double
         - name: reference__genome_context
           type:
             items: File

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/variantcall_batch_region.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/steps/variantcall_batch_region.cwl
@@ -22,7 +22,7 @@ hints:
 - class: ResourceRequirement
   coresMin: 2
   outdirMin: 1030
-  ramMin: 4096
+  ramMin: 6144
   tmpdirMin: 3
 - class: dx:InputResourceRequirement
   indirMin: 1
@@ -86,6 +86,9 @@ hints:
   - package: varscan
     specs:
     - https://anaconda.org/bioconda/varscan
+  - package: moreutils
+    specs:
+    - https://anaconda.org/bioconda/moreutils
   - package: vcfanno
     specs:
     - https://anaconda.org/bioconda/vcfanno
@@ -100,6 +103,9 @@ hints:
     - https://anaconda.org/bioconda/r
     version:
     - 3.4.1
+  - package: r-base=3.4.1=h4fe35fd_8
+    specs:
+    - https://anaconda.org/bioconda/r-base=3.4.1=h4fe35fd_8
   - package: perl
     specs:
     - https://anaconda.org/bioconda/perl
@@ -127,8 +133,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -142,12 +146,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -166,6 +170,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-alignment.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-alignment.cwl
@@ -59,6 +59,10 @@ inputs:
       type: string
     - name: rgnames__sample
       type: string
+    - name: config__algorithm__variant_regions
+      type:
+      - 'null'
+      - string
     name: alignment_rec
     type: record
 outputs:

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-svcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-svcall.cwl
@@ -10,10 +10,18 @@ inputs:
         type: string
       - name: description
         type: string
+      - name: config__algorithm__svprioritize
+        type: File
+      - name: genome_resources__variation__gc_profile
+        type: File
       - name: reference__snpeff__hg19
         type: File
       - name: genome_build
         type: string
+      - name: genome_resources__variation__germline_het_pon
+        type:
+        - 'null'
+        - string
       - name: config__algorithm__tools_off
         type:
         - 'null'
@@ -72,6 +80,10 @@ inputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'
@@ -147,6 +159,11 @@ outputs:
         type:
         - File
         - 'null'
+      - name: sv__supplemental
+        type:
+          items:
+          - File
+          type: array
       - name: svvalidate__summary
         type:
         - File
@@ -155,8 +172,16 @@ outputs:
         type: string
       - name: description
         type: string
+      - name: config__algorithm__svprioritize
+        type: File
+      - name: genome_resources__variation__gc_profile
+        type: File
       - name: genome_build
         type: string
+      - name: genome_resources__variation__germline_het_pon
+        type:
+        - 'null'
+        - string
       - name: config__algorithm__tools_off
         type:
         - 'null'
@@ -207,6 +232,10 @@ outputs:
         - File
         - 'null'
       - name: regions__bins__antitarget
+        type:
+        - File
+        - 'null'
+      - name: regions__bins__gcannotated
         type:
         - File
         - 'null'

--- a/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-variantcall.cwl
+++ b/centaur/src/main/resources/integrationTestCases/cwl/bcbio/svcall-workflow/wf-variantcall.cwl
@@ -22,8 +22,6 @@ inputs:
         type:
         - string
         - 'null'
-      - name: genome_resources__variation__train_hapmap
-        type: File
       - name: genome_resources__variation__clinvar
         type: File
       - name: genome_resources__variation__esp
@@ -37,12 +35,12 @@ inputs:
       - name: genome_resources__variation__1000g
         type: File
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: vrn_file
         type:
         - 'null'
         - string
-      - name: reference__twobit
+      - name: genome_resources__variation__train_hapmap
         type: File
       - name: reference__genome_context
         type:
@@ -61,6 +59,8 @@ inputs:
       - name: genome_build
         type: string
       - name: genome_resources__variation__exac
+        type: File
+      - name: genome_resources__variation__gnomad_exome
         type: File
       - name: metadata__phenotype
         type: string
@@ -180,7 +180,7 @@ outputs:
       - name: metadata__batch
         type: string
       - name: config__algorithm__min_allele_fraction
-        type: long
+        type: double
       - name: reference__genome_context
         type:
           items: File


### PR DESCRIPTION
Succeeded on this branch at https://gotc-jenkins.dsp-techops.broadinstitute.org/job/cromwell-cron-papiv2/224/ (VPN required)

This test is identical to the one in the [test_bcbio_cwl repo](https://github.com/bcbio/test_bcbio_cwl) with one exception: all storage locations have been converted to `gs://` paths (true before this PR also).

Brad's comment about `gs://` conversion:
>I believe Thibault was mapping over the relative file-based references into the equivalent gs:// URLs for Cromwell testing.