### PR TITLE
Google Auth Updates BA-5681

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -12,7 +12,8 @@ import centaur.test.metadata.WorkflowFlatMetadata
 import centaur.test.metadata.WorkflowFlatMetadata._
 import centaur.test.submit.SubmitHttpResponse
 import centaur.test.workflow.Workflow
-import com.google.api.services.genomics.Genomics
+import com.google.api.services.genomics.{Genomics, GenomicsScopes}
+import com.google.api.services.storage.StorageScopes
 import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.ServiceAccountCredentials
@@ -86,9 +87,10 @@ object Operations {
   lazy val googleConf: Config = CentaurConfig.conf.getConfig("google")
   lazy val authName: String = googleConf.getString("auth")
   lazy val genomicsEndpointUrl: String = googleConf.getString("genomics.endpoint-url")
+  lazy val genomicsAndStorageScopes = List(StorageScopes.CLOUD_PLATFORM_READ_ONLY, GenomicsScopes.GENOMICS)
   lazy val credentials: Credentials = configuration.auth(authName)
     .unsafe
-    .pipelinesApiCredentials(GoogleAuthMode.NoOptionLookup)
+    .credentials(genomicsAndStorageScopes)
   lazy val credentialsProjectOption: Option[String] = {
     Option(credentials) collect {
       case serviceAccountCredentials: ServiceAccountCredentials => serviceAccountCredentials.getProjectId

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
@@ -16,9 +16,7 @@ import cromwell.core.WorkflowOptions
 import cromwell.core.path.{PathBuilder, PathBuilderFactory}
 import org.apache.http.impl.client.HttpClientBuilder
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
-
 
 /**
   * Cromwell Wrapper around DrsFileSystems to load the configuration.
@@ -54,10 +52,9 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
 
   private def inputReadChannel(url: String, urlScheme: String, serviceAccount: String): IO[ReadableByteChannel] =  {
     urlScheme match {
-      case GcsScheme => {
+      case GcsScheme =>
         val Array(bucket, fileToBeLocalized) = url.replace(s"$GcsScheme://", "").split("/", 2)
         gcsInputStream(GcsFilePath(bucket, fileToBeLocalized), serviceAccount)
-      }
       case otherScheme => IO.raiseError(new UnsupportedOperationException(s"DRS currently doesn't support reading files for $otherScheme."))
     }
   }
@@ -82,8 +79,8 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
       // Profile and Email scopes are requirements for interacting with Martha v2
       Oauth2Scopes.USERINFO_EMAIL,
       Oauth2Scopes.USERINFO_PROFILE
-    ).asJavaCollection
-    val authCredentials = googleAuthMode.credentials((key: String) => options.get(key).get, marthaScopes)
+    )
+    val authCredentials = googleAuthMode.credentials(options.get(_).get, marthaScopes)
 
     Future.successful(DrsPathBuilder(new DrsCloudNioFileSystemProvider(singletonConfig.config, authCredentials, httpClientBuilder, drsReadInterpreter)))
   }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsPathBuilder.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.ContentTypes
 import better.files.File.OpenOptions
 import cats.effect.IO
 import com.google.api.gax.retrying.RetrySettings
+import com.google.api.services.storage.StorageScopes
 import com.google.auth.Credentials
 import com.google.cloud.storage.Storage.BlobTargetOption
 import com.google.cloud.storage.contrib.nio.{CloudStorageConfiguration, CloudStorageFileSystem, CloudStoragePath}
@@ -100,7 +101,7 @@ object GcsPathBuilder {
                    cloudStorageConfiguration: CloudStorageConfiguration,
                    options: WorkflowOptions,
                    defaultProject: Option[String])(implicit as: ActorSystem, ec: ExecutionContext): Future[GcsPathBuilder] = {
-    authMode.retryPipelinesApiCredentials(options) map { credentials =>
+    authMode.retryCredentials(options, List(StorageScopes.DEVSTORAGE_FULL_CONTROL)) map { credentials =>
       fromCredentials(credentials,
         applicationName,
         retrySettings,

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GoogleUtil.scala
@@ -24,13 +24,16 @@ object GoogleUtil {
 
   implicit class EnhancedGoogleAuthMode(val googleAuthMode: GoogleAuthMode) extends AnyVal {
     /**
-      * Retries getting the pipelines API credentials three times.
+      * Retries getting the credentials three times.
+      *
+      * There is nothing GCS specific about this method. This package just happens to be the lowest level with access
+      * to core's version of Retry + cloudSupport's implementation of GoogleAuthMode.
       */
-    def retryPipelinesApiCredentials(options: WorkflowOptions)
-                                    (implicit as: ActorSystem, ec: ExecutionContext): Future[Credentials] = {
+    def retryCredentials(options: WorkflowOptions, scopes: Iterable[String])
+                        (implicit actorSystem: ActorSystem, executionContext: ExecutionContext): Future[Credentials] = {
       def credential(): Credentials = {
         try {
-          googleAuthMode.pipelinesApiCredentials((key: String) => options.get(key).get)
+          googleAuthMode.credentials(options.get(_).get, scopes)
         } catch {
           case exception: OptionLookupException =>
             throw new IllegalArgumentException(s"Missing parameters in workflow options: ${exception.key}", exception)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiInitializationActor.scala
@@ -1,10 +1,18 @@
 package cromwell.backend.google.pipelines.common
 
 import akka.actor.ActorRef
+import com.google.api.services.cloudkms.v1.model.EncryptRequest
+import com.google.api.services.cloudkms.v1.{CloudKMS, CloudKMSScopes}
+import com.google.api.services.genomics.GenomicsScopes
+import com.google.api.services.storage.StorageScopes
 import com.google.auth.Credentials
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.OAuth2Credentials
+import cromwell.backend.google.pipelines.common.PipelinesApiInitializationActor._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory
 import cromwell.backend.standard.{StandardInitializationActor, StandardInitializationActorParams, StandardValidatedRuntimeAttributesBuilder}
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendWorkflowDescriptor}
+import cromwell.cloudsupport.gcp.auth.GoogleAuthMode.{httpTransport, jsonFactory}
 import cromwell.cloudsupport.gcp.auth.{GoogleAuthMode, UserServiceAccountMode}
 import cromwell.core.Dispatcher
 import cromwell.core.io.AsyncIoActorClient
@@ -40,12 +48,31 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
     PipelinesApiRuntimeAttributes.runtimeAttributesBuilder(pipelinesConfiguration)
 
   // Credentials object for the GCS API
-  private lazy val gcsCredentials: Future[Credentials] =
-    pipelinesConfiguration.papiAttributes.auths.gcs.retryPipelinesApiCredentials(workflowOptions)
+  private lazy val gcsCredentials: Future[Credentials] = pipelinesConfiguration.papiAttributes.auths.gcs
+      .retryCredentials(workflowOptions, List(StorageScopes.DEVSTORAGE_FULL_CONTROL))
 
   // Credentials object for the Genomics API
-  private lazy val genomicsCredentials: Future[Credentials] =
-    pipelinesConfiguration.papiAttributes.auths.genomics.retryPipelinesApiCredentials(workflowOptions)
+  private lazy val genomicsCredentials: Future[Credentials] = pipelinesConfiguration.papiAttributes.auths.genomics
+    .retryCredentials(workflowOptions, List(
+      GenomicsScopes.GENOMICS,
+      /*
+      Genomics Pipelines API v1alpha2 requires the COMPUTE scope. Does not seem to be required for v2alpha1.
+       */
+      GenomicsScopes.COMPUTE,
+      /*
+      Used to write so-called "auth" files. The `gcsAuthFilePath` could probably be refactored such that *this* created
+      `genomicsCredentials` doesn't actually need DEVSTORAGE_FULL_CONTROL, but it's also not clear how the magic
+      Genomics Pipelines API parameter "__extra_config_gcs_path" works nor where it's documented.
+
+      See also:
+      - cromwell.backend.google.pipelines.common.PipelinesApiWorkflowPaths#gcsAuthFilePath
+      - https://github.com/broadinstitute/cromwell/pull/2435
+      - cromwell.backend.google.pipelines.common.PipelinesApiConfiguration#needAuthFileUpload
+      - cromwell.cloudsupport.gcp.auth.GoogleAuthMode#requiresAuthFile
+      - cromwell.backend.google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor#gcsAuthParameter
+       */
+      StorageScopes.DEVSTORAGE_FULL_CONTROL,
+    ))
 
   // Genomics object to access the Genomics API
   private lazy val genomics: Future[PipelinesApiRequestFactory] = {
@@ -97,8 +124,9 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
       plain <- unencrypted
       auth <- effectiveAuth
       key <- privateDockerEncryptionKeyName
-      cred <- auth.apiClientGoogleCredential(k => workflowOptions.get(k).get)
-    } yield GoogleAuthMode.encryptKms(key, cred, plain)
+      credentials = auth.credentials(workflowOptions.get(_).get, List(CloudKMSScopes.CLOUD_PLATFORM))
+      encrypted = encryptKms(key, credentials, plain)
+    } yield encrypted
   }
 
   override lazy val workflowPaths: Future[PipelinesApiWorkflowPaths] = for {
@@ -140,4 +168,15 @@ class PipelinesApiInitializationActor(pipelinesParams: PipelinesApiInitializatio
 object PipelinesApiInitializationActor {
   // For metadata publishing purposes default to using the name of a standard stream as the stream's filename.
   def defaultStandardStreamNameToFileNameMetadataMapper(pipelinesApiJobPaths: PipelinesApiJobPaths, streamName: String): String = streamName
+
+  def encryptKms(keyName: String, credentials: OAuth2Credentials, plainText: String): String = {
+    val httpCredentialsAdapter = new HttpCredentialsAdapter(credentials)
+    val kms = new CloudKMS.Builder(httpTransport, jsonFactory, httpCredentialsAdapter)
+      .setApplicationName("cromwell")
+      .build()
+
+    val request = new EncryptRequest().encodePlaintext(plainText.toCharArray.map(_.toByte))
+    val response = kms.projects.locations.keyRings.cryptoKeys.encrypt(keyName, request).execute
+    response.getCiphertext
+  }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiFactoryInterface.scala
@@ -1,9 +1,8 @@
 package cromwell.backend.google.pipelines.common.api
 
-import com.google.api.client.http.{HttpRequest, HttpRequestInitializer}
+import com.google.api.client.http.HttpRequestInitializer
 import com.google.auth.Credentials
 import com.google.auth.http.HttpCredentialsAdapter
-import mouse.all._
 
 /**
   * The interface provides a single method to build a PipelinesApiRequestFactory
@@ -13,16 +12,10 @@ import mouse.all._
   * Pipelines API for this workflow.
   */
 abstract class PipelinesApiFactoryInterface {
-  private def httpRequestInitializerFromCredentials(credentials: Credentials) = {
-    val delegate = new HttpCredentialsAdapter(credentials)
-    new HttpRequestInitializer() {
-      def initialize(httpRequest: HttpRequest) = {
-        delegate.initialize(httpRequest)
-      }
-    }
+  final def fromCredentials(credentials: Credentials): PipelinesApiRequestFactory = {
+    val httpCredentialsAdapter = new HttpCredentialsAdapter(credentials)
+    build(httpCredentialsAdapter)
   }
-  
-  final def fromCredentials(credentials: Credentials): PipelinesApiRequestFactory = build(credentials |> httpRequestInitializerFromCredentials)
   
   protected def build(httpRequestInitializer: HttpRequestInitializer): PipelinesApiRequestFactory
 


### PR DESCRIPTION
- Replaced to-be-deprecated Credential (no 's') with Adapter around Credentials
- Removed dupe credentials adapting from PipelinesApiFactoryInterface
- Move service specific scopes (KMS, Genomics) out of GoogleAuthMode
- Changed credential creation methods to take scala collections