### PR TITLE
Change "push" tests to be opt-in

### DIFF
--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -103,7 +103,6 @@ cromwell::private::create_build_variables() {
             else
               CROMWELL_RUN_TESTS=false
             fi
-
             ;;
         "${CROMWELL_BUILD_PROVIDER_JENKINS}")
             # External variables must be passed through in the ENVIRONMENT of src/ci/docker-compose/docker-compose.yml

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -103,6 +103,7 @@ cromwell::private::create_build_variables() {
             else
               CROMWELL_RUN_TESTS=false
             fi
+
             ;;
         "${CROMWELL_BUILD_PROVIDER_JENKINS}")
             # External variables must be passed through in the ENVIRONMENT of src/ci/docker-compose/docker-compose.yml

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -78,6 +78,8 @@ cromwell::private::create_build_variables() {
       CROMWELL_BUILD_IS_VIRTUAL_ENV=false
     fi
 
+    CROMWELL_RUN_TESTS=true
+
     case "${CROMWELL_BUILD_PROVIDER}" in
         "${CROMWELL_BUILD_PROVIDER_TRAVIS}")
             CROMWELL_BUILD_IS_CI=true
@@ -98,9 +100,7 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
 
-            if [[ "${TRAVIS_COMMIT_MESSAGE}" == *"FORCETEST"* ]] || [[ "${TRAVIS_EVENT_TYPE}" != "push" ]]; then
-              CROMWELL_RUN_TESTS=true
-            else
+            if [[ "${TRAVIS_COMMIT_MESSAGE}" != *"FORCETEST"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
               CROMWELL_RUN_TESTS=false
             fi
             ;;

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -48,7 +48,6 @@ cromwell::private::create_build_variables() {
     else
         CROMWELL_BUILD_PROVIDER="${CROMWELL_BUILD_PROVIDER_UNKNOWN}"
     fi
-
     # simplified from https://stackoverflow.com/a/18434831/3320205
     CROMWELL_BUILD_OS_DARWIN="darwin";
     CROMWELL_BUILD_OS_LINUX="linux";
@@ -98,6 +97,13 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_PASSWORD=""
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
+
+            if [[ "${TRAVIS_COMMIT_MESSAGE}" == *"FORCETEST"* ]] || [[ "${TRAVIS_EVENT_TYPE}" != "push" ]]; then
+              CROMWELL_RUN_TESTS=true
+            else
+              CROMWELL_RUN_TESTS=false
+            fi
+
             ;;
         "${CROMWELL_BUILD_PROVIDER_JENKINS}")
             # External variables must be passed through in the ENVIRONMENT of src/ci/docker-compose/docker-compose.yml
@@ -119,6 +125,7 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_PASSWORD=""
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=false
+            CROMWELL_RUN_TESTS=true
             ;;
         *)
             CROMWELL_BUILD_IS_CI=false
@@ -138,6 +145,7 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_PASSWORD="${CROMWELL_BUILD_MYSQL_PASSWORD-}"
             CROMWELL_BUILD_MYSQL_SCHEMA="${CROMWELL_BUILD_MYSQL_SCHEMA-cromwell_test}"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
+            CROMWELL_RUN_TESTS=true
 
             local bash_script
             for bash_script in "${BASH_SOURCE[@]}"; do
@@ -747,6 +755,10 @@ cromwell::private::kill_tree() {
 
 cromwell::build::exec_test_script() {
     cromwell::private::create_build_variables
+    if [[ "${CROMWELL_RUN_TESTS}" == "false" ]]; then
+      echo "quittin early"
+      exit 0
+    fi
     cromwell::private::exec_test_script
 }
 

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -124,7 +124,6 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_PASSWORD=""
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=false
-            CROMWELL_RUN_TESTS=true
             ;;
         *)
             CROMWELL_BUILD_IS_CI=false
@@ -144,7 +143,6 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_PASSWORD="${CROMWELL_BUILD_MYSQL_PASSWORD-}"
             CROMWELL_BUILD_MYSQL_SCHEMA="${CROMWELL_BUILD_MYSQL_SCHEMA-cromwell_test}"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
-            CROMWELL_RUN_TESTS=true
 
             local bash_script
             for bash_script in "${BASH_SOURCE[@]}"; do

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -756,7 +756,7 @@ cromwell::private::kill_tree() {
 cromwell::build::exec_test_script() {
     cromwell::private::create_build_variables
     if [[ "${CROMWELL_RUN_TESTS}" == "false" ]]; then
-      echo "quittin early"
+      echo "Use 'FORCETEST' in commit message to run tests on 'push'"
       exit 0
     fi
     cromwell::private::exec_test_script

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -100,6 +100,8 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
 
+            # Always run on sbt, even for 'push'.
+            # This allows quick sanity checks before starting PRs *and* publishing after merges into develop.
             if [[ "${CROMWELL_BUILD_TYPE}" == "sbt" ]]; then
               CROMWELL_RUN_TESTS=true
             elif [[ "${TRAVIS_COMMIT_MESSAGE}" != *"[force ci]"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -102,7 +102,7 @@ cromwell::private::create_build_variables() {
 
             if [[ "${CROMWELL_BUILD_TYPE}" == "sbt" ]]; then
               CROMWELL_RUN_TESTS=true
-            elif [[ "${TRAVIS_COMMIT_MESSAGE}" != *"FORCETEST"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
+            elif [[ "${TRAVIS_COMMIT_MESSAGE}" != *"[force ci]"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
               CROMWELL_RUN_TESTS=false
             fi
             ;;

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -48,6 +48,7 @@ cromwell::private::create_build_variables() {
     else
         CROMWELL_BUILD_PROVIDER="${CROMWELL_BUILD_PROVIDER_UNKNOWN}"
     fi
+
     # simplified from https://stackoverflow.com/a/18434831/3320205
     CROMWELL_BUILD_OS_DARWIN="darwin";
     CROMWELL_BUILD_OS_LINUX="linux";
@@ -78,7 +79,7 @@ cromwell::private::create_build_variables() {
       CROMWELL_BUILD_IS_VIRTUAL_ENV=false
     fi
 
-    CROMWELL_RUN_TESTS=true
+    CROMWELL_BUILD_RUN_TESTS=true
 
     case "${CROMWELL_BUILD_PROVIDER}" in
         "${CROMWELL_BUILD_PROVIDER_TRAVIS}")
@@ -103,9 +104,9 @@ cromwell::private::create_build_variables() {
             # Always run on sbt, even for 'push'.
             # This allows quick sanity checks before starting PRs *and* publishing after merges into develop.
             if [[ "${CROMWELL_BUILD_TYPE}" == "sbt" ]]; then
-              CROMWELL_RUN_TESTS=true
+              CROMWELL_BUILD_RUN_TESTS=true
             elif [[ "${TRAVIS_COMMIT_MESSAGE}" != *"[force ci]"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
-              CROMWELL_RUN_TESTS=false
+              CROMWELL_BUILD_RUN_TESTS=false
             fi
             ;;
         "${CROMWELL_BUILD_PROVIDER_JENKINS}")
@@ -756,8 +757,8 @@ cromwell::private::kill_tree() {
 
 cromwell::build::exec_test_script() {
     cromwell::private::create_build_variables
-    if [[ "${CROMWELL_RUN_TESTS}" == "false" ]]; then
-      echo "Use 'FORCETEST' in commit message to run tests on 'push'"
+    if [[ "${CROMWELL_BUILD_RUN_TESTS}" == "false" ]]; then
+      echo "Use '[force ci]' in commit message to run tests on 'push'"
       exit 0
     fi
     cromwell::private::exec_test_script
@@ -882,8 +883,6 @@ cromwell::build::publish_artifacts() {
 
     fi
 }
-
-
 
 cromwell::build::exec_retry_function() {
     local retried_function

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -100,7 +100,9 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_MYSQL_SCHEMA="cromwell_test"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
 
-            if [[ "${TRAVIS_COMMIT_MESSAGE}" != *"FORCETEST"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
+            if [[ "${CROMWELL_BUILD_TYPE}" == "sbt" ]]; then
+              CROMWELL_RUN_TESTS=true
+            elif [[ "${TRAVIS_COMMIT_MESSAGE}" != *"FORCETEST"* ]] && [[ "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
               CROMWELL_RUN_TESTS=false
             fi
             ;;
@@ -878,6 +880,8 @@ cromwell::build::publish_artifacts() {
 
     fi
 }
+
+
 
 cromwell::build::exec_retry_function() {
     local retried_function


### PR DESCRIPTION
See the various commit test timings to see whether tests did or did not run.

Idea:
* One green light is as good as two since in any real situation the 'push' tests would be restarted if the 'PR' tests are green.
* We can still test on push if we really want to, using `FORCETEST` in the commit message
* We won't have so many "background" tests running at any given time, hopefully reducing the queue-time for PRs

In other words:
* Should significantly *increase* cycle time for PRs and *reduce* developer time shepherding PRs through two sets of identical tests