### PR TITLE
 Release WDL updates

### DIFF
--- a/release/release_inputs.json
+++ b/release/release_inputs.json
@@ -1,3 +1,5 @@
 {
-  "release_cromwell.githubToken": "<<GithubAPIToken>>"
+  "release_cromwell.githubToken": "<<GithubAPIToken>>",
+  "release_cromwell.organization": "<<broadinstitute for a real release, your github username if testing>>",
+  "release_cromwell.majorRelease": <<true for a major release, false for a minor release>>
 }

--- a/release/release_workflow.wdl
+++ b/release/release_workflow.wdl
@@ -1,102 +1,102 @@
 version 1.0
 
 task do_major_release {
-   input {
-      Int releaseVersion
-      String organization
-   }
-   
-   parameter_meta {
-     releaseVersion: "Current version being released"
-     organization: "Organization on which the release will be performed. Can be used for testing."
-   }
+    input {
+        Int releaseVersion
+        String organization
+    }
 
-   Int nextV = releaseVersion + 1
+    parameter_meta {
+        releaseVersion: "Current version being released"
+        organization: "Organization on which the release will be performed. Can be used for testing."
+    }
 
-   command {
-     set -e
-     set -x 
+    Int nextV = releaseVersion + 1
 
-     # Clone repo and checkout develop
-     git clone git@github.com:~{organization}/cromwell.git -b develop cromwell
-     cd cromwell
+    command {
+        set -e
+        set -x
 
-     # Merge develop into master
-     git checkout -t origin/master
-     git merge develop --no-edit
+        # Clone repo and checkout develop
+        git clone git@github.com:~{organization}/cromwell.git -b develop cromwell
+        cd cromwell
 
-     # Tag the release
-     git tag ~{releaseVersion}
+        # Merge develop into master
+        git checkout -t origin/master
+        git merge develop --no-edit
 
-     # Push master and push the tags
-     git push origin master
-     git push origin ~{releaseVersion}
+        # Tag the release
+        git tag ~{releaseVersion}
 
-     # Create and push the hotfix branch
-     git checkout -b ~{releaseVersion}_hotfix
+        # Push master and push the tags
+        git push origin master
+        git push origin ~{releaseVersion}
 
-     git push origin ~{releaseVersion}_hotfix
+        # Create and push the hotfix branch
+        git checkout -b ~{releaseVersion}_hotfix
 
-     # Assemble jar for cromwell
-     sbt -Dproject.version=~{releaseVersion} -Dproject.isSnapshot=false assembly
+        git push origin ~{releaseVersion}_hotfix
 
-     # Update develop to point to next release version
-     git checkout develop
-     sed -i '' -e '/cromwellVersion[[:space:]]=/s/[0-9][0-9]*/~{nextV}/' project/Version.scala
-     git add .
-     git diff-index --quiet HEAD || git commit -m "Update cromwell version from ~{releaseVersion} to ~{nextV}"
-     git push origin develop
-   }
+        # Assemble jar for cromwell
+        sbt -Dproject.version=~{releaseVersion} -Dproject.isSnapshot=false assembly
 
-   output {
-     File cromwellJar = "cromwell/server/target/scala-2.12/cromwell-~{releaseVersion}.jar"
-     File womtoolJar = "cromwell/womtool/target/scala-2.12/womtool-~{releaseVersion}.jar"
-   }
+        # Update develop to point to next release version
+        git checkout develop
+        sed -i '' -e '/cromwellVersion[[:space:]]=/s/[0-9][0-9]*/~{nextV}/' project/Version.scala
+        git add .
+        git diff-index --quiet HEAD || git commit -m "Update cromwell version from ~{releaseVersion} to ~{nextV}"
+        git push origin develop
+    }
+
+    output {
+        File cromwellJar = "cromwell/server/target/scala-2.12/cromwell-~{releaseVersion}.jar"
+        File womtoolJar = "cromwell/womtool/target/scala-2.12/womtool-~{releaseVersion}.jar"
+    }
 }
 
 # do_minor_release simply builds jars from the hotfix branch, tags the branch and push the tag to github
 task do_minor_release {
-   input {
-      # Current version being released. e.g: 33.1
-      String releaseVersion
-   
-      # Can be swapped out to try this on a fork
-      String organization
-   }
+    input {
+        # Current version being released. e.g: 33.1
+        String releaseVersion
 
-   Float releaseVersionAsFloat = releaseVersion
-   Int majorReleaseNumber = floor(releaseVersionAsFloat)   
-   String hotfixBranchName = "~{majorReleaseNumber}_hotfix"
+        # Can be swapped out to try this on a fork
+        String organization
+    }
 
-   command {
-     set -e
-     set -x 
+    Float releaseVersionAsFloat = releaseVersion
+    Int majorReleaseNumber = floor(releaseVersionAsFloat)
+    String hotfixBranchName = "~{majorReleaseNumber}_hotfix"
 
-     # Clone repo and checkout hotfix branch
-     git clone git@github.com:~{organization}/cromwell.git -b ~{hotfixBranchName} cromwell
-     cd cromwell
+    command {
+        set -e
+        set -x
 
-     # Make sure tests pass
-     sbt update
-     sbt test:compile
-     # Test with a backup just in case of timeouts
-     # If tests repeatedly timeout locally, ensure all tests pass in Travis and then comment out the next line
-     sbt test || sbt testQuick
+        # Clone repo and checkout hotfix branch
+        git clone git@github.com:~{organization}/cromwell.git -b ~{hotfixBranchName} cromwell
+        cd cromwell
 
-     # Tag the release
-     git tag ~{releaseVersion}
+        # Make sure tests pass
+        sbt update
+        sbt test:compile
+        # Test with a backup just in case of timeouts
+        # If tests repeatedly timeout locally, ensure all tests pass in Travis and then comment out the next line
+        sbt test || sbt testQuick
 
-     # Push the tags
-     git push origin ~{releaseVersion}
+        # Tag the release
+        git tag ~{releaseVersion}
 
-     # Assemble jar for cromwell
-     sbt -Dproject.version=~{releaseVersion} -Dproject.isSnapshot=false assembly
-   }
+        # Push the tags
+        git push origin ~{releaseVersion}
 
-   output {
-     File cromwellJar = "cromwell/server/target/scala-2.12/cromwell-~{releaseVersion}.jar"
-     File womtoolJar = "cromwell/womtool/target/scala-2.12/womtool-~{releaseVersion}.jar"
-   }
+        # Assemble jar for cromwell
+        sbt -Dproject.version=~{releaseVersion} -Dproject.isSnapshot=false assembly
+    }
+
+    output {
+        File cromwellJar = "cromwell/server/target/scala-2.12/cromwell-~{releaseVersion}.jar"
+        File womtoolJar = "cromwell/womtool/target/scala-2.12/womtool-~{releaseVersion}.jar"
+    }
 }
 
 task versionPrep {
@@ -106,12 +106,12 @@ task versionPrep {
     }
 
     command <<<
-      set -e
+        set -e
 
-      which jq || brew install jq
-      curl --fail -v -s https://api.github.com/repos/~{organization}/cromwell/releases/latest | jq --raw-output '.tag_name' > version
+        which jq || brew install jq
+        curl --fail -v -s https://api.github.com/repos/~{organization}/cromwell/releases/latest | jq --raw-output '.tag_name' > version
     >>>
-    
+
     output {
         String previouslyReleasedVersion = read_string("version")
         Float previouslyReleasedVersionAsFloat = read_float("version")
@@ -154,9 +154,9 @@ task draftGithubRelease {
         docker: "python:2.7"
     }
     output {
-      String release_id = read_string("release_id.txt")
-      String upload_url = sub(read_string("upload_url.txt"), "\\{.*", "")
-      Boolean draft_complete = true
+        String release_id = read_string("release_id.txt")
+        String upload_url = sub(read_string("upload_url.txt"), "\\{.*", "")
+        Boolean draft_complete = true
     }
 
 }
@@ -208,38 +208,38 @@ task releaseHomebrew {
     input {
         String organization
         String githubToken
-        
+
         String releaseVersion
-        
+
         String cromwellReleaseUrl
         String womtoolReleaseUrl
-        
+
         File cromwellJar
         File womtoolJar
     }
-    
+
     String branchName = "cromwell-~{releaseVersion}"
-    
+
     # This is to allow for testing. If the organization is not broadinstitute, meaning we're doing a test,
     # instead of creating the PR in the official homebrew repo make a PR in the test repo.
     String headBranch = if (organization == "broadinstitute") then "broadinstitute:~{branchName}" else branchName
     String baseBranch = "master"
     String pullRepo = if (organization == "broadinstitute") then "Homebrew" else organization
-    
+
     meta {
         doc: "https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request"
     }
 
-    # 'brew bump-formula-pr' seems very promising and could simplify a lot of this, however it's unclear if it would be 
+    # 'brew bump-formula-pr' seems very promising and could simplify a lot of this, however it's unclear if it would be
     # able to update the womtool version too.
     command <<<
         set -e
-        set -x 
+        set -x
 
         # Clone the homebrew fork
         git clone git@github.com:~{organization}/homebrew-core.git --depth=100
         cd homebrew-core
-        
+
         # See https://help.github.com/articles/syncing-a-fork/
         # Add the original homebrew repo as a remote
         git remote add upstream https://github.com/Homebrew/homebrew-core
@@ -249,22 +249,22 @@ task releaseHomebrew {
         git checkout master
         # Merge upstream homebrew to local master
         git merge upstream/master
-        
+
         # Create branch for release
 
         git checkout -b ~{branchName} master
-        
+
         ########################################################
         ##### Update url and hash for cromwell and womtool #####
         ########################################################
 
-        # Find the line with the cromwell url. Also grab the next one that we assume will be the sha. Push both in an array 
+        # Find the line with the cromwell url. Also grab the next one that we assume will be the sha. Push both in an array
         IFS=$'\r\n' command eval 'CROMWELL_ARRAY=($(grep -oh -A 1 'https://github.com/broadinstitute/cromwell/releases/download/.*/cromwell-.*\.jar' Formula/cromwell.rb))'
         # Put the url and sha into separate variables. Also trim any leading space
         CROMWELL_PREVIOUS_URL=$(echo "${CROMWELL_ARRAY[0]}" | sed -e 's/^[[:space:]]*//')
         CROMWELL_PREVIOUS_SHA=$(echo "${CROMWELL_ARRAY[1]}" | sed -e 's/^[[:space:]]*//')
-        
-        # Same for womtool 
+
+        # Same for womtool
         IFS=$'\r\n' command eval 'WOMTOOL_ARRAY=($(grep -oh -A 1 'https://github.com/broadinstitute/cromwell/releases/download/.*/womtool-.*\.jar' Formula/cromwell.rb))'
         WOMTOOL_PREVIOUS_URL=$(echo "${WOMTOOL_ARRAY[0]}" | sed -e 's/^[[:space:]]*//')
         WOMTOOL_PREVIOUS_SHA=$(echo "${WOMTOOL_ARRAY[1]}" | sed -e 's/^[[:space:]]*//')
@@ -281,119 +281,119 @@ task releaseHomebrew {
         sed -i '' -e "s;${CROMWELL_PREVIOUS_SHA};sha256 \"${CROMWELL_RELEASE_SHA}\";" Formula/cromwell.rb
         # Update womtool sha
         sed -i '' -e "s;${WOMTOOL_PREVIOUS_SHA};sha256 \"${WOMTOOL_RELEASE_SHA}\";" Formula/cromwell.rb
-        
+
         ########################################################
         #####   Verify install works and create PR if so   #####
         ########################################################
-        
+
         brew uninstall --force cromwell
         brew install --build-from-source Formula/cromwell.rb
         INSTALL=$?
         brew audit --strict Formula/cromwell.rb
         AUDIT=$?
-        
+
         if [[ "${INSTALL}" -eq 0 && "${AUDIT}" -eq 0 ]]; then
-          git commit -a -m "cromwell ~{releaseVersion}"
-          git push origin ~{branchName}
-          echo "Creating Homebew PR"
-          # Download a template for the homebrew PR
-          curl -o template.md https://raw.githubusercontent.com/brewsci/homebrew-bio/master/.github/PULL_REQUEST_TEMPLATE.md
-          
-          # Check the boxes in the template. White list the boxes to be checked so that if new boxes are added they're not 
-          # automatically checked and should be reviewed manually instead
-          sed -i '' -e '/guidelines for contributing/s/\[[[:space:]]\]/[x]/' \
-          -e "/checked that there aren't other open/s/\[[[:space:]]\]/[x]/" \
-          -e "/built your formula locally/s/\[[[:space:]]\]/[x]/" \
-          -e "/your build pass/s/\[[[:space:]]\]/[x]/" \
-          template.md
-          
-          curl -H "Content-Type: application/json" \
-           -H "Authorization: token ~{githubToken}" \
-           -d "{ \"title\": \"Cromwell ~{releaseVersion}\", \"head\": \"~{headBranch}\", \"base\": \"~{baseBranch}\", \"body\": \"$(cat template.md | sed -e 's/"/\\"/g' | sed 's/$/\\n/' | tr -d '\n')\" }" \
-           https://api.github.com/repos/~{pullRepo}/homebrew-core/pulls
+            git commit -a -m "cromwell ~{releaseVersion}"
+            git push origin ~{branchName}
+            echo "Creating Homebew PR"
+            # Download a template for the homebrew PR
+            curl -o template.md https://raw.githubusercontent.com/brewsci/homebrew-bio/master/.github/PULL_REQUEST_TEMPLATE.md
+
+            # Check the boxes in the template. White list the boxes to be checked so that if new boxes are added they're not
+            # automatically checked and should be reviewed manually instead
+            sed -i '' -e '/guidelines for contributing/s/\[[[:space:]]\]/[x]/' \
+                -e "/checked that there aren't other open/s/\[[[:space:]]\]/[x]/" \
+                -e "/built your formula locally/s/\[[[:space:]]\]/[x]/" \
+                -e "/your build pass/s/\[[[:space:]]\]/[x]/" \
+                template.md
+
+            curl -H "Content-Type: application/json" \
+                -H "Authorization: token ~{githubToken}" \
+                -d "{ \"title\": \"Cromwell ~{releaseVersion}\", \"head\": \"~{headBranch}\", \"base\": \"~{baseBranch}\", \"body\": \"$(cat template.md | sed -e 's/"/\\"/g' | sed 's/$/\\n/' | tr -d '\n')\" }" \
+                https://api.github.com/repos/~{pullRepo}/homebrew-core/pulls
         fi
     >>>
 }
 
 workflow release_cromwell {
-  input {
-    String githubToken
-    String organization = "broadinstitute"
-    Boolean majorRelease = true
-    Boolean publishHomebrew = true
-  }
-  
-  parameter_meta {
-    githubToken: "Github token to interact with github API"
-    organization: "Organization on which the release will be performed. Swap out for a test organization for testing"
-    majorRelease: "Set to false to do a .X minor release"
-  }
+    input {
+        String githubToken
+        String organization = "broadinstitute"
+        Boolean majorRelease = true
+        Boolean publishHomebrew = true
+    }
 
-  call versionPrep { input:
-    organization = organization,
-    majorRelease = majorRelease
-  }
+    parameter_meta {
+        githubToken: "Github token to interact with github API"
+        organization: "Organization on which the release will be performed. Swap out for a test organization for testing"
+        majorRelease: "Set to false to do a .X minor release"
+    }
 
-  call draftGithubRelease { input:
-      githubToken = githubToken,
-      organization = organization,
-      newVersion = cromwellVersion,
-      oldVersion = cromwellPreviousVersion
-  }
+    call versionPrep { input:
+        organization = organization,
+        majorRelease = majorRelease
+    }
 
-  # This is the version before the one being released
-  String cromwellPreviousVersion = versionPrep.previouslyReleasedVersion
-  # This is the version being released
-  String cromwellVersion = versionPrep.currentReleaseVersion
+    call draftGithubRelease { input:
+        githubToken = githubToken,
+        organization = organization,
+        newVersion = cromwellVersion,
+        oldVersion = cromwellPreviousVersion
+    }
 
-  if (draftGithubRelease.draft_complete) {
-      if (majorRelease) {
-        call do_major_release { input:
+    # This is the version before the one being released
+    String cromwellPreviousVersion = versionPrep.previouslyReleasedVersion
+    # This is the version being released
+    String cromwellVersion = versionPrep.currentReleaseVersion
+
+    if (draftGithubRelease.draft_complete) {
+        if (majorRelease) {
+            call do_major_release { input:
                 organization = organization,
                 releaseVersion = cromwellVersion
+            }
         }
-      }
 
-      if (!majorRelease) {
-        call do_minor_release { input:
-               organization = organization,
-               releaseVersion = cromwellVersion
+        if (!majorRelease) {
+            call do_minor_release { input:
+                organization = organization,
+                releaseVersion = cromwellVersion
+            }
         }
-      }
-  }
+    }
 
-  File cromwellJar = select_first([do_major_release.cromwellJar, do_minor_release.cromwellJar])
-  File womtoolJar = select_first([do_major_release.womtoolJar, do_minor_release.womtoolJar])
+    File cromwellJar = select_first([do_major_release.cromwellJar, do_minor_release.cromwellJar])
+    File womtoolJar = select_first([do_major_release.womtoolJar, do_minor_release.womtoolJar])
 
-  call publishGithubRelease { input:
-           githubToken = githubToken,
-           organization = organization,
-           cromwellJar = cromwellJar,
-           womtoolJar = womtoolJar,
-           newVersion = cromwellVersion,
-           release_id = draftGithubRelease.release_id,
-           upload_url = draftGithubRelease.upload_url
-  }
+    call publishGithubRelease { input:
+        githubToken = githubToken,
+        organization = organization,
+        cromwellJar = cromwellJar,
+        womtoolJar = womtoolJar,
+        newVersion = cromwellVersion,
+        release_id = draftGithubRelease.release_id,
+        upload_url = draftGithubRelease.upload_url
+    }
 
-  if (publishHomebrew) {
-      call releaseHomebrew { input:
-               organization = organization,
-               githubToken = githubToken,
-               releaseVersion = cromwellVersion,
-               cromwellReleaseUrl = publishGithubRelease.cromwellReleaseUrl,
-               womtoolReleaseUrl = publishGithubRelease.womtoolReleaseUrl,
-               cromwellJar = cromwellJar,
-               womtoolJar = womtoolJar
-      }
-  }
+    if (publishHomebrew) {
+        call releaseHomebrew { input:
+            organization = organization,
+            githubToken = githubToken,
+            releaseVersion = cromwellVersion,
+            cromwellReleaseUrl = publishGithubRelease.cromwellReleaseUrl,
+            womtoolReleaseUrl = publishGithubRelease.womtoolReleaseUrl,
+            cromwellJar = cromwellJar,
+            womtoolJar = womtoolJar
+        }
+    }
 
-  output {
-    File cromwellReleasedJar = cromwellJar
-    File womtoolReleasedJar = womtoolJar
-  }
-  
-  meta {
-    title: "Cromwell Release WDL"
-    doc: "https://docs.google.com/document/d/1khCqpOYpkCE95pE4a6VfBIxd2zHPWuMILgpisNKCF6c"
-  }
+    output {
+        File cromwellReleasedJar = cromwellJar
+        File womtoolReleasedJar = womtoolJar
+    }
+
+    meta {
+        title: "Cromwell Release WDL"
+        doc: "https://docs.google.com/document/d/1khCqpOYpkCE95pE4a6VfBIxd2zHPWuMILgpisNKCF6c"
+    }
 }


### PR DESCRIPTION
- Added comment that WDL can only handle increasing version numbers
- Sort through the first page of releases instead of using the latest-release-by-date
- Exit WDL commands that contain unset variables or have pipe failures (set -uo pipefail)
- Exit WDL commands on the first error (set -e)
- Log WDL commands verbosely as they run (set -x)
- Replaced usages of docker/python runtimes with brew'ed jq
- Remove call to sbt test from minor releases, thus operating like major releases
- Made the WDL input "organization" mandatory instead of optional
- Copy release notes for major releases from develop instead of master
- Copy release notes for minor releases from hotfix branches
- Pointed to correct homebrew pull request template
- Added additional homebrew test as required in the homebrew pull request template
- Fail the WDL call/workflow if any of homebrew's build/test/verify tasks fail