### PR TITLE
[develop] Ensure HealthMonitorServiceActor can initialize without google config

### DIFF
--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/workbench/WorkbenchHealthMonitorServiceActor.scala
@@ -42,11 +42,11 @@ abstract class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, glo
   protected lazy val Gcs = MonitoredSubsystem("GCS", () => checkGcs())
   protected lazy val PapiSubsystems = papiBackendConfigurations map papiMonitoredSubsystem
 
-  val googleConfig = GoogleConfiguration(globalConfig)
+  lazy val googleConfig = GoogleConfiguration(globalConfig)
 
-  val googleAuthName = serviceConfig.as[Option[String]]("google-auth-name").getOrElse("application-default")
+  lazy val googleAuthName = serviceConfig.as[Option[String]]("google-auth-name").getOrElse("application-default")
 
-  val googleAuth = googleConfig.auth(googleAuthName) match {
+  lazy val googleAuth = googleConfig.auth(googleAuthName) match {
     case Valid(a) => a
     case Invalid(e) => throw new IllegalArgumentException("Unable to configure WorkbenchHealthMonitor: " + e.toList.mkString(", "))
   }
@@ -64,13 +64,9 @@ abstract class WorkbenchHealthMonitorServiceActor(val serviceConfig: Config, glo
   }
 
   private def checkPapi(papiConfiguration: PapiConfiguration): Future[SubsystemStatus] = {
-    checkPapi(papiConfiguration.papiConfig, papiConfiguration.papiProviderConfig)
-  }
+    val papiConfig = papiConfiguration.papiConfig
+    val papiProviderConfig = papiConfiguration.papiProviderConfig
 
-  /**
-    * Demonstrates connectivity to Google Pipelines API (PAPI) by making sure it can access an authenticated endpoint
-    */
-  private def checkPapi(papiConfig: Config, papiProviderConfig: Config): Future[SubsystemStatus] = {
     val endpointUrl = new URL(papiConfig.as[String]("genomics.endpoint-url"))
     val papiProjectId = papiConfig.as[String]("project")
 

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -15,11 +15,11 @@ import scala.concurrent.duration._
 
 class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Eventually with AskSupport {
 
-  override implicit def patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = Span(500, Millis))
+  override implicit def patienceConfig = PatienceConfig(timeout = scaled(Span(15, Seconds)), interval = Span(500, Millis))
 
   behavior of "HealthMonitorServiceActor"
 
-  it should "be able to load an instance and ask questions even with only basic configuration" in {
+  it should "be able to load an instance and answer questions even with only basic configuration" in {
 
     val serviceConfigString =
       """check-dockerhub: false
@@ -41,7 +41,7 @@ class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with 
 
     eventually {
       testProbe.send(actor, GetCurrentStatus)
-      testProbe.expectMsg(1.second, StatusCheckResponse(ok = true, systems = Map.empty))
+      testProbe.expectMsg(5.seconds, StatusCheckResponse(ok = true, systems = Map.empty))
     }
   }
 }

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -1,0 +1,47 @@
+package cromwell.services.healthmonitor
+
+import akka.actor.Props
+import akka.pattern.AskSupport
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import cromwell.core.TestKitSuite
+import cromwell.services.healthmonitor.ProtoHealthMonitorServiceActor.{GetCurrentStatus, StatusCheckResponse}
+import cromwell.services.healthmonitor.impl.HealthMonitorServiceActor
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+
+class HealthMonitorServiceActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Eventually with AskSupport {
+
+  override implicit def patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = Span(500, Millis))
+
+  behavior of "HealthMonitorServiceActor"
+
+  it should "be able to load an instance and ask questions even with only basic configuration" in {
+
+    val serviceConfigString =
+      """check-dockerhub: false
+        |check-engine-database: false
+        |check-gcs: false
+        |check-papi-backends: []
+        |""".stripMargin
+
+
+    val globalConfigString =
+      s"""services.HealthMonitor.config: {
+         |$serviceConfigString
+         |}
+         |""".stripMargin
+
+    val actor = system.actorOf(Props(new HealthMonitorServiceActor(ConfigFactory.parseString(serviceConfigString), ConfigFactory.parseString(globalConfigString), null)))
+
+    val testProbe = TestProbe()
+
+    eventually {
+      testProbe.send(actor, GetCurrentStatus)
+      testProbe.expectMsg(1.second, StatusCheckResponse(ok = true, systems = Map.empty))
+    }
+  }
+}


### PR DESCRIPTION
Make some values lazy, move a one-use function inside its caller, add a test case