### PR TITLE
Womtool: Flag to list workflow dependencies (Approach 2) [BA-3501]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 45 Release Notes
 
+### List dependencies flag in Womtool Command Line [(#5098)](https://github.com/broadinstitute/cromwell/pull/5098)
+
+Womtool now outputs the list of files referenced in import statements using `-l` flag for `validate` command.
+More info [here](https://cromwell.readthedocs.io/en/stable/WOMtool/)
+
 ### BCS backend new Features support
 
 #### New docker registry

--- a/docs/WOMtool.md
+++ b/docs/WOMtool.md
@@ -25,10 +25,11 @@ Run the JAR file with no arguments to get the usage message:
 java -jar /path/to/womtool.jar <action> <parameters>
 
 Actions:
-validate <WDL file>
+validate [--list-dependencies] <WDL file>
 
   Performs full validation of the WDL file including syntax
-  and semantic checking
+  and semantic checking. -l or --list-dependencies is an optional flag to 
+  list files referenced in import statements.
 
 inputs <WDL file>
 
@@ -96,6 +97,20 @@ Import statement defined here (line 1, col 20):
 
 import "ps.wdl" as ps
                    ^
+```
+
+##### --list-dependencies or -l flag
+
+For a successful validation, this will output the list of files referenced in import statements in workflows and their subworkflows.
+
+`$ java -jar womtool.jar validate -l myWdl.wdl`
+
+```hocon
+Success!
+List of Workflow dependencies are:
+/path/to/my/import/myImport.wdl
+/path/to/another/import/anotherImport.wdl
+https://path-to-http-import/httpImport.wdl
 ```
 
 ### `inputs`

--- a/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
+++ b/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
@@ -14,6 +14,7 @@ import cromwell.languages.util.LanguageFactoryUtil
 import cromwell.languages.{LanguageFactory, ValidatedWomNamespace}
 import cwl.preprocessor.CwlReference
 import cwl.{Cwl, CwlDecoder}
+import wom.ResolvedImportRecord
 import wom.core.{WorkflowJson, WorkflowOptionsJson, WorkflowSource}
 import wom.executable.WomBundle
 import wom.expression.IoFunctionSet
@@ -55,6 +56,7 @@ class CwlV1_0LanguageFactory(override val config: Config) extends LanguageFactor
   }
 
   override def getWomBundle(workflowSource: WorkflowSource,
+                            workflowSourceOrigin: Option[ResolvedImportRecord],
                             workflowOptionsJson: WorkflowOptionsJson,
                             importResolvers: List[ImportResolver],
                             languageFactories: List[LanguageFactory],

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/LanguageFactory.scala
@@ -2,10 +2,11 @@ package cromwell.languages
 
 import com.typesafe.config.Config
 import common.Checked
-import common.validation.IOChecked.IOChecked
 import common.validation.Checked._
+import common.validation.IOChecked.IOChecked
 import cromwell.core.{WorkflowId, WorkflowOptions, WorkflowSourceFilesCollection}
 import cromwell.languages.util.ImportResolver.ImportResolver
+import wom.ResolvedImportRecord
 import wom.core._
 import wom.executable.WomBundle
 import wom.expression.IoFunctionSet
@@ -34,6 +35,7 @@ trait LanguageFactory {
   }
 
   def getWomBundle(workflowSource: WorkflowSource,
+                   workflowSourceOrigin: Option[ResolvedImportRecord],
                    workflowOptionsJson: WorkflowOptionsJson,
                    importResolvers: List[ImportResolver],
                    languageFactories: List[LanguageFactory],

--- a/languageFactories/language-factory-core/src/test/resources/sampleWorkflow.wdl
+++ b/languageFactories/language-factory-core/src/test/resources/sampleWorkflow.wdl
@@ -1,0 +1,1 @@
+This file is used for testing in ImportResolverSpec

--- a/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/ImportResolverSpec.scala
+++ b/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/ImportResolverSpec.scala
@@ -10,6 +10,9 @@ import org.scalatest.{FlatSpec, Matchers}
 class ImportResolverSpec extends FlatSpec with Matchers {
   behavior of "HttpResolver"
 
+  val relativeToGithubRoot = "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/"
+  val resolvedHttpPath = relativeToGithubRoot + "centaur/src/main/resources/standardTestCases/hello/hello.wdl"
+
   val canon = Map(
     "http://abc.com:8000/blah?x=5&y=10" -> "http://abc.com:8000/blah?x=5&y=10",
     "http://abc.com:8000/bob/loblaw/law/blog/../../blah/blah" -> "http://abc.com:8000/bob/loblaw/blah/blah",
@@ -39,13 +42,35 @@ class ImportResolverSpec extends FlatSpec with Matchers {
     toResolve shouldBeValid "http://abc.com:8000/blah1/blah2.wdl"
   }
 
+  it should "resolve a path and store the import in ResolvedImportRecord" in {
+    val resolver = HttpResolver()
+    val importUri = "https://raw.githubusercontent.com/broadinstitute/cromwell/develop/centaur/src/main/resources/standardTestCases/hello/hello.wdl"
+    val resolvedBundle = resolver.innerResolver(importUri, List(resolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe resolvedHttpPath
+    }
+  }
+
   behavior of "HttpResolver with a 'relativeTo' value"
 
   val relativeHttpResolver = HttpResolver(relativeTo = Some("http://abc.com:8000/blah1/blah2/"))
+  val relativeToGithubHttpResolver = HttpResolver(relativeTo = Some(relativeToGithubRoot))
 
-  it should "resolve an abolute path from a different initial root" in {
+  it should "resolve an absolute path from a different initial root" in {
     val pathToLookup = relativeHttpResolver.pathToLookup("http://def.org:8080/blah3.wdl")
     pathToLookup shouldBeValid "http://def.org:8080/blah3.wdl"
+  }
+
+  it should "resolve an absolute path from a different initial root and store it in ResolvedImportRecord" in {
+    val importUri = "https://github.com/DataBiosphere/job-manager/blob/master/CHANGELOG.md"
+    val resolvedBundle = relativeToGithubHttpResolver.innerResolver(importUri, List(relativeToGithubHttpResolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe importUri
+    }
   }
 
   it should "resolve a relative path" in {
@@ -53,9 +78,29 @@ class ImportResolverSpec extends FlatSpec with Matchers {
     pathToLookup shouldBeValid "http://abc.com:8000/blah1/blah2/tools/cool_tool.wdl"
   }
 
+  it should "resolve a relative path and store it in ResolvedImportRecord" in {
+    val importUri = "centaur/src/main/resources/standardTestCases/hello/hello.wdl"
+    val resolvedBundle = relativeToGithubHttpResolver.innerResolver(importUri, List(relativeToGithubHttpResolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe resolvedHttpPath
+    }
+  }
+
   it should "resolve a backtracking relative path" in {
     val pathToLookup = relativeHttpResolver.pathToLookup("../tools/cool_tool.wdl")
     pathToLookup shouldBeValid "http://abc.com:8000/blah1/tools/cool_tool.wdl"
+  }
+
+  it should "resolve a backtracking relative path and store it in ResolvedImportRecord" in {
+    val importUri = "../develop/centaur/src/main/resources/standardTestCases/hello/hello.wdl"
+    val resolvedBundle = relativeToGithubHttpResolver.innerResolver(importUri, List(relativeToGithubHttpResolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe resolvedHttpPath
+    }
   }
 
   it should "resolve from '/'" in {
@@ -63,8 +108,19 @@ class ImportResolverSpec extends FlatSpec with Matchers {
     pathToLookup shouldBeValid "http://abc.com:8000/tools/cool_tool.wdl"
   }
 
+  it should "resolve from '/' and store it in ResolvedImportRecord" in {
+    val importUri = "/broadinstitute/cromwell/develop/centaur/src/main/resources/standardTestCases/hello/hello.wdl"
+    val resolvedBundle = relativeToGithubHttpResolver.innerResolver(importUri, List(relativeToGithubHttpResolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe resolvedHttpPath
+    }
+  }
+
   behavior of "directory resolver from root"
 
+  val workingDirectory = sys.props("user.dir")
   val rootDirectoryResolver = DirectoryResolver(DefaultPath(Paths.get("/")), customName = None)
 
   it should "resolve a random path" in {
@@ -72,13 +128,36 @@ class ImportResolverSpec extends FlatSpec with Matchers {
     pathToLookup shouldBeValid Paths.get("/path/to/file.wdl")
   }
 
+  it should "resolve sampleWorkflow path and store absolute path in ResolvedImportRecord" in {
+    val path = s"$workingDirectory/languageFactories/language-factory-core/src/test/resources/sampleWorkflow.wdl"
+    val resolvedBundle = rootDirectoryResolver.innerResolver(path, List(rootDirectoryResolver))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe path
+    }
+  }
+
   behavior of "unprotected relative directory resolver"
 
   val relativeDirectoryResolver = DirectoryResolver(DefaultPath(Paths.get("/path/to/imports/")), customName = None)
 
+  val relativeDirForSampleWf = s"$workingDirectory/languageFactories/language-factory-core/src/test/"
+  val relativeDirResolverForSampleWf = DirectoryResolver(DefaultPath(Paths.get(relativeDirForSampleWf)), customName = None)
+
   it should "resolve an absolute path" in {
     val pathToLookup = relativeDirectoryResolver.resolveAndMakeAbsolute("/path/to/file.wdl")
     pathToLookup shouldBeValid Paths.get("/path/to/file.wdl")
+  }
+
+  it should "resolve an absolute path of sampleWorkflow" in {
+    val path = relativeDirForSampleWf + "resources/sampleWorkflow.wdl"
+    val resolvedBundle = relativeDirResolverForSampleWf.innerResolver(path, List(relativeDirResolverForSampleWf))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe path
+    }
   }
 
   it should "resolve a relative path" in {
@@ -86,13 +165,34 @@ class ImportResolverSpec extends FlatSpec with Matchers {
     pathToLookup shouldBeValid Paths.get("/path/to/imports/path/to/file.wdl")
   }
 
+  it should "resolve a relative path for SampleWorkflow" in {
+    val path = "resources/sampleWorkflow.wdl"
+    val resolvedBundle = relativeDirResolverForSampleWf.innerResolver(path, List(relativeDirResolverForSampleWf))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe(relativeDirForSampleWf + path)
+    }
+  }
+
   behavior of "protected relative directory resolver"
 
   val protectedRelativeDirectoryResolver = DirectoryResolver(DefaultPath(Paths.get("/path/to/imports/")), Some("/path/to/imports/"), customName = None)
+  val protectedRelativeDirResolverForSampleWf = DirectoryResolver(DefaultPath(Paths.get(relativeDirForSampleWf)), Some(relativeDirForSampleWf), customName = None)
 
   it should "resolve a good relative path" in {
     val pathToLookup = protectedRelativeDirectoryResolver.resolveAndMakeAbsolute("path/to/file.wdl")
     pathToLookup shouldBeValid Paths.get("/path/to/imports/path/to/file.wdl")
+  }
+
+  it should "resolve a good relative path to sampleWorkflow" in {
+    val path = "resources/sampleWorkflow.wdl"
+    val resolvedBundle = protectedRelativeDirResolverForSampleWf.innerResolver(path, List(protectedRelativeDirResolverForSampleWf))
+
+    resolvedBundle.map(_.resolvedImportRecord) match {
+      case Left(e) => fail(s"Expected ResolvedImportBundle but got $e")
+      case Right(resolvedImport) => resolvedImport.importPath shouldBe(relativeDirForSampleWf + path)
+    }
   }
 
   it should "not resolve an absolute path" in {

--- a/languageFactories/wdl-biscayne/src/main/scala/languages/wdl/biscayne/WdlBiscayneLanguageFactory.scala
+++ b/languageFactories/wdl-biscayne/src/main/scala/languages/wdl/biscayne/WdlBiscayneLanguageFactory.scala
@@ -16,6 +16,7 @@ import wdl.transforms.base.wdlom2wom._
 import wdl.transforms.biscayne.ast2wdlom._
 import wdl.transforms.biscayne.parsing._
 import wdl.transforms.biscayne.wdlom2wom._
+import wom.ResolvedImportRecord
 import wom.core.{WorkflowJson, WorkflowOptionsJson, WorkflowSource}
 import wom.executable.WomBundle
 import wom.expression.IoFunctionSet
@@ -38,7 +39,7 @@ class WdlBiscayneLanguageFactory(override val config: Config) extends LanguageFa
 
     val checked: Checked[ValidatedWomNamespace] = for {
       _ <- enabledCheck
-      bundle <- getWomBundle(workflowSource, source.workflowOptions.asPrettyJson, importResolvers, factories)
+      bundle <- getWomBundle(workflowSource, workflowSourceOrigin = None, source.workflowOptions.asPrettyJson, importResolvers, factories)
       executable <- createExecutable(bundle, source.inputsJson, ioFunctions)
     } yield executable
 
@@ -47,6 +48,7 @@ class WdlBiscayneLanguageFactory(override val config: Config) extends LanguageFa
   }
 
   override def getWomBundle(workflowSource: WorkflowSource,
+                            workflowSourceOrigin: Option[ResolvedImportRecord],
                             workflowOptionsJson: WorkflowOptionsJson,
                             importResolvers: List[ImportResolver],
                             languageFactories: List[LanguageFactory],
@@ -54,6 +56,7 @@ class WdlBiscayneLanguageFactory(override val config: Config) extends LanguageFa
     val checkEnabled: CheckedAtoB[FileStringParserInput, FileStringParserInput] = CheckedAtoB.fromCheck(x => enabledCheck map(_ => x))
     val converter: CheckedAtoB[FileStringParserInput, WomBundle] = checkEnabled andThen stringToAst andThen wrapAst andThen astToFileElement.map(FileElementToWomBundleInputs(_, workflowOptionsJson, convertNestedScatterToSubworkflow, importResolvers, languageFactories, workflowDefinitionElementToWomWorkflowDefinition, taskDefinitionElementToWomTaskDefinition)) andThen fileElementToWomBundle
     converter.run(FileStringParserInput(workflowSource, "input.wdl"))
+      .map(b => b.copyResolvedImportRecord(b, workflowSourceOrigin))
   }
 
   override def createExecutable(womBundle: WomBundle, inputsJson: WorkflowJson, ioFunctions: IoFunctionSet): Checked[ValidatedWomNamespace] = {

--- a/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/ArrayCoercionsSpec.scala
+++ b/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/ArrayCoercionsSpec.scala
@@ -54,7 +54,7 @@ class ArrayCoercionsSpec extends FlatSpec with Matchers {
 
   private def createExecutable(workflowSource: WorkflowSource): Unit = {
     val result = for {
-      bundle <- factory.getWomBundle(workflowSource, "{}", List.empty, List.empty)
+      bundle <- factory.getWomBundle(workflowSource, None, "{}", List.empty, List.empty)
       _ <- factory.createExecutable(bundle, inputs = "{}", ioFunctions = new EmptyIoFunctionSet)
     } yield ()
 

--- a/services/src/main/scala/cromwell/services/womtool/Describer.scala
+++ b/services/src/main/scala/cromwell/services/womtool/Describer.scala
@@ -46,7 +46,7 @@ object Describer {
     // Mirror of the inputs/no inputs fork in womtool.validate.Validate
     if (workflowSourceFilesCollection.inputsJson.isEmpty) {
       // No inputs: just load up the WomBundle
-      factory.getWomBundle(workflow, "{}", List(HttpResolver(None, Map.empty)), List(factory)) match {
+      factory.getWomBundle(workflow, workflowSourceOrigin = None, workflowOptionsJson = "{}", List(HttpResolver(None, Map.empty)), List(factory)) match {
         case Right(bundle: WomBundle) =>
           WorkflowDescription.fromBundle(bundle, factory.languageName, factory.languageVersionName, List.empty)
         case Left(workflowErrors) =>
@@ -54,7 +54,7 @@ object Describer {
       }
     } else {
       // Inputs: load up the WomBundle and then try creating an executable with WomBundle + inputs
-      factory.getWomBundle(workflow, "{}", List(HttpResolver(None, Map.empty)), List(factory)) match {
+      factory.getWomBundle(workflow, workflowSourceOrigin = None, workflowOptionsJson = "{}", List(HttpResolver(None, Map.empty)), List(factory)) match {
         case Right(bundle) =>
           factory.createExecutable(bundle, workflowSourceFilesCollection.inputsJson, NoIoFunctionSet) match {
             // Throw away the executable, all we care about is whether it created successfully (i.e. the inputs are valid)

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/examples/ex2.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/examples/ex2.scala
@@ -1,7 +1,8 @@
 package wdl.draft2.model.examples
 
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.WdlNamespaceWithWorkflow
-import wom.core._
+import wom.ResolvedImportRecord
 
 object ex2 {
   def main(args: Array[String]): Unit = {
@@ -14,9 +15,9 @@ object ex2 {
       | call a
       |}""".stripMargin
 
-    def resolver(importString: String): WorkflowSource = {
+    def resolver(importString: String): Draft2ResolvedImportBundle = {
       importString match {
-        case "some_string" => "task imported { command {ps} }"
+        case "some_string" => Draft2ResolvedImportBundle("task imported { command {ps} }", ResolvedImportRecord("some_string"))
         case s if s.startsWith("http://") =>
           // issue HTTP request
           throw new UnsupportedOperationException("not implemented")

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/examples/ex3.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/examples/ex3.scala
@@ -1,7 +1,8 @@
 package wdl.draft2.model.examples
 
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.WdlNamespaceWithWorkflow
-import wom.core._
+import wom.ResolvedImportRecord
 
 object ex3 {
   def main(args: Array[String]): Unit = {
@@ -14,9 +15,9 @@ object ex3 {
       | call a
       |}""".stripMargin
 
-    def resolver(importString: String): WorkflowSource = {
+    def resolver(importString: String): Draft2ResolvedImportBundle = {
       importString match {
-        case "some_string" => "task imported { command {ps} }"
+        case "some_string" => Draft2ResolvedImportBundle("task imported { command {ps} }", ResolvedImportRecord("some_string"))
         case _ => throw new UnsupportedOperationException()
       }
     }

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/package.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/package.scala
@@ -1,10 +1,13 @@
 package wdl.draft2
 
 import wdl.draft2.model.exception.OutputVariableLookupException
+import wom.ResolvedImportRecord
 import wom.core.WorkflowSource
 import wom.values.WomValue
 
 import scala.util.{Failure, Try}
+
+case class Draft2ResolvedImportBundle(source: WorkflowSource, resolvedImportRecord: ResolvedImportRecord)
 
 package object model {
   type WorkflowJson = String
@@ -12,7 +15,7 @@ package object model {
   type FullyQualifiedName = String
   type LocallyQualifiedName = String
   type EvaluatedTaskInputs = Map[Declaration, WomValue]
-  type Draft2ImportResolver = String => WorkflowSource
+  type Draft2ImportResolver = String => Draft2ResolvedImportBundle
   type OutputResolver = (WdlGraphNode, Option[Int]) => Try[WomValue]
 
   val NoOutputResolver: OutputResolver = (node: WdlGraphNode, i: Option[Int]) => Failure(OutputVariableLookupException(node, i))

--- a/wdl/model/draft2/src/test/scala/wdl/SyntaxErrorSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/SyntaxErrorSpec.scala
@@ -4,8 +4,10 @@ import wdl.draft2.parser.WdlParser.SyntaxError
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.WdlNamespace
 import wdl.util.StringUtil
+import wom.ResolvedImportRecord
 import wom.core.WorkflowSource
 
 import scala.util.{Failure, Success}
@@ -33,10 +35,10 @@ class SyntaxErrorSpec extends FlatSpec with Matchers {
      |  }
      |}""".stripMargin
 
-  private def resolver(importUri: String): WorkflowSource = {
+  private def resolver(importUri: String): Draft2ResolvedImportBundle = {
     importUri match {
-      case "ps" => psTaskWdl
-      case "cgrep" => cgrepTaskWdl
+      case "ps" => Draft2ResolvedImportBundle(psTaskWdl, ResolvedImportRecord("ps"))
+      case "cgrep" => Draft2ResolvedImportBundle(cgrepTaskWdl, ResolvedImportRecord("cgrep"))
       case _ => throw new RuntimeException(s"Can't resolve $importUri")
     }
   }

--- a/wdl/model/draft2/src/test/scala/wdl/SyntaxHighlightSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/SyntaxHighlightSpec.scala
@@ -1,9 +1,10 @@
 package wdl
 
 import org.scalatest.{Matchers, WordSpec}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.WdlNamespace
 import wdl.draft2.model.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter}
-import wom.core.WorkflowSource
+import wom.ResolvedImportRecord
 
 class SyntaxHighlightSpec extends WordSpec with Matchers {
   "SyntaxFormatter for typical workflow" should {
@@ -258,9 +259,9 @@ class SyntaxHighlightSpec extends WordSpec with Matchers {
                        |}
                      """.stripMargin
 
-    def resolver(importUri: String): WorkflowSource = {
+    def resolver(importUri: String): Draft2ResolvedImportBundle = {
       importUri match {
-        case "foo.wdl" => fooTaskWdl
+        case "foo.wdl" => Draft2ResolvedImportBundle(fooTaskWdl, ResolvedImportRecord("foo.wdl"))
         case _ => throw new RuntimeException(s"Can't resolve $importUri")
       }
     }

--- a/wdl/model/draft2/src/test/scala/wdl/ThreeStepImportNamespaceSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/ThreeStepImportNamespaceSpec.scala
@@ -1,9 +1,10 @@
 package wdl
 
 import org.scalatest.{FlatSpec, Matchers}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.exception.ValidationException
 import wdl.draft2.model.{WdlNamespace, WdlNamespaceWithWorkflow}
-import wom.core.WorkflowSource
+import wom.ResolvedImportRecord
 
 import scala.util.Failure
 
@@ -56,11 +57,11 @@ class ThreeStepImportNamespaceSpec extends FlatSpec with Matchers {
     |  }
     |}""".stripMargin
 
-  def resolver(importUri: String): WorkflowSource = {
+  def resolver(importUri: String): Draft2ResolvedImportBundle = {
     importUri match {
-      case "ps" => psTaskWdl
-      case "cgrep" => cgrepTaskWdl
-      case "wc" => wcTaskWdl
+      case "ps" => Draft2ResolvedImportBundle(psTaskWdl, ResolvedImportRecord("ps"))
+      case "cgrep" => Draft2ResolvedImportBundle(cgrepTaskWdl, ResolvedImportRecord("cgrep"))
+      case "wc" => Draft2ResolvedImportBundle(wcTaskWdl, ResolvedImportRecord("wc"))
       case _ => throw new RuntimeException(s"Can't resolve $importUri")
     }
   }
@@ -78,7 +79,7 @@ class ThreeStepImportNamespaceSpec extends FlatSpec with Matchers {
     namespace.namespaces flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
-    def badResolver(s: String): String = {
+    def badResolver(s: String): Draft2ResolvedImportBundle = {
       throw new RuntimeException(s"Can't Resolve")
     }
     WdlNamespace.loadUsingSource(workflowWdl, None, Option(Seq(badResolver))) match {

--- a/wdl/model/draft2/src/test/scala/wdl/ThreeStepImportSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/ThreeStepImportSpec.scala
@@ -1,8 +1,10 @@
 package wdl
 
 import org.scalatest.{FlatSpec, Matchers}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.exception.ValidationException
 import wdl.draft2.model.{WdlNamespace, WdlNamespaceWithWorkflow}
+import wom.ResolvedImportRecord
 
 import scala.util.Failure
 
@@ -55,11 +57,11 @@ class ThreeStepImportSpec extends FlatSpec with Matchers {
     |  }
     |}""".stripMargin
 
-  def resolver(importUri: String): String = {
+  def resolver(importUri: String): Draft2ResolvedImportBundle = {
     importUri match {
-      case "ps" => psTaskWdl
-      case "cgrep" => cgrepTaskWdl
-      case "wc" => wcTaskWdl
+      case "ps" => Draft2ResolvedImportBundle(psTaskWdl, ResolvedImportRecord("ps"))
+      case "cgrep" => Draft2ResolvedImportBundle(cgrepTaskWdl, ResolvedImportRecord("cgrep"))
+      case "wc" => Draft2ResolvedImportBundle(wcTaskWdl, ResolvedImportRecord("wc"))
       case _ => throw new RuntimeException(s"Can't resolve $importUri")
     }
   }
@@ -77,7 +79,7 @@ class ThreeStepImportSpec extends FlatSpec with Matchers {
     namespace.namespaces flatMap {_.tasks} map {_.name} shouldEqual Seq("ps", "cgrep", "wc")
   }
   it should "Throw an exception if the import resolver fails to resolve an import" in {
-    def badResolver(s: String): String = {
+    def badResolver(s: String): Draft2ResolvedImportBundle = {
       throw new RuntimeException(s"Can't Resolve")
     }
 

--- a/wdl/model/draft2/src/test/scala/wdl/WdlCallSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/WdlCallSpec.scala
@@ -1,10 +1,12 @@
 package wdl
 
 import org.scalatest.{Matchers, WordSpec}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.exception.ValidationException
 import wdl.draft2.model.expression.{NoFunctions, PureStandardLibraryFunctionsLike}
 import wdl.draft2.model.values.WdlCallOutputsObject
 import wdl.draft2.model.{WdlGraphNode, WdlNamespace, WdlNamespaceWithWorkflow, WorkflowCoercedInputs}
+import wom.ResolvedImportRecord
 import wom.types._
 import wom.values._
 
@@ -185,7 +187,7 @@ class WdlCallSpec extends WordSpec with Matchers {
         |}
       """.stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq((_: String) => subWorkflow)).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq((uri: String) => Draft2ResolvedImportBundle(subWorkflow, ResolvedImportRecord(uri)))).get
     ns.workflow.workflowCalls.size shouldBe 1
     ns.workflow.taskCalls.size shouldBe 1
   }

--- a/wdl/model/draft2/src/test/scala/wdl/WdlTest.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/WdlTest.scala
@@ -3,10 +3,13 @@ package wdl
 import better.files.File
 import better.files.File.currentWorkingDirectory
 import org.scalatest.{Matchers, WordSpecLike}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model._
+import wom.ResolvedImportRecord
 
 trait WdlTest extends Matchers with WordSpecLike {
-  def resolver(root: File)(relPath: String): String = (root / relPath).contentAsString
+  def resolver(root: File)(relPath: String): Draft2ResolvedImportBundle =
+    Draft2ResolvedImportBundle((root / relPath).contentAsString, ResolvedImportRecord((root / relPath).pathAsString))
   def loadWdl(path: String) = loadWdlFile(currentWorkingDirectory/"wom"/"src"/"test"/"resources"/path)
   def loadWdlFile(wdlFile: File) =
     WdlNamespaceWithWorkflow.load(wdlFile.contentAsString, Seq(resolver(wdlFile / "..") _)).get

--- a/wdl/model/draft2/src/test/scala/wdl/WdlWiringSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/WdlWiringSpec.scala
@@ -3,7 +3,9 @@ package wdl
 import better.files._
 import org.scalatest.{FlatSpec, Matchers}
 import spray.json._
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model._
+import wom.ResolvedImportRecord
 
 import scala.collection.immutable.ListMap
 
@@ -14,7 +16,8 @@ class WdlWiringSpec extends FlatSpec with Matchers {
   testCases.list.toSeq.filter(_.isDirectory) foreach { testDir =>
     val wdlFile = testDir / "test.wdl"
     if (!wdlFile.exists) fail(s"Expecting a 'test.wdl' file in directory 'cases/${testDir.name}'")
-    def resolvers: Seq[Draft2ImportResolver] = Seq((relPath: String) => (testDir / relPath).contentAsString)
+    def resolvers: Seq[Draft2ImportResolver] =
+      Seq((relPath: String) => Draft2ResolvedImportBundle((testDir / relPath).contentAsString, ResolvedImportRecord((testDir / relPath).pathAsString)))
     val namespace = WdlNamespaceWithWorkflow.load(File(wdlFile.path).contentAsString, resolvers).get
     val wdlFileRelPath = File(".").relativize(wdlFile)
 

--- a/wdl/model/draft2/src/test/scala/wdl/WdlWorkflowSpec.scala
+++ b/wdl/model/draft2/src/test/scala/wdl/WdlWorkflowSpec.scala
@@ -4,10 +4,12 @@ import common.util.TryUtil
 import org.scalactic.Equality
 import org.scalatest.enablers.Aggregating._
 import org.scalatest.{Matchers, WordSpec}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model._
 import wdl.draft2.model.expression.{NoFunctions, WdlFunctions}
 import wdl.draft2.model.values.WdlCallOutputsObject
 import wdl.draft2.parser.WdlParser.SyntaxError
+import wom.ResolvedImportRecord
 import wom.types._
 import wom.values._
 
@@ -169,7 +171,7 @@ class WdlWorkflowSpec extends WordSpec with Matchers {
     
     def verifyOutputs(outputString: String, declarationExpectations: Seq[WorkflowOutputExpectation], evaluationExpectations: Map[String, WomValue]) = {
       val ns = WdlNamespaceWithWorkflow.load(
-        wdl.replace("<<OUTPUTS>>", outputString), Seq((uri: String) => subWorkflow)).get
+        wdl.replace("<<OUTPUTS>>", outputString), Seq((uri: String) => Draft2ResolvedImportBundle(subWorkflow, ResolvedImportRecord(uri)))).get
       verifyOutputsForNamespace(ns, declarationExpectations, evaluationExpectations, outputResolverForWorkflow(ns.workflow))
     }
 
@@ -433,7 +435,7 @@ class WdlWorkflowSpec extends WordSpec with Matchers {
         """.stripMargin
 
       a[SyntaxError] should be thrownBy {
-        WdlNamespaceWithWorkflow.load(wdl.replace("<<OUTPUTS>>", output), Seq((uri: String) => subWorkflow)).get
+        WdlNamespaceWithWorkflow.load(wdl.replace("<<OUTPUTS>>", output), Seq((uri: String) => Draft2ResolvedImportBundle(subWorkflow, ResolvedImportRecord(uri)))).get
       }
     }
 
@@ -509,7 +511,7 @@ class WdlWorkflowSpec extends WordSpec with Matchers {
         """.stripMargin
       
       val exception = the[SyntaxError] thrownBy
-        WdlNamespaceWithWorkflow.load(parentWorkflow, Seq((uri: String) => subWorkflow)).get
+        WdlNamespaceWithWorkflow.load(parentWorkflow, Seq((uri: String) => Draft2ResolvedImportBundle(subWorkflow, ResolvedImportRecord(uri)))).get
       exception.getMessage shouldBe s"""Workflow sub_workflow is used as a sub workflow but has outputs declared with a deprecated syntax not compatible with sub workflows.
                                         |To use this workflow as a sub workflow please update the workflow outputs section to the latest WDL specification.
                                         |See https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs""".stripMargin

--- a/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
+++ b/wdl/transforms/draft2/src/main/scala/wdl/transforms/draft2/wdlom2wom/WdlDraft2WomBundleMakers.scala
@@ -24,7 +24,7 @@ object WdlDraft2WomBundleMakers {
           if (workflows.size == 1) {
             workflows.headOption
           } else None
-        WomBundle(primary, (tasks ++ workflows).map(c => c.name -> c).toMap, Map.empty) }
+        WomBundle(primary, (tasks ++ workflows).map(c => c.name -> c).toMap, Map.empty, from.resolvedImportRecords) }
       errorOr.toEither
     }
   }

--- a/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/WdlSubworkflowWomSpec.scala
+++ b/wdl/transforms/draft2/src/test/scala/wdl/transforms/wdlwom/WdlSubworkflowWomSpec.scala
@@ -2,12 +2,14 @@ package wdl.transforms.wdlwom
 
 import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
+import wdl.draft2.Draft2ResolvedImportBundle
 import wdl.draft2.model.{Draft2ImportResolver, WdlNamespace, WdlNamespaceWithWorkflow}
 import wom.graph._
 import wom.graph.expression.ExpressionNode
 import wom.transforms.WomWorkflowDefinitionMaker.ops._
 import wom.types.{WomArrayType, WomIntegerType, WomMaybeEmptyArrayType, WomStringType}
 import wdl.transforms.draft2.wdlom2wom._
+import wom.ResolvedImportRecord
 
 class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
 
@@ -47,7 +49,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       """.stripMargin
 
 
-    def innerResolver: Draft2ImportResolver = _ => innerWdl
+    def innerResolver: Draft2ImportResolver = str => Draft2ResolvedImportBundle(innerWdl, ResolvedImportRecord(str))
 
     val namespace = WdlNamespace.loadUsingSource(
       workflowSource = outerWdl,
@@ -138,7 +140,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       """.stripMargin
 
 
-    def innerResolver: Draft2ImportResolver = _ => innerWdl
+    def innerResolver: Draft2ImportResolver = str => Draft2ResolvedImportBundle(innerWdl, ResolvedImportRecord(str))
 
     val namespace = WdlNamespace.loadUsingSource(
       workflowSource = outerWdl,
@@ -200,7 +202,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin
 
-    def innerResolver: Draft2ImportResolver = _ => innerWdl
+    def innerResolver: Draft2ImportResolver = str => Draft2ResolvedImportBundle(innerWdl, ResolvedImportRecord(str))
 
     val namespace = WdlNamespace.loadUsingSource(
       workflowSource = outerWdl,

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/FileElementToWomBundle.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/FileElementToWomBundle.scala
@@ -64,7 +64,7 @@ object FileElementToWomBundle {
 
             val bundledCallableMap = (localTaskMapping.values.toSet ++ workflows).map(c => c.name -> c).toMap
 
-            WomBundle(primary, bundledCallableMap, allStructs)
+            WomBundle(primary, bundledCallableMap, allStructs, imports.flatMap(_.resolvedImportRecords).toSet)
           }
         }
       }
@@ -89,7 +89,7 @@ object FileElementToWomBundle {
 
     val languageFactoryKleislis: List[CheckedAtoB[ResolvedImportBundle, WomBundle]] = languageFactories map { factory =>
       CheckedAtoB.fromCheck { resolutionBundle: ResolvedImportBundle =>
-        factory.getWomBundle(resolutionBundle.source, optionsJson, resolutionBundle.newResolvers, languageFactories)
+        factory.getWomBundle(resolutionBundle.source, Option(resolutionBundle.resolvedImportRecord), optionsJson, resolutionBundle.newResolvers, languageFactories)
       }
     }
     val compoundLanguageFactory: CheckedAtoB[ResolvedImportBundle, WomBundle] = CheckedAtoB.firstSuccess(languageFactoryKleislis, s"convert imported '${importElement.importUrl}' to WOM")

--- a/wom/src/main/scala/wom/executable/WomBundle.scala
+++ b/wom/src/main/scala/wom/executable/WomBundle.scala
@@ -2,6 +2,7 @@ package wom.executable
 
 import common.Checked
 import common.validation.Checked._
+import wom.ResolvedImportRecord
 import wom.callable.{Callable, CallableTaskDefinition, ExecutableCallable, WorkflowDefinition}
 import wom.types.WomType
 
@@ -10,11 +11,15 @@ import wom.types.WomType
   */
 final case class WomBundle(primaryCallable: Option[Callable],
                            allCallables: Map[String, Callable],
-                           typeAliases: Map[String, WomType]) {
+                           typeAliases: Map[String, WomType],
+                           resolvedImportRecords: Set[ResolvedImportRecord]) {
   def toExecutableCallable: Checked[ExecutableCallable] = primaryCallable match {
     case Some(w: WorkflowDefinition) => w.validNelCheck
     case Some(c: CallableTaskDefinition) => c.toExecutable.toEither
     case Some(other) => s"Cannot convert WOM bundle to executable. Primary callable was an unknown type ${other.getClass.getSimpleName}.".invalidNelCheck
     case None => s"Cannot convert WOM bundle to executable. No primary callable was available.".invalidNelCheck
   }
+
+  def copyResolvedImportRecord(bundle: WomBundle, resolvedImportRecord: Option[ResolvedImportRecord]): WomBundle =
+    bundle.copy(resolvedImportRecords = bundle.resolvedImportRecords ++ resolvedImportRecord)
 }

--- a/wom/src/main/scala/wom/package.scala
+++ b/wom/src/main/scala/wom/package.scala
@@ -57,6 +57,11 @@ package object core {
   type ExecutableInputMap = Map[String, Any]
 }
 
+/***
+  * @param importPath The string representing the resolved import.
+  */
+final case class ResolvedImportRecord(importPath: String) extends AnyVal
+
 /**
   * @param commandString The string representing the instantiation of this command.
   * @param environmentVariables Key/value environment variable pairs.

--- a/womtool/src/main/scala/womtool/WomtoolMain.scala
+++ b/womtool/src/main/scala/womtool/WomtoolMain.scala
@@ -7,17 +7,17 @@ import common.validation.Validation._
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import cromwell.languages.util.ImportResolver.HttpResolver
 import languages.wdl.draft2.WdlDraft2LanguageFactory
-import wdl.draft2.model.{AstTools, WdlNamespace}
 import wdl.draft2.model.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxFormatter, SyntaxHighlighter}
+import wdl.draft2.model.{AstTools, WdlNamespace}
 import wdl.transforms.base.wdlom2wdl.WdlWriter.ops._
 import wdl.transforms.base.wdlom2wdl.WdlWriterImpl.fileElementWriter
-import womtool.wom2wdlom.WomToWdlom.womBundleToFileElement
 import womtool.cmdline.HighlightMode.{ConsoleHighlighting, HtmlHighlighting, UnrecognizedHighlightingMode}
 import womtool.cmdline._
 import womtool.graph.{GraphPrint, WomGraph}
 import womtool.input.WomGraphMaker
 import womtool.inputs.Inputs
 import womtool.validate.Validate
+import womtool.wom2wdlom.WomToWdlom.womBundleToFileElement
 
 import scala.util.{Failure, Success, Try}
 
@@ -47,7 +47,7 @@ object WomtoolMain extends App {
   }
 
   def dispatchCommand(commandLineArgs: ValidatedWomtoolCommandLine): Termination = commandLineArgs match {
-    case v: ValidateCommandLine => Validate.validate(v.workflowSource, v.inputs)
+    case v: ValidateCommandLine => Validate.validate(v.workflowSource, v.inputs, v.listDependencies)
     case p: ParseCommandLine => parse(p.workflowSource.pathAsString)
     case h: HighlightCommandLine => highlight(h.workflowSource.pathAsString, h.highlightMode)
     case i: InputsCommandLine => Inputs.inputsJson(i.workflowSource, i.showOptionals)
@@ -78,8 +78,8 @@ object WomtoolMain extends App {
   }
 
   def upgrade(workflowSourcePath: String): Termination = {
-    import wdl.model.draft3.elements.ImportElement
     import wdl.draft2.model.Import
+    import wdl.model.draft3.elements.ImportElement
 
     // Get imports directly from WdlNamespace, because they are erased during WOMification
     val maybeWdlNamespace: Try[WdlNamespace] =
@@ -141,7 +141,7 @@ object WomtoolMain extends App {
 
   def womGraph(workflowSourcePath: Path): Termination = {
     WomGraphMaker.fromFiles(mainFile = workflowSourcePath, inputs = None).contextualizeErrors("create wom Graph") match {
-      case Right(graph) => SuccessfulTermination (new WomGraph(graphName = "workflow", graph).digraphDot)
+      case Right(graphWithImports) => SuccessfulTermination (new WomGraph(graphName = "workflow", graphWithImports.graph).digraphDot)
       case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator, System.lineSeparator, System.lineSeparator))
     }
   }

--- a/womtool/src/main/scala/womtool/cmdline/PartialWomtoolCommandLineArguments.scala
+++ b/womtool/src/main/scala/womtool/cmdline/PartialWomtoolCommandLineArguments.scala
@@ -6,13 +6,15 @@ final case class PartialWomtoolCommandLineArguments(command: Option[WomtoolComma
                                                     workflowSource: Option[Path] = None,
                                                     workflowInputs: Option[Path] = None,
                                                     displayOptionalInputs: Option[Boolean] = None,
-                                                    highlightMode: Option[HighlightMode] = None
+                                                    highlightMode: Option[HighlightMode] = None,
+                                                    listDependencies: Option[Boolean] = None
                                                    )
 
 sealed trait ValidatedWomtoolCommandLine
 final case class ParseCommandLine(workflowSource: Path) extends ValidatedWomtoolCommandLine
 final case class ValidateCommandLine(workflowSource: Path,
-                                     inputs: Option[Path]) extends ValidatedWomtoolCommandLine
+                                     inputs: Option[Path],
+                                     listDependencies: Boolean) extends ValidatedWomtoolCommandLine
 final case class HighlightCommandLine(workflowSource: Path,
                                       highlightMode: HighlightMode) extends ValidatedWomtoolCommandLine
 final case class InputsCommandLine(workflowSource: Path, showOptionals: Boolean) extends ValidatedWomtoolCommandLine

--- a/womtool/src/main/scala/womtool/cmdline/WomtoolCommandLineParser.scala
+++ b/womtool/src/main/scala/womtool/cmdline/WomtoolCommandLineParser.scala
@@ -13,13 +13,13 @@ object WomtoolCommandLineParser {
   lazy val instance: scopt.OptionParser[PartialWomtoolCommandLineArguments] = new WomtoolCommandLineParser()
 
   def validateCommandLine(args: PartialWomtoolCommandLineArguments): Option[ValidatedWomtoolCommandLine] = args match {
-    case PartialWomtoolCommandLineArguments(Some(Validate), Some(mainFile), inputs, None, None) => Option(ValidateCommandLine(mainFile, inputs))
-    case PartialWomtoolCommandLineArguments(Some(Inputs), Some(mainFile), None, showOptionals, None) => Option(InputsCommandLine(mainFile, !showOptionals.contains(false)))
-    case PartialWomtoolCommandLineArguments(Some(Parse), Some(mainFile), None, None, None) => Option(ParseCommandLine(mainFile))
-    case PartialWomtoolCommandLineArguments(Some(Highlight), Some(mainFile), None, None, Some(mode)) => Option(HighlightCommandLine(mainFile, mode))
-    case PartialWomtoolCommandLineArguments(Some(Graph), Some(mainFile), None, None, None) => Option(WomtoolGraphCommandLine(mainFile))
-    case PartialWomtoolCommandLineArguments(Some(WomGraph), Some(mainFile), None, None, None) => Option(WomtoolWomGraphCommandLine(mainFile))
-    case PartialWomtoolCommandLineArguments(Some(Upgrade), Some(mainFile), None, None, None) => Option(WomtoolWdlUpgradeCommandLine(mainFile))
+    case PartialWomtoolCommandLineArguments(Some(Validate), Some(mainFile), inputs, None, None, listDependencies) => Option(ValidateCommandLine(mainFile, inputs, listDependencies.getOrElse(false)))
+    case PartialWomtoolCommandLineArguments(Some(Inputs), Some(mainFile), None, showOptionals, None, None) => Option(InputsCommandLine(mainFile, !showOptionals.contains(false)))
+    case PartialWomtoolCommandLineArguments(Some(Parse), Some(mainFile), None, None, None, None) => Option(ParseCommandLine(mainFile))
+    case PartialWomtoolCommandLineArguments(Some(Highlight), Some(mainFile), None, None, Some(mode), None) => Option(HighlightCommandLine(mainFile, mode))
+    case PartialWomtoolCommandLineArguments(Some(Graph), Some(mainFile), None, None, None, None) => Option(WomtoolGraphCommandLine(mainFile))
+    case PartialWomtoolCommandLineArguments(Some(WomGraph), Some(mainFile), None, None, None, None) => Option(WomtoolWomGraphCommandLine(mainFile))
+    case PartialWomtoolCommandLineArguments(Some(Upgrade), Some(mainFile), None, None, None, None) => Option(WomtoolWdlUpgradeCommandLine(mainFile))
     case _ => None
   }
 }
@@ -49,6 +49,11 @@ class WomtoolCommandLineParser extends scopt.OptionParser[PartialWomtoolCommandL
     .text("If set, optional inputs are also included in the inputs set. Default is 'true' (used only with the inputs command)")
     .optional
     .action((b, c) => c.copy(displayOptionalInputs = Some(b)))
+
+  opt[Unit]('l', name = "list-dependencies")
+    .text("An optional flag to list files referenced in import statements (used only with 'validate' command)")
+    .optional
+    .action((_, c) => c.copy(listDependencies = Option(true)))
 
   head("womtool", womtoolVersion)
 

--- a/womtool/src/main/scala/womtool/input/WomGraphMaker.scala
+++ b/womtool/src/main/scala/womtool/input/WomGraphMaker.scala
@@ -12,6 +12,7 @@ import languages.cwl.CwlV1_0LanguageFactory
 import languages.wdl.biscayne.WdlBiscayneLanguageFactory
 import languages.wdl.draft2.WdlDraft2LanguageFactory
 import languages.wdl.draft3.WdlDraft3LanguageFactory
+import wom.ResolvedImportRecord
 import wom.executable.WomBundle
 import wom.expression.NoIoFunctionSet
 import wom.graph._
@@ -36,24 +37,24 @@ object WomGraphMaker {
           .find(_.looksParsable(mainFileContents))
           .getOrElse(new WdlDraft2LanguageFactory(ConfigFactory.empty()))
 
-      val bundle = languageFactory.getWomBundle(mainFileContents, "{}", importResolvers, List(languageFactory))
+      val bundle = languageFactory.getWomBundle(mainFileContents, None, "{}", importResolvers, List(languageFactory))
       // Return the pair with the languageFactory
       bundle map ((_, languageFactory))
     }
   }
 
-  def fromFiles(mainFile: Path, inputs: Option[Path]): Checked[Graph] = {
+  def fromFiles(mainFile: Path, inputs: Option[Path]): Checked[WomGraphWithResolvedImports] = {
     getBundleAndFactory(mainFile) flatMap { case (womBundle, languageFactory) =>
       inputs match {
         case None =>
           for {
             executableCallable <- womBundle.toExecutableCallable
-          } yield executableCallable.graph
+          } yield WomGraphWithResolvedImports(executableCallable.graph, womBundle.resolvedImportRecords)
         case Some(inputsFile) =>
           for {
             inputsContents <- readFile(inputsFile.toAbsolutePath.pathAsString)
             validatedWomNamespace <- languageFactory.createExecutable(womBundle, inputsContents, NoIoFunctionSet)
-          } yield validatedWomNamespace.executable.graph
+          } yield WomGraphWithResolvedImports(validatedWomNamespace.executable.graph, womBundle.resolvedImportRecords)
       }
     }
   }
@@ -61,3 +62,6 @@ object WomGraphMaker {
   private def readFile(filePath: String): Checked[String] = Try(Files.readAllLines(Paths.get(filePath)).asScala.mkString(System.lineSeparator())).toChecked
 
 }
+
+
+case class WomGraphWithResolvedImports(graph: Graph, resolvedImportRecords: Set[ResolvedImportRecord])

--- a/womtool/src/main/scala/womtool/inputs/Inputs.scala
+++ b/womtool/src/main/scala/womtool/inputs/Inputs.scala
@@ -15,8 +15,8 @@ object Inputs {
   def inputsJson(main: Path, showOptionals: Boolean): Termination = {
 
     WomGraphMaker.fromFiles(main, inputs = None) match {
-      case Right(graph) =>
-        Try(graph.externalInputNodes.toJson(inputNodeWriter(showOptionals)).prettyPrint) match {
+      case Right(graphWithImports) =>
+        Try(graphWithImports.graph.externalInputNodes.toJson(inputNodeWriter(showOptionals)).prettyPrint) match {
           case Success(json) => SuccessfulTermination(json + System.lineSeparator)
           case Failure(error) => UnsuccessfulTermination(error.getMessage)
         }

--- a/womtool/src/main/scala/womtool/validate/Validate.scala
+++ b/womtool/src/main/scala/womtool/validate/Validate.scala
@@ -1,19 +1,37 @@
 package womtool.validate
 
 import cromwell.core.path.Path
+import wom.ResolvedImportRecord
 import womtool.WomtoolMain.{SuccessfulTermination, Termination, UnsuccessfulTermination}
 import womtool.input.WomGraphMaker
 
 object Validate {
-  def validate(main: Path, inputs: Option[Path]): Termination = if (inputs.isDefined) {
-    WomGraphMaker.fromFiles(main, inputs) match {
-      case Right(_) => SuccessfulTermination("Success!")
-      case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
+
+  def validate(main: Path, inputs: Option[Path], listDependencies: Boolean): Termination = {
+
+    def workflowDependenciesMsg(workflowResolvedImports: Set[ResolvedImportRecord]) = {
+      val msgPrefix = "\nList of Workflow dependencies is:\n"
+      val dependenciesList = if (workflowResolvedImports.nonEmpty) workflowResolvedImports.map(_.importPath).mkString("\n") else "None"
+
+      msgPrefix + dependenciesList
     }
-  } else {
-    WomGraphMaker.getBundle(main) match {
-      case Right(_) => SuccessfulTermination("Success!")
-      case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
+
+    def validationSuccessMsg(workflowResolvedImports: Set[ResolvedImportRecord]): String = {
+      val successMsg = "Success!"
+      val dependenciesMsg = if (listDependencies) workflowDependenciesMsg(workflowResolvedImports) else ""
+      successMsg + dependenciesMsg
+    }
+
+    if (inputs.isDefined) {
+      WomGraphMaker.fromFiles(main, inputs) match {
+        case Right(v) => SuccessfulTermination(validationSuccessMsg(v.resolvedImportRecords))
+        case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
+      }
+    } else {
+      WomGraphMaker.getBundle(main) match {
+        case Right(b) => SuccessfulTermination(validationSuccessMsg(b.resolvedImportRecords))
+        case Left(errors) => UnsuccessfulTermination(errors.toList.mkString(System.lineSeparator))
+      }
     }
   }
 }

--- a/womtool/src/test/resources/validate-with-imports/biscayne/afters_and_scatters/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/biscayne/afters_and_scatters/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+None

--- a/womtool/src/test/resources/validate-with-imports/biscayne/http_relative_imports/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/biscayne/http_relative_imports/expected_imports.txt
@@ -1,0 +1,5 @@
+Success!
+List of Workflow dependencies is:
+https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/structs/my_struct.wdl
+https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/tasks/add5.wdl
+https://raw.githubusercontent.com/broadinstitute/cromwell/develop/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl

--- a/womtool/src/test/resources/validate-with-imports/biscayne/relative_imports/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/biscayne/relative_imports/expected_imports.txt
@@ -1,0 +1,5 @@
+Success!
+List of Workflow dependencies is:
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/biscayne/valid/relative_imports/structs/my_struct.wdl
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/tasks/add5.wdl
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/biscayne/valid/relative_imports/sub_wfs/foo.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft2/http_import/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft2/http_import/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+https://raw.githubusercontent.com/broadinstitute/cromwell/5e0197d1c016d4c802ef3c2890f0ca4e0ca542c1/womtool/src/test/resources/validate/wdl_draft2/valid/task_only/task_only.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft2/relative_local_import/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft2/relative_local_import/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/wdl_draft2/valid/task_only/task_only.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft2/subworkflow_input/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft2/subworkflow_input/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/wdl_draft2/valid/subworkflow_input/subworkflow.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft2/task_only/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft2/task_only/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+None

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft3/http_import/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft3/http_import/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+https://raw.githubusercontent.com/broadinstitute/cromwell/5e0197d1c016d4c802ef3c2890f0ca4e0ca542c1/womtool/src/test/resources/validate/wdl_draft3/valid/task_only/task_only.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft3/relative_local_import/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft3/relative_local_import/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/wdl_draft3/valid/task_only/task_only.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft3/subworkflow_input/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft3/subworkflow_input/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+{REPLACE_WITH_ROOT_PATH}/womtool/src/test/resources/validate/wdl_draft3/valid/subworkflow_input/subworkflow.wdl

--- a/womtool/src/test/resources/validate-with-imports/wdl_draft3/task_only/expected_imports.txt
+++ b/womtool/src/test/resources/validate-with-imports/wdl_draft3/task_only/expected_imports.txt
@@ -1,0 +1,3 @@
+Success!
+List of Workflow dependencies is:
+None

--- a/womtool/src/test/scala/womtool/WomtoolValidateSpec.scala
+++ b/womtool/src/test/scala/womtool/WomtoolValidateSpec.scala
@@ -1,9 +1,13 @@
 package womtool
 
+import java.nio.file.Path
+
 import better.files.File
 import cromwell.core.path.DefaultPathBuilder
 import org.scalatest.{FlatSpec, Matchers}
 import womtool.WomtoolMain.{SuccessfulTermination, UnsuccessfulTermination}
+
+import scala.collection.immutable
 
 class WomtoolValidateSpec extends FlatSpec with Matchers {
 
@@ -38,8 +42,7 @@ class WomtoolValidateSpec extends FlatSpec with Matchers {
       it should s"run $versionName test '$ignoredCase'" ignore {}
     }
 
-    // The filterNot(_.contains(".DS")) stuff prevents Mac 'Desktop Services' hidden directories from accidentally being picked up:
-    Option(validTestCases.toFile.list).toList.flatten.filterNot(_.contains(".DS")) foreach { validCase =>
+    listFilesAndFilterDSFile(validTestCases) foreach { validCase =>
       val inputsFile = ifExists(validTestCases.resolve(validCase).resolve(validCase + ".inputs.json").toFile)
       val withInputsAddition = if (inputsFile.isDefined) " and inputs file" else ""
       it should s"successfully validate $versionName workflow: '$validCase'$withInputsAddition" in {
@@ -53,8 +56,7 @@ class WomtoolValidateSpec extends FlatSpec with Matchers {
       }
     }
 
-    // The filterNot(_.contains(".DS")) stuff prevents Mac 'Desktop Services' hidden directories from accidentally being picked up:
-    Option(invalidTestCases.toFile.list).toList.flatten.filterNot(_.contains(".DS")) foreach { invalidCase =>
+    listFilesAndFilterDSFile(invalidTestCases) foreach { invalidCase =>
       val inputsFile = ifExists(invalidTestCases.resolve(invalidCase).resolve(invalidCase + ".inputs.json").toFile)
       val withInputsAddition = if (inputsFile.isDefined) " and inputs file" else ""
 
@@ -78,7 +80,49 @@ class WomtoolValidateSpec extends FlatSpec with Matchers {
     }
   }
 
+
+  behavior of "womtool validate with --list-dependencies flag"
+
+  val validationWithImportsTests = File("womtool/src/test/resources/validate-with-imports")
+  val validateWithImportsLanguageVersions = Option(validationWithImportsTests.list).toList.flatten
+  val userDirectory = sys.props("user.dir")
+  val workingDirectory = File(sys.env.getOrElse("CROMWELL_BUILD_ROOT_DIRECTORY", userDirectory)).pathAsString
+
+  it should "test at least one version" in {
+    validateWithImportsLanguageVersions.isEmpty should be(false)
+  }
+
+  validateWithImportsLanguageVersions.filterNot(f => f.name.contains(".DS")) foreach { versionDirectory =>
+    val versionName = versionDirectory.name
+
+    it should s"test at least one $versionName workflow" in {
+      versionDirectory.isEmpty should be(false)
+    }
+
+    Option(versionDirectory.list).toList.flatten.filterNot(s => s.pathAsString.contains(".DS")) foreach { validCase =>
+      val caseName = validCase.name
+      val wdlFile = mustExist(versionDirectory.path.resolve(s"../../validate/$versionName/valid/$caseName/$caseName.wdl").toFile)
+       wdlFile.getAbsolutePath.split("cromwell/womtool")(0)
+
+      it should s"successfully validate and print the workflow dependencies for $versionName workflow: '$caseName'" in {
+        val rawOutput = expectedOutput(versionDirectory, caseName, "expected_imports.txt")
+        val importsExpectation = rawOutput.replaceAll("\\{REPLACE_WITH_ROOT_PATH\\}", workingDirectory)
+
+        val res = WomtoolMain.runWomtool(Seq("validate", "-l", wdlFile.getAbsolutePath))
+        assert(res.isInstanceOf[SuccessfulTermination])
+        val stdout = res.stdout.get
+        stdout shouldBe importsExpectation
+      }
+    }
+  }
+
+
   private def mustExist(file: java.io.File): java.io.File = if (file.exists) file else fail(s"No such file: ${file.getAbsolutePath}")
   private def ifExists(file: java.io.File): Option[java.io.File] = if (file.exists) Option(file) else None
 
+  // The filterNot(_.contains(".DS")) stuff prevents Mac 'Desktop Services' hidden directories from accidentally being picked up:
+  private def listFilesAndFilterDSFile(path: Path): immutable.Seq[String] =  Option(path.toFile.list).toList.flatten.filterNot(_.contains(".DS"))
+
+  private def expectedOutput(versionDirectory: File, caseName: String, outputTextFileName: String): String =
+    File(mustExist(versionDirectory.path.resolve(caseName).resolve(outputTextFileName).toFile).getAbsolutePath).contentAsString.trim
 }


### PR DESCRIPTION
This PR adds an optional flag `-l` or` --list-dependencies` for command `validate` to list the imported files in the workflow and their subworkflows.

JIRA ticket: [here](https://broadworkbench.atlassian.net/browse/BA-3501)