### PR TITLE
Fix PAPI v2 USA auth handling in config

### DIFF
--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
@@ -1,6 +1,6 @@
-name: docker_hash_dockerhub_private_wf_options
+name: docker_hash_dockerhub_private_config_usa_wf_options
 testFormat: workflowsuccess
-backends: [Papiv2NoDockerHubConfig]
+backends: [Papiv2USADockerhub]
 
 files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl

--- a/src/ci/resources/dockerhub_provider_config_v2_usa.inc.conf.ctmpl
+++ b/src/ci/resources/dockerhub_provider_config_v2_usa.inc.conf.ctmpl
@@ -1,0 +1,7 @@
+{{with $cromwellDockerhub := vault (printf "secret/dsde/cromwell/common/cromwell-dockerhub")}}
+dockerhub {
+  token = "{{$cromwellDockerhub.Data.token}}"
+  key-name = "{{$cromwellDockerhub.Data.key_name}}"
+  auth = "user_service_account"
+}
+{{end}}

--- a/src/ci/resources/papi_application.inc.conf.ctmpl
+++ b/src/ci/resources/papi_application.inc.conf.ctmpl
@@ -40,6 +40,10 @@ google {
       client-id = "{{$cromwellRefreshToken.Data.client_id}}"
       client-secret = "{{$cromwellRefreshToken.Data.client_secret}}"
     }
+    {
+      name = "user_service_account"
+      scheme = "user_service_account"
+    }
   ]
 }
 {{end}}

--- a/src/ci/resources/papi_v2_34_application.conf
+++ b/src/ci/resources/papi_v2_34_application.conf
@@ -39,3 +39,15 @@ backend.providers.Papi-Caching-No-Copy.config.filesystems.http {
   project = "broad-dsde-cromwell-dev"
   auth = "service_account"
 }
+backend.providers.Papiv2USADockerhub.config.filesystems.http {
+  project = "broad-dsde-cromwell-dev"
+  auth = "service_account"
+}
+
+# The default v2 config sets this to "user_service_account" but that value isn't handled correctly in
+# versions prior to 37 so override this to be `service_account`.
+backend.providers.Papi.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2RequesterPays.config.dockerhub.auth = "service_account"
+backend.providers.Papi-Caching-No-Copy.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2USADockerhub.config.dockerhub.auth = "service_account"

--- a/src/ci/resources/papi_v2_36_application.conf
+++ b/src/ci/resources/papi_v2_36_application.conf
@@ -1,0 +1,9 @@
+include "papi_v2_application.conf"
+
+# The default v2 config sets this to "user_service_account" but that value isn't handled correctly in
+# versions prior to 37 so override this to be `service_account`.
+backend.providers.Papi.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2RequesterPays.config.dockerhub.auth = "service_account"
+backend.providers.Papi-Caching-No-Copy.config.dockerhub.auth = "service_account"
+backend.providers.Papiv2USADockerhub.config.dockerhub.auth = "service_account"

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -36,6 +36,19 @@ backend {
         name-for-call-caching-purposes = "Papi"
       }
     }
+    # Same as Papi but specifying `user_service_account` auth in config.
+    Papiv2USADockerhub {
+      actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+      config {
+        include "papi_provider_config.inc.conf"
+        include "dockerhub_provider_config_v2_usa.inc.conf"
+        # This SA does not have permission to bill this project when accessing RP buckets.
+        # This is on purpose so that we can assert the failure (see requester_pays_localization_negative)
+        genomics.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
+        filesystems.http {}
+        name-for-call-caching-purposes = "Papi"
+      }
+    }
     # Same as Papiv2 but with no Docker Hub configuration so access to private Docker Hub images will
     # require correct handling of workflow options.
     Papiv2NoDockerHubConfig {


### PR DESCRIPTION
The previous code was needlessly trying to create a Google Credential at Cromwell startup time. For user service accounts that's nonsensical and unpossible since USAs are specified per-workflow in workflow options.