### PR TITLE
Custom google labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cromwell Change Log
 
+## 41 Release Notes
+
+### Workflow Options
+
+* It is now possible to supply custom `google-labels` in [workflow options](https://cromwell.readthedocs.io/en/stable/wf_options/Google/).
+
 ## 40 Release Notes
 
 ### Config Changes

--- a/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
+++ b/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
@@ -1,5 +1,5 @@
 {
   "google_labels": {
-    "custom-label-label-label-label-label-label-label": "0custom-value"
+    "custom-label-label-label-label-label-label-label-label-label-label": "0custom-value"
   }
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
+++ b/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
@@ -1,0 +1,5 @@
+{
+  "google_labels": {
+    "custom-label-label-label-label-label-label-label": "0custom-value"
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels/good_options.json
+++ b/centaur/src/main/resources/standardTestCases/google_labels/good_options.json
@@ -1,4 +1,5 @@
 {
+  "read_from_cache": false,
   "google_labels": {
     "custom-label": "custom-value"
   }

--- a/centaur/src/main/resources/standardTestCases/google_labels/good_options.json
+++ b/centaur/src/main/resources/standardTestCases/google_labels/good_options.json
@@ -1,0 +1,5 @@
+{
+  "google_labels": {
+    "custom-label": "custom-value"
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
+++ b/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
@@ -25,6 +25,10 @@ workflow google_labels {
     ] }
   }
 
+  output {
+    Boolean done = true
+  }
+
 }
 
 task check_labels {

--- a/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
+++ b/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
@@ -1,0 +1,30 @@
+version 1.0
+
+workflow google_labels {
+  call check_labels
+}
+
+task check_labels {
+
+  meta {
+    description: "Confirms that the google_labels workflow option is propogated correctly to tasks"
+  }
+
+  command {
+    # Check that the task metadata is correct:
+    INSTANCE=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google")
+    TOKEN=$(gcloud auth application-default print-access-token)
+    INSTANCE_INFO=$(curl -s "https://www.googleapis.com/compute/v1/projects/broad-dsde-cromwell-dev/zones/us-central1-c/instances/$INSTANCE" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H 'Accept: application/json')
+
+    # Check for the custom label in the instance info:
+    echo $INSTANCE_INFO | grep -q '"custom-label": "custom-value"' || echo "Couldn't find custom-label in instance info: $INSTANCE_INFO" 1>&2
+  }
+  runtime {
+    docker: "google/cloud-sdk:slim"
+    zones: ["us-central1-c"]
+
+    failOnStderr: true
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
+++ b/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
@@ -3,7 +3,7 @@ version 1.0
 workflow google_labels {
 
   meta {
-    description: "Confirms that the google_labels workflow option is propogated correctly to tasks"
+    description: "Confirms that the google_labels workflow option is propagated correctly to tasks"
   }
 
   input {
@@ -50,8 +50,6 @@ task check_labels {
   }
   runtime {
     docker: "google/cloud-sdk:slim"
-    zones: ["us-central1-c"]
-
     failOnStderr: true
   }
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
+++ b/centaur/src/main/resources/standardTestCases/google_labels/google_labels.wdl
@@ -50,6 +50,8 @@ task check_labels {
   }
   runtime {
     docker: "google/cloud-sdk:slim"
+    # Specify this zone because it's used in the curl commands above. We probably *could* work this out ad-hoc but it's easier to hard-code it here:
+    zones: ["us-central1-c"]
     failOnStderr: true
   }
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels/wrapper.wdl
+++ b/centaur/src/main/resources/standardTestCases/google_labels/wrapper.wdl
@@ -1,0 +1,10 @@
+version 1.0
+
+import "google_labels.wdl"
+
+workflow google_labels_wrapper {
+  call google_labels.google_labels { input:
+    expected_kvps = [ ("cromwell-sub-workflow-name", "google-labels"), ("wdl-task-name", "check-labels") ],
+    check_aliases = false
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -12,5 +12,6 @@ metadata {
   status: Failed
 
   "failures.0.message": "Invalid 'google_labels' in workflow options"
-  "failures.0.causedBy.0.message": "Invalid label field: `0custom-value` did not match the regex '[a-z]([-a-z0-9]*[a-z0-9])?'"
+  "failures.0.causedBy.0.message": "Invalid label field: `custom-label-label-label-label-label-label-label-label-label-label` is 66 characters. The maximum is 63."
+  "failures.0.causedBy.1.message": "Invalid label field: `0custom-value` did not match the regex '[a-z]([-a-z0-9]*[a-z0-9])?'"
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -1,0 +1,16 @@
+name: google_labels_bad
+testFormat: workflowfailure
+backends: [Papiv2]
+
+files {
+  workflow: google_labels/google_labels.wdl
+  options: google_labels/bad_options.json
+}
+
+metadata {
+  workflowName: google_labels
+  status: Failed
+  "calls.cont_while_possible.boundToFail.executionStatus": Failed
+  "calls.cont_while_possible.shouldSucceed.executionStatus": Done
+  "calls.cont_while_possible.delayedTask.executionStatus": Done
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -10,4 +10,7 @@ files {
 metadata {
   workflowName: google_labels
   status: Failed
+
+  "failures.0.message": "Invalid 'google_labels' in workflow options"
+  "failures.0.causedBy.0.message": "Invalid label field: `0custom-value` did not match the regex '[a-z]([-a-z0-9]*[a-z0-9])?'"
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -10,7 +10,4 @@ files {
 metadata {
   workflowName: google_labels
   status: Failed
-  "calls.cont_while_possible.boundToFail.executionStatus": Failed
-  "calls.cont_while_possible.shouldSucceed.executionStatus": Done
-  "calls.cont_while_possible.delayedTask.executionStatus": Done
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_good.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_good.test
@@ -10,4 +10,8 @@ files {
 metadata {
   workflowName: google_labels
   status: Succeeded
+
+  "calls.google_labels.check_labels.labels.wdl-task-name": "check_labels"
+
+  "calls.google_labels.check_labels.backendLabels.custom-label": "custom-value"
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_good.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_good.test
@@ -9,5 +9,5 @@ files {
 
 metadata {
   workflowName: google_labels
-  status: Success
+  status: Succeeded
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_good.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_good.test
@@ -1,0 +1,13 @@
+name: google_labels_good
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: google_labels/google_labels.wdl
+  options: google_labels/good_options.json
+}
+
+metadata {
+  workflowName: google_labels
+  status: Success
+}

--- a/centaur/src/main/resources/standardTestCases/google_labels_subworkflows.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_subworkflows.test
@@ -1,0 +1,16 @@
+name: google_labels_sub
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: google_labels/wrapper.wdl
+  options: google_labels/good_options.json
+  imports: [
+    google_labels/google_labels.wdl
+  ]
+}
+
+metadata {
+  workflowName: google_labels_wrapper
+  status: Succeeded
+}

--- a/core/src/main/scala/cromwell/core/WorkflowOptions.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowOptions.scala
@@ -65,6 +65,7 @@ object WorkflowOptions {
   private lazy val EncryptedFields: Seq[String] = WorkflowOptionsConf.getStringList("encrypted-fields").asScala
   private lazy val EncryptionKey: String = WorkflowOptionsConf.getString("base64-encryption-key")
   private lazy val defaultRuntimeOptionKey: String = DefaultRuntimeOptions.name
+  private lazy val validObjectKeys: Set[String] = Set(DefaultRuntimeOptions.name, "google_labels")
 
   def encryptField(value: JsString): Try[JsObject] = {
     Aes256Cbc.encrypt(value.value.getBytes("utf-8"), SecretKey(EncryptionKey)) match {
@@ -94,7 +95,7 @@ object WorkflowOptions {
       case (k, v: JsString) if EncryptedFields.contains(k) => k -> encryptField(v)
       case (k, v: JsString) => k -> Success(v)
       case (k, v: JsBoolean) => k -> Success(v)
-      case (k, v: JsObject) if defaultRuntimeOptionKey.equals(k) => k -> Success(v)
+      case (k, v: JsObject) if validObjectKeys.contains(k) => k -> Success(v)
       case (k, v: JsNumber) => k -> Success(v)
       case (k, v) if isEncryptedField(v) => k -> Success(v)
       case (k, v: JsArray) => k -> Success(v)

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -224,7 +224,8 @@ workflows using the Google backend.
 
 #### Google Labels
 
-Every call run on the Pipelines API backend is given certain labels by default, so that Google resources can be queried by these labels later. The current default label set automatically applied is:
+Every call run on the Pipelines API backend is given certain labels by default, so that Google resources can be queried by these labels later. 
+The current default label set automatically applied is:
 
 | Key | Value | Example | Notes |
 |-----|-------|---------|-------|
@@ -233,7 +234,7 @@ Every call run on the Pipelines API backend is given certain labels by default, 
 | wdl-task-name | The name of the WDL task | my-task | |
 | wdl-call-alias | The alias of the WDL call that created this job | my-task-1 | Only present if the task was called with an alias. |
 
-Any custom labels provided upon workflow submission are also applied to Google resources by the Pipelines API.
+Any custom labels provided as '`google_labels`' in the [workflow options](../wf_options/Google) are also applied to Google resources by the Pipelines API.
 
 ## Using NCBI Sequence Read Archive (SRA) Data
 

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -11,6 +11,7 @@ Keys | Possible Values | Description
 `auth_bucket` |`string` |     A GCS URL that only Cromwell can write to.  The Cromwell account is determined by the `google.authScheme` (and the corresponding `google.userAuth` and `google.serviceAuth`). Defaults to the the value in [jes_gcs_root](#jes_gcs_root).
 `monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
 `monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
+`google_labels` | `object` | String-to-string map representing label key-to-value pairs. Each key and value must conform to the regex `a-z]([-a-z0-9]*[a-z0-9])?`.
 
 # Example
 ```json

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -11,7 +11,7 @@ Keys | Possible Values | Description
 `auth_bucket` |`string` |     A GCS URL that only Cromwell can write to.  The Cromwell account is determined by the `google.authScheme` (and the corresponding `google.userAuth` and `google.serviceAuth`). Defaults to the the value in [jes_gcs_root](#jes_gcs_root).
 `monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
 `monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
-`google_labels` | `object` | String-to-string map representing label key-to-value pairs. Each key and value must conform to the regex `a-z]([-a-z0-9]*[a-z0-9])?`.
+`google_labels` | `object` | An object containing only string values. Represent custom google labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `a-z]([-a-z0-9]*[a-z0-9])?`.
 
 # Example
 ```json
@@ -22,6 +22,9 @@ Keys | Possible Values | Description
   "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com"
   "auth_bucket": "gs://my-auth-bucket/private",
   "monitoring_script": "gs://bucket/script.sh",
-  "monitoring_image": "quay.io/broadinstitute/cromwell-monitor"
+  "monitoring_image": "quay.io/broadinstitute/cromwell-monitor",
+  "google_labels": {
+    "custom-label": "custom-value"
+  }
 }
 ```

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -11,7 +11,7 @@ Keys | Possible Values | Description
 `auth_bucket` |`string` |     A GCS URL that only Cromwell can write to.  The Cromwell account is determined by the `google.authScheme` (and the corresponding `google.userAuth` and `google.serviceAuth`). Defaults to the the value in [jes_gcs_root](#jes_gcs_root).
 `monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
 `monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
-`google_labels` | `object` | An object containing only string values. Represent custom google labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `a-z]([-a-z0-9]*[a-z0-9])?`.
+`google_labels` | `object` | An object containing only string values. Represent custom labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `[a-z]([-a-z0-9]*[a-z0-9])?`.
 
 # Example
 ```json

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -7,6 +7,8 @@ import akka.actor.ActorRef
 import akka.http.scaladsl.model.ContentTypes
 import cats.data.Validated.{Invalid, Valid}
 import cats.syntax.validated._
+import cats.syntax.traverse._
+import cats.instances.list._
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.storage.contrib.nio.CloudStorageOptions
 import common.util.StringUtil._
@@ -35,6 +37,7 @@ import cromwell.google.pipelines.common.PreviousRetryReasons
 import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.keyvalue.KvClient
 import shapeless.Coproduct
+import spray.json.{JsObject, JsString}
 import wdl4s.parser.MemoryUnit
 import wom.CommandSetupSideEffectFile
 import wom.callable.AdHocValue
@@ -49,6 +52,7 @@ import wom.values._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import scala.util.control.NoStackTrace
 import scala.util.{Success, Try}
 
 object PipelinesApiAsyncBackendJobExecutionActor {
@@ -393,7 +397,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     }
   }
 
-  private def createPipelineParameters(inputOutputParameters: InputOutputParameters): CreatePipelineParameters = {
+  private def createPipelineParameters(inputOutputParameters: InputOutputParameters, customLabels: Seq[GoogleLabel]): CreatePipelineParameters = {
     standardParams.backendInitializationDataOption match {
       case Some(data: PipelinesApiBackendInitializationData) =>
         val dockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken] = for {
@@ -432,7 +436,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           inputOutputParameters,
           googleProject(jobDescriptor.workflowDescriptor),
           computeServiceAccount(jobDescriptor.workflowDescriptor),
-          backendLabels,
+          backendLabels ++ customLabels,
           preemptible,
           pipelinesConfiguration.jobShell,
           dockerKeyAndToken,
@@ -499,6 +503,24 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
       )
     })
 
+    def readCustomGoogleLabels(): Future[Seq[GoogleLabel]] = {
+
+      def extractGoogleLabelsFromJsObject(jsObject: JsObject): Try[Seq[GoogleLabel]] = {
+        val asErrorOr = jsObject.fields.toList.traverse {
+          case (key: String, value: JsString) => GoogleLabels.validateLabel(key, value.value)
+          case (_, other) => s"Invalid label value. Expected simple string but got $other".invalidNel : ErrorOr[GoogleLabel]
+        }
+
+        asErrorOr.toTry("parse 'google_labels' workflow option")
+      }
+
+      workflowDescriptor.workflowOptions.toMap.get("google_labels") match {
+        case Some(obj: JsObject) => Future.fromTry(extractGoogleLabelsFromJsObject(obj))
+        case Some(other) => Future.failed(new Exception(s"Workflow option 'google_labels' must be a simple JSON object mapping keys to values. Got $other") with NoStackTrace)
+        case None => Future.successful(Seq.empty)
+      }
+    }
+
     def uploadScriptFile = commandScriptContents.fold(
       errors => Future.failed(new RuntimeException(errors.toList.mkString(", "))),
       asyncIo.writeAsync(jobPaths.script, _, Seq(CloudStorageOptions.withMimeType("text/plain"))))
@@ -506,8 +528,9 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     val runPipelineResponse = for {
       _ <- evaluateRuntimeAttributes
       _ <- uploadScriptFile
+      customLabels <- readCustomGoogleLabels()
       jesParameters <- generateInputOutputParameters
-      createParameters = createPipelineParameters(jesParameters)
+      createParameters = createPipelineParameters(jesParameters, customLabels)
       _ = this.hasDockerCredentials = createParameters.privateDockerKeyAndEncryptedToken.isDefined
       runId <- runPipeline(workflowId, createParameters, jobLogger)
     } yield runId

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
@@ -125,6 +125,7 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     for {
       paths <- workflowPaths
       _ = publishWorkflowRoot(paths.workflowRoot.pathAsString)
+      _ <- Future.fromTry(GoogleLabels.fromWorkflowOptions(workflowOptions))
       data <- initializationData
     } yield Option(data)
   }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
@@ -125,6 +125,7 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     for {
       paths <- workflowPaths
       _ = publishWorkflowRoot(paths.workflowRoot.pathAsString)
+      // Validate the google-labels workflow options, and only succeed initialization if they're good:
       _ <- Future.fromTry(GoogleLabels.fromWorkflowOptions(workflowOptions))
       data <- initializationData
     } yield Option(data)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobCachingActorHelper.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobCachingActorHelper.scala
@@ -58,11 +58,11 @@ trait PipelinesApiJobCachingActorHelper extends StandardCachingActorHelper {
 
   lazy val originalLabels: Labels = defaultLabels
 
-  lazy val backendLabels: Labels = GoogleLabels.toLabels(originalLabels.asTuple :_*)
+  lazy val backendLabels: Seq[GoogleLabel] = GoogleLabels.safeLabels(originalLabels.asTuple :_*)
 
   lazy val originalLabelEvents: Map[String, String] = originalLabels.value map { l => s"${CallMetadataKeys.Labels}:${l.key}" -> l.value } toMap
 
-  lazy val backendLabelEvents: Map[String, String] = backendLabels.value map { l => s"${CallMetadataKeys.BackendLabels}:${l.key}" -> l.value } toMap
+  lazy val backendLabelEvents: Map[String, String] = backendLabels map { l => s"${CallMetadataKeys.BackendLabels}:${l.key}" -> l.value } toMap
 
   override protected def nonStandardMetadata: Map[String, Any] = {
     val googleProject = initializationData

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobCachingActorHelper.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobCachingActorHelper.scala
@@ -1,6 +1,5 @@
 package cromwell.backend.google.pipelines.common
 
-import akka.actor.Actor
 import cromwell.backend.google.pipelines.common.io.{PipelinesApiAttachedDisk, PipelinesApiWorkingDisk}
 import cromwell.backend.standard.StandardCachingActorHelper
 import cromwell.core.labels.Labels
@@ -11,7 +10,7 @@ import cromwell.services.metadata.CallMetadataKeys
 import scala.language.postfixOps
 
 trait PipelinesApiJobCachingActorHelper extends StandardCachingActorHelper {
-  this: Actor with JobLogging =>
+  this: PipelinesApiAsyncBackendJobExecutionActor with JobLogging =>
 
   lazy val initializationData: PipelinesApiBackendInitializationData = {
     backendInitializationDataAs[PipelinesApiBackendInitializationData]
@@ -62,8 +61,6 @@ trait PipelinesApiJobCachingActorHelper extends StandardCachingActorHelper {
 
   lazy val originalLabelEvents: Map[String, String] = originalLabels.value map { l => s"${CallMetadataKeys.Labels}:${l.key}" -> l.value } toMap
 
-  lazy val backendLabelEvents: Map[String, String] = backendLabels map { l => s"${CallMetadataKeys.BackendLabels}:${l.key}" -> l.value } toMap
-
   override protected def nonStandardMetadata: Map[String, Any] = {
     val googleProject = initializationData
       .workflowPaths
@@ -77,6 +74,6 @@ trait PipelinesApiJobCachingActorHelper extends StandardCachingActorHelper {
       PipelinesApiMetadataKeys.ExecutionBucket -> initializationData.workflowPaths.executionRootString,
       PipelinesApiMetadataKeys.EndpointUrl -> jesAttributes.endpointUrl,
       "preemptible" -> preemptible
-    ) ++ backendLabelEvents ++ originalLabelEvents
+    ) ++ originalLabelEvents
   }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -6,7 +6,6 @@ import cromwell.backend.google.pipelines.common._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.io.PipelinesApiAttachedDisk
 import cromwell.backend.standard.StandardAsyncJob
-import cromwell.core.labels.Labels
 import cromwell.core.logging.JobLogger
 import cromwell.core.path.Path
 import wom.runtime.WomOutputRuntimeExtractor
@@ -70,7 +69,7 @@ object PipelinesApiRequestFactory {
                                       inputOutputParameters: InputOutputParameters,
                                       projectId: String,
                                       computeServiceAccount: String,
-                                      labels: Labels,
+                                      googleLabels: Seq[GoogleLabel],
                                       preemptible: Boolean,
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
@@ -22,8 +22,8 @@ class GoogleLabelsSpec extends FlatSpec with Matchers {
   )
 
   googleLabelConversions foreach { case (label: String, conversion: String) =>
-    it should s"not validate the bad label string '$label'" in {
-      GoogleLabels.validateLabelRegex(label, GoogleLabels.GoogleLabelsRegexPattern.r) match {
+    it should s"not validate the bad label key '$label'" in {
+      GoogleLabels.validateLabelRegex(label) match {
         case Invalid(_) => // Good!
         case Valid(_) => fail(s"Label validation succeeded but should have failed.")
       }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
@@ -885,8 +885,6 @@ class PipelinesApiAsyncBackendJobExecutionActorSpec extends TestKitSuite("JesAsy
     val actual = jesBackend.startMetadataKeyValues.safeMapValues(_.toString)
     actual should be(
       Map(
-        "backendLabels:cromwell-workflow-id" -> s"cromwell-$workflowId",
-        "backendLabels:wdl-task-name" -> "goodbye",
         "backendLogs:log" -> s"$jesGcsRoot/wf_hello/$workflowId/call-goodbye/goodbye.log",
         "callRoot" -> s"$jesGcsRoot/wf_hello/$workflowId/call-goodbye",
         "jes:endpointUrl" -> "https://genomics.googleapis.com/",

--- a/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/main/scala/cromwell/backend/google/pipelines/v1alpha2/GenomicsFactory.scala
@@ -70,7 +70,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         rpargs.setInputs((inputParameters.safeMapValues(_.toGoogleRunParameter) ++ literalInputRunParameters).asJava)
         rpargs.setOutputs(outputParameters.safeMapValues(_.toGoogleRunParameter).asJava)
 
-        rpargs.setLabels(createPipelineParameters.labels.asJavaMap)
+        rpargs.setLabels(createPipelineParameters.googleLabels.map(label => label.key -> label.value).toMap.asJava)
 
         val rpr = new RunPipelineRequest().setEphemeralPipeline(pipeline).setPipelineArgs(rpargs)
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -117,7 +117,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         .setServiceAccount(serviceAccount)
         .setMachineType(createPipelineParameters.runtimeAttributes |> toMachineType(jobLogger))
         .setBootDiskSizeGb(adjustedBootDiskSize)
-        .setLabels(createPipelineParameters.labels.asJavaMap)
+        .setLabels(createPipelineParameters.googleLabels.map(label => label.key -> label.value).toMap.asJava)
         .setNetwork(network)
         .setAccelerators(accelerators)
 
@@ -139,7 +139,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
 
       val pipelineRequest = new RunPipelineRequest()
         .setPipeline(pipeline)
-        .setLabels(createPipelineParameters.labels.asJavaMap)
+        .setLabels(createPipelineParameters.googleLabels.map(label => label.key -> label.value).toMap.asJava)
 
       genomics.pipelines().run(pipelineRequest).buildHttpRequest()
     }


### PR DESCRIPTION
Re-add the ability to provide custom google labels. These can now be provided via the `google-labels` option in `workflowoptions.json`.

Closes #3900.
