### PR TITLE
Proof of concept Carbonite Thaw actor [BA-5880]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,12 @@ lazy val services = project
   .dependsOn(cwlV1_0LanguageFactory % "test->test")
   .dependsOn(core % "test->test")
 
+lazy val hybridCarboniteMetadataService = project
+  .withLibrarySettings("hybrid-carbonite-metadata-service")
+  .dependsOn(services)
+  .dependsOn(engine)
+  .dependsOn(core % "test->test")
+
 lazy val backendRoot = Path("supportedBackends")
 
 lazy val backend = project

--- a/common/src/main/scala/common/validation/Validation.scala
+++ b/common/src/main/scala/common/validation/Validation.scala
@@ -66,7 +66,9 @@ object Validation {
       Either.fromTry(t).leftMap { ex => NonEmptyList.one(throwableToStringFunction(ex)) }
     }
 
-    def toCheckedWithContext(context: String, throwableToStringFunction: ThrowableToStringFunction): Checked[A] = toErrorOrWithContext(context, throwableToStringFunction).toEither
+    def toCheckedWithContext(context: String): Checked[A] = toErrorOrWithContext(context, defaultThrowableToString).toEither
+    def toCheckedWithContext(context: String,
+                             throwableToStringFunction: ThrowableToStringFunction): Checked[A] = toErrorOrWithContext(context, throwableToStringFunction).toEither
   }
 
   implicit class ValidationTry[A](val e: ErrorOr[A]) extends AnyVal {

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
@@ -1,0 +1,90 @@
+package cromwell.services.metadata.hybridcarbonite
+
+import akka.actor.{ActorRef, LoggingFSM, Status}
+import akka.pattern.pipe
+import cromwell.core.WorkflowId
+import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
+import cromwell.services.metadata.MetadataService.{GetLabels, LabelLookupFailed, LabelLookupResponse}
+import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor._
+import cromwell.util.JsonEditor
+import io.circe.parser._
+import io.circe.{Json, Printer}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConfig, serviceRegistry: ActorRef, ioActor: ActorRef) extends LoggingFSM[CarbonitedMetadataThawingState, CarbonitedMetadataThawingData] {
+
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  val asyncIo = new AsyncIo(ioActor, DefaultIoCommandBuilder)
+
+  startWith(CarbonitedMetadataThawingActorPendingState, CarbonitedMetadataThawingActorPendingData)
+
+  when(CarbonitedMetadataThawingActorPendingState) {
+    case Event(ThawCarbonitedMetadata(workflowId), CarbonitedMetadataThawingActorPendingData) =>
+      asyncIo.contentAsStringAsync(carboniterConfig.makePath(workflowId), maxBytes = Option(30 * 1024 * 1024), failOnOverflow = true) flatMap { stringResponse =>
+        Future.fromTry(parse(stringResponse).toTry.map(GcsMetadataResponse.apply))
+      } pipeTo self
+      serviceRegistry ! GetLabels(workflowId)
+
+      goto(CarbonitedMetadataThawingActorRunningState) using CarbonitedMetadataThawingActorDataNothingYet(sender())
+  }
+
+  when(CarbonitedMetadataThawingActorRunningState) {
+
+    // Successful Responses:
+    case Event(GcsMetadataResponse(response), CarbonitedMetadataThawingActorDataNothingYet(requester)) =>
+      stay() using CarbonitedMetadataThawingActorDataWithGcsResponse(requester, response)
+
+    case Event(GcsMetadataResponse(response), CarbonitedMetadataThawingActorDataWithLabels(requester, labels)) =>
+      requester ! ThawCarboniteSucceeded(mergeResponses(response, labels))
+      stop()
+
+    case Event(LabelLookupResponse(_, labels), CarbonitedMetadataThawingActorDataNothingYet(requester)) =>
+      stay() using CarbonitedMetadataThawingActorDataWithLabels(requester, labels)
+
+    case Event(LabelLookupResponse(_, labels), CarbonitedMetadataThawingActorDataWithGcsResponse(requester, gcsResponse)) =>
+      requester ! ThawCarboniteSucceeded(mergeResponses(gcsResponse, labels))
+      stop()
+
+    // Failures:
+    case Event(Status.Failure(failure), data: CarbonitedMetadataThawingActorWorkingData) =>
+      data.requester ! ThawCarboniteFailed(failure)
+      stop()
+    case Event(LabelLookupFailed(_, failure), data: CarbonitedMetadataThawingActorWorkingData) =>
+      data.requester ! ThawCarboniteFailed(failure)
+      stop()
+  }
+
+  whenUnhandled {
+    case other =>
+      log.error(s"Programmer Error: Unexpected message to ${self.path.name}: $other")
+      stay()
+  }
+
+  def mergeResponses(metadata: Json, labels: Map[String, String]): String = JsonEditor.augmentLabels(metadata, labels).pretty(Printer.spaces2)
+
+}
+
+object CarbonitedMetadataThawingActor {
+
+  sealed trait ThawCarboniteMessage
+
+  final case class ThawCarbonitedMetadata(workflowId: WorkflowId) extends ThawCarboniteMessage
+  final case class ThawCarboniteSucceeded(value: String) extends ThawCarboniteMessage
+  final case class ThawCarboniteFailed(reason: Throwable) extends ThawCarboniteMessage
+
+  final case class GcsMetadataResponse(response: Json)
+
+  sealed trait CarbonitedMetadataThawingState
+  case object CarbonitedMetadataThawingActorPendingState extends CarbonitedMetadataThawingState
+  case object CarbonitedMetadataThawingActorRunningState extends CarbonitedMetadataThawingState
+
+  sealed trait CarbonitedMetadataThawingData
+  case object CarbonitedMetadataThawingActorPendingData extends CarbonitedMetadataThawingData
+  sealed trait CarbonitedMetadataThawingActorWorkingData extends CarbonitedMetadataThawingData { def requester: ActorRef }
+  final case class CarbonitedMetadataThawingActorDataNothingYet(requester: ActorRef) extends CarbonitedMetadataThawingActorWorkingData
+  final case class CarbonitedMetadataThawingActorDataWithGcsResponse(requester: ActorRef, gcsResponse: Json) extends CarbonitedMetadataThawingActorWorkingData
+  final case class CarbonitedMetadataThawingActorDataWithLabels(requester: ActorRef, labels: Map[String, String]) extends CarbonitedMetadataThawingActorWorkingData
+
+}

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
@@ -1,0 +1,34 @@
+package cromwell.services.metadata.hybridcarbonite
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import common.validation.Validation._
+import cromwell.core.{WorkflowId, WorkflowOptions}
+import cromwell.core.filesystem.CromwellFileSystems
+import cromwell.core.path.{PathBuilderFactory, PathFactory}
+import cromwell.core.path.PathFactory.PathBuilders
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+final case class HybridCarboniteConfig(pathBuilders: PathBuilders, bucket: String) {
+  def makePath(workflowId: WorkflowId)= PathFactory.buildPath(HybridCarboniteConfig.pathForWorkflow(workflowId, bucket), pathBuilders)
+}
+
+object HybridCarboniteConfig {
+
+  def pathForWorkflow(id: WorkflowId, bucket: String) = s"gs://$bucket/$id/$id.json"
+
+  // TODO: Make this an IO/Future/??? based method vs this unsafe monstrosity?
+  def make(carboniterConfig: Config)(implicit system: ActorSystem): HybridCarboniteConfig = {
+    lazy val pathBuilderFactories = CromwellFileSystems.instance.factoriesFromConfig(carboniterConfig).unsafe("Failed to instantiate engine filesystem")
+
+    lazy val pathBuilders = {
+      Await.result(PathBuilderFactory.instantiatePathBuilders(pathBuilderFactories.values.toList, WorkflowOptions.empty), 10.seconds)
+    }
+
+    lazy val bucket = carboniterConfig.getString("bucket")
+
+    HybridCarboniteConfig(pathBuilders, bucket)
+  }
+}

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
@@ -2,6 +2,7 @@ package cromwell.services.metadata.hybridcarbonite
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
+import common.Checked
 import common.validation.Validation._
 import cromwell.core.{WorkflowId, WorkflowOptions}
 import cromwell.core.filesystem.CromwellFileSystems
@@ -10,6 +11,7 @@ import cromwell.core.path.PathFactory.PathBuilders
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.util.Try
 
 final case class HybridCarboniteConfig(pathBuilders: PathBuilders, bucket: String) {
   def makePath(workflowId: WorkflowId)= PathFactory.buildPath(HybridCarboniteConfig.pathForWorkflow(workflowId, bucket), pathBuilders)
@@ -18,17 +20,15 @@ final case class HybridCarboniteConfig(pathBuilders: PathBuilders, bucket: Strin
 object HybridCarboniteConfig {
 
   def pathForWorkflow(id: WorkflowId, bucket: String) = s"gs://$bucket/$id/$id.json"
+  
+  def make(carboniterConfig: Config)(implicit system: ActorSystem): Checked[HybridCarboniteConfig] = {
 
-  // TODO: Make this an IO/Future/??? based method vs this unsafe monstrosity?
-  def make(carboniterConfig: Config)(implicit system: ActorSystem): HybridCarboniteConfig = {
-    lazy val pathBuilderFactories = CromwellFileSystems.instance.factoriesFromConfig(carboniterConfig).unsafe("Failed to instantiate engine filesystem")
+    for {
+      pathBuilderFactories <- CromwellFileSystems.instance.factoriesFromConfig(carboniterConfig)
+      pathBuilders <- Try(Await.result(PathBuilderFactory.instantiatePathBuilders(pathBuilderFactories.values.toList, WorkflowOptions.empty), 10.seconds)).toCheckedWithContext("construct Carboniter path builders from factories")
 
-    lazy val pathBuilders = {
-      Await.result(PathBuilderFactory.instantiatePathBuilders(pathBuilderFactories.values.toList, WorkflowOptions.empty), 10.seconds)
-    }
+      bucket <- Try(carboniterConfig.getString("bucket")).toCheckedWithContext(s"parse Carboniter 'bucket' field from config")
+    } yield HybridCarboniteConfig(pathBuilders, bucket)
 
-    lazy val bucket = carboniterConfig.getString("bucket")
-
-    HybridCarboniteConfig(pathBuilders, bucket)
   }
 }

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
@@ -1,0 +1,201 @@
+package cromwell.services.metadata.hybridcarbonite
+
+import java.util.UUID
+
+import akka.stream.ActorMaterializer
+import akka.testkit.{TestActorRef, TestProbe}
+import com.typesafe.config.ConfigFactory
+import cromwell.core.io.IoContentAsStringCommand
+import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
+import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.services.metadata.MetadataService.{GetLabels, LabelLookupResponse}
+import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor.{ThawCarboniteFailed, ThawCarboniteSucceeded, ThawCarbonitedMetadata}
+import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActorSpec._
+import org.scalatest.{FlatSpecLike, Matchers}
+import io.circe.parser._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadataThawingActorSpec") with FlatSpecLike with Matchers {
+
+  implicit val ec: ExecutionContext = system.dispatcher
+
+  val carboniterConfig = HybridCarboniteConfig.make(ConfigFactory.parseString(
+    """bucket = "carbonite-test-bucket"
+      |filesystems {
+      |  gcs {
+      |    # A reference to the auth to use for storing and retrieving metadata:
+      |    auth = "application-default"
+      |  }
+      |}""".stripMargin))
+
+  val serviceRegistryActor = TestProbe()
+  val ioActor = TestProbe()
+
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  it should "receive a message from GCS" in {
+
+    val clientProbe = TestProbe()
+
+    val actorUnderTest = TestActorRef(new CarbonitedMetadataThawingActor(carboniterConfig, serviceRegistryActor.ref, ioActor.ref), "ThawingActor")
+
+    clientProbe.send(actorUnderTest, ThawCarbonitedMetadata(workflowId))
+
+    serviceRegistryActor.expectMsg(GetLabels(workflowId))
+    serviceRegistryActor.send(actorUnderTest, LabelLookupResponse(workflowId, Map("bob loblaw" -> "law blog")))
+
+    ioActor.expectMsgPF(max = 5.seconds) {
+      case command @ IoCommandWithPromise(iocasc: IoContentAsStringCommand, _) if iocasc.file.pathAsString.contains(workflowId.toString) =>
+        command.promise.success(rawMetadataSample)
+    }
+
+    clientProbe.expectMsgPF(max = 5.seconds) {
+      case ThawCarboniteSucceeded(str) => parse(str) should be(parse(augmentedMetadataSample))
+      case ThawCarboniteFailed(reason) => fail(reason)
+    }
+  }
+}
+
+object CarbonitedMetadataThawingActorSpec {
+  val workflowId = WorkflowId(UUID.fromString("2ce544a0-4c0d-4cc9-8a0b-b412bb1e5f82"))
+
+  val rawMetadataSample = sampleMetadataContent("")
+  val augmentedMetadataSample = sampleMetadataContent("""
+                                          |"labels" : {
+                                          |    "bob loblaw" : "law blog"
+                                          |},
+                                          |  """.stripMargin)
+
+  def sampleMetadataContent(labelsContent: String) = s"""{$labelsContent
+                                                        |  "workflowName": "helloWorldWf",
+                                                        |  "workflowProcessingEvents": [
+                                                        |    {
+                                                        |      "cromwellId": "cromid-78ea393",
+                                                        |      "description": "PickedUp",
+                                                        |      "timestamp": "2019-07-31T20:19:02.165Z",
+                                                        |      "cromwellVersion": "43-e9c0f4c-SNAP"
+                                                        |    },
+                                                        |    {
+                                                        |      "cromwellId": "cromid-78ea393",
+                                                        |      "description": "Finished",
+                                                        |      "timestamp": "2019-07-31T20:19:35.058Z",
+                                                        |      "cromwellVersion": "43-e9c0f4c-SNAP"
+                                                        |    }
+                                                        |  ],
+                                                        |  "actualWorkflowLanguageVersion": "draft-2",
+                                                        |  "submittedFiles": {
+                                                        |    "workflow": "task helloWorld {\\n    \\n    command { echo \\"hello, world\\" }\\n\\n    output { String s = read_string(stdout()) }\\n    \\n    runtime {\\n      docker: \\"ubuntu:latest\\"\\n    }\\n}\\n\\nworkflow helloWorldWf {\\n    call helloWorld\\n}\\n",
+                                                        |    "root": "",
+                                                        |    "options": "{\\n\\n}",
+                                                        |    "inputs": "{}",
+                                                        |    "workflowUrl": "",
+                                                        |    "labels": "{}"
+                                                        |  },
+                                                        |  "calls": {
+                                                        |    "helloWorldWf.helloWorld": [
+                                                        |      {
+                                                        |        "executionStatus": "Done",
+                                                        |        "stdout": "gs://execution-bucket/$workflowId/call-name/stdout",
+                                                        |        "backendStatus": "Done",
+                                                        |        "compressedDockerSize": 26723061,
+                                                        |        "commandLine": "echo \\"hello, world\\"",
+                                                        |        "shardIndex": -1,
+                                                        |        "outputs": {
+                                                        |          "s": "hello, world"
+                                                        |        },
+                                                        |        "runtimeAttributes": {
+                                                        |          "docker": "ubuntu:latest",
+                                                        |          "failOnStderr": "false",
+                                                        |          "maxRetries": "0",
+                                                        |          "continueOnReturnCode": "0"
+                                                        |        },
+                                                        |        "callCaching": {
+                                                        |          "allowResultReuse": true,
+                                                        |          "hit": false,
+                                                        |          "result": "Cache Miss",
+                                                        |          "hashes": {
+                                                        |            "output count": "C4CA4238A0B923820DCC509A6F75849B",
+                                                        |            "runtime attribute": {
+                                                        |              "docker": "CFE62D82138579B4B9F4EE81EFC5745E",
+                                                        |              "continueOnReturnCode": "CFCD208495D565EF66E7DFF9F98764DA",
+                                                        |              "failOnStderr": "68934A3E9455FA72420237EB05902327"
+                                                        |            },
+                                                        |            "output expression": {
+                                                        |              "String s": "0183144CF6617D5341681C6B2F756046"
+                                                        |            },
+                                                        |            "input count": "CFCD208495D565EF66E7DFF9F98764DA",
+                                                        |            "backend name": "509820290D57F333403F490DDE7316F4",
+                                                        |            "command template": "720B86AE4F6DFD9C11FD9E01AEC6FDF9"
+                                                        |          },
+                                                        |          "effectiveCallCachingMode": "ReadAndWriteCache"
+                                                        |        },
+                                                        |        "inputs": {},
+                                                        |        "returnCode": 0,
+                                                        |        "jobId": "5399",
+                                                        |        "backend": "Local",
+                                                        |        "end": "2019-07-31T20:19:33.251Z",
+                                                        |        "dockerImageUsed": "ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a",
+                                                        |        "stderr": "gs://execution-bucket/$workflowId/call-name/stderr",
+                                                        |        "callRoot": "gs://execution-bucket/$workflowId/call-name",
+                                                        |        "attempt": 1,
+                                                        |        "executionEvents": [
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:05.344Z",
+                                                        |            "description": "PreparingJob",
+                                                        |            "endTime": "2019-07-31T20:19:06.450Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:06.532Z",
+                                                        |            "description": "RunningJob",
+                                                        |            "endTime": "2019-07-31T20:19:30.217Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:04.447Z",
+                                                        |            "description": "RequestingExecutionToken",
+                                                        |            "endTime": "2019-07-31T20:19:05.328Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:04.416Z",
+                                                        |            "description": "Pending",
+                                                        |            "endTime": "2019-07-31T20:19:04.447Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:30.217Z",
+                                                        |            "description": "UpdatingCallCache",
+                                                        |            "endTime": "2019-07-31T20:19:32.290Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:05.328Z",
+                                                        |            "description": "WaitingForValueStore",
+                                                        |            "endTime": "2019-07-31T20:19:05.344Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:32.290Z",
+                                                        |            "description": "UpdatingJobStore",
+                                                        |            "endTime": "2019-07-31T20:19:33.251Z"
+                                                        |          },
+                                                        |          {
+                                                        |            "startTime": "2019-07-31T20:19:06.450Z",
+                                                        |            "description": "CheckingCallCache",
+                                                        |            "endTime": "2019-07-31T20:19:06.532Z"
+                                                        |          }
+                                                        |        ],
+                                                        |        "start": "2019-07-31T20:19:04.392Z"
+                                                        |      }
+                                                        |    ]
+                                                        |  },
+                                                        |  "outputs": {
+                                                        |    "helloWorldWf.helloWorld.s": "hello, world"
+                                                        |  },
+                                                        |  "workflowRoot": "gs://execution-bucket/$workflowId",
+                                                        |  "actualWorkflowLanguage": "WDL",
+                                                        |  "id": "$workflowId",
+                                                        |  "inputs": {},
+                                                        |  "submission": "2019-07-31T20:19:02.067Z",
+                                                        |  "status": "Succeeded",
+                                                        |  "end": "2019-07-31T20:19:35.057Z",
+                                                        |  "start": "2019-07-31T20:19:02.228Z"
+                                                        |}""".stripMargin
+}

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
+import common.validation.Validation._
 import cromwell.core.io.IoContentAsStringCommand
 import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
 import cromwell.core.{TestKitSuite, WorkflowId}
@@ -28,7 +29,7 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
       |    # A reference to the auth to use for storing and retrieving metadata:
       |    auth = "application-default"
       |  }
-      |}""".stripMargin))
+      |}""".stripMargin)).unsafe("Make config file")
 
   val serviceRegistryActor = TestProbe()
   val ioActor = TestProbe()


### PR DESCRIPTION
Adds capability to

* Download metadata from GCS using the IoActor
* Fetch workflow labels from the database
* Combine the two into a single response

Currently tested using mock IoActor and ServiceRegistry, and not "created" by the main Cromwell process