### PR TITLE
Make Cromwell more resilient to GCS IOException

### DIFF
--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -238,7 +238,8 @@ class IoActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Impl
   it should "have correct non-retryable exceptions" in {
     val nonRetryables = List(
       new IOException("404 File Not Found"),
-      new Exception("5xx HTTP Status Code")
+      new Exception("5xx HTTP Status Code"),
+      new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-500/rc: 404 File Not Found")
     )
 
     nonRetryables foreach {IoActor.isRetryable(_) shouldBe false}

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -1,5 +1,6 @@
 package cromwell.engine.io
 
+import java.io.IOException
 import java.net.{SocketException, SocketTimeoutException}
 
 import akka.stream.ActorMaterializer
@@ -221,10 +222,26 @@ class IoActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Impl
       new StorageException(429, "message"),
       BatchFailedException(new Exception),
       new SocketException(),
-      new SocketTimeoutException()
+      new SocketTimeoutException(),
+      new IOException("text Error getting access token for service account some other text"),
+      new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 500 Internal Server Error Backend Error"),
+      new IOException("message: 500 Internal Server Error Backend Error"),
+      new Exception("500 Internal Server Error"),
+      new Exception("501 Not Implemented"),
+      new Exception("510 Extensions are Missing")
     )
 
     retryables foreach { IoActor.isRetryable(_) shouldBe true }
     retryables foreach { IoActor.isFatal(_) shouldBe false }
+  }
+
+  it should "have correct non-retryable exceptions" in {
+    val nonRetryables = List(
+      new IOException("404 File Not Found"),
+      new Exception("5xx HTTP Status Code")
+    )
+
+    nonRetryables foreach {IoActor.isRetryable(_) shouldBe false}
+    nonRetryables foreach {IoActor.isFatal(_) shouldBe true}
   }
 }


### PR DESCRIPTION
The description of the problem can be found here
https://broadworkbench.atlassian.net/browse/BA-5881
Unfortunately, there is no direct way to reproduce `500 Internal Server Error Backend Error`. Therefore, it is unclear how to show that this PR solves the problem.
However, since this error causes IOException, we think that reproducing some other IOException with this file should reproduce the problem close enough. If you are interested, we have an [experimental branch](https://github.com/EpamLifeSciencesTeam/cromwell/pull/9) for reproducing IOException. In that branch, Cromwell stops during execution, giving us time to delete the `rc` file if we want to. It allows us to see that this fix actually works and Cromwell indeed tries to read the file multiple times.