### PR TITLE
Fix: AWS Batch with CWL: did not localize cwl.inputs.json (Another way to fix) BA-4586

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -340,6 +340,17 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
   override lazy val commandDirectory: Path = AwsBatchWorkingDisk.MountPoint
 
+  /**
+    * Generates a script that moves all adhoc files to an execution directory ("/cromwell_root")
+    */
+  override lazy val scriptPreamble = (for {
+    adHocFiles <- evaluatedAdHocFiles.toList
+    adHocFile <- adHocFiles
+    adHocFilePath <- getPath(adHocFile.womValue.value).toOption
+  } yield {
+    s"""mv "${adHocFilePath.pathWithoutScheme}" ."""
+  }).mkString(System.lineSeparator)
+
   override def globParentDirectory(womGlobFile: WomGlobFile): Path = {
     val (_, disk) = relativePathAndVolume(womGlobFile.value, runtimeAttributes.disks)
     disk.mountPoint


### PR DESCRIPTION
The purpose of this PR is to fix issue #4586.
There's already a [PR](https://github.com/broadinstitute/cromwell/pull/5057) that fixes this issue. In the existing [PR](https://github.com/broadinstitute/cromwell/pull/5057) the issue was solved by changing the location of the file search. 
However, we are not sure if this is the best solution, as we are still waiting for your opinion. In case the existing [PR](https://github.com/broadinstitute/cromwell/pull/5057) is not consistent with the logic of the Cromwell, we have added another possible solution. In this PR the files themselves are moved to the place where the Cromwell expects them to be.