### PR TITLE
Revert auto-commit metadata inserts [37 hotfix]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -35,7 +35,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
                                  (implicit ec: ExecutionContext): Future[Unit] = {
     val action = DBIO.seq(metadataEntries.grouped(insertBatchSize).map(dataAccess.metadataEntries ++= _).toSeq:_*)
-    runAction(action)
+    runTransaction(action).map(_ => ())
   }
 
   override def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -164,14 +164,10 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
   private val debugExitStatusCodeOption = ConfigFactory.load.getAs[Int](debugExitConfigPath)
 
   protected[this] def runTransaction[R](action: DBIO[R], isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead): Future[R] = {
-    runActionInternal(action.transactionally.withTransactionIsolation(isolationLevel))
+    runAction(action.transactionally.withTransactionIsolation(isolationLevel))
   }
 
   protected[this] def runAction[R](action: DBIO[R]): Future[R] = {
-    runActionInternal(action.withPinnedSession)
-  }
-
-  private def runActionInternal[R](action: DBIO[R]): Future[R] = {
     //database.run(action) <-- See comment above private val actionThreadPool
     Future {
       try {


### PR DESCRIPTION
Revert problematic metadata autocommit changes.
This reverts commit c3f56e2c8775625e4c36303d61f75a75974a2ef4.