### PR TITLE
Virtual Private Network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The `/describe` endpoint now differentiates between an invalid workflow and a va
 
 Specifically, the new `validWorkflow` key indicates whether the workflow file is valid by itself. If inputs are provided, they are not considered when calculating this field; if inputs are not provided, the value is identical to `valid`.
 
+### Virtual Private Network
+
+Cromwell now allows PAPIV2 jobs to run on a private network by adding the network name inside `virtual-private-cloud` in backend configuration.
+More info [here](https://cromwell.readthedocs.io/en/stable/backends/Google/).
+
+
 ## 41 Release Notes
 
 ### Workflow Options

--- a/centaur/src/main/resources/standardTestCases/check_network_in_vpc.test
+++ b/centaur/src/main/resources/standardTestCases/check_network_in_vpc.test
@@ -1,0 +1,14 @@
+name: check_network_in_vpc
+testFormat: workflowsuccess
+backends: [Papiv2-Virtual-Private-Cloud]
+
+files {
+  workflow: virtual_private_cloud/check_network_in_vpc.wdl
+}
+
+metadata {
+  workflowName: check_network_in_vpc
+  status: Succeeded
+
+  "outputs.check_network_in_vpc.network_used": "cromwell-ci-vpc-network"
+}

--- a/centaur/src/main/resources/standardTestCases/virtual_private_cloud/check_network_in_vpc.wdl
+++ b/centaur/src/main/resources/standardTestCases/virtual_private_cloud/check_network_in_vpc.wdl
@@ -1,0 +1,29 @@
+version 1.0
+
+task get_network {
+  command {
+    apt-get install --assume-yes jq > /dev/null
+    INSTANCE=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google")
+    ZONE=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/zone" -H "Metadata-Flavor: Google" | sed -E 's!.*/(.*)!\1!')
+    TOKEN=$(gcloud auth application-default print-access-token)
+    INSTANCE_METADATA=$(curl "https://www.googleapis.com/compute/v1/projects/broad-dsde-cromwell-dev/zones/$ZONE/instances/$INSTANCE" -H "Authorization: Bearer $TOKEN" -H 'Accept: application/json')
+    echo $INSTANCE_METADATA | jq -r '.networkInterfaces[0].network' | sed -E 's!.*/(.*)!\1!'
+  }
+
+  runtime {
+    docker: "google/cloud-sdk:slim"
+    backend: "Papiv2-Virtual-Private-Cloud"
+  }
+
+  output {
+    String network = read_string(stdout())
+  }
+}
+
+workflow check_network_in_vpc {
+  call get_network
+
+   output {
+     String network_used = get_network.network
+   }
+}

--- a/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
@@ -9,5 +9,5 @@ files {
 metadata {
   workflowName: workbench_health_monitor_check
   status: Succeeded
-  "outputs.workbench_health_monitor_check.out": """{"DockerHub":{"ok":true},"Engine Database":{"ok":true},"GCS":{"ok":true},"Papi":{"ok":true},"Papi-Caching-No-Copy":{"ok":true},"Papiv2":{"ok":true},"Papiv2NoDockerHubConfig":{"ok":true},"Papiv2RequesterPays":{"ok":true},"Papiv2USADockerhub":{"ok":true}}"""
+  "outputs.workbench_health_monitor_check.out": """{"DockerHub":{"ok":true},"Engine Database":{"ok":true},"GCS":{"ok":true},"Papi":{"ok":true},"Papi-Caching-No-Copy":{"ok":true},"Papiv2":{"ok":true},"Papiv2-Virtual-Private-Cloud":{"ok":true},"Papiv2NoDockerHubConfig":{"ok":true},"Papiv2RequesterPays":{"ok":true},"Papiv2USADockerhub":{"ok":true}}"""
 }

--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -49,6 +49,13 @@ backend {
     
         # Number of workers to assaign to PAPI requests
         request-workers = 3
+
+        # Optional configuration to use high security network (Virtual Private Cloud) for running jobs.
+        # See https://cromwell.readthedocs.io/en/stable/backends/Google/ for more details.
+        # virtual-private-cloud {
+        #  network-label-key = "network-key"
+        #  auth = "application-default"
+        # }
     
         genomics {
           # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -262,3 +262,40 @@ This filesystem has two required configuration options:
   documentation](https://www.ncbi.nlm.nih.gov/books/NBK63512/#Download.are_downloaded_files_encrypted)
   for more information on obtaining your NGC.  The `ngc` value provided above
   is the sample credential file.
+
+### Virtual Private Network
+
+To run your jobs in a private network add the `virtual-private-cloud` stanza in the `config` stanza of the PAPI v2 backend:
+
+```
+backend {
+  ...
+  providers {
+  	...
+  	PapiV2 {
+  	  actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+  	  config {
+  		...
+  		virtual-private-cloud {
+  	          network-label-key = "my-private-network"
+  	          auth = "reference-to-auth-scheme"
+  	        }
+  	    ...
+  	  }  
+      }
+  }
+}
+```
+
+
+The `network-label-key` should reference the key in the label in your project whose value is the name of your private network.
+ `auth` should reference an auth scheme in the `google` stanza which should be used to the project metadata from Google Cloud.
+For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
+
+```
+"my-private-network" = "vpc-network"
+```
+
+Cromwell will get labels from the project's metadata and look for a label whose key is `my-private-network`.
+Then it will use the value of the label, which is `vpc-network` here, as the name of private network and run the jobs on this network.
+If the network key is not present in the project's metadata Cromwell will fall back to running jobs on the default network.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,10 @@ object Dependencies {
   private val googleCloudNioV = "0.61.0-alpha"
   private val googleGenomicsServicesV1ApiV = "v1alpha2-rev495-1.23.0"
   private val googleGenomicsServicesV2ApiV = "v2alpha1-rev31-1.25.0"
+  private val googleHttpClientApacheV = "2.1.1"
+  private val googleHttpClientV = "1.29.1"
   private val googleOauth2V = "0.13.0"
+  private val googleCloudResourceManagerV = "0.87.0-alpha"
   private val grpcV = "1.18.0"
   private val guavaV = "27.0.1-jre"
   private val heterodonV = "1.0.0-beta3"
@@ -128,7 +131,8 @@ object Dependencies {
     "com.google.api-client" % "google-api-client-java6" % googleApiClientV
       exclude("com.google.guava", "guava-jdk5"),
     "com.google.api-client" % "google-api-client-jackson2" % googleApiClientV
-      exclude("com.google.guava", "guava-jdk5")
+      exclude("com.google.guava", "guava-jdk5"),
+    "com.google.cloud" % "google-cloud-resourcemanager" % googleCloudResourceManagerV,
   )
 
   val spiDependencies = List(
@@ -540,6 +544,19 @@ object Dependencies {
   Older versions have known vulnerabilities, ex: CVE-2017-7525
    */
 
+  val googleHttpClientDependencies = List(
+    /*
+    Move the google-http-client versions past https://github.com/googleapis/google-http-java-client/issues/606
+    This created a situation where com/google/api/client/http/apache/ApacheHttpTransport.class was in *both*
+    transitive dependencies causing an assembly merge conflict.
+
+    At the time of this comment older versions are being pulled in via
+    https://mvnrepository.com/artifact/com.google.api-client/google-api-client/1.28.0
+     */
+    "com.google.http-client" % "google-http-client-apache" % googleHttpClientApacheV,
+    "com.google.http-client" % "google-http-client" % googleHttpClientV,
+  )
+
   val nettyDependencyOverrides = List(
     "buffer",
     "codec",
@@ -590,6 +607,7 @@ object Dependencies {
    */
   val cromwellDependencyOverrides =
     allProjectDependencies ++
+      googleHttpClientDependencies ++
       nettyDependencyOverrides ++
       rdf4jDependencyOverrides
 }

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -2,7 +2,15 @@ include required(classpath("application.conf"))
 include "build_application.inc.conf"
 include "papi_application.inc.conf"
 
-services.HealthMonitor.config.check-papi-backends: ["Papi", "Papiv2", "Papiv2USADockerhub", "Papiv2NoDockerHubConfig", "Papiv2RequesterPays", "Papi-Caching-No-Copy"]
+services.HealthMonitor.config.check-papi-backends: [
+  "Papi",
+  "Papiv2",
+  "Papiv2USADockerhub",
+  "Papiv2NoDockerHubConfig",
+  "Papiv2RequesterPays",
+  "Papi-Caching-No-Copy",
+  "Papiv2-Virtual-Private-Cloud"
+]
 
 backend {
   default = "Papi"
@@ -74,6 +82,18 @@ backend {
         include "papi_provider_config.inc.conf"
         filesystems.gcs.caching.duplication-strategy = "reference"
         filesystems.http {}
+      }
+    }
+    Papiv2-Virtual-Private-Cloud {
+      actor-factory = "cromwell.backend.google.pipelines.v2alpha1.PipelinesApiLifecycleActorFactory"
+      config {
+        include "papi_provider_config.inc.conf"
+        genomics.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
+        filesystems.http {}
+        virtual-private-cloud {
+          network-label-key = "cromwell-ci-network"
+          auth = "service_account"
+        }
       }
     }
   }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -431,15 +431,16 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           cloudCallRoot = callRootPath,
           commandScriptContainerPath = cmdInput.containerPath,
           logGcsPath = jesLogPath,
-          inputOutputParameters,
-          googleProject(jobDescriptor.workflowDescriptor),
-          computeServiceAccount(jobDescriptor.workflowDescriptor),
-          backendLabels ++ customLabels,
-          preemptible,
-          pipelinesConfiguration.jobShell,
-          dockerKeyAndToken,
-          jobDescriptor.workflowDescriptor.outputRuntimeExtractor,
-          adjustedSizeDisks
+          inputOutputParameters = inputOutputParameters,
+          projectId = googleProject(jobDescriptor.workflowDescriptor),
+          computeServiceAccount = computeServiceAccount(jobDescriptor.workflowDescriptor),
+          googleLabels = backendLabels ++ customLabels,
+          preemptible = preemptible,
+          jobShell = pipelinesConfiguration.jobShell,
+          privateDockerKeyAndEncryptedToken = dockerKeyAndToken,
+          womOutputRuntimeExtractor = jobDescriptor.workflowDescriptor.outputRuntimeExtractor,
+          adjustedSizeDisks = adjustedSizeDisks,
+          virtualPrivateCloudConfiguration = jesAttributes.virtualPrivateCloudConfiguration
         )
       case Some(other) =>
         throw new RuntimeException(s"Unexpected initialization data: $other")

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -2,6 +2,7 @@ package cromwell.backend.google.pipelines.common.api
 
 import com.google.api.client.http.HttpRequest
 import cromwell.backend.BackendJobDescriptor
+import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.VirtualPrivateCloudConfiguration
 import cromwell.backend.google.pipelines.common._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.io.PipelinesApiAttachedDisk
@@ -74,7 +75,8 @@ object PipelinesApiRequestFactory {
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],
-                                      adjustedSizeDisks: Seq[PipelinesApiAttachedDisk]) {
+                                      adjustedSizeDisks: Seq[PipelinesApiAttachedDisk],
+                                      virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration]) {
     def literalInputs = inputOutputParameters.literalInputParameters
     def inputParameters = inputOutputParameters.fileInputParameters
     def outputParameters = inputOutputParameters.fileOutputParameters

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActor.scala
@@ -20,7 +20,7 @@ class PipelinesApiBackendCacheHitCopyingActor(standardParams: StandardCacheHitCo
   override protected val commandBuilder = GcsBatchCommandBuilder
   private val cachingStrategy = BackendInitializationData
     .as[PipelinesApiBackendInitializationData](standardParams.backendInitializationDataOption)
-    .papiConfiguration.jesAttributes.duplicationStrategy
+    .papiConfiguration.jesAttributes.cacheHitDuplicationStrategy
   
   override def processSimpletons(womValueSimpletons: Seq[WomValueSimpleton], sourceCallRootPath: Path) = cachingStrategy match {
     case CopyCachedOutputs => super.processSimpletons(womValueSimpletons, sourceCallRootPath)

--- a/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/api/StatusResponseParsingSpec.scala
+++ b/supportedBackends/google/pipelines/v1alpha2/src/test/scala/cromwell/backend/google/pipelines/v1alpha2/api/StatusResponseParsingSpec.scala
@@ -33,7 +33,7 @@ class StatusResponseParsingSpec extends FlatSpec with Matchers with MockitoTrait
     val op = new Operation()
 
     val exception = intercept[RuntimeException](GetRequestHandler.interpretOperationStatus(op))
-    exception.getMessage should be("Caught NPE while processing operation null: {}")
+    exception.getMessage should startWith("Caught NPE while processing operation null")
   }
 
   it should "catch and wrap null pointer exceptions in a name only operation" in {
@@ -41,7 +41,7 @@ class StatusResponseParsingSpec extends FlatSpec with Matchers with MockitoTrait
     op.setName("my/customName")
 
     val exception = intercept[RuntimeException](GetRequestHandler.interpretOperationStatus(op))
-    exception.getMessage should be("Caught NPE while processing operation my/customName: {name=my/customName}")
+    exception.getMessage should startWith ("Caught NPE while processing operation my/customName")
   }
 
   it should "parse an operation without machine information" in {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -2,13 +2,15 @@ package cromwell.backend.google.pipelines.v2alpha1
 
 import java.net.URL
 
-import com.google.api.client.http.HttpRequestInitializer
+import cats.effect.IO
+import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponse}
+import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.compute.ComputeScopes
-import com.google.api.services.genomics.v2alpha1.{Genomics, GenomicsScopes}
 import com.google.api.services.genomics.v2alpha1.model._
+import com.google.api.services.genomics.v2alpha1.{Genomics, GenomicsScopes}
 import com.google.api.services.oauth2.Oauth2Scopes
 import com.google.api.services.storage.StorageScopes
-import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.LocalizationConfiguration
+import cromwell.backend.google.pipelines.common.PipelinesApiAttributes.{LocalizationConfiguration, VirtualPrivateCloudConfiguration}
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.api.{PipelinesApiFactoryInterface, PipelinesApiRequestFactory}
 import cromwell.backend.google.pipelines.v2alpha1.PipelinesConversions._
@@ -17,7 +19,11 @@ import cromwell.backend.standard.StandardAsyncJob
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import cromwell.core.DockerConfiguration
 import cromwell.core.logging.JobLogger
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.parser.decode
 import mouse.all._
+import org.apache.commons.lang3.exception.ExceptionUtils
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
@@ -31,6 +37,11 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
   with Delocalization {
 
   override def build(initializer: HttpRequestInitializer): PipelinesApiRequestFactory = new PipelinesApiRequestFactory {
+    implicit lazy val googleProjectMetadataLabelDecoder: Decoder[ProjectLabels] = deriveDecoder
+
+    val ResourceManagerAuthScopes = List(GenomicsScopes.CLOUD_PLATFORM).asJava
+    val VirtualPrivateCloudNetworkPath = "projects/%s/global/networks/%s/"
+
     val genomics = new Genomics.Builder(
       GoogleAuthMode.httpTransport,
       GoogleAuthMode.jsonFactory,
@@ -47,7 +58,74 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       genomics.projects().operations().get(job.jobId).buildHttpRequest()
     }
 
-    override def runRequest(createPipelineParameters: CreatePipelineParameters, jobLogger: JobLogger) = {
+    override def runRequest(createPipelineParameters: CreatePipelineParameters, jobLogger: JobLogger): HttpRequest = {
+
+      def projectMetadataRequest(vpcConfig: VirtualPrivateCloudConfiguration): IO[HttpRequest] = {
+        val workflowOptions = createPipelineParameters.jobDescriptor.workflowDescriptor.workflowOptions
+
+        val googleCredentialOption = vpcConfig.auth.apiClientGoogleCredential((key: String) => workflowOptions.get(key).get)
+
+        googleCredentialOption match {
+          case None => IO.raiseError(new RuntimeException(s"Programmer Error: Unable to find Google Credential for auth `${vpcConfig.auth.name}`."))
+          case Some(googleCredential) => IO {
+            val auth = googleCredential.createScoped(ResourceManagerAuthScopes)
+
+            val cloudResourceManagerBuilder = new CloudResourceManager
+              .Builder(GoogleAuthMode.httpTransport, GoogleAuthMode.jsonFactory, auth)
+              .build()
+
+            val project = cloudResourceManagerBuilder.projects().get(createPipelineParameters.projectId)
+
+            project.buildHttpRequest()
+          }
+        }
+      }
+
+
+      def projectMetadataResponseToLabels(httpResponse: HttpResponse): IO[ProjectLabels] = {
+        IO.fromEither(decode[ProjectLabels](httpResponse.parseAsString())).handleErrorWith {
+          e => IO.raiseError(new RuntimeException(s"Failed to parse labels from project metadata response from Google Cloud Resource Manager API. " +
+            s"${ExceptionUtils.getMessage(e)}", e))
+        }
+      }
+
+
+      def networkFromLabels(vpcConfig: VirtualPrivateCloudConfiguration, projectLabels: ProjectLabels): Network = {
+        val networkLabelOption = projectLabels.labels.find(l => l._1.equals(vpcConfig.name))
+
+        networkLabelOption match {
+          case Some(networkLabel) =>
+            new Network()
+              .setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
+              .setName(VirtualPrivateCloudNetworkPath.format(createPipelineParameters.projectId, networkLabel._2))
+          case None =>
+            jobLogger.debug("Project `{}` does not have high security network configured. " +
+              "Project metadata does not have network label key `{}`. Falling back to running the job on default network.", createPipelineParameters.projectId: Any, vpcConfig.name: Any)
+            new Network().setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
+        }
+      }
+
+
+      def createNetworkWithVPC(vpcConfig: VirtualPrivateCloudConfiguration): IO[Network] = {
+        for {
+          projectMetadataResponse <- projectMetadataRequest(vpcConfig).map(_.executeAsync().get())
+          projectLabels <- projectMetadataResponseToLabels(projectMetadataResponse)
+          networkLabels <- IO(networkFromLabels(vpcConfig, projectLabels))
+        } yield networkLabels
+      }
+
+
+      def createNetwork(): Network = {
+        createPipelineParameters.virtualPrivateCloudConfiguration match {
+          case None => new Network().setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
+          case Some(vpcConfig) =>
+            createNetworkWithVPC(vpcConfig).handleErrorWith {
+              e => IO.raiseError(new RuntimeException(s"Failed to create Network object for project `${createPipelineParameters.projectId}`. " +
+                s"Error(s): ${ExceptionUtils.getMessage(e)}", e))
+            }.unsafeRunSync()
+        }
+      }
+
       // Disks defined in the runtime attributes
       val disks = createPipelineParameters |> toDisks
       // Mounts for disks defined in the runtime attributes
@@ -83,8 +161,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
           ).asJava
         )
 
-      val network = new Network()
-        .setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
+      val network: Network = createNetwork()
 
       val accelerators = createPipelineParameters.runtimeAttributes
         .gpuResource.map(toAccelerator).toList.asJava
@@ -167,3 +244,5 @@ object GenomicsFactory {
     */
   val MonitoringWrite = "https://www.googleapis.com/auth/monitoring.write"
 }
+
+case class ProjectLabels(labels: Map[String, String])


### PR DESCRIPTION
This PR adds support for running PapiV2 jobs on a private network. The support for subnetwork is still in discussion and design phase, and hence it will be added in a future PR.

Closes #4806 for now.