### PR TITLE
Possible JobExecutionTokenDispenserActor crashing root cause fix

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -82,24 +82,16 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
     if (tokenAssignments.contains(sndr)) {
       sndr ! JobExecutionTokenDispensed
     } else {
+      val queue = tokenQueues.getOrElse(tokenType, TokenQueue(tokenType, tokenEventLogger))
+      tokenQueues += tokenType -> queue.enqueue(TokenQueuePlaceholder(sndr, hogGroup))
       context.watch(sndr)
-      val updatedTokenQueue = getTokenQueue(tokenType).enqueue(TokenQueuePlaceholder(sndr, hogGroup))
-      tokenQueues += tokenType -> updatedTokenQueue
+      ()
     }
-  }
-
-  private def getTokenQueue(tokenType: JobExecutionTokenType): TokenQueue = {
-    tokenQueues.getOrElse(tokenType, createNewQueue(tokenType))
-  }
-
-  private def createNewQueue(tokenType: JobExecutionTokenType): TokenQueue = {
-    val newQueue = TokenQueue(tokenType, tokenEventLogger)
-    tokenQueues += tokenType -> newQueue
-    newQueue
   }
 
   private def distribute(n: Int) = if (tokenQueues.nonEmpty) {
 
+    // Turning a mutable `Map` to a `List` and using an indexed pointer?
     val iterator = new RoundRobinQueueIterator(tokenQueues.values.toList, currentTokenQueuePointer)
 
     // In rare cases, an abort might empty an inner queue between "available" and "dequeue", which could cause an
@@ -126,6 +118,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
       case LeasedActor(queuePlaceholder, lease) =>
         log.error(s"Actor ${queuePlaceholder.actor.path} requested a job execution token more than once. This situation should have been impossible.")
         queuePlaceholder.actor ! JobExecutionTokenDispensed
+        // If there are going to be > 1 actors mapping to this lease why is the lease being released?
         lease.release()
     })
 
@@ -140,7 +133,8 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         leasedToken.release()
         context.unwatch(actor)
         ()
-      case None =>  log.error("Job execution token returned from incorrect actor: {}", actor.path.name)
+      case None =>
+        log.error("Job execution token returned from incorrect actor: {}", actor.path.name)
     }
   }
 
@@ -150,7 +144,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         log.debug("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
         self.tell(msg = JobExecutionTokenReturn, sender = terminee)
       case None =>
-        log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
+        log.error("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
         // This is a very inefficient way to remove the actor from the queue and can lead to very poor performance for a large queue and a large number of actors to remove
         tokenQueues = tokenQueues map {
           case (tokenType, tokenQueue) => tokenType -> tokenQueue.removeLostActor(terminee)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -144,10 +144,10 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         log.debug("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
         self.tell(msg = JobExecutionTokenReturn, sender = terminee)
       case None =>
-        log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
+        log.debug("Actor {} stopped before receiving a token, removing it from any queues if necessary", terminee)
         // This is a very inefficient way to remove the actor from the queue and can lead to very poor performance for a large queue and a large number of actors to remove
         tokenQueues = tokenQueues map {
-          case (tokenType, tokenQueue) => tokenType -> tokenQueue.removeLostActor(terminee)
+          case (tokenType, tokenQueue) => tokenType -> tokenQueue.removeTokenlessActor(terminee)
         }
     }
     context.unwatch(terminee)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/JobExecutionTokenDispenserActor.scala
@@ -144,7 +144,7 @@ class JobExecutionTokenDispenserActor(override val serviceRegistryActor: ActorRe
         log.debug("Actor {} stopped without returning its Job Execution Token. Reclaiming it!", terminee)
         self.tell(msg = JobExecutionTokenReturn, sender = terminee)
       case None =>
-        log.error("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
+        log.debug("Actor {} stopped while we were still watching it... but it doesn't have a token. Removing it from any queues if necessary", terminee)
         // This is a very inefficient way to remove the actor from the queue and can lead to very poor performance for a large queue and a large number of actors to remove
         tokenQueues = tokenQueues map {
           case (tokenType, tokenQueue) => tokenType -> tokenQueue.removeLostActor(terminee)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -78,12 +78,12 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
     }
   }
 
-  def removeLostActor(lostActor: ActorRef): TokenQueue = {
-    val lostActorRemovedQueues = queues.map { case (hogGroup, queue) =>
-      hogGroup -> queue.filterNot(_.actor == lostActor)
+  def removeTokenlessActor(actor: ActorRef): TokenQueue = {
+    val actorRemovedQueues = queues.map { case (hogGroup, queue) =>
+      hogGroup -> queue.filterNot(_.actor == actor)
     }
 
-    val (emptyQueues, nonEmptyQueues) = lostActorRemovedQueues partition { case (_, q) => q.isEmpty }
+    val (emptyQueues, nonEmptyQueues) = actorRemovedQueues partition { case (_, q) => q.isEmpty }
     val emptyHogGroups = emptyQueues.keys.toSet
 
     this.copy(

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -83,9 +83,13 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
       hogGroup -> queue.filterNot(_.actor == lostActor)
     }
 
+    val (emptyQueues, nonEmptyQueues) = lostActorRemovedQueues partition { case (_, q) => q.isEmpty }
+    val emptyHogGroups = emptyQueues.keys.toSet
+
     this.copy(
       // Filter out hog group mappings with empty queues
-      queues = lostActorRemovedQueues filterNot { case (_, q) => q.isEmpty }
+      queues = nonEmptyQueues,
+      queueOrder = queueOrder filterNot emptyHogGroups.contains
     )
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -78,11 +78,16 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
     }
   }
 
-  def removeLostActor(lostActor: ActorRef): TokenQueue = this.copy(
-    queues = queues.map { case (hogGroup, queue) =>
+  def removeLostActor(lostActor: ActorRef): TokenQueue = {
+    val lostActorRemovedQueues = queues.map { case (hogGroup, queue) =>
       hogGroup -> queue.filterNot(_.actor == lostActor)
     }
-  )
+
+    this.copy(
+      // Filter out hog group mappings with empty queues
+      queues = lostActorRemovedQueues filterNot { case (_, q) => q.isEmpty }
+    )
+  }
 
   /**
     * Returns true if there's at least on element that can be dequeued, false otherwise.

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
@@ -21,9 +21,9 @@ final class UnhoggableTokenPool(val tokenType: JobExecutionTokenType) extends Si
   _healthCheck = Function.const(true)) {
 
   lazy val hogLimitOption: Option[Int] = tokenType match {
-    case JobExecutionTokenType(_, None, _) => None
-    case JobExecutionTokenType(_, Some(limit), hogFactor) if hogFactor > 1 => Option(math.max(1, math.round(limit.floatValue() / hogFactor.floatValue())))
-    case JobExecutionTokenType(_, _, _) => None
+    case JobExecutionTokenType(_, Some(limit), hogFactor) if hogFactor > 1 =>
+      Option(math.max(1, math.round(limit.floatValue() / hogFactor.floatValue())))
+    case _ => None
   }
 
   private[this] val hogGroupAssignments: mutable.Map[String, HashSet[JobExecutionToken]] = mutable.Map.empty
@@ -55,7 +55,7 @@ final class UnhoggableTokenPool(val tokenType: JobExecutionTokenType) extends Si
         synchronized {
           val thisHogSet = hogGroupAssignments.getOrElse(hogGroup, HashSet.empty)
 
-          if (thisHogSet.size + 1 <= hogLimit) {
+          if (thisHogSet.size < hogLimit) {
             super.tryAcquire() match {
               case Some(lease) =>
                 val hoggingLease = new TokenHoggingLease(lease, hogGroup, this)


### PR DESCRIPTION
If an EJEA dies after requesting but before receiving a token there was the possibility for the `TokenQueue` of its hog group to become empty. That scenario would cause a crashing `.dequeue` which leads to [all sorts of badness](https://github.com/broadinstitute/cromwell/pull/4909).

Lots of other cleanup / "improvements" as I looked for problems. 