### PR TITLE
Pass through Cromwell & Sam HTTP errors to Cromiam.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Bug fixes
 - Fixed an issue that could cause Cromwell to consume disk space unnecessarily when using zipped dependencies
 
+#### HTTP responses
+
+- When returning errors as json the `Content-Type` header is set to `application/json`.
+
 ## 37 Release Notes
 
 ### Docker

--- a/CromIAM/src/main/scala/cromiam/sam/SamClient.scala
+++ b/CromIAM/src/main/scala/cromiam/sam/SamClient.scala
@@ -5,18 +5,21 @@ import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.unmarshalling._
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
+import cats.Monad
+import cats.effect.IO
 import com.softwaremill.sttp.{StatusCodes => _, _}
 import cromiam.auth.{Collection, User}
 import cromiam.instrumentation.CromIamInstrumentation
 import cromiam.sam.SamClient._
 import cromiam.sam.SamResourceJsonSupport._
 import cromiam.server.status.StatusCheckedSubsystem
+import cromwell.api.model._
 import mouse.boolean._
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.ExecutionContextExecutor
 
 /*
   TODO: There exists a swagger codegen Sam client somewhere, and there also exists a Scala wrapper for it in Leo.
@@ -35,11 +38,14 @@ class SamClient(scheme: String,
   override val statusUri = uri"$samBaseUri/status"
   override val serviceRegistryActor: ActorRef = serviceRegistryActorRef
 
-  def isSubmitWhitelisted(user: User, cromIamRequest: HttpRequest): Future[Boolean] = {
-    checkSubmitWhitelist.fold(isSubmitWhitelistedSam(user, cromIamRequest), Future.successful(true))
+  def isSubmitWhitelisted(user: User, cromIamRequest: HttpRequest): FailureResponseOrT[Boolean] = {
+    checkSubmitWhitelist.fold(
+      isSubmitWhitelistedSam(user, cromIamRequest),
+      FailureResponseOrT.pure(true)
+    )
   }
 
-  def isSubmitWhitelistedSam(user: User, cromIamRequest: HttpRequest): Future[Boolean] = {
+  def isSubmitWhitelistedSam(user: User, cromIamRequest: HttpRequest): FailureResponseOrT[Boolean] = {
     val request = HttpRequest(
       method = HttpMethods.GET,
       uri = samSubmitWhitelistUri,
@@ -47,21 +53,35 @@ class SamClient(scheme: String,
     )
 
     for {
-      response <- instrumentRequest(() => Http().singleRequest(request), cromIamRequest, instrumentationPrefixForSam(getWhitelistPrefix))
+      response <- instrumentRequest(
+        () => Http().singleRequest(request).asFailureResponseOrT,
+        cromIamRequest,
+        instrumentationPrefixForSam(getWhitelistPrefix)
+      )
       whitelisted <- response.status match {
-        case StatusCodes.OK => Unmarshal(response.entity).to[String].map(_.toBoolean)
-        case _ => Future.successful(false)
+        case StatusCodes.OK =>
+          // Does not seem to be already provided?
+          implicit val entityToBooleanUnmarshaller : Unmarshaller[HttpEntity, Boolean] =
+            (Unmarshaller.stringUnmarshaller flatMap Unmarshaller.booleanFromStringUnmarshaller).asScala
+          val unmarshal = IO.fromFuture(IO(Unmarshal(response.entity).to[Boolean]))
+          FailureResponseOrT.right[HttpResponse](unmarshal)
+        case _ => FailureResponseOrT.pure[IO, HttpResponse](false)
       }
       _ = if (!whitelisted) log.error("Submit Access Denied for user {}", user.userId)
     } yield whitelisted
   }
 
-  def collectionsForUser(user: User, cromIamRequest: HttpRequest): Future[List[Collection]] = {
+  def collectionsForUser(user: User, cromIamRequest: HttpRequest): FailureResponseOrT[List[Collection]] = {
     val request = HttpRequest(method = HttpMethods.GET, uri = samBaseCollectionUri, headers = List[HttpHeader](user.authorization))
 
     for {
-      response <- instrumentRequest(() => Http().singleRequest(request), cromIamRequest, instrumentationPrefixForSam(userCollectionPrefix))
-      resources <- Unmarshal(response.entity).to[List[SamResource]]
+      response <- instrumentRequest(
+        () => Http().singleRequest(request).asFailureResponseOrT,
+        cromIamRequest,
+        instrumentationPrefixForSam(userCollectionPrefix)
+      )
+      futureIO = IO.fromFuture(IO(Unmarshal(response.entity).to[List[SamResource]]))
+      resources <- FailureResponseOrT.right(futureIO)
     } yield resources.map(r => Collection(r.resourceId))
   }
 
@@ -69,15 +89,17 @@ class SamClient(scheme: String,
     * Requests authorization for the authenticated user to perform an action from the Sam service for a collection
     * @return Successful future if the auth is accepted, a Failure otherwise.
     */
-  def requestAuth(authorizationRequest: CollectionAuthorizationRequest, cromIamRequest: HttpRequest): Future[Unit] = {
+  def requestAuth(authorizationRequest: CollectionAuthorizationRequest,
+                  cromIamRequest: HttpRequest): FailureResponseOrT[Unit] = {
     val logString = authorizationRequest.action + " access for user " + authorizationRequest.user.userId +
       " on a request to " + authorizationRequest.action +  " for collection " + authorizationRequest.collection.name
 
-    def validateEntityBytes(byteString: ByteString): Future[Unit] = {
-      if (byteString.utf8String == "true") Future.successful(())
-      else {
+    def validateEntityBytes(byteString: ByteString): FailureResponseOrT[Unit] = {
+      if (byteString.utf8String == "true") {
+        Monad[FailureResponseOrT].unit
+      } else {
         log.warning("Sam denied " + logString)
-        Future.failed(new SamDenialException)
+        FailureResponseOrT[IO, HttpResponse, Unit](IO.raiseError(new SamDenialException))
       }
     }
 
@@ -88,8 +110,13 @@ class SamClient(scheme: String,
       headers = List[HttpHeader](authorizationRequest.user.authorization))
 
     for {
-      response <- instrumentRequest(() => Http().singleRequest(request), cromIamRequest, instrumentationPrefixForSam(authCollectionPrefix))
-      entityBytes <- response.entity.dataBytes.runFold(ByteString(""))(_ ++ _)
+      response <- instrumentRequest(
+        () => Http().singleRequest(request).asFailureResponseOrT,
+        cromIamRequest,
+        instrumentationPrefixForSam(authCollectionPrefix)
+      )
+      futureIO = IO.fromFuture(IO(response.entity.dataBytes.runFold(ByteString(""))(_ ++ _)))
+      entityBytes <- FailureResponseOrT.right(futureIO)
       _ <- validateEntityBytes(entityBytes)
     } yield ()
   }
@@ -101,21 +128,30 @@ class SamClient(scheme: String,
             - If user has the 'add' permission we're ok
         - else fail the future
    */
-  def requestSubmission(user: User, collection: Collection, cromIamRequest: HttpRequest): Future[Unit] = {
+  def requestSubmission(user: User,
+                        collection: Collection,
+                        cromIamRequest: HttpRequest
+                       ): FailureResponseOrT[Unit] = {
     log.info("Verifying user " + user.userId + " can submit a workflow to collection " + collection.name)
     val createCollection = registerCreation(user, collection, cromIamRequest)
 
     createCollection flatMap {
       case r if r.status == StatusCodes.Conflict => requestAuth(CollectionAuthorizationRequest(user, collection, "add"), cromIamRequest)
-      case r if r.status == StatusCodes.NoContent => Future.successful(())
-      case r => Future.failed(SamRegisterCollectionException(r.status))
+      case r if r.status == StatusCodes.NoContent => Monad[FailureResponseOrT].unit
+      case r => FailureResponseOrT[IO, HttpResponse, Unit](IO.raiseError(SamRegisterCollectionException(r.status)))
     }
   }
 
-  private def registerCreation(user: User, collection: Collection, cromIamRequest: HttpRequest): Future[HttpResponse] = {
+  private def registerCreation(user: User,
+                               collection: Collection,
+                               cromIamRequest: HttpRequest): FailureResponseOrT[HttpResponse] = {
     val request = HttpRequest(method = HttpMethods.POST, uri = samRegisterUri(collection), headers = List[HttpHeader](user.authorization))
 
-    instrumentRequest(() => Http().singleRequest(request), cromIamRequest, instrumentationPrefixForSam(registerCollectionPrefix))
+    instrumentRequest(
+      () => Http().singleRequest(request).asFailureResponseOrT,
+      cromIamRequest,
+      instrumentationPrefixForSam(registerCollectionPrefix)
+    )
   }
 
   private def samAuthorizeActionUri(authorizationRequest: CollectionAuthorizationRequest) = {

--- a/CromIAM/src/main/scala/cromiam/webservice/EngineRouteSupport.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/EngineRouteSupport.scala
@@ -1,14 +1,15 @@
 package cromiam.webservice
 
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import cromiam.cromwell.CromwellClient
 import cromiam.server.status.StatusService
-import EngineRouteSupport._
+import cromiam.webservice.EngineRouteSupport._
+import cromwell.api.model._
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport._
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -24,7 +25,7 @@ trait EngineRouteSupport extends RequestSupport with SprayJsonSupport {
   def versionRoute: Route = path("engine" / Segment / "version") { _ =>
     get {
       extractStrictRequest { req =>
-        complete { cromwellClient.forwardToCromwell(req) }
+        complete { cromwellClient.forwardToCromwell(req).asHttpResponse }
       }
     }
   }

--- a/CromIAM/src/test/scala/cromiam/sam/SamClientSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/sam/SamClientSpec.scala
@@ -1,13 +1,15 @@
 package cromiam.sam
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.ActorMaterializer
 import cromiam.auth.{Collection, User}
 import cromiam.sam.SamClient.{CollectionAuthorizationRequest, SamDenialException, SamRegisterCollectionException}
 import cromiam.webservice.MockSamClient
+import cromwell.api.model._
 import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
+import org.scalatest.EitherValues._
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
 
 import scala.concurrent.ExecutionContextExecutor
@@ -20,6 +22,9 @@ class SamClientSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll  
 
   val samClient = new MockSamClient()
   val samClientNoWhitelist = new MockSamClient(checkSubmitWhitelist = false)
+  val expectedErrorMessage = "expected error"
+  val expectedErrorResponse = HttpResponse(StatusCodes.InternalServerError, entity = HttpEntity(expectedErrorMessage))
+  val samClientWithError = new MockSamClient(samResponseOption = Option(expectedErrorResponse))
 
   val authorization = Authorization(OAuth2BearerToken("my-token"))
   val authorizedUserWithCollection: User = User(WorkbenchUserId(samClient.authorizedUserCollectionStr), authorization)
@@ -42,47 +47,80 @@ class SamClientSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll  
   behavior of "SamClient"
   it should "return true if user is whitelisted" in {
     samClient.isSubmitWhitelisted(authorizedUserWithCollection, emptyHttpRequest).map(v => assert(v))
+      .asIo.unsafeToFuture()
   }
 
   it should "return false if user is not whitelisted" in {
     samClient.isSubmitWhitelisted(notWhitelistedUser, emptyHttpRequest).map(v => assert(!v))
+      .asIo.unsafeToFuture()
+  }
+
+  it should "return sam errors while checking is whitelisted" in {
+    samClientWithError.isSubmitWhitelisted(notWhitelistedUser, emptyHttpRequest).value.unsafeToFuture() map {
+      _.left.value should be(expectedErrorResponse)
+    }
   }
 
   it should "eventually return the collection(s) of user" in {
     samClient.collectionsForUser(authorizedUserWithCollection, emptyHttpRequest).map(collectionList =>
       assert(collectionList == samClient.userCollectionList)
-    )
+    ).asIo.unsafeToFuture()
   }
 
   it should "fail if user doesn't have any collections" in {
     recoverToExceptionIf[Exception] {
       samClient.collectionsForUser(unauthorizedUserWithNoCollection, emptyHttpRequest)
+        .asIo.unsafeToFuture()
     } map(exception =>
       assert(exception.getMessage == s"Unable to look up collections for user ${unauthorizedUserWithNoCollection.userId.value}!")
     )
   }
 
+  it should "return sam errors while checking collections" in {
+    samClientWithError.collectionsForUser(unauthorizedUserWithNoCollection, emptyHttpRequest)
+      .value.unsafeToFuture() map {
+      _.left.value should be(expectedErrorResponse)
+    }
+  }
+
   it should "return true if user is authorized to perform action on collection" in {
     samClient.requestAuth(authorizedCollectionRequest, emptyHttpRequest).map(_ => succeed)
+      .asIo.unsafeToFuture()
   }
 
   it should "throw SamDenialException if user is not authorized to perform action on collection" in {
     recoverToExceptionIf[SamDenialException] {
       samClient.requestAuth(unauthorizedCollectionRequest, emptyHttpRequest)
+        .asIo.unsafeToFuture()
     } map { exception =>
       assert(exception.getMessage == "Access Denied")
     }
   }
 
+  it should "return sam errors while checking if user is authorized" in {
+    samClientWithError.requestAuth(authorizedCollectionRequest, emptyHttpRequest).value.unsafeToFuture() map {
+      _.left.value should be(expectedErrorResponse)
+    }
+  }
+
   it should "register collection to Sam if user has authorization to create/add to collection" in {
     samClient.requestSubmission(authorizedUserWithCollection, authorizedCollection, emptyHttpRequest).map(_ => succeed)
+      .asIo.unsafeToFuture()
   }
 
   it should "throw SamRegisterCollectionException if user doesn't have authorization to create/add to collection" in {
     recoverToExceptionIf[SamRegisterCollectionException] {
       samClient.requestSubmission(unauthorizedUserWithNoCollection, unauthorizedCollection, emptyHttpRequest).map(_ => succeed)
+        .asIo.unsafeToFuture()
     } map { exception =>
       assert(exception.getMessage == "Can't register collection with Sam. Status code: 400 Bad Request")
+    }
+  }
+
+  it should "return sam errors while checking user authorization" in {
+    samClientWithError.requestSubmission(unauthorizedUserWithNoCollection, unauthorizedCollection, emptyHttpRequest)
+      .value.unsafeToFuture() map {
+      _.left.value should be(expectedErrorResponse)
     }
   }
 }

--- a/CromIAM/src/test/scala/cromiam/webservice/CromIamApiServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/CromIamApiServiceSpec.scala
@@ -1,10 +1,9 @@
 package cromiam.webservice
 
 import akka.event.NoLogging
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader}
-import akka.http.scaladsl.model.headers.{OAuth2BearerToken, RawHeader}
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.headers.Authorization
+import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken, RawHeader}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpHeader}
 import akka.http.scaladsl.server.MissingHeaderRejection
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.Config
@@ -37,6 +36,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/status").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -44,6 +44,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/status").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -51,6 +52,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/status").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -58,6 +60,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/status").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -73,6 +76,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/outputs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -80,6 +84,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/outputs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -87,6 +92,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/outputs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -94,6 +100,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/outputs").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -109,6 +116,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/metadata").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -116,6 +124,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/metadata").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -123,6 +132,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/metadata").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -130,6 +140,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/metadata").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -145,6 +156,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/logs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -152,6 +164,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/logs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -159,6 +172,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/logs").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -166,6 +180,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/logs").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -181,6 +196,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/labels").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -188,6 +204,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/labels").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -195,6 +212,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/labels").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -202,6 +220,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/${cromwellClient.subworkflowId}/labels").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -219,6 +238,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Patch(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/labels").withHeaders(goodAuthHeaders).withEntity(labelEntity) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -229,6 +249,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Patch(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/labels").withHeaders(goodAuthHeaders).withEntity(labelEntity) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe "Submitted labels contain the key caas-collection-name, which is not allowed\n"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -239,6 +260,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Patch(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/labels").withHeaders(goodAuthHeaders).withEntity(labelEntity) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe "Labels must be a valid JSON object, received: \"key-1\":\"foo\"\n"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -248,6 +270,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Patch(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/labels").withHeaders(goodAuthHeaders).withEntity(labelEntity) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -257,6 +280,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Patch(s"/api/workflows/$version/${cromwellClient.subworkflowId}/labels").withHeaders(badAuthHeaders).withEntity(labelEntity) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -274,6 +298,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/backends").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -289,6 +314,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/releaseHold").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -296,6 +322,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/releaseHold").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -303,6 +330,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.subworkflowId}/releaseHold").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -318,6 +346,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.rootWorkflowIdWithCollection}/abort").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -325,6 +354,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.workflowIdWithoutCollection}/abort").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -332,6 +362,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Post(s"/api/workflows/$version/${cromwellClient.subworkflowId}/abort").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -348,6 +379,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/callcaching/diff?$callCacheDiffParams").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -356,6 +388,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/callcaching/diff?$callCacheDiffParams").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe BadRequest
       responseAs[String] shouldBe "Must supply both workflowA and workflowB to the /callcaching/diff endpoint"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -364,6 +397,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/callcaching/diff?$callCacheDiffParams").withHeaders(goodAuthHeaders) ~> allRoutes ~> check {
       status shouldBe InternalServerError
       responseAs[String] shouldBe s"CromIAM unexpected error: java.lang.IllegalArgumentException: Workflow ${cromwellClient.workflowIdWithoutCollection} has no associated collection"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -372,6 +406,7 @@ class CromIamApiServiceSpec extends FlatSpec with Matchers with CromIamApiServic
     Get(s"/api/workflows/$version/callcaching/diff?$callCacheDiffParams").withHeaders(badAuthHeaders) ~> allRoutes ~> check {
       status shouldBe Forbidden
       responseAs[String] shouldBe "Access Denied"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 

--- a/CromIAM/src/test/scala/cromiam/webservice/EngineRouteSupportSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/EngineRouteSupportSpec.scala
@@ -1,7 +1,8 @@
 package cromiam.webservice
 
-import akka.http.scaladsl.model.headers.Authorization
+import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers.Authorization
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromiam.server.status.{MockStatusService, StatusService}
 import org.scalatest.{FlatSpec, Matchers}
@@ -23,6 +24,7 @@ class EngineRouteSupportSpec extends FlatSpec with Matchers with ScalatestRouteT
     Get(statsRoutePath).withHeaders(emptyAuthHeader) ~> engineRoutes ~> check {
       status shouldBe Forbidden
       response.entity shouldBe EngineRouteSupport.CromIamStatsForbidden.entity
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -30,6 +32,7 @@ class EngineRouteSupportSpec extends FlatSpec with Matchers with ScalatestRouteT
     Get(versionRoutePath) ~> engineRoutes ~> check {
       status shouldBe OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -39,6 +42,7 @@ class EngineRouteSupportSpec extends FlatSpec with Matchers with ScalatestRouteT
       assertResult("""{"ok":true,"systems":{"Cromwell":{"ok":true},"Sam":{"ok":true}}}""") {
         responseAs[String]
       }
+      assertResult(ContentTypes.`application/json`)(contentType)
     }
   }
 }

--- a/CromIAM/src/test/scala/cromiam/webservice/QuerySupportSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/QuerySupportSpec.scala
@@ -70,24 +70,28 @@ class QuerySupportSpec extends FlatSpec with Matchers with ScalatestRouteTest wi
 
   "GET query" should "peacefully forward to Cromwell if nothing is untoward" in {
     Get(getQuery).withHeaders(authHeaders) ~> queryGetRoute ~> check {
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
       responseAs[String] shouldBe "Response from Cromwell"
     }
   }
 
   it should "reject requests that contain labelOrs" in {
     Get(badGetQuery).withHeaders(authHeaders) ~> queryGetRoute ~> check {
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
       status shouldEqual StatusCodes.InternalServerError
     }
   }
 
   "POST query" should "peacefully forward to Cromwell is nothing is untoward" in {
     Post(queryPath).withHeaders(authHeaders).withEntity(goodPostEntity) ~> queryPostRoute ~> check {
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
       responseAs[String] shouldBe "Response from Cromwell"
     }
   }
 
   it should "reject requests that contain labelOrs" in {
     Post(queryPath).withHeaders(authHeaders).withEntity(badPostEntity) ~> queryPostRoute ~> check {
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
       status shouldEqual StatusCodes.InternalServerError
     }
   }

--- a/CromIAM/src/test/scala/cromiam/webservice/SubmissionSupportSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SubmissionSupportSpec.scala
@@ -5,9 +5,10 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken, RawHeader}
 import akka.http.scaladsl.server.AuthorizationFailedRejection
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import org.scalatest.{FlatSpec, Matchers}
-import scala.concurrent.duration._
 import akka.testkit._
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
 
 class SubmissionSupportSpec extends FlatSpec with Matchers with ScalatestRouteTest with SubmissionSupport {
   override val cromwellClient = new MockCromwellClient()
@@ -48,12 +49,15 @@ class SubmissionSupportSpec extends FlatSpec with Matchers with ScalatestRouteTe
     Post(submitPath).withHeaders(goodAuthHeaders).withEntity(formData) ~> submitRoute ~> check {
       status shouldEqual StatusCodes.OK
       responseAs[String] shouldBe "Response from Cromwell"
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
   it should "fail with BadRequest for unauthorized SAM user and not forward the request to Cromwell" in {
     Post(submitPath).withHeaders(badAuthHeaders).withEntity(formData) ~> submitRoute ~> check {
       status shouldEqual StatusCodes.BadRequest
+      responseAs[String] should be("Can't register collection with Sam. Status code: 400 Bad Request")
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
@@ -1,6 +1,6 @@
 package cromiam.webservice
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cromiam.server.config.SwaggerOauthConfig
 import io.swagger.models.properties.RefProperty
@@ -26,6 +26,7 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
       swaggerUiResourceRoute ~>
       check {
         status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/octet-stream`)
 
         val body = responseAs[String]
         val yaml = new SnakeYaml(new UniqueKeyConstructor()).loadAs(body, classOf[java.util.Map[String, AnyRef]])
@@ -39,6 +40,7 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
       swaggerUiResourceRoute ~>
       check {
         status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/octet-stream`)
 
         /*
         BUG: Right now swagger-parser says that type is unexpected in security definitions. Should be fixed in
@@ -81,6 +83,7 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
         assertResult("<!-- HTML for static distribution bundle build -->") {
           responseAs[String].take(50)
         }
+        assertResult(ContentTypes.`text/html(UTF-8)`)(contentType)
       }
   }
 
@@ -100,6 +103,7 @@ class SwaggerServiceSpec extends FlatSpec with SwaggerService with ScalatestRout
           assertResult("OK") {
             responseAs[String]
           }
+          assertResult(ContentTypes.`text/plain(UTF-8)`)(contentType)
         }
     }
   }

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -1,14 +1,14 @@
 package cromiam.webservice
 
 import akka.http.scaladsl.model.headers.Location
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.{ContentTypes, StatusCodes, Uri}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.typesafe.config.ConfigFactory
 import cromiam.server.config.SwaggerOauthConfig
+import cromiam.webservice.SwaggerUiHttpServiceSpec._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
-import cromiam.webservice.SwaggerUiHttpServiceSpec._
 
 trait SwaggerUiHttpServiceSpec extends FlatSpec with Matchers with ScalatestRouteTest with SwaggerUiHttpService {
   def actorRefFactory = system
@@ -46,12 +46,14 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     Get() ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
   it should "not return options for /" in {
     Options() ~> Route.seal(swaggerUiRoute) ~> check {
       status should be(StatusCodes.MethodNotAllowed)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -59,6 +61,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     Get("/swagger") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
@@ -66,6 +69,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should include("replaced-client-id")
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 }
@@ -78,12 +82,14 @@ class NoRedirectRootSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   it should "not redirect / to /swagger" in {
     Get() ~> Route.seal(swaggerUiRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
   it should "not return options for /" in {
     Options() ~> Route.seal(swaggerUiRoute) ~> check {
       status should be(StatusCodes.MethodNotAllowed)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -91,12 +97,14 @@ class NoRedirectRootSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     Get("/swagger") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
   it should "return index.html from the swagger-ui jar" in {
     Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 }
@@ -110,6 +118,7 @@ class DefaultSwaggerUiConfigHttpServiceSpec extends SwaggerUiHttpServiceSpec wit
     Get("/swagger") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
@@ -117,6 +126,7 @@ class DefaultSwaggerUiConfigHttpServiceSpec extends SwaggerUiHttpServiceSpec wit
     Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String].take(SwaggerIndexPreamble.length) should be(SwaggerIndexPreamble)
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 }
@@ -136,6 +146,7 @@ class OverriddenSwaggerUiConfigHttpServiceSpec extends SwaggerUiHttpServiceSpec 
     Get("/ui/path") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/base/ui/path/index.html?url=/base/swagger/cromiam.yaml"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
@@ -143,6 +154,7 @@ class OverriddenSwaggerUiConfigHttpServiceSpec extends SwaggerUiHttpServiceSpec 
     Get("/ui/path/index.html") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String].take(SwaggerIndexPreamble.length) should be(SwaggerIndexPreamble)
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 }
@@ -156,18 +168,21 @@ class YamlSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
     Get("/swagger/testservice.yaml") ~> swaggerResourceRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should startWith("swagger: '2.0'\n")
+      contentType should be(ContentTypes.`application/octet-stream`)
     }
   }
 
   it should "not service swagger json" in {
     Get("/swagger/testservice.json") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
   it should "not service /swagger" in {
     Get("/swagger") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -176,6 +191,7 @@ class YamlSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
       Options(path) ~> swaggerResourceRoute ~> check {
         status should be(StatusCodes.OK)
         responseAs[String] should be("OK")
+        contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }
   }
@@ -192,18 +208,21 @@ class JsonSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
     Get("/swagger/testservice.json") ~> swaggerResourceRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should startWith("{\n  \"swagger\": \"2.0\",\n")
+      contentType should be(ContentTypes.`application/json`)
     }
   }
 
   it should "not service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
   it should "not service /swagger" in {
     Get("/swagger") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -212,6 +231,7 @@ class JsonSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
       Options(path) ~> swaggerResourceRoute ~> check {
         status should be(StatusCodes.OK)
         responseAs[String] should be("OK")
+        contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }
   }
@@ -228,18 +248,21 @@ class NoOptionsSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpService
     Get("/swagger/testservice.yaml") ~> swaggerResourceRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should startWith("swagger: '2.0'\n")
+      contentType should be(ContentTypes.`application/octet-stream`)
     }
   }
 
   it should "not service swagger json" in {
     Get("/swagger/testservice.json") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
   it should "not service /swagger" in {
     Get("/swagger") ~> Route.seal(swaggerResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -247,6 +270,7 @@ class NoOptionsSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpService
     forAll(testPathsForOptions) { path =>
       Options(path) ~> Route.seal(swaggerResourceRoute) ~> check {
         status should be(StatusCodes.MethodNotAllowed)
+        contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }
   }
@@ -263,6 +287,7 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
     Get("/swagger") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.yaml"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
@@ -270,12 +295,14 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
     Get("/swagger/testservice.yaml") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should startWith("swagger: '2.0'\n")
+      contentType should be(ContentTypes.`application/octet-stream`)
     }
   }
 
   it should "not service swagger json" in {
     Get("/swagger/testservice.json") ~> Route.seal(swaggerUiResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -284,6 +311,7 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
       Options(path) ~> swaggerUiResourceRoute ~> check {
         status should be(StatusCodes.OK)
         responseAs[String] should be("OK")
+        contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }
   }
@@ -303,6 +331,7 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
     Get("/swagger") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.TemporaryRedirect)
       header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.json"))))
+      contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
 
@@ -310,12 +339,14 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
     Get("/swagger/testservice.json") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
       responseAs[String] should startWith("{\n  \"swagger\": \"2.0\",\n")
+      contentType should be(ContentTypes.`application/json`)
     }
   }
 
   it should "not service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> Route.seal(swaggerUiResourceRoute) ~> check {
       status should be(StatusCodes.NotFound)
+      contentType should be(ContentTypes.`text/plain(UTF-8)`)
     }
   }
 
@@ -324,6 +355,7 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
       Options(path) ~> swaggerUiResourceRoute ~> check {
         status should be(StatusCodes.OK)
         responseAs[String] should be("OK")
+        contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }
   }

--- a/centaur/src/it/scala/centaur/CentaurTestSuite.scala
+++ b/centaur/src/it/scala/centaur/CentaurTestSuite.scala
@@ -22,7 +22,7 @@ object CentaurTestSuite {
     }
   }
 
-  val cromwellBackends = CentaurCromwellClient.backends.get.supportedBackends.map(_.toLowerCase)
+  val cromwellBackends = CentaurCromwellClient.backends.unsafeRunSync().supportedBackends.map(_.toLowerCase)
   
   def runSequential(testCase: CentaurTestCase): Boolean = testCase.testFormat match {
     case _: RestartFormat| _: ScheduledAbort | InstantAbort => true

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -14,7 +14,7 @@ import centaur.{CentaurConfig, CromwellManager}
 import com.typesafe.config.ConfigFactory
 import cromwell.api.CromwellClient
 import cromwell.api.CromwellClient.UnsuccessfulRequestException
-import cromwell.api.model.{CallCacheDiff, CromwellBackends, ShardIndex, SubmittedWorkflow, WorkflowId, WorkflowMetadata, WorkflowOutputs, WorkflowStatus}
+import cromwell.api.model._
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent._
@@ -75,23 +75,30 @@ object CentaurCromwellClient {
     sendReceiveFutureCompletion(() => cromwellClient.metadata(id, args))
   }
   
-  lazy val backends: Try[CromwellBackends] = Try(Await.result(cromwellClient.backends, CromwellManager.timeout * 2))
-
   implicit private val timer = IO.timer(blockingEc)
   implicit private val contextShift = IO.contextShift(blockingEc)
 
-  def retryRequest[T](x: () => Future[T], timeout: FiniteDuration): IO[T] = {
-    // If Cromwell is known not to be ready, delay the request to avoid requests bound to fail 
+  lazy val backends: IO[CromwellBackends] = cromwellClient.backends.timeout(CromwellManager.timeout * 2).asIo
+
+  def retryRequest[T](func: () => FailureResponseOrT[T], timeout: FiniteDuration): IO[T] = {
+    // If Cromwell is known not to be ready, delay the request to avoid requests bound to fail
     val ioDelay = if (!CromwellManager.isReady) IO.sleep(10.seconds) else IO.unit
 
     ioDelay.flatMap( _ =>
       // Could probably use IO to do the retrying too. For now use a copyport of Retry from cromwell core. Retry 5 times,
       // wait 5 seconds between retries. Timeout the whole thing using the IO timeout.
-      IO.fromFuture(IO(Retry.withRetry(x, Option(5), 5.seconds, isTransient = isTransient)).timeout(timeout))
+      // https://github.com/cb372/cats-retry
+      // https://typelevel.org/cats-effect/datatypes/io.html#example-retrying-with-exponential-backoff
+      IO.fromFuture(IO(Retry.withRetry(
+        () => func().asIo.unsafeToFuture(),
+        Option(5),
+        5.seconds,
+        isTransient = isTransient)
+      ).timeout(timeout))
     )
   }
 
-  def sendReceiveFutureCompletion[T](x: () => Future[T]) = {
+  def sendReceiveFutureCompletion[T](x: () => FailureResponseOrT[T]): IO[T] = {
     retryRequest(x, CentaurConfig.sendReceiveTimeout)
   }
 

--- a/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
@@ -2,24 +2,21 @@ package cromwell.api
 
 import java.net.URL
 
-import akka.http.scaladsl.Http
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
 import akka.http.scaladsl.coding.{Deflate, Gzip, NoCoding}
-import akka.http.scaladsl.model.{HttpEntity, _}
-import akka.http.scaladsl.model.headers.Authorization
-import akka.http.scaladsl.model.headers.HttpCredentials
-import akka.http.scaladsl.model.headers.HttpEncodings
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{Authorization, HttpCredentials, HttpEncodings}
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.ActorMaterializer
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.util.ByteString
+import cats.effect.IO
+import cromwell.api.CromwellClient._
 import cromwell.api.model._
 import spray.json._
 
-import scala.concurrent.{ExecutionContext, Future}
-import cromwell.api.CromwellClient._
-
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.ExecutionContext
 
 class CromwellClient(val cromwellUrl: URL,
                      val apiVersion: String,
@@ -47,15 +44,16 @@ class CromwellClient(val cromwellUrl: URL,
   lazy val backendsEndpoint = s"$submitEndpoint/backends"
   lazy val versionEndpoint = s"$engineEndpoint/version"
 
-  import model.CromwellStatusJsonSupport._
-  import model.WorkflowOutputsJsonSupport._
-  import model.WorkflowLogsJsonSupport._
-  import model.CromwellBackendsJsonSupport._
-  import model.CromwellVersionJsonSupport._
   import model.CallCacheDiffJsonSupport._
+  import model.CromwellBackendsJsonSupport._
+  import model.CromwellStatusJsonSupport._
+  import model.CromwellVersionJsonSupport._
   import model.WorkflowLabelsJsonSupport._
+  import model.WorkflowLogsJsonSupport._
+  import model.WorkflowOutputsJsonSupport._
 
-  def submit(workflow: WorkflowSubmission)(implicit ec: ExecutionContext): Future[SubmittedWorkflow] = {
+  def submit(workflow: WorkflowSubmission)
+            (implicit ec: ExecutionContext): FailureResponseOrT[SubmittedWorkflow] = {
     val requestEntity = requestEntityForSubmit(workflow)
 
     makeRequest[CromwellStatus](HttpRequest(HttpMethods.POST, submitEndpoint, List.empty[HttpHeader], requestEntity)) map { status =>
@@ -63,7 +61,8 @@ class CromwellClient(val cromwellUrl: URL,
     }
   }
 
-  def submitBatch(workflow: WorkflowBatchSubmission)(implicit ec: ExecutionContext): Future[List[SubmittedWorkflow]] = {
+  def submitBatch(workflow: WorkflowBatchSubmission)
+                 (implicit ec: ExecutionContext): FailureResponseOrT[List[SubmittedWorkflow]] = {
     import DefaultJsonProtocol._
 
     val requestEntity = requestEntityForSubmit(workflow)
@@ -88,27 +87,51 @@ class CromwellClient(val cromwellUrl: URL,
     }
   }
 
-  def abort(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowStatus] = simpleRequest[CromwellStatus](uri = abortEndpoint(workflowId), method = HttpMethods.POST) map WorkflowStatus.apply
-  def status(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowStatus] = simpleRequest[CromwellStatus](statusEndpoint(workflowId)) map WorkflowStatus.apply
+  def abort(workflowId: WorkflowId)(implicit ec: ExecutionContext): FailureResponseOrT[WorkflowStatus] = {
+    simpleRequest[CromwellStatus](uri = abortEndpoint(workflowId), method = HttpMethods.POST) map WorkflowStatus.apply
+  }
+
+  def status(workflowId: WorkflowId)(implicit ec: ExecutionContext): FailureResponseOrT[WorkflowStatus] = {
+    simpleRequest[CromwellStatus](statusEndpoint(workflowId)) map WorkflowStatus.apply
+  }
 
   def metadata(workflowId: WorkflowId,
                args: Option[Map[String, List[String]]] = None,
                headers: List[HttpHeader] = defaultHeaders
-               )(implicit ec: ExecutionContext): Future[WorkflowMetadata] = {
+              )(implicit ec: ExecutionContext): FailureResponseOrT[WorkflowMetadata] = {
     simpleRequest[String](metadataEndpoint(workflowId, args), headers=headers) map WorkflowMetadata
   }
 
-  def outputs(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowOutputs] = simpleRequest[WorkflowOutputs](outputsEndpoint(workflowId))
+  def outputs(workflowId: WorkflowId)(implicit ec: ExecutionContext): FailureResponseOrT[WorkflowOutputs] = {
+    simpleRequest[WorkflowOutputs](outputsEndpoint(workflowId))
+  }
 
-  def labels(workflowId: WorkflowId, headers: List[HttpHeader] = defaultHeaders)(implicit ec: ExecutionContext): Future[WorkflowLabels] = {
+  def labels(workflowId: WorkflowId, headers: List[HttpHeader] = defaultHeaders)
+            (implicit ec: ExecutionContext): FailureResponseOrT[WorkflowLabels] = {
     simpleRequest[WorkflowLabels](labelsEndpoint(workflowId), headers=headers)
   }
 
-  def logs(workflowId: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowLogs] = simpleRequest[WorkflowLogsStruct](outputsEndpoint(workflowId)) map WorkflowLogs.apply
-  def callCacheDiff(workflowA: WorkflowId, callA: String, shardIndexA: ShardIndex, workflowB: WorkflowId, callB: String, shardIndexB: ShardIndex)(implicit ec: ExecutionContext): Future[CallCacheDiff] =
+  def logs(workflowId: WorkflowId)(implicit ec: ExecutionContext): FailureResponseOrT[WorkflowLogs] = {
+    simpleRequest[WorkflowLogsStruct](outputsEndpoint(workflowId)) map WorkflowLogs.apply
+  }
+
+  def callCacheDiff(workflowA: WorkflowId,
+                    callA: String,
+                    shardIndexA: ShardIndex,
+                    workflowB: WorkflowId,
+                    callB: String,
+                    shardIndexB: ShardIndex
+                   )(implicit ec: ExecutionContext): FailureResponseOrT[CallCacheDiff] = {
     simpleRequest[CallCacheDiff](diffEndpoint(workflowA, callA, shardIndexA, workflowB, callB, shardIndexB))
-  def backends(implicit ec: ExecutionContext): Future[CromwellBackends] = simpleRequest[CromwellBackends](backendsEndpoint)
-  def version(implicit ec: ExecutionContext): Future[CromwellVersion] = simpleRequest[CromwellVersion](versionEndpoint)
+  }
+
+  def backends(implicit ec: ExecutionContext): FailureResponseOrT[CromwellBackends] = {
+    simpleRequest[CromwellBackends](backendsEndpoint)
+  }
+
+  def version(implicit ec: ExecutionContext): FailureResponseOrT[CromwellVersion] = {
+    simpleRequest[CromwellVersion](versionEndpoint)
+  }
 
   private [api] def executeRequest(request: HttpRequest, headers: List[HttpHeader]) = Http().singleRequest(request.withHeaders(headers))
 
@@ -117,24 +140,21 @@ class CromwellClient(val cromwellUrl: URL,
     * @tparam A The type of response expected. Must be supported by an implicit unmarshaller from ResponseEntity.
     */
   private def makeRequest[A](request: HttpRequest, headers: List[HttpHeader] = defaultHeaders)
-                            (implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = for {
-    response <- executeRequest(request, headers)
-    decoded <- Future.fromTry(decodeResponse(response))
-    entity <- Future.fromTry(decoded.toEntity)
-    unmarshalled <- unmarshall(response, entity)(um, ec)
-  } yield unmarshalled
-
-  private def unmarshall[A](response: HttpResponse, entity: Unmarshal[ResponseEntity])(implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = {
-    import CromwellFailedResponseExceptionJsonSupport._
-
-    if (response.status.isSuccess()) entity.to[A]
-    else entity.to[CromwellFailedResponseException] flatMap Future.failed
+                            (implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext):
+  FailureResponseOrT[A] = {
+    for {
+      response <- executeRequest(request, headers).asFailureResponseOrT
+      decoded <- FailureResponseOrT.right(decodeResponse(response))
+      entity <- FailureResponseOrT.right(decoded.toEntity)
+      unmarshalled <- FailureResponseOrT.right(IO.fromFuture(IO(entity.to[A])))
+    } yield unmarshalled
   }
 
   private def simpleRequest[A](uri: Uri,
                                method: HttpMethod = HttpMethods.GET,
                                headers: List[HttpHeader] = defaultHeaders)
-                              (implicit um: Unmarshaller[ResponseEntity, A], ec: ExecutionContext): Future[A] = {
+                              (implicit um: Unmarshaller[ResponseEntity, A],
+                               ec: ExecutionContext): FailureResponseOrT[A] = {
     makeRequest[A](HttpRequest(uri = uri, method = method), headers)
   }
 
@@ -144,26 +164,23 @@ class CromwellClient(val cromwellUrl: URL,
     HttpEncodings.identity -> NoCoding
   )
 
-  private def decodeResponse(response: HttpResponse): Try[HttpResponse] = {
+  private def decodeResponse(response: HttpResponse): IO[HttpResponse] = {
     decoders.get(response.encoding) map { decoder =>
-      Try(decoder.decodeMessage(response))
-    } getOrElse Failure(UnsuccessfulRequestException(s"No decoder for ${response.encoding}", response))
+      IO(decoder.decodeMessage(response))
+    } getOrElse IO.raiseError(UnsuccessfulRequestException(s"No decoder for ${response.encoding}", response))
   }
 }
 
 object CromwellClient {
   final implicit class EnhancedHttpResponse(val response: HttpResponse) extends AnyVal {
 
-    def toEntity: Try[Unmarshal[ResponseEntity]] = response match {
-      case HttpResponse(_: StatusCodes.Success, _, entity, _) => Success(Unmarshal(entity))
-      case HttpResponse(_: StatusCodes.ServerError, _, entity, _) => Success(Unmarshal(entity))
-      case other => Failure(UnsuccessfulRequestException("Unmarshalling error", other))
+    def toEntity: IO[Unmarshal[ResponseEntity]] = response match {
+      case HttpResponse(_: StatusCodes.Success, _, entity, _) => IO(Unmarshal(entity))
+      case other => IO.raiseError(UnsuccessfulRequestException("Unmarshalling error", other))
     }
   }
 
-  final case class UnsuccessfulRequestException(message: String, httpResponse: HttpResponse) extends Exception {
-    override def getMessage: String = message + ": " + httpResponse.toString
-  }
+  final case class UnsuccessfulRequestException(message: String, httpResponse: HttpResponse) extends Exception(message)
 
   /**
     * Optionally replace a json value. Returns the original json if:

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellFailedResponseException.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellFailedResponseException.scala
@@ -1,9 +1,0 @@
-package cromwell.api.model
-
-import spray.json.DefaultJsonProtocol
-
-object CromwellFailedResponseExceptionJsonSupport extends DefaultJsonProtocol {
-  implicit val CromwellFailedResponseExceptionFormat = jsonFormat2(CromwellFailedResponseException)
-}
-
-case class CromwellFailedResponseException(status: String, message: String) extends Exception(message)

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/package.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/package.scala
@@ -2,7 +2,17 @@ package cromwell.api
 
 import java.time.OffsetDateTime
 
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import cats.arrow.FunctionK
+import cats.data.EitherT
+import cats.effect.{ContextShift, IO, Timer}
+import cromwell.api.CromwellClient.UnsuccessfulRequestException
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 
 package object model {
 
@@ -15,6 +25,61 @@ package object model {
         case JsString(string) => OffsetDateTime.parse(string)
         case other => throw new UnsupportedOperationException(s"Cannot deserialize $other into an OffsetDateTime")
       }
+    }
+  }
+
+  type FailureResponseOrT[A] = EitherT[IO, HttpResponse, A]
+  val FailureResponseOrT = EitherT
+
+  implicit class EnhancedFutureHttpResponse(val responseFuture: Future[HttpResponse]) extends AnyVal {
+    def asFailureResponseOrT: FailureResponseOrT[HttpResponse] = {
+      val ioHttpResponse = IO.fromFuture(IO(responseFuture))
+      val ioEither = ioHttpResponse map {
+        case response if response.status.isFailure() => Left(response)
+        case response => Right(response)
+      }
+      FailureResponseOrT(ioEither)
+    }
+  }
+
+  implicit class EnhancedFailureResponseOrHttpResponseT(val responseIoT: FailureResponseOrT[HttpResponse])
+    extends AnyVal {
+    def asHttpResponse: Future[HttpResponse] = {
+      val io = responseIoT.value map {
+        case Left(response) => response
+        case Right(response) => response
+      }
+      io.unsafeToFuture()
+    }
+  }
+
+  implicit class EnhancedFailureResponseOrT[SuccessType](val responseIoT: FailureResponseOrT[SuccessType]) extends AnyVal {
+    final def timeout(duration: FiniteDuration)
+                     (implicit timer: Timer[IO], cs: ContextShift[IO]): FailureResponseOrT[SuccessType] = {
+      EitherT(responseIoT.value.timeout(duration))
+    }
+
+    def asIo(implicit materializer: ActorMaterializer, executionContext: ExecutionContext): IO[SuccessType] = {
+      responseIoT.value flatMap {
+        case Left(response) =>
+          IO.fromFuture(IO {
+            Unmarshal(response.entity).to[String] flatMap { responseString =>
+              Future.failed(UnsuccessfulRequestException(responseString, response))
+            }
+          })
+        case Right(a) => IO.pure(a)
+      }
+    }
+
+    /**
+      * Transforms the IO error from one type to another.
+      */
+    def mapErrorWith(mapper: Throwable => IO[Nothing]): FailureResponseOrT[SuccessType] = {
+      def handleErrorIo[A](ioIn: IO[A]): IO[A] = {
+        ioIn handleErrorWith mapper
+      }
+
+      responseIoT.mapK(FunctionK.lift(handleErrorIo))
     }
   }
 }

--- a/engine/src/main/scala/cromwell/webservice/WebServiceUtils.scala
+++ b/engine/src/main/scala/cromwell/webservice/WebServiceUtils.scala
@@ -1,10 +1,10 @@
 package cromwell.webservice
 
-import akka.http.scaladsl.model.{Multipart, StatusCode}
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
 import akka.util.{ByteString, Timeout}
 import cromwell.webservice.routes.CromwellApiService._
@@ -24,9 +24,31 @@ trait WebServiceUtils {
     }.runFold(Map.empty[String, ByteString])((map, tuple) => map + tuple)(materializer)
   }
 
-  def completeResponse[A](statusCode: StatusCode, value: A, warnings: Seq[String])
-                         (implicit mt: ToEntityMarshaller[A]): Route = {
-    val warningHeaders = warnings.toIndexedSeq map { warning =>
+  /**
+    * Completes a response of a Product, probably a case class, using an implicit marshaller, probably a json encoder.
+    */
+  def completeResponse[A <: Product](statusCode: StatusCode, value: A, warnings: Seq[String])
+                                    (implicit mt: ToEntityMarshaller[A]): Route = {
+    complete((statusCode, warningHeaders(warnings), value))
+  }
+
+  /**
+    * Completes a response of string with the supplied content type.
+    *
+    * This is currently only used for pretty printing json, which should ideally be a query string option wired into
+    * the json marshaller. See cromwell.webservice.WebServiceUtils.EnhancedThrowable below.
+    *
+    * Ex: https://www.elastic.co/guide/en/elasticsearch/reference/6.6/common-options.html#_pretty_results
+    */
+  def completeResponse(statusCode: StatusCode,
+                       contentType: ContentType.NonBinary,
+                       value: String,
+                       warnings: Seq[String]): Route = {
+    complete((statusCode, warningHeaders(warnings), HttpEntity(contentType, value)))
+  }
+
+  def warningHeaders(warnings: Seq[String]): List[HttpHeader] = {
+    warnings.toList map { warning =>
       /*
       Need a quoted string.
       https://stackoverflow.com/questions/7886782
@@ -39,10 +61,7 @@ trait WebServiceUtils {
       // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.46
       RawHeader("Warning", s"299 cromwell/$cromwellVersion $quotedString")
     }
-
-    complete((statusCode, warningHeaders, value))
   }
-
 }
 
 object WebServiceUtils extends WebServiceUtils {
@@ -52,10 +71,10 @@ object WebServiceUtils extends WebServiceUtils {
   // AEN 2018-12-05
   implicit class EnhancedThrowable(val e: Throwable) extends AnyVal {
     def failRequest(statusCode: StatusCode, warnings: Seq[String] = Vector.empty): Route = {
-      completeResponse(statusCode, prettyPrint(APIResponse.fail(e)), warnings)
+      completeResponse(statusCode, ContentTypes.`application/json`, prettyPrint(APIResponse.fail(e)), warnings)
     }
     def errorRequest(statusCode: StatusCode, warnings: Seq[String] = Vector.empty): Route = {
-      completeResponse(statusCode, prettyPrint(APIResponse.error(e)), warnings)
+      completeResponse(statusCode, ContentTypes.`application/json`, prettyPrint(APIResponse.error(e)), warnings)
     }
   }
 

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -2,8 +2,8 @@ package cromwell.webservice.routes
 
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ContentTypes._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.stream.ActorMaterializer
 import common.util.VersionUtil
@@ -20,10 +20,10 @@ import cromwell.services.metadata._
 import cromwell.services.womtool.WomtoolServiceMessages.{DescribeFailure, DescribeRequest, DescribeSuccess}
 import cromwell.services.womtool.models.WorkflowDescription
 import cromwell.util.SampleWdl.HelloWorld
-import cromwell.webservice.EngineStatsActor
+import cromwell.webservice.WorkflowJsonSupport._
+import cromwell.webservice.{EngineStatsActor, FailureResponse}
 import mouse.boolean._
 import org.scalatest.{AsyncFlatSpec, Matchers}
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import scala.concurrent.duration._
@@ -36,16 +36,15 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
 
   implicit def default = RouteTestTimeout(5.seconds)
 
-  "REST ENGINE /stats endpoint" should "return 200 for stats" ignore {
+  "REST ENGINE /stats endpoint" should "no longer return 200 for stats" in {
     Get(s"/engine/$version/stats") ~>
       akkaHttpService.engineRoutes ~>
       check {
-        status should be(StatusCodes.OK)
-        val resp = responseAs[JsObject]
-        val workflows = resp.fields("workflows").asInstanceOf[JsNumber].value.toInt
-        val jobs = resp.fields("jobs").asInstanceOf[JsNumber].value.toInt
-        workflows should be(1)
-        jobs should be(23)
+        status should be(StatusCodes.Forbidden)
+        contentType should be(ContentTypes.`application/json`)
+        responseAs[FailureResponse] should be(
+          FailureResponse("fail", "The /stats endpoint is currently disabled.", None)
+        )
       }
   }
 
@@ -54,6 +53,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
       akkaHttpService.engineRoutes ~>
       check {
         status should be(StatusCodes.OK)
+        contentType should be(ContentTypes.`application/json`)
         val resp = responseAs[JsObject]
         val cromwellVersion = resp.fields("cromwell").asInstanceOf[JsString].value
         cromwellVersion should fullyMatch regex
@@ -66,6 +66,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
       akkaHttpService.engineRoutes ~>
         check {
           status should be(StatusCodes.OK)
+          contentType should be(ContentTypes.`application/json`)
           val resp = responseAs[JsObject]
           val db = resp.fields("Engine Database").asJsObject
           db.fields("ok").asInstanceOf[JsBoolean].value should be(true)
@@ -83,6 +84,16 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.NotFound) {
             status
           }
+          assertResult {
+            s"""|{
+                |  "status": "error",
+                |  "message": "Couldn't abort $workflowId because no workflow with that ID is in progress"
+                |}
+                |""".stripMargin.trim
+          } {
+            responseAs[String]
+          }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -101,6 +112,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           ) {
             responseAs[String]
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -115,6 +127,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
         assertResult(StatusCodes.OK) {
           status
         }
+        assertResult(ContentTypes.`application/json`)(contentType)
       }
     }
 
@@ -129,6 +142,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
         assertResult(StatusCodes.OK) {
           status
         }
+        assertResult(ContentTypes.`application/json`)(contentType)
       }
   }
 
@@ -143,6 +157,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.OK) {
             status
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -285,6 +300,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
               |}
               |""".stripMargin.trim
         )
+        contentType should be(ContentTypes.`application/json`)
         headers.size should be(1)
         val warningHeader = header("Warning")
         warningHeader shouldNot be(empty)
@@ -315,6 +331,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.BadRequest) {
             status
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -337,6 +354,16 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.BadRequest) {
             status
           }
+          assertResult {
+            """|{
+               |  "status": "fail",
+               |  "message": "Error(s): Invalid workflow options provided: Unsupported key/value pair in WorkflowOptions: defaultRuntimeOptions -> {\"cpu\":1}"
+               |}
+               |""".stripMargin.trim
+          } {
+            responseAs[String]
+          }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -355,6 +382,16 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.BadRequest) {
             status
           }
+          assertResult {
+            """|{
+               |  "status": "fail",
+               |  "message": "Error(s): Invalid workflow options provided: Unexpected end-of-input at input index 28 (line 3, position 1), expected '}':\n\n^\n"
+               |}
+               |""".stripMargin.trim
+          } {
+            responseAs[String]
+          }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -374,6 +411,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.BadRequest) {
             status
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -400,6 +438,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.Created) {
             status
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -419,6 +458,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
           assertResult(StatusCodes.BadRequest) {
             status
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 
@@ -463,6 +503,7 @@ class CromwellApiServiceSpec extends AsyncFlatSpec with ScalatestRouteTest with 
                |}""".stripMargin) {
             responseAs[String].parseJson.prettyPrint
           }
+          assertResult(ContentTypes.`application/json`)(contentType)
         }
     }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -134,7 +134,6 @@ object Dependencies {
   val spiUtilDependencies = List(
     "com.iheart" %% "ficus" % ficusV,
     "org.typelevel" %% "cats-effect" % catsEffectV,
-    "org.scalatest" %% "scalatest" % scalatestV % Test
   )
 
   val implFtpDependencies = List(
@@ -173,8 +172,9 @@ object Dependencies {
    */
   private val slf4jBindingDependencies = List(
     // http://logback.qos.ch/dependencies.html
-    "ch.qos.logback" % "logback-classic" % logbackV,
     "ch.qos.logback" % "logback-access" % logbackV,
+    "ch.qos.logback" % "logback-classic" % logbackV,
+    "ch.qos.logback" % "logback-core" % logbackV,
     "com.typesafe.akka" %% "akka-slf4j" % akkaV,
     "io.sentry" % "sentry-logback" % sentryLogbackV,
     "org.codehaus.janino" % "janino" % janinoV,
@@ -335,9 +335,6 @@ object Dependencies {
     "org.apache.commons" % "commons-lang3" % commonsLang3V,
     "org.apache.commons" % "commons-text" % commonsTextV,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
-    "ch.qos.logback" % "logback-access" % logbackV,
-    "ch.qos.logback" % "logback-classic" % logbackV,
-    "ch.qos.logback" % "logback-core" % logbackV,
   ) ++ catsDependencies ++ configDependencies
 
   val cloudSupportDependencies = googleApiClientDependencies ++ googleCloudDependencies ++ betterFilesDependencies ++ awsCloudDependencies
@@ -447,8 +444,9 @@ object Dependencies {
 
   val cromwellApiClientDependencies = List(
     "org.scalaz" %% "scalaz-core" % scalazV,
+    "org.typelevel" %% "cats-effect" % catsEffectV,
     "co.fs2" %% "fs2-io" % fs2V % Test,
-  ) ++ akkaHttpDependencies ++ betterFilesDependencies
+  ) ++ akkaHttpDependencies ++ betterFilesDependencies ++ catsDependencies
 
   val centaurDependencies = List(
     "com.github.kxbmap" %% "configs" % configsV,
@@ -474,7 +472,7 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,
     "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV,
     "org.broadinstitute.dsde.workbench" %% "workbench-util" % workbenchUtilV
-  ) ++ akkaHttpDependencies ++ catsDependencies ++ swaggerUiDependencies ++ slf4jBindingDependencies
+  ) ++ akkaHttpDependencies ++ swaggerUiDependencies ++ slf4jBindingDependencies
 
   val wes2cromwellDependencies = coreDependencies ++ akkaHttpDependencies
 

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -2,16 +2,17 @@ package cromwell
 
 import akka.actor.ActorSystem
 import akka.actor.CoordinatedShutdown.JvmExitReason
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.pattern.GracefulStopSupport
 import akka.stream.ActorMaterializer
 import cats.data.Validated._
+import cats.effect.IO
 import cats.syntax.apply._
 import cats.syntax.validated._
 import com.typesafe.config.ConfigFactory
 import common.exception.MessageAggregation
 import common.validation.ErrorOr._
-import cromwell.CommandLineArguments.ValidSubmission
-import cromwell.CommandLineArguments.WorkflowSourceOrUrl
+import cromwell.CommandLineArguments.{ValidSubmission, WorkflowSourceOrUrl}
 import cromwell.CromwellApp._
 import cromwell.api.CromwellClient
 import cromwell.api.model.{Label, LabelsJsonFormatter, WorkflowSingleSubmission}
@@ -78,13 +79,26 @@ object CromwellEntryPoint extends GracefulStopSupport {
     val cromwellClient = new CromwellClient(args.host, "v2")
 
     val singleSubmission = validateSubmitArguments(args)
-    val submissionFuture = () => cromwellClient.submit(singleSubmission).andThen({
-      case Success(submitted) =>
-        Log.info(s"Workflow ${submitted.id} submitted to ${args.host}")
-      case Failure(t) =>
-        Log.error(s"Failed to submit workflow to cromwell server at ${args.host}")
-        Log.error(t.getMessage)
-    })
+    val submissionFuture = () => {
+      val io = cromwellClient.submit(singleSubmission).value.attempt flatMap {
+        case Right(Right(submitted)) =>
+          IO {
+            Log.info(s"Workflow ${submitted.id} submitted to ${args.host}")
+          }
+        case Right(Left(httpResponse)) =>
+          IO.fromFuture(IO {
+            Unmarshal(httpResponse.entity).to[String] map { stringEntity =>
+              Log.error(s"Workflow failed to submit to ${args.host}: $stringEntity")
+            }
+          })
+        case Left(exception: Exception) =>
+          IO {
+            Log.error(s"Workflow failed to submit to ${args.host}: ${exception.getMessage}", exception)
+          }
+        case Left(throwable) => throw throwable
+      }
+      io.unsafeToFuture()
+    }
 
     waitAndExit(submissionFuture, () => actorSystem.terminate())
   }


### PR DESCRIPTION
- Refactored more `Future` to `IO`.
- Hard-coded pretty-printed json now returns correct content-type.
- Check content-type of responses in tests.