### PR TITLE
Tactical fix for centaur AWS 429s

### DIFF
--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -3,7 +3,7 @@ include "build_application.inc.conf"
 
 system.job-rate-control {
   jobs = 1
-  per = 500 milliseconds
+  per = 1 second
 }
 
 aws {

--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -3,7 +3,7 @@ include "build_application.inc.conf"
 
 system.job-rate-control {
   jobs = 1
-  per = 1 second
+  per = 2 seconds
 }
 
 aws {
@@ -60,6 +60,3 @@ backend {
     }
   }
 }
-
-system.job-rate-control.jobs = 1
-system.job-rate-control.per = 2 seconds

--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -1,6 +1,11 @@
 include required(classpath("application"))
 include "build_application.inc.conf"
 
+system.job-rate-control {
+  jobs = 1
+  per = 500 milliseconds
+}
+
 aws {
 
   application-name = "cromwell"

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -234,9 +234,10 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
    *  @return Current RunStatus
    *
    */
-  def status(jobId: String): Try[RunStatus] = {
-     RunStatus.fromJobStatus(detail(jobId).status, jobId)
-  }
+  def status(jobId: String): Try[RunStatus] = for {
+    statusString <- Try(detail(jobId).status)
+    runStatus <- RunStatus.fromJobStatus(statusString, jobId)
+  } yield runStatus
 
   def detail(jobId: String): JobDetail = {
     //TODO: This client call should be wrapped in a cats Effect


### PR DESCRIPTION
~~Might not make much difference until *all* our PRs are rebased to include this throttle~~

Actually this PR is more about allowing the AWS backend to hook into the existing poll retry logic to allow more resilience in the face of "429 / Too Many Request" exceptions during status polling.