### PR TITLE
Make the file read limits effectively "opt-in" [BA-5723]

### DIFF
--- a/centaur/src/it/resources/application.conf
+++ b/centaur/src/it/resources/application.conf
@@ -2,26 +2,3 @@ akka {
   log-dead-letters = "off"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
-
-system {
-  input-read-limits {
-
-    lines = 128000
-
-    bool = 7
-
-    int = 19
-
-    float = 50
-
-    string = 128000
-
-    json = 128000
-
-    tsv = 128000
-
-    map = 128000
-
-    object = 128000
-  }
-}

--- a/centaur/src/it/resources/application.conf
+++ b/centaur/src/it/resources/application.conf
@@ -2,3 +2,26 @@ akka {
   log-dead-letters = "off"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
+
+system {
+  input-read-limits {
+
+    lines = 128000
+
+    bool = 7
+
+    int = 19
+
+    float = 50
+
+    string = 128000
+
+    json = 128000
+
+    tsv = 128000
+
+    map = 128000
+
+    object = 128000
+  }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -196,7 +196,7 @@ system {
   # If exceeded a FileSizeTooBig exception will be thrown.
   input-read-limits {
 
-    lines = 128000
+    lines = 512000000
 
     bool = 7
 
@@ -204,15 +204,15 @@ system {
 
     float = 50
 
-    string = 128000
+    string = 512000000
 
-    json = 128000
+    json = 512000000
 
-    tsv = 128000
+    tsv = 512000000
 
-    map = 128000
+    map = 512000000
 
-    object = 128000
+    object = 512000000
   }
 
   # Rate at which Cromwell updates its instrumentation gauge metrics (e.g: Number of workflows running, queued, etc..)

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -25,6 +25,29 @@ system {
   hog-safety {
     token-log-interval-seconds = 300
   }
+
+  input-read-limits {
+
+    lines = 128000
+
+    bool = 7
+
+    int = 19
+
+    float = 50
+
+    string = 128000
+
+    json = 128000
+
+    tsv = 128000
+
+    map = 128000
+
+    object = 128000
+  }
 }
+
+
 
 include "cromwell_database.inc.conf"


### PR DESCRIPTION
On Cromwells which are not our own production instance, people seem to be more frustrated than delighted by having the initial read limits be arbitrarily restrictive.

- [x] Will probably need to update `firecloud-develop` to set some values which are still relying on the previous low defaults back down to 128k