### PR TITLE
Metadata is more informative for unexpected return code

### DIFF
--- a/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
+++ b/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
@@ -8,8 +8,13 @@ abstract class KnownJobFailureException extends Exception {
   def stderrPath: Option[Path]
 }
 
-final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path]) extends KnownJobFailureException {
-  override def getMessage = s"Job $jobTag exited with return code $returnCode which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path], errorMessage: Option[String] = None) extends KnownJobFailureException {
+  val explanation = errorMessage match {
+    case Some(message) => s"Possibly caused by: '$message'"
+    case None => "No additional info can be provided by now"
+  }
+  override def getMessage =
+    s"Job $jobTag exited with return code $returnCode which has not been declared as a valid return code. $explanation. See 'continueOnReturnCode' runtime attribute for more details."
 }
 
 final case class ReturnCodeIsNotAnInt(jobTag: String, returnCode: String, stderrPath: Option[Path]) extends KnownJobFailureException {

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -1096,7 +1096,10 @@ trait StandardAsyncExecutionActor
             case Success(returnCodeAsInt) if isAbort(returnCodeAsInt) =>
               Future.successful(AbortedExecutionHandle)
             case Success(returnCodeAsInt) if !continueOnReturnCode.continueFor(returnCodeAsInt) =>
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption), Option(returnCodeAsInt)))
+              // Read stderr content only if there is need to get detailed info about failure
+              // Should not read large files completely
+              val errorMessageAsString = stderr.annotatedContentAsStringWithLimit(limitBytes = 1024)
+              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption, Option(errorMessageAsString)), Option(returnCodeAsInt)))
               retryElseFail(status, executionHandle)
             case Success(returnCodeAsInt) =>
               handleExecutionSuccess(status, oldHandle, returnCodeAsInt)

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/SharedFileSystemJobExecutionActorSpec.scala
@@ -61,7 +61,7 @@ class SharedFileSystemJobExecutionActorSpec extends TestKitSuite("SharedFileSyst
 
   it should "send back an execution failure if the task fails" in {
     val expectedResponse =
-      JobFailedNonRetryableResponse(mock[BackendJobDescriptorKey], WrongReturnCode("wf_goodbye.goodbye:NA:1", 1, None), Option(1))
+      JobFailedNonRetryableResponse(mock[BackendJobDescriptorKey], WrongReturnCode("wf_goodbye.goodbye:NA:1", 1, None, Some("")), Option(1))
     val workflow = TestWorkflow(buildWdlWorkflowDescriptor(GoodbyeWorld), TestConfig.backendRuntimeConfigDescriptor, expectedResponse)
     val backend = createBackend(jobDescriptorFromSingleCallWorkflow(workflow.workflowDescriptor, Map.empty, WorkflowOptions.empty, runtimeAttributeDefinitions), workflow.config)
     testWorkflow(workflow, backend)


### PR DESCRIPTION
The purpose of this PR is to make `/metadata` more informative, as described in #4856.
It appears that Cromwell already stores the necessary info in a `stderr.log` file. Therefore, reading the content of that file and printing to the user should be enough.
However, one thing bothers us. In the method `handleExecutionResult` of the trait `StandardAsyncExecutionActor`, the comment says that 
```   
Only check stderr size if we need to, otherwise this results in a lot of unnecessary I/O that
may fail due to race conditions on quickly-executing jobs.
```
But in order to give additional info to the user, we have to read the content of that file. Also, we do not understand, why this is such a big deal. The method `handleExecutionResult` must be called when the execution is finished and that file is written. What race conditions may arise and is it important in this case?