### PR TITLE
noop health check by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The `ConfigBackendLifecycleActorFactory` path variables `script`, `out` and `err
 and without docker. Similarly, when killing a docker task the `kill-docker` configuration key is now used instead of
 `kill`. For more information see the [online documentation](https://cromwell.readthedocs.io/en/stable/backends/SGE/).
 
+### No-op Health Monitor is now the default health monitor
+
+Previous versions of Cromwell defaulted to using a health monitor service that checked Docker Hub and engine database status.
+Neither check was useful if the `status` endpoint was never consulted as is likely the case in most deployments. Cromwell 38
+now defaults to a `NoopHealthMonitorServiceActor` which does nothing. The previous health service implementation is still
+available as `StandardHealthMonitorServiceActor`.
+
 ### Bug fixes
 - Fixed an issue that could cause Cromwell to consume disk space unnecessarily when using zipped dependencies
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -498,7 +498,7 @@ services {
     class = "cromwell.services.instrumentation.impl.noop.NoopInstrumentationServiceActor"
   }
   HealthMonitor {
-    class = "cromwell.services.healthmonitor.impl.standard.StandardHealthMonitorServiceActor"
+    class = "cromwell.services.healthmonitor.impl.noop.NoopHealthMonitorServiceActor"
     # Override the standard dispatcher. In particular this one has a low throughput so as to be lower in priority
     dispatcher = "akka.dispatchers.health-monitor-dispatcher"
   }


### PR DESCRIPTION
For discussion. The current default `StandardHealthMonitorServiceActor` checks both Docker and the Engine database. Depending on deployment the first check may be completely unnecessary or undesirable (see #4626) and the second check is only really useful if there are queries to Cromwell's status endpoint to read the status.

If the basic idea is accepted there would need to be additional documentation announcing the change in default and how to restore the previous default behavior.