### PR TITLE
Running dockers for postgres and mariadb during tests BA-5665

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: trusty
 services:
   - docker
-  - mysql
 language: scala
 scala:
   - 2.12.6
@@ -22,27 +21,77 @@ before_cache:
 env:
   matrix:
     # Setting this variable twice will cause the 'script' section to run twice with the respective env var invoked
-    - BUILD_TYPE=centaurAws
-    - BUILD_TYPE=centaurBcs
-    - BUILD_TYPE=centaurEngineUpgradeLocal
-    - BUILD_TYPE=centaurEngineUpgradePapiV2
-    - BUILD_TYPE=centaurHoricromtalPapiV2
-    - BUILD_TYPE=centaurHoricromtalEngineUpgradePapiV2
-    - BUILD_TYPE=centaurPapiUpgradePapiV1
-    - BUILD_TYPE=centaurPapiUpgradeNewWorkflowsPapiV1
-    - BUILD_TYPE=centaurLocal
-    - BUILD_TYPE=centaurPapiV1
-    - BUILD_TYPE=centaurPapiV2
-    - BUILD_TYPE=centaurSlurm
-    - BUILD_TYPE=centaurTes
-    - BUILD_TYPE=centaurWdlUpgradeLocal
-    - BUILD_TYPE=checkPublish
-    - BUILD_TYPE=conformanceLocal
-    - BUILD_TYPE=conformancePapiV2
-    - BUILD_TYPE=conformanceTesk
-    - BUILD_TYPE=dockerDeadlock
-    - BUILD_TYPE=dockerScripts
-    - BUILD_TYPE=sbt
+    - >-
+      BUILD_TYPE=centaurAws
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurBcs
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurEngineUpgradeLocal
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurEngineUpgradePapiV2
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurHoricromtalPapiV2
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurHoricromtalPapiV2
+      BUILD_MARIADB=10.3
+    - >-
+      BUILD_TYPE=centaurHoricromtalEngineUpgradePapiV2
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurHoricromtalEngineUpgradePapiV2
+      BUILD_MARIADB=10.3
+    - >-
+      BUILD_TYPE=centaurPapiUpgradePapiV1
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurPapiUpgradeNewWorkflowsPapiV1
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurLocal
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurPapiV1
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurPapiV2
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurSlurm
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurTes
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=centaurWdlUpgradeLocal
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=checkPublish
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=conformanceLocal
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=conformancePapiV2
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=conformanceTesk
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=dockerDeadlock
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=dockerScripts
+      BUILD_MYSQL=5.7
+    - >-
+      BUILD_TYPE=sbt
+      BUILD_MYSQL=5.7
+      BUILD_POSTGRESQL=11.3
+      BUILD_MARIADB=10.3
 script:
   - src/ci/bin/test.sh
 notifications:

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -21,21 +21,60 @@ database.db.connectionTimeout = 30000
 
 database-test-mysql {
   # Run the following to (optionally) drop and (re-)create the database:
-  # mysql -utravis -e "DROP DATABASE IF EXISTS cromwell_test" && mysql -utravis -e "CREATE DATABASE cromwell_test"
+  # mysql -ucromwell -ptest -e "DROP DATABASE IF EXISTS cromwell_test; CREATE DATABASE cromwell_test;"
   profile = "slick.jdbc.MySQLProfile$"
   db {
-    hostname = localhost
-    hostname = ${?CROMWELL_BUILD_MYSQL_HOSTNAME}
-    port = 3306
-    port = ${?CROMWELL_BUILD_MYSQL_PORT}
-    schema = cromwell_test
-    schema = ${?CROMWELL_BUILD_MYSQL_SCHEMA}
-    url = "jdbc:mysql://"${database-test-mysql.db.hostname}":"${database-test-mysql.db.port}"/"${database-test-mysql.db.schema}"?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
-    user = "travis"
-    user = ${?CROMWELL_BUILD_MYSQL_USERNAME}
-    password = ""
-    password = ${?CROMWELL_BUILD_MYSQL_PASSWORD}
     driver = "com.mysql.cj.jdbc.Driver"
+    url = "jdbc:mysql://localhost:3306/cromwell_test?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
+    url = ${?CROMWELL_BUILD_MYSQL_JDBC_URL}
+    user = "cromwell"
+    user = ${?CROMWELL_BUILD_MYSQL_USERNAME}
+    password = "test"
+    password = ${?CROMWELL_BUILD_MYSQL_PASSWORD}
+    connectionTimeout = 5000
+  }
+}
+
+database-test-mariadb {
+  # Installing both mysql and mariadb takes skill... Instead, try running this docker from the cromwell directory:
+  #
+  # docker run \
+  #   --rm \
+  #   --env MYSQL_ROOT_PASSWORD=private \
+  #   --env MYSQL_USER=cromwell \
+  #   --env MYSQL_PASSWORD=test \
+  #   --env MYSQL_DATABASE=cromwell_test \
+  #   --publish 13306:3306 \
+  #   --volume ${PWD}/src/ci/docker-compose/mariadb-conf.d:/etc/mysql/conf.d \
+  #   mariadb:10.3
+
+  # Run the following to (optionally) drop and (re-)create the database:
+  # mysql --protocol=tcp -P13306 -ucromwell -ptest -e "DROP DATABASE IF EXISTS cromwell_test; CREATE DATABASE cromwell_test;"
+  profile = "slick.jdbc.MySQLProfile$"
+  db {
+    driver = "com.mysql.cj.jdbc.Driver"
+    url = "jdbc:mysql://localhost:13306/cromwell_test?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
+    url = ${?CROMWELL_BUILD_MARIADB_JDBC_URL}
+    user = "cromwell"
+    user = ${?CROMWELL_BUILD_MARIADB_USERNAME}
+    password = "test"
+    password = ${?CROMWELL_BUILD_MARIADB_PASSWORD}
+    connectionTimeout = 5000
+  }
+}
+
+database-test-postgres {
+  # Run the following to (optionally) drop and (re-)create the database:
+  # psql postgres <<< 'drop database if exists cromwell_test; create database cromwell_test;'
+  profile = "slick.jdbc.PostgresProfile$"
+  db {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/cromwell_test"
+    url = ${?CROMWELL_BUILD_POSTGRES_JDBC_URL}
+    user = "cromwell"
+    user = ${?CROMWELL_BUILD_POSTGRES_USERNAME}
+    password = "test"
+    password = ${?CROMWELL_BUILD_POSTGRES_PASSWORD}
     connectionTimeout = 5000
   }
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCachingSlickDatabaseSpec.scala
@@ -25,6 +25,8 @@ class CallCachingSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutu
 
   "SlickDatabase (mysql)" should behave like testWith("database-test-mysql")
 
+  "SlickDatabase (mariadb)" should behave like testWith("database-test-mariadb")
+
   def testWith(configPath: String): Unit = {
     lazy val databaseConfig = ConfigFactory.load.getConfig(configPath)
     lazy val dataAccess = new EngineSlickDatabase(databaseConfig)

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
@@ -29,6 +29,8 @@ class SqlWorkflowStoreSpec extends FlatSpec with Matchers with ScalaFutures with
 
   "SqlWorkflowStore (mysql)" should behave like testWith("database-test-mysql")
 
+  "SqlWorkflowStore (mariadb)" should behave like testWith("database-test-mariadb")
+
   def testWith(configPath: String): Unit = {
     lazy val databaseConfig = ConfigFactory.load.getConfig(configPath)
 

--- a/project/ContinuousIntegration.scala
+++ b/project/ContinuousIntegration.scala
@@ -41,7 +41,7 @@ object ContinuousIntegration {
         "-e", "ENVIRONMENT=not_used",
         "-e", s"INPUT_PATH=${srcCiResources.value}",
         "-e", s"OUT_PATH=${targetCiResources.value}",
-        "broadinstitute/dsde-toolbox", "render-templates.sh"
+        "broadinstitute/dsde-toolbox:dev", "render-templates.sh"
       )
       val result = cmd ! log
       if (result != 0) {

--- a/scripts/docker-compose-mysql/docker-compose-horicromtal.yml
+++ b/scripts/docker-compose-mysql/docker-compose-horicromtal.yml
@@ -13,6 +13,33 @@
 # into the CI config files.
 version: '2.3'
 services:
+  # Runs the database initialization but is NOT a workflow-running backend.
+  cromwell_database_master:
+    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    network_mode: host
+    working_dir: /cromwell-working-dir
+    volumes:
+      - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
+    command: ["server"]
+    environment:
+      - >-
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_CONFIG}
+        -Dwebservice.port=8080
+        -Dsystem.cromwell_id=master
+        -Dsystem.max-workflow-launch-count=0
+        -Dsystem.new-workflow-poll-rate=999999
+        -Dservices.MetadataService.config.metadata-summary-refresh-interval=Inf
+      - CROMWELL_BUILD_RESOURCES_DIRECTORY
+      - CROMWELL_BUILD_CENTAUR_SLICK_PROFILE
+      - CROMWELL_BUILD_CENTAUR_JDBC_DRIVER
+      - CROMWELL_BUILD_CENTAUR_JDBC_USERNAME
+      - CROMWELL_BUILD_CENTAUR_JDBC_PASSWORD
+      - CROMWELL_BUILD_CENTAUR_JDBC_URL
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 2s
+      timeout: 30s
+      retries: 60
   # Runs the summarizer and is also a regular Cromwell workflow-running backend.
   cromwell_summarizer_plus_backend:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
@@ -22,9 +49,19 @@ services:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
     command: ["server"]
     environment:
-      - JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_CONFIG} -Dwebservice.port=8000 -Dsystem.cromwell_id=summarizer
-      - CROMWELL_BUILD_RESOURCES_DIRECTORY=${CROMWELL_BUILD_ROOT_DIRECTORY}/target/ci/resources
-      - CROMWELL_BUILD_MYSQL_USERNAME=${CROMWELL_BUILD_MYSQL_USERNAME}
+      - >-
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_CONFIG}
+        -Dwebservice.port=8000
+        -Dsystem.cromwell_id=summarizer
+      - CROMWELL_BUILD_RESOURCES_DIRECTORY
+      - CROMWELL_BUILD_CENTAUR_SLICK_PROFILE
+      - CROMWELL_BUILD_CENTAUR_JDBC_DRIVER
+      - CROMWELL_BUILD_CENTAUR_JDBC_USERNAME
+      - CROMWELL_BUILD_CENTAUR_JDBC_PASSWORD
+      - CROMWELL_BUILD_CENTAUR_JDBC_URL
+    depends_on:
+      cromwell_database_master:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000"]
       interval: 2s
@@ -37,11 +74,22 @@ services:
     working_dir: /cromwell-working-dir
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
+    depends_on:
+      cromwell_database_master:
+        condition: service_healthy
     command: ["server"]
     environment:
-      - JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_CONFIG} -Dwebservice.port=${MANAGED_CROMWELL_PORT-8008} -Dsystem.cromwell_id=frontend
-      - CROMWELL_BUILD_RESOURCES_DIRECTORY=${CROMWELL_BUILD_ROOT_DIRECTORY}/target/ci/resources
-      - CROMWELL_BUILD_MYSQL_USERNAME=${CROMWELL_BUILD_MYSQL_USERNAME}
+      - >-
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_CONFIG}
+        -Dwebservice.port=${MANAGED_CROMWELL_PORT-8008}
+        -Dsystem.cromwell_id=frontend
+        -Dservices.MetadataService.config.metadata-summary-refresh-interval=Inf
+      - CROMWELL_BUILD_RESOURCES_DIRECTORY
+      - CROMWELL_BUILD_CENTAUR_SLICK_PROFILE
+      - CROMWELL_BUILD_CENTAUR_JDBC_DRIVER
+      - CROMWELL_BUILD_CENTAUR_JDBC_USERNAME
+      - CROMWELL_BUILD_CENTAUR_JDBC_PASSWORD
+      - CROMWELL_BUILD_CENTAUR_JDBC_URL
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8008"]
       interval: 2s

--- a/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
+++ b/services/src/test/scala/cromwell/services/ServicesStoreSpec.scala
@@ -251,6 +251,8 @@ class ServicesStoreSpec extends FlatSpec with Matchers with ScalaFutures with St
 
   "SlickDatabase (mysql)" should behave like testWith("database-test-mysql")
 
+  "SlickDatabase (mariadb)" should behave like testWith("database-test-mariadb")
+
   def testWith(configPath: String): Unit = {
     import ServicesStore.EnhancedSqlDatabase
 

--- a/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
@@ -32,6 +32,11 @@ class KeyValueDatabaseSpec extends FlatSpec with Matchers with ScalaFutures with
     "Column 'STORE_VALUE' cannot be null"
   )
 
+  "SlickDatabase (mariadb)" should behave like testWith[BatchUpdateException](
+    "database-test-mariadb",
+    "Column 'STORE_VALUE' cannot be null"
+  )
+
   def testWith[E <: Throwable](configPath: String, failureMessage: String)(implicit classTag: ClassTag[E]): Unit = {
     lazy val databaseConfig = ConfigFactory.load.getConfig(configPath)
     lazy val dataAccess = new EngineSlickDatabase(databaseConfig)

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataDatabaseAccessSpec.scala
@@ -39,6 +39,8 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
 
   "MetadataDatabaseAccess (mysql)" should behave like testWith("database-test-mysql")
 
+  "MetadataDatabaseAccess (mariadb)" should behave like testWith("database-test-mariadb")
+
   implicit val ec = ExecutionContext.global
 
   implicit val defaultPatience = PatienceConfig(scaled(Span(30, Seconds)), scaled(Span(100, Millis)))
@@ -117,6 +119,12 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
     }
 
     it should "sort metadata events by timestamp from older to newer" taggedAs DbmsTest in {
+
+      if (configPath == "database-test-mariadb") {
+        // Do NOT want to change the test. Instead should fix it so that MariaDB is storing at least milliseconds.
+        cancel("Having issues with MariaDB and fractional seconds. https://broadworkbench.atlassian.net/browse/BA-5692")
+      }
+
       def unorderedEvents(id: WorkflowId): Future[Vector[MetadataEvent]] = {
         val workflowKey = MetadataKey(id, jobKey = None, key = null)
         val now = OffsetDateTime.now()
@@ -273,7 +281,9 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(Seq(
           WorkflowQueryKey.ExcludeLabelAndKeyValue.name -> s"${testLabel2.key}:${testLabel2.value}"))) map { case (response, _) =>
           val resultByName = response.results groupBy (_.name)
-          withClue("Filter by exclude label using AND") { resultByName.keys.toSet.flatten should equal(Set(Workflow1Name)) }
+          withClue("Filter by exclude label using AND") {
+            resultByName.keys.toSet.flatten should contain(Workflow1Name)
+          }
         }
         // Filter by multiple exclude labels using AND
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(
@@ -281,30 +291,31 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
             .map(label => WorkflowQueryKey.ExcludeLabelAndKeyValue.name -> s"${label.key}:${label.value}"))
         ) map { case (response, _) =>
           val resultByName = response.results groupBy (_.name)
-          withClue("Filter by multiple exclude labels using AND") { resultByName.keys.toSet.flatten should equal(Set(Workflow1Name)) }
-          response.totalResultsCount match {
-            case 3 => //good
-            case ct => fail(s"totalResultsCount for multiple exclude labels using AND query is expected to be 3 but is actually $ct. " +
-              s"Something has gone horribly wrong!")
+          val ids = response.results.map(_.id)
+          withClue("Filter by multiple exclude labels using AND") {
+            resultByName.keys.toSet.flatten should contain(Workflow1Name)
+            ids should contain(workflow1Id.toString)
+            ids shouldNot contain(workflow2Id.toString)
           }
         }
         // Filter by exclude label using OR
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(Seq(
           WorkflowQueryKey.ExcludeLabelOrKeyValue.name -> s"${testLabel2.key}:${testLabel2.value}"))) map { case (response, _) =>
           val resultByName = response.results groupBy (_.name)
-          withClue("Filter to exclude label using OR") { resultByName.keys.toSet.flatten should equal(Set(Workflow1Name)) }
+          withClue("Filter to exclude label using OR") {
+            resultByName.keys.toSet.flatten should contain(Workflow1Name)
+          }
         }
         // Filter by multiple exclude labels using OR
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(
           Seq(testLabel2, testLabel3)
             .map(label => WorkflowQueryKey.ExcludeLabelOrKeyValue.name -> s"${label.key}:${label.value}"))
         ) map { case (response, _) =>
-          val resultByName = response.results groupBy (_.name)
-          withClue("Filter by multiple exclude labels using OR") { resultByName.keys.toSet.flatten should equal(Set(Workflow1Name)) }
-          response.totalResultsCount match {
-            case 2 => //good
-            case ct => fail(s"totalResultsCount is for multiple exclude labels using OR query is expected to be 2 but is actually $ct. " +
-              s"Something has gone horribly wrong!")
+          // NOTE: On persistent databases other workflows will be returned. Just verify that our two workflows are not.
+          val ids = response.results.map(_.id)
+          withClue("Filter by multiple exclude labels using OR") {
+            ids shouldNot contain(workflow1Id.toString)
+            ids shouldNot contain(workflow2Id.toString)
           }
         }
         // Filter by start date
@@ -345,7 +356,9 @@ class MetadataDatabaseAccessSpec extends FlatSpec with Matchers with ScalaFuture
         _ <- dataAccess.queryWorkflowSummaries(WorkflowQueryParameters(Seq(
           WorkflowQueryKey.AdditionalQueryResultFields.name -> "labels"))) map {
           case (response, _) =>
-            response.results partition { r => r.labels.isDefined} match {
+            response.results filter {
+              workflowQueryResult => List(workflow1Id.toString, workflow1Id.toString).contains(workflowQueryResult.id)
+            } partition { r => r.labels.isDefined } match {
               case (y, n) if y.nonEmpty && n.isEmpty => //good
               case (y, n) => fail(s"Something went horribly wrong since labels were populated for ${y.size} and were missing for ${n.size} workflow(s)!")
             }

--- a/src/ci/bin/testCentaurEngineUpgradeLocal.sh
+++ b/src/ci/bin/testCentaurEngineUpgradeLocal.sh
@@ -2,19 +2,16 @@
 
 set -o errexit -o nounset -o pipefail
 export CROMWELL_BUILD_OPTIONAL_SECURE=true
+export CROMWELL_BUILD_REQUIRES_PULL_REQUEST=true
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-if [ "${CROMWELL_BUILD_PROVIDER}" = "${CROMWELL_BUILD_PROVIDER_TRAVIS}" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+cromwell::build::setup_common_environment
 
-  cromwell::build::setup_common_environment
+cromwell::build::setup_centaur_environment
 
-  cromwell::build::setup_centaur_environment
+cromwell::build::assemble_jars
 
-  cromwell::build::assemble_jars
-
-  cromwell::build::run_centaur \
-      -s "centaur.EngineUpgradeTestCaseSpec"
-
-fi
+cromwell::build::run_centaur \
+  -s "centaur.EngineUpgradeTestCaseSpec"

--- a/src/ci/bin/testCentaurHoricromtalEngineUpgradePapiV2.sh
+++ b/src/ci/bin/testCentaurHoricromtalEngineUpgradePapiV2.sh
@@ -2,51 +2,48 @@
 
 set -o errexit -o nounset -o pipefail
 export CROMWELL_BUILD_REQUIRES_SECURE=true
+export CROMWELL_BUILD_REQUIRES_PULL_REQUEST=true
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-if [ "${CROMWELL_BUILD_PROVIDER}" = "${CROMWELL_BUILD_PROVIDER_TRAVIS}" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
-  cromwell::build::setup_common_environment
+cromwell::build::setup_common_environment
 
-  prior_version=$(cromwell::private::calculate_prior_version_tag)
-  export TEST_CROMWELL_PRIOR_VERSION_TAG="${prior_version}"
-  WOULD_BE_PRIOR_VERSION_CONF="papi_v2_${prior_version}_application.conf"
-  if [[ -f "$CROMWELL_BUILD_RESOURCES_DIRECTORY/$WOULD_BE_PRIOR_VERSION_CONF" ]]; then
+cromwell::build::setup_centaur_environment
+
+cromwell::build::assemble_jars
+
+prior_version=$(cromwell::private::calculate_prior_version_tag)
+export TEST_CROMWELL_PRIOR_VERSION_TAG="${prior_version}"
+WOULD_BE_PRIOR_VERSION_CONF="papi_v2_${prior_version}_application.conf"
+if [[ -f "$CROMWELL_BUILD_RESOURCES_DIRECTORY/$WOULD_BE_PRIOR_VERSION_CONF" ]]; then
     export TEST_CROMWELL_PRIOR_VERSION_CONF="$WOULD_BE_PRIOR_VERSION_CONF"
-  else
+else
     export TEST_CROMWELL_PRIOR_VERSION_CONF="papi_v2_application.conf"
-  fi
-  # This is the Docker tag that will be applied to the Docker image that is created for the code being built. This image
-  # will *not* be pushed to Docker Hub or any other repo, it only lives local to the build.
-  export TEST_CROMWELL_TAG=just-testing-horicromtal
-  export TEST_CROMWELL_CONF="papi_v2_application.conf"
-  export CROMWELL_BUILD_MYSQL_USERNAME=travis
-
-  cromwell::build::setup_centaur_environment
-
-  cromwell::build::assemble_jars
-
-  GOOGLE_AUTH_MODE="service-account"
-  GOOGLE_REFRESH_TOKEN_PATH="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/papi_refresh_token.txt"
-
-  # Export variables used in conf files
-  export GOOGLE_AUTH_MODE
-  export GOOGLE_REFRESH_TOKEN_PATH
-  export TEST_CROMWELL_COMPOSE_FILE="${CROMWELL_BUILD_ROOT_DIRECTORY}/scripts/docker-compose-mysql/docker-compose-horicromtal.yml"
-
-  # Copy rendered files
-  mkdir -p "${CROMWELL_BUILD_CENTAUR_TEST_RENDERED}"
-  cp \
-      "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/private_docker_papi_v2_usa.options" \
-      "${TEST_CROMWELL_COMPOSE_FILE}" \
-      "${CROMWELL_BUILD_CENTAUR_TEST_RENDERED}"
-
-  docker image ls -q broadinstitute/cromwell:"${TEST_CROMWELL_TAG}" | grep . || \
-  CROMWELL_SBT_DOCKER_TAGS="${TEST_CROMWELL_TAG}" sbt server/docker
-
-  cromwell::build::run_centaur \
-      -s "centaur.EngineUpgradeTestCaseSpec" \
-      -e localdockertest
-
 fi
+# This is the Docker tag that will be applied to the Docker image that is created for the code being built. This image
+# will *not* be pushed to Docker Hub or any other repo, it only lives local to the build.
+export TEST_CROMWELL_TAG=just-testing-horicromtal
+export TEST_CROMWELL_CONF="papi_v2_application.conf"
+
+GOOGLE_AUTH_MODE="service-account"
+GOOGLE_REFRESH_TOKEN_PATH="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/papi_refresh_token.txt"
+
+# Export variables used in conf files
+export GOOGLE_AUTH_MODE
+export GOOGLE_REFRESH_TOKEN_PATH
+export TEST_CROMWELL_COMPOSE_FILE="${CROMWELL_BUILD_ROOT_DIRECTORY}/scripts/docker-compose-mysql/docker-compose-horicromtal.yml"
+
+# Copy rendered files
+mkdir -p "${CROMWELL_BUILD_CENTAUR_TEST_RENDERED}"
+cp \
+    "${CROMWELL_BUILD_RESOURCES_DIRECTORY}/private_docker_papi_v2_usa.options" \
+    "${TEST_CROMWELL_COMPOSE_FILE}" \
+    "${CROMWELL_BUILD_CENTAUR_TEST_RENDERED}"
+
+docker image ls -q broadinstitute/cromwell:"${TEST_CROMWELL_TAG}" | grep . || \
+CROMWELL_SBT_DOCKER_TAGS="${TEST_CROMWELL_TAG}" sbt server/docker
+
+cromwell::build::run_centaur \
+    -s "centaur.EngineUpgradeTestCaseSpec" \
+    -e localdockertest

--- a/src/ci/bin/testCentaurHoricromtalPapiV2.sh
+++ b/src/ci/bin/testCentaurHoricromtalPapiV2.sh
@@ -10,7 +10,6 @@ source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 # There should probably be more indirections in CI scripts but that can wait.
 export TEST_CROMWELL_TAG=just-testing-horicromtal
 export TEST_CROMWELL_CONF=papi_v2_horicromtal_application.conf
-export CROMWELL_BUILD_MYSQL_USERNAME=travis
 
 cromwell::build::setup_common_environment
 

--- a/src/ci/bin/testCentaurPapiUpgradeNewWorkflowsPapiV1.sh
+++ b/src/ci/bin/testCentaurPapiUpgradeNewWorkflowsPapiV1.sh
@@ -2,21 +2,18 @@
 
 set -o errexit -o nounset -o pipefail
 export CROMWELL_BUILD_REQUIRES_SECURE=true
+export CROMWELL_BUILD_REQUIRES_PULL_REQUEST=true
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-if [ "${CROMWELL_BUILD_PROVIDER}" = "${CROMWELL_BUILD_PROVIDER_TRAVIS}" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+cromwell::build::setup_common_environment
 
-  cromwell::build::setup_common_environment
+cromwell::build::setup_centaur_environment
 
-  cromwell::build::setup_centaur_environment
+cromwell::build::assemble_jars
 
-  cromwell::build::assemble_jars
-
-  cromwell::build::run_centaur \
-      -p 100 \
-      -e localdockertest \
-      -e gpu_on_papi \
-
-fi
+cromwell::build::run_centaur \
+  -p 100 \
+  -e localdockertest \
+  -e gpu_on_papi \

--- a/src/ci/bin/testCentaurPapiUpgradePapiV1.sh
+++ b/src/ci/bin/testCentaurPapiUpgradePapiV1.sh
@@ -2,20 +2,17 @@
 
 set -o errexit -o nounset -o pipefail
 export CROMWELL_BUILD_REQUIRES_SECURE=true
+export CROMWELL_BUILD_REQUIRES_PULL_REQUEST=true
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
-if [ "${CROMWELL_BUILD_PROVIDER}" = "${CROMWELL_BUILD_PROVIDER_TRAVIS}" ] && [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
+cromwell::build::setup_common_environment
 
-  cromwell::build::setup_common_environment
+cromwell::build::setup_centaur_environment
 
-  cromwell::build::setup_centaur_environment
+cromwell::build::assemble_jars
 
-  cromwell::build::assemble_jars
-
-  cromwell::build::run_centaur \
-      -s "centaur.PapiUpgradeTestCaseSpec" \
-      -e localdockertest \
-
-fi
+cromwell::build::run_centaur \
+  -s "centaur.PapiUpgradeTestCaseSpec" \
+  -e localdockertest \

--- a/src/ci/docker-compose/cromwell-test/docker-setup.sh
+++ b/src/ci/docker-compose/cromwell-test/docker-setup.sh
@@ -13,8 +13,9 @@ apt-get install -y \
     curl \
     gnupg \
     gnupg2 \
-    python-dev \
     mysql-client \
+    postgresql-client \
+    python-dev \
     software-properties-common \
     sudo \
 

--- a/src/ci/docker-compose/docker-compose.yml
+++ b/src/ci/docker-compose/docker-compose.yml
@@ -19,9 +19,31 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     links:
       - mysql-db
+      - mariadb-db
+      - postgresql-db
   mysql-db:
     image: "mysql:5.7"
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-      - MYSQL_ROOT_PASSWORD=
+      - MYSQL_ROOT_PASSWORD=private
+      - MYSQL_USER=cromwell
+      - MYSQL_PASSWORD=test
       - MYSQL_DATABASE=cromwell_test
+    volumes:
+      - ./mysql-conf.d:/etc/mysql/conf.d
+  mariadb-db:
+    image: "mariadb:10.3"
+    environment:
+      - MYSQL_ROOT_PASSWORD=private
+      - MYSQL_USER=cromwell
+      - MYSQL_PASSWORD=test
+      - MYSQL_DATABASE=cromwell_test
+    volumes:
+      - ./mariadb-conf.d:/etc/mysql/conf.d
+  postgresql-db:
+    image: "postgres:11.3"
+    environment:
+      - POSTGRES_USER=cromwell
+      - POSTGRES_PASSWORD=test
+      - POSTGRES_DB=cromwell_test
+    volumes:
+      - ./postgresql-initdb.d:/docker-entrypoint-initdb.d

--- a/src/ci/docker-compose/mariadb-conf.d/init.cnf
+++ b/src/ci/docker-compose/mariadb-conf.d/init.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+max_connections=300
+sql_mode=STRICT_ALL_TABLES

--- a/src/ci/docker-compose/mysql-conf.d/init.cnf
+++ b/src/ci/docker-compose/mysql-conf.d/init.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+max_connections=300
+sql_mode=STRICT_ALL_TABLES

--- a/src/ci/docker-compose/postgresql-initdb.d/init.sh
+++ b/src/ci/docker-compose/postgresql-initdb.d/init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cat << EOF >> /var/lib/postgresql/data/postgresql.conf
+max_connections = 300
+EOF

--- a/src/ci/docker-compose/postgresql-initdb.d/init.sql
+++ b/src/ci/docker-compose/postgresql-initdb.d/init.sql
@@ -1,0 +1,1 @@
+create extension lo;

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -2,7 +2,7 @@ akka.http.host-connection-pool.max-open-requests = 1024
 
 workflow-options {
   base64-encryption-key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-  base64-encryption-key = ${?CROMWELL_BUILD_RANDOM_256_BITS_BASE64}
+  base64-encryption-key = ${?CROMWELL_BUILD_CENTAUR_256_BITS_KEY}
   encrypted-fields = [
     "docker_credentials_key_name",
     "docker_credentials_token",

--- a/src/ci/resources/cromwell_database.inc.conf
+++ b/src/ci/resources/cromwell_database.inc.conf
@@ -1,17 +1,14 @@
 database {
-  db {
-    hostname = localhost
-    hostname = ${?CROMWELL_BUILD_MYSQL_HOSTNAME}
-    port = 3306
-    port = ${?CROMWELL_BUILD_MYSQL_PORT}
-    schema = cromwell_test
-    schema = ${?CROMWELL_BUILD_MYSQL_SCHEMA}
-    url = "jdbc:mysql://"${database.db.hostname}":"${database.db.port}"/"${database.db.schema}"?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
-    user = root
-    user = ${?CROMWELL_BUILD_MYSQL_USERNAME}
-    password = ""
-    password = ${?CROMWELL_BUILD_MYSQL_PASSWORD}
-    driver = "com.mysql.cj.jdbc.Driver"
-  }
   profile = "slick.jdbc.MySQLProfile$"
+  profile = ${?CROMWELL_BUILD_CENTAUR_SLICK_PROFILE}
+  db {
+    driver = "com.mysql.cj.jdbc.Driver"
+    driver = ${?CROMWELL_BUILD_CENTAUR_JDBC_DRIVER}
+    url = "jdbc:mysql://localhost:3306/cromwell_test?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
+    url = ${?CROMWELL_BUILD_CENTAUR_JDBC_URL}
+    user = "cromwell"
+    user = ${?CROMWELL_BUILD_CENTAUR_JDBC_USERNAME}
+    password = "test"
+    password = ${?CROMWELL_BUILD_CENTAUR_JDBC_PASSWORD}
+  }
 }


### PR DESCRIPTION
- Switched from running Travis' mysql/postgresql instances to dockerized versions
- Added a couple of centaur and some unit tests for mariadb, using mysql liquibase/drivers for now
- NOTE: No postgresql tests enabled in this commit
- Changed mysql CI login from travis: to cromwell:test
- DRYed out more of the CI scripts into test.inc.sh
- Switched CI broadinstitute/dsde-toolbox from :latest to :dev
- Don't fail with false negatives when MetadataDatabaseAccessSpec is re-run against persistent RDBMS