### PR TITLE
Token logging sanity log

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -55,7 +55,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         }(context.dispatcher)
         ()
       case None =>
-        log.info(s"Not triggering log of token queue status. Effective log interval = $effectiveLogInterval")
+        log.info(s"Not triggering log of token queue status. Effective log interval = None")
         ()
     }
   }(context.dispatcher)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -38,20 +38,25 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
     sendGaugeJob(ExecutionStatus.QueuedInCromwell.toString, tokenQueues.values.map(_.size).sum.toLong)
   }
 
-  val effectiveLogInterval: Option[FiniteDuration] = logInterval.filterNot(_ == 0.seconds)
+  lazy val effectiveLogInterval: Option[FiniteDuration] = logInterval.filterNot(_ == 0.seconds)
 
-  val tokenEventLogger = effectiveLogInterval match {
+  lazy val tokenEventLogger = effectiveLogInterval match {
     case Some(someInterval) => new CachingTokenEventLogger(log, someInterval)
     case None => NullTokenEventLogger
   }
 
   // Give the actor time to warm up, then start scheduling token allocation logging:
-  context.system.scheduler.scheduleOnce(10.seconds) {
-    effectiveLogInterval.foreach { someInterval =>
-      log.info(s"Triggering log of token queue status every $someInterval")
-      context.system.scheduler.scheduleOnce(someInterval) {
-        self ! LogJobExecutionTokenAllocation(someInterval)
-      }(context.dispatcher)
+  context.system.scheduler.scheduleOnce(5.seconds) {
+    effectiveLogInterval match {
+      case Some(someInterval) =>
+        log.info(s"Triggering log of token queue status. Effective log interval = $someInterval")
+        context.system.scheduler.scheduleOnce(someInterval) {
+          self ! LogJobExecutionTokenAllocation(someInterval)
+        }(context.dispatcher)
+        ()
+      case None =>
+        log.info(s"Not triggering log of token queue status. Effective log interval = $effectiveLogInterval")
+        ()
     }
   }(context.dispatcher)
 

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -21,6 +21,10 @@ system {
     lines = ${?CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT}
   }
   abbreviate-command-length = 1000
+
+  hog-safety {
+    token-log-interval-seconds = 300
+  }
 }
 
 include "cromwell_database.inc.conf"


### PR DESCRIPTION
* Makes the logging start after 5 rather than 10 seconds
* Logs at least once, even if just to say that there will be no further logging
* Runs in centaur too (so that we can see the logs, and the code gets exercised more)