### PR TITLE
remove unnecessary and slow migration BA-5732

### DIFF
--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_hash_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_hash_entry_id.xml
@@ -3,17 +3,15 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet author="mcovarr" id="enlarge_call_caching_hash_entry_id">
-        <comment>
-            Larger integer data type for the PK since > 2 billion rows.
-        </comment>
-        <modifyDataType
-                tableName="CALL_CACHING_HASH_ENTRY"
-                columnName="CALL_CACHING_HASH_ENTRY_ID"
-                newDataType="BIGINT"/>
-    </changeSet>
-
+    <!-- This changeset is misleadingly named. This used to be part of a two-changeset migration that widened the PK and
+         then added autoincrement. At the time this was first written the author did not realize that `addAutoIncrement`
+         could both alter the datatype of and add autoincrement to the PK in one shot. The changeset cannot be renamed
+         as the name is part of the Liquibase key that will prevent it from running again in environments that already
+         suffered through the old two-changeset migration. -->
     <changeSet author="mcovarr" id="restore_auto_increment_call_caching_hash_entry_id">
+        <!-- This is the original comment from the two-changeset version of the code and it doesn't make a lot of sense in
+             the new one-changeset reality. Removing the comment doesn't alter the Liquibase hash but it does make the
+             resulting row in the DATABASECHANGELOG different. Keeping it for now out of an abundance of caution. -->
         <comment>
             Factored into a separate changeset from the above to allow for handling various RDBMS implementations differently.
         </comment>


### PR DESCRIPTION
Omits the first of the two CCHE migrations which appears to be made unnecessary by the second, hopefully avoiding Götterdämmerung.