### PR TITLE
Job rate control for AWS CI

### DIFF
--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -55,3 +55,6 @@ backend {
     }
   }
 }
+
+system.job-rate-control.jobs = 1
+system.job-rate-control.per = 2 seconds


### PR DESCRIPTION
I confirmed this does throttle the token dispenser from the log output, though it may not get the AWS build passing until everyone rebases.