### PR TITLE
Double summarization to reduce skipping rows

### DIFF
--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -10,7 +10,7 @@ sealed trait WorkflowState {
 }
 
 object WorkflowState {
-  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
+  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowStarting, WorkflowRunning, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
 
   def withName(str: String): WorkflowState = WorkflowStateValues.find(_.toString.equalsIgnoreCase(str)).getOrElse(
     throw new NoSuchElementException(s"No such WorkflowState: $str"))
@@ -34,32 +34,38 @@ case object WorkflowSubmitted extends WorkflowState {
   override val ordinal = 1
 }
 
+case object WorkflowStarting extends WorkflowState {
+  override val toString: String = "Starting"
+  override val isTerminal = false
+  override val ordinal = 2
+}
+
 case object WorkflowRunning extends WorkflowState {
   override val toString: String = "Running"
   override val isTerminal = false
-  override val ordinal = 2
+  override val ordinal = 3
 }
 
 case object WorkflowAborting extends WorkflowState {
   override val toString: String = "Aborting"
   override val isTerminal = false
-  override val ordinal = 3
+  override val ordinal = 4
 }
 
 case object WorkflowAborted extends WorkflowState {
   override val toString: String = "Aborted"
   override val isTerminal = true
-  override val ordinal = 4
+  override val ordinal = 5
 }
 
 case object WorkflowSucceeded extends WorkflowState {
   override val toString: String = "Succeeded"
   override val isTerminal = true
-  override val ordinal = 5
+  override val ordinal = 6
 }
 
 case object WorkflowFailed extends WorkflowState {
   override val toString: String = "Failed"
   override val isTerminal = true
-  override val ordinal = 6
+  override val ordinal = 7
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -113,9 +113,9 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   private def updateWorkflowMetadataSummaryEntry(buildUpdatedWorkflowMetadataSummaryEntry:
                                                  (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry]) =>
                                                    WorkflowMetadataSummaryEntry)
-                                                (workflowExecutionUuuidAndMetadataEntries: (String, Seq[MetadataEntry]))
+                                                (workflowExecutionUuidAndMetadataEntries: (String, Seq[MetadataEntry]))
                                                 (implicit ec: ExecutionContext): DBIO[Unit] = {
-    val (workflowExecutionUuid, metadataEntries) = workflowExecutionUuuidAndMetadataEntries
+    val (workflowExecutionUuid, metadataEntries) = workflowExecutionUuidAndMetadataEntries
     for {
     // There might not be a preexisting summary for a given UUID, so `headOption` the result
       existingWorkflowMetadataSummaryEntry <- dataAccess.

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -143,7 +143,7 @@ trait MetadataEntryComponent {
      statusMetadataKey: Rep[String], likeLabelMetadataKey: Rep[String], submissionMetadataKey: Rep[String]) => for {
       metadataEntry <- metadataEntries
       if metadataEntry.metadataEntryId >= minimumMetadataEntryId
-      if metadataEntry.metadataEntryId < maximumMetadataEntryId
+      if metadataEntry.metadataEntryId <= maximumMetadataEntryId
       if (metadataEntry.metadataKey === startMetadataKey || metadataEntry.metadataKey === endMetadataKey ||
         metadataEntry.metadataKey === nameMetadataKey || metadataEntry.metadataKey === statusMetadataKey ||
         metadataEntry.metadataKey.like(likeLabelMetadataKey) || metadataEntry.metadataKey === submissionMetadataKey) &&

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -135,6 +135,23 @@ trait MetadataEntryComponent {
     } yield metadataEntry
   )
 
+  // This is only used for metadata summary which should not require metadata sorting if rows are committed
+  // with monotonically increasing IDs. The metadata summary logic records the maximum ID it last saw and uses
+  // that last ID + 1 as the minimum ID for the next query iteration.
+  val metadataEntriesForIdInRange = Compiled(
+    (minimumMetadataEntryId: Rep[Long], maximumMetadataEntryId: Rep[Long], startMetadataKey: Rep[String], endMetadataKey: Rep[String], nameMetadataKey: Rep[String],
+     statusMetadataKey: Rep[String], likeLabelMetadataKey: Rep[String], submissionMetadataKey: Rep[String]) => for {
+      metadataEntry <- metadataEntries
+      if metadataEntry.metadataEntryId >= minimumMetadataEntryId
+      if metadataEntry.metadataEntryId < maximumMetadataEntryId
+      if (metadataEntry.metadataKey === startMetadataKey || metadataEntry.metadataKey === endMetadataKey ||
+        metadataEntry.metadataKey === nameMetadataKey || metadataEntry.metadataKey === statusMetadataKey ||
+        metadataEntry.metadataKey.like(likeLabelMetadataKey) || metadataEntry.metadataKey === submissionMetadataKey) &&
+        (metadataEntry.callFullyQualifiedName.isEmpty && metadataEntry.jobIndex.isEmpty &&
+          metadataEntry.jobAttempt.isEmpty)
+    } yield metadataEntry
+  )
+
   /**
     * Returns metadata entries that are "like" metadataKeys for the specified workflow.
     * If requireEmptyJobKey is true, only workflow level keys are returned, otherwise both workflow and call level

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -72,7 +72,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                                     buildUpdatedSummary:
                                     (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
                                       => WorkflowMetadataSummaryEntry)
-                                   (implicit ec: ExecutionContext): Future[Long]
+                                   (implicit ec: ExecutionContext): Future[(Long, Long)]
 
   def getWorkflowStatus(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Option[String]]
 

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -72,7 +72,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                                     buildUpdatedSummary:
                                     (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
                                       => WorkflowMetadataSummaryEntry)
-                                   (implicit ec: ExecutionContext): Future[(Long, Long)]
+                                   (implicit ec: ExecutionContext): Future[(Long, Long, Vector[Long], Vector[Long])]
 
   def getWorkflowStatus(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Option[String]]
 

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -60,9 +60,7 @@ object WorkflowActor {
   /**
     * Waiting for a Start or Restart command.
     */
-  case object WorkflowUnstartedState extends WorkflowActorState {
-    override val workflowState = WorkflowSubmitted
-  }
+  case object WorkflowUnstartedState extends WorkflowActorState { override val workflowState = WorkflowStarting }
 
   /**
     * The WorkflowActor is created. It now needs to validate and create its WorkflowDescriptor

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -29,6 +29,7 @@ object SqlWorkflowStore {
   object WorkflowStoreState extends Enumeration {
     type WorkflowStoreState = Value
     val Submitted = Value("Submitted")
+    val Starting = Value("Starting")
     val Running = Value("Running")
     val Aborting = Value("Aborting")
     val OnHold = Value("On Hold")

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreSubmitActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreSubmitActor.scala
@@ -90,6 +90,7 @@ final case class WorkflowStoreSubmitActor(store: WorkflowStore, serviceRegistryA
   private def convertDatabaseStateToApiState(workflowStoreState: WorkflowStoreState): WorkflowState ={
     workflowStoreState match {
       case WorkflowStoreState.Submitted => WorkflowSubmitted
+      case WorkflowStoreState.Starting => WorkflowStarting
       case WorkflowStoreState.OnHold => WorkflowOnHold
       case WorkflowStoreState.Aborting => WorkflowAborting
       case WorkflowStoreState.Running => WorkflowRunning

--- a/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/metadata/MetadataBuilderActor.scala
@@ -321,6 +321,7 @@ class MetadataBuilderActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Me
   }
 
   def processStatusResponse(workflowId: WorkflowId, status: WorkflowState): JsObject = {
+    log.info(s"Responding to status query for ${workflowId.id.toString} with $status")
     JsObject(Map(
       WorkflowMetadataKeys.Status -> JsString(status.toString),
       WorkflowMetadataKeys.Id -> JsString(workflowId.toString)

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesState.scala
@@ -21,6 +21,7 @@ object WesState {
     cromwellStatus match {
       case WorkflowOnHold => Paused
       case WorkflowSubmitted => Queued
+      case WorkflowStarting => Initializing
       case WorkflowRunning => Running
       case WorkflowAborting => Canceling
       case WorkflowAborted => Canceled

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -152,7 +152,7 @@ trait MetadataDatabaseAccess {
       metadataToMetadataEvents(id)
   }
 
-  def refreshWorkflowMetadataSummaries()(implicit ec: ExecutionContext): Future[Long] = {
+  def refreshWorkflowMetadataSummaries()(implicit ec: ExecutionContext): Future[(Long, Long)] = {
     metadataDatabaseInterface.refreshMetadataSummaryEntries(WorkflowMetadataKeys.StartTime, WorkflowMetadataKeys.EndTime, WorkflowMetadataKeys.Name,
       WorkflowMetadataKeys.Status, WorkflowMetadataKeys.Labels, WorkflowMetadataKeys.SubmissionTime, MetadataDatabaseAccess.buildUpdatedSummary)
   }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -152,7 +152,7 @@ trait MetadataDatabaseAccess {
       metadataToMetadataEvents(id)
   }
 
-  def refreshWorkflowMetadataSummaries()(implicit ec: ExecutionContext): Future[(Long, Long)] = {
+  def refreshWorkflowMetadataSummaries()(implicit ec: ExecutionContext): Future[(Long, Long, Vector[Long], Vector[Long])] = {
     metadataDatabaseInterface.refreshMetadataSummaryEntries(WorkflowMetadataKeys.StartTime, WorkflowMetadataKeys.EndTime, WorkflowMetadataKeys.Name,
       WorkflowMetadataKeys.Status, WorkflowMetadataKeys.Labels, WorkflowMetadataKeys.SubmissionTime, MetadataDatabaseAccess.buildUpdatedSummary)
   }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -45,11 +45,11 @@ class MetadataSummaryRefreshActor()
   when (WaitingForRequest) {
     case Event(SummarizeMetadata(respondTo), oldData @ SummaryRefreshData(mostRecentlyLoggedTotal)) =>
       refreshWorkflowMetadataSummaries() onComplete {
-        case Success(newMaximumSummaryId) =>
+        case Success((newMaximumSummaryId, newBackupSummaryId)) =>
           val newData = if(mostRecentlyLoggedTotal.contains(newMaximumSummaryId)) {
             oldData
           } else {
-            log.info(s"Metadata summarizer has now reached: $newMaximumSummaryId")
+            log.info(s"Main summarizer has now reached '$newMaximumSummaryId'; backup summarizer has now reached '$newBackupSummaryId'")
             SummaryRefreshData(Some(newMaximumSummaryId))
           }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -44,7 +44,7 @@ class MetadataSummaryRefreshActor()
 
   when (WaitingForRequest) {
     case Event(SummarizeMetadata(respondTo), oldData @ SummaryRefreshData(mostRecentlyLoggedTotal)) =>
-      refreshWorkflowMetadataSummaries() onComplete {
+      refreshWorkflowMetadataSummaries(log.info) onComplete {
         case Success((newMaximumSummaryId, newRefreshedSummaryId, allSummarized, allRefreshed)) =>
           val newData = if(mostRecentlyLoggedTotal.contains(newMaximumSummaryId)) {
             oldData

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -44,7 +44,8 @@ class MetadataSummaryRefreshActor()
   when (WaitingForRequest) {
     case (Event(SummarizeMetadata(respondTo), _)) =>
       refreshWorkflowMetadataSummaries() onComplete {
-        case Success(_) =>
+        case Success(maximumSummaryId) =>
+          log.info(s"Metadata summarizer has now reached: $maximumSummaryId")
           respondTo ! MetadataSummarySuccess
           self ! MetadataSummaryComplete
         case Failure(t) =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataSummaryRefreshActor.scala
@@ -45,12 +45,18 @@ class MetadataSummaryRefreshActor()
   when (WaitingForRequest) {
     case Event(SummarizeMetadata(respondTo), oldData @ SummaryRefreshData(mostRecentlyLoggedTotal)) =>
       refreshWorkflowMetadataSummaries() onComplete {
-        case Success((newMaximumSummaryId, newBackupSummaryId)) =>
+        case Success((newMaximumSummaryId, newRefreshedSummaryId, allSummarized, allRefreshed)) =>
           val newData = if(mostRecentlyLoggedTotal.contains(newMaximumSummaryId)) {
             oldData
           } else {
-            log.info(s"Main summarizer has now reached '$newMaximumSummaryId'; backup summarizer has now reached '$newBackupSummaryId'")
             SummaryRefreshData(Some(newMaximumSummaryId))
+          }
+
+          if (allSummarized.nonEmpty) {
+            log.info(s"""Main summarizer has now reached '$newMaximumSummaryId' via [${allSummarized.mkString(", ")}]""")
+          }
+          if (allRefreshed.nonEmpty) {
+            log.info(s"""Backup summarizer has now reached '$newRefreshedSummaryId' via [${allRefreshed.mkString(", ")}]""")
           }
 
           respondTo ! MetadataSummarySuccess

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
@@ -166,7 +166,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         workflow2Id <- baseWorkflowMetadata(Workflow2Name, Set(testLabel2, testLabel3))
 
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _) =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _, _, _) =>
           withClue("max") { max should be > 0L }
         }
 
@@ -345,7 +345,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _) =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _, _, _) =>
           max should be > 0L
         }
         //get totalResultsCount when page and pagesize are specified

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
@@ -166,7 +166,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         workflow2Id <- baseWorkflowMetadata(Workflow2Name, Set(testLabel2, testLabel3))
 
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { max =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _) =>
           withClue("max") { max should be > 0L }
         }
 
@@ -345,7 +345,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { max =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _) =>
           max should be > 0L
         }
         //get totalResultsCount when page and pagesize are specified
@@ -369,7 +369,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
           MetadataEvent.labelsToMetadataEvents(Labels(customLabelKey -> customLabelValue), workflowId)
         for {
           _ <- dataAccess.addMetadataEvents(metadataEvents)
-          _ <- dataAccess.refreshWorkflowMetadataSummaries().map(_ should be > 0L)
+          _ <- dataAccess.refreshWorkflowMetadataSummaries().map(_._1 should be > 0L)
           _ <- dataAccess.getWorkflowLabels(workflowId).map(_.toList should contain(customLabelKey -> customLabelValue))
         } yield ()
       }

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
@@ -166,7 +166,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         workflow2Id <- baseWorkflowMetadata(Workflow2Name, Set(testLabel2, testLabel3))
 
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _, _, _) =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries(_ => ()) map { case (max, _, _, _) =>
           withClue("max") { max should be > 0L }
         }
 
@@ -345,7 +345,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         _ <- baseWorkflowMetadata(uniqueWorkflow3Name)
         // refresh the metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries() map { case (max, _, _, _) =>
+        _ <- dataAccess.refreshWorkflowMetadataSummaries(_ => ()) map { case (max, _, _, _) =>
           max should be > 0L
         }
         //get totalResultsCount when page and pagesize are specified
@@ -369,7 +369,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
           MetadataEvent.labelsToMetadataEvents(Labels(customLabelKey -> customLabelValue), workflowId)
         for {
           _ <- dataAccess.addMetadataEvents(metadataEvents)
-          _ <- dataAccess.refreshWorkflowMetadataSummaries().map(_._1 should be > 0L)
+          _ <- dataAccess.refreshWorkflowMetadataSummaries(_ => ()).map(_._1 should be > 0L)
           _ <- dataAccess.getWorkflowLabels(workflowId).map(_.toList should contain(customLabelKey -> customLabelValue))
         } yield ()
       }
@@ -404,7 +404,7 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         // associate subworkflow 2 to parent
         _ <- subworkflowMetadata(parentWorkflow2, Subworkflow2Name)
         // refresh metadata
-        _ <- dataAccess.refreshWorkflowMetadataSummaries()
+        _ <- dataAccess.refreshWorkflowMetadataSummaries(_ => ())
         // include subworkflows
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(Seq(WorkflowQueryKey.IncludeSubworkflows.name -> true.toString))) map { case (resp, _) =>
           val resultByName = resp.results groupBy (_.name)

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataSummarizationSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataSummarizationSpec.scala
@@ -1,0 +1,78 @@
+package cromwell.services.metadata.impl
+
+import java.sql.Timestamp
+import java.util.UUID
+
+import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
+import org.scalatest.{FlatSpec, Matchers}
+import javax.sql.rowset.serial.SerialClob
+import common.assertion.ManyTimes._
+
+import scala.util.Random
+
+class MetadataSummarizationSpec extends FlatSpec with Matchers {
+
+  behavior of "buildUpdatedSummary"
+
+  def toClobOption(str: String) = Some(new SerialClob(str.toCharArray))
+
+  it should "Correctly create an update" in {
+
+    val workflowUuid = UUID.randomUUID().toString
+
+    val existingSummary: Option[WorkflowMetadataSummaryEntry] = Some(WorkflowMetadataSummaryEntry(
+      workflowExecutionUuid = workflowUuid,
+      workflowName = None,
+      workflowStatus = Some("Submitted"),
+      startTimestamp = None,
+      endTimestamp = None,
+      submissionTimestamp = Some(Timestamp.valueOf("2019-02-21 18:59:51.777000"))
+    ))
+
+    val runningEvent = MetadataEntry(workflowUuid, None, None, None, "status", toClobOption("Running"), Some("string"), Timestamp.valueOf("2019-02-21 19:00:08.507000"))
+    val workflowNameEvent = MetadataEntry(workflowUuid, None, None, None, "workflowName", toClobOption("test"), Some("string"), Timestamp.valueOf("2019-02-21 19:00:08.554000"))
+
+    def makeEvents() = Seq(workflowNameEvent, runningEvent) ++ shuffleAndConcatenate(Seq(
+      MetadataEntry(workflowUuid, None, None, None, "status", toClobOption("Submitted"), Some("string"), Timestamp.valueOf("2019-02-21 19:00:08.505000")),
+      MetadataEntry(workflowUuid, None, None, None, "status", toClobOption("Starting"), Some("string"), Timestamp.valueOf("2019-02-21 19:00:08.505000")),
+      runningEvent,
+      workflowNameEvent,
+    ), Seq.empty)
+
+    val expectedSummary: WorkflowMetadataSummaryEntry = WorkflowMetadataSummaryEntry(
+      workflowExecutionUuid = workflowUuid.toString,
+      workflowName = Some("test"),
+      workflowStatus = Some("Running"),
+      startTimestamp = None,
+      endTimestamp = None,
+      submissionTimestamp = Some(Timestamp.valueOf("2019-02-21 18:59:51.777000"))
+    )
+
+    100.times {
+      // Uses .toString() because object equality in timestamps seems a little off:
+      val events = makeEvents()
+
+      if (!(MetadataDatabaseAccess.buildUpdatedSummary(existingSummary, events).toString == expectedSummary.toString)) {
+        println(s"Bad event sequence: ${events.map(MetadataSummarizationSpec.printable).mkString(System.lineSeparator, System.lineSeparator, System.lineSeparator)}")
+        fail("Bad event sequence detected")
+      }
+    }
+  }
+
+  def shuffleAndConcatenate[A](as: Seq[A], result: Seq[A]): Seq[A] = {
+
+    if (Random.nextInt(100) > 15) {
+      val toInclude = as.filter(_ => Random.nextInt(100) > 40)
+      val shuffled = Random.shuffle(result ++ toInclude)
+      shuffleAndConcatenate(as, shuffled)
+    } else {
+      result
+    }
+  }
+
+}
+
+object MetadataSummarizationSpec {
+  def printable(metadataEntry: MetadataEntry): String =
+    s"""MetadataEntry("${metadataEntry.workflowExecutionUuid}", None, None, None, "${metadataEntry.metadataKey}", toClobOption("${metadataEntry.metadataValue.get.getSubString(1, metadataEntry.metadataValue.get.length.toInt)}"), Some("${metadataEntry.metadataValueType.get}"), Timestamp.valueOf("${metadataEntry.metadataTimestamp.toString}"))"""
+}


### PR DESCRIPTION
Obviously not a *good*  fallback position, but so long as we are skipping metadata entries for summarization, reducing the probability seems like an idea worth considering (with the obvious intention to turn this off as soon as we work out the problems at the database layer).

NB: the actual change here is the third commit - the other two are just ride-alongs to make the FSM nicer and provide status reporting