### PR TITLE
[develop] Job execution token dispenser actor fixes

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.tokens
 
 import akka.actor.ActorRef
+import com.typesafe.scalalogging.LazyLogging
 import cromwell.core.JobExecutionToken
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.TokenQueue._
@@ -17,7 +18,7 @@ import scala.collection.immutable.Queue
 final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
                             queueOrder: Vector[String],
                             eventLogger: TokenEventLogger,
-                            private [tokens] val pool: UnhoggableTokenPool) {
+                            private [tokens] val pool: UnhoggableTokenPool) extends LazyLogging {
   val tokenType = pool.tokenType
 
   /**
@@ -47,7 +48,14 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
     * Returns a dequeue'd actor if one exists and there's a token available for it
     * Returns an updated token queue based on this request (successful queuees get removed, hogs get sent to the back)
     */
-  def dequeue: DequeueResult = recursingDequeue(queues, Vector.empty, queueOrder)
+  def dequeue: DequeueResult = {
+    val guaranteedNonEmptyQueues = queues.filterNot { case (hogGroup, q: Queue[_]) =>
+      val empty = q.isEmpty
+      if (empty) logger.warn(s"Programmer error: Empty token queue value still present in TokenQueue: $hogGroup")
+      empty
+    }
+    recursingDequeue(guaranteedNonEmptyQueues, Vector.empty, queueOrder)
+  }
 
   private def recursingDequeue(queues: Map[String, Queue[TokenQueuePlaceholder]], queuesTried: Vector[String], queuesRemaining: Vector[String]): DequeueResult = {
     if (queuesRemaining.isEmpty) {
@@ -57,23 +65,30 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
       val remainingHogGroups = queuesRemaining.tail
       val leaseTry = pool.tryAcquire(hogGroup)
 
-      leaseTry match {
-        case thl: TokenHoggingLease =>
-          val oldQueue = queues(hogGroup)
-          val (placeholder, newQueue) = oldQueue.dequeue
-          val (newQueues, newQueueOrder) = if (newQueue.isEmpty) {
-            (queues - hogGroup, remainingHogGroups ++ queuesTried)
-          } else {
-            (queues + (hogGroup -> newQueue), remainingHogGroups ++ queuesTried :+ hogGroup)
-          }
-          DequeueResult(Some(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
-        case TokenTypeExhausted =>
-          // The pool is completely full right now, so there's no benefit trying the other hog groups:
-          eventLogger.outOfTokens(tokenType.backend)
-          DequeueResult(None, this)
-        case HogLimitExceeded =>
-          eventLogger.flagTokenHog(hogGroup)
-          recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+      val oldQueue = queues(hogGroup)
+
+      if (oldQueue.isEmpty) {
+        // We should have caught this above. But just in case:
+        logger.warn(s"Programmer error: Empty token queue value still present in TokenQueue: $hogGroup *and* made it through into recursiveDequeue(!): $hogGroup")
+        recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+      } else {
+        leaseTry match {
+          case thl: TokenHoggingLease =>
+            val (placeholder, newQueue) = oldQueue.dequeue
+            val (newQueues, newQueueOrder) = if (newQueue.isEmpty) {
+              (queues - hogGroup, remainingHogGroups ++ queuesTried)
+            } else {
+              (queues + (hogGroup -> newQueue), remainingHogGroups ++ queuesTried :+ hogGroup)
+            }
+            DequeueResult(Some(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
+          case TokenTypeExhausted =>
+            // The pool is completely full right now, so there's no benefit trying the other hog groups:
+            eventLogger.outOfTokens(tokenType.backend)
+            DequeueResult(None, this)
+          case HogLimitExceeded =>
+            eventLogger.flagTokenHog(hogGroup)
+            recursingDequeue(queues, queuesTried :+ hogGroup, remainingHogGroups)
+        }
       }
     }
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/TokenQueue.scala
@@ -1,7 +1,7 @@
 package cromwell.engine.workflow.tokens
 
 import akka.actor.ActorRef
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.StrictLogging
 import cromwell.core.JobExecutionToken
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.engine.workflow.tokens.TokenQueue._
@@ -18,7 +18,7 @@ import scala.collection.immutable.Queue
 final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
                             queueOrder: Vector[String],
                             eventLogger: TokenEventLogger,
-                            private [tokens] val pool: UnhoggableTokenPool) extends LazyLogging {
+                            private [tokens] val pool: UnhoggableTokenPool) extends StrictLogging {
   val tokenType = pool.tokenType
 
   /**
@@ -80,7 +80,7 @@ final case class TokenQueue(queues: Map[String, Queue[TokenQueuePlaceholder]],
             } else {
               (queues + (hogGroup -> newQueue), remainingHogGroups ++ queuesTried :+ hogGroup)
             }
-            DequeueResult(Some(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
+            DequeueResult(Option(LeasedActor(placeholder, thl)), TokenQueue(newQueues, newQueueOrder, eventLogger, pool))
           case TokenTypeExhausted =>
             // The pool is completely full right now, so there's no benefit trying the other hog groups:
             eventLogger.outOfTokens(tokenType.backend)

--- a/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/tokens/UnhoggableTokenPool.scala
@@ -21,9 +21,9 @@ final class UnhoggableTokenPool(val tokenType: JobExecutionTokenType) extends Si
   _healthCheck = Function.const(true)) {
 
   lazy val hogLimitOption: Option[Int] = tokenType match {
-    case JobExecutionTokenType(_, None, _) => None
-    case JobExecutionTokenType(_, Some(limit), hogFactor) if hogFactor > 1 => Option(math.max(1, math.round(limit.floatValue() / hogFactor.floatValue())))
-    case JobExecutionTokenType(_, _, _) => None
+    case JobExecutionTokenType(_, Some(limit), hogFactor) if hogFactor > 1 =>
+      Option(math.max(1, math.round(limit.floatValue() / hogFactor.floatValue())))
+    case _ => None
   }
 
   private[this] val hogGroupAssignments: mutable.Map[String, HashSet[JobExecutionToken]] = mutable.Map.empty
@@ -55,7 +55,7 @@ final class UnhoggableTokenPool(val tokenType: JobExecutionTokenType) extends Si
         synchronized {
           val thisHogSet = hogGroupAssignments.getOrElse(hogGroup, HashSet.empty)
 
-          if (thisHogSet.size + 1 <= hogLimit) {
+          if (thisHogSet.size < hogLimit) {
             super.tryAcquire() match {
               case Some(lease) =>
                 val hoggingLease = new TokenHoggingLease(lease, hogGroup, this)


### PR DESCRIPTION
Closes #4908.

Combines the changes in #4909 (sanity check in case this happens again) and #4923 (should prevent it happening in the first place) and adds a test case for one scenario which was found to cause this problem