### PR TITLE
Fewer execution event entries during call cache cycles [BA-5843]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -397,7 +397,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   onTransition {
     case fromState -> toState =>
-      if (log.isDebugEnabled) log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
+      log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
 
       EngineJobExecutionActorState.transitionEventString(fromState, toState) foreach {
         eventList :+= ExecutionEvent(_)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -397,8 +397,12 @@ class EngineJobExecutionActor(replyTo: ActorRef,
 
   onTransition {
     case fromState -> toState =>
-      log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
-      eventList :+= ExecutionEvent(toState.toString)
+      if (log.isDebugEnabled) log.debug("Transitioning from {}({}) to {}({})", fromState, stateData, toState, nextStateData)
+
+      EngineJobExecutionActorState.transitionEventString(fromState, toState) foreach {
+        eventList :+= ExecutionEvent(_)
+      }
+
   }
 
   whenUnhandled {
@@ -758,6 +762,26 @@ object EngineJobExecutionActor {
   case object CheckingCacheEntryExistence extends EngineJobExecutionActorState
   case object UpdatingJobStore extends EngineJobExecutionActorState
   case object InvalidatingCacheEntry extends EngineJobExecutionActorState
+
+  object EngineJobExecutionActorState {
+    def transitionEventString(fromState: EngineJobExecutionActorState, toState: EngineJobExecutionActorState): Option[String] = {
+
+      def callCacheStateGroup: Set[EngineJobExecutionActorState] = Set(
+        CheckingCallCache,
+        FetchingCachedOutputsFromDatabase,
+        BackendIsCopyingCachedOutputs,
+        CheckingCacheEntryExistence,
+        InvalidatingCacheEntry
+      )
+
+      if (fromState == toState) None
+      else if (callCacheStateGroup.contains(fromState) && callCacheStateGroup.contains(toState)) None
+      else if (callCacheStateGroup.contains(toState)) Option("CallCacheReading")
+      else Option(toState.toString)
+    }
+  }
+
+
 
   /** Commands */
   sealed trait EngineJobExecutionActorCommand

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorTransitionsSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorTransitionsSpec.scala
@@ -1,0 +1,62 @@
+package cromwell.engine.workflow.lifecycle.execution.ejea
+
+import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
+import org.scalatest.{FlatSpec, Matchers}
+
+class EngineJobExecutionActorTransitionsSpec extends FlatSpec with Matchers {
+
+  val callCachingStateCycle = List(
+    CheckingCallCache,
+    FetchingCachedOutputsFromDatabase,
+    BackendIsCopyingCachedOutputs,
+    InvalidatingCacheEntry
+  )
+
+  "EngineJobExecutionActor transitions" should "not list all cache cycle iterations" in {
+
+    import EngineJobExecutionActorTransitionsSpec.MultipliableList
+
+    val cacheReadCycles = 5
+
+    val longCallCachingCycleStateSequence = List(
+      Pending,
+      RequestingExecutionToken,
+      CheckingJobStore,
+      CheckingCallCache,
+      FetchingCachedOutputsFromDatabase,
+      CheckingCacheEntryExistence) ++ callCachingStateCycle * cacheReadCycles ++ List(
+      WaitingForValueStore,
+      PreparingJob,
+      RunningJob,
+      UpdatingCallCache,
+      UpdatingJobStore
+    )
+
+    longCallCachingCycleStateSequence.length should be(11 + cacheReadCycles * callCachingStateCycle.size)
+
+    val transitionSequence = longCallCachingCycleStateSequence.sliding(2) map {
+      case fromState :: toState :: _ => EngineJobExecutionActorState.transitionEventString(fromState, toState)
+      case _ => fail("Programmer blunder. This test writer had one job to do...")
+    } collect {
+      case Some(stateName) => stateName
+    }
+
+    transitionSequence.toList should be(List(
+      // "Pending", <-- NB: There's no transition into "Pending" because that was the start state
+      "RequestingExecutionToken",
+      "CheckingJobStore",
+      "CallCacheReading",
+      "WaitingForValueStore",
+      "PreparingJob",
+      "RunningJob",
+      "UpdatingCallCache",
+      "UpdatingJobStore",
+    ))
+  }
+}
+
+object EngineJobExecutionActorTransitionsSpec {
+  implicit class MultipliableList[A](val list: List[A]) extends AnyVal {
+    final def *(i: Int): List[A] = if (i == 0 ) List.empty else if (i == 1) list else list ++ (list * (i - 1))
+  }
+}


### PR DESCRIPTION
Specifically to prevent extremely long cycles of the states `CheckingCallCache`, `FetchingCachedOutputsFromDatabase`, `BackendIsCopyingCachedOutputs`.

This has been observed in cases where cache copying has failed, the system goes back to the call cache to try another entry, it fails again, and so on and so on, indefinitely... The upshot in one case was 49,000 "cache cycles", a 30MB pile of metadata, and a non-responsive Job Manager page.

This PR collapses these three similar states (and a few others) into a single transition event (now called `CallCacheReading`) to cover the entire duration of the call cache read process.

EDIT: Note that this is not a panacea. The workflow identified in another ticket (BA-5830) had over 250,000 "execution events", but this was just because there were almost 20,000 scattered shards - and only one "call cache cycle" per shard. In that case this PR will only have a marginal impact.