### PR TITLE
Log warnings for long running jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 * It is now possible to supply custom `google-labels` in [workflow options](https://cromwell.readthedocs.io/en/stable/wf_options/Google/).
 
-### Heartbeat failure shutdown
+### Config Changes
+
+#### Heartbeat failure shutdown
 
 When a Cromwell instance is unable to write heartbeats for some period of time it will automatically shut down. For more
 information see the docs on [configuring Workflow Hearbeats](https://cromwell.readthedocs.io/en/stable/Configuring/).
@@ -15,12 +17,21 @@ NOTE: In the remote chance that the `system.workflow-heartbeats.ttl` has been co
 then the new configuration value `system.workflow-heartbeats.write-failure-shutdown-duration` must also be explicitly
 set less than the `ttl`.
 
+#### PAPI long running jobs
+
+The PAPI and PAPIv2 backends can now emit slow job warnings after a configurable time running in PAPI:
+```conf
+# Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck in PAPI.
+backend.providers.PAPIv2.config.slow-job-warning-time: 24 hours
+```
+
 ### Bug fixes
 
 #### Better validation of workflow heartbeats
 
 An error will be thrown on startup when the `system.workflow-heartbeats.heartbeat-interval` is not less than the
 `system.workflow-heartbeats.ttl`.
+
 
 ## 40 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ set less than the `ttl`.
 
 #### PAPI long running jobs
 
-The PAPI and PAPIv2 backends can now emit slow job warnings after a configurable time running in PAPI:
+The PAPIv1 and PAPIv2 backends can now emit slow job warnings after a configurable time running in the cloud:
 ```conf
 # Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck in PAPI.
 backend.providers.PAPIv2.config.slow-job-warning-time: 24 hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,21 @@ NOTE: In the remote chance that the `system.workflow-heartbeats.ttl` has been co
 then the new configuration value `system.workflow-heartbeats.write-failure-shutdown-duration` must also be explicitly
 set less than the `ttl`.
 
-#### PAPI long running jobs
+#### Logging long running jobs
 
-The PAPIv1 and PAPIv2 backends can now emit slow job warnings after a configurable time running in the cloud:
+All backends can now emit slow job warnings after a configurable time running. 
+NB This example shows how to configure this setting for the PAPIv2 backend:
 ```conf
-# Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck in PAPI.
-backend.providers.PAPIv2.config.slow-job-warning-time: 24 hours
+# Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck.
+backend {
+  providers {
+    PAPIv2 {
+      config { 
+        slow-job-warning-time: 24 hours
+      }
+    }
+  }
+}
 ```
 
 ### Bug fixes

--- a/backend/src/main/scala/cromwell/backend/SlowJobWarning.scala
+++ b/backend/src/main/scala/cromwell/backend/SlowJobWarning.scala
@@ -1,9 +1,9 @@
-package cromwell.backend.google.pipelines.common
+package cromwell.backend
 
 import java.time.OffsetDateTime
 
 import akka.actor.{Actor, ActorLogging}
-import cromwell.backend.google.pipelines.common.SlowJobWarning.{WarnAboutSlownessAfter, WarnAboutSlownessIfNecessary, WarningDetails}
+import cromwell.backend.SlowJobWarning._
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/backend/src/main/scala/cromwell/backend/backend.scala
+++ b/backend/src/main/scala/cromwell/backend/backend.scala
@@ -12,6 +12,7 @@ import cromwell.core.path.{DefaultPathBuilderFactory, PathBuilderFactory}
 import cromwell.core.{CallKey, WorkflowId, WorkflowOptions}
 import cromwell.docker.DockerInfoActor.DockerSize
 import cromwell.services.keyvalue.KeyValueServiceActor.KvResponse
+import net.ceedubs.ficus.Ficus._
 import wom.callable.{ExecutableCallable, MetaValueElement}
 import wom.graph.CommandCallNode
 import wom.graph.GraphNodePort.OutputPort
@@ -19,6 +20,7 @@ import wom.runtime.WomOutputRuntimeExtractor
 import wom.values.WomArray.WomArrayLike
 import wom.values._
 
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -142,6 +144,8 @@ case class BackendConfigurationDescriptor(backendConfig: Config, globalConfig: C
   def pathBuildersWithDefault(workflowOptions: WorkflowOptions)(implicit as: ActorSystem) = {
     PathBuilderFactory.instantiatePathBuilders(configuredFactoriesWithDefault.values.toList, workflowOptions)
   }
+
+  lazy val slowJobWarningAfter = backendConfig.as[Option[FiniteDuration]](path="slow-job-warning-time")
 }
 
 final case class AttemptedLookupResult(name: String, value: Try[WomValue]) {

--- a/cromwell.example.backends/AWS.conf
+++ b/cromwell.example.backends/AWS.conf
@@ -58,6 +58,9 @@ backend {
             auth = "default"
           }
         }
+
+        # Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck in the cloud.
+        slow-job-warning-time: 24 hours
       }
     }
   }

--- a/cromwell.example.backends/LSF.conf
+++ b/cromwell.example.backends/LSF.conf
@@ -22,4 +22,5 @@ backend {
         job-id-regex = "Job <(\\d+)>.*"
       }
     }
+  }
 }

--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -24,7 +24,10 @@ backend {
     
         # Make the name of the backend used for call caching purposes insensitive to the PAPI version.
         name-for-call-caching-purposes: PAPI
-    
+
+        # Emit a warning if jobs last longer than this amount of time. This might indicate that something got stuck in PAPI.
+        slow-job-warning-time: 24 hours
+
         # Set this to the lower of the two values "Queries per 100 seconds" and "Queries per 100 seconds per user" for
         # your project.
         #

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
@@ -8,6 +8,8 @@ import cromwell.core.BackendDockerConfiguration
 import net.ceedubs.ficus.Ficus._
 import spray.json._
 
+import scala.concurrent.duration.FiniteDuration
+
 
 class PipelinesApiConfiguration(val configurationDescriptor: BackendConfigurationDescriptor,
                                 val genomicsFactory: PipelinesApiFactoryInterface,
@@ -32,4 +34,6 @@ class PipelinesApiConfiguration(val configurationDescriptor: BackendConfiguratio
   val needAuthFileUpload = jesAuths.gcs.requiresAuthFile || dockerCredentials.isDefined || jesAttributes.restrictMetadataAccess
   val jobShell = configurationDescriptor.backendConfig.as[Option[String]]("job-shell").getOrElse(
     configurationDescriptor.globalConfig.getOrElse("system.job-shell", "/bin/bash"))
+
+  lazy val slowJobWarningAfter = configurationDescriptor.backendConfig.as[Option[FiniteDuration]](path="slow-job-warning-time")
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
@@ -8,9 +8,6 @@ import cromwell.core.BackendDockerConfiguration
 import net.ceedubs.ficus.Ficus._
 import spray.json._
 
-import scala.concurrent.duration.FiniteDuration
-
-
 class PipelinesApiConfiguration(val configurationDescriptor: BackendConfigurationDescriptor,
                                 val genomicsFactory: PipelinesApiFactoryInterface,
                                 val googleConfig: GoogleConfiguration,
@@ -34,6 +31,4 @@ class PipelinesApiConfiguration(val configurationDescriptor: BackendConfiguratio
   val needAuthFileUpload = jesAuths.gcs.requiresAuthFile || dockerCredentials.isDefined || jesAttributes.restrictMetadataAccess
   val jobShell = configurationDescriptor.backendConfig.as[Option[String]]("job-shell").getOrElse(
     configurationDescriptor.globalConfig.getOrElse("system.job-shell", "/bin/bash"))
-
-  lazy val slowJobWarningAfter = configurationDescriptor.backendConfig.as[Option[FiniteDuration]](path="slow-job-warning-time")
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/SlowJobWarning.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/SlowJobWarning.scala
@@ -1,0 +1,46 @@
+package cromwell.backend.google.pipelines.common
+
+import java.time.OffsetDateTime
+
+import akka.actor.{Actor, ActorLogging}
+import cromwell.backend.google.pipelines.common.SlowJobWarning.{WarnAboutSlownessAfter, WarnAboutSlownessIfNecessary, WarningDetails}
+
+import scala.concurrent.duration.FiniteDuration
+
+trait SlowJobWarning { this: Actor with ActorLogging =>
+
+  def slowJobWarningReceive: Actor.Receive = {
+    case WarnAboutSlownessAfter(jobId, duration) =>
+      alreadyWarned = false
+      warningDetails = Some(WarningDetails(jobId, OffsetDateTime.now(), OffsetDateTime.now().plusSeconds(duration.toSeconds)))
+    case WarnAboutSlownessIfNecessary => handleWarnMessage()
+  }
+
+  var warningDetails: Option[WarningDetails] = None
+  var alreadyWarned: Boolean = false
+
+  def warnAboutSlowJobIfNecessary(jobId: String) = {
+    // Don't do anything here because we might need to update state.
+    // Instead, send a message and handle this in the receive block.
+    self ! WarnAboutSlownessIfNecessary
+  }
+
+  private def handleWarnMessage(): Unit = {
+    if (!alreadyWarned) {
+      warningDetails match {
+        case Some(WarningDetails(jobId, startTime, warningTime)) if OffsetDateTime.now().isAfter(warningTime) =>
+          log.warning(s"Job with ID '{}' has been running since {} and might not be making progress", jobId, startTime)
+          alreadyWarned = true
+        case _ => // Nothing to do
+      }
+    }
+  }
+
+}
+
+object SlowJobWarning {
+  final case class WarnAboutSlownessAfter(jobId: String, duration: FiniteDuration)
+  case object WarnAboutSlownessIfNecessary
+
+  final case class WarningDetails(jobId: String, startTime: OffsetDateTime, warningTime: OffsetDateTime)
+}

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/SlowJobWarning.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/SlowJobWarning.scala
@@ -12,7 +12,7 @@ trait SlowJobWarning { this: Actor with ActorLogging =>
   def slowJobWarningReceive: Actor.Receive = {
     case WarnAboutSlownessAfter(jobId, duration) =>
       alreadyWarned = false
-      warningDetails = Some(WarningDetails(jobId, OffsetDateTime.now(), OffsetDateTime.now().plusSeconds(duration.toSeconds)))
+      warningDetails = Option(WarningDetails(jobId, OffsetDateTime.now(), OffsetDateTime.now().plusSeconds(duration.toSeconds)))
     case WarnAboutSlownessIfNecessary => handleWarnMessage()
   }
 


### PR DESCRIPTION
This was inspired by the surprise discovery of several suspiciously long running PAPI jobs.

We can find these by running ad-hoc database queries but I personally like the idea of a more proactive warning being emitted.

Sample log message: `2019-04-19 15:26:56,383 cromwell-system-akka.dispatchers.backend-dispatcher-53 WARN  - Job with ID 'projects/broad-dsde-cromwell-dev/operations/17748569219664621060' has been running since 2019-04-19T15:26:23.283-04:00 and might not be making progress`