### PR TITLE
Programmer error and logging in PAPI request manager

### DIFF
--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/TestTokenGrabbingActor.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/TestTokenGrabbingActor.scala
@@ -3,10 +3,7 @@ package cromwell.engine.workflow.tokens
 import akka.actor.{Actor, ActorRef, Props, SupervisorStrategy}
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDispensed, JobExecutionTokenRequest}
-import cromwell.util.AkkaTestUtil
 import cromwell.util.AkkaTestUtil.DeathTestActor
-
-import scala.util.control.NoStackTrace
 
 /**
   * Grabs a token and doesn't let it go!

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/TestTokenGrabbingActor.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/TestTokenGrabbingActor.scala
@@ -4,22 +4,19 @@ import akka.actor.{Actor, ActorRef, Props, SupervisorStrategy}
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDispensed, JobExecutionTokenRequest}
 import cromwell.util.AkkaTestUtil
+import cromwell.util.AkkaTestUtil.DeathTestActor
 
 import scala.util.control.NoStackTrace
 
 /**
   * Grabs a token and doesn't let it go!
   */
-class TestTokenGrabbingActor(tokenDispenser: ActorRef, tokenType: JobExecutionTokenType) extends Actor {
+class TestTokenGrabbingActor(tokenDispenser: ActorRef, tokenType: JobExecutionTokenType) extends DeathTestActor {
 
   var hasToken: Boolean = false
 
-  def receive = {
+  override def receive = stoppingReceive orElse {
     case JobExecutionTokenDispensed => hasToken = true
-    case AkkaTestUtil.ThrowException =>
-      throw new RuntimeException("Test exception (don't be scared by the stack trace, it's deliberate!)")
-        with NoStackTrace
-    case AkkaTestUtil.InternalStop => context.stop(self)
   }
 
   tokenDispenser ! JobExecutionTokenRequest("hogGroupA", tokenType)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendSingletonActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendSingletonActor.scala
@@ -17,7 +17,7 @@ final case class PipelinesApiBackendSingletonActor(qps: Int Refined Positive, re
   override def receive = {
     case abort: BackendSingletonActorAbortWorkflow => jesApiQueryManager.forward(abort)
     case apiQuery: PAPIApiRequest =>
-      log.debug("Forwarding API query to JES API query manager actor")
+      log.debug("Forwarding API query to PAPI request manager actor")
       jesApiQueryManager.forward(apiQuery)
   }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendSingletonActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendSingletonActor.scala
@@ -9,7 +9,7 @@ import cromwell.core.Mailbox
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 
-final case class PipelinesApiBackendSingletonActor(qps: Int Refined Positive, requestWorkers: Int Refined Positive, serviceRegistryActor: ActorRef)
+final class PipelinesApiBackendSingletonActor(qps: Int Refined Positive, requestWorkers: Int Refined Positive, serviceRegistryActor: ActorRef)
                                                   (implicit batchHandler: PipelinesApiRequestHandler) extends Actor with ActorLogging {
 
   val jesApiQueryManager = context.actorOf(PipelinesApiRequestManager.props(qps, requestWorkers, serviceRegistryActor).withMailbox(Mailbox.PriorityMailbox), "PAPIQueryManager")
@@ -24,5 +24,5 @@ final case class PipelinesApiBackendSingletonActor(qps: Int Refined Positive, re
 
 object PipelinesApiBackendSingletonActor {
   def props[O](qps: Int Refined Positive, requestWorkers: Int Refined Positive, serviceRegistryActor: ActorRef)
-              (implicit batchHandler: PipelinesApiRequestHandler): Props = Props(PipelinesApiBackendSingletonActor(qps, requestWorkers, serviceRegistryActor)).withDispatcher(BackendDispatcher)
+              (implicit batchHandler: PipelinesApiRequestHandler): Props = Props(new PipelinesApiBackendSingletonActor(qps, requestWorkers, serviceRegistryActor)).withDispatcher(BackendDispatcher)
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
@@ -274,7 +274,10 @@ object PipelinesApiRequestManager {
     def withFailedAttempt: PAPIApiRequest
     def backoff: Backoff
     def httpRequest: HttpRequest
-    def contentLength: Long = Option(httpRequest).map(_.getContent).map(_.getLength).getOrElse(0L)
+    def contentLength: Long = (for {
+      r <- Option(httpRequest)
+      content <- Option(r.getContent)
+    } yield content.getLength).getOrElse(0L)
   }
   private object PAPIApiRequest {
     // This must be a def, we want a new one each time (they're mutable! Boo!)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorker.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestWorker.scala
@@ -11,7 +11,7 @@ import cromwell.services.instrumentation.CromwellInstrumentationActor
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Random, Success, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Sends batched requests to JES as a worker to the JesApiQueryManager

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManagerSpec.scala
@@ -1,7 +1,8 @@
 package cromwell.backend.google.pipelines.common.api
 
-import akka.actor.{ActorRef, Props}
+import akka.actor.{ActorLogging, ActorRef, Props}
 import akka.testkit.{TestActorRef, TestProbe, _}
+import cats.data.NonEmptyList
 import com.google.api.client.googleapis.batch.BatchRequest
 import cromwell.backend.BackendSingletonActorAbortWorkflow
 import cromwell.backend.google.pipelines.common.PipelinesApiTestConfig
@@ -133,13 +134,11 @@ class PipelinesApiRequestManagerSpec extends TestKitSuite("PipelinesApiRequestMa
       - That statusPoller is the second ActorRef (and artifact of TestJesApiQueryManager)
      */
     it should s"catch polling actors if they $name, recreate them and add work back to the queue" in {
-      val jaqmBox = new JaqmBox()
 
-      val statusPoller1 = TestActorRef(Props(new TestPapiWorkerActor(jaqmBox, 1)), TestActorRef(new AkkaTestUtil.StoppingSupervisor()))
-      val statusPoller2 = TestActorRef(Props(new TestPapiWorkerActor(jaqmBox, 1)), TestActorRef(new AkkaTestUtil.StoppingSupervisor()))
-      val jaqmActor: TestActorRef[TestPipelinesApiRequestManager] = TestActorRef(TestPipelinesApiRequestManager.props(registryProbe, statusPoller1, statusPoller2), s"TestJesApiQueryManager-${Random.nextInt()}")
-      jaqmBox.jaqm = jaqmActor
-
+      val statusPoller1 = TestActorRef[TestPapiWorkerActor](Props(new TestPapiWorkerActor(1)), TestActorRef(new AkkaTestUtil.StoppingSupervisor()), "statusPoller1")
+      val statusPoller2 = TestActorRef[TestPapiWorkerActor](Props(new TestPapiWorkerActor(1)), TestActorRef(new AkkaTestUtil.StoppingSupervisor()), "statusPoller2")
+      val statusPoller3 = TestActorRef[TestPapiWorkerActor](Props(new TestPapiWorkerActor(1)), TestActorRef(new AkkaTestUtil.StoppingSupervisor()), "statusPoller3")
+      val jaqmActor: TestActorRef[TestPipelinesApiRequestManager] = TestActorRef(TestPipelinesApiRequestManager.props(registryProbe, statusPoller1, statusPoller2, statusPoller3), s"TestJesApiQueryManager-${Random.nextInt()}")
 
       val emptyActor = system.actorOf(Props.empty)
 
@@ -149,14 +148,52 @@ class PipelinesApiRequestManagerSpec extends TestKitSuite("PipelinesApiRequestMa
         jaqmActor.tell(msg = request, sender = emptyActor)
       }
 
-      jaqmActor.tell(msg = PipelinesApiRequestManager.PipelinesWorkerRequestWork(BatchSize), sender = statusPoller1)
+      // The work queue should be filled and the manager should have one poller active:
+      eventually {
+        jaqmActor.underlyingActor.queueSize should be (BatchSize)
+        jaqmActor.underlyingActor.testPollerCreations should be (1)
+        jaqmActor.underlyingActor.statusPollers.size should be(1)
+        jaqmActor.underlyingActor.statusPollers.head should be(statusPoller1)
+      }
 
+      // Status poller 1 should get some work:
+      jaqmActor ! SpecOnly_TriggerRequestForWork(jaqmActor, BatchSize)
+
+      // Therefore, there's no work left in the work queue because it's all been given to the worker:
+      eventually {
+        jaqmActor.underlyingActor.queueSize should be (0)
+        statusPoller1.underlyingActor.workToDo.map(_.size) should be(Some(BatchSize))
+      }
+
+      // Uh oh, something happens to status poller 1:
       stopMethod(statusPoller1)
 
+      // The work queue receives all the work that couldn't be completed, and a new poller is created:
       eventually {
-        jaqmActor.underlyingActor.testPollerCreations should be (2)
         jaqmActor.underlyingActor.queueSize should be (BatchSize)
-        jaqmActor.underlyingActor.statusPollerEquals(statusPoller2) should be (true)
+        jaqmActor.underlyingActor.testPollerCreations should be (2)
+        jaqmActor.underlyingActor.statusPollers.size should be(1)
+        jaqmActor.underlyingActor.statusPollers.head should be(statusPoller2)
+      }
+
+      // Next, status poller 2 should be able to get some work:
+      jaqmActor ! SpecOnly_TriggerRequestForWork(jaqmActor, BatchSize)
+
+      // The queue is emptied again and this time statusPoller2 has it:
+      eventually {
+        jaqmActor.underlyingActor.queueSize should be (0)
+        statusPoller2.underlyingActor.workToDo.map(_.size) should be(Some(BatchSize))
+      }
+
+      // Uh oh, something *also* happens to status poller 2!!
+      stopMethod(statusPoller2)
+
+      // The work queue receives all the work that couldn't be completed *again*, and a new poller is created *again*:
+      eventually {
+        jaqmActor.underlyingActor.queueSize should be (BatchSize)
+        jaqmActor.underlyingActor.testPollerCreations should be (3)
+        jaqmActor.underlyingActor.statusPollers.size should be(1)
+        jaqmActor.underlyingActor.statusPollers.head should be(statusPoller3)
       }
     }
   }
@@ -176,7 +213,7 @@ class PipelinesApiRequestManagerSpec extends TestKitSuite("PipelinesApiRequestMa
     // abort workflow A
     jaqmActor ! BackendSingletonActorAbortWorkflow(workflowIdA)
 
-    // It should remove all and only run requests for workflow A 
+    // It should remove all and only run requests for workflow A
     eventually {
       jaqmActor.underlyingActor.queueSize shouldBe 1
       jaqmActor.underlyingActor.workQueue.head.asInstanceOf[PipelinesApiRequestManager.PAPIRunCreationRequest].workflowId shouldBe workflowIdB
@@ -194,26 +231,35 @@ object TestPipelinesApiRequestManagerSpec {
 /**
   * This test class allows us to hook into the JesApiQueryManager's makeStatusPoller and provide our own TestProbes instead
   */
-class TestPipelinesApiRequestManager(qps: Int Refined Positive, requestWorkers: Int Refined Positive, registry: ActorRef, statusPollerProbes: ActorRef*)
+class TestPipelinesApiRequestManager(qps: Int Refined Positive,
+                                     requestWorkers: Int Refined Positive,
+                                     registry: ActorRef,
+                                     availableRequestWorkers: ActorRef*)
   extends PipelinesApiRequestManager(qps, requestWorkers, registry)(new MockPipelinesRequestHandler) {
-  var testProbes: Queue[ActorRef] = _
+
+  var testProbeQueue: Queue[ActorRef] = _
   var testPollerCreations: Int = _
 
+  private def askForWorkReceive: PartialFunction[Any, Unit] = {
+    case afw: SpecOnly_TriggerRequestForWork => statusPollers.head ! afw
+  }
+
+  override def receive: PartialFunction[Any, Unit] = askForWorkReceive orElse super.receive
+
   private def init() = {
-    testProbes = Queue(statusPollerProbes: _*)
+    testProbeQueue = Queue(availableRequestWorkers: _*)
     testPollerCreations = 0
   }
 
   override private[api] lazy val nbWorkers = 1
   override private[api] def resetAllWorkers() = {
-    val pollers = Vector.fill(1) { makeWorkerActor() }
-    pollers.foreach(context.watch)
+    val pollers = Vector.fill(1) { makeAndWatchWorkerActor() }
     pollers
   }
 
   override private[api] def makeWorkerActor(): ActorRef = {
     // Initialize the queue, if necessary:
-    if (testProbes == null) {
+    if (testProbeQueue == null) {
       init()
     }
 
@@ -221,8 +267,8 @@ class TestPipelinesApiRequestManager(qps: Int Refined Positive, requestWorkers: 
     testPollerCreations += 1
 
     // Pop the queue to get the next test probe:
-    val (probe, newQueue) = testProbes.dequeue
-    testProbes = newQueue
+    val (probe, newQueue) = testProbeQueue.dequeue
+    testProbeQueue = newQueue
     probe
   }
 
@@ -230,28 +276,30 @@ class TestPipelinesApiRequestManager(qps: Int Refined Positive, requestWorkers: 
   def statusPollerEquals(otherStatusPoller: ActorRef) = statusPollers sameElements Array(otherStatusPoller)
 }
 
-class JaqmBox() {
-  var jaqm: ActorRef = _
-  def getJaqm: ActorRef = jaqm
-}
-
 /**
   * Grabs some work but doesn't ever work on it (let alone completing it!)
   */
-class TestPapiWorkerActor(requestManagerInABox: JaqmBox, maxBatchSize: Int) extends DeathTestActor {
+class TestPapiWorkerActor(maxBatchSize: Int) extends DeathTestActor with ActorLogging {
 
-  var workToDo: Int = 0
+  var workToDo: Option[NonEmptyList[PAPIApiRequest]] = None
 
   override def receive = stoppingReceive orElse {
 
-    case PipelinesApiWorkBatch(work) => workToDo = work.size
-    case NoWorkToDo => workToDo = 0
+    case PipelinesApiWorkBatch(work) =>
+      log.info(s"received ${work.size} requests from ${sender().path.name}")
+      workToDo = Some(work)
+    case NoWorkToDo =>
+      log.info(s"received 0 requests from ${sender().path.name}")
+      workToDo = None
+    case SpecOnly_TriggerRequestForWork(manager, batchSize) => requestWork(manager, batchSize)
   }
 
-  def requestWork(): Unit = {
-    requestManagerInABox.getJaqm ! PipelinesWorkerRequestWork(maxBatchSize)
+  def requestWork(papiRequestManager: ActorRef, batchSize: Int): Unit = {
+    papiRequestManager ! PipelinesWorkerRequestWork(batchSize)
   }
 }
+
+case class SpecOnly_TriggerRequestForWork(papiRequestManager: ActorRef, batchSize: Int)
 
 class MockPipelinesRequestHandler extends PipelinesApiRequestHandler {
   override def makeBatchRequest = throw new UnsupportedOperationException


### PR DESCRIPTION
* Addresses the "programmer error" in JES API manager
* Makes the logging in these classes more usable and traceable
* Replaces strings like `"JES API polling worker"` with strings like `"PAPI request worker"`
