### PR TITLE
Metadata is more informative for unexpected return code (WORK IN PROGRESS)

### DIFF
--- a/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
+++ b/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
@@ -8,8 +8,13 @@ abstract class KnownJobFailureException extends Exception {
   def stderrPath: Option[Path]
 }
 
-final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path]) extends KnownJobFailureException {
-  override def getMessage = s"Job $jobTag exited with return code $returnCode which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path], errorMessage: Option[String] = None) extends KnownJobFailureException {
+  val explanation = errorMessage match {
+    case Some(message) => s"Possibly caused by: '$message'"
+    case None => "No additional info can be provided by now"
+  }
+  override def getMessage =
+    s"Job $jobTag exited with return code $returnCode which has not been declared as a valid return code. $explanation. See 'continueOnReturnCode' runtime attribute for more details."
 }
 
 final case class ReturnCodeIsNotAnInt(jobTag: String, returnCode: String, stderrPath: Option[Path]) extends KnownJobFailureException {

--- a/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
+++ b/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
@@ -21,10 +21,7 @@ object KnownJobFailureException {
 }
 
 final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path], errorMessage: Option[String] = None) extends KnownJobFailureException {
-  val explanation = errorMessage match {
-    case Some(message) => message
-    case None => "No additional info can be provided by now"
-  }
+  val explanation = errorMessage.getOrElse("No additional info can be provided by now")
   override def getMessage =
     s"Job $jobTag exited with return code $returnCode which has not been declared as a valid return code. $explanation. See 'continueOnReturnCode' runtime attribute for more details."
 }

--- a/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
+++ b/backend/src/main/scala/cromwell/backend/async/KnownJobFailureException.scala
@@ -22,7 +22,7 @@ object KnownJobFailureException {
 
 final case class WrongReturnCode(jobTag: String, returnCode: Int, stderrPath: Option[Path], errorMessage: Option[String] = None) extends KnownJobFailureException {
   val explanation = errorMessage match {
-    case Some(message) => s"Possibly caused by: '$message'"
+    case Some(message) => message
     case None => "No additional info can be provided by now"
   }
   override def getMessage =

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -1096,7 +1096,15 @@ trait StandardAsyncExecutionActor
             case Success(returnCodeAsInt) if isAbort(returnCodeAsInt) =>
               Future.successful(AbortedExecutionHandle)
             case Success(returnCodeAsInt) if !continueOnReturnCode.continueFor(returnCodeAsInt) =>
-              val executionHandle = Future.successful(FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption), Option(returnCodeAsInt)))
+              // Read stderr content only if there is need to get detailed info about failure
+              // Should not read large files completely
+              val errorMessageAsFutureString = asyncIo.contentAsStringAsync(stderr, maxBytes = Option(1024), failOnOverflow = false)
+              val executionHandle = errorMessageAsFutureString map {errorMessageAsString =>
+                val errorMessageAsOptionString = errorMessageAsString match {
+                  case message if message.nonEmpty => Some(message)
+                  case _ => None
+                }
+                FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption, errorMessageAsOptionString), Option(returnCodeAsInt))}
               retryElseFail(status, executionHandle)
             case Success(returnCodeAsInt) =>
               handleExecutionSuccess(status, oldHandle, returnCodeAsInt)

--- a/centaur/src/main/resources/standardTestCases/invalid_return_code.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_return_code.test
@@ -7,5 +7,5 @@ files {
 
 metadata {
     "calls.invalid_return_code_wf.invalid_return_code.returnCode": 0
-    "calls.invalid_return_code_wf.invalid_return_code.failures.0.message": "Job invalid_return_code_wf.invalid_return_code:NA:1 exited with return code 0 which has not been declared as a valid return code. No additional info can be provided by now. See 'continueOnReturnCode' runtime attribute for more details."
+    "calls.invalid_return_code_wf.invalid_return_code.failures.0.message": "Job invalid_return_code_wf.invalid_return_code:NA:1 exited with return code 0 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
 }

--- a/centaur/src/main/resources/standardTestCases/invalid_return_code.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_return_code.test
@@ -7,5 +7,5 @@ files {
 
 metadata {
     "calls.invalid_return_code_wf.invalid_return_code.returnCode": 0
-    "calls.invalid_return_code_wf.invalid_return_code.failures.0.message": "Job invalid_return_code_wf.invalid_return_code:NA:1 exited with return code 0 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+    "calls.invalid_return_code_wf.invalid_return_code.failures.0.message": "Job invalid_return_code_wf.invalid_return_code:NA:1 exited with return code 0 which has not been declared as a valid return code. No additional info can be provided by now. See 'continueOnReturnCode' runtime attribute for more details."
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -327,7 +327,8 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
     reasons map {
       case reason: ThrowableAggregation => expandFailureReasons(reason.throwables.toSeq)
       case reason: KnownJobFailureException =>
-        val stderrMessage = KnownJobFailureException.stderrExplanation(reason.stderrPath)
+        val stderrMessageAsOption = KnownJobFailureException.stderrExplanation(reason.stderrPath)
+        val stderrMessage = stderrMessageAsOption.getOrElse("")
         reason.getMessage + stderrMessage
       case reason => ExceptionUtils.getStackTrace(reason)
     } mkString "\n"

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -327,12 +327,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
     reasons map {
       case reason: ThrowableAggregation => expandFailureReasons(reason.throwables.toSeq)
       case reason: KnownJobFailureException =>
-        val stderrMessage = reason.stderrPath map { path => 
-          val content = Try(path.annotatedContentAsStringWithLimit(300)).recover({
-            case e => s"Could not retrieve content: ${e.getMessage}"
-          }).get
-          s"\nCheck the content of stderr for potential additional information: ${path.pathAsString}.\n $content" 
-        } getOrElse ""
+        val stderrMessage = KnownJobFailureException.stderrExplanation(reason.stderrPath)
         reason.getMessage + stderrMessage
       case reason => ExceptionUtils.getStackTrace(reason)
     } mkString "\n"


### PR DESCRIPTION
The purpose of this PR is to make `/metadata` more informative, as described in #4856.
It appears that Cromwell already stores the necessary info in a `stderr.log` file. Therefore, reading the content of that file and printing to the user should be enough.
However, one thing bothers us. In the method `handleExecutionResult` of the trait `StandardAsyncExecutionActor`, the comment says that
```
Only check stderr size if we need to, otherwise this results in a lot of unnecessary I/O that
may fail due to race conditions on quickly-executing jobs.
```
But in order to give additional info to the user, we have to read the content of that file. Also, we do not understand, why this is such a big deal. The method `handleExecutionResult` must be called when the execution is finished and that file is written. What race conditions may arise and is it important in this case?