### PR TITLE
Reallow custom ImportResolvers

### DIFF
--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -30,7 +30,7 @@ object ImportResolver {
   case class ImportResolutionRequest(toResolve: String, currentResolvers: List[ImportResolver])
   case class ResolvedImportBundle(source: WorkflowSource, newResolvers: List[ImportResolver])
 
-  sealed trait ImportResolver {
+  trait ImportResolver {
     def name: String
     protected def innerResolver(path: String, currentResolvers: List[ImportResolver]): Checked[ResolvedImportBundle]
     def resolver: CheckedAtoB[ImportResolutionRequest, ResolvedImportBundle] = CheckedAtoB.fromCheck { request =>


### PR DESCRIPTION
There's no reason we should be precluding callers from bringing their own import resolvers