### PR TITLE
Create documentation for Cromwell and containers

### DIFF
--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -356,6 +356,9 @@ With a job queue like SLURM, you just need to wrap this script in an `sbatch` su
 
 ```
 submit-docker = """
+    # Pull the image using the head node, in case our workers don't have network access
+    udocker pull ${docker}
+    
     sbatch \
       -J ${job_name} \
       -D ${cwd} \

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -75,13 +75,13 @@ ___
 
 #### Docker on a Local Backend
 
-On a single machine (laptop or server), no extra configuration is needed to allow docker to run provided Docker is installed.
+On a single machine (laptop or server), no extra configuration is needed to allow docker to run, provided Docker is installed.
 
 You can install Docker for Linux, Mac or Windows from [Docker Hub](https://hub.docker.com/search/?type=edition&offering=community)
 
 #### Docker on Cloud
 
-It is strongly advised that you provider Docker tags to tasks that will run on Cloud backends, and in fact most Cloud providers require it.
+It is strongly advised that you provide Docker tags to tasks that will run on Cloud backends, and in fact most Cloud providers require it.
 
 It might be possible to use an alternative container engine, but this is not recommended if Docker is supported.
 
@@ -434,7 +434,7 @@ Within the two configurations above:
 
 By enabling Cromwell's run-in-background mode, you remove the necessity for the `kill`, `check-alive` and `job-id-regex` blocks, which disables some safety checks when running workflows:
 
-- If there is an error starting the container or executing the script, Cromwell may not recognise this error and hang.
+- If there is an error starting the container or executing the script, Cromwell may not recognise this error and hang. For example, this may occur if the container attempts to exceed its allocated resources (runs out of memory); the container daemon may terminate the container without completing the script.
 - If you abort the workflow (by attempting to close Cromwell or issuing an abort command), Cromwell does not have a reference to the job and will not be able to execute the container.
 
 This is only necessary in local environments where there is no job manager to control this, however if your container technology can emit an identifier to stdout, then you are able to remove the run-in-background flag. Note that the check-alive block is not called to check a job-status, rather Cromwell looks for the presence of an `rc` file (see the previous section for more information).

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -103,7 +103,7 @@ You can install Docker for Linux, Mac or Windows from [Docker Hub](https://hub.d
 
 #### Docker on Cloud
 
-It is strongly advised that you provide Docker tags to tasks that will run on Cloud backends, and in fact most Cloud providers require it.
+It is strongly advised that you provide a Docker image to tasks that will run on Cloud backends, and in fact most Cloud providers require it.
 
 It might be possible to use an alternative container engine, but this is not recommended if Docker is supported.
 
@@ -464,7 +464,6 @@ By enabling Cromwell's run-in-background mode, you remove the necessity for the 
 - If you abort the workflow (by attempting to close Cromwell or issuing an abort command), Cromwell does not have a reference to the job and will not be able to execute the container.
 
 This is only necessary in local environments where there is no job manager to control this, however if your container technology can emit an identifier to stdout, then you are able to remove the run-in-background flag. Note that the check-alive block is not called to check a job-status, rather Cromwell looks for the presence of an `rc` file (see the previous section for more information).
-
 
 ### Next Steps
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -1,7 +1,7 @@
 ## Containers
 
 Containers are self-contained software archives, that hold everything from the tool you want to run, to libraries and runtimes it requires, and the operating system it runs on.
-
+ 
 Best Practise WDL and CWL define containers for their tasks to run in, to ensure reproducibility and portability - that running the same task on a different system will run the exact same software. 
 
 Docker images are the most common container format, but it is not advisable for certain systems to run Docker itself, and for this reason Cromwell can be configured to support a number of alternatives.
@@ -65,6 +65,7 @@ task hello_world {
         docker: 'ubuntu:latest'
     }
 }
+
 workflow hello {
     call hello_world
 }
@@ -84,6 +85,7 @@ inputs:
           prefix: "Hello, "
 outputs:
     out: stdout
+
 requirements:
     DockerRequirement:
         dockerPull: "ubuntu:latest"
@@ -145,12 +147,14 @@ As the Singularity container does not emit a job-id, we must include the `run-in
 Putting this together, we have an example base configuration for a local environment:
 ```hocon
 include required(classpath("application"))
+
 backend {
     default: singularity
     providers: {
         singularity {
             # The backend custom configuration.
             actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
             config {
                 run-in-background = true
                 runtime-attributes = """
@@ -212,6 +216,7 @@ Putting this all together, a complete SLURM + Singularity config might look like
 ```
 backend {
   default = slurm
+
   providers {
     slurm {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"                                                                                     
@@ -222,6 +227,7 @@ backend {
         Int requested_memory_mb_per_core = 8000
         String? docker
         """
+
         submit = """
             sbatch \
               --wait \
@@ -234,6 +240,7 @@ backend {
               --mem-per-cpu=${requested_memory_mb_per_core} \
               --wrap "/bin/bash ${script}"
         """
+
         submit-docker = """
             # Ensure singularity is loaded if it's installed as a module
             module load Singularity/3.0.1
@@ -241,6 +248,7 @@ backend {
             # Build the Docker image into a singularity image
             IMAGE=${cwd}/${docker}.sif
             singularity build $IMAGE docker://${docker}
+
             # Submit the script to SLURM
             sbatch \
               --wait \
@@ -253,6 +261,7 @@ backend {
               --mem-per-cpu=${requested_memory_mb_per_core} \
               --wrap "singularity exec --bind ${cwd}:${docker_cwd} $IMAGE ${job_shell} ${script}"
         """
+
         kill = "scancel ${job_id}"
         check-alive = "squeue -j ${job_id}"
         job-id-regex = "Submitted batch job (\\d+).*"
@@ -269,10 +278,12 @@ In addition, if you or your sysadmins were not able to give `setuid` permissions
 ```
 submit-docker = """
     [...]
+
     # Build the Docker image into a singularity image
     # We don't add the .sif file extension because sandbox images are directories, not files
     IMAGE=${cwd}/${docker}
     singularity build --sandbox $IMAGE docker://${docker}
+
     # Now submit the job
     # Note the use of --userns here
     sbatch \
@@ -362,7 +373,7 @@ For instance, when you run a normal Docker image with `docker run image`, it wil
 However, by default Cromwell requests and runs images using their `sha` hash, rather than using tags.
 This strategy is actually preferable, because it ensures every execution of the task or workflow will use the exact same version of the image, but some engines such as `udocker` don't support this feature.
 
-If you are using `udocker` or want to enable the use of hash-based image references, you can set the following config option:
+If you are using `udocker` or want to disable the use of hash-based image references, you can set the following config option:
 ```
 docker.hash-lookup.enabled = false
 ```
@@ -399,10 +410,13 @@ docker {
   hash-lookup {
     # Set this to match your available quota against the Google Container Engine API
     #gcr-api-queries-per-100-seconds = 1000
+
     # Time in minutes before an entry expires from the docker hashes cache and needs to be fetched again
     #cache-entry-ttl = "20 minutes"
+
     # Maximum number of elements to be kept in the cache. If the limit is reached, old elements will be removed from the cache
     #cache-size = 200
+
     # How should docker hashes be looked up. Possible values are "local" and "remote"
     # "local": Lookup hashes on the local docker daemon using the cli
     # "remote": Lookup hashes on docker hub and gcr
@@ -432,6 +446,7 @@ runtime {
 ```
 
 You can find the `sha256` of an image using `docker images --digests`
+ 
  
 ### Notes
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -328,7 +328,7 @@ To configure `udocker` to work in a local environment, you must tag the provider
 ```
 run-in-background = true
 submit-docker = """
-    udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${script}
+    udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}
 """
 ```
 
@@ -347,7 +347,7 @@ submit-docker = """
       -t ${runtime_minutes} \
       ${"-c " + cpus} \
       --mem-per-cpu=${requested_memory_mb_per_core} \
-      --wrap "udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${script}"
+      --wrap "udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}"
 """
 ```
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -370,7 +370,7 @@ submit-docker = """
 ```
 
 In addition, to run `udocker`, you'll have to make sure `hash-lookup` is disabled.
-Refer to [this section](#docker_digests) for more detail.
+Refer to [this section](#docker-digests) for more detail.
 
 ### Configuration in Detail
 The behaviour of Cromwell with containers can be modified using a few other options.

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -1,15 +1,10 @@
 ## Containers
 
-Containers are technologies that describe an environment's software requirements. Broadly, there are two primary types of containers:
+Containers are self-contained software archives, that hold everything from the tool you want to run, to libraries and runtimes it requires, and the operating system it runs on.
+ 
+Best Practise WDL and CWL define containers for their tasks to run in, to ensure reproducibility and portability - that running the same task on a different system will run the exact same software. 
 
-* Images - Software requirements that describe a sandbox environment that you.
-* Runtime - Specifies a series of processes that run inside a container image.
-
-Containers aim to be content-agnostic, infrastructure-agnostic, designed for automation and promote reproducibility.
-
-There are organisations such as the [Open Container Initiative](https://www.opencontainers.org) that are aiming to standardise the interface that container technologies can implement.
-
-The motivation for this tutorial was driven by: "I want to use containers, but can't use Docker".
+Docker images are the most common container format, but is is not advisable for certain systems to run Docker itself, and for this reason Cromwell supports a number of alternatives
 
 ### Prerequisites
 This tutorial page relies on completing the previous tutorials:
@@ -27,7 +22,7 @@ We'll discuss:
 * [Singularity](https://www.sylabs.io/docs/)
 * [udocker](https://github.com/indigo-dc/udocker)
 
-### Let's get started
+### Specifying Containers in your Workflow
 
 Containers are specified on a per-task level, this can be achieved in WDL by specifying a [`docker`](https://software.broadinstitute.org/wdl/documentation/spec#docker) tag in the `runtime` section. For example, specifying that the following WDL script should use the container `ubuntu:latest` can be achieved by:
 
@@ -50,7 +45,7 @@ workflow hello {
 }
 ```
 
-<!-- Similarly in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
+Similarly in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
 
 ```cwl
 cwlVersion: v1.0

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -218,7 +218,7 @@ backend {
 
         submit-docker = """
             # Ensure singularity is loaded if it's installed as a module
-            module load Singularity/version
+            module load Singularity/3.0.1
             
             # Build the Docker image into a singularity image
             # We don't add the .sif file extension because sandbox images are directories, not files

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -312,7 +312,7 @@ To configure `udocker` to work in a local environment, you must tag the provider
 ```
 run-in-background = true
 submit-docker = """
-    udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}
+    udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}
 """
 ```
 
@@ -331,7 +331,7 @@ submit-docker = """
       -t ${runtime_minutes} \
       ${"-c " + cpus} \
       --mem-per-cpu=${requested_memory_mb_per_core} \
-      --wrap "udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}"
+      --wrap "udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}"
 """
 ```
 
@@ -439,9 +439,8 @@ You can find the `sha256` of an image using `docker images --digests`
 #### How does Cromwell know when a job or container has completed?
 Cromwell uses the presence of the `rc` (returncode) file to determine whether a task has succeeded or failed. This `rc` file is generated as part of the `script` within the execution directory, where the script is assembled at runtime. This is important as if the script executes successfully but the container doesn't terminate, Cromwell will continue the execution of the workflow and the container will persist hogging system resources.
 
-Within the two configurations above:
+Within the configurations above:
 - `singularity`: The exec mode does not run a container on the background
-- `udocker`: the `--rm` flag is included so that the container is terminated after execution script.
 
 #### Cromwell: Run-in-background
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -45,7 +45,7 @@ workflow hello {
 }
 ```
 
-Similarly in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
+Similarly in CWL, you can specify a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
 
 ```cwl
 cwlVersion: v1.0
@@ -159,7 +159,7 @@ backend {
 
 ### Enforcing container requirements
 
-You can enforce container requirements by not including the standard `submit` attribute on the provider attributes. You shold only use the `submit-docker` strings, however note that some environment variables (`stdout`, `stderr`) are different beween these two.
+You can enforce container requirements by not including the standard `submit` attribute on the provider attributes. You should only use the `submit-docker` strings, however note that some environment variables (`stdout`, `stderr`) are different between these two.
 
 ### Notes
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -1,5 +1,14 @@
 ## Containers
 
+Containers are technologies that describe an environment's software requirements. Broadly, there are two primary types of containers:
+
+* Images - Software requirements that describe a sandbox environment that you.
+* Runtime - Specifies a series of processes that run inside a container image.
+
+Containers aim to be content-agnostic, infrastructure-agnostic, designed for automation and promote reproducibility.
+
+There are organisations such as the [Open Container Initiative](https://www.opencontainers.org) that are aiming to standardise the interface that container technologies can implement.
+
 ### Prerequisites
 This tutorial page relies on completing the previous tutorials:
 
@@ -10,5 +19,34 @@ This tutorial page relies on completing the previous tutorials:
 
 At the end of this tutorial, you'll become familiar with container technologies and how to configure Cromwell to use these indepdently, or with job schedulers.
 
-### Let's get started!
+We'll discuss:
 
+* [Docker](https://www.docker.com)
+* [Singularity](https://www.sylabs.io/docs/)
+* [udocker](https://github.com/indigo-dc/udocker)
+
+### Let's get started
+
+Container's are specified on a per-task level, this can be achieved in WDL ou specify a container in WDL as a Docker tag in the runtime section of a task
+
+#### Docker
+
+Docker is a popular container technology that is natively supported by Cromwell and WDL. No extra configuration must be provided to allow docker to run (provided Docker is installed).
+
+##### Shortfalls of Docker
+
+#### Singularity
+
+#### udocker
+
+### Enforcing container requirements
+
+You can enforce container requirements by configuring Cromwell to only accept `submit-docker` strings.
+
+
+### Notes
+
+#### Docker Digests
+
+_Notes about disabling docker digests_
+ 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -15,11 +15,11 @@ Docker images are the most common container format, but it is not advisable for 
     * [Docker on HPC](#docker-on-hpc)
 * [Singularity](#singularity)
     * [Installation](#installation)
-    * [Singularity Cache](#singularity-cache)
     * [Configuring Cromwell for Singularity](#configuring-cromwell-for-singularity)
         * [Local environments](#local-environments)
         * [Job schedulers](#job-schedulers)
     * [Without Setuid](#without-setuid)
+    * [Singularity Cache](#singularity-cache)
 * [udocker](#udocker)
     * [Installation](#installation-1)
     * [Configuration](#configuration)
@@ -129,16 +129,6 @@ If that is the case, you might consider forwarding [this letter](https://www.syl
 
 If you are not able to get Singularity installed with these privileges, you can attempt a user install.
 If this is the case, you will have to alter your Cromwell configuration to work in "sandbox" mode, which is explained in [this part](#without-setuid) of the documentation. 
-
-#### Singularity Cache
-By default, Singularity will cache the Docker images you pull in `~/.singularity`, your home directory.
-
-However, if you are sharing your Docker images with other users or have limited space in your user directory, you can redirect this caching location by exporting the `SINGULARITY_CACHEDIR` variable in your `.bashrc` or at the start of the `submit-docker` block.
-```
-export SINGULARITY_CACHEDIR=/path/to/shared/cache
-```
-
-For further information on the Singularity Cache, refer to the [Singularity 2 caching documentation](https://www.sylabs.io/guides/2.6/user-guide/build_environment.html#cache-folders) (this hasn't yet been updated for Singularity 3).
 
 #### Configuring Cromwell for Singularity
 
@@ -288,7 +278,18 @@ submit-docker = """
 """
 ```
 
+#### Singularity Cache
+By default, Singularity will cache the Docker images you pull in `~/.singularity`, your home directory.
+
+However, if you are sharing your Docker images with other users or have limited space in your user directory, you can redirect this caching location by exporting the `SINGULARITY_CACHEDIR` variable in your `.bashrc` or at the start of the `submit-docker` block.
+```
+export SINGULARITY_CACHEDIR=/path/to/shared/cache
+```
+
+For further information on the Singularity Cache, refer to the [Singularity 2 caching documentation](https://www.sylabs.io/guides/2.6/user-guide/build_environment.html#cache-folders) (this hasn't yet been updated for Singularity 3).
+
 ___
+
 ### udocker
 
 [udocker](https://github.com/indigo-dc/udocker) is a tool designed to "execute simple docker containers in user space without requiring root privileges".

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -335,6 +335,8 @@ However, like Singularity, if you want to share a cache with other users in your
 * A config file [described here](https://github.com/indigo-dc/udocker/blob/master/doc/installation_manual.md#9-configuration), containing a line such as `topdir = "/path/to/cache"`.
 * Using the environment variable `$UDOCKER_DIR`
 
+___
+
 ### Configuration in Detail
 The behaviour of Cromwell with containers can be modified using a few other options.
 
@@ -446,7 +448,7 @@ This is only necessary in local environments where there is no job manager to co
 
 ### Next Steps
 
-Congratulations for improving the reproducibility of you workflows! You might find the following cloud-based tutorials interesting to test your workflows (and ensure the same results) in a completely different environment:
+Congratulations for improving the reproducibility of your workflows! You might find the following cloud-based tutorials interesting to test your workflows (and ensure the same results) in a completely different environment:
 
 - [Getting started with AWS Batch](AwsBatch101.md)
 - [Getting started on Google Pipelines API](PipelinesApi101.md)

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -11,6 +11,7 @@ This tutorial page relies on completing the previous tutorials:
 
 * [Five Minute Introduction](FiveMinuteIntro.md)
 * [Configuration Files](ConfigurationFiles.md)
+* Recommended: [Getting started on HPC clusters](HPCIntro.md)
 
 ### Goals
 
@@ -157,6 +158,62 @@ backend {
 
 #### udocker
 
+udocker is a user-installable tool that allows the execution of docker containers in non-privileged environments. Similar to Singuarlity, it will need to be available on the worker node.
+
+As of writing this tutorial ([udocker 1.1.3](https://github.com/indigo-dc/udocker/releases/tag/v1.1.3)), there was no support for [docker digests](https://github.com/indigo-dc/udocker/issues/112). For this reason, docker hash-lookup will need to be disabled, this will disable call caching for [floating tags](https://github.com/broadinstitute/cromwell/pull/4039#issuecomment-454829890).
+
+##### Local
+
+For a local configuration, it is enough to use a docker-submit string to start singularity, ie:
+
+```HOCON
+include required(classpath("application"))
+
+docker.hash-lookup.enabled = false
+
+backend {
+  default: singularity
+  providers: {
+    singularity {
+      # The backend custom configuration.
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+      config {
+        run-in-background = true
+        runtime-attributes = """
+          String? docker
+          String? docker_user
+        """
+        submit-docker = """
+          udocker run ${"--user " + docker_user} --rm -v ${cwd}:${docker_cwd} ${docker} ${script}
+        """
+      }
+    }
+  }
+}
+```
+
+##### Job Scheduler
+
+Similar to Singularity, the premise when running udocker on job schedulers is to include a udocker run command as part of the wrapped command. As HPCs often don't have internet access on worker nodes, some work is required to allow the head node to pull a container so that the worker nodes don't have to.
+
+If you're familiar with `udocker`, please contribute (or complete the following) configuration:
+
+```bash
+export UDOCKER_CACHEDIR=/path/to/udocker_cache
+# ensure udocker is loaded or in path
+IMAGE=/path/to/docker_location/${docker}
+# ask udocker to pull ${docker}, and store in UDOCKER_CACHEDIR
+udocker pull ${docker}
+sbatch -J ${job_name} -D ${cwd} -o ${cwd}/execution/stdout -e ${cwd}/execution/stderr ${"-p " + queue} \
+  -t ${runtime_minutes} ${"-c " + cpus} --mem-per-cpu=${requested_memory_mb_per_core} \
+  --wrap "udocker run ${"--user " + docker_user} --rm -v ${cwd}:${docker_cwd} ${docker} ${script}"
+```
+
+##### Limitations
+
+udocker will not be able to perform tasks that require elevated privileges, some of these operations are provided in their [documentation](https://github.com/indigo-dc/udocker#Limitations).
+
 ### Enforcing container requirements
 
 You can enforce container requirements by not including the standard `submit` attribute on the provider attributes. You should only use the `submit-docker` strings, however note that some environment variables (`stdout`, `stderr`) are different between these two.
@@ -165,7 +222,7 @@ You can enforce container requirements by not including the standard `submit` at
 
 #### Job signalling
 
-Cromwell uses the presence of an `rc` file in the execution directory 
+Cromwell uses the presence of an `rc` file in the execution directory or the contents of the `stderr` to determine a task's status. If you're job fails before starting, or during the startup of a container, it's likely that Cromwell will hang and fail to correctly report this error.
 
 #### Recommendations
 
@@ -173,5 +230,9 @@ It's recommended against using `:latest` in favour of versioned tags or the more
 
 #### Docker Digests
 
-_Notes about disabling docker digests_
+[Docker digests](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier) are SHA256 strings that uniqely identify an image. It cannot be updated later by a developer so you ensure reproducibility in your containers. Within Cromwell, the docker tag is parsed and the through a web request, the digest is found, and is used to optimise call caching.
+
+Some container technologies that use docker or dockerhub may not be able to parse this digest (eg: udocker); the digest-lookup functionality can be disabled by including the following in your configuration file at the root level:
+
+```docker.hash-lookup.enabled = false```
  

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -9,6 +9,8 @@ Containers aim to be content-agnostic, infrastructure-agnostic, designed for aut
 
 There are organisations such as the [Open Container Initiative](https://www.opencontainers.org) that are aiming to standardise the interface that container technologies can implement.
 
+The motivation for this tutorial was driven by: "I want to use containers, but can't use Docker".
+
 ### Prerequisites
 This tutorial page relies on completing the previous tutorials:
 
@@ -27,7 +29,7 @@ We'll discuss:
 
 ### Let's get started
 
-Container's are specified on a per-task level, this can be achieved in WDL by specifying a [`docker`](https://software.broadinstitute.org/wdl/documentation/spec#docker) tag in the `runtime` section. For example, specifying that the following WDL script should use the container `ubuntu:latest` can be achieved by:
+Containers are specified on a per-task level, this can be achieved in WDL by specifying a [`docker`](https://software.broadinstitute.org/wdl/documentation/spec#docker) tag in the `runtime` section. For example, specifying that the following WDL script should use the container `ubuntu:latest` can be achieved by:
 
 ```wdl
 task hello_world {
@@ -48,7 +50,7 @@ workflow hello {
 }
 ```
 
-<!-- Similar in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
+<!-- Similarly in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
 
 ```cwl
 cwlVersion: v1.0
@@ -76,16 +78,103 @@ Docker is a popular container technology that is natively supported by Cromwell 
 
 Docker can allow running users to gain superuser privileges, called the [Docker daemon attack surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface). In HPC and multi-user environments, Docker recommends that "only trusted users should be allowed to control your Docker Daemon" [source](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface). For this reason it's worth exploring other technologies that will support the reproducibility and simplicity of running a workflow that's tagged with docker containers.
 
+#### Docker on GCP and AWS
+
+Docker is a required tag on some cloud providers as it is used to request or provision resources. It's currently unknown whether you could run other container technologies on these cloud providers however given the same docker image, they should give exactly the same results.
+
 #### Singularity
+
+<!-- Singularity introduction here -->
+
+##### Local environments
+
+In local environments, you must configure Cromwell to use a different `submit-docker` script that would start Singularity instead of docker. Singularity requires docker images to be prefixed with the prefix `docker://`. The submit string for Singularity is:
+```bash
+  singularity exec --bind ${cwd}:${docker_cwd} docker://${docker} ${job_shell} ${script}
+```
+
+As the Singularity container does not emit a job-id, we must include the `run-in-background` tag within the the provider section in addition to the docker-submit script. As Cromwell watches for the existence of the `rc` file, the `run-in-background` option has the caveat that we require the Singularity container to successfully complete, otherwise the workflow might hang indefinitely.
+
+Putting this together, we have an example base configuration for a local environment:
+```hocon
+include required(classpath("application"))
+
+backend {
+    default: singularity
+    providers: {
+        singularity {
+            # The backend custom configuration.
+            actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+            config {
+                run-in-background = true
+                runtime-attributes = """
+                  String? docker
+                """
+                submit-docker = """
+                  singularity exec --bind ${cwd}:${docker_cwd} docker://${docker} ${job_shell} ${script}
+                """
+            }
+        }
+    }
+}
+```
+
+##### Job schedulers
+
+The premise when running Singularity on job schedulers it include the singularity submit script as part of the wrapped command. On some HPCs, worker nodes do not have stable access to the internet or build access, for this reason within the submit-docker configuration we'll include a `singularity build` command that is run on the worker node. In the following example configuration for SLURM, we set a cache directory for Singularity so that once we've built the image, the worker nodes are able to access the image without any work.
+
+The following configuration also includes the `--userns` argument, which will "run \[the\] container in a new user namespace, allowing Singularity to run completely unprivileged on recent kernels" (source: Singuarlity 3.0.3 CLI).
+
+```hocon
+include required(classpath("application"))
+
+backend {
+  default: SLURM
+  providers: {
+    SLURM {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        runtime-attributes = """
+          Int runtime_minutes = 60
+          Int cpus = 2
+          Int requested_memory_mb_per_core = 8000
+          String? queue
+          String? docker
+        """
+        submit-docker = """
+          export SINGULARITY_CACHEDIR=/path/to/singularity_cache
+          # ensure singularity is loaded, potentially by: module load Singularity/3.0.1
+          IMAGE=/path/to/docker_location/${docker}
+          singularity build --sandbox $IMAGE docker://${docker} > /dev/null
+          sbatch -J ${job_name} -D ${cwd} -o ${cwd}/execution/stdout -e ${cwd}/execution/stderr ${"-p " + queue} \
+            -t ${runtime_minutes} ${"-c " + cpus} --mem-per-cpu=${requested_memory_mb_per_core} \
+            --wrap "singularity exec --userns -B ${cwd}:${docker_cwd} $IMAGE ${job_shell} ${script}"
+          """
+        kill = "scancel ${job_id}"
+        check-alive = "squeue -j ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+      }
+    }
+  }
+}
+```
 
 #### udocker
 
 ### Enforcing container requirements
 
-You can enforce container requirements by configuring Cromwell to only accept `submit-docker` strings.
-
+You can enforce container requirements by not including the standard `submit` attribute on the provider attributes. You shold only use the `submit-docker` strings, however note that some environment variables (`stdout`, `stderr`) are different beween these two.
 
 ### Notes
+
+#### Job signalling
+
+Cromwell uses the presence of an `rc` file in the execution directory 
+
+#### Recommendations
+
+It's recommended against using `:latest` in favour of versioned tags or the more unique digests, as the latest tag can change through time, reducing the chance that your workflow will work or is exactly reproducible.
 
 #### Docker Digests
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -285,72 +285,12 @@ For further information on the Singularity Cache, refer to the [Singularity 2 ca
 
 [udocker](https://github.com/indigo-dc/udocker) is a tool designed to "execute simple docker containers in user space without requiring root privileges".
 
-<<<<<<< HEAD
-udocker is a user-installable tool that allows the execution of docker containers in non-privileged environments. Similar to Singuarlity, it will need to be available on the worker node.
-
-As of writing this tutorial ([udocker 1.1.3](https://github.com/indigo-dc/udocker/releases/tag/v1.1.3)), there was no support for [docker digests](https://github.com/indigo-dc/udocker/issues/112). For this reason, docker hash-lookup will need to be disabled, this will disable call caching for [floating tags](https://github.com/broadinstitute/cromwell/pull/4039#issuecomment-454829890).
-
-##### Local
-
-For a local configuration, it is enough to use a docker-submit string to start singularity, ie:
-
-```HOCON
-include required(classpath("application"))
-
-docker.hash-lookup.enabled = false
-
-backend {
-  default: singularity
-  providers: {
-    singularity {
-      # The backend custom configuration.
-      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-
-      config {
-        run-in-background = true
-        runtime-attributes = """
-          String? docker
-          String? docker_user
-        """
-        submit-docker = """
-          udocker run ${"--user " + docker_user} --rm -v ${cwd}:${docker_cwd} ${docker} ${script}
-        """
-      }
-    }
-  }
-}
-```
-
-##### Job Scheduler
-
-Similar to Singularity, the premise when running udocker on job schedulers is to include a udocker run command as part of the wrapped command. As HPCs often don't have internet access on worker nodes, some work is required to allow the head node to pull a container so that the worker nodes don't have to.
-
-If you're familiar with `udocker`, please contribute (or complete the following) configuration:
-
-```bash
-export UDOCKER_CACHEDIR=/path/to/udocker_cache
-# ensure udocker is loaded or in path
-IMAGE=/path/to/docker_location/${docker}
-# ask udocker to pull ${docker}, and store in UDOCKER_CACHEDIR
-udocker pull ${docker}
-sbatch -J ${job_name} -D ${cwd} -o ${cwd}/execution/stdout -e ${cwd}/execution/stderr ${"-p " + queue} \
-  -t ${runtime_minutes} ${"-c " + cpus} --mem-per-cpu=${requested_memory_mb_per_core} \
-  --wrap "udocker run ${"--user " + docker_user} --rm -v ${cwd}:${docker_cwd} ${docker} ${script}"
-```
-
-##### Limitations
-
-udocker will not be able to perform tasks that require elevated privileges, some of these operations are provided in their [documentation](https://github.com/indigo-dc/udocker#Limitations).
-
-### Enforcing container requirements
-=======
 In essence, udocker provides a command line interface that mimics `docker`, and implements the commands using one of four different container backends:
 
 * PRoot
 * Fakechroot
 * runC
 * Singularity
->>>>>>> 0f38ef79a... Elaborate on uDocker, advanced config, best practices
 
 #### Installation
 udocker can be installed without any kind of root permissions. Refer to the installation documentation [here](https://github.com/indigo-dc/udocker/blob/master/doc/installation_manual.md).
@@ -364,11 +304,7 @@ submit-docker = """
 """
 ```
 
-<<<<<<< HEAD
-Cromwell uses the presence of an `rc` file in the execution directory or the contents of the `stderr` to determine a task's status. If you're job fails before starting, or during the startup of a container, it's likely that Cromwell will hang and fail to correctly report this error.
-=======
 With a job queue like SLURM, you just need to wrap this script in an `sbatch` submission like we did with Singularity:
->>>>>>> 0f38ef79a... Elaborate on uDocker, advanced config, best practices
 
 ```
 submit-docker = """

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -121,9 +121,14 @@ ___
 Singularity is a container technology designed for use on HPC systems in particular, while ensuring an appropriate level of security that Docker cannot provide.
 
 #### Installation
-Before you can configure Cromwell on your HPC system, you (or your sysadmin) will have to install Singularity, which is documented [here](https://www.sylabs.io/guides/3.0/admin-guide/admin_quickstart.html#installation). It's recommended to perform an installation with root access to gain access to the full set of features in Singularity. You might consider forwarding [this letter](https://www.sylabs.io/guides/3.0/user-guide/installation.html#singularity-on-a-shared-resource) to your admins.
+Before you can configure Cromwell on your HPC system, you will have to install Singularity, which is documented [here](https://www.sylabs.io/guides/3.0/admin-guide/admin_quickstart.html#installation).
+In order to gain access to the full set of features in Singularity, it is strongly recommended that Singularity is installed by root, with the `setuid` bit enabled, as is ([documented here](https://www.sylabs.io/guides/2.6/admin-guide/security.html#how-does-singularity-do-it)).
+This likely means that you will have to ask your sysadmin to install it for you.
+Because `singularity` ideally needs `setuid`, your admins may have some qualms about giving Singularity this privilege.
+If that is the case, you might consider forwarding [this letter](https://www.sylabs.io/guides/3.0/user-guide/installation.html#singularity-on-a-shared-resource) to your admins.
 
-Although the installation of Singularity doesn't strictly require root, to access the full features of Singularity, such as the use of its preferred image format, the Singularity binary must be owned by root with the `setuid` bit enabled ([documented here](https://www.sylabs.io/guides/2.6/admin-guide/security.html#how-does-singularity-do-it)).
+If you are not able to get Singularity installed with these privileges, you can attempt a user install.
+If this is the case, you will have to alter your Cromwell configuration to work in "sandbox" mode, which is explained in [this part](#without-setuid) of the documentation. 
 
 #### Singularity Cache
 By default, Singularity will cache the Docker images you pull in `~/.singularity`, your home directory.

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -27,13 +27,54 @@ We'll discuss:
 
 ### Let's get started
 
-Container's are specified on a per-task level, this can be achieved in WDL ou specify a container in WDL as a Docker tag in the runtime section of a task
+Container's are specified on a per-task level, this can be achieved in WDL by specifying a [`docker`](https://software.broadinstitute.org/wdl/documentation/spec#docker) tag in the `runtime` section. For example, specifying that the following WDL script should use the container `ubuntu:latest` can be achieved by:
+
+```wdl
+task hello_world {
+    String name = "World"
+    command {
+        echo 'Hello, ${name}'
+    }
+    output {
+        File out = stdout()
+    }
+    runtime {
+        docker: 'ubuntu:latest'
+    }
+}
+
+workflow hello {
+    call hello_world
+}
+```
+
+<!-- Similar in CWL, you can specifiy a [`DockerRequirement`](https://www.commonwl.org/v1.0/CommandLineTool.html#DockerRequirement) inside the requirements section:
+
+```cwl
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+    name:
+        type: string
+        default: "World"
+        inputBinding:
+          prefix: "Hello, "
+outputs:
+    out: stdout
+
+requirements:
+    DockerRequirement:
+        dockerPull: "ubuntu:latest"
+``` -->
 
 #### Docker
 
 Docker is a popular container technology that is natively supported by Cromwell and WDL. No extra configuration must be provided to allow docker to run (provided Docker is installed).
 
 ##### Shortfalls of Docker
+
+Docker can allow running users to gain superuser privileges, called the [Docker daemon attack surface](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface). In HPC and multi-user environments, Docker recommends that "only trusted users should be allowed to control your Docker Daemon" [source](https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface). For this reason it's worth exploring other technologies that will support the reproducibility and simplicity of running a workflow that's tagged with docker containers.
 
 #### Singularity
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -1,0 +1,14 @@
+## Containers
+
+### Prerequisites
+This tutorial page relies on completing the previous tutorials:
+
+* [Five Minute Introduction](FiveMinuteIntro.md)
+* [Configuration Files](ConfigurationFiles.md)
+
+### Goals
+
+At the end of this tutorial, you'll become familiar with container technologies and how to configure Cromwell to use these indepdently, or with job schedulers.
+
+### Let's get started!
+

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -221,7 +221,6 @@ backend {
             module load Singularity/3.0.1
             
             # Build the Docker image into a singularity image
-            # We don't add the .sif file extension because sandbox images are directories, not files
             IMAGE=${cwd}/${docker}.sif
             singularity build $IMAGE docker://${docker}
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -121,12 +121,10 @@ Singularity is a container engine designed for use on HPC systems in particular,
 
 #### Installation
 Before you can configure Cromwell on your HPC system, you (or your sysadmin) will have to install Singularity, which is documented [here](https://www.sylabs.io/guides/3.0/admin-guide/admin_quickstart.html#installation).
-
-When installing Singularity, your admins have to make a decision: do they grant `setuid` to the Singularity binary or not?
-[As is documented here](https://www.sylabs.io/guides/2.6/admin-guide/security.html#how-does-singularity-do-it), Singularity can run either using "sandbox" containers, or using proper image files.
-However, unless `setuid` is set, you are restricted to using sandbox images, which come with a number of downsides.
-If you can't convince Singularity can be trusted with `setuid`, don't fear, Cromwell will still work.
-However, this is not ideal, so you might consider forwarding [this letter](https://www.sylabs.io/guides/3.0/user-guide/installation.html#singularity-on-a-shared-resource) to your admins.
+Installation of Singularity doesn't require root, but to access the full features of Singularity, such as the use of its preferred image format, the Singularity binary must be owned by root, with the `setuid` bit enabled.
+This is [documented here](https://www.sylabs.io/guides/2.6/admin-guide/security.html#how-does-singularity-do-it).
+If you do not give Singularity these privileges, you are restricted to using sandbox images, which come with a number of downsides.
+Because this is not an ideal way to run Singularity, you might consider forwarding [this letter](https://www.sylabs.io/guides/3.0/user-guide/installation.html#singularity-on-a-shared-resource) to your admins.
 
 #### Configuring Cromwell for Singularity
 
@@ -351,6 +349,12 @@ submit-docker = """
       --wrap "udocker run --rm -v ${cwd}:${docker_cwd} ${docker} ${script}"
 """
 ```
+
+#### Caching
+udocker caches images in a single directory, which defaults to [`~/.udocker`](https://github.com/indigo-dc/udocker/blob/master/udocker.py#L137), meaning that caching is done on a per-user basis. 
+However, like Singularity, if you want to share a cache with other users in your project,you you can override the location of the udocker cache directory either using:
+* A config file [described here](https://github.com/indigo-dc/udocker/blob/master/doc/installation_manual.md#9-configuration), containing a line such as `topdir = "/path/to/cache"`.
+* Using the environment variable `$UDOCKER_DIR`
 
 ### Configuration in Detail
 The behaviour of Cromwell with containers can be modified using a few other options.

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -14,7 +14,7 @@ This tutorial page relies on completing the previous tutorials:
 
 ### Goals
 
-At the end of this tutorial, you'll become familiar with container technologies and how to configure Cromwell to use these indepdently, or with job schedulers.
+At the end of this tutorial, you'll become familiar with container technologies and how to configure Cromwell to use these independently, or with job schedulers.
 
 We'll discuss:
 

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -463,16 +463,16 @@ docker {
 When choosing the image version for your pipeline stages, it is highly recommended that you use a hash rather than a tag, for the sake of reproducibility
 For example, in WDL, you could do this:
 ```wdl
-    runtime {
-        docker: 'ubuntu:latest'
-    }
+runtime {
+    docker: 'ubuntu:latest'
+}
 ```
 
 But what you should do is this:
 ```wdl
-    runtime {
-        docker: 'ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210'
-    }
+runtime {
+    docker: 'ubuntu@sha256:7a47ccc3bbe8a451b500d2b53104868b46d60ee8f5b35a24b41a86077c650210'
+}
 ```
 
 You can find the `sha256` of an image using `docker images --digests`

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -6,6 +6,35 @@ Best Practise WDL and CWL define containers for their tasks to run in, to ensure
 
 Docker images are the most common container format, but it is not advisable for certain systems to run Docker itself, and for this reason Cromwell can be configured to support a number of alternatives.
 
+* [Prerequisites](#prerequisites)
+* [Goals](#goals)
+* [Specifying Containers in your Workflow](#specifying-containers-in-your-workflow)
+* [Docker](#docker)
+    * [Docker on a Local Backend](#docker-on-a-local-backend)
+    * [Docker on Cloud](#docker-on-cloud)
+    * [Docker on HPC](#docker-on-hpc)
+* [Singularity](#singularity)
+    * [Installation](#installation)
+    * [Configuring Cromwell for Singularity](#configuring-cromwell-for-singularity)
+        * [Local environments](#local-environments)
+        * [Job schedulers](#job-schedulers)
+    * [Without Setuid](#without-setuid)
+    * [Singularity Cache](#singularity-cache)
+* [udocker](#udocker)
+    * [Installation](#installation-1)
+    * [Configuration](#configuration)
+* [Configuration in Detail](#configuration-in-detail)
+    * [Enforcing container requirements](#enforcing-container-requirements)
+    * [Docker Digests](#docker-digests)
+    * [Docker Root](#docker-root)
+    * [Docker Config Block](#docker-config-block)
+* [Best Practices](#best-practices)
+    * [Image Versions](#image-versions)
+* [Notes](#notes)
+    * [How does Cromwell know when a job or container has completed?](#how-does-cromwell-know-when-a-job-or-container-has-completed)
+    * [Cromwell: Run-in-background](#cromwell-run-in-background)
+* [Next Steps](#next-steps)
+
 ### Prerequisites
 This tutorial page relies on completing the previous tutorials:
 
@@ -17,13 +46,6 @@ This tutorial page relies on completing the previous tutorials:
 
 At the end of this tutorial, you'll become familiar with container technologies and how to configure Cromwell to use these independently, or with job schedulers.
 
-We'll discuss:
-
-[//]: # (These are external links, but I think they may look like TOC references.)
-
-* [Docker](https://www.docker.com)
-* [Singularity](https://www.sylabs.io/docs/)
-* [udocker](https://github.com/indigo-dc/udocker)
 
 ### Specifying Containers in your Workflow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ pages:
     - Server Mode: tutorials/ServerMode.md
     - Configuring the Local backend: tutorials/LocalBackendIntro.md
     - Viewing Metadata: tutorials/MetadataEndpoint.md
+    - Getting started with Containers: tutorials/Containers.md
 #    - Introduction to Call Caching: tutorials/CallCaching101.md
 #    - Common Errors: tutorials/FrequentErrors.md
 #    - General Debugging Tips: tutorials/GeneralDebuggingTips.md


### PR DESCRIPTION
Following on from the conversation at #4039, I've started a "Getting started with Containers" on the Cromwell docs. My thoughts are it might be a good place to put thoughts about containers, how they can be used and any caveats about them.

This tutorial follows the [user goal](https://github.com/broadinstitute/cromwell/issues/2177#issuecomment-330341279) (from #2177):
> As a **user with images in Singularity**, I want **Cromwell to support using Singularity images (either via Singularity Hub and the command line, or connecting via API)**, so that I can **use Singularity images and not have to duplicate them in Docker**.

However, without any code changes, just purely through configuration. 

I think it's worth touching on using these container technologies with job schedulers, so I've included the ConfigurationFile and the HPCIntro tutorials as prerequisites.