### PR TITLE
Changed google label checks to closer match requirements [BA-5674]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
+++ b/centaur/src/main/resources/standardTestCases/google_labels/bad_options.json
@@ -1,5 +1,5 @@
 {
   "google_labels": {
-    "custom-label-label-label-label-label-label-label-label-label-label": "0custom-value"
+    "custom-label-label-label-label-label-label-label-label-label-label": "~custom-value"
   }
 }

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -13,5 +13,5 @@ metadata {
 
   "failures.0.message": "Invalid 'google_labels' in workflow options"
   "failures.0.causedBy.0.message": "Invalid label field: `custom-label-label-label-label-label-label-label-label-label-label` is 66 characters. The maximum is 63."
-  "failures.0.causedBy.1.message": "Invalid label field: `0custom-value` did not match the regex '[a-z]([-a-z0-9]*[a-z0-9])?'"
+  "failures.0.causedBy.1.message": "Invalid label field: `~custom-value` did not match the regex '[-_a-z0-9]*'"
 }

--- a/centaur/src/main/resources/standardTestCases/jes_labels.test
+++ b/centaur/src/main/resources/standardTestCases/jes_labels.test
@@ -12,8 +12,8 @@ metadata {
   workflowName: I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_
   status: Succeeded
   "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.backendLabels.cromwell-workflow-id": "cromwell-<<UUID>>"
-  "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.backendLabels.wdl-task-name": "my-task"
-  "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.backendLabels.wdl-call-alias": "my-task-aliased"
+  "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.backendLabels.wdl-task-name": "my_task"
+  "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.backendLabels.wdl-call-alias": "my_task_aliased"
   "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.labels.wdl-task-name": "MY_TASK"
   "calls.I_hope_nobody_names_workflows_like_this_as_it_seems_very_unnecessary_.my_task_aliased.labels.wdl-call-alias": "my_task_aliased"
   "labels.cromwell-workflow-id": "cromwell-<<UUID>>"

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
@@ -18,9 +18,9 @@ final case class GoogleLabel(key: String, value: String)
 object GoogleLabels {
 
   val MaxLabelLength = 63
-  val GoogleLabelKeyRegexPattern = "[a-z]([_-a-z0-9]*[a-z0-9])?"
+  val GoogleLabelKeyRegexPattern = "[a-z]([-_a-z0-9]*[a-z0-9])?"
   val GoogleLabelKeyRegex = GoogleLabelKeyRegexPattern.r
-  val GoogleLabelValueRegexPattern = "[_-a-z0-9]*"
+  val GoogleLabelValueRegexPattern = "[-_a-z0-9]*"
   val GoogleLabelValueRegex = GoogleLabelValueRegexPattern.r
 
   // This function is used to coerce a string into one that meets the requirements for a label submission to Google Pipelines API.
@@ -41,10 +41,11 @@ object GoogleLabels {
 
         val foldResult = mainText.toCharArray.foldLeft("")(appendSafe)
 
-        val startsValid = if (labelKey) foldResult.headOption.exists(_.isLetter) else foldResult.lastOption.exists(_.isLetterOrDigit)
-        val endsValid = (
-          foldResult.lastOption.exists(_.isLetterOrDigit)
-          || foldResult.last.equals("-") || foldResult.last.equals("_")
+        val startsValid = foldResult.headOption.exists(
+          e => e.isLetter || (!labelKey && (e.isDigit || e == '_'))
+        )
+        val endsValid = foldResult.lastOption.exists(
+          e => e.isLetterOrDigit || (!labelKey && (e == '_' || e == '-'))
         )
 
         val validStart = if (startsValid) foldResult else "x--" + foldResult

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
@@ -27,7 +27,7 @@ object GoogleLabels {
   // See 'labels' in https://cloud.google.com/genomics/reference/rpc/google.genomics.v1alpha2#google.genomics.v1alpha2.RunPipelineArgs
   def safeGoogleName(mainText: String, labelKey: Boolean): String = {
 
-    val validator = if(labelKey) validateLabelKeyRegex else validateLabelValueRegex
+  val validator = if(labelKey) validateLabelKeyRegex(_) else validateLabelValueRegex(_)
     validator(mainText) match {
       case Valid(labelText) => labelText
       case invalid @ _ if mainText.equals("") && (!labelKey) => mainText

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
@@ -18,16 +18,18 @@ final case class GoogleLabel(key: String, value: String)
 object GoogleLabels {
 
   val MaxLabelLength = 63
-  val GoogleLabelRegexPattern = "[a-z]([-a-z0-9]*[a-z0-9])?"
-  val GoogleLabelRegex = GoogleLabelRegexPattern.r
+  val GoogleLabelKeyRegexPattern = "[a-z]([_-a-z0-9]*[a-z0-9])?"
+  val GoogleLabelKeyRegex = GoogleLabelKeyRegexPattern.r
+  val GoogleLabelValueRegexPattern = "[_-a-z0-9]*"
+  val GoogleLabelValueRegex = GoogleLabelValueRegexPattern.r
 
   // This function is used to coerce a string into one that meets the requirements for a label submission to Google Pipelines API.
   // See 'labels' in https://cloud.google.com/genomics/reference/rpc/google.genomics.v1alpha2#google.genomics.v1alpha2.RunPipelineArgs
-  def safeGoogleName(mainText: String, emptyAllowed: Boolean = false): String = {
+  def safeGoogleName(mainText: String, labelKey: Boolean): String = {
 
     validateLabelRegex(mainText) match {
       case Valid(labelText) => labelText
-      case invalid @ _ if mainText.equals("") && emptyAllowed => mainText
+      case invalid @ _ if mainText.equals("") && (!labelKey) => mainText
       case invalid @ _ =>
         def appendSafe(current: String, nextChar: Char): String = {
           nextChar match {
@@ -38,8 +40,11 @@ object GoogleLabels {
 
         val foldResult = mainText.toCharArray.foldLeft("")(appendSafe)
 
-        val startsValid = foldResult.headOption.exists(_.isLetter)
-        val endsValid = foldResult.lastOption.exists(_.isLetterOrDigit)
+        val startsValid = if (labelKey) foldResult.headOption.exists(_.isLetter) else foldResult.lastOption.exists(_.isLetterOrDigit)
+        val endsValid = (
+          foldResult.lastOption.exists(_.isLetterOrDigit)
+          || foldResult.last.equals("-") || foldResult.last.equals("_")
+        )
 
         val validStart = if (startsValid) foldResult else "x--" + foldResult
         val validStartAndEnd = if (endsValid) validStart else validStart + "--x"
@@ -57,11 +62,20 @@ object GoogleLabels {
     }
   }
 
-  def validateLabelRegex(s: String): ErrorOr[String] = {
-    (GoogleLabelRegex.pattern.matcher(s).matches, s.length <= MaxLabelLength) match {
+  def validateLabelKeyRegex(s: String): ErrorOr[String] = {
+    (GoogleLabelKeyRegex.pattern.matcher(s).matches, s.length <= MaxLabelLength) match {
       case (true, true) => s.validNel
-      case (false, false) => s"Invalid label field: `$s` did not match regex '$GoogleLabelRegexPattern' and it is ${s.length} characters. The maximum is $MaxLabelLength.".invalidNel
-      case (false, _) => s"Invalid label field: `$s` did not match the regex '$GoogleLabelRegexPattern'".invalidNel
+      case (false, false) => s"Invalid label field: `$s` did not match regex '$GoogleLabelKeyRegexPattern' and it is ${s.length} characters. The maximum is $MaxLabelLength.".invalidNel
+      case (false, _) => s"Invalid label field: `$s` did not match the regex '$GoogleLabelKeyRegexPattern'".invalidNel
+      case (_, false) => s"Invalid label field: `$s` is ${s.length} characters. The maximum is $MaxLabelLength.".invalidNel
+    }
+  }
+
+  def validateLabelValueRegex(s: String): ErrorOr[String] = {
+    (GoogleLabelValueRegex.pattern.matcher(s).matches, s.length <= MaxLabelLength) match {
+      case (true, true) => s.validNel
+      case (false, false) => s"Invalid label field: `$s` did not match regex '$GoogleLabelValueRegexPattern' and it is ${s.length} characters. The maximum is $MaxLabelLength.".invalidNel
+      case (false, _) => s"Invalid label field: `$s` did not match the regex '$GoogleLabelValueRegexPattern'".invalidNel
       case (_, false) => s"Invalid label field: `$s` is ${s.length} characters. The maximum is $MaxLabelLength.".invalidNel
     }
   }
@@ -69,13 +83,13 @@ object GoogleLabels {
 
   def safeLabels(values: (String, String)*): Seq[GoogleLabel] = {
     def safeGoogleLabel(kvp: (String, String)): GoogleLabel = {
-      GoogleLabel(safeGoogleName(kvp._1), safeGoogleName(kvp._2, emptyAllowed = true))
+      GoogleLabel(safeGoogleName(kvp._1, labelKey = true), safeGoogleName(kvp._2, labelKey = false))
     }
     values.map(safeGoogleLabel)
   }
 
   def validateLabel(key: String, value: String): ErrorOr[GoogleLabel] = {
-    (validateLabelRegex(key), validateLabelRegex(value)).mapN { (validKey, validValue) => GoogleLabel(validKey, validValue)  }
+    (validateLabelKeyRegex(key), validateLabelValueRegex(value)).mapN { (validKey, validValue) => GoogleLabel(validKey, validValue)  }
   }
 
   def fromWorkflowOptions(workflowOptions: WorkflowOptions): Try[Seq[GoogleLabel]] = {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GoogleLabels.scala
@@ -27,7 +27,8 @@ object GoogleLabels {
   // See 'labels' in https://cloud.google.com/genomics/reference/rpc/google.genomics.v1alpha2#google.genomics.v1alpha2.RunPipelineArgs
   def safeGoogleName(mainText: String, labelKey: Boolean): String = {
 
-    validateLabelRegex(mainText) match {
+    val validator = if(labelKey) validateLabelKeyRegex else validateLabelValueRegex
+    validator(mainText) match {
       case Valid(labelText) => labelText
       case invalid @ _ if mainText.equals("") && (!labelKey) => mainText
       case invalid @ _ =>

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
@@ -16,7 +16,6 @@ class GoogleLabelsSpec extends FlatSpec with Matchers {
     "cromwell-root-workflow-id-" -> "cromwell-root-workflow-id---x",
     "0-cromwell-root-workflow-id-" -> "x--0-cromwell-root-workflow-id---x",
     "Cromwell-root-workflow-id" -> "cromwell-root-workflow-id",
-    "cromwell_root_workflow_id" -> "cromwell-root-workflow-id",
     "too-long-too-long-too-long-too-long-too-long-too-long-too-long-t" -> "too-long-too-long-too-long-too---g-too-long-too-long-too-long-t",
     "0-too-long-and-invalid-too-long-and-invalid-too-long-and-invali+" -> "x--0-too-long-and-invalid-too----nvalid-too-long-and-invali---x"
   )
@@ -30,7 +29,7 @@ class GoogleLabelsSpec extends FlatSpec with Matchers {
     }
 
     it should s"convert the bad label string '$label' into the safe label string '$conversion'" in {
-      GoogleLabels.safeGoogleName(label, true) should be(conversion)
+      GoogleLabels.safeGoogleName(label, labelKey = true) should be(conversion)
     }
   }
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/GoogleLabelsSpec.scala
@@ -23,14 +23,14 @@ class GoogleLabelsSpec extends FlatSpec with Matchers {
 
   googleLabelConversions foreach { case (label: String, conversion: String) =>
     it should s"not validate the bad label key '$label'" in {
-      GoogleLabels.validateLabelRegex(label) match {
+      GoogleLabels.validateLabelKeyRegex(label) match {
         case Invalid(_) => // Good!
         case Valid(_) => fail(s"Label validation succeeded but should have failed.")
       }
     }
 
     it should s"convert the bad label string '$label' into the safe label string '$conversion'" in {
-      GoogleLabels.safeGoogleName(label) should be(conversion)
+      GoogleLabels.safeGoogleName(label, true) should be(conversion)
     }
   }
 }


### PR DESCRIPTION
Follow up to #4825

Attempted to change Cromwell's checks on labels to match what [Google Specifies](https://cloud.google.com/compute/docs/labeling-resources). Specifically: current implementation does not allow for label values to start with numbers, while Google does.

**Note:** I'm unfamiliar with the Cromwell codebase, as well as Scala itself. There are probably issues with my changes that I don't know to look for.