### PR TITLE
Fix submit-docker to point to the right script in example configuration [BA-5689]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -397,7 +397,7 @@ backend {
           ${"--user " + docker_user} \
           --entrypoint ${job_shell} \
           -v ${cwd}:${docker_cwd} \
-          ${docker} ${script}
+          ${docker} ${docker_script}
         """
 
         # Root directory where Cromwell writes job results.  This directory must be


### PR DESCRIPTION
In the example configuration, the submit-docker tries to run

    docker run ... ${docker} ${script}

but ${script} will not be accessible from the docker image unless, by coincidence, the location where we are running from in the local filesystem is the same as the dockerRoot. What we want to run instead is 

    docker run .... ${docker} ${docker_script}

Since this is the default configuration, it has the potential to cause a lot of unnecessary confusion (eg for me)