### PR TITLE
Clarify exit-code-timeout-seconds docs

### DIFF
--- a/cromwell.example.backends/HtCondor.conf
+++ b/cromwell.example.backends/HtCondor.conf
@@ -23,15 +23,15 @@ backend {
           String? nativeSpecs
           String? docker
         """
-    
+
         # If an 'exit-code-timeout-seconds' value is specified:
-        # - When a job has not been alive for longer than this timeout
-        # - And has still not produced an RC file
+        # - check-alive will be run at this interval for every job
+        # - if a job is found to be not alive, and no RC file appears after this interval
         # - Then it will be marked as Failed.
-        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    
+        # Warning: If set, Cromwell will run 'check-alive' for every job at this interval
+
         # exit-code-timeout-seconds = 120
-    
+
         submit = """
           chmod 755 ${script}
           cat > ${cwd}/execution/submitFile <<EOF
@@ -50,7 +50,7 @@ backend {
           EOF
           condor_submit ${cwd}/execution/submitFile
         """
-    
+
         submit-docker = """
           chmod 755 ${script}
           cat > ${cwd}/execution/dockerScript <<EOF
@@ -74,7 +74,7 @@ backend {
           EOF
           condor_submit ${cwd}/execution/submitFile
         """
-    
+
         kill = "condor_rm ${job_id}"
         check-alive = "condor_q ${job_id}"
         job-id-regex = "(?sm).*cluster (\\d+)..*"

--- a/cromwell.example.backends/SGE.conf
+++ b/cromwell.example.backends/SGE.conf
@@ -16,25 +16,25 @@ backend {
     SGE {
       actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
       config {
-    
+
         # Limits the number of concurrent jobs
         concurrent-job-limit = 5
-    
+
         # If an 'exit-code-timeout-seconds' value is specified:
-        # - When a job has not been alive for longer than this timeout
-        # - And has still not produced an RC file
+        # - check-alive will be run at this interval for every job
+        # - if a job is found to be not alive, and no RC file appears after this interval
         # - Then it will be marked as Failed.
-        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    
+        # Warning: If set, Cromwell will run 'check-alive' for every job at this interval
+
         # exit-code-timeout-seconds = 120
-    
+
         runtime-attributes = """
         Int cpu = 1
         Float? memory_gb
         String? sge_queue
         String? sge_project
         """
-    
+
         submit = """
         qsub \
         -terse \
@@ -50,7 +50,7 @@ backend {
         ${"-P " + sge_project} \
         /usr/bin/env bash ${script}
         """
-    
+
         kill = "qdel ${job_id}"
         check-alive = "qstat -j ${job_id}"
         job-id-regex = "(\\d+)"

--- a/cromwell.example.backends/slurm.conf
+++ b/cromwell.example.backends/slurm.conf
@@ -22,15 +22,15 @@ backend {
         Int requested_memory_mb_per_core = 8000
         String queue = "short"
         """
-    
+
         # If an 'exit-code-timeout-seconds' value is specified:
-        # - When a job has not been alive for longer than this timeout
-        # - And has still not produced an RC file
+        # - check-alive will be run at this interval for every job
+        # - if a job is found to be not alive, and no RC file appears after this interval
         # - Then it will be marked as Failed.
-        # Warning: If set, Cromwell has to run 'check-alive' for every job at regular intervals (unrelated to this timeout)
-    
+        # Warning: If set, Cromwell will run 'check-alive' for every job at this interval
+
         # exit-code-timeout-seconds = 120
-    
+
         submit = """
             sbatch -J ${job_name} -D ${cwd} -o ${out} -e ${err} -t ${runtime_minutes} -p ${queue} \
             ${"-n " + cpus} \

--- a/docs/backends/HPC.md
+++ b/docs/backends/HPC.md
@@ -48,7 +48,7 @@ backend.providers.MyHPCBackend {
     gcs {
       # A reference to a potentially different auth for manipulating files via engine functions.
       auth = "application-default"
-    }  
+    }
   }
 }
 ```
@@ -56,11 +56,13 @@ backend.providers.MyHPCBackend {
 ### Exit code timeout
 
 If the cluster forcefully kills a job, it is unable to write its exit code anymore.
-To fix this the option `exit-code-timeout-seconds` can be used. When a job is no longer running and the timeout has passed without an RC file being made, Cromwell can mark the job as failed.
+To address this the option `exit-code-timeout-seconds` can be used.
+Cromwell will check the aliveness of the job with the `check-alive` script, every `exit-code-timeout-seconds` (polling).
+When a job is no longer alive and another `exit-code-timeout-seconds` seconds have passed without an RC file being made, Cromwell can mark the job as failed.
 If retries are enabled the job is submitted again.
-This option will implicitly enable polling with the `check-alive` option.
+This option will enable polling with the `check-alive` option, this could cause high load on whatever system `check-alive` calls.
 
-When the option `exit-code-timeout-seconds` is **not** set cromwell will only execute the  `check-alive` option after a restart of a cromwell server.
+When the option `exit-code-timeout-seconds` is **not** set cromwell will only execute the `check-alive` option after a restart of a cromwell server.
 
 ```
 backend {


### PR DESCRIPTION
https://github.com/broadinstitute/cromwell/issues/4877

I also have this (only barely tested) script that may be useful to other HPC users:

https://gist.github.com/EvanTheB/8f9e07746af0c84831fc17f94ac4672d

It reduces the load on qstat of having thousands of jobs running. Let me know if it can be improved or incorporated here somewhere