### PR TITLE
Allow public key retrieval in centaur test connection string [BA-5665 follow up]

### DIFF
--- a/src/ci/resources/cromwell_database.inc.conf
+++ b/src/ci/resources/cromwell_database.inc.conf
@@ -4,7 +4,7 @@ database {
   db {
     driver = "com.mysql.cj.jdbc.Driver"
     driver = ${?CROMWELL_BUILD_CENTAUR_JDBC_DRIVER}
-    url = "jdbc:mysql://localhost:3306/cromwell_test?useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
+    url = "jdbc:mysql://localhost:3306/cromwell_test?allowPublicKeyRetrieval=true&useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC"
     url = ${?CROMWELL_BUILD_CENTAUR_JDBC_URL}
     user = "cromwell"
     user = ${?CROMWELL_BUILD_CENTAUR_JDBC_USERNAME}


### PR DESCRIPTION
For those of us who like to use the centaur configs when running Cromwell locally