### PR TITLE
Consolidated GCS Input and Output Localization [BA-5666]

### DIFF
--- a/cwl/src/main/scala/cwl/CommandOutputBinding.scala
+++ b/cwl/src/main/scala/cwl/CommandOutputBinding.scala
@@ -228,12 +228,26 @@ object CommandOutputBinding {
       case WomMaybePopulatedFileType if isRegularFile(cwlPath) =>
         loadFileWithContents(ioFunctionSet, commandOutputBinding)(cwlPath).to[IOChecked].map(List(_))
       case WomMaybePopulatedFileType =>
+        //TODO: HACK ALERT - DB: I am starting on ticket https://github.com/broadinstitute/cromwell/issues/3092 which will redeem me of this mortal sin.
+        val detritusFiles = List(
+          "docker_cid",
+          "gcs_delocalization",
+          "gcs_localization",
+          "rc.tmp",
+          "script",
+          "script.background",
+          "script.submit",
+          "stderr",
+          "stderr.background",
+          "stdout",
+          "stdout.background",
+        )
         val globs: IOChecked[Seq[String]] = 
           ioFunctionSet.glob(cwlPath).toIOChecked
               .map({
-                _ //TODO: HACK ALERT - DB: I am starting on ticket https://github.com/broadinstitute/cromwell/issues/3092 which will redeem me of this mortal sin.
-                .filterNot{s =>
-                  s.endsWith("rc.tmp") || s.endsWith("docker_cid") || s.endsWith("script") || s.endsWith("script.background") || s.endsWith("script.submit") || s.endsWith("stderr") || s.endsWith("stderr.background") || s.endsWith("stdout") || s.endsWith("stdout.background")
+                _
+                .filterNot{ s =>
+                  detritusFiles exists s.endsWith
                 }
               })
 

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
@@ -9,6 +9,8 @@ object PipelinesApiJobPaths {
   val JesLogPathKey = "jesLog"
   val JesMonitoringKey = "monitoring"
   val JesExecParamName = "exec"
+  val GcsLocalizationScriptName = "gcs_localization"
+  val GcsDelocalizationScriptName = "gcs_delocalization"
 }
 
 final case class PipelinesApiJobPaths(override val workflowPaths: PipelinesApiWorkflowPaths, jobKey: BackendJobDescriptorKey) extends JobPaths {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiParameters.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiParameters.scala
@@ -38,7 +38,9 @@ sealed trait PipelinesParameter {
 }
 
 sealed trait PipelinesApiInput extends PipelinesParameter
-sealed trait PipelinesApiOutput extends PipelinesParameter
+sealed trait PipelinesApiOutput extends PipelinesParameter {
+  def contentType: Option[ContentType] = None
+}
 
 final case class PipelinesApiFileInput(name: String,
                                        cloudPath: Path,
@@ -57,7 +59,7 @@ final case class PipelinesApiFileOutput(name: String,
                                         optional: Boolean,
                                         secondary: Boolean,
                                         uploadPeriod: Option[FiniteDuration] = None,
-                                        contentType: Option[ContentType] = None) extends PipelinesApiOutput
+                                        override val contentType: Option[ContentType] = None) extends PipelinesApiOutput
 
 final case class PipelinesApiDirectoryOutput(name: String,
                                              cloudPath: Path,
@@ -65,7 +67,7 @@ final case class PipelinesApiDirectoryOutput(name: String,
                                              mount: PipelinesApiAttachedDisk,
                                              optional: Boolean,
                                              secondary: Boolean,
-                                             contentType: Option[ContentType] = None) extends PipelinesApiOutput
+                                             override val contentType: Option[ContentType] = None) extends PipelinesApiOutput
 
 // TODO: Remove when support for V1 is stopped, this is only used to pass the extra_param auth file
 final case class PipelinesApiLiteralInput(name: String, value: String)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# The `papi_v2_log` Centaur test is opinionated about the number of log messages around localization/delocalization.
+# The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
+set +x
+
+gsutil_log="gsutil_output.txt"
+
+
+localize_file() {
+  local cloud="$1"
+  local container="$2"
+  local rpflag="$3"
+  # Do not quote rpflag, when that is set it will be -u project which should be two distinct arguments.
+  rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m cp "$cloud" "$container" > "$gsutil_log" 2>&1
+}
+
+localize_directory() {
+  local cloud="$1"
+  local container="$2"
+  local rpflag="$3"
+  # Do not quote rpflag, when that is set it will be -u project which should be two distinct arguments.
+  mkdir -p "${container}" && rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m rsync -r "${cloud}" "${container}" > "$gsutil_log" 2>&1
+}
+
+delocalize_file() {
+  local cloud="$1"
+  local container="$2"
+  local rpflag="$3"
+  local required="$4"
+  local content="$5"
+
+  # From Thibault:
+  #
+  # As per https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork, rule #2
+  # If one attempts a
+  #  gsutil cp /local/file.txt gs://bucket/subdir/file.txt
+  #  AND
+  #  there exists a folder gs://bucket/subdir/file.txt_thisCouldBeAnything
+  #  then gs://bucket/subdir/file.txt will be treated as a directory, and /local/file.txt will be copied under gs://bucket/subdir/file.txt/file.txt
+  #  and not gs://bucket/subdir/file.txt.
+  #
+  # By instead using the parent directory (and ensuring it ends with a slash), gsutil will treat that as a directory and put the file under it.
+  # So the final gsutil command will look something like gsutil cp /local/file.txt gs://bucket/subdir/
+  local cloud_parent=$(dirname "$cloud")
+  cloud_parent="${cloud_parent}/"
+
+  if [[ -f "$container" && -n "$content" ]]; then
+    rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m -h "Content-Type: $content" cp "$container" "$cloud_parent" > "$gsutil_log" 2>&1
+  elif [[ -f "$container" ]]; then
+    rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m cp "$container" "$cloud_parent" > "$gsutil_log" 2>&1
+  elif [[ -e "$container" ]]; then
+    echo "File output '$container' exists but is not a file"
+    exit 1
+  elif [[ "$required" = "required" ]]; then
+    echo "Required file output '$container' does not exist."
+    exit 1
+  fi
+}
+
+delocalize_directory() {
+  local cloud="$1"
+  local container="$2"
+  local rpflag="$3"
+  local required="$4"
+  local content="$5"
+
+  if [[ -d "$container" && -n "$content" ]]; then
+    rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m -h "Content-Type: $content" rsync -r "$container" "$cloud" > "$gsutil_log" 2>&1
+  elif [[ -d "$container" ]]; then
+    rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m rsync -r "$container" "$cloud" > "$gsutil_log" 2>&1
+  elif [[ -e "$container" ]]; then
+    echo "Directory output '$container' exists but is not a directory"
+    exit 1
+  elif [[ "$required" = "required" ]]; then
+    echo "Required directory output '$container' does not exist."
+    exit 1
+  fi
+}
+
+delocalize_file_or_directory() {
+  local cloud="$1"
+  local container="$2"
+  local rpflag="$3"
+  local required="$4"
+  local content="$5"
+
+  # required must be optional for 'file_or_directory' and was checked in the caller
+  if [[ -f "$container" ]]; then
+    delocalize_file "$cloud" "$container" "$rpflag" "$required" "$content"
+  elif [[ -d "$container" ]]; then
+    delocalize_directory "$cloud" "$container" "$rpflag" "$required" "$content"
+  elif [[ -e "$container" ]]; then
+    echo "'file_or_directory' output '$container' exists but is neither a file nor a directory"
+    exit 1
+  fi
+}
+
+timestamped_message() {
+  printf '%s %s\n' "$(date -u '+%Y/%m/%d %H:%M:%S')" "$1"
+}
+
+localize_message() {
+  local cloud="$1"
+  local container="$2"
+  local message=$(printf "Localizing input %s -> %s" "$cloud" "$container")
+  timestamped_message "${message}"
+}
+
+delocalize_message() {
+  local cloud="$1"
+  local container="$2"
+  local message=$(printf "Delocalizing output %s -> %s" "$container" "$cloud")
+  timestamped_message "${message}"
+}
+
+# Transfer a bundle of files or directories to or from the same GCS bucket.
+transfer() {
+  local direction="$1"
+  local project="$2"
+  local max_attempts="$3"
+
+  shift 3 # direction + project + max_attempts
+
+  if [[ "$direction" != "localize" && "$direction" != "delocalize" ]]; then
+    echo "direction must be 'localize' or 'delocalize' but got '$direction'"
+    exit 1
+  fi
+
+  # Whether the requester pays status of the GCS bucket is certain. rp status is presumed false until proven otherwise.
+  local rp_status_certain=false
+  local use_requester_pays=false
+
+  local message_fn="${direction}_message"
+
+  # Loop while there are still items in the bundle to transfer.
+  while [[ $# -gt 0 ]]; do
+    file_or_directory="$1"
+    cloud="$2"
+    container="$3"
+
+    if [[ "$file_or_directory" = "file" ]]; then
+      transfer_fn_name="${direction}_file"
+    elif [[ "$file_or_directory" = "directory" ]]; then
+      transfer_fn_name="${direction}_directory"
+    elif [[ "$direction" = "delocalize" && "$file_or_directory" = "file_or_directory" ]]; then
+      transfer_fn_name="delocalize_file_or_directory"
+    else
+      echo "file_or_directory must be 'file' or 'directory' or (for delocalization only) 'file_or_directory' but got '$file_or_directory' with direction = '$direction'"
+      exit 1
+    fi
+
+    content_type=""
+    required=""
+    if [[ "${direction}" = "delocalize" ]]; then
+      # 'required' and 'content type' only appear in delocalization bundles.
+      required="$4"
+      content_type="$5"
+      if [[ "$required" != "required" && "$required" != "optional" ]]; then
+        echo "'required' must be 'required' or 'optional' but got '$required'"
+        exit 1
+      elif [[ "$required" = "required" && "$file_or_directory" = "file_or_directory" ]]; then
+        echo "Invalid combination of required = required and file_or_directory = file_or_directory, file_or_directory only valid with optional secondary outputs"
+        exit 1
+      fi
+      shift 2 # required + content_type
+    fi
+    shift 3 # file_or_directory + cloud + container
+
+    # Log what is being localized or delocalized (at least one test depends on this).
+    ${message_fn} "$cloud" "$container"
+
+    attempt=1
+    transfer_rc=0
+    # Loop attempting transfers for this file or directory while attempts are not exhausted.
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+
+      if [[ ${use_requester_pays} = true ]]; then
+        rpflag="-u ${project}"
+      else
+        rpflag=""
+      fi
+
+      # Note the localization versions of transfer functions are passed "required" and "content_type" parameters they will not use.
+      ${transfer_fn_name} "$cloud" "$container" "$rpflag" "$required" "$content_type"
+      transfer_rc=$?
+
+      if [[ ${transfer_rc} = 0 ]]; then
+        rp_status_certain=true
+        break
+      else
+        timestamped_message "${transfer_fn_name} \"$cloud\" \"$container\" \"$rpflag\" \"$required\" \"$content_type\" failed"
+
+        # Print the reason of the failure.
+        cat "${gsutil_log}"
+
+        # If the requester pays status of the GCS bucket is not certain look for requester pays errors.
+        if [[ ${rp_status_certain} = false ]]; then
+          if grep -q "Bucket is requester pays bucket but no user project provided." "${gsutil_log}"; then
+            timestamped_message "Retrying with user project"
+            use_requester_pays=true
+            # Do not increment the attempt number, a requester pays failure does not count against retries.
+            # Do mark that the bucket in question is certain to have requester pays status.
+            rp_status_certain=true
+          else
+            # Requester pays status is not certain but this transfer failed for non-requester pays reasons.
+            # Increment the attempt number.
+            attempt=$((attempt+1))
+          fi
+        else
+          attempt=$((attempt+1))
+        fi
+      fi
+    done
+    if [[ ${attempt} -gt ${max_attempts} ]]; then # out of attempts
+      exit ${transfer_rc}
+    fi
+  done
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -1,17 +1,31 @@
 package cromwell.backend.google.pipelines.v2alpha1
 
+import cats.data.NonEmptyList
+import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.foldable._
+import com.google.api.services.genomics.v2alpha1.model.Mount
+import com.google.cloud.storage.contrib.nio.CloudStorageOptions
 import cromwell.backend.BackendJobDescriptor
+import cromwell.backend.google.pipelines.common.PipelinesApiConfigurationAttributes.LocalizationConfiguration
 import cromwell.backend.google.pipelines.common._
+import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.io.PipelinesApiWorkingDisk
+import cromwell.backend.google.pipelines.v2alpha1.PipelinesApiAsyncBackendJobExecutionActor._
 import cromwell.backend.standard.StandardAsyncExecutionActorParams
-import cromwell.core.path.DefaultPathBuilder
-import cromwell.filesystems.gcs.GcsPathBuilder
+import cromwell.core.path.{DefaultPathBuilder, Path}
 import cromwell.filesystems.gcs.GcsPathBuilder.ValidFullGcsPath
+import cromwell.filesystems.gcs.{GcsPath, GcsPathBuilder}
+import org.apache.commons.codec.digest.DigestUtils
 import wom.core.FullyQualifiedName
 import wom.expression.FileEvaluation
 import wom.values.{GlobFunctions, WomFile, WomGlobFile, WomMaybeListedDirectory, WomMaybePopulatedFile, WomSingleFile, WomUnlistedDirectory}
 
-class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExecutionActorParams) extends cromwell.backend .google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor(standardParams) {
+import scala.concurrent.Future
+import scala.io.Source
+import scala.language.postfixOps
+
+class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExecutionActorParams) extends cromwell.backend.google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor(standardParams) {
 
   // The original implementation assumes the WomFiles are all WomMaybePopulatedFiles and wraps everything in a PipelinesApiFileInput
   // In v2 we can differentiate files from directories 
@@ -37,6 +51,96 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
       key -> womFile.collectAsSeq({
         case womFile: WomFile if !inputsToNotLocalize.contains(womFile) => womFile
       })
+  }
+
+  private lazy val transferScriptTemplate =
+    Source.fromInputStream(Thread.currentThread.getContextClassLoader.getResourceAsStream("gcs_transfer.sh")).mkString
+
+  private def gcsLocalizationTransferBundle[T <: PipelinesApiInput](localizationConfiguration: LocalizationConfiguration)(bucket: String, inputs: NonEmptyList[T]): String = {
+    val project = inputs.head.cloudPath.asInstanceOf[GcsPath].projectId
+    val maxAttempts = localizationConfiguration.localizationAttempts
+    val transferItems = inputs.toList.flatMap { i =>
+      val kind = i match {
+        case _: PipelinesApiFileInput => "file"
+        case _: PipelinesApiDirectoryInput => "directory"
+      }
+      List(kind, i.cloudPath, i.containerPath)
+    } mkString("\"", "\"\n|  \"", "\"")
+
+    // Use a digest as bucket names can contain characters that are not legal in bash identifiers.
+    val arrayIdentifier = s"localize_" + DigestUtils.md5Hex(bucket)
+    s"""
+       |# $bucket
+       |$arrayIdentifier=(
+       |  "localize" # direction
+       |  "$project"       # project
+       |  "$maxAttempts"   # max attempts
+       |  $transferItems
+       |)
+       |
+       |transfer "$${$arrayIdentifier[@]}"
+      """.stripMargin
+  }
+
+  private def gcsDelocalizationTransferBundle[T <: PipelinesApiOutput](localizationConfiguration: LocalizationConfiguration)(bucket: String, outputs: NonEmptyList[T]): String = {
+    val project = outputs.head.cloudPath.asInstanceOf[GcsPath].projectId
+    val maxAttempts = localizationConfiguration.localizationAttempts
+
+    val transferItems = outputs.toList.flatMap { output =>
+      val kind = output match {
+        case o: PipelinesApiFileOutput if o.secondary => "file_or_directory" // if secondary the type is unknown
+        case _: PipelinesApiFileOutput => "file" // a primary file
+        case _: PipelinesApiDirectoryOutput => "directory" // a primary directory
+      }
+
+      val optional = Option(output) collectFirst { case o: PipelinesApiFileOutput if o.secondary || o.optional => "optional" } getOrElse "required"
+      val contentType = output.contentType.getOrElse("")
+
+      List(kind, output.cloudPath, output.containerPath, optional, contentType)
+    } mkString("\"", "\"\n|  \"", "\"")
+
+
+    // Use a digest as bucket names can contain characters that are not legal in bash identifiers.
+    val arrayIdentifier = s"delocalize_" + DigestUtils.md5Hex(bucket)
+    s"""
+       |# $bucket
+       |$arrayIdentifier=(
+       |  "delocalize" # direction
+       |  "$project"       # project
+       |  "$maxAttempts"   # max attempts
+       |  $transferItems
+       |)
+       |
+       |transfer "$${$arrayIdentifier[@]}"
+      """.stripMargin
+  }
+
+  private def generateGcsLocalizationScript(inputs: List[PipelinesApiInput], mounts: List[Mount])(implicit localizationConfiguration: LocalizationConfiguration): String = {
+    val bundleFunction = (gcsLocalizationTransferBundle(localizationConfiguration) _).tupled
+    generateGcsTransferScript(inputs, mounts, bundleFunction)
+  }
+
+  private def generateGcsDelocalizationScript(outputs: List[PipelinesApiOutput], mounts: List[Mount])(implicit localizationConfiguration: LocalizationConfiguration): String = {
+    val bundleFunction = (gcsDelocalizationTransferBundle(localizationConfiguration) _).tupled
+    generateGcsTransferScript(outputs, mounts, bundleFunction)
+  }
+
+  private def generateGcsTransferScript[T <: PipelinesParameter](items: List[T], mounts: List[Mount], bundleFunction: ((String, NonEmptyList[T])) => String): String = {
+    val gcsItems = items collect { case i if i.cloudPath.isInstanceOf[GcsPath] => i }
+    val localizationBundles = groupParametersByGcsBucket(gcsItems) map bundleFunction mkString "\n"
+    transferScriptTemplate + localizationBundles
+  }
+
+  override def uploadGcsLocalizationScript(createPipelineParameters: CreatePipelineParameters, cloudPath: Path, localizationConfiguration: LocalizationConfiguration): Future[Unit] = {
+    val mounts = PipelinesConversions.toMounts(createPipelineParameters)
+    val content = generateGcsLocalizationScript(createPipelineParameters.inputOutputParameters.fileInputParameters, mounts)(localizationConfiguration)
+    asyncIo.writeAsync(cloudPath, content, Seq(CloudStorageOptions.withMimeType("text/plain")))
+  }
+
+  override def uploadGcsDelocalizationScript(createPipelineParameters: CreatePipelineParameters, cloudPath: Path, localizationConfiguration: LocalizationConfiguration): Future[Unit] = {
+    val mounts = PipelinesConversions.toMounts(createPipelineParameters)
+    val content = generateGcsDelocalizationScript(createPipelineParameters.inputOutputParameters.fileOutputParameters, mounts)(localizationConfiguration)
+    asyncIo.writeAsync(cloudPath, content, Seq(CloudStorageOptions.withMimeType("text/plain")))
   }
 
   // Simply create a PipelinesApiDirectoryOutput in v2 instead of globbing
@@ -84,12 +188,12 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
             * call-A/file.txt
             *
             * This code is called as part of a path mapper that will be applied to the WOMified cwl.output.json.
-            * The cwl.output.json when it's being read by Cromwell from the bucket still contains local paths 
+            * The cwl.output.json when it's being read by Cromwell from the bucket still contains local paths
             * (as they were created by the cwl tool).
             * In order to keep things working we need to map those local paths to where they were actually delocalized,
             * which is determined in cromwell.backend.google.pipelines.v2alpha1.api.Delocalization.
             */
-          case _ => (callRootPath / 
+          case _ => (callRootPath /
             RuntimeOutputMapping
                 .prefixFilters(workflowPaths.workflowRoot)
                 .foldLeft(path)({
@@ -135,5 +239,20 @@ class PipelinesApiAsyncBackendJobExecutionActor(standardParams: StandardAsyncExe
     val destination = callRootPath.resolve(normalizedPath)
     val jesFileOutput = PipelinesApiFileOutput(makeSafeReferenceName(womFile.value), destination, relpath, disk, fileEvaluation.optional, fileEvaluation.secondary)
     List(jesFileOutput)
+  }
+}
+
+object PipelinesApiAsyncBackendJobExecutionActor {
+  private val gcsPathMatcher = "^gs://?([^/]+)/.*".r
+
+  private [v2alpha1] def groupParametersByGcsBucket[T <: PipelinesParameter](parameters: List[T]): Map[String, NonEmptyList[T]] = {
+    parameters.map { param =>
+      param.cloudPath.toString match {
+        case gcsPathMatcher(bucket) =>
+          Map(bucket -> NonEmptyList.of(param))
+        case other =>
+          throw new RuntimeException(s"Programmer error: Path '$other' did not match the expected regex. This should have been impossible")
+      }
+    } combineAll
   }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -204,10 +204,7 @@ object ActionBuilder {
     )
   }
 
-  // This "sleep 5" is ugly, but hopefully prevents a PAPIv2 race condition whereby very-fast-completing tests never
-  // get identified as complete (and thus PAPIv2 continues to run the operation indefinitely.
-  def timestampedMessage(withSleep: Boolean)(message: String) =
-    (if (withSleep) "sleep 5 && " else "") +
+  def timestampedMessage(message: String): String =
     s"""printf '%s %s\\n' "$$(date -u '+%Y/%m/%d %H:%M:%S')" ${shellEscaped(message)}"""
 
   /**
@@ -227,7 +224,7 @@ object ActionBuilder {
                                    actionLabels: Map[String, String]): Action = {
     // Uses the cloudSdk image as that image will be used for other operations as well.
     cloudSdkShellAction(
-      timestampedMessage(withSleep = true)(message)
+      timestampedMessage(message)
     )(
       flags = actionFlags,
       labels = actionLabels collect {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -90,7 +90,7 @@ object ActionCommands {
        |    break
        |  fi
        |  if [ $$i -lt ${localizationConfiguration.localizationAttempts} ]; then
-       |    ${s"""Waiting ${wait.toSeconds} seconds and retrying""" |> timestampedMessage(withSleep = false)}
+       |    ${s"""Waiting ${wait.toSeconds} seconds and retrying""" |> timestampedMessage}
        |    sleep ${wait.toSeconds}
        |  fi
        |done
@@ -125,13 +125,13 @@ object ActionCommands {
        |# Record the exit code of the gsutil command without project flag
        |RC_GSUTIL=$$?
        |if [ "$$RC_GSUTIL" != "0" ]; then
-       |  ${s"$commandWithoutProject failed" |> timestampedMessage(withSleep = false)}
+       |  ${s"$commandWithoutProject failed" |> timestampedMessage}
        |  # Print the reason of the failure
        |  cat gsutil_output.txt
        |
        |  # Check if it matches the BucketIsRequesterPaysErrorMessage
        |  if grep -q "$BucketIsRequesterPaysErrorMessage" gsutil_output.txt; then
-       |    ${"Retrying with user project" |> timestampedMessage(withSleep = false)}
+       |    ${"Retrying with user project" |> timestampedMessage}
        |    $commandWithProject
        |  else
        |    exit "$$RC_GSUTIL"

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Delocalization.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.model.ContentTypes
 import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
 import common.util.StringUtil._
 import cromwell.backend.google.pipelines.common.PipelinesApiConfigurationAttributes.LocalizationConfiguration
+import cromwell.backend.google.pipelines.common.PipelinesApiJobPaths.GcsDelocalizationScriptName
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.v2alpha1.PipelinesConversions._
 import cromwell.backend.google.pipelines.v2alpha1.RuntimeOutputMapping
@@ -130,8 +131,15 @@ trait Delocalization {
       )
     }
 
+    val gcsDelocalizationContainerPath = createPipelineParameters.commandScriptContainerPath.sibling(GcsDelocalizationScriptName)
+
+    val delocalizationLabel = Map(Key.Tag -> Value.Delocalization)
+    val runGcsDelocalizationScript: Action = cloudSdkShellAction(
+      s"/bin/bash $gcsDelocalizationContainerPath")(mounts = mounts, labels = delocalizationLabel)
+
     ActionBuilder.annotateTimestampedActions("delocalization", Value.Delocalization)(
-      createPipelineParameters.outputParameters.flatMap(_.toActions(mounts).toList) ++
+      runGcsDelocalizationScript ::
+        createPipelineParameters.outputParameters.flatMap(_.toActions(mounts).toList) ++
         runtimeExtractionActions
     ) :+
       copyAggregatedLogToLegacyPath(callExecutionContainerRoot, gcsLegacyLogPath) :+

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Localization.scala
@@ -2,14 +2,37 @@ package cromwell.backend.google.pipelines.v2alpha1.api
 
 import com.google.api.services.genomics.v2alpha1.model.Mount
 import cromwell.backend.google.pipelines.common.PipelinesApiConfigurationAttributes.LocalizationConfiguration
+import cromwell.backend.google.pipelines.common.PipelinesApiJobPaths._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.v2alpha1.PipelinesConversions._
 import cromwell.backend.google.pipelines.v2alpha1.ToParameter.ops._
-import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels.Value
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.Labels.{Key, Value}
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionBuilder.cloudSdkShellAction
+import cromwell.backend.google.pipelines.v2alpha1.api.ActionCommands.localizeFile
+
 
 trait Localization {
   def localizeActions(createPipelineParameters: CreatePipelineParameters, mounts: List[Mount])(implicit localizationConfiguration: LocalizationConfiguration) = {
-    val jobInputLocalization = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toActions(mounts).toList)
-    ActionBuilder.annotateTimestampedActions("localization", Value.Localization)(jobInputLocalization)
+    val localizationLabel = Map(Key.Tag -> Value.Localization)
+
+    val gcsLocalizationContainerPath = createPipelineParameters.commandScriptContainerPath.sibling(GcsLocalizationScriptName)
+    val localizeGcsLocalizationScript = cloudSdkShellAction(localizeFile(
+      cloudPath = createPipelineParameters.cloudCallRoot / GcsLocalizationScriptName,
+      containerPath = gcsLocalizationContainerPath))(mounts = mounts, labels = localizationLabel)
+
+    val gcsDelocalizationContainerPath = createPipelineParameters.commandScriptContainerPath.sibling(GcsDelocalizationScriptName)
+    val localizeGcsDelocalizationScript = cloudSdkShellAction(localizeFile(
+      cloudPath = createPipelineParameters.cloudCallRoot / GcsDelocalizationScriptName,
+      containerPath = gcsDelocalizationContainerPath))(mounts = mounts, labels = localizationLabel)
+
+    val runGcsLocalizationScript = cloudSdkShellAction(
+      s"/bin/bash $gcsLocalizationContainerPath")(mounts = mounts, labels = localizationLabel)
+
+    // Any "classic" PAPI v2 one-at-a-time localizations for non-GCS inputs.
+    val singletonLocalizations = createPipelineParameters.inputOutputParameters.fileInputParameters.flatMap(_.toActions(mounts).toList)
+
+    val localizations = localizeGcsLocalizationScript :: runGcsLocalizationScript :: localizeGcsDelocalizationScript :: singletonLocalizations
+
+    ActionBuilder.annotateTimestampedActions("localization", Value.Localization)(localizations)
   }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesApiAsyncBackendJobExecutionActorSpec.scala
@@ -1,0 +1,40 @@
+package cromwell.backend.google.pipelines.v2alpha1
+
+import java.nio.file.Paths
+
+import cats.data.NonEmptyList
+import cromwell.backend.google.pipelines.common.PipelinesApiFileInput
+import cromwell.core.path.DefaultPathBuilder
+import org.scalatest.{FlatSpec, Matchers}
+
+class PipelinesApiAsyncBackendJobExecutionActorSpec extends FlatSpec with Matchers {
+  behavior of "PipelinesParameterConversions"
+
+  it should "group files by bucket" in {
+
+    def makeInput(bucket: String, name: String): PipelinesApiFileInput = {
+      PipelinesApiFileInput(
+        name = name,
+        cloudPath = DefaultPathBuilder.build(Paths.get(s"gs://$bucket/$name")),
+        relativeHostPath = DefaultPathBuilder.build(Paths.get(s"$bucket/$name")),
+        mount = null
+      )
+    }
+
+    val inputs: List[PipelinesApiFileInput] = List(
+      ("foo", "file1"),
+      ("foo", "file2"),
+      ("bar", "file1"),
+      ("bar", "file2"),
+      ("bar", "file3"),
+      ("baz", "file1")
+    ) map (makeInput _).tupled.apply
+
+    val expected =
+      Map("foo" -> (NonEmptyList.of(0, 1) map inputs.apply)) ++
+      Map("bar" -> (NonEmptyList.of(2, 3, 4) map inputs.apply)) ++
+      Map("baz" -> NonEmptyList.of(inputs(5)))
+
+    PipelinesApiAsyncBackendJobExecutionActor.groupParametersByGcsBucket(inputs) shouldEqual expected
+  }
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesConversionsSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/PipelinesConversionsSpec.scala
@@ -58,7 +58,7 @@ class PipelinesConversionsSpec extends FlatSpec with Matchers {
 
     logging.get("commands") should be(a[java.util.List[_]])
     logging.get("commands").asInstanceOf[java.util.List[_]] should contain(
-      """sleep 5 && printf '%s %s\n' "$(date -u '+%Y/%m/%d %H:%M:%S')" """ +
+      """printf '%s %s\n' "$(date -u '+%Y/%m/%d %H:%M:%S')" """ +
         """Localizing\ input\ dos://dos.example.org/aaaabbbb-cccc-dddd-eeee-abcd0000dcba\ """ +
         """-\>\ /cromwell_root/path/to/file.bai"""
     )


### PR DESCRIPTION
Consolidates GCS localizations and delocalizations into one Action each. Speeds up the `lots_of_inputs` Centaur test from more than 70 minutes to about 20 minutes. This PR creates a localization script that groups localizations by source bucket, stages the localization script to GCS, then localizes the localization script to the node and runs it.

This PR does not:

* Attempt any gsutil optimizations in copying.
* Consolidate localization or delocalization on other PAPI v2 supported input types: HTTP, DRS or SRA. These other input types may require separate localization script executions since at least some of them (DRS and SRA) will likely require different Docker images to actually run their localizations.