### PR TITLE
Enforce git secrets are configured before allowing development [BA-5810]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,12 @@
 import Dependencies._
 import Settings._
 import com.typesafe.config.ConfigFactory
-import complete.DefaultParsers._
 
 import scala.sys.process._
 
 // Pre-sbt checks:
 
 lazy val preCompile = taskKey[Unit]("Execute pre-compile scripts")
-
-val demo = inputKey[Unit]("A demo input task.")
-
-demo := {
-  // get the result of parsing
-  val args: Seq[String] = spaceDelimited("<arg>").parsed
-  // Here, we also use the value of the `scalaVersion` setting
-  println("The current Scala version is " + scalaVersion.value)
-  println("The arguments to demo were:")
-  args foreach println
-}
 
 preCompile := {
   val s: TaskStreams = streams.value

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ preCompile := {
       s.log.warn(message)
     } else {
       s.log.error(message)
-      s.log.error("If you don't want to set up hooks (if you never intend to commit to the cromwell repo, can be sure that you won't commit secrets by accident, or have already installed git-secrets in this repo separately), you can suppress this error by compiling with: 'sbt -Dignore-hooks-check=true compile'")
+      s.log.error("If you don't want to set up hooks (if you never intend to commit to the cromwell repo, can be sure that you won't commit secrets by accident, or have already installed git-secrets in this repo separately), you can suppress this error by running with: 'sbt -Dignore-hooks-check=true [...]'")
       System.exit(1)
     }
   }
@@ -43,6 +43,7 @@ preCompile := {
 
 
 (Compile / compile) := (Compile / compile dependsOn preCompile).value
+(Test / test) := (Test / test dependsOn preCompile).value
 
 // Libraries
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,28 @@
 import Dependencies._
 import Settings._
+import scala.sys.process._
+
+// Pre-sbt checks:
+
+lazy val preCompile = taskKey[Unit]("Execute pre-compile scripts")
+
+preCompile := {
+  val s: TaskStreams = streams.value
+  val checkHooksDir: Seq[String] = Seq("bash", "-c", "git config core.hooksPath | grep -q 'hooks/'")
+  s.log.info("Executing pre-compile script...")
+  if((checkHooksDir !) == 0) {
+    s.log.success("Pre compile script ran successfully!")
+  } else {
+    s.log.error("Pre compile script failed.")
+    s.log.error("Git hooks directory is not configured.")
+    s.log.error("Run before continuing: git config --add core.hooksPath hooks/")
+    System.exit(1)
+//    throw new sbt.MessageOnlyException("Git hooks directory is not configured. Run 'git config --add core.hooksPath hooks/' before continuing.")
+
+  }
+}
+
+(Compile / compile) := (Compile / compile dependsOn preCompile).value
 
 // Libraries
 

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git secrets --commit_msg_hook -- "$@"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git secrets --pre_commit_hook -- "$@"

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+git secrets --prepare_commit_msg_hook -- "$@"

--- a/src/ci/bin/test.sh
+++ b/src/ci/bin/test.sh
@@ -6,6 +6,6 @@ set -o errexit -o nounset -o pipefail
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
 # Make sure our hooks are configured before building:
-git config core.hooksPath | grep -q 'hooks/'
+git config --add core.hooksPath hooks/
 
 cromwell::build::exec_test_script

--- a/src/ci/bin/test.sh
+++ b/src/ci/bin/test.sh
@@ -5,4 +5,7 @@ set -o errexit -o nounset -o pipefail
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
+# Make sure our hooks are configured before building:
+git config core.hooksPath | grep -q 'hooks/'
+
 cromwell::build::exec_test_script


### PR DESCRIPTION
Where "enforce" means "don't allow Cromwell to compile unless you have the hooks set up."

Workaround is running `sbt -Dignore-hooks-check=true`