### PR TITLE
Meta section in draft-3

### DIFF
--- a/wdl/transforms/draft3/src/test/cases/task_with_metas2.wdl
+++ b/wdl/transforms/draft3/src/test/cases/task_with_metas2.wdl
@@ -1,6 +1,6 @@
 version 1.0
 
-task task_with_metas {
+task task_with_metas2 {
   input {
   }
 
@@ -8,7 +8,6 @@ task task_with_metas {
   }
 
   command {
-    echo "Hello World"
   }
 
   meta {

--- a/wdl/transforms/draft3/src/test/cases/task_with_metas2.wdl
+++ b/wdl/transforms/draft3/src/test/cases/task_with_metas2.wdl
@@ -1,0 +1,18 @@
+version 1.0
+
+task task_with_metas {
+  input {
+  }
+
+  output {
+  }
+
+  command {
+    echo "Hello World"
+  }
+
+  meta {
+    author: "John Doe"
+    email: "john.doe@yahoo.com"
+  }
+}

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/ast2wdlom/WdlFileToWdlomSpec.scala
@@ -352,6 +352,24 @@ object WdlFileToWdlomSpec {
                   "k3" -> MetaValueElementInteger(3)))
               )))
           ))),
+    "task_with_metas2" ->
+      FileElement(
+        imports = Vector.empty,
+        structs = Vector.empty,
+        workflows = Vector.empty,
+        tasks = Vector(
+          TaskDefinitionElement(
+            name = "task_with_metas2",
+            inputsSection = Some(InputsSectionElement(Vector.empty)),
+            declarations = Vector.empty,
+            outputsSection = Some(OutputsSectionElement(Vector.empty)),
+            commandSection = CommandSectionElement(List.empty),
+            runtimeSection = None,
+            metaSection = Some(MetaSectionElement(
+              Map("author" -> MetaValueElementString("John Doe"),
+                  "email" -> MetaValueElementString("john.doe@yahoo.com")))),
+            parameterMetaSection = None
+          ))),
     "no_input_no_output_workflow" ->
       FileElement(
         imports = Vector.empty,

--- a/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
+++ b/wdl/transforms/draft3/src/test/scala/wdl/draft3/transforms/wdlom2wom/WdlFileToWomSpec.scala
@@ -78,6 +78,7 @@ class WdlFileToWomSpec extends FlatSpec with Matchers {
     "command_syntaxes" -> validateCommandSyntaxes,
     "standalone_task" -> anyWomWillDo,
     "task_with_metas" -> anyWomWillDo,
+    "task_with_metas2" -> validateMetaSection,
     "input_values" -> anyWomWillDo,
     "gap_in_command" -> anyWomWillDo,
     "nio_file" -> validateNioFile,
@@ -158,5 +159,12 @@ class WdlFileToWomSpec extends FlatSpec with Matchers {
     callInputs(1).inputPorts.head.upstream should be theSameInstanceAs exposedExpressionNode.outputPorts.head
     callInputs(2).inputPorts.head.upstream should be theSameInstanceAs exposedExpressionNode.outputPorts.head
     callInputs(3).inputPorts.head.upstream should be theSameInstanceAs exposedExpressionNode.outputPorts.head
+  }
+
+  private def validateMetaSection(b: WomBundle): Assertion = {
+    val task = b.primaryCallable.get.asInstanceOf[CallableTaskDefinition]
+
+    task.meta should be (Map("author" -> "John Doe",
+                             "email" -> "john.doe@yahoo.com"))
   }
 }

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
@@ -58,15 +58,14 @@ object TaskDefinitionElementToWomTaskDefinition {
       }
 
       val metaSection : ErrorOr[Map[String, String]] = a.taskDefinitionElement.metaSection match {
-        case None => Map.empty.validNel
+        case None => Map.empty[String, String].validNel
         case Some(MetaSectionElement(meta)) =>
-          val m : Map[String, String] = meta.map{
-            case (key, MetaValueElement.MetaValueElementString(value)) =>
-              key -> value
-            case (key, other) =>
-              throw new Exception(s"non string meta values are not handled currently <${key} -> ${other}>")
-          }.toMap
-          m.validNel
+              meta.traverse{
+                  case (key, MetaValueElement.MetaValueElementString(value)) =>
+                      (key -> value).validNel
+                  case (key, other) =>
+                      s"non string meta values are not handled currently <${key} -> ${other}>, see https://github.com/broadinstitute/cromwell/issues/4746".invalidNel
+          }
       }
 
       (validRuntimeAttributes, validCommand, metaSection) mapN { (runtime, command, metaSection) =>

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/TaskDefinitionElementToWomTaskDefinition.scala
@@ -57,8 +57,20 @@ object TaskDefinitionElementToWomTaskDefinition {
         }.map(_.toSeq)
       }
 
-      (validRuntimeAttributes, validCommand) mapN { (runtime, command) =>
-        CallableTaskDefinition(a.taskDefinitionElement.name, Function.const(command.validNel), runtime, Map.empty, Map.empty, taskGraph.outputs, taskGraph.inputs, Set.empty, Map.empty)
+      val metaSection : ErrorOr[Map[String, String]] = a.taskDefinitionElement.metaSection match {
+        case None => Map.empty.validNel
+        case Some(MetaSectionElement(meta)) =>
+          val m : Map[String, String] = meta.map{
+            case (key, MetaValueElement.MetaValueElementString(value)) =>
+              key -> value
+            case (key, other) =>
+              throw new Exception(s"non string meta values are not handled currently <${key} -> ${other}>")
+          }.toMap
+          m.validNel
+      }
+
+      (validRuntimeAttributes, validCommand, metaSection) mapN { (runtime, command, metaSection) =>
+        CallableTaskDefinition(a.taskDefinitionElement.name, Function.const(command.validNel), runtime, metaSection, Map.empty, taskGraph.outputs, taskGraph.inputs, Set.empty, Map.empty)
       }
     }
 


### PR DESCRIPTION
Currently, the WDL draft-3 parser drops the meta section. This branch addresses some of this functionality, by adding support for strings values in the meta section of task.  