### PR TITLE
Call cache no copy fixups and centaur error improvements

### DIFF
--- a/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
@@ -24,9 +24,10 @@ class Slf4jReporter(override val params: ErrorReporterParams)
     IO {
       val message =
         s"Test '${testEnvironment.name}' " +
-          centaurTestException.workflowIdOption.map("with workflow id '" + _ + "' ").getOrElse("") +
           s"failed on attempt ${testEnvironment.attempt + 1} " +
-          s"of ${testEnvironment.retries + 1}"
+          s"of ${testEnvironment.retries + 1} " +
+          centaurTestException.workflowIdOption.map("with workflow id '" + _ + "' ").getOrElse("")
+
       logger.error(message, centaurTestException)
     }
   }

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
@@ -2,6 +2,9 @@ name: invalidate_bad_caches_jes_no_copy
 testFormat: workflowsuccess
 backends: [Papi-Caching-No-Copy]
 
+# No point retrying failures since they'll just end up colliding with previous results:
+retryTestFailures: false
+
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches_no_copy.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
@@ -5,7 +5,6 @@ backends: [Papi-Caching-No-Copy]
 # No point retrying failures since they'll just end up colliding with previous results:
 retryTestFailures: false
 
-
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches_no_copy.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes_no_copy.test
@@ -5,6 +5,7 @@ backends: [Papi-Caching-No-Copy]
 # No point retrying failures since they'll just end up colliding with previous results:
 retryTestFailures: false
 
+
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches_no_copy.wdl
 }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -230,7 +230,7 @@ object Operations {
                     metadataJson <- parse(metadata.value).toOption
                     asObject <- metadataJson.asObject
                     failures <- asObject.toMap.get("failures")
-                  } yield s" Metadata 'failures' content: ${failures.pretty(Printer.spaces2)}").getOrElse("No additional failure information found in metadata.")
+                  } yield s" Metadata 'failures' content: ${failures.spaces2}").getOrElse("No additional failure information found in metadata.")
                 } else {
                   ""
                 }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -383,10 +383,10 @@ object Operations {
     new Test[WorkflowMetadata] {
       def eventuallyMetadata(workflow: SubmittedWorkflow,
                              expectedMetadata: WorkflowFlatMetadata): IO[WorkflowMetadata] = {
-        validateMetadata(workflow, expectedMetadata).handleErrorWith({ _ =>
+        validateMetadata(workflow, expectedMetadata).handleErrorWith({ f =>
           for {
             _ <- IO.sleep(2.seconds)
-            _ = if (LogFailures) Console.err.println(s"Metadata mismatch for ${submittedWorkflow.id} - retrying")
+            _ = if (LogFailures) Console.err.println(s"Metadata mismatch for ${submittedWorkflow.id} (${f.getMessage}) - retrying")
             recurse <- eventuallyMetadata(workflow, expectedMetadata)
           } yield recurse
         })

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -8,7 +8,6 @@ import cats.instances.list._
 import cats.syntax.traverse._
 import centaur._
 import centaur.api.CentaurCromwellClient
-import centaur.api.CentaurCromwellClient.LogFailures
 import centaur.test.metadata.WorkflowFlatMetadata
 import centaur.test.metadata.WorkflowFlatMetadata._
 import centaur.test.submit.SubmitHttpResponse
@@ -396,10 +395,9 @@ object Operations {
     new Test[WorkflowMetadata] {
       def eventuallyMetadata(workflow: SubmittedWorkflow,
                              expectedMetadata: WorkflowFlatMetadata): IO[WorkflowMetadata] = {
-        validateMetadata(workflow, expectedMetadata).handleErrorWith({ f =>
+        validateMetadata(workflow, expectedMetadata).handleErrorWith({ _ =>
           for {
             _ <- IO.sleep(2.seconds)
-            _ = if (LogFailures) Console.err.println(s"Metadata mismatch for ${submittedWorkflow.id} (${f.getMessage}) - retrying")
             recurse <- eventuallyMetadata(workflow, expectedMetadata)
           } yield recurse
         })

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -24,7 +24,6 @@ import cromwell.api.CromwellClient.UnsuccessfulRequestException
 import cromwell.api.model.{CallCacheDiff, Failed, SubmittedWorkflow, Succeeded, TerminalStatus, WorkflowId, WorkflowMetadata, WorkflowStatus}
 import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
-import io.circe.Printer
 import io.circe.parser._
 import spray.json.JsString
 

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -206,6 +206,7 @@ object Operations {
 
 
       override def run: IO[SubmittedWorkflow] = status(timeout).timeout(CentaurConfig.maxWorkflowLength)
+
     }
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -397,8 +397,6 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   onTransition {
     case fromState -> toState =>
-      // TODO: UNDO THIS!
-      log.info("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
       eventList :+= ExecutionEvent(toState.toString)
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -397,6 +397,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   onTransition {
     case fromState -> toState =>
+      log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
       eventList :+= ExecutionEvent(toState.toString)
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -397,7 +397,8 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   onTransition {
     case fromState -> toState =>
-      log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
+      // TODO: UNDO THIS!
+      log.info("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
       eventList :+= ExecutionEvent(toState.toString)
   }
 


### PR DESCRIPTION
These changes are side effects of my investigation into the `invalidate_bad_caches_jes_no_copy`
 test on PAPIv1:

- Don't retry `invalidate_bad_caches_jes_no_copy` because it will never work the second time (even on v2)
- Print out any failure metadata we get if we expected `Succeeded` to speed up the debug cycle
- Don't log the "metadata mismatch" as errors just because we're waiting for metadata consistency.