### PR TITLE
Parallelize GCS file input localization [BA-5899]

### DIFF
--- a/centaur/src/main/resources/papiUpgradeTestCases/papi_upgrade/papi_upgrade.wdl
+++ b/centaur/src/main/resources/papiUpgradeTestCases/papi_upgrade/papi_upgrade.wdl
@@ -7,7 +7,7 @@ task sum {
     File out = "file.md5"
   }
   runtime {
-    docker: "ubuntu:latest"
+    docker: "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
   }
 }
 
@@ -18,7 +18,7 @@ task cromwell_killer {
     echo restarting yo
   }
   runtime {
-    docker: "ubuntu:latest"
+    docker: "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
   }
 }
 

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.inputs
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.inputs
@@ -1,0 +1,1 @@
+{ "lots_of_inputs.how_many_is_lots": 400 }

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.wdl
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.wdl
@@ -32,7 +32,7 @@ task make_array {
 }
 
 workflow lots_of_inputs {
-  call make_array { input: n = 400 }
+  call make_array { input: n = 20000 }
   call do_nothing { input: f = make_array.a }
 
   output {

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.wdl
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs.wdl
@@ -32,7 +32,8 @@ task make_array {
 }
 
 workflow lots_of_inputs {
-  call make_array { input: n = 20000 }
+  Int how_many_is_lots
+  call make_array { input: n = how_many_is_lots }
   call do_nothing { input: f = make_array.a }
 
   output {

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs_papiv2.inputs
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs_papiv2.inputs
@@ -1,1 +1,1 @@
-{ "lots_of_inputs.how_many_is_lots": 20000 }
+{ "lots_of_inputs.how_many_is_lots": 10000 }

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs_papiv2.inputs
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs/lots_of_inputs_papiv2.inputs
@@ -1,0 +1,1 @@
+{ "lots_of_inputs.how_many_is_lots": 20000 }

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -1,6 +1,6 @@
 # This test makes sure that:
-# - 400 output files are all found and collected by the glob() method
-# - 400 input files to a task doesn't make anything explode inappropriately
+# - 20000 output files are all found and collected by the glob() method
+# - 20000 input files to a task doesn't make anything explode inappropriately
 name: lots_of_inputs_papiv2
 testFormat: workflowsuccess
 tags: [ big_metadata ]
@@ -14,6 +14,6 @@ files {
 metadata {
     workflowName: lots_of_inputs
     status: Succeeded
-    "outputs.lots_of_inputs.out_count": "400"
+    "outputs.lots_of_inputs.out_count": "20000"
     "outputs.lots_of_inputs.nothing_out": "no-op"
 }

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -8,7 +8,7 @@ backends: [ Papiv2 ]
 
 files {
   workflow: lots_of_inputs/lots_of_inputs.wdl
-  inputs: lots_of_inputs/logs_of_inputs_papiv2.inputs
+  inputs: lots_of_inputs/lots_of_inputs_papiv2.inputs
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -1,6 +1,6 @@
 # This test makes sure that:
-# - 20000 output files are all found and collected by the glob() method
-# - 20000 input files to a task doesn't make anything explode inappropriately
+# - 10000 output files are all found and collected by the glob() method
+# - 10000 input files to a task doesn't make anything explode inappropriately
 name: lots_of_inputs_papiv2
 testFormat: workflowsuccess
 tags: [ big_metadata ]
@@ -14,6 +14,6 @@ files {
 metadata {
     workflowName: lots_of_inputs
     status: Succeeded
-    "outputs.lots_of_inputs.out_count": "20000"
+    "outputs.lots_of_inputs.out_count": "10000"
     "outputs.lots_of_inputs.nothing_out": "no-op"
 }

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -1,13 +1,14 @@
 # This test makes sure that:
 # - 400 output files are all found and collected by the glob() method
 # - 400 input files to a task doesn't make anything explode inappropriately
-name: lots_of_inputs
+name: lots_of_inputs_papiv2
 testFormat: workflowsuccess
 tags: [ big_metadata ]
+backends: [ Papiv2 ]
 
 files {
   workflow: lots_of_inputs/lots_of_inputs.wdl
-  inputs: lots_of_inputs/lots_of_inputs.inputs
+  inputs: lots_of_inputs/logs_of_inputs_papiv2.inputs
 }
 
 metadata {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -2,7 +2,7 @@
 # The `papi_v2_log` Centaur test is opinionated about the number of log messages around localization/delocalization.
 # The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
 set +x
-set -euo pipefail
+set -uo pipefail
 
 gsutil_log=gsutil.log
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -155,8 +155,8 @@ localize_files() {
   fi
 
   # We need to determine requester pays status of the first file attempting at most `max_attempts` times.
-  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components="${num_cpus}"' cp '$first_cloud_file' '$container_parent'"
-  REQUESTER_PAYS_COMMAND="gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components="${num_cpus}"' -u $project cp '$first_cloud_file' '$container_parent'"
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' cp '$first_cloud_file' '$container_parent'"
+  REQUESTER_PAYS_COMMAND="gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' -u $project cp '$first_cloud_file' '$container_parent'"
 
   basefile=$(basename "$first_cloud_file")
   private::localize_message "$first_cloud_file" "${container_parent}${basefile}"

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -148,7 +148,8 @@ localize_files() {
   NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$first_cloud_file' '$container_parent'"
   REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$first_cloud_file' '$container_parent'"
 
-  private::localize_message "$first_cloud_file" "${container_parent}$(basename $first_cloud_file)"
+  basefile=$(basename "$first_cloud_file")
+  private::localize_message "$first_cloud_file" "${container_parent}${basefile}"
   private::determine_requester_pays ${max_attempts}
 
   if [[ ${USE_REQUESTER_PAYS} = true ]]; then
@@ -164,10 +165,11 @@ localize_files() {
   if [[ $# -gt 0 ]]; then
     touch files_to_localize.txt
     while [[ $# -gt 0 ]]; do
-      cloud="$0"
-      container="${container_parent}$(basename $cloud)"
+      cloud="$1"
+      basefile=$(basename "$cloud")
+      container="${container_parent}${basefile}"
       private::localize_message "$cloud" "$container"
-      echo "$0" >> files_to_localize.txt
+      echo "$cloud" >> files_to_localize.txt
       shift
     done
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -3,24 +3,11 @@
 # The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
 set +x
 
-gsutil_log=$(mktemp /tmp/gsutil.XXXXXXXXXXXXXXXX)
+gsutil_log=gsutil.log
 
+NO_REQUESTER_PAYS_COMMAND=
+REQUESTER_PAYS_COMMAND=
 
-private::localize_file() {
-  local cloud="$1"
-  local container="$2"
-  local rpflag="$3"
-  # Do not quote rpflag, when that is set it will be -u project which should be two distinct arguments.
-  rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m cp "$cloud" "$container" > "$gsutil_log" 2>&1
-}
-
-private::localize_directory() {
-  local cloud="$1"
-  local container="$2"
-  local rpflag="$3"
-  # Do not quote rpflag, when that is set it will be -u project which should be two distinct arguments.
-  mkdir -p "${container}" && rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m rsync -r "${cloud}" "${container}" > "$gsutil_log" 2>&1
-}
 
 private::delocalize_file() {
   local cloud="$1"
@@ -99,12 +86,12 @@ private::timestamped_message() {
   printf '%s %s\n' "$(date -u '+%Y/%m/%d %H:%M:%S')" "$1"
 }
 
-private::localize_message() {
-  local cloud="$1"
-  local container="$2"
-  local message=$(printf "Localizing input %s -> %s" "$cloud" "$container")
-  private::timestamped_message "${message}"
-}
+#private::localize_message() {
+#  local cloud="$1"
+#  local container="$2"
+#  local message=$(printf "Localizing input %s -> %s" "$cloud" "$container")
+#  private::timestamped_message "${message}"
+#}
 
 private::delocalize_message() {
   local cloud="$1"
@@ -113,67 +100,175 @@ private::delocalize_message() {
   private::timestamped_message "${message}"
 }
 
-# Transfer a bundle of files or directories to or from the same GCS bucket.
-transfer() {
-  # Begin the transfer with uncertain requester pays status and first attempting transfers without requester pays.
-  private::transfer false false "$@"
+
+# Requires both NO_REQUESTER_PAYS_COMMAND and USE_REQUESTER_PAYS_COMMAND to be set.
+private::determine_requester_pays() {
+  local max_attempts="$1"
+  local attempt=1
+  shift
+
+  local command="$NO_REQUESTER_PAYS_COMMAND"
+  local use_requester_pays=false
+  # assume the worst
+  USE_REQUESTER_PAYS=error
+
+  while [[ "$attempt" -le ${max_attempts} ]]; do
+    eval ${command} > ${gsutil_log} 2>&1
+    rc="$?"
+
+    if [[ "$rc" = 0 ]]; then
+      USE_REQUESTER_PAYS=${use_requester_pays}
+      break
+    elif [[ "$use_requester_pays" = "false" ]]; then
+      if grep -q "Bucket is requester pays bucket but no user project provided." ${gsutil_log}; then
+        use_requester_pays=true
+        command="$REQUESTER_PAYS_COMMAND"
+      else
+        attempt=$((attempt + 1))
+      fi
+    else
+      attempt=$((attempt + 1))
+    fi
+  done
 }
 
-private::transfer() {
-  local rp_status_certain="$1"
-  local use_requester_pays="$2"
-  local direction="$3"
-  local project="$4"
-  local max_attempts="$5"
 
-  shift 5 # rp_status_certain + use_requester_pays + direction + project + max_attempts
+localize_files() {
+  local project="$1"
+  local max_attempts="$2"
+  local container_parent="$3"
+  local first_cloud_file="$4"
+  shift 4
 
-  if [[ "$direction" != "localize" && "$direction" != "delocalize" ]]; then
-    echo "direction must be 'localize' or 'delocalize' but got '$direction'"
+  # All inputs are required. We need to determine requester pays status of the first file attempting at most `max_attempts` times.
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$first_cloud_file' '$container_parent'"
+  REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$first_cloud_file' '$container_parent'"
+
+  private::determine_requester_pays ${max_attempts}
+
+  if [[ ${USE_REQUESTER_PAYS} = true ]]; then
+    rpflag="-u $project"
+  elif [[ ${USE_REQUESTER_PAYS} = false ]]; then
+    rpflag=""
+  else
+    # error
     exit 1
   fi
 
+
+  if [[ $# -gt 0 ]]; then
+    attempt=1
+    while [[ ${attempt} -le ${max_attempts} ]]; do
+      # parallel transfer the remaining files
+      echo "$@" | gsutil -m ${rpflag} cp -I "$container_parent"
+      if [[ $? = 0 ]]; then
+        break
+      else
+        attempt=$((attempt + 1))
+      fi
+    done
+  fi
+}
+
+# Requires known requester pays status.
+private::localize_directory() {
+  local cloud="$1"
+  local container="$2"
+  local max_attempts="$3"
+  local rpflag="$4"
+
+  local attempt=1
+  while [[ ${attempt} -lt ${max_attempts} ]]; do
+    # Do not quote rpflag, when that is set it will be -u project which should be two distinct arguments.
+    mkdir -p "${container}" && rm -f "$HOME/.config/gcloud/gce" && gsutil ${rpflag} -m rsync -r "${cloud}" "${container}" > /dev/null 2>&1
+    if [[ $? = 0 ]]; then
+      break
+    else
+      attempt=$(($attempt + 1))
+    fi
+  done
+
+  if [[ ${attempt} -gt ${max_attempts} ]]; then
+    exit 1
+  fi
+}
+
+# Called from the localization script with unknown requester pays status on the source bucket. This attempts to localize
+# the first input directory without requester pays. If that fails with a requester pays error, this attempts again with
+# the project flag required for requester pays. Both no-requester-pays and requester-pays attempts are retried up to
+# max_attempts times. Once requester# pays status is determined the remaining files are localized with or without the
+# project flag as appropriate.
+localize_directories() {
+  local project="$1"
+  local max_attempts="$2"
+  local cloud_directory="$3"
+  local container_directory="$4"
+  shift 4
+
+  BASE_COMMAND="private::localize_directory '${cloud_directory}' '${container_directory}' '${max_attempts}'"
+  NO_REQUESTER_PAYS_COMMAND="${BASE_COMMAND} ''"
+  REQUESTER_PAYS_COMMAND="${BASE_COMMAND} '-u $project'"
+
+  private::determine_requester_pays_n_attempts ${max_attempts}
+
+  if [[ ${USE_REQUESTER_PAYS} = true ]]; then
+    rpflag="-u $project"
+  elif [[ ${USE_REQUESTER_PAYS} = false ]]; then
+    rpflag=""
+  else
+    exit 1
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    cloud_directory="$1"
+    container_directory="$2"
+    shift 2
+    private::localize_directory "$cloud_directory" "$container_directory" "$max_attempts" "$rpflag"
+  done
+}
+
+# Handles all delocalizations for a transfer bundle (a grouping of file, directories, or files_or_directories targeting
+# a single GCS bucket).
+delocalize() {
+  local project="$1"
+  local max_attempts="$2"
+
+  shift 2
+
   # Whether the requester pays status of the GCS bucket is certain. rp status is presumed false until proven otherwise.
+  local rp_status_certain=false
+  local use_requester_pays=false
 
-  local message_fn="private::${direction}_message"
-
-  # If requester pays status is unknown, loop through the items in the transfer bundle until requester pays status is determined.
-  # Once determined, the remaining items can be transferred in parallel.
   while [[ $# -gt 0 ]]; do
     file_or_directory="$1"
     cloud="$2"
     container="$3"
+    required="$4"
+    content_type="$5"
+
+    shift 5
 
     if [[ "$file_or_directory" = "file" ]]; then
-      transfer_fn_name="private::${direction}_file"
+      transfer_fn_name="private::delocalize_file"
     elif [[ "$file_or_directory" = "directory" ]]; then
-      transfer_fn_name="private::${direction}_directory"
-    elif [[ "$direction" = "delocalize" && "$file_or_directory" = "file_or_directory" ]]; then
+      transfer_fn_name="private::delocalize_directory"
+    elif [[ "$file_or_directory" = "file_or_directory" ]]; then
       transfer_fn_name="private::delocalize_file_or_directory"
     else
-      echo "file_or_directory must be 'file' or 'directory' or (for delocalization only) 'file_or_directory' but got '$file_or_directory' with direction = '$direction'"
+      echo "file_or_directory must be 'file' or 'directory' or 'file_or_directory' but got '$file_or_directory'"
       exit 1
     fi
 
-    content_type=""
-    required=""
-    if [[ "${direction}" = "delocalize" ]]; then
-      # 'required' and 'content type' only appear in delocalization bundles.
-      required="$4"
-      content_type="$5"
-      if [[ "$required" != "required" && "$required" != "optional" ]]; then
-        echo "'required' must be 'required' or 'optional' but got '$required'"
-        exit 1
-      elif [[ "$required" = "required" && "$file_or_directory" = "file_or_directory" ]]; then
-        echo "Invalid combination of required = required and file_or_directory = file_or_directory, file_or_directory only valid with optional secondary outputs"
-        exit 1
-      fi
-      shift 2 # required + content_type
+    if [[ "$required" != "required" && "$required" != "optional" ]]; then
+      echo "'required' must be 'required' or 'optional' but got '$required'"
+      exit 1
+    elif [[ "$required" = "required" && "$file_or_directory" = "file_or_directory" ]]; then
+      echo "Invalid combination of required = required and file_or_directory = file_or_directory, file_or_directory only valid with optional secondary outputs"
+      exit 1
     fi
-    shift 3 # file_or_directory + cloud + container
 
-    # Log what is being localized or delocalized (at least one test depends on this).
-    ${message_fn} "$cloud" "$container"
+    # Log what is being delocalized (at least one test depends on this).
+    private::delocalize_message "$cloud" "$container"
 
     attempt=1
     transfer_rc=0

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -44,6 +44,7 @@ private::delocalize_file() {
   fi
 }
 
+
 private::delocalize_directory() {
   local cloud="$1"
   local container="$2"
@@ -64,6 +65,7 @@ private::delocalize_directory() {
   fi
 }
 
+
 private::delocalize_file_or_directory() {
   local cloud="$1"
   local container="$2"
@@ -82,16 +84,11 @@ private::delocalize_file_or_directory() {
   fi
 }
 
+
 private::timestamped_message() {
   printf '%s %s\n' "$(date -u '+%Y/%m/%d %H:%M:%S')" "$1"
 }
 
-#private::localize_message() {
-#  local cloud="$1"
-#  local container="$2"
-#  local message=$(printf "Localizing input %s -> %s" "$cloud" "$container")
-#  private::timestamped_message "${message}"
-#}
 
 private::delocalize_message() {
   local cloud="$1"
@@ -114,9 +111,8 @@ private::determine_requester_pays() {
 
   while [[ "$attempt" -le ${max_attempts} ]]; do
     eval ${command} > ${gsutil_log} 2>&1
-    rc="$?"
 
-    if [[ "$rc" = 0 ]]; then
+    if [[ $? = 0 ]]; then
       USE_REQUESTER_PAYS=${use_requester_pays}
       break
     elif [[ "$use_requester_pays" = "false" ]]; then
@@ -170,6 +166,7 @@ localize_files() {
   fi
 }
 
+
 # Requires known requester pays status.
 private::localize_directory() {
   local cloud="$1"
@@ -193,11 +190,12 @@ private::localize_directory() {
   fi
 }
 
+
 # Called from the localization script with unknown requester pays status on the source bucket. This attempts to localize
 # the first input directory without requester pays. If that fails with a requester pays error, this attempts again with
 # the project flag required for requester pays. Both no-requester-pays and requester-pays attempts are retried up to
-# max_attempts times. Once requester# pays status is determined the remaining files are localized with or without the
-# project flag as appropriate.
+# max_attempts times. Once requester pays status is determined via the first directory the remaining files are localized
+# with or without the project flag as appropriate.
 localize_directories() {
   local project="$1"
   local max_attempts="$2"
@@ -226,6 +224,7 @@ localize_directories() {
     private::localize_directory "$cloud_directory" "$container_directory" "$max_attempts" "$rpflag"
   done
 }
+
 
 # Handles all delocalizations for a transfer bundle (a grouping of file, directories, or files_or_directories targeting
 # a single GCS bucket).

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # The `papi_v2_log` Centaur test is opinionated about the number of log messages around localization/delocalization.
 # The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
-set -x
+set +x
 
 gsutil_log=gsutil.log
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -2,6 +2,7 @@
 # The `papi_v2_log` Centaur test is opinionated about the number of log messages around localization/delocalization.
 # The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
 set +x
+set -euo pipefail
 
 gsutil_log=gsutil.log
 
@@ -117,7 +118,7 @@ private::determine_requester_pays() {
   # assume the worst
   USE_REQUESTER_PAYS=error
 
-  while [[ "$attempt" -le ${max_attempts} ]]; do
+  while [[ ${attempt} -le ${max_attempts} ]]; do
     eval ${command} > ${gsutil_log} 2>&1
 
     if [[ $? = 0 ]]; then
@@ -134,6 +135,11 @@ private::determine_requester_pays() {
       attempt=$((attempt + 1))
     fi
   done
+
+  if [[ ${attempt} -gt ${max_attempts} ]]; then
+    echo "Error attempting to localize file with command: '$command'"
+    cat ${gsutil_log}
+  fi
 }
 
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -149,6 +149,10 @@ localize_files() {
   shift 4
 
   local num_cpus=$(grep -c ^processor /proc/cpuinfo)
+  # 32 is the max component count currently supported by gsutil cp.
+  if [[ ${num_cpus} -gt 32 ]]; then
+    num_cpus=32
+  fi
 
   # We need to determine requester pays status of the first file attempting at most `max_attempts` times.
   NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components="${num_cpus}"' cp '$first_cloud_file' '$container_parent'"

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -344,6 +344,8 @@ delocalize() {
 }
 
 
+# Required for files whose names are not consistent between cloud and container. There should be very few of these,
+# the monitoring script being the single known example.
 localize_singleton_file() {
   local project="$1"
   local max_attempts="$2"

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -136,7 +136,7 @@ localize_files() {
   local first_cloud_file="$4"
   shift 4
 
-  # All inputs are required. We need to determine requester pays status of the first file attempting at most `max_attempts` times.
+  # We need to determine requester pays status of the first file attempting at most `max_attempts` times.
   NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$first_cloud_file' '$container_parent'"
   REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$first_cloud_file' '$container_parent'"
 
@@ -153,10 +153,16 @@ localize_files() {
 
 
   if [[ $# -gt 0 ]]; then
+    touch files_to_localize.txt
+    while [[ $# -gt 0 ]]; do
+      echo "$0" >> files_to_localize.txt
+      shift
+    done
+
     attempt=1
     while [[ ${attempt} -le ${max_attempts} ]]; do
       # parallel transfer the remaining files
-      echo "$@" | gsutil -m ${rpflag} cp -I "$container_parent"
+      cat files_to_localize.txt | gsutil -m ${rpflag} cp -I "$container_parent"
       if [[ $? = 0 ]]; then
         break
       else

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -207,7 +207,7 @@ localize_directories() {
   NO_REQUESTER_PAYS_COMMAND="${BASE_COMMAND} ''"
   REQUESTER_PAYS_COMMAND="${BASE_COMMAND} '-u $project'"
 
-  private::determine_requester_pays_n_attempts ${max_attempts}
+  private::determine_requester_pays ${max_attempts}
 
   if [[ ${USE_REQUESTER_PAYS} = true ]]; then
     rpflag="-u $project"

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -148,9 +148,11 @@ localize_files() {
   local first_cloud_file="$4"
   shift 4
 
+  local num_cpus=$(grep -c ^processor /proc/cpuinfo)
+
   # We need to determine requester pays status of the first file attempting at most `max_attempts` times.
-  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$first_cloud_file' '$container_parent'"
-  REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$first_cloud_file' '$container_parent'"
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components="${num_cpus}"' cp '$first_cloud_file' '$container_parent'"
+  REQUESTER_PAYS_COMMAND="gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components="${num_cpus}"' -u $project cp '$first_cloud_file' '$container_parent'"
 
   basefile=$(basename "$first_cloud_file")
   private::localize_message "$first_cloud_file" "${container_parent}${basefile}"
@@ -180,7 +182,7 @@ localize_files() {
     attempt=1
     while [[ ${attempt} -le ${max_attempts} ]]; do
       # parallel transfer the remaining files
-      if cat files_to_localize.txt | gsutil -m ${rpflag} cp -I "$container_parent"; then
+      if cat files_to_localize.txt | gsutil -o "GSUtil:parallel_thread_count=1" -o "GSUtil:sliced_object_download_max_components=${num_cpus}" -m ${rpflag} cp -I "$container_parent"; then
         break
       else
         attempt=$((attempt + 1))

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 gsutil_log=gsutil.log
 
-NO_REQUESTER_PAYS_COMMAND=
-REQUESTER_PAYS_COMMAND=
+NO_REQUESTER_PAYS_COMMAND=""
+REQUESTER_PAYS_COMMAND=""
 
 
 private::delocalize_file() {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # The `papi_v2_log` Centaur test is opinionated about the number of log messages around localization/delocalization.
 # The trace logging of `set -x` must be turned off for the `papi_v2_log` test to pass.
-set +x
+set -x
 
 gsutil_log=gsutil.log
 
@@ -341,4 +341,20 @@ delocalize() {
   done
 
   rm -f "${gsutil_log}"
+}
+
+
+localize_singleton_file() {
+  local project="$1"
+  local max_attempts="$2"
+  local cloud="$3"
+  local container="$4"
+
+  local container_parent=$(dirname "$container")
+
+  private::localize_message "$cloud" "$container"
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$cloud' '$container'"
+  REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$cloud' '$container'"
+  # As a side effect of determining requester pays this one file will be localized.
+  private::determine_requester_pays ${max_attempts}
 }


### PR DESCRIPTION
Partition same-named file inputs from other kinds of inputs for special `gsutil -m cp` treatment. 

`lots_of_inputs` Centaur test 400-input timings on the (misleadingly named) `do_nothing` call:

* Cromwell 44:  4765.68 seconds / 400 inputs = 11.91 seconds / input
* Cromwell 45:  1181.64 seconds / 400 inputs = 2.95 seconds / input
* Cromwell 46: 200.82 seconds / 400 inputs = 0.50 seconds / input

But 400 inputs isn't really "lots", so trying this test again on 46 with 20,000 inputs to drown out the lower order terms:

* Cromwell 46: 2663.71 seconds / 20,000 inputs = 0.13 seconds / input