### PR TITLE
Revert auto-commit metadata inserts [36 hotfix]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -35,7 +35,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
                                  (implicit ec: ExecutionContext): Future[Unit] = {
     val action = DBIO.seq(metadataEntries.grouped(insertBatchSize).map(dataAccess.metadataEntries ++= _).toSeq:_*)
-    runAction(action)
+    runTransaction(action).map(_ => ())
   }
 
   override def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -101,15 +101,7 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
   }
 
   protected[this] def runTransaction[R](action: DBIO[R]): Future[R] = {
-    runActionInternal(action.transactionally)
-  }
-
-  protected[this] def runAction[R](action: DBIO[R]): Future[R] = {
-    runActionInternal(action.withPinnedSession)
-  }
-
-  private def runActionInternal[R](action: DBIO[R]): Future[R] = {
-    database.run(action)
+    database.run(action.transactionally)
   }
 
   /*


### PR DESCRIPTION
Revert problematic metadata autocommit changes.
This reverts commit 6b6d83bcb24461de90ddc2691654fb9b324baaa9.