### PR TITLE
Ensure workflowLogger always gets closed [BA-4826]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -441,11 +441,10 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
         workflowOptions.get(FinalWorkflowLogDir).toOption match {
           case Some(destinationDir) =>
             pathBuilders.map(pb => workflowLogCopyRouter ! CopyWorkflowLogsActor.Copy(workflowId, PathFactory.buildPath(destinationDir, pb)))(ec)
-          case None if WorkflowLogger.isTemporary => workflowLogger.close(andDelete = true) match {
+          case None => workflowLogger.close(andDelete = WorkflowLogger.isTemporary) match {
             case Failure(f) => log.error(f, "Failed to delete workflow log")
             case _ =>
           }
-          case _ =>
         }
       }
       context stop self


### PR DESCRIPTION
Per #4826, when Cromwell is configured with `workflow-log-temporary: false` and workflow does not specify `final_workflow_log_dir`, Cromwell server does not close the log file resulting in a file handle leak. The lack of a file close also prevents certain FUSE drivers from flushing any file contents to remote storage, making it impossible for clients to actually read the logs until the server is terminated (which may be never). 

Looking at the code, there is no call to `workflowLogger.close()` or `workflowLogger.close(andDelete = false)` unless the file is being copied.

This line in WorkflowActor.scala:
`case None if WorkflowLogger.isTemporary => workflowLogger.close(andDelete = true)`
should change to:
`case None => workflowLogger.close(andDelete = WorkflowLogger.isTemporary)`

At this point in the code, the log contents have been fully written and the log should be closed, regardless of whether the logs are temporary or not. 

I've tested that this fix resolves the issue according to repro instructions in #4826.