### PR TITLE
Log metadata summarization totals

### DIFF
--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -44,7 +44,8 @@ class MetadataSummaryRefreshActor()
   when (WaitingForRequest) {
     case (Event(SummarizeMetadata(respondTo), _)) =>
       refreshWorkflowMetadataSummaries() onComplete {
-        case Success(_) =>
+        case Success(maximumSummaryId) =>
+          log.info(s"Metadata summarizer has now reached: $maximumSummaryId")
           respondTo ! MetadataSummarySuccess
           self ! MetadataSummaryComplete
         case Failure(t) =>


### PR DESCRIPTION
A useful refactor of the summarizer FSM, and a log of where the summarizer has reached
- Don't be afraid to vote 👎 on the logging if you think it's going to be too noisy

Sample log message: `2019-02-13 12:52:19,609 cromwell-system-akka.dispatchers.service-dispatcher-97 INFO  - Metadata summarizer has now reached: 52837`