### PR TITLE
Handle WomCoproductValue in inputs

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray.test
@@ -1,0 +1,16 @@
+name: cwl_input_typearray
+testFormat: workflowsuccess
+workflowType: CWL
+workflowTypeVersion: v1.0
+workflowRoot: input_typearray
+
+files {
+  workflow: cwl_input_typearray/input_typearray.cwl
+  inputs: cwl_input_typearray/input_typearray.yml
+}
+
+metadata {
+  "submittedFiles.workflowType": CWL
+  "submittedFiles.workflowTypeVersion": v1.0
+  "outputs.input_typearray.response": "input.txt\n"
+}

--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray.test
@@ -12,5 +12,6 @@ files {
 metadata {
   "submittedFiles.workflowType": CWL
   "submittedFiles.workflowTypeVersion": v1.0
-  "outputs.input_typearray.response": "input.txt\n"
+  "outputs.input_typearray.response_f": "input.txt"
+  "outputs.input_typearray.response_s": "nonexistent_path.txt"
 }

--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.cwl
@@ -9,17 +9,34 @@ $graph:
   - class: DockerRequirement
     dockerPull: "ubuntu:latest"
   - class: InlineJavascriptRequirement
+  arguments:
+      - position: 3
+        valueFrom: "sentinel"
   inputs:
-    value:
+    value_f:
       type:
         - string
         - File
       inputBinding:
         position: 1
+      doc: "an input to test with a File value"
+    value_s:
+      type:
+        - string
+        - File
+      inputBinding:
+        position: 2
+      doc: "an input to test with a string value"
   outputs:
-    response:
+    response_f:
       type: string
       outputBinding:
         glob: response.txt
         loadContents: true
-        outputEval: $(self[0].contents.split("/").slice(-1)[0])
+        outputEval: $(self[0].contents.split(" ")[0].split("/").slice(-1)[0])
+    response_s:
+      type: string
+      outputBinding:
+        glob: response.txt
+        loadContents: true
+        outputEval: $(self[0].contents.split(" ")[1].split("/").slice(-1)[0])

--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.cwl
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.cwl
@@ -1,0 +1,25 @@
+cwlVersion: v1.0
+$graph:
+- id: input_typearray
+  cwlVersion: v1.0
+  class: CommandLineTool
+  baseCommand: ['/bin/echo']
+  stdout: "response.txt"
+  requirements:
+  - class: DockerRequirement
+    dockerPull: "ubuntu:latest"
+  - class: InlineJavascriptRequirement
+  inputs:
+    value:
+      type:
+        - string
+        - File
+      inputBinding:
+        position: 1
+  outputs:
+    response:
+      type: string
+      outputBinding:
+        glob: response.txt
+        loadContents: true
+        outputEval: $(self[0].contents.split("/").slice(-1)[0])

--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.yml
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.yml
@@ -1,3 +1,4 @@
-value:
+value_f:
   class: File
   path: "centaur/src/main/resources/standardTestCases/cwl_input_typearray/input.txt"
+value_s: "centaur/src/main/resources/standardTestCases/cwl_input_typearray/nonexistent_path.txt"

--- a/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.yml
+++ b/centaur/src/main/resources/standardTestCases/cwl_input_typearray/input_typearray.yml
@@ -1,0 +1,3 @@
+value:
+  class: File
+  path: "centaur/src/main/resources/standardTestCases/cwl_input_typearray/input.txt"

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -125,6 +125,7 @@ abstract class CommandLineBindingCommandPart(commandLineBinding: CommandLineBind
       }
       case _: WomObjectLike => prefixAsList
       case WomEnumerationValue(_, value) => handlePrefix(value)
+      case WomCoproductValue(_, value) => processValue(value)
       case w => throw new RuntimeException(s"Unhandled CwlExpressionCommandPart value '$w' of type ${w.womType.stableName}")
     }
 

--- a/wom/src/main/scala/wom/WomFileMapper.scala
+++ b/wom/src/main/scala/wom/WomFileMapper.scala
@@ -55,6 +55,7 @@ object WomFileMapper {
             o map Option.apply recover { case _: FileNotFoundException => None } map buildWomOptionalValue
           case None => Success(buildWomOptionalValue(None))
         }
+      case coproduct: WomCoproductValue => mapWomFiles(mapper, exceptions)(coproduct.womValue)
       case other => Success(other)
     }
   }


### PR DESCRIPTION
When testing out a change to a CWL workflow I ran into a RuntimeException:
```
java.lang.RuntimeException: Unhandled CwlExpressionCommandPart value 'WomCoproductValue(WomCoproductType(NonEmptyList(WomStringType, WomIntegerType)),WomString(42))' of type Coproduct[String, Int]
```
This simple CWL file will reproduce the error:
```cwl
#!/usr/bin/env cwl-runner

cwlVersion: v1.0
class: CommandLineTool

baseCommand: ["/bin/echo"]
arguments: ["I got this value:"]
stdout: response.txt
inputs:
    value:
        type:
            - string
            - int
            - "null"
        inputBinding:
            position: 1
outputs:
    response:
        type: stdout
```
with an appropriate input YAML, e.g.:
```yaml
value: 42
```

The first commit in this PR was enough to get past that error; however, there was another issue if one of the possible types was instead a `File`.  The file did not appear to be getting localized.  So, a second example:

```cwl
#!/usr/bin/env cwl-runner

cwlVersion: v1.0
class: CommandLineTool

baseCommand: ["/bin/echo"]
arguments: ["I got this value:"]
stdout: response.txt
inputs:
    value:
        type:
            - string
            - File
            - "null"
        secondaryFiles: [.fai, .ann, .index]
        inputBinding:
            position: 1
outputs:
    response:
        type: stdout
```

The second commit to this PR addresses that issue.  (Without this commit Cromwell did not crash when run locally without Docker, but did crash with an `IllegalArgumentException` from calling `subpath` with an invalid range [here](https://github.com/broadinstitute/cromwell/blob/384f0b8f22399342705dc43ab9dac2d6b16bbf3b/backend/src/main/scala/cromwell/backend/io/JobPathsWithDocker.scala#L57) with Docker.)

These changes were enough to get my workflow running, but I'm not sure if there are other changes that should be made to properly handle `WomCoproductValue`.  (For instance, I have not tried it in GCP yet.)