### PR TITLE
Token Queue Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ Support `InputResourceRequirement` hint
 
 ### Changing configuration options
 
+#### Logging Token Distribution
+
+In cases where its not obvious why jobs are queued in Cromwell, you can enable logging for the Job Execution Token Dispenser, using
+the `system.hog-safety.token-log-interval-seconds` configuration value.
+
+The default, `0`, means that no logging will occur. 
+
+#### HTTP Filesystem
+
 - The HTTP filesystem is now enabled for engine use by default. To continue without an HTTP filesystem, you can add the 
 following content into the appropriate stanza of your configuration file:
 ```

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -130,6 +130,10 @@ system {
 
     # Setting to '1' means that a hog group can use the full resources of the Cromwell instance if it needs to:
     hog-factor = 1
+
+    # Time to wait before repeating token log messages - including "queue state" and "group X is a hog" style messages.
+    # Leave at 0 to never log these types of message.
+    token-log-interval-seconds = 0
   }
 
   # Number of seconds between workflow launches

--- a/core/src/main/scala/cromwell/core/JobExecutionToken.scala
+++ b/core/src/main/scala/cromwell/core/JobExecutionToken.scala
@@ -1,11 +1,12 @@
 package cromwell.core
 
 import java.util.UUID
-
+import _root_.io.circe.generic.JsonCodec
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 
 case class JobExecutionToken(jobExecutionTokenType: JobExecutionTokenType, id: UUID)
 
 object JobExecutionToken {
+  @JsonCodec
   case class JobExecutionTokenType(backend: String, maxPoolSize: Option[Int], hogFactor: Int)
 }

--- a/docs/cromwell_features/HogFactors.md
+++ b/docs/cromwell_features/HogFactors.md
@@ -52,13 +52,14 @@ running jobs.
 
 ## Configuration
 
-Cromwell accepts two configuration values for hog factors in the `hog-safety` stanza of `system` in the configuration 
+Cromwell accepts the following configuration values for hog factors in the `hog-safety` stanza of `system` in the configuration 
 file:
 ```conf
 system {
   hog-safety {
     hog-factor = 1
     workflow-option = "hogGroup"
+    token-log-interval-seconds = 0
   }
 }
 ```
@@ -85,6 +86,18 @@ workflow's hog group:
     + You can choose a field that is already being used for other reasons
 - If a workflow is submitted without a value for the designated field in its workflow options, the workflow ID is used 
 as the hog group identifier. 
+
+### Logging
+
+Because the system is not a simple first-in-first-out, it can be valuable to see the status of all 
+the existing queues inside Cromwell. 
+
+To have this information logged on a regular basis, you can enable periodic queue logging. This will
+also alert you at the same frequency when events are happening, such as hog groups being at their individual limits.
+
+* You can enable logging for the Job Execution Token Dispenser, using
+the `system.hog-safety.token-log-interval-seconds` configuration value.
+* The default, `0`, means that no logging will occur.
 
 ## Effects
 

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -191,7 +191,7 @@ object JobExecutionTokenDispenserActor {
   implicit val tokenEncoder = deriveEncoder[JobExecutionTokenType]
 
   @JsonCodec(encodeOnly = true)
-  final case class TokenDispenserState(queues: Vector[TokenTypeState], pointer: Int, leased: Int)
+  final case class TokenDispenserState(tokenTypes: Vector[TokenTypeState], pointer: Int, leased: Int)
 
   @JsonCodec(encodeOnly = true)
   final case class TokenTypeState(tokenType: JobExecutionTokenType, queue: TokenQueueState)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -38,7 +38,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
     sendGaugeJob(ExecutionStatus.QueuedInCromwell.toString, tokenQueues.values.map(_.size).sum.toLong)
   }
 
-  val effectiveLogInterval: Option[FiniteDuration] = logInterval.filter(_ == 0.seconds)
+  val effectiveLogInterval: Option[FiniteDuration] = logInterval.filterNot(_ == 0.seconds)
 
   val tokenEventLogger = effectiveLogInterval match {
     case Some(someInterval) => new CachingTokenEventLogger(log, someInterval)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenEventLogger.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenEventLogger.scala
@@ -1,0 +1,44 @@
+package cromwell.engine.workflow.tokens
+
+import akka.event.LoggingAdapter
+import com.google.common.cache.CacheBuilder
+
+import scala.concurrent.duration.FiniteDuration
+
+trait TokenEventLogger {
+  def flagTokenHog(hogGroup: String): Unit
+  def outOfTokens(backend: String): Unit
+}
+
+case object NullTokenEventLogger extends TokenEventLogger {
+  override def flagTokenHog(hogGroup: String): Unit = ()
+  override def outOfTokens(backend: String): Unit = ()
+}
+
+class CachingTokenEventLogger(log: LoggingAdapter,
+                              cacheEntryTTL: FiniteDuration) extends TokenEventLogger {
+
+  log.info("Using CachingTokenEventLogger with an interval of {} to log token queue events", cacheEntryTTL)
+
+  private val cache = CacheBuilder.newBuilder()
+    .expireAfterWrite(cacheEntryTTL._1, cacheEntryTTL._2)
+    .maximumSize(10000)
+    .build[String, Object]()
+
+
+  override def flagTokenHog(hogGroup: String): Unit = {
+    if (Option(cache.getIfPresent("HOG_" + hogGroup)).isEmpty) {
+      log.info(s"Token Dispenser: The hog group $hogGroup is starting too many jobs. It is being hog limited.")
+      cache.put("HOG_" + hogGroup, new Object())
+    }
+  }
+
+
+  override def outOfTokens(backend: String): Unit = {
+    if (Option(cache.getIfPresent("OOT_" + backend)).isEmpty) {
+      log.info(s"Token Dispenser: The backend $backend is starting too many jobs. New jobs are being limited.")
+      cache.put("OOT_" + backend, new Object())
+    }
+  }
+
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
@@ -109,7 +109,8 @@ final class UnhoggableTokenPool(val tokenType: JobExecutionTokenType) extends Si
       "hog groups" -> hogGroupUsages,
       "hog limit" -> hogLimitValue,
       "capacity" -> JsNumber(capacity),
-      "leased" -> JsNumber(leased)
+      "leased" -> JsNumber(leased),
+      "available" -> JsBoolean(leased < capacity)
     ))
   }
 }

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -133,8 +133,9 @@ abstract class CromwellRootActor(gracefulShutdown: Boolean, abortJobsOnTerminate
   lazy val backendSingletonCollection = BackendSingletonCollection(backendSingletons)
 
   lazy val rate = DynamicRateLimiter.Rate(systemConfig.as[Int]("job-rate-control.jobs"), systemConfig.as[FiniteDuration]("job-rate-control.per"))
+  lazy val tokenLogInterval: Option[FiniteDuration] = systemConfig.as[Option[Int]]("hog-safety.token-log-interval-seconds").map(_.seconds)
 
-  lazy val jobExecutionTokenDispenserActor = context.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistryActor, rate), "JobExecutionTokenDispenser")
+  lazy val jobExecutionTokenDispenserActor = context.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistryActor, rate, tokenLogInterval), "JobExecutionTokenDispenser")
 
   lazy val workflowManagerActor = context.actorOf(
     WorkflowManagerActor.props(

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActorSpec.scala
@@ -280,7 +280,7 @@ class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec
       eventually { nextInLine(3).underlyingActor.hasToken shouldBe true }
 
       // And kill off the rest of the actors:
-      (withTokens.toList :+ nextInLine(3)) foreach { actor => actor ! PoisonPill }
+      (withTokens :+ nextInLine(3)) foreach { actor => actor ! PoisonPill }
     }
 
     actorRefUnderTest.underlyingActor.tokenQueues.map(x => x._2.size).sum should be(0)
@@ -289,7 +289,7 @@ class JobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem("JETDASpec
   var actorRefUnderTest: TestActorRef[JobExecutionTokenDispenserActor] = _
 
   before {
-    actorRefUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(10, 4.second)))
+    actorRefUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(10, 4.second), None))
   }
   after {
     actorRefUnderTest = null

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/RoundRobinQueueIteratorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/RoundRobinQueueIteratorSpec.scala
@@ -12,7 +12,9 @@ class RoundRobinQueueIteratorSpec extends TestKitSuite with FlatSpecLike with Ma
   val InfiniteTokenType = JobExecutionTokenType("infinite", None, 1)
   val Pool1 = JobExecutionTokenType("pool1", Option(1), 1)
   val Pool2 = JobExecutionTokenType("pool2", Option(2), 1)
-  
+
+  val tokenEventLogger = NullTokenEventLogger
+
   it should "be empty if there's no queue" in {
     new RoundRobinQueueIterator(List.empty, 0).hasNext shouldBe false
   }
@@ -20,7 +22,7 @@ class RoundRobinQueueIteratorSpec extends TestKitSuite with FlatSpecLike with Ma
   it should "return an element if a queue can dequeue" in {
     val probe1 = TestProbe().ref
     val queues = List(
-      TokenQueue(InfiniteTokenType).enqueue(TokenQueuePlaceholder(probe1, "hogGroupA"))
+      TokenQueue(InfiniteTokenType, tokenEventLogger).enqueue(TokenQueuePlaceholder(probe1, "hogGroupA"))
     )
     val iterator = new RoundRobinQueueIterator(queues, 0)
     iterator.hasNext shouldBe true
@@ -37,8 +39,8 @@ class RoundRobinQueueIteratorSpec extends TestKitSuite with FlatSpecLike with Ma
     val probe2 = TestProbe("probe-2").ref
     val probe3 = TestProbe("probe-3").ref
     val queues = List(
-      TokenQueue(InfiniteTokenType).enqueue(TokenQueuePlaceholder(probe1, "hogGroupA")).enqueue(TokenQueuePlaceholder(probe3, "hogGroupA")),
-      TokenQueue(Pool2).enqueue(TokenQueuePlaceholder(probe2, "hogGroupA"))
+      TokenQueue(InfiniteTokenType, tokenEventLogger).enqueue(TokenQueuePlaceholder(probe1, "hogGroupA")).enqueue(TokenQueuePlaceholder(probe3, "hogGroupA")),
+      TokenQueue(Pool2, tokenEventLogger).enqueue(TokenQueuePlaceholder(probe2, "hogGroupA"))
     )
     val iterator = new RoundRobinQueueIterator(queues, 0)
     iterator.hasNext shouldBe true
@@ -68,10 +70,10 @@ class RoundRobinQueueIteratorSpec extends TestKitSuite with FlatSpecLike with Ma
     val probe4 = TestProbe("probe-4").ref
     val probe5 = TestProbe("probe-5").ref
     val queues = List(
-      TokenQueue(Pool1)
+      TokenQueue(Pool1, tokenEventLogger)
         .enqueue(TokenQueuePlaceholder(probe1, "hogGroupA"))
         .enqueue(TokenQueuePlaceholder(probe3, "hogGroupA")),
-      TokenQueue(Pool2)
+      TokenQueue(Pool2, tokenEventLogger)
         .enqueue(TokenQueuePlaceholder(probe2, "hogGroupA"))
         .enqueue(TokenQueuePlaceholder(probe4, "hogGroupA"))
         .enqueue(TokenQueuePlaceholder(probe5, "hogGroupA"))

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPoolSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPoolSpec.scala
@@ -1,9 +1,10 @@
 package cromwell.engine.workflow.tokens
 
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
-import cromwell.engine.workflow.tokens.UnhoggableTokenPool.{ComeBackLater, Oink, TokenHoggingLease}
+import cromwell.engine.workflow.tokens.UnhoggableTokenPool.{HogLimitExceeded, TokenHoggingLease, TokenTypeExhausted, TokensAvailable}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpec, Matchers}
+
 import scala.concurrent.duration._
 
 class UnhoggableTokenPoolSpec extends FlatSpec with Matchers with Eventually {
@@ -41,43 +42,47 @@ class UnhoggableTokenPoolSpec extends FlatSpec with Matchers with Eventually {
         (0 until hogLimit) foreach { index =>
           pool.tryAcquire(hogGroup) match {
             case _: TokenHoggingLease => // great!
-            case ComeBackLater => fail(s"Unhoggable token pool ran out after $index tokens distributed to $hogGroupNumber")
-            case Oink => fail(s"Unhoggable token pool making unfounded accusations of hogging after $index tokens distributed to $hogGroupNumber")
+            case TokenTypeExhausted => fail(s"Unhoggable token pool ran out after $index tokens distributed to $hogGroupNumber")
+            case HogLimitExceeded => fail(s"Unhoggable token pool making unfounded accusations of hogging after $index tokens distributed to $hogGroupNumber")
           }
         }
         // Step two: one more is too many...
-        pool.tryAcquire(hogGroup) should be(Oink)
+        if (hogGroupNumber != tokenType.hogFactor - 1) {
+          // While the overall token type is not full we get the hog limit push-back:
+          pool.tryAcquire(hogGroup) should be(HogLimitExceeded)
+        } else {
+          // The final time, the entire token type is used up so we get this instead:
+          pool.tryAcquire(hogGroup) should be(TokenTypeExhausted)
+        }
       }
-
-      // Any more requests should be told to come back later:
-      pool.tryAcquire("somebody else") should be(ComeBackLater)
     }
   }
 
   it should "allow tokens to be returned" in {
     // A pool distributing tokens with a hogLimit of 2:
-    val hogLimit2Pool = new UnhoggableTokenPool(JobExecutionTokenType("backend", Some(150), 75))
+    val hogLimitPool = new UnhoggableTokenPool(JobExecutionTokenType("backend", Some(150), 75))
 
     // Use all the "group1" tokens:
-    val lease1 = hogLimit2Pool.tryAcquire("group1").asInstanceOf[TokenHoggingLease]
-    val lease2 = hogLimit2Pool.tryAcquire("group1").asInstanceOf[TokenHoggingLease]
-    hogLimit2Pool.tryAcquire("group1") should be(Oink)
+    val lease1 = hogLimitPool.tryAcquire("group1").asInstanceOf[TokenHoggingLease]
+    val lease2 = hogLimitPool.tryAcquire("group1").asInstanceOf[TokenHoggingLease]
+    hogLimitPool.available("group1") shouldBe HogLimitExceeded
+    hogLimitPool.tryAcquire("group1") should be(HogLimitExceeded)
 
     lease1.release()
-    eventually { hogLimit2Pool.available("group1") shouldBe true }
-    hogLimit2Pool.tryAcquire("group1") match {
+    eventually { hogLimitPool.available("group1") shouldBe TokensAvailable }
+    hogLimitPool.tryAcquire("group1") match {
       case _: TokenHoggingLease => // Great!
       case other => fail(s"expected lease but got $other")
     }
-    hogLimit2Pool.tryAcquire("group1") should be(Oink)
+    hogLimitPool.tryAcquire("group1") should be(HogLimitExceeded)
 
     lease2.release()
-    eventually { hogLimit2Pool.available("group1") shouldBe true }
-    hogLimit2Pool.tryAcquire("group1") match {
+    eventually { hogLimitPool.available("group1") shouldBe TokensAvailable }
+    hogLimitPool.tryAcquire("group1") match {
       case _: TokenHoggingLease => // Great!
       case other => fail(s"expected lease but got $other")
     }
-    hogLimit2Pool.tryAcquire("group1") should be(Oink)
+    hogLimitPool.tryAcquire("group1") should be(HogLimitExceeded)
   }
 
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/large/LargeScaleJobExecutionTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/large/LargeScaleJobExecutionTokenDispenserActorSpec.scala
@@ -30,7 +30,7 @@ class LargeScaleJobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem(
     val totalJobsPerWorkflow = maxConcurrencyToTest + 1
     val tokenType = JobExecutionTokenType(backendName, Some(maxConcurrencyToTest), hogFactor)
 
-    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyToTest + 1, 100.millis)), "tokenDispenserUnderTest1")
+    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyToTest + 1, 100.millis), None), "tokenDispenserUnderTest1")
 
     val globalRunningJobsCounter = new RunningJobCounter()
     val bigWorkflow1 = TestActorRef(new MultipleTokenUsingActor(tokenDispenserUnderTest, tokenType, totalJobsPerWorkflow, hogGroup = "hogGroupA", globalRunningJobsCounter), multipleTokenUsingActorName())
@@ -64,7 +64,7 @@ class LargeScaleJobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem(
     val totalJobsPerWorkflow = maxConcurrencyExpected + 1
     val tokenType = JobExecutionTokenType(backendName, Some(totalTokensAvailable), hogFactor)
 
-    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyExpected + 1, 100.millis)), "tokenDispenserUnderTest2")
+    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyExpected + 1, 100.millis), None), "tokenDispenserUnderTest2")
 
     val globalRunningJobsCounter = new RunningJobCounter()
     val bigWorkflow1 = TestActorRef(new MultipleTokenUsingActor(tokenDispenserUnderTest, tokenType, totalJobsPerWorkflow, hogGroup = "hogGroupA", globalRunningJobsCounter), multipleTokenUsingActorName())
@@ -98,7 +98,7 @@ class LargeScaleJobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem(
     val totalJobsPerWorkflow = maxConcurrencyPerWorkflow + 1
     val tokenType = JobExecutionTokenType(backendName, Some(totalTokensAvailable), hogFactor)
 
-    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis)), "tokenDispenserUnderTest3")
+    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis), None), "tokenDispenserUnderTest3")
 
     val globalRunningJobsCounter = new RunningJobCounter()
     val bigWorkflow1 = TestActorRef(new MultipleTokenUsingActor(tokenDispenserUnderTest, tokenType, totalJobsPerWorkflow, hogGroup = "hogGroupA", globalRunningJobsCounter), multipleTokenUsingActorName())
@@ -132,7 +132,7 @@ class LargeScaleJobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem(
     val totalJobsPerWorkflow = maxConcurrencyPerWorkflow * 2
     val tokenType = JobExecutionTokenType(backendName, Some(totalTokensAvailable), hogFactor)
 
-    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis)), "tokenDispenserUnderTest4")
+    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis), None), "tokenDispenserUnderTest4")
 
     val globalRunningJobsCounter = new RunningJobCounter()
 
@@ -168,7 +168,7 @@ class LargeScaleJobExecutionTokenDispenserActorSpec extends TestKit(ActorSystem(
     val totalJobsPerWorkflow = maxConcurrencyPerHogGroup * 2
     val tokenType = JobExecutionTokenType(backendName, Some(totalTokensAvailable), hogFactor)
 
-    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis)), "tokenDispenserUnderTest5")
+    val tokenDispenserUnderTest = TestActorRef(new JobExecutionTokenDispenserActor(TestProbe().ref, Rate(maxConcurrencyOverall + 1, 100.millis), None), "tokenDispenserUnderTest5")
 
     val hogGroupConcurrencyCounters = (0 until totalHogGroups).toVector map { _ => new RunningJobCounter() }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/large/TokenDispenserBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/large/TokenDispenserBenchmark.scala
@@ -4,9 +4,8 @@ import akka.actor.ActorSystem
 import akka.testkit.TestProbe
 import cromwell.core.ExecutionStatus.{apply => _}
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
-import cromwell.engine.workflow.tokens.RoundRobinQueueIterator
+import cromwell.engine.workflow.tokens.{NullTokenEventLogger, RoundRobinQueueIterator, TokenQueue}
 import cromwell.engine.workflow.tokens.TokenQueue.TokenQueuePlaceholder
-import cromwell.engine.workflow.tokens.TokenQueue
 import org.scalameter.api._
 import org.scalameter.picklers.Implicits._
 import spray.json.DefaultJsonProtocol
@@ -81,7 +80,7 @@ object TokenDispenserBenchmark extends Bench[Double] with DefaultJsonProtocol {
       } yield (jobCount, hogFactor, tokenType)
 
       using(queues) in { case (jobCount, hogFactor, tokenType) =>
-        var tokenQueue = TokenQueue(tokenType)
+        var tokenQueue = TokenQueue(tokenType, NullTokenEventLogger)
         val hogGroups = ((0 until hogFactor) map { i => i -> s"hogGroup$i" }).toMap
 
         tokenQueue = fillQueue(tokenQueue, jobCount / hogFactor, hogGroups.values.toList)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -436,7 +436,7 @@ object Dependencies {
     "com.chuusai" %% "shapeless" % shapelessV,
     "com.github.scopt" %% "scopt" % scoptV,
     "org.scalamock" %% "scalamock" % scalamockV % Test,
-  ) ++ akkaStreamDependencies ++ configDependencies ++ catsDependencies ++
+  ) ++ akkaStreamDependencies ++ configDependencies ++ catsDependencies ++ circeDependencies
     googleApiClientDependencies ++ statsDDependencies ++ betterFilesDependencies ++
     // TODO: We're not using the "F" in slf4j. Core only supports logback, specifically the WorkflowLogger.
     slf4jBindingDependencies

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -436,7 +436,7 @@ object Dependencies {
     "com.chuusai" %% "shapeless" % shapelessV,
     "com.github.scopt" %% "scopt" % scoptV,
     "org.scalamock" %% "scalamock" % scalamockV % Test,
-  ) ++ akkaStreamDependencies ++ configDependencies ++ catsDependencies ++ circeDependencies
+  ) ++ akkaStreamDependencies ++ configDependencies ++ catsDependencies ++ circeDependencies ++
     googleApiClientDependencies ++ statsDDependencies ++ betterFilesDependencies ++
     // TODO: We're not using the "F" in slf4j. Core only supports logback, specifically the WorkflowLogger.
     slf4jBindingDependencies

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -65,7 +65,7 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
         callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props),
         callCacheWriteActor = system.actorOf(EmptyCallCacheWriteActor.props),
         dockerHashActor = system.actorOf(EmptyDockerHashActor.props),
-        jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second))),
+        jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second), None)),
         backendSingletonCollection = BackendSingletonCollection(Map("Local" -> None)),
         serverMode = true,
         workflowStoreActor = system.actorOf(Props.empty),

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -70,7 +70,7 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec wit
   private val callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)
   private val callCacheWriteActor = system.actorOf(EmptyCallCacheWriteActor.props)
   private val dockerHashActor = system.actorOf(EmptyDockerHashActor.props)
-  private val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second)))
+  private val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second), None))
 
 
   def workflowManagerActor(): ActorRef = {

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorSpec.scala
@@ -64,7 +64,7 @@ class WorkflowExecutionActorSpec extends CromwellTestKitSpec with FlatSpecLike w
     val jobStoreActor = system.actorOf(AlwaysHappyJobStoreActor.props)
     val ioActor = system.actorOf(SimpleIoActor.props)
     val subWorkflowStoreActor = system.actorOf(AlwaysHappySubWorkflowStoreActor.props)
-    val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second)))
+    val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second), None))
     val MockBackendConfigEntry = BackendConfigurationEntry(
       name = "Mock",
       lifecycleActorFactoryClass = "cromwell.engine.backend.mock.RetryableBackendLifecycleActorFactory",


### PR DESCRIPTION
Closes #4557 

- Adds a configurable value `token-log-interval-seconds` in the `hog-safety` stanza.
- Logs when a hog group is at its limit (no more than once per `token-log-interval-seconds` seconds per hog group)
- Logs when a backend has used all tokens (no more than once per `token-log-interval-seconds` seconds per backend)
- Logs the current status of the Cromwell token queues (no more than once per `token-log-interval-seconds` seconds)

Sample log message:
```
Token Dispenser: The backend Local is starting too many jobs. New jobs are being limited.
```

Sample queue status output:
```
  "Token Dispenser state": {
    "queues": [{
      "token type": "BACKEND=Local/TOKENLIMIT=Some(10)/HOGFACTOR=5",
      "queue state": {
        "queue": [{
          "name": "4a458483",
          "queue size": 2
        }, {
          "name": "b106f1f4",
          "queue size": 2
        }],
        "pool": {
          "hog groups": [{
            "hog group": "4a458483",
            "used": 2,
            "available": false
          }, {
            "hog group": "b106f1f4",
            "used": 2,
            "available": false
          }],
          "hog limit": 2,
          "capacity": 10,
          "leased": 4
        }
      }
    }],
    "pointer": 0,
    "total token assignments": 4
  }
}
```