### PR TITLE
Ensure womtool disallows autoboxing inputs in WDL 1.0

### DIFF
--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing_inputs/array_autoboxing_inputs.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing_inputs/array_autoboxing_inputs.wdl
@@ -1,0 +1,31 @@
+version 1.0
+
+task ls {
+    input {
+        Array[File] files
+    }
+    command {
+        ls ${sep=" " files}
+    }
+
+    output {
+        Array[String] filename = read_lines(stdout())
+    }
+}
+
+
+workflow array_autoboxing_inputs {
+    input {
+        Array[File] files
+    }
+
+    scatter (i in files) {
+        call ls {
+            input: files = i
+        }
+    }
+
+    output {
+        Array[Array[String]] F = ls.filename
+    }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing_inputs/error.txt
+++ b/womtool/src/test/resources/validate/wdl_draft3/invalid/array_autoboxing_inputs/error.txt
@@ -1,0 +1,1 @@
+Failed to process workflow definition 'array_autoboxing_inputs' (reason 1 of 1): Failed to process 'call ls' (reason 1 of 1): Failed to supply input files = i (reason 1 of 1): Cannot coerce expression of type 'File' to 'Array[File]'


### PR DESCRIPTION
As extra `womtool validate` test to make sure WDL 1.0 is catching this.

Unfortunately there's no draft-2 equivalent of this test yet because of the bug spotted in #4550 