### PR TITLE
Remove leading slash from S3Path's pathWithoutSchema

### DIFF
--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -161,13 +161,9 @@ case class S3Path private[s3](nioPath: NioPath,
                                ) extends Path {
   override protected def newPath(nioPath: NioPath): S3Path = S3Path(nioPath, bucket, client)
 
-  override def pathAsString: String = {
-    // pathWithoutScheme will have a leading '/', so by only prepending 's3:/', we'll end up with s3:// as expected
-    s"s3:/$pathWithoutScheme"
-  }
+  override def pathAsString: String = s"s3://$pathWithoutScheme"
 
-  override def pathWithoutScheme: String =
-   safeAbsolutePath.stripPrefix("s3://s3.amazonaws.com")
+  override def pathWithoutScheme: String = safeAbsolutePath.stripPrefix("s3://s3.amazonaws.com/")
 
   def key: String = safeAbsolutePath
 

--- a/src/ci/bin/testCentaurAws.sh
+++ b/src/ci/bin/testCentaurAws.sh
@@ -25,5 +25,8 @@ cromwell::build::run_centaur \
     -i long_cmd \
     -i haplotypecaller.aws \
     -i singlesample.aws \
+    -i inline_files \
+    -i sizeenginefunction \
+    -i if_then_else_expressions \
 
 cromwell::build::generate_code_coverage

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -419,7 +419,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   override def mapCommandLineWomFile(womFile: WomFile): WomFile = {
     womFile.mapFile(value =>
       getPath(value) match {
-        case Success(path: S3Path) => workingDisk.mountPoint.resolve(path.pathWithoutScheme.stripPrefix("/")).pathAsString
+        case Success(path: S3Path) => workingDisk.mountPoint.resolve(path.pathWithoutScheme).pathAsString
         case _ => value
       }
     )


### PR DESCRIPTION
Fixes three centaur tests: input_mirror, sizeenginefunction, if_then_…else_expressions