### PR TITLE
AWS Batch with CWL: did not localize cwl.inputs.json [BA-4586]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test.aws.test
@@ -1,0 +1,14 @@
+name: ad_hoc_file_test.aws
+testFormat: workflowsuccess
+backends: [ AWSBATCH ]
+
+files {
+  workflow: ad_hoc_file_test/workflow.cwl
+  imports: [
+    ad_hoc_file_test/cwl-test.cwl
+  ]
+}
+
+metadata {
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/cwl-test.cwl
@@ -1,0 +1,21 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: ["sh", "example.sh"]
+hints:
+  DockerRequirement:
+    dockerPull: ubuntu:latest
+inputs: []
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: example.sh
+        entry: |-
+          PREFIX='Message is:'
+          MSG="\${PREFIX} Hello world!"
+          echo \${MSG}
+
+outputs:
+  example_out:
+    type: stdout
+stdout: output.txt

--- a/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
+++ b/centaur/src/main/resources/standardTestCases/ad_hoc_file_test/workflow.cwl
@@ -1,0 +1,10 @@
+cwlVersion: v1.0
+class: Workflow
+inputs: []
+outputs: []
+
+steps:
+  test:
+    run: cwl-test.cwl
+    in: []
+    out: []

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -57,7 +57,6 @@ import cromwell.services.keyvalue.KeyValueServiceActor._
 import cromwell.services.keyvalue.KvClient
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.batch.model.{BatchException, SubmitJobResponse}
-import wom.CommandSetupSideEffectFile
 import wom.callable.Callable.OutputDefinition
 import wom.core.FullyQualifiedName
 import wom.expression.NoIoFunctionSet
@@ -199,7 +198,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
     * relativeLocalizationPath("s3://some/bucket/foo.txt") -> "some/bucket/foo.txt"
     */
-  private def relativeLocalizationPath(file: WomFile): WomFile = {
+  override protected def relativeLocalizationPath(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         case Success(path) => {
@@ -216,8 +215,6 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   private[aws] def generateAwsBatchInputs(jobDescriptor: BackendJobDescriptor): Set[AwsBatchInput] = {
     val writeFunctionFiles = instantiatedCommand.createdFiles map { f => f.file.value.md5SumShort -> List(f) } toMap
 
-    def localizationPath(f: CommandSetupSideEffectFile) =
-      f.relativeLocalPath.fold(ifEmpty = relativeLocalizationPath(f.file))(WomFile(f.file.womFileType, _))
     val writeFunctionInputs = writeFunctionFiles flatMap {
       case (name, files) => inputsFromWomFiles(name, files.map(_.file), files.map(localizationPath), jobDescriptor)
     }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -39,7 +39,6 @@ import cromwell.services.keyvalue.KvClient
 import cromwell.services.metadata.CallMetadataKeys
 import shapeless.Coproduct
 import wdl4s.parser.MemoryUnit
-import wom.CommandSetupSideEffectFile
 import wom.callable.AdHocValue
 import wom.callable.Callable.OutputDefinition
 import wom.callable.MetaValueElement.{MetaValueElementBoolean, MetaValueElementObject}
@@ -172,7 +171,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     * relativeLocalizationPath("foo/bar.txt") -> "foo/bar.txt"
     * relativeLocalizationPath("gs://some/bucket/foo.txt") -> "some/bucket/foo.txt"
     */
-  protected def relativeLocalizationPath(file: WomFile): WomFile = {
+  override protected def relativeLocalizationPath(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         case Success(drsPath: DrsPath) => DrsResolver.getContainerRelativePath(drsPath).unsafeRunSync()
@@ -182,7 +181,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     )
   }
 
-  protected def fileName(file: WomFile): WomFile = {
+  override protected def fileName(file: WomFile): WomFile = {
     file.mapFile(value =>
       getPath(value) match {
         case Success(drsPath: DrsPath) => DefaultPathBuilder.get(DrsResolver.getContainerRelativePath(drsPath).unsafeRunSync()).name
@@ -215,11 +214,6 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           case womFile: WomFile => womFile
         }
     }
-  }
-
-  protected def localizationPath(f: CommandSetupSideEffectFile) = {
-    val fileTransformer = if (isAdHocFile(f.file)) fileName _ else relativeLocalizationPath _
-    f.relativeLocalPath.fold(ifEmpty = fileTransformer(f.file))(WomFile(f.file.womFileType, _))
   }
 
   private[pipelines] def generateInputs(jobDescriptor: BackendJobDescriptor): Set[PipelinesApiInput] = {


### PR DESCRIPTION
The purpose of this PR is to fix issue #4586.
It turns out that Cromwell looks for the ad hoc files in the wrong location while using AWS. These files placed in the S3 bucket, while Cromwell expects them to be in the root execution directory. There were already two PRs from us ([1](https://github.com/broadinstitute/cromwell/pull/5064), [2](https://github.com/broadinstitute/cromwell/pull/5057)) aimed to solve this issue, but these were not the appropriate solutions.
This time we found what part of GCP backend handles these ad hoc files and implemented the same logic on AWS. Also, in order to reduce the amount of duplicate code, we made a small refactoring.