### PR TITLE
Make cached-copy localization strategy aware of the maximum number of hardlinks. [BA-5748]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -421,6 +421,10 @@ backend {
             localization: [
               "hard-link", "soft-link", "copy"
             ]
+            # An experimental localization strategy called "cached-copy" is also available for SFS backends.
+            # This will copy a file to a cache and then hard-link from the cache. It will copy the file to the cache again
+            # when the maximum number of hardlinks for a file is reached. The maximum number of hardlinks can be set with:
+            # max-hardlinks: 950
 
             # Call caching strategies
             caching {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -101,11 +101,16 @@ object SharedFileSystem extends StrictLogging {
       Thread.sleep(1)
     }
   }
+
+  private def countLinks(path: Path): Int = {
+    path.getAttribute("unix:nlink").asInstanceOf[Int]
+  }
 }
 
 trait SharedFileSystem extends PathFactory {
   import SharedFileSystem._
 
+  val maxHardLinks: Int = 950  // Windows limit 1024. Keep a safe margin.
   def sharedFileSystemConfig: Config
 
   lazy val cachedCopyDir: Option[Path] = None
@@ -124,7 +129,7 @@ trait SharedFileSystem extends PathFactory {
       val cachedCopyPath: Path = cachedCopySubDir./(pathAndModTime)
       val cachedCopyPathLockFile: Path = cachedCopyPath.plusSuffix(".lock")
 
-      if (!cachedCopyPath.exists) {
+      if (!cachedCopyPath.exists || countLinks(cachedCopyPath) > maxHardLinks) {
         // This variable is used so we can release the lock before we start with the copying.
         var shouldCopy = false
 
@@ -133,10 +138,11 @@ trait SharedFileSystem extends PathFactory {
         // decisions which are not time consuming.
         SharedFileSystem.synchronized {
 
-          // We check again if cachedCopyPath is there. It may have been created while waiting on the lock.
-          // If it is not there, is it already being copied by another thread?
+          // We check again if cachedCopyPath is there or if the number of Hardlinks is still exceeded.
+          // The copying may have been started while waiting on the lock.
+          // If it is not there or the maxHardLinks are exceeded, is it already being copied by another thread?
           // if not copied by another thread, is it copied by another cromwell process? (Lock file present)
-          if (!cachedCopyPath.exists &&
+          if ((!cachedCopyPath.exists || countLinks(cachedCopyPath) > maxHardLinks) &&
             !SharedFileSystem.beingCopied.getOrElse(cachedCopyPath, false) &&
             !cachedCopyPathLockFile.exists) {
             // Create a lock file so other cromwell processes know copying has started
@@ -163,7 +169,9 @@ trait SharedFileSystem extends PathFactory {
         if (shouldCopy) {
           try {
             val cachedCopyTmpPath = cachedCopyPath.plusExt("tmp")
-            originalPath.copyTo(cachedCopyTmpPath, overwrite = true).moveTo(cachedCopyPath)
+            // CachedCopyPath is overwritten. It is possible that the number of hardlinks is exceeded. In which case
+            // the file is already there.
+            originalPath.copyTo(cachedCopyTmpPath, overwrite = true).moveTo(cachedCopyPath, overwrite = true)
           } catch {
             case e: Exception => throw e
           }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/sfs/SharedFileSystem.scala
@@ -14,6 +14,7 @@ import cromwell.backend.io.JobPaths
 import cromwell.core.CromwellFatalExceptionMarker
 import cromwell.core.path.{DefaultPath, DefaultPathBuilder, Path, PathFactory}
 import cromwell.filesystems.http.HttpPathBuilder
+import net.ceedubs.ficus.Ficus._
 import wom.WomFileMapper
 import wom.values._
 
@@ -110,9 +111,8 @@ object SharedFileSystem extends StrictLogging {
 trait SharedFileSystem extends PathFactory {
   import SharedFileSystem._
 
-  lazy val maxHardLinks: Int = 950  // Windows limit 1024. Keep a safe margin.
   def sharedFileSystemConfig: Config
-
+  lazy val maxHardLinks: Int = sharedFileSystemConfig.getOrElse[Int]("max-hardlinks",950)  // Windows limit 1024. Keep a safe margin.
   lazy val cachedCopyDir: Option[Path] = None
 
   private def localizePathViaCachedCopy(originalPath: Path, executionPath: Path, docker: Boolean): Try[Unit] = {

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -143,7 +143,7 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
   }
 
 it should "copy the file again when the copy-cached file has exceeded the maximum number of hardlinks" in {
-    val callDirs: List[Path] = 1 to 3 map { _ => DefaultPathBuilder.createTempDirectory("SharedFileSystem") }
+    val callDirs: IndexedSeq[Path] = 1 to 3 map { _ => DefaultPathBuilder.createTempDirectory("SharedFileSystem") }
     val orig = DefaultPathBuilder.createTempFile("inputFile")
     val dests = callDirs.map(_./(orig.parent.pathAsString.hashCode.toString())./(orig.name))
     orig.touch()

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -143,7 +143,7 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
   }
 
 it should "copy the file again when the copy-cached file has exceeded the maximum number of hardlinks" in {
-    val callDirs: List[Path] = List(1,2,3).map(x => DefaultPathBuilder.createTempDirectory("SharedFileSystem"))
+    val callDirs: List[Path] = 1 to 3 map { _ => DefaultPathBuilder.createTempDirectory("SharedFileSystem") }
     val orig = DefaultPathBuilder.createTempFile("inputFile")
     val dests = callDirs.map(_./(orig.parent.pathAsString.hashCode.toString())./(orig.name))
     orig.touch()

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemSpec.scala
@@ -20,6 +20,7 @@ class SharedFileSystemSpec extends FlatSpec with Matchers with Mockito with Tabl
   val hardLinkLocalization = ConfigFactory.parseString(""" localization: [hard-link] """)
   val softLinkLocalization = ConfigFactory.parseString(""" localization: [soft-link] """)
   val cachedCopyLocalization = ConfigFactory.parseString(""" localization: [cached-copy] """)
+  val cachedCopyLocalizationMaxHardlinks = ConfigFactory.parseString("""{localization: [cached-copy], max-hardlinks: 3 }""")
   val localPathBuilder = List(DefaultPathBuilder)
 
 
@@ -149,10 +150,9 @@ it should "copy the file again when the copy-cached file has exceeded the maximu
     val inputs = fqnWdlMapToDeclarationMap(Map("input" -> WomSingleFile(orig.pathAsString)))
     val sharedFS = new SharedFileSystem {
       override val pathBuilders = localPathBuilder
-      override val sharedFileSystemConfig = cachedCopyLocalization
+      override val sharedFileSystemConfig = cachedCopyLocalizationMaxHardlinks
       override implicit def actorContext: ActorContext = null
       override lazy val cachedCopyDir = Some(DefaultPathBuilder.createTempDirectory("cached-copy"))
-      override lazy val maxHardLinks = 3
     }
     val cachedFile: Option[Path] = sharedFS.cachedCopyDir.map(
       _./(orig.parent.pathAsString.hashCode.toString)./(orig.lastModifiedTime.toEpochMilli.toString + orig.name))


### PR DESCRIPTION
Hi!

First of all, thanks for merging the PR on the cached-copy localization strategy. We have been using at as a patch for about a month now in the LUMC on our SGE cluster.

Since our cluster filesystem also interacts with Windows PC's which have a hard-link limit of 1024, the maximum hardlink limit on our cluster is set to 1000. Unfortunately we run into this limit fairly often when using the `cached-copy` strategy. When this happens cromwell will fallback to copying. This is good design, but unfortunately it uses a lot of disk space and takes a lot of time.

This PR addresses that issue. When the hard-link limit is reached the hard-link in the cache will be removed. This hard-link will have pointed for example to inode 13820. Because there are plenty of hard-links still pointing to 13820, this inode is not removed, and all the jobs dependent on these files will still function.
Cromwell will copy the required file to the same path in the cache. This means the same path will now point to a different inode (for example: 13835). This inode has only 1 hardlink, so the hardlinking from this file in the cache can start with renewed vigor. Because the same path in the cache can be used, complex additional code in cromwell is not needed.

Ideally I could get the maximum hard-link limit that Cromwell uses from the filesystem itself. But I could not find a way to do that. The limit is made to be configurable with a default of 950.

Take the example case of having 9000 jobs that require the 3.8 GB reference genome, using a hard-link limit of 1000. Before this PR:

strategy | result
--- | ---
hard-link | fails when cromwell-executions is on a different disk. Allows up to 1000 hardlinks if on the same disk.
cached-copy | Allows up to  1000 hard-links regardless of which disk the original file is stored on.
soft-link | does not work with containers and is excluded.
copy | since hard-link or cached-copy can only handle a 1000 links, copy will be used 8000 times. Using 8000*3,8 = Approx. 3 TB of disk space.

Afer this PR:

strategy | result
--- | ---
hard-link | fails when cromwell-executions is on a different disk. Allows up to 1000 hardlinks if on the same disk.
cached-copy | Copies the reference 9 times. Each file is hard-linked 1000 times from the cache before the cache-link is removed. Using 9*3,8 GB = Approx. 36 GB of disk space.
soft-link | does not work with containers and is excluded.
copy | Not used.

