### PR TITLE
Update AWS Batch example conf to reflect our docs

### DIFF
--- a/cromwell.example.backends/AWS.conf
+++ b/cromwell.example.backends/AWS.conf
@@ -9,16 +9,59 @@
 # Documentation
 # https://cromwell.readthedocs.io/en/stable/tutorials/AwsBatch101/
 
-backend {
-  default = AWS
+include required(classpath("application"))
 
+aws {
+
+  application-name = "cromwell"
+
+  auths = [
+    {
+      name = "default"
+      scheme = "default"
+    }
+  ]
+
+  region = "<your-region>"
+}
+
+engine {
+  filesystems {
+    s3 {
+      auth = "default"
+    }
+  }
+}
+
+backend {
+  default = "AWSBATCH"
   providers {
-    AWS {
-      actor-factory = "cromwell.backend.impl.aws.AwsBackendActorFactory"
+    AWSBATCH {
+      actor-factory = "cromwell.backend.impl.aws.AwsBatchBackendLifecycleActorFactory"
       config {
-        ## These two settings are required to authenticate with the ECS service:
-        accessKeyId = "..."
-        secretKey = "..."
+
+        numSubmitAttempts = 6
+        numCreateDefinitionAttempts = 6
+
+        // Base bucket for workflow executions
+        root = "s3://<s3-bucket-name>/cromwell-execution"
+
+        // A reference to an auth defined in the `aws` stanza at the top.  This auth is used to create
+        // Jobs and manipulate auth JSONs.
+        auth = "default"
+
+        default-runtime-attributes {
+          queueArn: "<your arn here>"
+        }
+
+        filesystems {
+          s3 {
+            // A reference to a potentially different auth for manipulating files via engine functions.
+            auth = "default"
+          }
+        }
       }
     }
+  }
 }
+

--- a/cromwell.example.backends/AWS.conf
+++ b/cromwell.example.backends/AWS.conf
@@ -9,8 +9,6 @@
 # Documentation
 # https://cromwell.readthedocs.io/en/stable/tutorials/AwsBatch101/
 
-include required(classpath("application"))
-
 aws {
 
   application-name = "cromwell"


### PR DESCRIPTION
Addresses(-ish) #4740 

Our docs were telling users to do one thing, but our copy/paste example was telling users to do something else