### PR TITLE
Unify tutorial links in ReadTheDocs

### DIFF
--- a/docs/tutorials/AwsBatch101.md
+++ b/docs/tutorials/AwsBatch101.md
@@ -1,4 +1,4 @@
-## Getting started with AWS with AWS Batch (beta)
+## Getting started on AWS with AWS Batch (beta)
 
 ### Prerequisites
 

--- a/docs/tutorials/AwsBatch101.md
+++ b/docs/tutorials/AwsBatch101.md
@@ -1,4 +1,4 @@
-## Getting started with AWS Batch (beta)
+## Getting started with AWS with AWS Batch (beta)
 
 ### Prerequisites
 

--- a/docs/tutorials/BCSIntro.md
+++ b/docs/tutorials/BCSIntro.md
@@ -1,4 +1,4 @@
-## Getting started on Alibaba Cloud
+## Getting started on Alibaba Cloud with the Batch Compute Service
 
 ### Prerequisites
 
@@ -8,7 +8,7 @@ This tutorial page relies on completing the previous tutorials:
 
 ### Goals
 
-In this tutorial you'll learn to run the first workflow against the BatchCompute service on Alibaba Cloud.
+In this tutorial you'll learn to run the first workflow against the Batch Compute service on Alibaba Cloud.
 
 ### Let's get started!
 

--- a/docs/tutorials/PipelinesApi101.md
+++ b/docs/tutorials/PipelinesApi101.md
@@ -1,4 +1,4 @@
-## Getting started on Google Pipelines API
+## Getting started on Google Cloud with the Genomics Pipelines API
 
 ## Pipelines API v2
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,9 +11,9 @@ pages:
 #    - Tutorial Map: tutorials/Overview.md
     - Quick Introduction: tutorials/FiveMinuteIntro.md
     - How to Configure Cromwell: tutorials/ConfigurationFiles.md
-    - Getting started with Pipelines API: tutorials/PipelinesApi101.md
+    - Getting started with Google Cloud: tutorials/PipelinesApi101.md
     - Getting started with Alibaba Cloud: tutorials/BCSIntro.md
-    - Getting started with AWS Batch (beta): tutorials/AwsBatch101.md
+    - Getting started with AWS (beta): tutorials/AwsBatch101.md
     - View the Timing Diagrams: tutorials/TimingDiagrams.md
     - Persisting data between restarts: tutorials/PersistentServer.md
     - Getting started on HPC Clusters: tutorials/HPCIntro.md


### PR DESCRIPTION
It was pointed out that we weren't being consistent in read the docs between the various cloud tutorials