### PR TITLE
fix for the problem with running single tasks described by CWL [BA-4969]

### DIFF
--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -200,11 +200,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
     val validation = args.validateSubmission(EntryPointLogger) map {
       case ValidSubmission(w, u, r, i, o, l, z) =>
-        val finalWorkflowSourceAndUrl: WorkflowSourceOrUrl = {
-          if (w.isDefined) WorkflowSourceOrUrl(w,u)  // submission has CWL workflow file path and no imports
-          else if (u.get.startsWith("http")) WorkflowSourceOrUrl(w, u)
-          else WorkflowSourceOrUrl(Option(DefaultPathBuilder.get(u.get).contentAsString), None) //case where url is a WDL/CWL file
-        }
+        val finalWorkflowSourceAndUrl: WorkflowSourceOrUrl = getFinalWorkflowSourceAndUrl(w, u)
 
         WorkflowSingleSubmission(
           workflowSource = finalWorkflowSourceAndUrl.source,
@@ -225,10 +221,11 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
     val sourceFileCollection = (args.validateSubmission(EntryPointLogger), writeableMetadataPath(args.metadataOutput)) mapN {
       case (ValidSubmission(w, u, r, i, o, l, Some(z)), _) =>
+        val finalWorkflowSourceAndUrl: WorkflowSourceOrUrl = getFinalWorkflowSourceAndUrl(w, u)
         //noinspection RedundantDefaultArgument
         WorkflowSourceFilesWithDependenciesZip.apply(
-          workflowSource = w,
-          workflowUrl = u,
+          workflowSource = finalWorkflowSourceAndUrl.source,
+          workflowUrl = finalWorkflowSourceAndUrl.url,
           workflowRoot = r,
           workflowType = args.workflowType,
           workflowTypeVersion = args.workflowTypeVersion,
@@ -239,10 +236,11 @@ object CromwellEntryPoint extends GracefulStopSupport {
           warnings = Vector.empty,
           workflowOnHold = false)
       case (ValidSubmission(w, u, r, i, o, l, None), _) =>
+        val finalWorkflowSourceAndUrl: WorkflowSourceOrUrl = getFinalWorkflowSourceAndUrl(w, u)
         //noinspection RedundantDefaultArgument
         WorkflowSourceFilesWithoutImports.apply(
-          workflowSource = w,
-          workflowUrl = u,
+          workflowSource = finalWorkflowSourceAndUrl.source,
+          workflowUrl = finalWorkflowSourceAndUrl.url,
           workflowRoot = r,
           workflowType = args.workflowType,
           workflowTypeVersion = args.workflowTypeVersion,
@@ -266,6 +264,12 @@ object CromwellEntryPoint extends GracefulStopSupport {
       override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell:"
       override def errorMessages: Traversable[String] = errors.toList
     })
+  }
+
+  private def getFinalWorkflowSourceAndUrl(workflowSource: Option[String], workflowUrl: Option[String]): WorkflowSourceOrUrl = {
+    if (workflowSource.isDefined) WorkflowSourceOrUrl(workflowSource, workflowUrl) // submission has CWL workflow file path and no imports
+    else if (workflowUrl.get.startsWith("http")) WorkflowSourceOrUrl(workflowSource, workflowUrl)
+    else WorkflowSourceOrUrl(Option(DefaultPathBuilder.get(workflowUrl.get).contentAsString), None) //case where url is a WDL/CWL file
   }
 
   private def writeableMetadataPath(path: Option[Path]): ErrorOr[Unit] = {

--- a/server/src/test/scala/cromwell/CromwellCommandLineSpec.scala
+++ b/server/src/test/scala/cromwell/CromwellCommandLineSpec.scala
@@ -60,8 +60,8 @@ class CromwellCommandLineSpec extends FlatSpec with Matchers with BeforeAndAfter
 
     val validation = Try(CromwellEntryPoint.validateRunArguments(optionsFirst))
     validation.isSuccess shouldBe true
-    validation.get.workflowSource shouldBe None
-    validation.get.workflowUrl shouldBe Some(threeStep.wdl)
+    validation.get.workflowSource shouldBe Some(threeStep.sampleWdl.workflowSource())
+    validation.get.workflowUrl shouldBe None
   }
 
   it should "run single when supplying workflow using url" in {


### PR DESCRIPTION
Initially, this PR was aimed to fix issue #5085. But it turned out that there are other related issues.
It looks like [test case](https://github.com/broadinstitute/cromwell/issues/4969#issuecomment-492445214) made by @jeremiahsavage in issue #4969 has nothing to do with a zip file subdirectories. At least his test works fine if you apply the changes made in this PR.
Another issue described in [JIRA](https://broadworkbench.atlassian.net/browse/BA-5873). Although workflows fail and throw an exception even with changes in this PR, the exception is different. The exact reason is unclear for me, but this workflow fails even when you submit a task in a server mode, so maybe something is wrong with the workflow.

It turns out the problem with running CWL files on Cromwell was caused by this [PR](https://github.com/broadinstitute/cromwell/pull/3988).
Something was changed in this PR, which required changes to the [`validateSubmitArguments`](https://github.com/broadinstitute/cromwell/pull/3988/files#diff-9ed42892250e1b424f671593631297a5R174) method of the `CromwellEntryPoint` object. But since the [`validateRunArguments`](https://github.com/broadinstitute/cromwell/pull/3988/files#diff-9ed42892250e1b424f671593631297a5R201) method is almost identical to the `validateSubmitArguments` method, similar changes should have been made there too. But this was not noticed, and therefore this problem arose.

Therefore, to fix the issues it is enough to use in the `validateRunArguments` method the same logic as in the `validateSubmitArguments` method.