### PR TITLE
Temporarily disable long_cmd on BCS

### DIFF
--- a/src/ci/bin/testCentaurBcs.sh
+++ b/src/ci/bin/testCentaurBcs.sh
@@ -75,7 +75,7 @@ include_tests=( \
     -i invalid_runtime_attributes \
     -i invalid_wdl \
     -i length \
-    -i long_cmd \
+    # -i long_cmd \ # 2019-08-05 consistently timing out trying to read a < 100KB file in 60 seconds
     -i lots_of_nesting \
     -i member_access \
     -i missing_imports \


### PR DESCRIPTION
...until such time as 100KB can be read from OSS in under 60 seconds. Multiple PRs are backed up behind this chronic test failure.