### PR TITLE
Don't attempt to dequeue from empty queues

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -74,7 +74,6 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
       } else {
         leaseTry match {
           case thl: TokenHoggingLease =>
-            val oldQueue = queues(hogGroup)
             val (placeholder, newQueue) = oldQueue.dequeue
             val (newQueues, newQueueOrder) = if (newQueue.isEmpty) {
               (queues - hogGroup, remainingHogGroups ++ queuesTried)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -50,9 +50,9 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
     */
   def dequeue: DequeueResult = {
     val guaranteedNonEmptyQueues = queues.filterNot { case (hogGroup, q: Queue[_]) =>
-      val result = q.isEmpty
-      if (!result) logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup")
-      result
+      val empty = q.isEmpty
+      if (empty) logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup")
+      empty
     }
     recursingDequeue(guaranteedNonEmptyQueues, Vector.empty, queueOrder)
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -51,7 +51,7 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
   def dequeue: DequeueResult = {
     val guaranteedNonEmptyQueues = queues.filterNot { case (hogGroup, q: Queue[_]) =>
       val empty = q.isEmpty
-      if (empty) logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup")
+      if (empty) logger.warn(s"Programmer error: Empty token queue value still present in TokenQueue: $hogGroup")
       empty
     }
     recursingDequeue(guaranteedNonEmptyQueues, Vector.empty, queueOrder)
@@ -69,7 +69,7 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
 
       if (oldQueue.isEmpty) {
         // We should have caught this above. But just in case:
-        logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup *and* made it through into recursiveDequeue(!): $hogGroup")
+        logger.warn(s"Programmer error: Empty token queue value still present in TokenQueue: $hogGroup *and* made it through into recursiveDequeue(!): $hogGroup")
         recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
       } else {
         leaseTry match {

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.tokens
 
 import akka.actor.ActorRef
+import com.typesafe.scalalogging.LazyLogging
 import cromwell.core.JobExecutionToken
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.TokenQueue._
@@ -17,7 +18,7 @@ import scala.collection.immutable.Queue
 final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
                             queueOrder: Vector[String],
                             eventLogger: TokenEventLogger,
-                            private [tokens] val pool: UnhoggableTokenPool) {
+                            private [tokens] val pool: UnhoggableTokenPool) extends LazyLogging {
   val tokenType = pool.tokenType
 
   /**
@@ -47,7 +48,14 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
     * Returns a dequeue'd actor if one exists and there's a token available for it
     * Returns an updated token queue based on this request (successful queuees get removed, hogs get sent to the back)
     */
-  def dequeue: DequeueResult = recursingDequeue(queues, Vector.empty, queueOrder)
+  def dequeue: DequeueResult = {
+    val guaranteedNonEmptyQueues = queues.filterNot { case (hogGroup, q: Queue[_]) =>
+      val result = q.isEmpty
+      if (!result) logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup")
+      result
+    }
+    recursingDequeue(guaranteedNonEmptyQueues, Vector.empty, queueOrder)
+  }
 
   private def recursingDequeue(queues: Map[String, Queue[TokenQueuePlaceholder]], queuesTried: Vector[String], queuesRemaining: Vector[String]): DequeueResult = {
     if (queuesRemaining.isEmpty) {
@@ -57,23 +65,31 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
       val remainingHogGroups = queuesRemaining.tail
       val leaseTry = pool.tryAcquire(hogGroup)
 
-      leaseTry match {
-        case thl: TokenHoggingLease =>
-          val oldQueue = queues(hogGroup)
-          val (placeholder, newQueue) = oldQueue.dequeue
-          val (newQueues, newQueueOrder) = if (newQueue.isEmpty) {
-            (queues - hogGroup, remainingHogGroups ++ queuesTried)
-          } else {
-            (queues + (hogGroup -> newQueue), remainingHogGroups ++ queuesTried :+ hogGroup)
-          }
-          DequeueResult(Some(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
-        case TokenTypeExhausted =>
-          // The pool is completely full right now, so there's no benefit trying the other hog groups:
-          eventLogger.outOfTokens(tokenType.backend)
-          DequeueResult(None, this)
-        case HogLimitExceeded =>
-          eventLogger.flagTokenHog(hogGroup)
-          recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+      val oldQueue = queues(hogGroup)
+
+      if (oldQueue.isEmpty) {
+        // We should have caught this above. But just in case:
+        logger.warn(s"Empty token queue value still present in TokenQueue: $hogGroup *and* made it through into recursiveDequeue(!): $hogGroup")
+        recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+      } else {
+        leaseTry match {
+          case thl: TokenHoggingLease =>
+            val oldQueue = queues(hogGroup)
+            val (placeholder, newQueue) = oldQueue.dequeue
+            val (newQueues, newQueueOrder) = if (newQueue.isEmpty) {
+              (queues - hogGroup, remainingHogGroups ++ queuesTried)
+            } else {
+              (queues + (hogGroup -> newQueue), remainingHogGroups ++ queuesTried :+ hogGroup)
+            }
+            DequeueResult(Some(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
+          case TokenTypeExhausted =>
+            // The pool is completely full right now, so there's no benefit trying the other hog groups:
+            eventLogger.outOfTokens(tokenType.backend)
+            DequeueResult(None, this)
+          case HogLimitExceeded =>
+            eventLogger.flagTokenHog(hogGroup)
+            recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+        }
       }
     }
   }


### PR DESCRIPTION
Potential hotfix candidate but would be nice to know why these empty queues are appearing in the first place.

An attempt to recover from (though probably not fix the underlying cause of) tokens going missing due to stack traces like:
```
[cromwell-system-akka.actor.default-dispatcher-1158] ERROR akka.actor.OneForOneStrategy - dequeue on empty queue
java.util.NoSuchElementException: dequeue on empty queue
	at scala.collection.immutable.Queue.dequeue(Queue.scala:155)
	at cromwell.engine.workflow.tokens.TokenQueue.recursingDequeue(TokenQueue.scala:63)
	at cromwell.engine.workflow.tokens.TokenQueue.dequeue(TokenQueue.scala:50)
	at cromwell.engine.workflow.tokens.RoundRobinQueueIterator.$anonfun$findFirst$1(RoundRobinQueueIterator.scala:46)
	at cromwell.engine.workflow.tokens.RoundRobinQueueIterator.$anonfun$findFirst$1$adapted(RoundRobinQueueIterator.scala:46)
	at scala.collection.immutable.Stream.$anonfun$map$1(Stream.scala:415)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1169)
	at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1159)
	at scala.collection.immutable.StreamIterator.$anonfun$next$1(Stream.scala:1058)
	at scala.collection.immutable.StreamIterator$LazyCell.v$lzycompute(Stream.scala:1047)
	at scala.collection.immutable.StreamIterator$LazyCell.v(Stream.scala:1047)
	at scala.collection.immutable.StreamIterator.hasNext(Stream.scala:1052)
	at scala.collection.TraversableOnce.collectFirst(TraversableOnce.scala:144)
	at scala.collection.TraversableOnce.collectFirst$(TraversableOnce.scala:132)
	at scala.collection.AbstractTraversable.collectFirst(Traversable.scala:104)
	at cromwell.engine.workflow.tokens.RoundRobinQueueIterator.findFirst(RoundRobinQueueIterator.scala:48)
	at cromwell.engine.workflow.tokens.RoundRobinQueueIterator.next(RoundRobinQueueIterator.scala:32)
	at cromwell.engine.workflow.tokens.RoundRobinQueueIterator.next(RoundRobinQueueIterator.scala:10)
	at scala.collection.Iterator$SliceIterator.next(Iterator.scala:268)
	at scala.collection.Iterator.foreach(Iterator.scala:944)
	at scala.collection.Iterator.foreach$(Iterator.scala:944)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1432)
	at scala.collection.generic.Growable.$plus$plus$eq(Growable.scala:59)
	at scala.collection.generic.Growable.$plus$plus$eq$(Growable.scala:50)
	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:186)
	at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:44)
	at scala.collection.TraversableOnce.to(TraversableOnce.scala:310)
	at scala.collection.TraversableOnce.to$(TraversableOnce.scala:308)
	at scala.collection.AbstractIterator.to(Iterator.scala:1432)
	at scala.collection.TraversableOnce.toList(TraversableOnce.scala:294)
	at scala.collection.TraversableOnce.toList$(TraversableOnce.scala:294)
	at scala.collection.AbstractIterator.toList(Iterator.scala:1432)
	at cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.cromwell$engine$workflow$tokens$JobExecutionTokenDispenserActor$$distribute(JobExecutionTokenDispenserActor.scala:109)
	at cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor$$anonfun$tokenDistributionReceive$1.applyOrElse(JobExecutionTokenDispenserActor.scala:75)
	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:171)
	at akka.actor.Actor.aroundReceive(Actor.scala:517)
	at akka.actor.Actor.aroundReceive$(Actor.scala:515)
	at cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.akka$actor$Timers$$super$aroundReceive(JobExecutionTokenDispenserActor.scala:24)
	at akka.actor.Timers.aroundReceive(Timers.scala:55)
	at akka.actor.Timers.aroundReceive$(Timers.scala:40)
	at cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.aroundReceive(JobExecutionTokenDispenserActor.scala:24)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:588)
	at akka.actor.ActorCell.invoke(ActorCell.scala:557)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:258)
	at akka.dispatch.Mailbox.run(Mailbox.scala:225)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:235)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
```