### PR TITLE
 Log workflow IDs and counts, and retry, if metadata fails to be written

### DIFF
--- a/common/src/main/scala/common/collections/EnhancedCollections.scala
+++ b/common/src/main/scala/common/collections/EnhancedCollections.scala
@@ -71,9 +71,9 @@ object EnhancedCollections {
             case (element, dequeued) => (element, weightFunction(element), dequeued)
           }) match {
           // If the element's weight is > maxWeight and strict is true, drop the element
-          case Some((_, elementWeight, dequeued)) if c.gt(elementWeight, maxWeight) && strict => takeWhileWeightedRec(dequeued, head, weight)
+          case Some((_, elementWeight, dequeued)) if c.gteq(elementWeight, maxWeight) && strict => takeWhileWeightedRec(dequeued, head, weight)
           // If we're under the max weight, add the element to the head and recurse
-          case Some((element, elementWeight, dequeued)) if c.lt(elementWeight + weight, maxWeight) => takeWhileWeightedRec(dequeued, head :+ element, weight + elementWeight)
+          case Some((element, elementWeight, dequeued)) if c.lteq(elementWeight + weight, maxWeight) => takeWhileWeightedRec(dequeued, head :+ element, weight + elementWeight)
           // Otherwise stop here (make sure to return the original queue so we don't lose the last dequeued element)
           case _ => head -> tail
         }

--- a/engine/src/test/scala/cromwell/MetadataWatchActor.scala
+++ b/engine/src/test/scala/cromwell/MetadataWatchActor.scala
@@ -17,13 +17,13 @@ final case class MetadataWatchActor(promise: Promise[Unit], matchers: Matcher*) 
   var unsatisfiedMatchers = matchers
 
   override def receive = {
-    case PutMetadataAction(events) if unsatisfiedMatchers.nonEmpty =>
+    case PutMetadataAction(events, _) if unsatisfiedMatchers.nonEmpty =>
       unsatisfiedMatchers = unsatisfiedMatchers.filterNot { m => m.matches(events) }
       if (unsatisfiedMatchers.isEmpty) {
         promise.trySuccess(())
         ()
       }
-    case PutMetadataAction(_) => // Superfluous message. Ignore
+    case PutMetadataAction(_, _) => // Superfluous message. Ignore
     // Because the MetadataWatchActor is sometimes used in place of the ServiceRegistryActor, this allows WFs to continue:
     case kvGet: KvGet => sender ! KvKeyLookupFailed(kvGet)
     case kvPut: KvPut => sender ! KvPutSuccess(kvPut)

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -592,7 +592,7 @@ object CromwellApiServiceSpec {
       case GetSingleWorkflowMetadataAction(id, None, None, _) => sender ! MetadataLookupResponse(metadataQuery(id), fullMetadataResponse(id))
       case GetSingleWorkflowMetadataAction(id, Some(_), None, _) => sender ! MetadataLookupResponse(metadataQuery(id), filteredMetadataResponse(id))
       case GetSingleWorkflowMetadataAction(id, None, Some(_), _) => sender ! MetadataLookupResponse(metadataQuery(id), filteredMetadataResponse(id))
-      case PutMetadataActionAndRespond(events, _) =>
+      case PutMetadataActionAndRespond(events, _, _) =>
         events.head.key.workflowId match {
           case CromwellApiServiceSpec.ExistingWorkflowId => sender ! MetadataWriteSuccess(events)
           case CromwellApiServiceSpec.SummarizedWorkflowId => sender ! MetadataWriteSuccess(events)

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -71,11 +71,12 @@ object MetadataService {
   }
 
   sealed trait MetadataWriteAction extends MetadataServiceAction {
+    def ttl: Int
     def events: Iterable[MetadataEvent]
     def size: Int = events.size
   }
-  final case class PutMetadataAction(events: Iterable[MetadataEvent]) extends MetadataWriteAction 
-  final case class PutMetadataActionAndRespond(events: Iterable[MetadataEvent], replyTo: ActorRef) extends MetadataWriteAction
+  final case class PutMetadataAction(events: Iterable[MetadataEvent], ttl: Int = 10) extends MetadataWriteAction
+  final case class PutMetadataActionAndRespond(events: Iterable[MetadataEvent], replyTo: ActorRef, ttl: Int = 10) extends MetadataWriteAction
 
   final case object ListenToMetadataWriteActor extends MetadataServiceAction with ListenToMessage
 

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -71,12 +71,14 @@ object MetadataService {
   }
 
   sealed trait MetadataWriteAction extends MetadataServiceAction {
-    def ttl: Int
+    def maxAttempts: Int
     def events: Iterable[MetadataEvent]
     def size: Int = events.size
   }
-  final case class PutMetadataAction(events: Iterable[MetadataEvent], ttl: Int = 10) extends MetadataWriteAction
-  final case class PutMetadataActionAndRespond(events: Iterable[MetadataEvent], replyTo: ActorRef, ttl: Int = 10) extends MetadataWriteAction
+
+  val MaximumMetadataWriteAttempts = 10
+  final case class PutMetadataAction(events: Iterable[MetadataEvent], maxAttempts: Int = MaximumMetadataWriteAttempts) extends MetadataWriteAction
+  final case class PutMetadataActionAndRespond(events: Iterable[MetadataEvent], replyTo: ActorRef, maxAttempts: Int = MaximumMetadataWriteAttempts) extends MetadataWriteAction
 
   final case object ListenToMetadataWriteActor extends MetadataServiceAction with ListenToMessage
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -39,7 +39,7 @@ class WriteMetadataActor(override val batchSize: Int,
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteSuccess(ev) }
       case Failure(regerts) =>
         val workflowMetadataFailureCounts = e.toVector.flatMap(_.events).groupBy(x => x.key.workflowId).map { case (wfid, list) => s"$wfid: ${list.size}" }
-        log.error("Metadata events permanently dropped for the following workflows: " + workflowMetadataFailureCounts.mkString(","))
+        log.error("Count of metadata events missed for the following workflows: " + workflowMetadataFailureCounts.mkString(","))
 
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteFailure(regerts, ev) }
     }

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -54,6 +54,7 @@ class WriteMetadataActor(override val batchSize: Int,
 
     writeActions foreach {
       case PutMetadataActionAndRespond(ev, replyTo, _) => replyTo ! MetadataWriteFailure(reason, ev)
+      case _: PutMetadataAction => () // We need to satisfy the exhaustive match but there's nothing special to do here
     }
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -39,7 +39,7 @@ class WriteMetadataActor(override val batchSize: Int,
         putWithResponse foreach { case (ev, replyTo) => replyTo ! MetadataWriteSuccess(ev) }
       case Failure(regerts) =>
 
-        val (outOfLives, stillGood) = e.toVector.partition(_.ttl <= 1)
+        val (outOfLives, stillGood) = e.toVector.partition(_.maxAttempts <= 1)
 
         handleOutOfLives(outOfLives, regerts)
         handleEventsToReconsider(stillGood)
@@ -63,8 +63,8 @@ class WriteMetadataActor(override val batchSize: Int,
     log.warning("Metadata event writes have failed for the following workflows. They will be reconsidered: " + workflowMetadataFailureCounts.mkString(","))
 
     writeActions foreach {
-      case action: PutMetadataAction => self ! action.copy(ttl = action.ttl - 1)
-      case action: PutMetadataActionAndRespond => self ! action.copy(ttl = action.ttl - 1)
+      case action: PutMetadataAction => self ! action.copy(maxAttempts = action.maxAttempts - 1)
+      case action: PutMetadataActionAndRespond => self ! action.copy(maxAttempts = action.maxAttempts - 1)
     }
   }
 


### PR DESCRIPTION
Alternative to #4837 - this version will retry up to 10 times to write metadata before failing (and logging along the way)