### PR TITLE
Log workflow IDs and counts if metadata fails to be written

### DIFF
--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -38,6 +38,9 @@ class WriteMetadataActor(override val batchSize: Int,
       case Success(_) =>
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteSuccess(ev) }
       case Failure(regerts) =>
+        val workflowMetadataFailureCounts = e.toVector.flatMap(_.events).groupBy(x => x.key.workflowId).map { case (wfid, list) => s"$wfid: ${list.size}" }
+        log.error("Count of metadata events missed for the following workflows: " + workflowMetadataFailureCounts.mkString(","))
+
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteFailure(regerts, ev) }
     }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -39,7 +39,7 @@ class WriteMetadataActor(override val batchSize: Int,
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteSuccess(ev) }
       case Failure(regerts) =>
         val workflowMetadataFailureCounts = e.toVector.flatMap(_.events).groupBy(x => x.key.workflowId).map { case (wfid, list) => s"$wfid: ${list.size}" }
-        log.error("Count of metadata events missed for the following workflows: " + workflowMetadataFailureCounts.mkString(","))
+        log.error("Metadata events permanently dropped for the following workflows: " + workflowMetadataFailureCounts.mkString(","))
 
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteFailure(regerts, ev) }
     }


### PR DESCRIPTION
I'm still hoping to add some metrics around this, but "log if metadata is dropped" seems like it could be a valuable "really quick win"?