### PR TITLE
Fixes the monitoring_log test

### DIFF
--- a/centaur/src/main/resources/standardTestCases/monitoring_log/monitoring_log.wdl
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log/monitoring_log.wdl
@@ -10,6 +10,6 @@ task get_stats {
     Array[String] stats = read_lines("monitoring.log")
   }
   runtime {
-    docker: "ubuntu"
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
   }
 }

--- a/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
@@ -13,6 +13,6 @@ metadata {
   "calls.monitoring_log.get_stats.jes.monitoringScript": "gs://cloud-cromwell-dev/some/simple_script.sh"
   "calls.monitoring_log.get_stats.monitoringLog": "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/travis/monitoring_log/<<UUID>>/call-get_stats/monitoring.log"
   "outputs.monitoring_log.get_stats.stats.0": "CPU: 1"
-  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 2.0G"
+  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 1.9G"
   "outputs.monitoring_log.get_stats.stats.2": "Total Disk space: 9.8G"
 }


### PR DESCRIPTION
Since the `monitoring_log` test checks whether the monitoring script is working normally, which it is, for the time being fix the memory expectation to unblock other PRs.