### PR TITLE
Fix: AWS Batch with CWL: did not localize cwl.inputs.json [BA-4586]

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -268,6 +268,12 @@ trait StandardAsyncExecutionActor
   def cwd: Path = commandDirectory
   def rcPath: Path = cwd./(jobPaths.returnCodeFilename)
 
+  /**
+    * Directory where workflow user commands will be executed.
+    * It's overridden in AwsBatchAsyncBackendJobExecutionActor in order to allow Cromwell find adHoc files.
+    * */
+  def adHocCwd: String = cwd.pathAsString
+
   // The standard input filename can be as ephemeral as the execution: the name needs to match the expectations of
   // the command, but the standard input file will never be accessed after the command completes. standard output and
   // error on the other hand will be accessed and the names of those files need to be known to be delocalized and read
@@ -383,7 +389,7 @@ trait StandardAsyncExecutionActor
         |tee $stdoutRedirection < "$$$out" &
         |tee $stderrRedirection < "$$$err" >&2 &
         |(
-        |cd $cwd
+        |cd $adHocCwd
         |ENVIRONMENT_VARIABLES
         |INSTANTIATED_COMMAND
         |) $stdinRedirection > "$$$out" 2> "$$$err"

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
@@ -1,0 +1,14 @@
+name: ad_hoc_file_test.aws
+testFormat: workflowsuccess
+backends: [ AWSBATCH ]
+
+files {
+  workflow: ad_hoc_file_test/workflow.cwl
+  imports: [
+    ad_hoc_file_test/cwl-test.cwl
+  ]
+}
+
+metadata {
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
@@ -1,0 +1,21 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: ["sh", "example.sh"]
+hints:
+  DockerRequirement:
+    dockerPull: ubuntu:latest
+inputs: []
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: example.sh
+        entry: |-
+          PREFIX='Message is:'
+          MSG="\${PREFIX} Hello world!"
+          echo \${MSG}
+
+outputs:
+  example_out:
+    type: stdout
+stdout: output.txt

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
@@ -1,0 +1,10 @@
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs: []
+
+steps:
+  test:
+    run: cwl-test.cwl
+    in: []
+    out: []

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -345,6 +345,8 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     disk.mountPoint
   }
 
+  override def adHocCwd = runtimeEnvironment.outputPath
+
   override def isTerminal(runStatus: RunStatus): Boolean = {
     runStatus match {
       case _: TerminalRunStatus => true


### PR DESCRIPTION
The purpose of this PR is to fix issue https://github.com/broadinstitute/cromwell/issues/4586.
It turns out that Cromwell looks for the ad hoc files in the wrong location, while using AWS. These files placed in the S3 bucket, while Cromwell expects them to be in the root execution directory.
Therefore, we have changed the place where Cromwell searches that files. We also added an integration test that reproduces the problem.