### PR TITLE
AWS backend: sleep 60 secs and retry 5 times if download or upload fails

### DIFF
--- a/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
+++ b/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
@@ -40,6 +40,27 @@
 # AWS_CROMWELL_INPUTS
 # AWS_CROMWELL_OUTPUTS
 
+
+awscp() {
+  initExitCode=1
+  retryTimes=0
+  while [ $initExitCode -ne 0 ]
+  do
+    echo "aws s3 $1 --sse AES256 --no-progress $2 $3"
+    aws s3 $1 --sse AES256 --no-progress "$2" "$3"
+    initExitCode=$?
+    if [ $initExitCode -ne 0 ]; then
+      if [ $retryTimes -gt 4 ]; then
+        echo "Have tried 5 more times. Will exit ..."
+        exit 1
+      fi
+      echo "Copying failed. Wait for 60 secs and try again ..."
+      sleep 60
+      retryTimes=$((retryTimes+1))
+    fi
+  done
+}
+
 copyfile() {
   IFS="," read -r -a components <<< "$1"
   name=${components[0]}
@@ -71,15 +92,12 @@ copyfile() {
   if [ "$2" == "out" ]; then
     # Globbed outputs are in a specially-named directory
     if [[ "$localname" == glob-*/"*" ]]; then
-      echo "aws s3 sync --sse AES256 --no-progress ${localdirectory}/${name} ${s3location}"
-      aws s3 sync --sse AES256 --no-progress "${localdirectory}/${name}" "${s3location}"
+      awscp sync "${localdirectory}/${name}" "${s3location}"
     else
-      echo "aws s3 cp --sse AES256 --no-progress ${localdirectory}/${localname} ${s3location}"
-      aws s3 cp --sse AES256 --no-progress "${localdirectory}/${localname}" "${s3location}"
+      awscp cp "${localdirectory}/${localname}" "${s3location}"
     fi
   else
-    echo "aws s3 cp --sse AES256 --no-progress ${s3location} ${localdirectory}/${localname}"
-    aws s3 cp --sse AES256 --no-progress "${s3location}" "${localdirectory}/${localname}"
+    awscp cp "${s3location}" "${localdirectory}/${localname}"
   fi
 }
 
@@ -93,8 +111,7 @@ copyfiles() {
 
 copyToS3() {
   if [ ! -z "${1}" ]; then
-    echo "aws s3 cp --sse AES256 --no-progress ${1} ${2}"
-    aws s3 cp --sse AES256 --no-progress "${1}" "${2}"
+    awscp cp "${1}" "${2}"
   else
     echo "Variable defining file to be copied does not exist"
   fi


### PR DESCRIPTION
When download input from S3 to instance, it may fail. But the workflow will continue to run.
Retry and exit after 5 times.