### PR TITLE
Refactor CAJEA pollStatus logic

### DIFF
--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
@@ -253,8 +253,8 @@ class DispatchedConfigAsyncJobExecutionActor(override val standardParams: Standa
     val timeout = configurationDescriptor.backendConfig.as[Option[Long]](ExitCodeTimeoutConfig)
     timeout match {
       case Some(x) =>
-      jobLogger.info("Cromwell will watch for an rc file *and* double-check every {} seconds to make sure this job is still alive", x)
-      if (x < 0) throw new IllegalArgumentException(s"config value '$ExitCodeTimeoutConfig' must be 0 or higher")
+        jobLogger.info("Cromwell will watch for an rc file *and* double-check every {} seconds to make sure this job is still alive", x)
+        if (x < 0) throw new IllegalArgumentException(s"config value '$ExitCodeTimeoutConfig' must be 0 or higher")
       case None =>
         jobLogger.info("Cromwell will watch for an rc file but will *not* double-check whether this job is actually alive (unless Cromwell restarts)")
     }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
@@ -1,8 +1,7 @@
 package cromwell.backend.impl.sfs.config
 
-import java.io.PrintWriter
 import java.nio.file.FileAlreadyExistsException
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 
 import common.validation.Validation._
 import cromwell.backend.RuntimeEnvironmentBuilder

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigAsyncJobExecutionActor.scala
@@ -313,8 +313,15 @@ class DispatchedConfigAsyncJobExecutionActor(override val standardParams: Standa
               // If the process has already completed, there will be an existing RC:
               // Essentially, this covers the rare race condition whereby the task completes between starting to write the
               // fake RC, and trying to copy it:
+
+              log.error(s"An RC file appeared at ${jobPaths.returnCode} whilst trying to copy a fake exitcode file from ${returnCodeTemp}. Not to worry: the real file should now be picked up on the next poll.")
+
+              // Delete the fake file since it's not needed:
               returnCodeTemp.delete(true)
-              // Looks like a new RC file has appeared - let's go back out of this loop and wait for it:
+
+              // We shouldn't be here anymore...
+              // Return a "no-op" for now and allow the now-existing rc file to be picked up as normal on the next
+              // iteration through the polling logic:
               waiting
           }
         } else {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -18,6 +18,8 @@ import scala.util.{Failure, Success, Try}
 sealed trait SharedFileSystemRunState {
   def status: String
   def terminal: Boolean = false
+
+  override def toString: String = status
 }
 
 case class SharedFileSystemJobRunning(validUntil: Option[LocalDateTime]) extends SharedFileSystemRunState {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -17,12 +17,13 @@ import scala.util.{Failure, Success, Try}
 
 sealed trait SharedFileSystemRunState {
   def status: String
-  def terminal: Boolean = false
+  def terminal: Boolean
 
   override def toString: String = status
 }
 
 case class SharedFileSystemJobRunning(validUntil: Option[Instant]) extends SharedFileSystemRunState {
+  override def terminal: Boolean = true
   override def status = "Running"
 
   // Whether this running state is stale (ie has the 'validUntil' time passed?)
@@ -30,6 +31,7 @@ case class SharedFileSystemJobRunning(validUntil: Option[Instant]) extends Share
 }
 
 case class SharedFileSystemJobWaitingForReturnCode(waitUntil: Option[Instant]) extends SharedFileSystemRunState {
+  override def terminal: Boolean = true
   override def status = "WaitingForReturnCode"
 
   // Whether or not to give up waiting for the RC to appear (ie has the 'waitUntil' time passed?)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.sfs
 
 import java.nio.file.FileAlreadyExistsException
-import java.time.LocalDateTime
+import java.time.Instant
 
 import cromwell.backend._
 import cromwell.backend.async.{ExecutionHandle, FailedNonRetryableExecutionHandle, PendingExecutionHandle}
@@ -22,18 +22,18 @@ sealed trait SharedFileSystemRunState {
   override def toString: String = status
 }
 
-case class SharedFileSystemJobRunning(validUntil: Option[LocalDateTime]) extends SharedFileSystemRunState {
+case class SharedFileSystemJobRunning(validUntil: Option[Instant]) extends SharedFileSystemRunState {
   override def status = "Running"
 
   // Whether this running state is stale (ie has the 'validUntil' time passed?)
-  def stale: Boolean = validUntil.exists(t => t.isBefore(LocalDateTime.now))
+  def stale: Boolean = validUntil.exists(t => t.isBefore(Instant.now))
 }
 
-case class SharedFileSystemJobWaitingForReturnCode(waitUntil: Option[LocalDateTime]) extends SharedFileSystemRunState {
+case class SharedFileSystemJobWaitingForReturnCode(waitUntil: Option[Instant]) extends SharedFileSystemRunState {
   override def status = "WaitingForReturnCode"
 
   // Whether or not to give up waiting for the RC to appear (ie has the 'waitUntil' time passed?)
-  def giveUpWaiting: Boolean = waitUntil.exists(_.isBefore(LocalDateTime.now))
+  def giveUpWaiting: Boolean = waitUntil.exists(_.isBefore(Instant.now))
 }
 
 case object SharedFileSystemJobDone extends SharedFileSystemRunState {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystemAsyncJobExecutionActor.scala
@@ -23,7 +23,7 @@ sealed trait SharedFileSystemRunState {
 }
 
 case class SharedFileSystemJobRunning(validUntil: Option[Instant]) extends SharedFileSystemRunState {
-  override def terminal: Boolean = true
+  override def terminal: Boolean = false
   override def status = "Running"
 
   // Whether this running state is stale (ie has the 'validUntil' time passed?)
@@ -31,7 +31,7 @@ case class SharedFileSystemJobRunning(validUntil: Option[Instant]) extends Share
 }
 
 case class SharedFileSystemJobWaitingForReturnCode(waitUntil: Option[Instant]) extends SharedFileSystemRunState {
-  override def terminal: Boolean = true
+  override def terminal: Boolean = false
   override def status = "WaitingForReturnCode"
 
   // Whether or not to give up waiting for the RC to appear (ie has the 'waitUntil' time passed?)


### PR DESCRIPTION
To fix the "unmatched case" error in #4651 :

* Make states a strict ADT rather than string-based
* Hopefully made the `pollStatus` logic a little easier to follow

Closes #4651 