### PR TITLE
adding cromwell example backends folder

### DIFF
--- a/cromwell.example.backends/AWS.conf
+++ b/cromwell.example.backends/AWS.conf
@@ -1,0 +1,24 @@
+# This is an example of how you can use the Amazon Web Services Backend
+# provider. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/tutorials/AwsBatch101/
+
+backend {
+  default = AWS
+
+  providers {
+    AWS {
+      actor-factory = "cromwell.backend.impl.aws.AwsBackendActorFactory"
+      config {
+        ## These two settings are required to authenticate with the ECS service:
+        accessKeyId = "..."
+        secretKey = "..."
+      }
+    }
+}

--- a/cromwell.example.backends/BCS.conf
+++ b/cromwell.example.backends/BCS.conf
@@ -1,0 +1,56 @@
+# This is an example of how you can use the Alibaba Cloud Batch Compute (BCS)
+# backend provider. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/BCS/
+
+backend {
+  default = BCS
+
+  providers {
+    BCS {
+      actor-factory = "cromwell.backend.impl.bcs.BcsBackendLifecycleActorFactory"
+      config {
+        root = "oss://your-bucket/cromwell-exe"
+        dockerRoot = "/cromwell-executions"
+        region = ""
+
+        #access-id = ""
+        #access-key = ""
+	#	#security-token = ""
+
+        filesystems {
+          oss {
+            auth {
+                #endpoint = ""
+                #access-id = ""
+                #access-key = ""
+		#security-token = ""
+            }
+          }
+        }
+
+        default-runtime-attributes {
+            #failOnStderr: false
+            #continueOnReturnCode: 0
+            #cluster: "cls-mycluster"
+            #mounts: "oss://bcs-bucket/bcs-dir/ /home/inputs/ false"
+            #docker: "ubuntu/latest oss://bcs-reg/ubuntu/"
+            #userData: "key value"
+            #reserveOnFail: true
+            #autoReleaseJob: true
+            #verbose: false
+            #workerPath: "oss://bcs-bucket/workflow/worker.tar.gz"
+            #systemDisk: "cloud 50"
+            #dataDisk: "cloud 250 /home/data/"
+            #timeout: 3000
+            #vpc: "192.168.0.0/16 vpc-xxxx"
+        }
+      }
+    }
+}

--- a/cromwell.example.backends/Docker.conf
+++ b/cromwell.example.backends/Docker.conf
@@ -1,0 +1,28 @@
+# This is an example of how you can use Docker only workflows as a Cromwell
+# backend provider. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# This backend doesn't have an official page, but you can read about general
+# Docker use here: https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#docker
+# If you want to use containers, the other sections on that page will be useful to you.
+
+backend {
+  default = Docker
+
+  providers {
+
+    # Example backend that _only_ runs workflows that specify docker for every command.
+    Docker {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        run-in-background = true
+        runtime-attributes = "String docker"
+        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${script}"
+      }
+    }
+}

--- a/cromwell.example.backends/Docker.conf
+++ b/cromwell.example.backends/Docker.conf
@@ -22,7 +22,7 @@ backend {
       config {
         run-in-background = true
         runtime-attributes = "String docker"
-        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${script}"
+        submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${docker_script}"
       }
     }
 }

--- a/cromwell.example.backends/HtCondor.conf
+++ b/cromwell.example.backends/HtCondor.conf
@@ -1,0 +1,84 @@
+# This is an example of how you can use the the HtCondor backend with Cromwell.
+# *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/HTcondor/
+
+backend {
+  default = HtCondor
+
+  providers {
+    HtCondor {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        runtime-attributes = """
+          Int cpu = 1
+          Float memory_mb = 512.0
+          Float disk_kb = 256000.0
+          String? nativeSpecs
+          String? docker
+        """
+    
+        # If an 'exit-code-timeout-seconds' value is specified:
+        # - When a job has not been alive for longer than this timeout
+        # - And has still not produced an RC file
+        # - Then it will be marked as Failed.
+        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    
+        # exit-code-timeout-seconds = 120
+    
+        submit = """
+          chmod 755 ${script}
+          cat > ${cwd}/execution/submitFile <<EOF
+          Iwd=${cwd}/execution
+          requirements=${nativeSpecs}
+          leave_in_queue=true
+          request_memory=${memory_mb}
+          request_disk=${disk_kb}
+          error=${err}
+          output=${out}
+          log_xml=true
+          request_cpus=${cpu}
+          executable=${script}
+          log=${cwd}/execution/execution.log
+          queue
+          EOF
+          condor_submit ${cwd}/execution/submitFile
+        """
+    
+        submit-docker = """
+          chmod 755 ${script}
+          cat > ${cwd}/execution/dockerScript <<EOF
+          #!/bin/bash
+          docker run --rm -i -v ${cwd}:${docker_cwd} ${docker} /bin/bash ${script}
+          EOF
+          chmod 755 ${cwd}/execution/dockerScript
+          cat > ${cwd}/execution/submitFile <<EOF
+          Iwd=${cwd}/execution
+          requirements=${nativeSpecs}
+          leave_in_queue=true
+          request_memory=${memory_mb}
+          request_disk=${disk_kb}
+          error=${cwd}/execution/stderr
+          output=${cwd}/execution/stdout
+          log_xml=true
+          request_cpus=${cpu}
+          executable=${cwd}/execution/dockerScript
+          log=${cwd}/execution/execution.log
+          queue
+          EOF
+          condor_submit ${cwd}/execution/submitFile
+        """
+    
+        kill = "condor_rm ${job_id}"
+        check-alive = "condor_q ${job_id}"
+        job-id-regex = "(?sm).*cluster (\\d+)..*"
+      }
+    }
+}
+

--- a/cromwell.example.backends/LSF.conf
+++ b/cromwell.example.backends/LSF.conf
@@ -1,0 +1,25 @@
+# This is an example of how you can use the LSF platform backend
+# with Cromwell. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/LSF/
+
+backend {
+  default = LSF
+
+  providers {
+    LSF {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /usr/bin/env bash ${script}"
+        kill = "bkill ${job_id}"
+        check-alive = "bjobs ${job_id}"
+        job-id-regex = "Job <(\\d+)>.*"
+      }
+    }
+}

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -1,0 +1,117 @@
+# This is an example of how you can use the LocalExample backend to define
+# a new backend provider. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/Local/
+
+    # Define a new backend provider.
+
+    LocalExample {
+
+      # The actor that runs the backend. In this case, it's the Shared File System (SFS) ConfigBackend.
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+      # The backend custom configuration.
+      config {
+
+        # Optional limits on the number of concurrent jobs
+        #concurrent-job-limit = 5
+
+        # If true submits scripts to the bash background using "&". Only usefull for dispatchers that do NOT submit
+        # the job and then immediately return a scheduled job id.
+        run-in-background = true
+
+        # `temporary-directory` creates the temporary directory for commands.
+        #
+        # If this value is not set explicitly, the default value creates a unique temporary directory, equivalent to:
+        # temporary-directory = "$(mktemp -d \"$PWD\"/tmp.XXXXXX)"
+        #
+        # The expression is run from the execution directory for the script. The expression must create the directory
+        # if it does not exist, and then return the full path to the directory.
+        #
+        # To create and return a non-random temporary directory, use something like:
+        # temporary-directory = "$(mkdir -p /tmp/mydir && echo /tmp/mydir)"
+
+        # `script-epilogue` configures a shell command to run after the execution of every command block.
+        #
+        # If this value is not set explicitly, the default value is `sync`, equivalent to:
+        # script-epilogue = "sync"
+        #
+        # To turn off the default `sync` behavior set this value to an empty string:
+        # script-epilogue = ""
+
+        # The list of possible runtime custom attributes.
+        runtime-attributes = """
+        String? docker
+        String? docker_user
+        """
+
+        # Submit string when there is no "docker" runtime attribute.
+        submit = "/usr/bin/env bash ${script}"
+
+        # Submit string when there is a "docker" runtime attribute.
+        submit-docker = """
+        docker run \
+          --rm -i \
+          ${"--user " + docker_user} \
+          --entrypoint ${job_shell} \
+          -v ${cwd}:${docker_cwd} \
+          ${docker} ${script}
+        """
+
+        # Root directory where Cromwell writes job results.  This directory must be
+        # visible and writeable by the Cromwell process as well as the jobs that Cromwell
+        # launches.
+        root = "cromwell-executions"
+
+        # Root directory where Cromwell writes job results in the container. This value
+        # can be used to specify where the execution folder is mounted in the container.
+        # it is used for the construction of the docker_cwd string in the submit-docker
+        # value above.
+        dockerRoot = "/cromwell-executions"
+
+        # File system configuration.
+        filesystems {
+
+          # For SFS backends, the "local" configuration specifies how files are handled.
+          local {
+
+            # Try to hard link (ln), then soft-link (ln -s), and if both fail, then copy the files.
+            localization: [
+              "hard-link", "soft-link", "copy"
+            ]
+
+            # Call caching strategies
+            caching {
+              # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
+              duplication-strategy: [
+                "hard-link", "soft-link", "copy"
+              ]
+
+              # Possible values: file, path, path+modtime
+              # "file" will compute an md5 hash of the file content.
+              # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
+              # in order to allow for the original file path to be hashed.
+              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+              # Default: file
+              hashing-strategy: "file"
+
+              # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
+              # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.
+              check-sibling-md5: false
+            }
+          }
+        }
+
+        # The defaults for runtime attributes if not provided.
+        default-runtime-attributes {
+          failOnStderr: false
+          continueOnReturnCode: 0
+        }
+      }
+    }

--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -1,0 +1,107 @@
+# This is an example of how you can use the Google Pipelines API backend
+# provider. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/Google/
+
+backend {
+  default = PAPIv2
+
+  providers {
+    PAPIv2 {
+      actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+      config {
+        # Google project
+        project = "my-cromwell-workflows"
+    
+        # Base bucket for workflow executions
+        root = "gs://my-cromwell-workflows-bucket"
+    
+        # Make the name of the backend used for call caching purposes insensitive to the PAPI version.
+        name-for-call-caching-purposes: PAPI
+    
+        # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
+        # your project.
+        #
+        # Used to help determine maximum throughput to the Google Genomics API. Setting this value too low will
+        # cause a drop in performance. Setting this value too high will cause QPS based locks from Google.
+        # 1000 is the default "Queries per 100 seconds per user", 50000 is the default "Queries per 100 seconds"
+        # See https://cloud.google.com/genomics/quotas for more information
+        genomics-api-queries-per-100-seconds = 1000
+    
+        # Polling for completion backs-off gradually for slower-running jobs.
+        # This is the maximum polling interval (in seconds):
+        maximum-polling-interval = 600
+    
+        # Optional Dockerhub Credentials. Can be used to access private docker images.
+        dockerhub {
+          # account = ""
+          # token = ""
+        }
+    
+        # Number of workers to assaign to PAPI requests
+        request-workers = 3
+    
+        genomics {
+          # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
+          # Pipelines and manipulate auth JSONs.
+          auth = "application-default"
+    
+    
+          // alternative service account to use on the launched compute instance
+          // NOTE: If combined with service account authorization, both that serivce account and this service account
+          // must be able to read and write to the 'root' GCS path
+          compute-service-account = "default"
+    
+          # Endpoint for APIs, no reason to change this unless directed by Google.
+          endpoint-url = "https://genomics.googleapis.com/"
+    
+          # Restrict access to VM metadata. Useful in cases when untrusted containers are running under a service
+          # account not owned by the submitting user
+          restrict-metadata-access = false
+          
+          # Pipelines v2 only: specify the number of times localization and delocalization operations should be attempted
+          # There is no logic to determine if the error was transient or not, everything is retried upon failure
+          # Defaults to 3
+          localization-attempts = 3
+        }
+    
+        filesystems {
+          gcs {
+            # A reference to a potentially different auth for manipulating files via engine functions.
+            auth = "application-default"
+            # Google project which will be billed for the requests
+            project = "google-billing-project"
+    
+            caching {
+              # When a cache hit is found, the following duplication strategy will be followed to use the cached outputs
+              # Possible values: "copy", "reference". Defaults to "copy"
+              # "copy": Copy the output files
+              # "reference": DO NOT copy the output files but point to the original output files instead.
+              #              Will still make sure than all the original output files exist and are accessible before
+              #              going forward with the cache hit.
+              duplication-strategy = "copy"
+            }
+          }
+        }
+    
+        default-runtime-attributes {
+          cpu: 1
+          failOnStderr: false
+          continueOnReturnCode: 0
+          memory: "2048 MB"
+          bootDiskSizeGb: 10
+          # Allowed to be a String, or a list of Strings
+          disks: "local-disk 10 SSD"
+          noAddress: false
+          preemptible: 0
+          zones: ["us-central1-a", "us-central1-b"]
+        }
+      }
+    }
+}

--- a/cromwell.example.backends/README.md
+++ b/cromwell.example.backends/README.md
@@ -1,0 +1,112 @@
+# Cromwell Example Backends
+
+This is a folder of example backend providers for Cromwell. You can read about
+the providers here, and then copy paste one or more of the providers you want
+to use to your Cromwell configuration file, represented here as the
+[cromwell.example.conf](../cromwell.example.conf) file in the base of the 
+repository.
+
+## What are the backend providers?
+
+### Cloud Providers
+
+ - [AWS](AWS.conf): Amazon Web Services ([documentation](https://cromwell.readthedocs.io/en/stable/tutorials/AwsBatch101/))
+ - [BCS](BCS.conf) Alibaba Cloud Batch Compute (BCS) backend ([documentation](https://cromwell.readthedocs.io/en/stable/backends/BCS/))
+ - [TES](TES.conf) is a backend that submits jobs to a server with protocol defined by GA4GH ([documentation](https://cromwell.readthedocs.io/en/stable/backends/TES/))
+ - [PAPIv2](PAPIv2.conf): Google Pipelines API backend (version 2!) ([documentation](https://cromwell.readthedocs.io/en/stable/backends/Google/))
+
+### Containers
+
+ - [Docker](Docker.conf): an example backend that only runs workflows with docker in *every* command
+ - [Singularity](singularity.conf): run Singularity containers locally ([documentation](https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#local-environments))
+ - [Singularity+Slurm](singularity.slurm.conf): An example using Singularity with SLURM ([documentation](https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#job-schedulers))
+ - [TESK](TESK.conf) is the same, but intended for Kubernetes. See the [TES docs](https://cromwell.readthedocs.io/en/stable/backends/TES/) at the bottom.
+ - [udocker](udocker.conf): to interact with udocker locally [documentation](https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#udocker)
+ - [udocker+Slurm](udocker.slurm.conf): to interact with udocker on SLURM ([documentation](https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#udocker))
+
+### Workflow Managers
+
+ - [HtCondor](HtCondor.conf): a workload manager at UW-Madison ([documentation](https://cromwell.readthedocs.io/en/stable/backends/HTcondor/))
+ - [LSF](LSF.conf): the Platform Load Sharing Facility backend ([documentation](https://cromwell.readthedocs.io/en/stable/backends/LSF/))
+ - [SGE](SGE.conf): a backend for Sungrid Engine ([documentation](https://cromwell.readthedocs.io/en/stable/backends/SGE))
+ - [slurm](slurm.conf): SLURM workload manager ([documentation](https://cromwell.readthedocs.io/en/stable/backends/SLURM/))
+ - [Spark](Spark.conf): a backend for a Spark cluster ([documentation](https://cromwell.readthedocs.io/en/stable/backends/Spark/))
+
+### Custom
+
+ - [LocalExample](LocalExample.conf): What you should use if you want to define a new backend provider ([documentation](https://cromwell.readthedocs.io/en/stable/backends/Local/))
+
+
+## How do I add a backend provider?
+
+The section in the file called "backends" has a key, "providers" that looks like
+this:
+
+```
+
+backend {
+
+  # Override the default backend.
+  #default = "LocalExample"
+
+  # The list of providers. Copy paste the contents of a backend provider in this section
+  providers {
+        ....
+  }
+
+}
+```
+
+The examples here also have this section. You would want to copy paste the content
+of the file, specifically the section for the provider under backend -> providers,
+into the backend -> providers section in the [cromwell.example.conf](../cromwell.example.conf).
+Here is what it would look like to add the [slurm](slurm.conf) backend
+provider example. 
+
+```
+backend {
+
+  # Override the default backend.
+  #default = "LocalExample"
+
+  # The list of providers. Copy paste the contents of a backend provider in this section
+  providers {
+    slurm {
+         ...
+      }
+    }
+
+    # Second backend provider would be copy pasted here!
+
+  }
+}
+```
+
+This isn't json, so you don't need to add commas between the providers - just
+copy paste them one after the other in the backend -> providers section.
+Let's say we wanted slurm to be our default! We would do this:
+
+```
+backend {
+
+  # Override the default backend.
+  default = slurm
+
+  # The list of providers. Copy paste the contents of a backend provider in this section
+  providers {
+    slurm {
+         ...
+      }
+    }
+  }
+}
+```
+
+Don't forget to customize the sections for your purposes! If anything is
+not explained clearly, please [open an issue](https://github.com/broadinstitute/cromwell/issues).
+
+## What if a provider is missing?
+
+If a provider is missing and you don't want to use the [LocalExample](LocalExample.conf)
+to write a custom provider, please [let us know](https://github.com/broadinstitute/cromwell/issues)
+and we can start discussion about how to define your backend.

--- a/cromwell.example.backends/SGE.conf
+++ b/cromwell.example.backends/SGE.conf
@@ -1,0 +1,59 @@
+# This is an example of how you can use the the Sungrid Engine backend
+# for Cromwell. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation:
+# https://cromwell.readthedocs.io/en/stable/backends/SGE
+
+backend {
+  default = SGE
+
+  providers {
+    SGE {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+    
+        # Limits the number of concurrent jobs
+        concurrent-job-limit = 5
+    
+        # If an 'exit-code-timeout-seconds' value is specified:
+        # - When a job has not been alive for longer than this timeout
+        # - And has still not produced an RC file
+        # - Then it will be marked as Failed.
+        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    
+        # exit-code-timeout-seconds = 120
+    
+        runtime-attributes = """
+        Int cpu = 1
+        Float? memory_gb
+        String? sge_queue
+        String? sge_project
+        """
+    
+        submit = """
+        qsub \
+        -terse \
+        -V \
+        -b y \
+        -N ${job_name} \
+        -wd ${cwd} \
+        -o ${out}.qsub \
+        -e ${err}.qsub \
+        -pe smp ${cpu} \
+        ${"-l mem_free=" + memory_gb + "g"} \
+        ${"-q " + sge_queue} \
+        ${"-P " + sge_project} \
+        /usr/bin/env bash ${script}
+        """
+    
+        kill = "qdel ${job_id}"
+        check-alive = "qstat -j ${job_id}"
+        job-id-regex = "(\\d+)"
+      }
+    }
+}

--- a/cromwell.example.backends/Spark.conf
+++ b/cromwell.example.backends/Spark.conf
@@ -1,0 +1,37 @@
+# This is an example of how you can use the Spark cluster backend provider
+# with Cromwell. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/Spark/
+
+backend {
+  default = Spark
+
+  providers {
+    Spark {
+     actor-factory = "cromwell.backend.impl.spark.SparkBackendFactory"
+     config {
+       # Root directory where Cromwell writes job results.  This directory must be
+        # visible and writeable by the Cromwell process as well as the jobs that Cromwell
+       # launches.
+       root: "cromwell-executions"
+    
+       filesystems {
+         local {
+           localization: [
+             "hard-link", "soft-link", "copy"
+           ]
+         }
+        }
+          # change (master, deployMode) to (yarn, client), (yarn, cluster)
+          #  or (spark://hostname:port, cluster) for spark standalone cluster mode
+         master: "local"
+         deployMode: "client"
+      }
+     }
+}

--- a/cromwell.example.backends/TES.conf
+++ b/cromwell.example.backends/TES.conf
@@ -1,0 +1,32 @@
+# This is an example of how you can use the TES backend provider. 
+# *This is not a complete configuration file!* The
+# content here should be copy pasted to the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation:
+# https://cromwell.readthedocs.io/en/stable/backends/TES/
+# If you are interested in using TES with kubernetes, see TESK.conf
+
+backend {
+  default = TES
+
+  providers {
+    TES {
+      actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
+      config {
+        root = "cromwell-executions"
+        dockerRoot = "/cromwell-executions"
+        endpoint = "http://127.0.0.1:9000/v1/tasks"
+        default-runtime-attributes {
+          cpu: 1
+          failOnStderr: false
+          continueOnReturnCode: 0
+          memory: "2 GB"
+          disk: "2 GB"
+        }
+      }
+    }
+}

--- a/cromwell.example.backends/TESK.conf
+++ b/cromwell.example.backends/TESK.conf
@@ -1,0 +1,26 @@
+# This is an example of how you can use the TES (with kubernetes) 
+# backend provider, *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/TES/
+# scroll down to the bottom
+
+backend {
+  default = TESK
+
+  providers {
+    TESK {
+      actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
+      config {
+        root = "ftp://your.ftphost.com/cromwell-executions"
+        dockerRoot = "/cromwell-executions"
+        endpoint = "http://your-tesk-endpoint/v1/tasks"
+        glob-link-command = "ls -L GLOB_PATTERN 2> /dev/null | xargs -I ? ln -s ? GLOB_DIRECTORY"
+      }
+    }
+}

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -1,0 +1,903 @@
+# This line is required. It pulls in default overrides from the embedded cromwell `application.conf` needed for proper
+# performance of cromwell.
+include required(classpath("application"))
+
+# Cromwell HTTP server settings
+webservice {
+  #port = 8000
+  #interface = 0.0.0.0
+  #binding-timeout = 5s
+  #instance.name = "reference"
+}
+
+akka {
+  # Optionally set / override any akka settings
+}
+
+# Cromwell "system" settings
+system {
+  # If 'true', a SIGINT will trigger Cromwell to attempt to abort all currently running jobs before exiting
+  #abort-jobs-on-terminate = false
+
+  # If 'true', a SIGTERM or SIGINT will trigger Cromwell to attempt to gracefully shutdown in server mode,
+  # in particular clearing up all queued database writes before letting the JVM shut down.
+  # The shutdown is a multi-phase process, each phase having its own configurable timeout. See the Dev Wiki for more details.
+  #graceful-server-shutdown = true
+
+  # If 'true' then when Cromwell starts up, it tries to restart incomplete workflows
+  #workflow-restart = true
+
+  # Cromwell will cap the number of running workflows at N
+  #max-concurrent-workflows = 5000
+
+  # Cromwell will launch up to N submitted workflows at a time, regardless of how many open workflow slots exist
+  #max-workflow-launch-count = 50
+
+  # Number of seconds between workflow launches
+  #new-workflow-poll-rate = 20
+
+  # Since the WorkflowLogCopyRouter is initialized in code, this is the number of workers
+  #number-of-workflow-log-copy-workers = 10
+
+  # Default number of cache read workers
+  #number-of-cache-read-workers = 25
+
+  io {
+    # Global Throttling - This is mostly useful for GCS and can be adjusted to match
+    # the quota availble on the GCS API
+    #number-of-requests = 100000
+    #per = 100 seconds
+
+    # Number of times an I/O operation should be attempted before giving up and failing it.
+    #number-of-attempts = 5
+  }
+
+  # Maximum number of input file bytes allowed in order to read each type.
+  # If exceeded a FileSizeTooBig exception will be thrown.
+  input-read-limits {
+
+    #lines = 128000
+
+    #bool = 7
+
+    #int = 19
+
+    #float = 50
+
+    #string = 128000
+
+    #json = 128000
+
+    #tsv = 128000
+
+    #map = 128000
+
+    #object = 128000
+  }
+
+  abort {
+    # These are the default values in Cromwell, in most circumstances there should not be a need to change them.
+
+    # How frequently Cromwell should scan for aborts.
+    scan-frequency: 30 seconds
+
+    # The cache of in-progress aborts. Cromwell will add entries to this cache once a WorkflowActor has been messaged to abort.
+    # If on the next scan an 'Aborting' status is found for a workflow that has an entry in this cache, Cromwell will not ask
+    # the associated WorkflowActor to abort again.
+    cache {
+      enabled: true
+      # Guava cache concurrency.
+      concurrency: 1
+      # How long entries in the cache should live from the time they are added to the cache.
+      ttl: 20 minutes
+      # Maximum number of entries in the cache.
+      size: 100000
+    }
+  }
+}
+
+workflow-options {
+  # These workflow options will be encrypted when stored in the database
+  #encrypted-fields: []
+
+  # AES-256 key to use to encrypt the values in `encrypted-fields`
+  #base64-encryption-key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+  # Directory where to write per workflow logs
+  #workflow-log-dir: "cromwell-workflow-logs"
+
+  # When true, per workflow logs will be deleted after copying
+  #workflow-log-temporary: true
+
+  # Workflow-failure-mode determines what happens to other calls when a call fails. Can be either ContinueWhilePossible or NoNewCalls.
+  # Can also be overridden in workflow options. Defaults to NoNewCalls. Uncomment to change:
+  #workflow-failure-mode: "ContinueWhilePossible"
+
+  default {
+    # When a workflow type is not provided on workflow submission, this specifies the default type.
+    #workflow-type: WDL
+
+    # When a workflow type version is not provided on workflow submission, this specifies the default type version.
+    #workflow-type-version: "draft-2"
+
+    # To set a default hog group rather than defaulting to workflow ID:
+    #hogGroup: "static"
+  }
+}
+
+# Optional call-caching configuration.
+call-caching {
+  # Allows re-use of existing results for jobs you've already run
+  # (default: false)
+  #enabled = false
+
+  # Whether to invalidate a cache result forever if we cannot reuse them. Disable this if you expect some cache copies
+  # to fail for external reasons which should not invalidate the cache (e.g. auth differences between users):
+  # (default: true)
+  #invalidate-bad-cache-results = true
+
+  # blacklist-cache {
+  #   # The call caching blacklist cache is off by default. This cache is used to blacklist cache hit paths based on the
+  #   # prefixes of cache hit paths that Cromwell has previously failed to copy for permissions reasons.
+  #   enabled: true
+  #   # Guava cache concurrency.
+  #   concurrency: 10000
+  #   # How long entries in the cache should live from the time of their last access.
+  #   ttl: 20 minutes
+  #   # Maximum number of entries in the cache.
+  #   size: 1000
+  # }
+}
+
+# Google configuration
+google {
+
+  #application-name = "cromwell"
+
+  # Default: just application default
+  #auths = [
+
+    # Application default
+    #{
+    #  name = "application-default"
+    #  scheme = "application_default"
+    #},
+
+    # Use a refresh token
+    #{
+    #  name = "user-via-refresh"
+    #  scheme = "refresh_token"
+    #  client-id = "secret_id"
+    #  client-secret = "secret_secret"
+    #},
+
+
+    # Use a static service account
+    #{
+    #  name = "service-account"
+    #  scheme = "service_account"
+    #  Choose between PEM file and JSON file as a credential format. They're mutually exclusive.
+    #  PEM format:
+    #  service-account-id = "my-service-account"
+    #  pem-file = "/path/to/file.pem"
+    #  JSON format:
+    #  json-file = "/path/to/file.json"
+    #}
+
+    # Use service accounts provided through workflow options
+    #{
+    #   name = "user-service-account"
+    #   scheme = "user_service_account"
+    #}
+  #]
+}
+
+docker {
+  hash-lookup {
+    # Set this to match your available quota against the Google Container Engine API
+    #gcr-api-queries-per-100-seconds = 1000
+
+    # Time in minutes before an entry expires from the docker hashes cache and needs to be fetched again
+    #cache-entry-ttl = "20 minutes"
+
+    # Maximum number of elements to be kept in the cache. If the limit is reached, old elements will be removed from the cache
+    #cache-size = 200
+
+    # How should docker hashes be looked up. Possible values are "local" and "remote"
+    # "local": Lookup hashes on the local docker daemon using the cli
+    # "remote": Lookup hashes on docker hub and gcr
+    #method = "remote"
+  }
+}
+
+engine {
+  # This instructs the engine which filesystems are at its disposal to perform any IO operation that it might need.
+  # For instance, WDL variables declared at the Workflow level will be evaluated using the filesystems declared here.
+  # If you intend to be able to run workflows with this kind of declarations:
+  # workflow {
+  #    String str = read_string("gs://bucket/my-file.txt")
+  # }
+  # You will need to provide the engine with a gcs filesystem
+  # Note that the default filesystem (local) is always available.
+  filesystems {
+    #  gcs {
+    #    auth = "application-default"
+    #    # Google project which will be billed for the requests
+    #    project = "google-billing-project"
+    #  }
+    #  oss {
+    #    auth {
+    #      endpoint = ""
+    #      access-id = ""
+    #      access-key = ""
+    #      security-token = ""
+    #    }
+    #  }
+    local {
+      #enabled: true
+    }
+  }
+}
+
+# You probably don't want to override the language factories here, but the strict-validation and enabled fields might be of interest:
+#
+# `enabled`: Defaults to `true`. Set to `false` to disallow workflows of this language/version from being run.
+# `strict-validation`: Specifies whether workflows fail if the inputs JSON (or YAML) file contains values which the workflow did not ask for (and will therefore have no effect).
+languages {
+  WDL {
+    versions {
+      "draft-2" {
+        # language-factory = "languages.wdl.draft2.WdlDraft2LanguageFactory"
+        # config {
+        #   strict-validation: true
+        #   enabled: true
+        #   caching {
+        #     # WDL Draft 2 namespace caching is off by default, this value must be set to true to enable it.
+        #     enabled: false
+        #     # Guava cache concurrency
+        #     concurrency: 2
+        #     # How long entries in the cache should live from the time of their last access.
+        #     ttl: 20 minutes
+        #     # Maximum number of entries in the cache (i.e. the number of workflow source + imports => namespace entries).
+        #     size: 1000
+        #   }
+        # }
+      }
+      # draft-3 is the same as 1.0 so files should be able to be submitted to Cromwell as 1.0
+      # "draft-3" {
+        # language-factory = "languages.wdl.draft3.WdlDraft3LanguageFactory"
+        # config {
+        #   strict-validation: true
+        #   enabled: true
+        # }
+      # }
+      "1.0" {
+        # 1.0 is just a rename of draft-3, so yes, they really do use the same factory:
+        # language-factory = "languages.wdl.draft3.WdlDraft3LanguageFactory"
+        # config {
+        #   strict-validation: true
+        #   enabled: true
+        # }
+      }
+    }
+  }
+  CWL {
+    versions {
+      "v1.0" {
+        # language-factory = "languages.cwl.CwlV1_0LanguageFactory"
+        # config {
+        #   strict-validation: false
+        #   enabled: true
+        # }
+      }
+    }
+  }
+}
+
+
+backend {
+  # Override the default backend.
+  #default = "LocalExample"
+
+  # The list of providers.
+  providers {
+
+    # The local provider is included by default in the reference.conf. This is an example.
+
+    # Define a new backend provider.
+    LocalExample {
+      # The actor that runs the backend. In this case, it's the Shared File System (SFS) ConfigBackend.
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+      # The backend custom configuration.
+      config {
+
+        # Optional limits on the number of concurrent jobs
+        #concurrent-job-limit = 5
+
+        # If true submits scripts to the bash background using "&". Only usefull for dispatchers that do NOT submit
+        # the job and then immediately return a scheduled job id.
+        run-in-background = true
+
+        # `temporary-directory` creates the temporary directory for commands.
+        #
+        # If this value is not set explicitly, the default value creates a unique temporary directory, equivalent to:
+        # temporary-directory = "$(mktemp -d \"$PWD\"/tmp.XXXXXX)"
+        #
+        # The expression is run from the execution directory for the script. The expression must create the directory
+        # if it does not exist, and then return the full path to the directory.
+        #
+        # To create and return a non-random temporary directory, use something like:
+        # temporary-directory = "$(mkdir -p /tmp/mydir && echo /tmp/mydir)"
+
+        # `script-epilogue` configures a shell command to run after the execution of every command block.
+        #
+        # If this value is not set explicitly, the default value is `sync`, equivalent to:
+        # script-epilogue = "sync"
+        #
+        # To turn off the default `sync` behavior set this value to an empty string:
+        # script-epilogue = ""
+
+        # The list of possible runtime custom attributes.
+        runtime-attributes = """
+        String? docker
+        String? docker_user
+        """
+
+        # Submit string when there is no "docker" runtime attribute.
+        submit = "/usr/bin/env bash ${script}"
+
+        # Submit string when there is a "docker" runtime attribute.
+        submit-docker = """
+        docker run \
+          --rm -i \
+          ${"--user " + docker_user} \
+          --entrypoint ${job_shell} \
+          -v ${cwd}:${docker_cwd} \
+          ${docker} ${script}
+        """
+
+        # Root directory where Cromwell writes job results.  This directory must be
+        # visible and writeable by the Cromwell process as well as the jobs that Cromwell
+        # launches.
+        root = "cromwell-executions"
+
+        # Root directory where Cromwell writes job results in the container. This value
+        # can be used to specify where the execution folder is mounted in the container.
+        # it is used for the construction of the docker_cwd string in the submit-docker
+        # value above.
+        dockerRoot = "/cromwell-executions"
+
+        # File system configuration.
+        filesystems {
+
+          # For SFS backends, the "local" configuration specifies how files are handled.
+          local {
+
+            # Try to hard link (ln), then soft-link (ln -s), and if both fail, then copy the files.
+            localization: [
+              "hard-link", "soft-link", "copy"
+            ]
+
+            # Call caching strategies
+            caching {
+              # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
+              duplication-strategy: [
+                "hard-link", "soft-link", "copy"
+              ]
+
+              # Possible values: file, path, path+modtime
+              # "file" will compute an md5 hash of the file content.
+              # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
+              # in order to allow for the original file path to be hashed.
+              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+              # Default: file
+              hashing-strategy: "file"
+
+              # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
+              # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.
+              check-sibling-md5: false
+            }
+          }
+        }
+
+        # The defaults for runtime attributes if not provided.
+        default-runtime-attributes {
+          failOnStderr: false
+          continueOnReturnCode: 0
+        }
+      }
+    }
+
+    # Other backend examples. Uncomment the block/stanza for your configuration. May need more tweaking/configuration
+    # for your specific environment.
+
+    #TES {
+    #  actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
+    #  config {
+    #    root = "cromwell-executions"
+    #    dockerRoot = "/cromwell-executions"
+    #    endpoint = "http://127.0.0.1:9000/v1/tasks"
+    #    default-runtime-attributes {
+    #      cpu: 1
+    #      failOnStderr: false
+    #      continueOnReturnCode: 0
+    #      memory: "2 GB"
+    #      disk: "2 GB"
+    #    }
+    #  }
+    #}
+
+    #TESK {
+    #  actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
+    #  config {
+    #    root = "ftp://your.ftphost.com/cromwell-executions"
+    #    dockerRoot = "/cromwell-executions"
+    #    endpoint = "http://your-tesk-endpoint/v1/tasks"
+    #    glob-link-command = "ls -L GLOB_PATTERN 2> /dev/null | xargs -I ? ln -s ? GLOB_DIRECTORY"
+    #  }
+    #}
+
+    #BCS {
+    #  actor-factory = "cromwell.backend.impl.bcs.BcsBackendLifecycleActorFactory"
+    #  config {
+    #    root = "oss://your-bucket/cromwell-exe"
+    #    dockerRoot = "/cromwell-executions"
+    #    region = ""
+
+    #    #access-id = ""
+    #    #access-key = ""
+	#	#security-token = ""
+
+    #    filesystems {
+    #      oss {
+    #        auth {
+    #            #endpoint = ""
+    #            #access-id = ""
+    #            #access-key = ""
+	#	        #security-token = ""
+    #        }
+    #      }
+    #    }
+
+    #    default-runtime-attributes {
+    #        #failOnStderr: false
+    #        #continueOnReturnCode: 0
+    #        #cluster: "cls-mycluster"
+    #        #mounts: "oss://bcs-bucket/bcs-dir/ /home/inputs/ false"
+    #        #docker: "ubuntu/latest oss://bcs-reg/ubuntu/"
+    #        #userData: "key value"
+    #        #reserveOnFail: true
+    #        #autoReleaseJob: true
+    #        #verbose: false
+    #        #workerPath: "oss://bcs-bucket/workflow/worker.tar.gz"
+    #        #systemDisk: "cloud 50"
+    #        #dataDisk: "cloud 250 /home/data/"
+    #        #timeout: 3000
+    #        #vpc: "192.168.0.0/16 vpc-xxxx"
+    #    }
+    #  }
+    #}
+
+    #SGE {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #
+    #    # Limits the number of concurrent jobs
+    #    concurrent-job-limit = 5
+    #
+    #    # If an 'exit-code-timeout-seconds' value is specified:
+    #    # - When a job has not been alive for longer than this timeout
+    #    # - And has still not produced an RC file
+    #    # - Then it will be marked as Failed.
+    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    #
+    #    # exit-code-timeout-seconds = 120
+    #
+    #    runtime-attributes = """
+    #    Int cpu = 1
+    #    Float? memory_gb
+    #    String? sge_queue
+    #    String? sge_project
+    #    """
+    #
+    #    submit = """
+    #    qsub \
+    #    -terse \
+    #    -V \
+    #    -b y \
+    #    -N ${job_name} \
+    #    -wd ${cwd} \
+    #    -o ${out}.qsub \
+    #    -e ${err}.qsub \
+    #    -pe smp ${cpu} \
+    #    ${"-l mem_free=" + memory_gb + "g"} \
+    #    ${"-q " + sge_queue} \
+    #    ${"-P " + sge_project} \
+    #    /usr/bin/env bash ${script}
+    #    """
+    #
+    #    kill = "qdel ${job_id}"
+    #    check-alive = "qstat -j ${job_id}"
+    #    job-id-regex = "(\\d+)"
+    #  }
+    #}
+
+    #LSF {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /usr/bin/env bash ${script}"
+    #    kill = "bkill ${job_id}"
+    #    check-alive = "bjobs ${job_id}"
+    #    job-id-regex = "Job <(\\d+)>.*"
+    #  }
+    #}
+
+    #SLURM {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #    runtime-attributes = """
+    #    Int runtime_minutes = 600
+    #    Int cpus = 2
+    #    Int requested_memory_mb_per_core = 8000
+    #    String queue = "short"
+    #    """
+    #
+    #    # If an 'exit-code-timeout-seconds' value is specified:
+    #    # - When a job has not been alive for longer than this timeout
+    #    # - And has still not produced an RC file
+    #    # - Then it will be marked as Failed.
+    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    #
+    #    # exit-code-timeout-seconds = 120
+    #
+    #    submit = """
+    #        sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
+    #        ${"-n " + cpus} \
+    #        --mem-per-cpu=${requested_memory_mb_per_core} \
+    #        --wrap "/usr/bin/env bash ${script}"
+    #    """
+    #    kill = "scancel ${job_id}"
+    #    check-alive = "squeue -j ${job_id}"
+    #    job-id-regex = "Submitted batch job (\\d+).*"
+    #  }
+    #}
+
+    # Example backend that _only_ runs workflows that specify docker for every command.
+    #Docker {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #    run-in-background = true
+    #    runtime-attributes = "String docker"
+    #    submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${script}"
+    #  }
+    #}
+
+    #HtCondor {
+    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    #  config {
+    #    runtime-attributes = """
+    #      Int cpu = 1
+    #      Float memory_mb = 512.0
+    #      Float disk_kb = 256000.0
+    #      String? nativeSpecs
+    #      String? docker
+    #    """
+    #
+    #    # If an 'exit-code-timeout-seconds' value is specified:
+    #    # - When a job has not been alive for longer than this timeout
+    #    # - And has still not produced an RC file
+    #    # - Then it will be marked as Failed.
+    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    #
+    #    # exit-code-timeout-seconds = 120
+    #
+    #    submit = """
+    #      chmod 755 ${script}
+    #      cat > ${cwd}/execution/submitFile <<EOF
+    #      Iwd=${cwd}/execution
+    #      requirements=${nativeSpecs}
+    #      leave_in_queue=true
+    #      request_memory=${memory_mb}
+    #      request_disk=${disk_kb}
+    #      error=${err}
+    #      output=${out}
+    #      log_xml=true
+    #      request_cpus=${cpu}
+    #      executable=${script}
+    #      log=${cwd}/execution/execution.log
+    #      queue
+    #      EOF
+    #      condor_submit ${cwd}/execution/submitFile
+    #    """
+    #
+    #    submit-docker = """
+    #      chmod 755 ${script}
+    #      cat > ${cwd}/execution/dockerScript <<EOF
+    #      #!/bin/bash
+    #      docker run --rm -i -v ${cwd}:${docker_cwd} ${docker} /bin/bash ${script}
+    #      EOF
+    #      chmod 755 ${cwd}/execution/dockerScript
+    #      cat > ${cwd}/execution/submitFile <<EOF
+    #      Iwd=${cwd}/execution
+    #      requirements=${nativeSpecs}
+    #      leave_in_queue=true
+    #      request_memory=${memory_mb}
+    #      request_disk=${disk_kb}
+    #      error=${cwd}/execution/stderr
+    #      output=${cwd}/execution/stdout
+    #      log_xml=true
+    #      request_cpus=${cpu}
+    #      executable=${cwd}/execution/dockerScript
+    #      log=${cwd}/execution/execution.log
+    #      queue
+    #      EOF
+    #      condor_submit ${cwd}/execution/submitFile
+    #    """
+    #
+    #    kill = "condor_rm ${job_id}"
+    #    check-alive = "condor_q ${job_id}"
+    #    job-id-regex = "(?sm).*cluster (\\d+)..*"
+    #  }
+    #}
+
+    #Spark {
+    # actor-factory = "cromwell.backend.impl.spark.SparkBackendFactory"
+    # config {
+    #   # Root directory where Cromwell writes job results.  This directory must be
+    #    # visible and writeable by the Cromwell process as well as the jobs that Cromwell
+    #   # launches.
+    #   root: "cromwell-executions"
+    #
+    #   filesystems {
+    #     local {
+    #       localization: [
+    #         "hard-link", "soft-link", "copy"
+    #       ]
+    #     }
+    #    }
+    #      # change (master, deployMode) to (yarn, client), (yarn, cluster)
+    #      #  or (spark://hostname:port, cluster) for spark standalone cluster mode
+    #     master: "local"
+    #     deployMode: "client"
+    #  }
+    # }
+
+    #PAPIv2 {
+    #  actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+    #  config {
+    #    # Google project
+    #    project = "my-cromwell-workflows"
+    #
+    #    # Base bucket for workflow executions
+    #    root = "gs://my-cromwell-workflows-bucket"
+    #
+    #    # Make the name of the backend used for call caching purposes insensitive to the PAPI version.
+    #    name-for-call-caching-purposes: PAPI
+    #
+    #    # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
+    #    # your project.
+    #    #
+    #    # Used to help determine maximum throughput to the Google Genomics API. Setting this value too low will
+    #    # cause a drop in performance. Setting this value too high will cause QPS based locks from Google.
+    #    # 1000 is the default "Queries per 100 seconds per user", 50000 is the default "Queries per 100 seconds"
+    #    # See https://cloud.google.com/genomics/quotas for more information
+    #    genomics-api-queries-per-100-seconds = 1000
+    #
+    #    # Polling for completion backs-off gradually for slower-running jobs.
+    #    # This is the maximum polling interval (in seconds):
+    #    maximum-polling-interval = 600
+    #
+    #    # Optional Dockerhub Credentials. Can be used to access private docker images.
+    #    dockerhub {
+    #      # account = ""
+    #      # token = ""
+    #    }
+    #
+    #    # Number of workers to assaign to PAPI requests
+    #    request-workers = 3
+    #
+    #    genomics {
+    #      # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
+    #      # Pipelines and manipulate auth JSONs.
+    #      auth = "application-default"
+    #
+    #
+    #      // alternative service account to use on the launched compute instance
+    #      // NOTE: If combined with service account authorization, both that serivce account and this service account
+    #      // must be able to read and write to the 'root' GCS path
+    #      compute-service-account = "default"
+    #
+    #      # Endpoint for APIs, no reason to change this unless directed by Google.
+    #      endpoint-url = "https://genomics.googleapis.com/"
+    #
+    #      # Restrict access to VM metadata. Useful in cases when untrusted containers are running under a service
+    #      # account not owned by the submitting user
+    #      restrict-metadata-access = false
+    #      
+    #      # Pipelines v2 only: specify the number of times localization and delocalization operations should be attempted
+    #      # There is no logic to determine if the error was transient or not, everything is retried upon failure
+    #      # Defaults to 3
+    #      localization-attempts = 3
+    #    }
+    #
+    #    filesystems {
+    #      gcs {
+    #        # A reference to a potentially different auth for manipulating files via engine functions.
+    #        auth = "application-default"
+    #        # Google project which will be billed for the requests
+    #        project = "google-billing-project"
+    #
+    #        caching {
+    #          # When a cache hit is found, the following duplication strategy will be followed to use the cached outputs
+    #          # Possible values: "copy", "reference". Defaults to "copy"
+    #          # "copy": Copy the output files
+    #          # "reference": DO NOT copy the output files but point to the original output files instead.
+    #          #              Will still make sure than all the original output files exist and are accessible before
+    #          #              going forward with the cache hit.
+    #          duplication-strategy = "copy"
+    #        }
+    #      }
+    #    }
+    #
+    #    default-runtime-attributes {
+    #      cpu: 1
+    #      failOnStderr: false
+    #      continueOnReturnCode: 0
+    #      memory: "2048 MB"
+    #      bootDiskSizeGb: 10
+    #      # Allowed to be a String, or a list of Strings
+    #      disks: "local-disk 10 SSD"
+    #      noAddress: false
+    #      preemptible: 0
+    #      zones: ["us-central1-a", "us-central1-b"]
+    #    }
+    #  }
+    #}
+
+    #AWS {
+    #  actor-factory = "cromwell.backend.impl.aws.AwsBackendActorFactory"
+    #  config {
+    #    ## These two settings are required to authenticate with the ECS service:
+    #    accessKeyId = "..."
+    #    secretKey = "..."
+    #  }
+    #}
+
+  }
+}
+
+services {
+  MetadataService {
+    config {
+      # For the standard MetadataService implementation, cromwell.services.metadata.impl.MetadataServiceActor:
+      #   Set this value to "Inf" to turn off metadata summary refresh.  The default value is currently "2 seconds".
+      #   metadata-summary-refresh-interval = "Inf"
+      #   For higher scale environments, e.g. many workflows and/or jobs, DB write performance for metadata events
+      #   can improved by writing to the database in batches. Increasing this value can dramatically improve overall
+      #   performance but will both lead to a higher memory usage as well as increase the risk that metadata events
+      #   might not have been persisted in the event of a Cromwell crash.
+      #
+      #   For normal usage the default value of 200 should be fine but for larger/production environments we recommend a
+      #   value of at least 500. There'll be no one size fits all number here so we recommend benchmarking performance and
+      #   tuning the value to match your environment.
+      #   db-batch-size = 200
+      #
+      #   Periodically the stored metadata events will be forcibly written to the DB regardless of if the batch size
+      #   has been reached. This is to prevent situations where events wind up never being written to an incomplete batch
+      #   with no new events being generated. The default value is currently 5 seconds
+      #   db-flush-rate = 5 seconds
+
+      # For the Google PubSub MetadataService implementation: cromwell.services.metadata.impl.pubsub.PubSubMetadataServiceActor:
+      #   Google project
+      #   project = "my-project"
+      #   The auth *must* be a service-account auth with JSON auth.
+      #   auth = "service-account"
+      #   The PubSub topic to write to. Will be created if it doesn't already exist. Defaults to "cromwell-metadata"
+      #   topic = "cromwell-metadata"
+      #   An optional PubSub subscription name. If supplied and if it doesn't already exist, it will be created and
+      #   subscribed to the topic
+      #   subscription = "optional-subscription"
+      #   An application name to set on your PubSub interaction.
+      #   appName = "cromwell"
+    }
+  }
+
+  Instrumentation {
+    # StatsD - Send metrics to a StatsD server over UDP
+    # class = "cromwell.services.instrumentation.impl.statsd.StatsDInstrumentationServiceActor"
+    # config.statsd {
+    #   hostname = "localhost"
+    #   port = 8125
+    #   prefix = "" # can be used to prefix all metrics with an api key for example
+    #   flush-rate = 1 second # rate at which aggregated metrics will be sent to statsd
+    # }
+  }
+  HealthMonitor {
+    config {
+      # How long to wait between status check sweeps
+      # check-refresh-time = 5 minutes
+      # For any given status check, how long to wait before assuming failure
+      # check-timeout = 1 minute
+      # For any given status datum, the maximum time a value will be kept before reverting back to "Unknown"
+      # status-ttl = 15 minutes
+      # For any given status check, how many times to retry a failure before setting status to failed. Note this
+      # is the number of retries before declaring failure, not the total number of tries which is 1 more than
+      # the number of retries.
+      # check-failure-retry-count = 3
+      # For any given status check, how long to wait between failure retries.
+      # check-failure-retry-interval = 30 seconds
+
+      ## When using the WorkbenchHealthMonitorServiceActor, the following are possibilities
+
+      # This *MUST* be set to the name of the PAPI backend one defined in the Backends stanza.
+      # papi-backend-name = PAPIv2
+
+      # The name of an authentication scheme to use for e.g. pinging PAPI and GCS. This should be either an application
+      # default or service account auth, otherwise things won't work as there'll not be a refresh token where you need
+      # them.
+      # google-auth-name = application-default
+
+      # A bucket in GCS to periodically stat to check for connectivity. This must be accessible by the auth mode
+      # specified by google-auth-name
+      # gcs-bucket-to-check = some-bucket-name
+    }
+  }
+  LoadController {
+    config {
+      # The load controller service will periodically look at the status of various metrics its collecting and make an
+      # assessment of the system's load. If necessary an alert will be sent to the rest of the system.
+      # This option sets how frequently this should happen
+      # To disable load control, set this to "Inf"
+      # control-frequency = 5 seconds
+    }
+  }
+}
+
+database {
+  # mysql example
+  #driver = "slick.driver.MySQLDriver$"
+
+  # see all possible parameters and default values here:
+  # http://slick.lightbend.com/doc/3.2.0/api/index.html#slick.jdbc.JdbcBackend$DatabaseFactoryDef@forConfig(String,Config,Driver):Database
+  #db {
+  #  driver = "com.mysql.jdbc.Driver"
+  #  url = "jdbc:mysql://host/cromwell?rewriteBatchedStatements=true"
+  #  user = "user"
+  #  password = "pass"
+  #  connectionTimeout = 5000
+  #}
+
+  # For batch inserts the number of inserts to send to the DB at a time
+  # insert-batch-size = 2000
+
+  migration {
+    # For databases with a very large number of symbols, selecting all the rows at once can generate a variety of
+    # problems. In order to avoid any issue, the selection is paginated. This value sets how many rows should be
+    # retrieved and processed at a time, before asking for the next chunk.
+    #read-batch-size = 100000
+
+    # Because a symbol row can contain any arbitrary wdl value, the amount of metadata rows to insert from a single
+    # symbol row can vary from 1 to several thousands (or more). To keep the size of the insert batch from growing out
+    # of control we monitor its size and execute/commit when it reaches or exceeds writeBatchSize.
+    #write-batch-size = 100000
+  }
+
+  # To customize the metadata database connection, create a block under `database` with the metadata database settings.
+  #
+  # For example, the default database stores all data in memory. This commented out block would store `metadata` in an
+  # hsqldb file, without modifying the internal engine database connection.
+  #
+  # The value `${uniqueSchema}` is always replaced with a unqiue UUID on each cromwell startup.
+  #
+  # This feature should be considered experimental and likely to change in the future.
+
+  #metadata {
+  #  profile = "slick.jdbc.HsqldbProfile$"
+  #  db {
+  #    driver = "org.hsqldb.jdbcDriver"
+  #    url = "jdbc:hsqldb:file:metadata-${uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
+  #    connectionTimeout = 3000
+  #  }
+  #}
+}

--- a/cromwell.example.backends/singularity.conf
+++ b/cromwell.example.backends/singularity.conf
@@ -1,0 +1,30 @@
+# This is an example of how you can use Singularity containers with Cromwell
+# *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#singularity
+
+backend {
+  default = singularity
+
+  providers {
+    singularity {
+        # The backend custom configuration.
+        actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+        config {
+            run-in-background = true
+            runtime-attributes = """
+              String? docker
+            """
+            submit-docker = """
+              singularity exec --bind ${cwd}:${docker_cwd} docker://${docker} ${job_shell} ${script}
+            """
+        }
+    }
+}

--- a/cromwell.example.backends/singularity.slurm.conf
+++ b/cromwell.example.backends/singularity.slurm.conf
@@ -1,0 +1,66 @@
+# This is an example of how you can use Singularity containers with Cromwell
+# *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#job-schedulers
+
+backend {
+  default = slurm
+
+  providers {
+    slurm {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"                                                                                     
+      config {
+        runtime-attributes = """
+        Int runtime_minutes = 600
+        Int cpus = 2
+        Int requested_memory_mb_per_core = 8000
+        String? docker
+        """
+
+        submit = """
+            sbatch \
+              --wait \
+              -J ${job_name} \
+              -D ${cwd} \
+              -o ${out} \
+              -e ${err} \
+              -t ${runtime_minutes} \
+              ${"-c " + cpus} \
+              --mem-per-cpu=${requested_memory_mb_per_core} \
+              --wrap "/bin/bash ${script}"
+        """
+
+        submit-docker = """
+            # Ensure singularity is loaded if it's installed as a module
+            module load Singularity/3.0.1
+
+            # Build the Docker image into a singularity image
+            IMAGE=${cwd}/${docker}.sif
+            singularity build $IMAGE docker://${docker}
+
+            # Submit the script to SLURM
+            sbatch \
+              --wait \
+              -J ${job_name} \
+              -D ${cwd} \
+              -o ${cwd}/execution/stdout \
+              -e ${cwd}/execution/stderr \
+              -t ${runtime_minutes} \
+              ${"-c " + cpus} \
+              --mem-per-cpu=${requested_memory_mb_per_core} \
+              --wrap "singularity exec --bind ${cwd}:${docker_cwd} $IMAGE ${job_shell} ${script}"
+        """
+
+        kill = "scancel ${job_id}"
+        check-alive = "squeue -j ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+      }
+    }
+  }
+}

--- a/cromwell.example.backends/slurm.conf
+++ b/cromwell.example.backends/slurm.conf
@@ -1,0 +1,45 @@
+# This is an example of how you can use Cromwell to interact with SLURM
+# workload manager. *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/stable/backends/SLURM/
+
+backend {
+  default = slurm
+
+  providers {
+    slurm {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        runtime-attributes = """
+        Int runtime_minutes = 600
+        Int cpus = 2
+        Int requested_memory_mb_per_core = 8000
+        String queue = "short"
+        """
+    
+        # If an 'exit-code-timeout-seconds' value is specified:
+        # - When a job has not been alive for longer than this timeout
+        # - And has still not produced an RC file
+        # - Then it will be marked as Failed.
+        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
+    
+        # exit-code-timeout-seconds = 120
+    
+        submit = """
+            sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
+            ${"-n " + cpus} \
+            --mem-per-cpu=${requested_memory_mb_per_core} \
+            --wrap "/usr/bin/env bash ${script}"
+        """
+        kill = "scancel ${job_id}"
+        check-alive = "squeue -j ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+      }
+    }
+}

--- a/cromwell.example.backends/udocker.conf
+++ b/cromwell.example.backends/udocker.conf
@@ -1,0 +1,30 @@
+# This is an example of how you can use udocker with Cromwell
+# *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#udocker
+
+backend {
+  default = udocker
+
+  providers {
+    udocker {
+        # The backend custom configuration.
+        actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+
+        config {
+            run-in-background = true
+            runtime-attributes = """
+              String? docker
+             """ 
+             submit-docker = """
+               udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}
+             """
+        }
+    }
+}

--- a/cromwell.example.backends/udocker.slurm.conf
+++ b/cromwell.example.backends/udocker.slurm.conf
@@ -1,0 +1,60 @@
+# This is an example of how you can use udocker containers with slurm
+# *This is not a complete configuration file!* The
+# content here should be copy pasted into the backend -> providers section
+# of the cromwell.examples.conf in the root of the repository. You should
+# uncomment lines that you want to define, and read carefully to customize
+# the file. If you have any questions, please open an issue at
+# https://www.github.com/broadinstitute/cromwell/issues
+
+# Documentation
+# https://cromwell.readthedocs.io/en/develop/tutorials/Containers/#configuration
+
+backend {
+  default = slurm
+
+  providers {
+    slurm {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"                                                                                     
+      config {
+        runtime-attributes = """
+        Int runtime_minutes = 600
+        Int cpus = 2
+        Int requested_memory_mb_per_core = 8000
+        String? docker
+        """
+
+        submit = """
+            sbatch \
+              --wait \
+              -J ${job_name} \
+              -D ${cwd} \
+              -o ${out} \
+              -e ${err} \
+              -t ${runtime_minutes} \
+              ${"-c " + cpus} \
+              --mem-per-cpu=${requested_memory_mb_per_core} \
+              --wrap "/bin/bash ${script}"
+        """
+
+        submit-docker = """
+          # Pull the image using the head node, in case our workers don't have network access
+          udocker pull ${docker}
+
+          sbatch \
+            -J ${job_name} \
+            -D ${cwd} \
+            -o ${cwd}/execution/stdout \
+            -e ${cwd}/execution/stderr \
+            -t ${runtime_minutes} \
+            ${"-c " + cpus} \
+           --mem-per-cpu=${requested_memory_mb_per_core} \
+           --wrap "udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}"
+        """
+
+        kill = "scancel ${job_id}"
+        check-alive = "squeue -j ${job_id}"
+        job-id-regex = "Submitted batch job (\\d+).*"
+      }
+    }
+  }
+}

--- a/cromwell.example.backends/udocker.slurm.conf
+++ b/cromwell.example.backends/udocker.slurm.conf
@@ -28,12 +28,10 @@ backend {
               --wait \
               -J ${job_name} \
               -D ${cwd} \
-              -o ${out} \
-              -e ${err} \
               -t ${runtime_minutes} \
               ${"-c " + cpus} \
               --mem-per-cpu=${requested_memory_mb_per_core} \
-              --wrap "/bin/bash ${script}"
+              --wrap "/bin/bash ${docker_script}"
         """
 
         submit-docker = """
@@ -43,12 +41,10 @@ backend {
           sbatch \
             -J ${job_name} \
             -D ${cwd} \
-            -o ${cwd}/execution/stdout \
-            -e ${cwd}/execution/stderr \
             -t ${runtime_minutes} \
             ${"-c " + cpus} \
            --mem-per-cpu=${requested_memory_mb_per_core} \
-           --wrap "udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${script}"
+           --wrap "udocker run -v ${cwd}:${docker_cwd} ${docker} ${job_shell} ${docker_script}"
         """
 
         kill = "scancel ${job_id}"

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -319,7 +319,10 @@ backend {
   # The list of providers. Copy paste the contents of a backend provider in this section
   providers {
 
-    # The local provider is included by default in the reference.conf.
+    # The local provider is included by default in the reference.conf. This
+    # means that you will have a working Cromwell system *without* adding
+    # any of the backends below. However, it's likely that you will want this
+    # customization.
 
     # Examples in cromwell.example.backends include:
     # LocalExample: What you should use if you want to define a new backend provider

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -1,5 +1,12 @@
-# This line is required. It pulls in default overrides from the embedded cromwell `application.conf` needed for proper
-# performance of cromwell.
+# This is a "default" Cromwell example that is intended for you you to start with
+# and edit for your needs. Specifically, you will be interested to customize
+# the configuration based on your preferred backend (see the backends section
+# below in the file). For backend-specific examples for you to copy paste here,
+# please see the cromwell.backend.examples folder in the repository. The files
+# there also include links to online documentation (if it exists)
+
+# This line is required. It pulls in default overrides from the embedded cromwell 
+# `application.conf` needed for proper performance of cromwell.
 include required(classpath("application"))
 
 # Cromwell HTTP server settings
@@ -149,6 +156,8 @@ call-caching {
   # }
 }
 
+
+
 # Google configuration
 google {
 
@@ -294,475 +303,29 @@ languages {
   }
 }
 
+# Here is where you can define the backend providers that Cromwell understands.
+# The default is a local provider, and you can see it defined in references.conf.
+# To add additional backend providers, you should copy paste additional backends
+# of interest that you can find in the cromwell.example.backends folder
+# folder at https://www.github.com/broadinstitute/cromwell 
+# Other backend providers include SGE, SLURM, Docker, udocker, Singularity. etc.
+# Don't forget you will need to customize them for your particular use case.
 
 backend {
+
   # Override the default backend.
   #default = "LocalExample"
 
-  # The list of providers.
+  # The list of providers. Copy paste the contents of a backend provider in this section
   providers {
 
-    # The local provider is included by default in the reference.conf. This is an example.
+    # The local provider is included by default in the reference.conf.
 
-    # Define a new backend provider.
-    LocalExample {
-      # The actor that runs the backend. In this case, it's the Shared File System (SFS) ConfigBackend.
-      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+    # Examples in cromwell.example.backends include:
+    # LocalExample: What you should use if you want to define a new backend provider
 
-      # The backend custom configuration.
-      config {
-
-        # Optional limits on the number of concurrent jobs
-        #concurrent-job-limit = 5
-
-        # If true submits scripts to the bash background using "&". Only usefull for dispatchers that do NOT submit
-        # the job and then immediately return a scheduled job id.
-        run-in-background = true
-
-        # `temporary-directory` creates the temporary directory for commands.
-        #
-        # If this value is not set explicitly, the default value creates a unique temporary directory, equivalent to:
-        # temporary-directory = "$(mktemp -d \"$PWD\"/tmp.XXXXXX)"
-        #
-        # The expression is run from the execution directory for the script. The expression must create the directory
-        # if it does not exist, and then return the full path to the directory.
-        #
-        # To create and return a non-random temporary directory, use something like:
-        # temporary-directory = "$(mkdir -p /tmp/mydir && echo /tmp/mydir)"
-
-        # `script-epilogue` configures a shell command to run after the execution of every command block.
-        #
-        # If this value is not set explicitly, the default value is `sync`, equivalent to:
-        # script-epilogue = "sync"
-        #
-        # To turn off the default `sync` behavior set this value to an empty string:
-        # script-epilogue = ""
-
-        # The list of possible runtime custom attributes.
-        runtime-attributes = """
-        String? docker
-        String? docker_user
-        """
-
-        # Submit string when there is no "docker" runtime attribute.
-        submit = "/usr/bin/env bash ${script}"
-
-        # Submit string when there is a "docker" runtime attribute.
-        submit-docker = """
-        docker run \
-          --rm -i \
-          ${"--user " + docker_user} \
-          --entrypoint ${job_shell} \
-          -v ${cwd}:${docker_cwd} \
-          ${docker} ${script}
-        """
-
-        # Root directory where Cromwell writes job results.  This directory must be
-        # visible and writeable by the Cromwell process as well as the jobs that Cromwell
-        # launches.
-        root = "cromwell-executions"
-
-        # Root directory where Cromwell writes job results in the container. This value
-        # can be used to specify where the execution folder is mounted in the container.
-        # it is used for the construction of the docker_cwd string in the submit-docker
-        # value above.
-        dockerRoot = "/cromwell-executions"
-
-        # File system configuration.
-        filesystems {
-
-          # For SFS backends, the "local" configuration specifies how files are handled.
-          local {
-
-            # Try to hard link (ln), then soft-link (ln -s), and if both fail, then copy the files.
-            localization: [
-              "hard-link", "soft-link", "copy"
-            ]
-
-            # Call caching strategies
-            caching {
-              # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
-              duplication-strategy: [
-                "hard-link", "soft-link", "copy"
-              ]
-
-              # Possible values: file, path, path+modtime
-              # "file" will compute an md5 hash of the file content.
-              # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
-              # in order to allow for the original file path to be hashed.
-              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
-              # Default: file
-              hashing-strategy: "file"
-
-              # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
-              # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.
-              check-sibling-md5: false
-            }
-          }
-        }
-
-        # The defaults for runtime attributes if not provided.
-        default-runtime-attributes {
-          failOnStderr: false
-          continueOnReturnCode: 0
-        }
-      }
-    }
-
-    # Other backend examples. Uncomment the block/stanza for your configuration. May need more tweaking/configuration
-    # for your specific environment.
-
-    #TES {
-    #  actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
-    #  config {
-    #    root = "cromwell-executions"
-    #    dockerRoot = "/cromwell-executions"
-    #    endpoint = "http://127.0.0.1:9000/v1/tasks"
-    #    default-runtime-attributes {
-    #      cpu: 1
-    #      failOnStderr: false
-    #      continueOnReturnCode: 0
-    #      memory: "2 GB"
-    #      disk: "2 GB"
-    #    }
-    #  }
-    #}
-
-    #TESK {
-    #  actor-factory = "cromwell.backend.impl.tes.TesBackendLifecycleActorFactory"
-    #  config {
-    #    root = "ftp://your.ftphost.com/cromwell-executions"
-    #    dockerRoot = "/cromwell-executions"
-    #    endpoint = "http://your-tesk-endpoint/v1/tasks"
-    #    glob-link-command = "ls -L GLOB_PATTERN 2> /dev/null | xargs -I ? ln -s ? GLOB_DIRECTORY"
-    #  }
-    #}
-
-    #BCS {
-    #  actor-factory = "cromwell.backend.impl.bcs.BcsBackendLifecycleActorFactory"
-    #  config {
-    #    root = "oss://your-bucket/cromwell-exe"
-    #    dockerRoot = "/cromwell-executions"
-    #    region = ""
-
-    #    #access-id = ""
-    #    #access-key = ""
-	#	#security-token = ""
-
-    #    filesystems {
-    #      oss {
-    #        auth {
-    #            #endpoint = ""
-    #            #access-id = ""
-    #            #access-key = ""
-	#	        #security-token = ""
-    #        }
-    #      }
-    #    }
-
-    #    default-runtime-attributes {
-    #        #failOnStderr: false
-    #        #continueOnReturnCode: 0
-    #        #cluster: "cls-mycluster"
-    #        #mounts: "oss://bcs-bucket/bcs-dir/ /home/inputs/ false"
-    #        #docker: "ubuntu/latest oss://bcs-reg/ubuntu/"
-    #        #userData: "key value"
-    #        #reserveOnFail: true
-    #        #autoReleaseJob: true
-    #        #verbose: false
-    #        #workerPath: "oss://bcs-bucket/workflow/worker.tar.gz"
-    #        #systemDisk: "cloud 50"
-    #        #dataDisk: "cloud 250 /home/data/"
-    #        #timeout: 3000
-    #        #vpc: "192.168.0.0/16 vpc-xxxx"
-    #    }
-    #  }
-    #}
-
-    #SGE {
-    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    #  config {
-    #
-    #    # Limits the number of concurrent jobs
-    #    concurrent-job-limit = 5
-    #
-    #    # If an 'exit-code-timeout-seconds' value is specified:
-    #    # - When a job has not been alive for longer than this timeout
-    #    # - And has still not produced an RC file
-    #    # - Then it will be marked as Failed.
-    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    #
-    #    # exit-code-timeout-seconds = 120
-    #
-    #    runtime-attributes = """
-    #    Int cpu = 1
-    #    Float? memory_gb
-    #    String? sge_queue
-    #    String? sge_project
-    #    """
-    #
-    #    submit = """
-    #    qsub \
-    #    -terse \
-    #    -V \
-    #    -b y \
-    #    -N ${job_name} \
-    #    -wd ${cwd} \
-    #    -o ${out}.qsub \
-    #    -e ${err}.qsub \
-    #    -pe smp ${cpu} \
-    #    ${"-l mem_free=" + memory_gb + "g"} \
-    #    ${"-q " + sge_queue} \
-    #    ${"-P " + sge_project} \
-    #    /usr/bin/env bash ${script}
-    #    """
-    #
-    #    kill = "qdel ${job_id}"
-    #    check-alive = "qstat -j ${job_id}"
-    #    job-id-regex = "(\\d+)"
-    #  }
-    #}
-
-    #LSF {
-    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    #  config {
-    #    submit = "bsub -J ${job_name} -cwd ${cwd} -o ${out} -e ${err} /usr/bin/env bash ${script}"
-    #    kill = "bkill ${job_id}"
-    #    check-alive = "bjobs ${job_id}"
-    #    job-id-regex = "Job <(\\d+)>.*"
-    #  }
-    #}
-
-    #SLURM {
-    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    #  config {
-    #    runtime-attributes = """
-    #    Int runtime_minutes = 600
-    #    Int cpus = 2
-    #    Int requested_memory_mb_per_core = 8000
-    #    String queue = "short"
-    #    """
-    #
-    #    # If an 'exit-code-timeout-seconds' value is specified:
-    #    # - When a job has not been alive for longer than this timeout
-    #    # - And has still not produced an RC file
-    #    # - Then it will be marked as Failed.
-    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    #
-    #    # exit-code-timeout-seconds = 120
-    #
-    #    submit = """
-    #        sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
-    #        ${"-n " + cpus} \
-    #        --mem-per-cpu=${requested_memory_mb_per_core} \
-    #        --wrap "/usr/bin/env bash ${script}"
-    #    """
-    #    kill = "scancel ${job_id}"
-    #    check-alive = "squeue -j ${job_id}"
-    #    job-id-regex = "Submitted batch job (\\d+).*"
-    #  }
-    #}
-
-    # Example backend that _only_ runs workflows that specify docker for every command.
-    #Docker {
-    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    #  config {
-    #    run-in-background = true
-    #    runtime-attributes = "String docker"
-    #    submit-docker = "docker run --rm -v ${cwd}:${docker_cwd} -i ${docker} /bin/bash < ${script}"
-    #  }
-    #}
-
-    #HtCondor {
-    #  actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
-    #  config {
-    #    runtime-attributes = """
-    #      Int cpu = 1
-    #      Float memory_mb = 512.0
-    #      Float disk_kb = 256000.0
-    #      String? nativeSpecs
-    #      String? docker
-    #    """
-    #
-    #    # If an 'exit-code-timeout-seconds' value is specified:
-    #    # - When a job has not been alive for longer than this timeout
-    #    # - And has still not produced an RC file
-    #    # - Then it will be marked as Failed.
-    #    # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    #
-    #    # exit-code-timeout-seconds = 120
-    #
-    #    submit = """
-    #      chmod 755 ${script}
-    #      cat > ${cwd}/execution/submitFile <<EOF
-    #      Iwd=${cwd}/execution
-    #      requirements=${nativeSpecs}
-    #      leave_in_queue=true
-    #      request_memory=${memory_mb}
-    #      request_disk=${disk_kb}
-    #      error=${err}
-    #      output=${out}
-    #      log_xml=true
-    #      request_cpus=${cpu}
-    #      executable=${script}
-    #      log=${cwd}/execution/execution.log
-    #      queue
-    #      EOF
-    #      condor_submit ${cwd}/execution/submitFile
-    #    """
-    #
-    #    submit-docker = """
-    #      chmod 755 ${script}
-    #      cat > ${cwd}/execution/dockerScript <<EOF
-    #      #!/bin/bash
-    #      docker run --rm -i -v ${cwd}:${docker_cwd} ${docker} /bin/bash ${script}
-    #      EOF
-    #      chmod 755 ${cwd}/execution/dockerScript
-    #      cat > ${cwd}/execution/submitFile <<EOF
-    #      Iwd=${cwd}/execution
-    #      requirements=${nativeSpecs}
-    #      leave_in_queue=true
-    #      request_memory=${memory_mb}
-    #      request_disk=${disk_kb}
-    #      error=${cwd}/execution/stderr
-    #      output=${cwd}/execution/stdout
-    #      log_xml=true
-    #      request_cpus=${cpu}
-    #      executable=${cwd}/execution/dockerScript
-    #      log=${cwd}/execution/execution.log
-    #      queue
-    #      EOF
-    #      condor_submit ${cwd}/execution/submitFile
-    #    """
-    #
-    #    kill = "condor_rm ${job_id}"
-    #    check-alive = "condor_q ${job_id}"
-    #    job-id-regex = "(?sm).*cluster (\\d+)..*"
-    #  }
-    #}
-
-    #Spark {
-    # actor-factory = "cromwell.backend.impl.spark.SparkBackendFactory"
-    # config {
-    #   # Root directory where Cromwell writes job results.  This directory must be
-    #    # visible and writeable by the Cromwell process as well as the jobs that Cromwell
-    #   # launches.
-    #   root: "cromwell-executions"
-    #
-    #   filesystems {
-    #     local {
-    #       localization: [
-    #         "hard-link", "soft-link", "copy"
-    #       ]
-    #     }
-    #    }
-    #      # change (master, deployMode) to (yarn, client), (yarn, cluster)
-    #      #  or (spark://hostname:port, cluster) for spark standalone cluster mode
-    #     master: "local"
-    #     deployMode: "client"
-    #  }
-    # }
-
-    #PAPIv2 {
-    #  actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
-    #  config {
-    #    # Google project
-    #    project = "my-cromwell-workflows"
-    #
-    #    # Base bucket for workflow executions
-    #    root = "gs://my-cromwell-workflows-bucket"
-    #
-    #    # Make the name of the backend used for call caching purposes insensitive to the PAPI version.
-    #    name-for-call-caching-purposes: PAPI
-    #
-    #    # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
-    #    # your project.
-    #    #
-    #    # Used to help determine maximum throughput to the Google Genomics API. Setting this value too low will
-    #    # cause a drop in performance. Setting this value too high will cause QPS based locks from Google.
-    #    # 1000 is the default "Queries per 100 seconds per user", 50000 is the default "Queries per 100 seconds"
-    #    # See https://cloud.google.com/genomics/quotas for more information
-    #    genomics-api-queries-per-100-seconds = 1000
-    #
-    #    # Polling for completion backs-off gradually for slower-running jobs.
-    #    # This is the maximum polling interval (in seconds):
-    #    maximum-polling-interval = 600
-    #
-    #    # Optional Dockerhub Credentials. Can be used to access private docker images.
-    #    dockerhub {
-    #      # account = ""
-    #      # token = ""
-    #    }
-    #
-    #    # Number of workers to assaign to PAPI requests
-    #    request-workers = 3
-    #
-    #    genomics {
-    #      # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
-    #      # Pipelines and manipulate auth JSONs.
-    #      auth = "application-default"
-    #
-    #
-    #      // alternative service account to use on the launched compute instance
-    #      // NOTE: If combined with service account authorization, both that serivce account and this service account
-    #      // must be able to read and write to the 'root' GCS path
-    #      compute-service-account = "default"
-    #
-    #      # Endpoint for APIs, no reason to change this unless directed by Google.
-    #      endpoint-url = "https://genomics.googleapis.com/"
-    #
-    #      # Restrict access to VM metadata. Useful in cases when untrusted containers are running under a service
-    #      # account not owned by the submitting user
-    #      restrict-metadata-access = false
-    #      
-    #      # Pipelines v2 only: specify the number of times localization and delocalization operations should be attempted
-    #      # There is no logic to determine if the error was transient or not, everything is retried upon failure
-    #      # Defaults to 3
-    #      localization-attempts = 3
-    #    }
-    #
-    #    filesystems {
-    #      gcs {
-    #        # A reference to a potentially different auth for manipulating files via engine functions.
-    #        auth = "application-default"
-    #        # Google project which will be billed for the requests
-    #        project = "google-billing-project"
-    #
-    #        caching {
-    #          # When a cache hit is found, the following duplication strategy will be followed to use the cached outputs
-    #          # Possible values: "copy", "reference". Defaults to "copy"
-    #          # "copy": Copy the output files
-    #          # "reference": DO NOT copy the output files but point to the original output files instead.
-    #          #              Will still make sure than all the original output files exist and are accessible before
-    #          #              going forward with the cache hit.
-    #          duplication-strategy = "copy"
-    #        }
-    #      }
-    #    }
-    #
-    #    default-runtime-attributes {
-    #      cpu: 1
-    #      failOnStderr: false
-    #      continueOnReturnCode: 0
-    #      memory: "2048 MB"
-    #      bootDiskSizeGb: 10
-    #      # Allowed to be a String, or a list of Strings
-    #      disks: "local-disk 10 SSD"
-    #      noAddress: false
-    #      preemptible: 0
-    #      zones: ["us-central1-a", "us-central1-b"]
-    #    }
-    #  }
-    #}
-
-    #AWS {
-    #  actor-factory = "cromwell.backend.impl.aws.AwsBackendActorFactory"
-    #  config {
-    #    ## These two settings are required to authenticate with the ECS service:
-    #    accessKeyId = "..."
-    #    secretKey = "..."
-    #  }
-    #}
+    # Note that these other backend examples will need tweaking and configuration. 
+    # Please open an issue https://www.github.com/broadinstitute/cromwell if you have any questions 
 
   }
 }

--- a/cromwell.examples.conf
+++ b/cromwell.examples.conf
@@ -323,6 +323,21 @@ backend {
 
     # Examples in cromwell.example.backends include:
     # LocalExample: What you should use if you want to define a new backend provider
+    # AWS: Amazon Web Services
+    # BCS: Alibaba Cloud Batch Compute
+    # TES: protocol defined by GA4GH
+    # TESK: the same, with kubernetes support
+    # Google Pipelines, v2 (PAPIv2)
+    # Docker
+    # Singularity: a container safe for HPC
+    # Singularity+Slurm: and an example on Slurm
+    # udocker: another rootless container solution
+    # udocker+slurm: also exemplified on slurm
+    # HtCondor: workload manager at UW-Madison
+    # LSF: the Platform Load Sharing Facility backend 
+    # SGE: Sun Grid Engine
+    # SLURM: workload manager
+    # Spark: cluster
 
     # Note that these other backend examples will need tweaking and configuration. 
     # Please open an issue https://www.github.com/broadinstitute/cromwell if you have any questions 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -6,8 +6,8 @@ Check out the tutorial on [How to Configure Cromwell](tutorials/ConfigurationFil
 
 ### Configuration examples
 
-You can find a description of options and example stanzas in the [file
-`cromwell.examples.conf`](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf).
+You can find a description of options and example stanzas in the [Cromwell Example Configuration][cromwell-examples-conf],
+along with backend provider examples in the [Example Providers Folder][cromwell-examples-folder].
 
 ### Custom configuration files
 
@@ -395,3 +395,6 @@ per-backend basis with `<config-key-for-backend>.job-shell`. For example:
 
 For the Config backend the value of the job shell will be available in the `${job_shell}` variable. See Cromwell's `reference.conf` for an example
 of how this is used for the default configuration of the `Local` backend.
+
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends

--- a/docs/backends/Local.md
+++ b/docs/backends/Local.md
@@ -5,10 +5,15 @@ It is pre-enabled by default and there is no further configuration needed to sta
 
 It uses the local filesystem on which Cromwell is running to store the workflow directory structure.
 
-You can find the complete set of configurable settings with explanations in the [example configuration file](https://github.com/broadinstitute/cromwell/blob/b47feaa207fcf9e73e105a7d09e74203fff6f73b/cromwell.examples.conf#L193).
+You can find the complete set of configurable settings with explanations in the 
+[Cromwell Example Configuration File][cromwell-examples-conf],
+along with backend provider examples in the [Example Providers Folder][cromwell-examples-folder].
 
 The Local backend makes use of the same generic configuration as HPC backends. The same [filesystem considerations](HPC#filesystems) apply.
 
 **Note to OSX users**: Docker on Mac restricts the directories that can be mounted. Only some directories are allowed by default.
 If you try to mount a volume from a disallowed directory, jobs can fail in an odd manner. Before mounting a directory make sure it is in the list
 of allowed directories. See the [Docker documentation](https://docs.docker.com/docker-for-mac/osxfs/#namespaces) for how to configure those directories.
+
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends

--- a/docs/cromwell_features/HogFactors.md
+++ b/docs/cromwell_features/HogFactors.md
@@ -192,6 +192,6 @@ Yes, to various degrees:
 - To opt out of round-robin allocation between workflows, and preserve a strict first-in-first-out allocation of jobs,
 assign all workflows to the same hog-group in their workflow options.
     + To set this as the default, you can add a value to the default workflow options. 
-    + For an example see the `workflow-options` / `default` stanza of [cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/master/cromwell.examples.conf).
+    + For an example see the `workflow-options` / `default` stanza of [cromwell.examples.conf][cromwell-examples-conf].
 
-
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf

--- a/docs/tutorials/ConfigurationFiles.md
+++ b/docs/tutorials/ConfigurationFiles.md
@@ -60,7 +60,11 @@ When you then run Cromwell updated config file, cromwell will now be listening o
 
 #### Finding more configuration properties
 
-In addition to the common configuration properties listed on the [configuration](../Configuring) page, there are also a large number of example configuration stanzas commented in [cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf).
+In addition to the common configuration properties listed on the [configuration](../Configuring) page, there are also a large number of example configuration stanzas commented in [cromwell.examples.conf][cromwell-examples-conf], and
+backend provider examples in [cromwell.example.backends][cromwell-examples-folder].
+
+
+[cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf).
 
 ### Next Steps
 
@@ -68,3 +72,6 @@ After completing this tutorial you might find the following page interesting:
 
 * [Configuring the Local Backend](LocalBackendIntro)
 * [Server Mode](ServerMode.md)
+
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -390,7 +390,9 @@ backend {
 
 #### Docker Config Block
 Further docker configuration options available to be put into your config file are as follows. 
-For the latest list of parameters, refer to the [example configurations](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf) file.
+For the latest list of parameters, refer to the [example configuration file][cromwell-examples-conf],
+and [specific backend provider examples][cromwell-examples-folder].
+
 ```
 docker {
   hash-lookup {
@@ -458,3 +460,7 @@ Congratulations for improving the reproducibility of your workflows! You might f
 - [Getting started with AWS Batch](AwsBatch101.md)
 - [Getting started on Google Pipelines API](PipelinesApi101.md)
 - [Getting started on Alibaba Cloud](BCSIntro/)
+
+
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends


### PR DESCRIPTION
This pull request will add a folder of example backend providers to cromwell, along with a README.md to (verbosely) describe them. Importantly:

 - links to documentation are included in the examples
 - the user understands the context of where to provide it under backend -> providers
 - the user doesn't have to uncomment a million things

I couldn't find the backend page for AWS - the closest I found was https://cromwell.readthedocs.io/en/stable/tutorials/AwsBatch101/. Is there a backend page, proper?

I've done my best to add notes and documentation, and maybe it would be useful to bring in others with expertise for the various providers? This is a first shot, and I expect we will want feedback from others to get it in good shape!