### PR TITLE
Add config option to shutdown cromwell when unable to write heartbeats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 * It is now possible to supply custom `google-labels` in [workflow options](https://cromwell.readthedocs.io/en/stable/wf_options/Google/).
 
+### Heartbeat failure shutdown
+
+When a Cromwell instance is unable to write heartbeats for some period of time it will automatically shut down. For more
+information see the docs on [configuring Workflow Hearbeats](https://cromwell.readthedocs.io/en/stable/Configuring/).
+
+NOTE: In the remote chance that the `system.workflow-heartbeats.ttl` has been configured to be less than `5 minutes`
+then the new configuration value `system.workflow-heartbeats.write-failure-shutdown-duration` must also be explicitly
+set less than the `ttl`.
+
+### Bug fixes
+
+#### Better validation of workflow heartbeats
+
+An error will be thrown on startup when the `system.workflow-heartbeats.heartbeat-interval` is not less than the
+`system.workflow-heartbeats.ttl`.
+
 ## 40 Release Notes
 
 ### Config Changes

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -226,6 +226,7 @@ system {
   workflow-heartbeats {
     heartbeat-interval: 2 minutes
     ttl: 10 minutes
+    write-failure-shutdown-duration: 5 minutes
     write-batch-size: 10000
     write-threshold: 10000
   }

--- a/core/src/test/scala/cromwell/core/TestKitSuite.scala
+++ b/core/src/test/scala/cromwell/core/TestKitSuite.scala
@@ -21,10 +21,10 @@ abstract class TestKitSuite(actorSystemName: String = TestKitSuite.randomName,
     shutdown()
   }
 
-  val emptyActor = system.actorOf(Props.empty)
-  val mockIoActor = system.actorOf(MockIoActor.props())
-  val simpleIoActor = system.actorOf(SimpleIoActor.props)
-  val failIoActor = system.actorOf(FailIoActor.props())
+  val emptyActor = system.actorOf(Props.empty, "TestKitSuiteEmptyActor")
+  val mockIoActor = system.actorOf(MockIoActor.props(), "TestKitSuiteMockIoActor")
+  val simpleIoActor = system.actorOf(SimpleIoActor.props, "TestKitSuiteSimpleIoActor")
+  val failIoActor = system.actorOf(FailIoActor.props(), "TestKitSuiteFailIoActor")
 }
 
 object TestKitSuite {

--- a/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
@@ -107,13 +107,13 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
   }
 
   override def writeWorkflowHeartbeats(workflowExecutionUuids: Seq[String],
-                                       heartbeatTimestampOption: Option[Timestamp])
+                                       heartbeatTimestamp: Timestamp)
                                       (implicit ec: ExecutionContext): Future[Int] = {
     // Return the count of heartbeats written. This could legitimately be less than the size of the `workflowExecutionUuids`
     // List if any of those workflows completed and their workflow store entries were removed.
     val action = for {
       counts <- DBIO.sequence(workflowExecutionUuids map { workflowExecutionUuid =>
-        dataAccess.heartbeatForWorkflowStoreEntry(workflowExecutionUuid).update(heartbeatTimestampOption)
+        dataAccess.heartbeatForWorkflowStoreEntry(workflowExecutionUuid).update(Option(heartbeatTimestamp))
       })
     } yield counts.sum
     // Auto-commit mode, so each statement is individually committed to avoid deadlocks

--- a/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
@@ -78,7 +78,7 @@ ____    __    ____  ______   .______       __  ___  _______  __        ______   
                            (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]]
 
   def writeWorkflowHeartbeats(workflowExecutionUuids: Seq[String],
-                              heartbeatTimestampOption: Option[Timestamp])
+                              heartbeatTimestamp: Timestamp)
                              (implicit ec: ExecutionContext): Future[Int]
 
   /**

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -242,7 +242,8 @@ For more information about docker compose: [Docker compose doc](https://docs.doc
 
 **Insert Batch Size**
 
-Cromwell queues up and then inserts batches of records into the database for increased performance. You can adjust the number of database rows batch inserted by cromwell as follows:
+Cromwell queues up and then inserts batches of records into the database for increased performance. You can adjust the
+number of database rows batch inserted by Cromwell as follows:
 
 ```hocon
 database {
@@ -420,3 +421,105 @@ of how this is used for the default configuration of the `Local` backend.
 
 [cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
 [cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends
+
+### Workflow Heartbeats
+
+**Cromwell ID**
+
+Each Cromwell instance is given a `cromwell_id` that is either randomly generated or configured.
+
+By default, the Cromwell ID is `cromid-<7_digit_random_hex>`.
+
+A custom identifier may replace the "cromid" portion of the string. For example:
+
+```hocon
+system {
+  cromwell_id = "main"
+}
+```
+
+This would generates a `cromwell_id` of `main-<7_digit_random_hex>`. Each time Cromwell restarts the random part of the
+ID will change, however the `main` prefix would remain the same.
+
+If the random part of the Cromwell ID should not be generated, set the configuration value:
+
+```hocon
+system {
+  cromwell_id_random_suffix = false
+}
+```
+
+**Heartbeat TTL**
+
+When a Cromwell instance begins running or resuming a workflow it stores the above `cromwell_id` within the database row
+for the workflow, along with a timestamp called the "heartbeat". As the workflow continues to run the Cromwell instance
+will intermittently update the heartbeat for the running workflow.  If the Cromwell dies, after some time-to-live (TTL),
+the workflow has been abandoned, and will be resumed by another available Cromwell instance.
+
+Adjust the heartbeat TTL via the configuration value:
+
+```hocon
+system.workflow-heartbeats {
+  ttl = 10 minutes
+}
+```
+
+The default TTL is 10 minutes. The shortest the TTL option is 10 seconds.
+
+**Heartbeat Interval**
+
+The interval for writing heartbeats may be adjusted via:
+
+```hocon
+system.workflow-heartbeats {
+  heartbeat-interval = 2 minutes
+}
+```
+
+The default interval is 2 minutes. The shortest interval option is 3.333 seconds. The interval may not be greater than
+the TTL.
+
+**Heartbeat Failure Shutdown**
+
+Cromwell will automatically shutdown when unable to write heartbeats for a period of time. This period of time may be
+adjusted via:
+
+```hocon
+system.workflow-heartbeats {
+  write-failure-shutdown-duration = 5 minutes
+}
+```
+
+The default shutdown duration is 5 minutes. The maximum allowed shutdown duration is the TTL.
+
+**Heartbeat Batch Size**
+
+Workflow heartbeats are internally queued by Cromwell and written in batches. When the configurable batch size is
+reached, all of the heartbeats within the batch will be written at the same time, even if the heartbeat interval has not
+elapsed.
+
+This batch threshold may be adjusted via:
+
+```hocon
+system.workflow-heartbeats {
+  write-batch-size = 100
+}
+```
+
+The default batch size is 100.
+
+**Heartbeat Threshold**
+
+Cromwell writes one batch of workflow heartbeats at a time. While the internal queue of heartbeats-to-write passes above
+a configurable threshold then [instrumentation](developers/Instrumentation.md) may send a metric signal that the
+heartbeat load is above normal.
+
+This threshold may be configured the configuration value:
+
+```hocon
+system.workflow-heartbeats {
+  write-threshold = 100
+}
+```
+
+The default threshold value is 100, just like the default for the heartbeat batch size.

--- a/engine/src/main/scala/cromwell/engine/CromwellTerminator.scala
+++ b/engine/src/main/scala/cromwell/engine/CromwellTerminator.scala
@@ -1,0 +1,10 @@
+package cromwell.engine
+
+import akka.Done
+import akka.actor.CoordinatedShutdown
+
+import scala.concurrent.Future
+
+trait CromwellTerminator {
+  def beginCromwellShutdown(reason: CoordinatedShutdown.Reason): Future[Done]
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
@@ -74,8 +74,11 @@ class InMemoryWorkflowStore extends WorkflowStore {
     }
   }
 
-  override def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)])(implicit ec: ExecutionContext): Future[Int] =
+  override def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)],
+                                       heartbeatDateTime: OffsetDateTime)
+                                      (implicit ec: ExecutionContext): Future[Int] = {
     Future.successful(workflowIds.size)
+  }
 
   override def switchOnHoldToSubmitted(id: WorkflowId)(implicit ec: ExecutionContext): Future[Unit] = Future.successful(())
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -101,9 +101,11 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase) extends Workf
     }
   }
 
-  override def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)])(implicit ec: ExecutionContext): Future[Int] = {
+  override def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)],
+                                       heartbeatDateTime: OffsetDateTime)
+                                      (implicit ec: ExecutionContext): Future[Int] = {
     val sortedWorkflowIds = workflowIds.toList sortBy(_._2) map (_._1.toString)
-    sqlDatabase.writeWorkflowHeartbeats(sortedWorkflowIds, Option(OffsetDateTime.now.toSystemTimestamp))
+    sqlDatabase.writeWorkflowHeartbeats(sortedWorkflowIds, heartbeatDateTime.toSystemTimestamp)
   }
 
   /**

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfig.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfig.scala
@@ -2,22 +2,26 @@ package cromwell.engine.workflow.workflowstore
 
 import java.util.UUID
 
+import cats.syntax.apply._
+import cats.syntax.validated._
 import com.typesafe.config.{Config, ConfigFactory}
+import common.validation.ErrorOr._
+import common.validation.Validation._
 import cromwell.engine.workflow.workflowstore.WorkflowHeartbeatConfig._
 import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.syntax._
+import mouse.all._
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
-import mouse.all._
 
 /**
   *
   * @param cromwellId         Identifier for this Cromwell for horizontaling purposes.
   * @param heartbeatInterval  How long between `WorkflowActor` heartbeats and `WorkflowStoreHeartbeatWriteActor` database flushes.
   * @param ttl                Entries in the workflow store with heartbeats older than `ttl` ago are presumed abandoned and up for grabs.
+  * @param failureShutdownDuration How long writing heartbeats are allow to fail before cromwell shuts down.
   * @param writeBatchSize     The maximum size of a write batch.
   * @param writeThreshold     The threshold of heartbeat writes above which load is considered high.
   */
@@ -25,9 +29,9 @@ case class WorkflowHeartbeatConfig(
                                     cromwellId: String,
                                     heartbeatInterval: FiniteDuration,
                                     ttl: FiniteDuration,
+                                    failureShutdownDuration: FiniteDuration,
                                     writeBatchSize: Int,
-                                    writeThreshold: Int)
-{
+                                    writeThreshold: Int) {
   override def toString: String = this.asInstanceOf[WorkflowHeartbeatConfig].asJson.spaces2
 }
 
@@ -43,28 +47,60 @@ object WorkflowHeartbeatConfig {
   private[engine] implicit lazy val encodeWorkflowHeartbeatConfig: Encoder[WorkflowHeartbeatConfig] = deriveEncoder
 
   def apply(config: Config): WorkflowHeartbeatConfig = {
+    validate(config).toTry("Errors parsing WorkflowHeartbeatConfig").get
+  }
+
+  private def validate(config: Config): ErrorOr[WorkflowHeartbeatConfig] = {
     val randomSuffix = config
       .getOrElse("system.cromwell_id_random_suffix", true)
       .fold("-" + UUID.randomUUID().toString.take(7), "")
     val cromwellId: String = config.getOrElse("system.cromwell_id", "cromid") + randomSuffix
 
     val heartbeats: Config = config.getOrElse("system.workflow-heartbeats", ConfigFactory.empty())
-    // Default to 10 mins and don't allow values less than 10 secs except for testing purposes.
+    // Use defaults from reference.conf but don't allow values less than 10 secs except for testing purposes.
     val minHeartbeatTtl = config.getOrElse("danger.debug.only.minimum-heartbeat-ttl", 10.seconds)
-    val ttl: FiniteDuration = heartbeats.getOrElse("ttl", 10 minutes).max(minHeartbeatTtl)
-    // Default to one third the TTL and don't allow values less than one third of the minimum heartbeat TTL.
-    val heartbeatInterval: FiniteDuration = heartbeats.getOrElse("heartbeat-interval", ttl / 3).max(minHeartbeatTtl / 3)
+    val ttl: FiniteDuration = heartbeats.as[FiniteDuration]("ttl").max(minHeartbeatTtl)
+    // Use the defaults in reference.conf but don't allow values less than one third of the minimum TTL.
+    val heartbeatIntervalValidation: ErrorOr[FiniteDuration] = {
+      val minHeartbeatInterval = minHeartbeatTtl / 3
+      val heartbeatInterval = heartbeats.as[FiniteDuration]("heartbeat-interval") max minHeartbeatInterval
+      if (heartbeatInterval >= ttl) {
+        val errorMessage =
+          s"The system.workflow-heartbeats.heartbeat-interval ($heartbeatInterval)" +
+            s" is not less than the system.workflow-heartbeats.ttl ($ttl)."
+        errorMessage.invalidNel
+      } else {
+        heartbeatInterval.valid
+      }
+    }
 
-    // Default and sanity bound all other parameters as well.
-    val writeBatchSize: Int = Math.max(heartbeats.getOrElse("write-batch-size", 100), 1)
-    val writeThreshold: Int = Math.max(heartbeats.getOrElse("write-threshold", 100), 1)
+    val failureShutdownDurationValidation: ErrorOr[FiniteDuration] = {
+      // Don't allow shutdown duration to be more than the heartbeat TTL.
+      val failureShutdownDuration = heartbeats.as[FiniteDuration]("write-failure-shutdown-duration") max 0.seconds
+      if (failureShutdownDuration > ttl) {
+        val errorMessage =
+          s"The system.workflow-heartbeats.write-failure-shutdown-duration ($failureShutdownDuration)" +
+            s" is greater than the system.workflow-heartbeats.ttl ($ttl)."
+        errorMessage.invalidNel
+      } else {
+        failureShutdownDuration.valid
+      }
+    }
 
-    WorkflowHeartbeatConfig(
-      cromwellId = cromwellId,
-      heartbeatInterval = heartbeatInterval,
-      ttl = ttl,
-      writeBatchSize = writeBatchSize,
-      writeThreshold = writeThreshold
-    )
+    // Sanity bound all other parameters as well.
+    val writeBatchSize: Int = heartbeats.getInt("write-batch-size") max 1
+    val writeThreshold: Int = heartbeats.getInt("write-threshold") max 1
+
+    (heartbeatIntervalValidation, failureShutdownDurationValidation) mapN {
+      (heartbeatInterval, failureShutdownDuration) =>
+        WorkflowHeartbeatConfig(
+          cromwellId = cromwellId,
+          heartbeatInterval = heartbeatInterval,
+          ttl = ttl,
+          failureShutdownDuration = failureShutdownDuration,
+          writeBatchSize = writeBatchSize,
+          writeThreshold = writeThreshold
+        )
+    }
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -38,7 +38,9 @@ trait WorkflowStore {
     */
   def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
 
-  def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)])(implicit ec: ExecutionContext): Future[Int]
+  def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)],
+                              heartbeatDateTime: OffsetDateTime)
+                             (implicit ec: ExecutionContext): Future[Int]
 
   def switchOnHoldToSubmitted(id: WorkflowId)(implicit ec: ExecutionContext): Future[Unit]
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
@@ -7,6 +7,7 @@ import akka.pattern.pipe
 import cats.data.NonEmptyList
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core._
+import cromwell.engine.CromwellTerminator
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 
@@ -14,6 +15,7 @@ final case class WorkflowStoreActor private(
                                              workflowStore: WorkflowStore,
                                              workflowStoreAccess: WorkflowStoreAccess,
                                              serviceRegistryActor: ActorRef,
+                                             terminator: CromwellTerminator,
                                              abortAllJobsOnTerminate: Boolean,
                                              workflowHeartbeatConfig: WorkflowHeartbeatConfig)
   extends Actor with ActorLogging with GracefulShutdownHelper {
@@ -40,6 +42,7 @@ final case class WorkflowStoreActor private(
     WorkflowStoreHeartbeatWriteActor.props(
       workflowStoreAccess = workflowStoreAccess,
       workflowHeartbeatConfig = workflowHeartbeatConfig,
+      terminator = terminator,
       serviceRegistryActor = serviceRegistryActor),
     "WorkflowStoreHeartbeatWriteActor")
 
@@ -82,6 +85,7 @@ object WorkflowStoreActor {
              workflowStoreDatabase: WorkflowStore,
              workflowStoreAccess: WorkflowStoreAccess,
              serviceRegistryActor: ActorRef,
+             terminator: CromwellTerminator,
              abortAllJobsOnTerminate: Boolean,
              workflowHeartbeatConfig: WorkflowHeartbeatConfig
       ) = {
@@ -89,6 +93,7 @@ object WorkflowStoreActor {
       workflowStore = workflowStoreDatabase,
       workflowStoreAccess = workflowStoreAccess,
       serviceRegistryActor = serviceRegistryActor,
+      terminator = terminator,
       abortAllJobsOnTerminate = abortAllJobsOnTerminate,
       workflowHeartbeatConfig = workflowHeartbeatConfig)).withDispatcher(EngineDispatcher)
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActor.scala
@@ -30,15 +30,16 @@ class WorkflowStoreCoordinatedAccessActor(workflowStore: WorkflowStore) extends 
   }
 
   override def receive: Receive = {
-    case WriteHeartbeats(ids) =>
-      workflowStore.writeWorkflowHeartbeats(ids.toVector.toSet) |> run
+    case WriteHeartbeats(ids, heartbeatDateTime) =>
+      workflowStore.writeWorkflowHeartbeats(ids.toVector.toSet, heartbeatDateTime) |> run
     case FetchStartableWorkflows(count, cromwellId, heartbeatTtl) =>
       workflowStore.fetchStartableWorkflows(count, cromwellId, heartbeatTtl) |> run
   }
 }
 
 object WorkflowStoreCoordinatedAccessActor {
-  final case class WriteHeartbeats(workflowIds: NonEmptyVector[(WorkflowId, OffsetDateTime)])
+  final case class WriteHeartbeats(workflowIds: NonEmptyVector[(WorkflowId, OffsetDateTime)],
+                                   heartbeatDateTime: OffsetDateTime)
   final case class FetchStartableWorkflows(count: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
 
   val Timeout = 1 minute

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActor.scala
@@ -1,19 +1,25 @@
 package cromwell.engine.workflow.workflowstore
 
-import java.time.OffsetDateTime
+import java.time.{OffsetDateTime, Duration => JDuration}
+import java.util.concurrent.TimeUnit
 
-import akka.actor.{ActorRef, Props}
+import akka.actor.{ActorRef, CoordinatedShutdown, Props}
 import cats.data.{NonEmptyList, NonEmptyVector}
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.WorkflowId
 import cromwell.core.instrumentation.InstrumentationPrefixes
+import cromwell.engine.CromwellTerminator
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowStoreWriteHeartbeatCommand
 import cromwell.services.EnhancedBatchActor
+import mouse.all._
 
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success, Try}
 
 case class WorkflowStoreHeartbeatWriteActor(workflowStoreAccess: WorkflowStoreAccess,
                                             workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+                                            terminator: CromwellTerminator,
                                             override val serviceRegistryActor: ActorRef)
 
   extends EnhancedBatchActor[(WorkflowId, OffsetDateTime)](
@@ -22,13 +28,23 @@ case class WorkflowStoreHeartbeatWriteActor(workflowStoreAccess: WorkflowStoreAc
 
   override val threshold = workflowHeartbeatConfig.writeThreshold
 
+  private val failureShutdownDuration = workflowHeartbeatConfig.failureShutdownDuration
+
+  //noinspection ActorMutableStateInspection
+  private var lastSuccessOption: Option[OffsetDateTime] = None
+
   /**
     * Process the data asynchronously
     *
     * @return the number of elements processed
     */
   override protected def process(data: NonEmptyVector[(WorkflowId, OffsetDateTime)]): Future[Int] = instrumentedProcess {
-    workflowStoreAccess.writeWorkflowHeartbeats(data)
+    val heartbeatDateTime = OffsetDateTime.now()
+    val processFuture = workflowStoreAccess.writeWorkflowHeartbeats(data, heartbeatDateTime)
+    processFuture transform {
+      // Track the `Try`, and then return the original `Try`. Similar to `andThen` but doesn't swallow exceptions.
+      _ <| trackRepeatedFailures(heartbeatDateTime, data.length)
+    }
   }
 
   override def receive = enhancedReceive.orElse(super.receive)
@@ -38,18 +54,67 @@ case class WorkflowStoreHeartbeatWriteActor(workflowStoreAccess: WorkflowStoreAc
   override def commandToData(snd: ActorRef): PartialFunction[Any, (WorkflowId, OffsetDateTime)] = {
     case command: WorkflowStoreWriteHeartbeatCommand => (command.workflowId, command.submissionTime)
   }
+
+  /*
+  WARNING: Even though this is in an actor, the logic deals with instances of Future that could complete in _any_ order,
+  and even call this method at the same time from different threads.
+
+  We are expecting the underlying FSM to ensure that the call to this method does NOT occur in parallel, waiting for
+  the call to `process` to complete.
+   */
+  private def trackRepeatedFailures(heartbeatDateTime: OffsetDateTime, workflowCount: Int)(processTry: Try[Int]): Unit = {
+    processTry match {
+      case Success(_) =>
+        lastSuccessOption = Option(heartbeatDateTime)
+      case Failure(_: Exception) =>
+        /*
+        If this is the first time processing heartbeats, then initialize the "last success" to when this heartbeat check
+        began. This allows configuring the failure shutdown as low as zero seconds.
+         */
+        val lastSuccess = lastSuccessOption getOrElse {
+          lastSuccessOption = Option(heartbeatDateTime)
+          heartbeatDateTime
+        }
+        val now = OffsetDateTime.now()
+        val failureJDuration = JDuration.between(lastSuccess, now)
+        if (failureJDuration.toNanos >= failureShutdownDuration.toNanos) {
+          val failureUnits = failureShutdownDuration.unit
+          val failureLength = FiniteDuration(failureJDuration.toNanos, TimeUnit.NANOSECONDS).toUnit(failureUnits)
+          log.error(String.format(
+            "Shutting down %s as at least %s of heartbeat write errors have occurred between %s and %s (%s %s)",
+            workflowHeartbeatConfig.cromwellId,
+            failureShutdownDuration,
+            lastSuccess,
+            now,
+            failureLength.toString,
+            failureUnits.toString.toLowerCase
+          ))
+          terminator.beginCromwellShutdown(WorkflowStoreHeartbeatWriteActor.Shutdown)
+        }
+        ()
+      case Failure(throwable) =>
+        log.error(throwable, s"Shutting down due to ${throwable.getMessage}")
+        terminator.beginCromwellShutdown(WorkflowStoreHeartbeatWriteActor.Shutdown)
+        ()
+    }
+  }
+
 }
 
 object WorkflowStoreHeartbeatWriteActor {
+  object Shutdown extends CoordinatedShutdown.Reason
+
   def props(
              workflowStoreAccess: WorkflowStoreAccess,
              workflowHeartbeatConfig: WorkflowHeartbeatConfig,
+             terminator: CromwellTerminator,
              serviceRegistryActor: ActorRef
            ): Props =
     Props(
       WorkflowStoreHeartbeatWriteActor(
         workflowStoreAccess = workflowStoreAccess,
         workflowHeartbeatConfig = workflowHeartbeatConfig,
+        terminator = terminator,
         serviceRegistryActor = serviceRegistryActor
       )).withDispatcher(EngineDispatcher)
 }

--- a/engine/src/main/scala/cromwell/server/CromwellServer.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellServer.scala
@@ -26,7 +26,13 @@ object CromwellServer {
 }
 
 class CromwellServerActor(cromwellSystem: CromwellSystem, gracefulShutdown: Boolean, abortJobsOnTerminate: Boolean)(override implicit val materializer: ActorMaterializer)
-  extends CromwellRootActor(gracefulShutdown, abortJobsOnTerminate, serverMode = true)
+  extends CromwellRootActor(
+    terminator = cromwellSystem,
+    gracefulShutdown = gracefulShutdown,
+    abortJobsOnTerminate = abortJobsOnTerminate,
+    serverMode = true,
+    config = cromwellSystem.config
+  )
     with CromwellApiService
     with CromwellInstrumentationActor
     with WesRouteSupport
@@ -36,7 +42,7 @@ class CromwellServerActor(cromwellSystem: CromwellSystem, gracefulShutdown: Bool
   override implicit val ec = context.dispatcher
   override def actorRefFactory: ActorContext = context
 
-  val webserviceConf = cromwellSystem.conf.getConfig("webservice")
+  val webserviceConf = cromwellSystem.config.getConfig("webservice")
   val interface = webserviceConf.getString("interface")
   val port = webserviceConf.getInt("port")
 

--- a/engine/src/test/scala/cromwell/engine/MockCromwellTerminator.scala
+++ b/engine/src/test/scala/cromwell/engine/MockCromwellTerminator.scala
@@ -1,0 +1,12 @@
+package cromwell.engine
+
+import akka.Done
+import akka.actor.CoordinatedShutdown
+
+import scala.concurrent.Future
+
+object MockCromwellTerminator extends CromwellTerminator {
+  override def beginCromwellShutdown(notUsed: CoordinatedShutdown.Reason): Future[Done] = {
+    Future.successful(Done)
+  }
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
@@ -80,7 +80,7 @@ class SqlWorkflowStoreSpec extends FlatSpec with Matchers with ScalaFutures with
           _ = startableWorkflows.map(_.id).intersect(submissionResponses.map(_.id).toList) should be(empty)
           abortWorkflowId = submissionResponses.head.id
           _ <- workflowStore.switchOnHoldToSubmitted(abortWorkflowId)
-          _ <- workflowStore.writeWorkflowHeartbeats(Set((abortWorkflowId, OffsetDateTime.now)))
+          _ <- workflowStore.writeWorkflowHeartbeats(Set((abortWorkflowId, OffsetDateTime.now)), OffsetDateTime.now)
           workflowStoreAbortResponse <- workflowStore.aborting(abortWorkflowId)
           _ = workflowStoreAbortResponse should be(WorkflowStoreAbortResponse.AbortedOnHoldOrSubmitted)
         } yield ()).futureValue
@@ -121,7 +121,7 @@ class SqlWorkflowStoreSpec extends FlatSpec with Matchers with ScalaFutures with
             WorkflowStoreState.Submitted.toString,
             WorkflowStoreState.Running.toString
           )
-          _ <- workflowStore.writeWorkflowHeartbeats(Set((abortWorkflowId, OffsetDateTime.now)))
+          _ <- workflowStore.writeWorkflowHeartbeats(Set((abortWorkflowId, OffsetDateTime.now)), OffsetDateTime.now)
           workflowStoreAbortResponse <- workflowStore.aborting(abortWorkflowId)
           _ = workflowStoreAbortResponse should be(WorkflowStoreAbortResponse.AbortRequested)
         } yield ()).futureValue

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfigSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowHeartbeatConfigSpec.scala
@@ -1,0 +1,163 @@
+package cromwell.engine.workflow.workflowstore
+
+import com.typesafe.config.ConfigFactory
+import common.exception.AggregatedMessageException
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.duration._
+
+class WorkflowHeartbeatConfigSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
+
+  behavior of "WorkflowHeartbeatConfig"
+
+  it should "generate a default config" in {
+    val workflowHeartbeatConfig = WorkflowHeartbeatConfig(WorkflowHeartbeatConfigSpec.DefaultConfig)
+    workflowHeartbeatConfig.cromwellId should startWith("cromid-")
+    workflowHeartbeatConfig.cromwellId should have length 14
+    workflowHeartbeatConfig.heartbeatInterval should be (2.minutes)
+    workflowHeartbeatConfig.ttl should be(10.minutes)
+    workflowHeartbeatConfig.failureShutdownDuration should be(5.minutes)
+    workflowHeartbeatConfig.writeBatchSize should be(10000)
+    workflowHeartbeatConfig.writeThreshold should be(10000)
+  }
+
+  private val validConfigTests = Table(
+    ("description", "config", "expected"),
+    (
+      "from an empty config",
+      "system.cromwell_id_random_suffix = false",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 10.minutes, 5.minutes, 10000, 10000),
+    ),
+    (
+      "with a specified cromid",
+      """system.cromwell_id = "new_crom_name"""",
+      WorkflowHeartbeatConfig("new_crom_name", 2.minutes, 10.minutes, 5.minutes, 10000, 10000),
+    ),
+    (
+      "with a specified heartbeat interval",
+      "system.workflow-heartbeats.heartbeat-interval = 3 minutes",
+      WorkflowHeartbeatConfig("cromid", 3.minutes, 10.minutes, 5.minutes, 10000, 10000),
+    ),
+    (
+      "with a specified ttl",
+      "system.workflow-heartbeats.ttl = 5 minutes",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 5.minutes, 5.minutes, 10000, 10000),
+    ),
+    (
+      "with a ttl less than the default heartbeat interval",
+      """|system.workflow-heartbeats.ttl = 1 minutes
+         |system.workflow-heartbeats.heartbeat-interval = 59 seconds
+         |system.workflow-heartbeats.write-failure-shutdown-duration = 0 minutes
+         |""".stripMargin,
+      WorkflowHeartbeatConfig("cromid", 59.seconds, 1.minutes, 0.minutes, 10000, 10000),
+    ),
+    (
+      "with a specified shutdown duration",
+      "system.workflow-heartbeats.write-failure-shutdown-duration = 1 minute",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 10.minutes, 1.minute, 10000, 10000),
+    ),
+    (
+      "with a specified batch size",
+      "system.workflow-heartbeats.write-batch-size = 2000",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 10.minutes, 5.minutes, 2000, 10000),
+    ),
+    (
+      "with a specified threshold",
+      "system.workflow-heartbeats.write-threshold = 5000",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 10.minutes, 5.minutes, 10000, 5000),
+    ),
+    (
+      "when trying to set the ttl below the minimum",
+      """|system.workflow-heartbeats.ttl = 9 seconds
+         |system.workflow-heartbeats.heartbeat-interval = 8 seconds
+         |system.workflow-heartbeats.write-failure-shutdown-duration = 0 minutes
+         |""".stripMargin,
+      WorkflowHeartbeatConfig("cromid", 8.seconds, 10.seconds, 0.minutes, 10000, 10000),
+    ),
+    (
+      "when trying to set the interval below the minimum",
+      "system.workflow-heartbeats.heartbeat-interval = 3 seconds",
+      WorkflowHeartbeatConfig("cromid", 10.seconds / 3, 10.minutes, 5.minutes, 10000, 10000),
+    ),
+    (
+      "when trying to set a negative shutdown duration",
+      "system.workflow-heartbeats.write-failure-shutdown-duration = -1 seconds",
+      WorkflowHeartbeatConfig("cromid", 2.minutes, 10.minutes, 0.minutes, 10000, 10000),
+    ),
+  )
+
+  forAll(validConfigTests) { (description, configString, expected) =>
+    it should s"create an instance $description" in {
+      val config = ConfigFactory.parseString(
+        // Remove the randomness from the cromid
+        s"""|system.cromwell_id_random_suffix = false
+            |$configString
+            |""".stripMargin
+      ).withFallback(WorkflowHeartbeatConfigSpec.DefaultConfig)
+      WorkflowHeartbeatConfig(config) should be(expected)
+    }
+  }
+
+  private val invalidConfigTests = Table(
+    ("description", "config", "expected"),
+    (
+      "when the heartbeat interval is equal to the ttl",
+      """|system.workflow-heartbeats {
+         |  ttl = 2 minutes
+         |  write-failure-shutdown-duration = 0 seconds
+         |}
+         |""".stripMargin,
+      AggregatedMessageException(
+        "Errors parsing WorkflowHeartbeatConfig",
+        List(
+          "The system.workflow-heartbeats.heartbeat-interval (2 minutes)" +
+            " is not less than the system.workflow-heartbeats.ttl (2 minutes).",
+        )
+      )
+    ),
+    (
+      "when the heartbeat interval is not less than the ttl",
+      """|system.workflow-heartbeats {
+         |  ttl = 1 minute
+         |  write-failure-shutdown-duration = 0 seconds
+         |}
+         |""".stripMargin,
+      AggregatedMessageException(
+        "Errors parsing WorkflowHeartbeatConfig",
+        List(
+          "The system.workflow-heartbeats.heartbeat-interval (2 minutes)" +
+            " is not less than the system.workflow-heartbeats.ttl (1 minute).",
+        )
+      )
+    ),
+    (
+      "when the failure duration is greater than the ttl",
+      """|system.workflow-heartbeats {
+         |  ttl = 5 minutes
+         |  write-failure-shutdown-duration = 301 seconds
+         |}
+         |""".stripMargin,
+      AggregatedMessageException(
+        "Errors parsing WorkflowHeartbeatConfig",
+        List(
+          "The system.workflow-heartbeats.write-failure-shutdown-duration (301 seconds)" +
+            " is greater than the system.workflow-heartbeats.ttl (5 minutes).",
+        )
+      )
+    ),
+  )
+
+  forAll(invalidConfigTests) { (description, configString, expected: AggregatedMessageException) =>
+    it should s"fail to create an instance $description" in {
+      val config = ConfigFactory.parseString(configString).withFallback(WorkflowHeartbeatConfigSpec.DefaultConfig)
+      val exception = the[AggregatedMessageException] thrownBy WorkflowHeartbeatConfig(config)
+      exception.getMessage should be(expected.getMessage)
+      exception.errorMessages should contain theSameElementsAs expected.errorMessages
+    }
+  }
+}
+
+object WorkflowHeartbeatConfigSpec {
+  val DefaultConfig = ConfigFactory.load()
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreHeartbeatWriteActorSpec.scala
@@ -1,0 +1,75 @@
+package cromwell.engine.workflow.workflowstore
+
+import java.time.OffsetDateTime
+
+import akka.Done
+import akka.actor.CoordinatedShutdown
+import com.typesafe.config.ConfigFactory
+import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.engine.CromwellTerminator
+import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowStoreWriteHeartbeatCommand
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NoStackTrace
+
+class WorkflowStoreHeartbeatWriteActorSpec extends TestKitSuite("WorkflowStoreHeartbeatWriteActorSpec")
+  with FlatSpecLike with Matchers with Eventually {
+
+  behavior of "WorkflowStoreHeartbeatWriteActor"
+
+  it should "send a shutdown signal when unable to write workflow heartbeats" in {
+
+    var shutdownCalled = false
+
+    val workflowStore = new InMemoryWorkflowStore {
+      override def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)],
+                                           heartbeatDateTime: OffsetDateTime)
+                                          (implicit ec: ExecutionContext): Future[Int] = {
+        Future.failed(new RuntimeException("this is expected") with NoStackTrace)
+      }
+    }
+
+    val workflowStoreAccess = UncoordinatedWorkflowStoreAccess(workflowStore)
+    val workflowHeartbeatTypesafeConfig = ConfigFactory.parseString(
+      """|danger.debug.only.minimum-heartbeat-ttl = 10 ms
+         |system.workflow-heartbeats {
+         |  heartbeat-interval = 500 ms
+         |  write-batch-size = 1
+         |  write-failure-shutdown-duration = 1 s
+         |}
+         |""".stripMargin
+    ).withFallback(ConfigFactory.load())
+    val workflowHeartbeatConfig = WorkflowHeartbeatConfig(workflowHeartbeatTypesafeConfig)
+    val terminator = new CromwellTerminator {
+      override def beginCromwellShutdown(reason: CoordinatedShutdown.Reason): Future[Done] = {
+        shutdownCalled = true
+        Future.successful(Done)
+      }
+    }
+    val serviceRegistryActor = emptyActor
+    val workflowStoreHeartbeatWriteActor = system.actorOf(
+      WorkflowStoreHeartbeatWriteActor.props(
+        workflowStoreAccess,
+        workflowHeartbeatConfig,
+        terminator,
+        serviceRegistryActor
+      ),
+      "WorkflowStoreHeartbeatWriteActor"
+    )
+
+    val workflowId = WorkflowId.randomId()
+    val submissionTime = OffsetDateTime.now()
+
+    implicit val patienceConfig = PatienceConfig(timeout = 30.seconds, interval = 200.milliseconds)
+    eventually {
+      if (!shutdownCalled) {
+        // Workflow heartbeats are not automatically retried. Instead, write the heartbeat each time we retry.
+        workflowStoreHeartbeatWriteActor ! WorkflowStoreWriteHeartbeatCommand(workflowId, submissionTime)
+        fail("shutdown was not called")
+      }
+    }
+  }
+}

--- a/server/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowManagerActorSpec.scala
@@ -78,7 +78,7 @@ class WorkflowManagerActorSpec extends CromwellTestKitWordSpec with WorkflowDesc
           )
       }
 
-      val config = CromwellTestKitSpec.DefaultConfig.
+      val config = CromwellTestKitSpec.NooPServiceActorConfig.
         withValue("system.max-concurrent-workflows", ConfigValueFactory.fromAnyRef(2)).
         withValue("system.new-workflow-poll-rate", ConfigValueFactory.fromAnyRef(1))
 

--- a/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/SingleWorkflowRunnerActorSpec.scala
@@ -7,16 +7,16 @@ import akka.pattern.ask
 import akka.stream.ActorMaterializer
 import akka.testkit._
 import akka.util.Timeout
-import com.typesafe.config.ConfigFactory
 import cromwell.CromwellTestKitSpec._
 import cromwell._
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import cromwell.core.{SimpleIoActor, WorkflowSourceFilesCollection}
+import cromwell.engine.MockCromwellTerminator
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.SingleWorkflowRunnerActor.RunWorkflow
 import cromwell.engine.workflow.SingleWorkflowRunnerActorSpec._
-import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.Rate
+import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor
 import cromwell.engine.workflow.workflowstore._
 import cromwell.util.SampleWdl
 import cromwell.util.SampleWdl.{ExpressionsInInputs, GoodbyeWorld, ThreeStep}
@@ -52,29 +52,53 @@ object SingleWorkflowRunnerActorSpec {
 
   class TestSingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
                                       metadataOutputPath: Option[Path])(implicit materializer: ActorMaterializer)
-    extends SingleWorkflowRunnerActor(source, metadataOutputPath, false, false) {
+    extends SingleWorkflowRunnerActor(
+      source = source,
+      metadataOutputPath = metadataOutputPath,
+      terminator = MockCromwellTerminator,
+      gracefulShutdown = false,
+      abortJobsOnTerminate = false,
+      config = CromwellTestKitSpec.DefaultConfig
+    ) {
     override lazy val serviceRegistryActor = CromwellTestKitSpec.ServiceRegistryActorInstance
     override private [workflow] def done() = context.stop(self)
   }
 }
 
 abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec with CoordinatedWorkflowStoreBuilder with Mockito {
-  private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(ConfigFactory.load())
+  private val workflowHeartbeatConfig = WorkflowHeartbeatConfig(CromwellTestKitSpec.DefaultConfig)
   val store = new InMemoryWorkflowStore
   private val workflowStore =
-    system.actorOf(WorkflowStoreActor.props(store, store |> access, dummyServiceRegistryActor, abortAllJobsOnTerminate = false, workflowHeartbeatConfig))
-  private val serviceRegistry = TestProbe().ref
-  private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props)
-  private val ioActor = system.actorOf(SimpleIoActor.props)
-  private val subWorkflowStore = system.actorOf(AlwaysHappySubWorkflowStoreActor.props)
-  private val callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props)
-  private val callCacheWriteActor = system.actorOf(EmptyCallCacheWriteActor.props)
-  private val dockerHashActor = system.actorOf(EmptyDockerHashActor.props)
-  private val jobTokenDispenserActor = system.actorOf(JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second), None))
+    system.actorOf(
+      WorkflowStoreActor.props(
+        store,
+        store |> access,
+        dummyServiceRegistryActor,
+        MockCromwellTerminator,
+        abortAllJobsOnTerminate = false,
+        workflowHeartbeatConfig
+      ),
+      "WorkflowStoreActor"
+    )
+  private val serviceRegistry = TestProbe("ServiceRegistryProbe").ref
+  private val jobStore = system.actorOf(AlwaysHappyJobStoreActor.props, "AlwaysHappyJobStoreActor")
+  private val ioActor = system.actorOf(SimpleIoActor.props, "SimpleIoActor")
+  private val subWorkflowStore = system.actorOf(
+    AlwaysHappySubWorkflowStoreActor.props,
+    "AlwaysHappySubWorkflowStoreActor"
+  )
+  private val callCacheReadActor = system.actorOf(EmptyCallCacheReadActor.props, "EmptyCallCacheReadActor")
+  private val callCacheWriteActor = system.actorOf(EmptyCallCacheWriteActor.props, "EmptyCallCacheWriteActor")
+  private val dockerHashActor = system.actorOf(EmptyDockerHashActor.props, "EmptyDockerHashActor")
+  private val jobTokenDispenserActor = system.actorOf(
+    JobExecutionTokenDispenserActor.props(serviceRegistry, Rate(100, 1.second), None),
+    "JobExecutionTokenDispenserActor"
+  )
 
 
   def workflowManagerActor(): ActorRef = {
-    val params = WorkflowManagerActorParams(ConfigFactory.load(),
+    val params = WorkflowManagerActorParams(
+      CromwellTestKitSpec.DefaultConfig,
       workflowStore = workflowStore,
       ioActor = ioActor,
       serviceRegistryActor = dummyServiceRegistryActor,
@@ -93,7 +117,10 @@ abstract class SingleWorkflowRunnerActorSpec extends CromwellTestKitWordSpec wit
   
   def createRunnerActor(sampleWdl: SampleWdl = ThreeStep, managerActor: => ActorRef = workflowManagerActor(),
                           outputFile: => Option[Path] = None): ActorRef = {
-    system.actorOf(Props(new TestSingleWorkflowRunnerActor(sampleWdl.asWorkflowSources(), outputFile)))
+    system.actorOf(
+      Props(new TestSingleWorkflowRunnerActor(sampleWdl.asWorkflowSources(), outputFile)),
+      "TestSingleWorkflowRunnerActor"
+    )
   }
 
   def singleWorkflowActor(sampleWdl: SampleWdl = ThreeStep, managerActor: => ActorRef = workflowManagerActor(),

--- a/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/InstrumentedBatchActor.scala
@@ -5,6 +5,7 @@ import cromwell.core.actor.BatchActor
 import cromwell.services.instrumentation.InstrumentedBatchActor.{QueueSizeTimerAction, QueueSizeTimerKey}
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 object InstrumentedBatchActor {
   case object QueueSizeTimerKey
@@ -26,6 +27,7 @@ trait InstrumentedBatchActor[C] { this: BatchActor[C] with CromwellInstrumentati
     instrumentationPath.concatNel(NonEmptyList.one(name))
 
   private val processedPath = makePath("processed")
+  private val failurePath = makePath("failure")
   private val queueSizePath = makePath("queue")
 
   timers.startSingleTimer(QueueSizeTimerKey, QueueSizeTimerAction, CromwellInstrumentation.InstrumentationRate)
@@ -49,7 +51,10 @@ trait InstrumentedBatchActor[C] { this: BatchActor[C] with CromwellInstrumentati
     */
   protected def instrumentedProcess(f: => Future[Int]) = {
     val action = f
-    action foreach { n => count(processedPath, n.toLong, instrumentationPrefix) }
+    action onComplete {
+      case Success(numProcessed) => count(processedPath, numProcessed.toLong, instrumentationPrefix)
+      case Failure(_) => count(failurePath, 1L, instrumentationPrefix)
+    }
     action
   }
 }


### PR DESCRIPTION
- Additional wiring for the cromwell terminator.
- Reduced duplicate calls to ConfigFactory.load().
- Increased ability to pass around test configs.
- Provide names for more actors.
- Instrument failures in batch actors.