### PR TITLE
Upgrade mysql connector

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -3,7 +3,7 @@ package cromwell.database.slick
 import java.sql.{Connection, PreparedStatement, Statement}
 import java.util.concurrent.{ExecutorService, Executors}
 
-import com.mysql.jdbc.exceptions.jdbc4.MySQLTransactionRollbackException
+import com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.database.slick.tables.DataAccessComponent
 import cromwell.database.sql.SqlDatabase

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,7 @@ object Dependencies {
   private val mockFtpServerV = "2.7.1"
   private val mockserverNettyV = "5.5.1"
   private val mouseV = "0.20"
-  private val mysqlV = "5.1.47"
+  private val mysqlV = "8.0.15"
   private val nettyV = "4.1.33.Final"
   private val owlApiV = "5.1.9"
   private val paradiseV = "2.1.1"


### PR DESCRIPTION
According to [the docs](https://dev.mysql.com/downloads/connector/j/) it is "highly recommended" that we upgrade to the latest version, even if our MySQL is behind - `5.6.36-google-log` in our case.

Reason I started looking into this was https://github.com/broadinstitute/cromwell/issues/4689