### PR TITLE
Consistently apply workflow name BA-5765

### DIFF
--- a/centaur/src/main/resources/standardTestCases/sub_workflow_name_length.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_name_length.test
@@ -1,0 +1,14 @@
+name: sub_workflow_name_length
+testFormat: workflowsuccess
+tags: [localdockertest]
+
+files {
+  workflow: workflow_name_length/importer_ok.wdl
+  imports: [
+    workflow_name_length/workflow_name_length_ok.wdl
+  ]
+}
+
+metadata {
+    status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/workflow_name_length/importer_ok.wdl
+++ b/centaur/src/main/resources/standardTestCases/workflow_name_length/importer_ok.wdl
@@ -1,0 +1,5 @@
+import "workflow_name_length_ok.wdl"
+
+workflow good_and_short {
+ call workflow_name_length_ok.hippopotomonstrosesquippedaliophobes_look_away_now_because_we_are_on_the_fast_train_to_Chargoggagog
+}

--- a/centaur/src/main/resources/standardTestCases/workflow_name_length/workflow_name_length_ok.wdl
+++ b/centaur/src/main/resources/standardTestCases/workflow_name_length/workflow_name_length_ok.wdl
@@ -1,0 +1,5 @@
+workflow hippopotomonstrosesquippedaliophobes_look_away_now_because_we_are_on_the_fast_train_to_Chargoggagog {
+ output {
+  String s = "hello, words!"
+ }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -220,7 +220,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
 
     val events = List(
       MetadataEvent(parentWorkflowMetadataKey, MetadataValue(subWorkflowId)),
-      MetadataEvent(MetadataKey(subWorkflowId, None, WorkflowMetadataKeys.Name), MetadataValue(key.node.callable.name)),
+      MetadataEvent(MetadataKey(subWorkflowId, None, WorkflowMetadataKeys.Name), MetadataValue(key.node.localName)),
       MetadataEvent(MetadataKey(subWorkflowId, None, WorkflowMetadataKeys.ParentWorkflowId), MetadataValue(parentWorkflow.id)),
       MetadataEvent(MetadataKey(subWorkflowId, None, WorkflowMetadataKeys.RootWorkflowId), MetadataValue(parentWorkflow.rootWorkflow.id))
     )


### PR DESCRIPTION
To stay under 100 character limit in our MySQL summary table, we use the local name instead of FQN.

The parser is enforcing the 100 character limit here.