### PR TITLE
Proposed addition of cpuPlatform for PAPIv2 VM creation

### DIFF
--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
@@ -25,7 +25,7 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
     )))
   }
 
-  val expectedDefaults = new PipelinesApiRuntimeAttributes(refineMV(1), None, Vector("us-central1-b", "us-central1-a"), 0, 10,
+  val expectedDefaults = new PipelinesApiRuntimeAttributes(refineMV(1), None, None, Vector("us-central1-b", "us-central1-a"), 0, 10,
     MemorySize(2, MemoryUnit.GB), Vector(PipelinesApiWorkingDisk(DiskType.SSD, 10)), "ubuntu:latest", false,
     ContinueOnReturnCodeSet(Set(0)), false)
 
@@ -277,6 +277,18 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
       val expectedRuntimeAttributes = expectedDefaults.copy(cpu = refineMV(4))
       assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes, workflowOptions)
     }
+  }
+
+  "should parse cpuPlatform correctly" in {
+    val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"))
+    val workflowOptionsJson =
+      """{
+        |  "default_runtime_attributes": { "cpuPlatform": "the platform" }
+        |}
+      """.stripMargin.parseJson.asInstanceOf[JsObject]
+    val workflowOptions = WorkflowOptions.fromJsonObject(workflowOptionsJson).get
+    val expectedRuntimeAttributes = expectedDefaults.copy(cpuPlatform = Some("the platform"))
+    assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes, workflowOptions)
   }
 
   private def assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WomValue],

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
@@ -287,7 +287,7 @@ class PipelinesApiRuntimeAttributesSpec extends WordSpecLike with Matchers with 
         |}
       """.stripMargin.parseJson.asInstanceOf[JsObject]
     val workflowOptions = WorkflowOptions.fromJsonObject(workflowOptionsJson).get
-    val expectedRuntimeAttributes = expectedDefaults.copy(cpuPlatform = Some("the platform"))
+    val expectedRuntimeAttributes = expectedDefaults.copy(cpuPlatform = Option("the platform"))
     assertJesRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes, workflowOptions)
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -125,6 +125,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         virtualMachine.setNvidiaDriverVersion(resource.nvidiaDriverVersion)
       }
 
+      createPipelineParameters.runtimeAttributes.cpuPlatform.map(virtualMachine.setCpuPlatform)
+
       val resources = new Resources()
         .setProjectId(createPipelineParameters.projectId)
         .setZones(createPipelineParameters.runtimeAttributes.zones.asJava)

--- a/wom/src/main/scala/wom/RuntimeAttributes.scala
+++ b/wom/src/main/scala/wom/RuntimeAttributes.scala
@@ -9,6 +9,7 @@ object RuntimeAttributesKeys {
     * Equivalent to CPUMinKey
     */
   val CpuKey = "cpu"
+  val CpuPlatformKey = "cpuPlatform"
   val CpuMinKey = "cpuMin"
   val CpuMaxKey = "cpuMax"
   /**


### PR DESCRIPTION
This is my attempt at addressing issue #4608 

- add `cpuPlatform` as a new runtime attribute
- contents are not validated; they're passed on directly to PAPI V2