### PR TITLE
Adjust CromIAM timeout to match Cromwell

### DIFF
--- a/CromIAM/src/main/resources/application.conf
+++ b/CromIAM/src/main/resources/application.conf
@@ -34,4 +34,12 @@ swagger_oauth {
 akka {
   log-dead-letters = "off"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
+
+  http {
+    server {
+      request-timeout = 40s
+      bind-timeout = 5s
+    }
+    client.connecting-timeout = 40s
+  }
 }


### PR DESCRIPTION
Searched the codebase for `request-timeout`, found that we seem to use 40 seconds not the 55 previously discussed.

Copied the config stanza from `cromwell/server/src/main/resources/application.conf` to CromIAM.