### PR TITLE
PAPIv2 defensive programming

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -80,7 +80,7 @@ trait GetRequestHandler extends LazyLogging { this: RequestHandler =>
       }
     } catch {
       case npe: NullPointerException =>
-        throw new RuntimeException(s"Caught NPE while interpreting operation ${operation.getName}: ${ExceptionUtils.getStackTrace(npe)} ")
+        throw new RuntimeException(s"Caught NPE while interpreting operation ${operation.getName}: ${ExceptionUtils.getStackTrace(npe)}. JSON was $operation")
     }
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -78,7 +78,7 @@ trait GetRequestHandler { this: RequestHandler =>
       }
     } catch {
       case npe: NullPointerException =>
-        throw new RuntimeException(s"Caught NPE while processing operation ${operation.getName}: ${npe.toString}", npe)
+        throw npe
     }
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -6,7 +6,6 @@ import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.services.genomics.v2alpha1.model._
-import com.typesafe.scalalogging.LazyLogging
 import common.validation.Validation._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.RunStatus

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -60,7 +60,7 @@ trait GetRequestHandler { this: RequestHandler =>
         // preemptible is only used if the job fails, as a heuristic to guess if the VM was preempted.
         // If we can't get the value of preempted we still need to return something, returning false will not make the failure count
         // as a preemption which seems better than saying that it was preemptible when we really don't know
-        val preemptible = pipeline.exists(_.getResources.getVirtualMachine.getPreemptible.booleanValue())
+        val preemptible = pipeline.exists(pipeline => Option(pipeline.getResources.getVirtualMachine.getPreemptible).exists(_.booleanValue()))
         val instanceName = workerEvent.map(_.getInstance())
         val zone = workerEvent.map(_.getZone)
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -17,6 +17,7 @@ import cromwell.backend.google.pipelines.v2alpha1.api.Deserialization._
 import cromwell.backend.google.pipelines.v2alpha1.api.request.ErrorReporter._
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import cromwell.core.ExecutionEvent
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -79,9 +80,7 @@ trait GetRequestHandler extends LazyLogging { this: RequestHandler =>
       }
     } catch {
       case npe: NullPointerException =>
-        logger.error(s"Caught NPE while interpreting operation ${operation.getName} from the following JSON response: $operation")
-
-        throw npe
+        throw new RuntimeException(s"Caught NPE while interpreting operation ${operation.getName}: ${ExceptionUtils.getStackTrace(npe)} ")
     }
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -48,8 +48,7 @@ trait GetRequestHandler { this: RequestHandler =>
 
     try {
       if (operation.getDone) {
-        import collection.immutable.SortedMap
-        val metadata = SortedMap[String, AnyRef](operation.getMetadata.asScala.toMap.)
+        val metadata = operation.getMetadata.asScala.toMap.toSeq.sorted.toMap
         // Deserialize the response
         val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
         val pipeline: Option[Pipeline] = operation.pipeline.toErrorOr.fallBack(pollingRequest.workflowId -> operation)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -48,7 +48,8 @@ trait GetRequestHandler { this: RequestHandler =>
 
     try {
       if (operation.getDone) {
-        val metadata = operation.getMetadata.asScala.toMap
+        import collection.immutable.SortedMap
+        val metadata = SortedMap[String, AnyRef](operation.getMetadata.asScala.toMap.)
         // Deserialize the response
         val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
         val pipeline: Option[Pipeline] = operation.pipeline.toErrorOr.fallBack(pollingRequest.workflowId -> operation)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -48,7 +48,8 @@ trait GetRequestHandler { this: RequestHandler =>
 
     try {
       if (operation.getDone) {
-        val metadata = operation.getMetadata.asScala.toMap.toSeq.sorted.toMap
+        import collection.immutable.SortedMap
+        val metadata = SortedMap(operation.getMetadata.asScala.toMap.toSeq:_*)
         // Deserialize the response
         val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
         val pipeline: Option[Pipeline] = operation.pipeline.toErrorOr.fallBack(pollingRequest.workflowId -> operation)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -48,8 +48,7 @@ trait GetRequestHandler { this: RequestHandler =>
 
     try {
       if (operation.getDone) {
-        import collection.immutable.SortedMap
-        val metadata = SortedMap(operation.getMetadata.asScala.toMap.toSeq:_*)
+        val metadata = operation.getMetadata.asScala.toMap
         // Deserialize the response
         val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
         val pipeline: Option[Pipeline] = operation.pipeline.toErrorOr.fallBack(pollingRequest.workflowId -> operation)
@@ -79,7 +78,7 @@ trait GetRequestHandler { this: RequestHandler =>
       }
     } catch {
       case npe: NullPointerException =>
-        throw new RuntimeException(s"Caught NPE while processing operation ${operation.getName}: $operation", npe)
+        throw new RuntimeException(s"Caught NPE while processing operation ${operation.getName}: ${npe.toString}", npe)
     }
   }
 


### PR DESCRIPTION
`pipeline.getResources.getVirtualMachine.getPreemptible` is intended to be `null` if there was no preemption.

Aaron says,
>Client code should be updated to properly access these fields even if they are absent.

Closes https://github.com/broadinstitute/cromwell/issues/4772