### PR TITLE
Improved "error 10" tests

### DIFF
--- a/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
+++ b/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
@@ -1,0 +1,11 @@
+name: error_10_preemptible
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: error_10_preemptible/error_10_preemptible.wdl
+}
+
+metadata {
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/error_10_preemptible/error_10_preemptible.wdl
+++ b/centaur/src/main/resources/standardTestCases/error_10_preemptible/error_10_preemptible.wdl
@@ -1,0 +1,30 @@
+version 1.0
+
+task delete_self_if_preemptible {
+
+  command {
+
+    preemptible=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/scheduling/preemptible")
+
+    # Delete self if running on a preemptible VM. This should produce an "error 10" which Cromwell should treat as a preemption.
+    # Since `preemptible: 1` the job should be restarted on a non-preemptible VM.
+    if [ "$preemptible" = "TRUE" ]; then
+    
+      fully_qualified_zone=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone)
+      zone=$(basename "$fully_qualified_zone")
+
+      gcloud compute instances delete $(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google") --zone=$zone -q
+    fi
+
+  }
+
+  runtime {
+    preemptible: 1
+    docker: "google/cloud-sdk:slim"
+  }
+}
+
+
+workflow error_10_preemptible {
+  call delete_self_if_preemptible
+}

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
@@ -55,10 +55,7 @@ object RunStatus {
               wasPreemptible: Boolean): UnsuccessfulRunStatus = {
       val jesCode: Option[Int] = errorMessage flatMap { em => Try(em.substring(0, em.indexOf(':')).toInt).toOption }
 
-      /*
-       Because of Reasons, sometimes errors which aren't indicative of preemptions are treated as preemptions. The belief
-       is that PAPI v2 will get rid of this so we should look into removing in the future
-        */
+      // Because of Reasons, sometimes errors which aren't indicative of preemptions are treated as preemptions.
       val unsuccessfulStatusBuilder = errorCode match {
         case Status.ABORTED if jesCode.contains(PipelinesApiAsyncBackendJobExecutionActor.JesPreemption) => Preempted.apply _
         case Status.ABORTED if jesCode.contains(PipelinesApiAsyncBackendJobExecutionActor.JesUnexpectedTermination) && wasPreemptible => Preempted.apply _


### PR DESCRIPTION
No issues found with the production code, but a recent CaaS scare led to one additional unit and Centaur test each.

The Centaur test would definitely benefit from some "flock programming" (h/t @aednichols) for more robust metadata assertions. Right now the only assertion is workflow success, which seems pretty weak except that it's better than what CaaS reported.  Ideally I'd like to assert on something like the following: 

From 
`
curl --silent -X GET "http://localhost:8000/api/workflows/v1/<<UUID>>/metadata?expandSubWorkflows=false" -H "accept: application/json"  | jq -M '[.calls["error_10_preemptible.delete_self_if_preemptible"] | .[] | {attempt,preemptible,retryableFailure,executionStatus,backendStatus} | del(.[]| nulls)]'
`

```
[
  {
    "attempt": 1,
    "preemptible": true,
    "retryableFailure": true,
    "executionStatus": "RetryableFailure",
    "backendStatus": "Preempted"
  },
  {
    "attempt": 2,
    "preemptible": false,
    "executionStatus": "Done",
    "backendStatus": "Success"
  }
]
``` 