### PR TITLE
CWL conformance: always set basename in outputs

### DIFF
--- a/centaurCwlRunner/src/main/scala/centaur/cwl/OutputManipulator.scala
+++ b/centaurCwlRunner/src/main/scala/centaur/cwl/OutputManipulator.scala
@@ -134,9 +134,8 @@ object OutputManipulator extends Poly1 {
       val defaultSize = sizeContent.orElse(sizeFile(path)).map(Json.fromLong).getOrElse(Json.Null)
       val size = valueOrNull("size", defaultSize)
 
-      val basename: Option[Json] = if (isInsideDirectory) {
+      val basename: Option[Json] =
         Option(valueOrNull("basename", path.exists.option(path.nameWithoutExtension).map(Json.fromString).getOrElse(Json.Null)))
-      } else None
 
       /*
       In order of priority use:


### PR DESCRIPTION
This change is necessary, but not sufficient, for us to pass conformance #135, i.e. packed CWL.

We do not yet run #135 because it was added after our pinned commit. Once the other other necessary change, https://github.com/common-workflow-language/common-workflow-language/pull/849, lands I will make a PR to bump the pinned test cases.

I should disclose that I am aware of [an old comment](https://github.com/broadinstitute/cromwell/pull/3468#discussion_r178306868) explaining why the conditional is necessary, but conformance passes on the branch and as we say the proof of the pudding is in the eating.