### PR TITLE
Refactor metadata builder inside the metadata service [BA-5842]

### DIFF
--- a/common/src/main/scala/common/validation/ErrorOr.scala
+++ b/common/src/main/scala/common/validation/ErrorOr.scala
@@ -10,7 +10,7 @@ object ErrorOr {
   type ErrorOr[+A] = Validated[NonEmptyList[String], A]
 
   implicit class EnhancedErrorOr[A](val eoa: ErrorOr[A]) extends AnyVal {
-    def contextualizeErrors(s: String): ErrorOr[A] = eoa.leftMap { errors =>
+    def contextualizeErrors(s: => String): ErrorOr[A] = eoa.leftMap { errors =>
       val total = errors.size
       errors.zipWithIndex map { case (e, i) => s"Failed to $s (reason ${i + 1} of $total): $e" }
     }

--- a/core/src/test/scala/cromwell/core/TestKitSuite.scala
+++ b/core/src/test/scala/cromwell/core/TestKitSuite.scala
@@ -2,8 +2,8 @@ package cromwell.core
 
 import java.util.UUID
 
-import akka.actor.{ActorSystem, Props}
-import akka.testkit.TestKit
+import akka.actor.ActorSystem
+import akka.testkit.{TestActors, TestKit}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
@@ -21,7 +21,9 @@ abstract class TestKitSuite(actorSystemName: String = TestKitSuite.randomName,
     shutdown()
   }
 
-  val emptyActor = system.actorOf(Props.empty, "TestKitSuiteEmptyActor")
+  // 'BlackHoleActor' swallows messages without logging them (thus reduces log file overhead):
+  val emptyActor = system.actorOf(TestActors.blackholeProps, "TestKitSuiteEmptyActor")
+
   val mockIoActor = system.actorOf(MockIoActor.props(), "TestKitSuiteMockIoActor")
   val simpleIoActor = system.actorOf(SimpleIoActor.props, "TestKitSuiteSimpleIoActor")
   val failIoActor = system.actorOf(FailIoActor.props(), "TestKitSuiteFailIoActor")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -109,7 +109,7 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
     val response = (callACachingMetadata, callBCachingMetadata) flatMapN { case (callA, callB) =>
 
         val callADetails = extractCallDetails(queryA, callA)
-        val callBDetails = extractCallDetails(queryA, callB)
+        val callBDetails = extractCallDetails(queryB, callB)
 
       (callADetails, callBDetails) mapN { (cad, cbd) =>
         val callAHashes = callA.callCachingMetadataJson.hashes
@@ -313,7 +313,7 @@ object CallCacheDiffActor {
       case (key, value) if hashesB.get(key) != Option(value) => HashDifference(key, Option(value), hashesB.get(key))
     }
     val hashesUniqueToB: List[HashDifference] = hashesB.toList.collect {
-      case (key, value) if hashesA.keySet.contains(key) => HashDifference(key, None, Option(value))
+      case (key, value) if !hashesA.keySet.contains(key) => HashDifference(key, None, Option(value))
     }
     hashesInANotMatchedInB ++ hashesUniqueToB
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -8,11 +8,11 @@ import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallCacheDiffActorData, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
 import cromwell.services.metadata.CallMetadataKeys.CallCachingKeys
-import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
+import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
 import cromwell.services.metadata._
-import cromwell.webservice.metadata.MetadataComponent._
-import cromwell.webservice.metadata._
+import cromwell.services.metadata.impl.builder._
 import spray.json.JsObject
+import cromwell.services.metadata.impl.builder.MetadataComponent.metadataComponentJsonWriter
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -57,8 +57,8 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
     case Event(CallCacheDiffQueryParameter(callA, callB), CallCacheDiffNoData) =>
       val queryA = makeMetadataQuery(callA)
       val queryB = makeMetadataQuery(callB)
-      serviceRegistryActor ! GetMetadataQueryAction(queryA)
-      serviceRegistryActor ! GetMetadataQueryAction(queryB)
+      serviceRegistryActor ! GetMetadataAction(queryA)
+      serviceRegistryActor ! GetMetadataAction(queryB)
       goto(WaitingForMetadata) using CallCacheDiffWithRequest(queryA, queryB, None, None, sender())
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -2,53 +2,19 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import akka.actor.{ActorRef, LoggingFSM, Props}
 import cats.data.NonEmptyList
+import cats.syntax.validated._
+import cats.syntax.apply._
+import cats.syntax.traverse._
 import cats.instances.list._
-import cats.syntax.foldable._
+import common.validation.ErrorOr.{ErrorOr, ShortCircuitingFlatMap}
+import common.validation.Validation._
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallCacheDiffActorData, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
-import cromwell.services.metadata.CallMetadataKeys.CallCachingKeys
-import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
+import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataServiceKeyLookupFailed}
 import cromwell.services.metadata._
-import cromwell.services.metadata.impl.builder._
-import spray.json.JsObject
-import cromwell.services.metadata.impl.builder.MetadataComponent.metadataComponentJsonWriter
-
-import scala.language.postfixOps
-import scala.util.{Failure, Success, Try}
-
-object CallCacheDiffActor {
-  private val PlaceholderMissingHashValue = MetadataPrimitive(MetadataValue("Error: there is a hash entry for this key but the value is null !"))
-
-  final case class CachedCallNotFoundException(message: String) extends Exception {
-    override def getMessage = message
-  }
-
-  // Exceptions when calls exist but have no hashes in their metadata, indicating they were run pre-28
-  private val HashesForCallAAndBNotFoundException = new Exception("callA and callB have not finished yet, or were run on a previous version of Cromwell on which this endpoint was not supported.")
-  private val HashesForCallANotFoundException = new Exception("callA has not finished yet, or was run on a previous version of Cromwell on which this endpoint was not supported.")
-  private val HashesForCallBNotFoundException = new Exception("callB has not finished yet, or was run on a previous version of Cromwell on which this endpoint was not supported.")
-
-  sealed trait CallCacheDiffActorState
-  case object Idle extends CallCacheDiffActorState
-  case object WaitingForMetadata extends CallCacheDiffActorState
-
-  sealed trait CallCacheDiffActorData
-  case object CallCacheDiffNoData extends CallCacheDiffActorData
-  case class CallCacheDiffWithRequest(queryA: MetadataQuery,
-                                      queryB: MetadataQuery,
-                                      responseA: Option[MetadataLookupResponse],
-                                      responseB: Option[MetadataLookupResponse],
-                                      replyTo: ActorRef
-                                     ) extends CallCacheDiffActorData
-
-  sealed abstract class CallCacheDiffActorResponse
-  case class BuiltCallCacheDiffResponse(response: JsObject) extends CallCacheDiffActorResponse
-  case class FailedCallCacheDiffResponse(reason: Throwable) extends CallCacheDiffActorResponse
-
-
-  def props(serviceRegistryActor: ActorRef) = Props(new CallCacheDiffActor(serviceRegistryActor)).withDispatcher(EngineDispatcher)
-}
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import spray.json.{JsArray, JsObject, JsString, JsValue}
 
 class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[CallCacheDiffActorState, CallCacheDiffActorData] {
   startWith(Idle, CallCacheDiffNoData)
@@ -65,69 +31,86 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
   when(WaitingForMetadata) {
     // First Response
     // Response A
-    case Event(response: MetadataLookupResponse, data @ CallCacheDiffWithRequest(queryA, _, None, None, _)) if queryA == response.query =>
-      stay() using data.copy(responseA = Option(response))
+    case Event(BuiltMetadataResponse(GetMetadataAction(originalQuery), responseJson), data@CallCacheDiffWithRequest(queryA, _, None, None, _)) if queryA == originalQuery =>
+      stay() using data.copy(responseA = Option(WorkflowMetadataJson(responseJson)))
     // Response B
-    case Event(response: MetadataLookupResponse, data @ CallCacheDiffWithRequest(_, queryB, None, None, _)) if queryB == response.query =>
-      stay() using data.copy(responseB = Option(response))
+    case Event(BuiltMetadataResponse(GetMetadataAction(originalQuery), responseJson), data@CallCacheDiffWithRequest(_, queryB, None, None, _)) if queryB == originalQuery =>
+      stay() using data.copy(responseB = Option(WorkflowMetadataJson(responseJson)))
     // Second Response
     // Response A
-    case Event(response: MetadataLookupResponse, CallCacheDiffWithRequest(queryA, queryB, None, Some(responseB), replyTo)) if queryA == response.query =>
-      buildDiffAndRespond(queryA, queryB, response, responseB, replyTo)
+    case Event(BuiltMetadataResponse(GetMetadataAction(originalQuery), responseJson), CallCacheDiffWithRequest(queryA, queryB, None, Some(responseB), replyTo)) if queryA == originalQuery =>
+      buildDiffAndRespond(queryA, queryB, WorkflowMetadataJson(responseJson), responseB, replyTo)
     // Response B
-    case Event(response: MetadataLookupResponse, CallCacheDiffWithRequest(queryA, queryB, Some(responseA), None, replyTo)) if queryB == response.query =>
-      buildDiffAndRespond(queryA, queryB, responseA, response, replyTo)
+    case Event(BuiltMetadataResponse(GetMetadataAction(originalQuery), responseJson), CallCacheDiffWithRequest(queryA, queryB, Some(responseA), None, replyTo)) if queryB == originalQuery =>
+      buildDiffAndRespond(queryA, queryB, responseA, WorkflowMetadataJson(responseJson), replyTo)
     case Event(MetadataServiceKeyLookupFailed(_, failure), data: CallCacheDiffWithRequest) =>
       data.replyTo ! FailedCallCacheDiffResponse(failure)
       context stop self
       stay()
   }
 
+  whenUnhandled {
+    case Event(oops, oopsData) =>
+      log.error(s"Programmer Error: Unexpected event received by ${this.getClass.getSimpleName}: $oops / $oopsData (in state $stateName)")
+      stay()
+
+  }
+
   /**
     * Builds a response and sends it back as Json.
     * The response is structured in the following way
     * {
-    *   "callA": {
-    *     -- information about call A --
-    *   },
-    *   "callB": {
-    *     -- information about call B --
-    *   },
-    *   "hashDifferential": [
-    *     {
-    *       "hash key": {
-    *         "callA": -- hash value for call A, or null --,
-    *         "callB": -- hash value for call B, or null --
-    *       }
-    *     },
-    *     ...
-    *   ]
+    * "callA": {
+    * -- information about call A --
+    * },
+    * "callB": {
+    * -- information about call B --
+    * },
+    * "hashDifferential": [
+    * {
+    * "hash key": {
+    * "callA": -- hash value for call A, or null --,
+    * "callB": -- hash value for call B, or null --
+    * }
+    * },
+    * ...
+    * ]
     * }
     */
   private def buildDiffAndRespond(queryA: MetadataQuery,
                                   queryB: MetadataQuery,
-                                  responseA: MetadataLookupResponse,
-                                  responseB: MetadataLookupResponse,
+                                  responseA: WorkflowMetadataJson,
+                                  responseB: WorkflowMetadataJson,
                                   replyTo: ActorRef) = {
 
-    lazy val buildResponse = {
-      diffHashes(responseA.eventList, responseB.eventList) match {
-        case Success(diff) =>
-          val diffObject = MetadataObject(Map(
-            "callA" -> makeCallInfo(queryA, responseA.eventList),
-            "callB" -> makeCallInfo(queryB, responseB.eventList),
-            "hashDifferential" -> diff
-          ))
+    //    lazy val buildResponse = {
+    //      diffHashes(responseA.responseJson, responseB.responseJson) match {
+    //        case Success(diff) =>
+    //          val diffObject = MetadataObject(Map(
+    //            "callA" -> makeCallInfo(queryA, responseA.responseJson),
+    //            "callB" -> makeCallInfo(queryB, responseB.responseJson),
+    //            "hashDifferential" -> diff
+    //          ))
+    //
+    //          BuiltCallCacheDiffResponse(metadataComponentJsonWriter.write(diffObject).asJsObject)
+    //        case Failure(f) => FailedCallCacheDiffResponse(f)
+    //      }
+    //    }
+    //
+    //    val response = checkCallsExistence(queryA, queryB, responseA, responseB) match {
+    //      case Some(msg) => FailedCallCacheDiffResponse(CachedCallNotFoundException(msg))
+    //      case None => buildResponse
+    //    }
 
-          BuiltCallCacheDiffResponse(metadataComponentJsonWriter.write(diffObject).asJsObject)
-        case Failure(f) => FailedCallCacheDiffResponse(f)
-      }
+    val callACachingMetadata = extractCallCachingMetadata(queryA, responseA)
+    val callBCachingMetadata = extractCallCachingMetadata(queryB, responseB)
+
+    (callACachingMetadata, callBCachingMetadata) mapN { case (callA, callB) =>
+      println(extractHashes(callA))
+      println(extractHashes(callB))
     }
 
-    val response = checkCallsExistence(queryA, queryB, responseA, responseB) match {
-      case Some(msg) => FailedCallCacheDiffResponse(CachedCallNotFoundException(msg))
-      case None => buildResponse
-    }
+    val response = FailedCallCacheDiffResponse(CachedCallNotFoundException("Not implemented"))
 
     replyTo ! response
 
@@ -135,171 +118,217 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
     stay()
   }
 
-  /**
-    * Returns an error message if one or both of the calls are not found, or None if it does
-    */
-  private def checkCallsExistence(queryA: MetadataQuery,
-                                  queryB: MetadataQuery,
-                                  responseA: MetadataLookupResponse,
-                                  responseB: MetadataLookupResponse): Option[String] = {
-    import cromwell.core.ExecutionIndex._
+  //  /**
+  //    * Returns an error message if one or both of the calls are not found, or None if it does
+  //    */
+  //  private def checkCallsExistence(queryA: MetadataQuery,
+  //                                  queryB: MetadataQuery,
+  //                                  responseA: BuiltMetadataResponse,
+  //                                  responseB: BuiltMetadataResponse): Option[String] = {
+  //    import cromwell.core.ExecutionIndex._
+  //
+  //    def makeTag(query: MetadataQuery) = {
+  //      s"${query.workflowId}:${query.jobKey.get.callFqn}:${query.jobKey.get.index.fromIndex}"
+  //    }
+  //
+  //    def makeNotFoundMessage(queries: NonEmptyList[MetadataQuery]) = {
+  //      val plural = if (queries.tail.nonEmpty) "s" else ""
+  //      s"Cannot find call$plural ${queries.map(makeTag).toList.mkString(", ")}"
+  //    }
+  //
+  //    (responseA.eventList, responseB.eventList) match {
+  //      case (a, b) if a.isEmpty && b.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryA, queryB)))
+  //      case (a, _) if a.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryA)))
+  //      case (_, b) if b.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryB)))
+  //      case _ => None
+  //    }
+  //  }
 
-    def makeTag(query: MetadataQuery) = {
-      s"${query.workflowId}:${query.jobKey.get.callFqn}:${query.jobKey.get.index.fromIndex}"
-    }
+  //  /**
+  //    * Generates the "info" section of callA or callB
+  //    */
+  //  private def makeCallInfo(query: MetadataQuery, eventList: JsObject): MetadataComponent = {
+  //    val callKey = MetadataObject(Map(
+  //      "workflowId" -> MetadataPrimitive(MetadataValue(query.workflowId.toString)),
+  //      "callFqn" -> MetadataPrimitive(MetadataValue(query.jobKey.get.callFqn)),
+  //      "jobIndex" -> MetadataPrimitive(MetadataValue(query.jobKey.get.index.getOrElse(-1)))
+  //    ))
+  //
+  //    val allowResultReuse = attributeToComponent(eventList, { _ == CallCachingKeys.AllowReuseMetadataKey }, { _ => "allowResultReuse" })
+  //    val executionStatus = attributeToComponent(eventList, { _ == CallMetadataKeys.ExecutionStatus })
+  //
+  //    List(callKey, allowResultReuse, executionStatus) combineAll
+  //  }
+  //
+  //  /**
+  //    * Collects events from the list for which the keys verify the keyFilter predicate
+  //    * and apply keyModifier to the event's key
+  //    */
+  //  private def collectEvents(events: Seq[MetadataEvent],
+  //                            keyFilter: (String  => Boolean),
+  //                            keyModifier: (String => String)) = events collect {
+  //    case event @ MetadataEvent(metadataKey @ MetadataKey(_, _, key), _, _) if keyFilter(key) =>
+  //      event.copy(key = metadataKey.copy(key = keyModifier(key)))
+  //  }
 
-    def makeNotFoundMessage(queries: NonEmptyList[MetadataQuery]) = {
-      val plural = if (queries.tail.nonEmpty) "s" else ""
-      s"Cannot find call$plural ${queries.map(makeTag).toList.mkString(", ")}"
-    }
+  //  /**
+  //    * Given a list of events, a keyFilter and a keyModifier, returns the associated MetadataComponent.
+  //    * Ensures that events are properly aggregated together (CRDTs and latest timestamp rule)
+  //    */
+  //  private def attributeToComponent(events: Seq[MetadataEvent], keyFilter: (String  => Boolean), keyModifier: (String => String) = identity[String]) = {
+  //    MetadataComponent(collectEvents(events, keyFilter, keyModifier))
+  //  }
 
-    (responseA.eventList, responseB.eventList) match {
-      case (a, b) if a.isEmpty && b.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryA, queryB)))
-      case (a, _) if a.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryA)))
-      case (_, b) if b.isEmpty => Option(makeNotFoundMessage(NonEmptyList.of(queryB)))
-      case _ => None
-    }
+  //  /**
+  //    * Makes a diff object out of a key and a pair of values.
+  //    * Values are Option[Option[MetadataValue]] for the following reason:
+  //    *
+  //    * The outer option represents whether or not this key had a corresponding hash metadata entry for the given call
+  //    * If the above is true, the inner value is the metadata value for this entry, which is nullable, hence an Option.
+  //    * The first outer option will determine whether the resulting json value will be null (no hash entry for this key),
+  //    * or the actual value.
+  //    * If the metadata value (inner option) happens to be None, it's an error, as we don't expect to publish null hash values.
+  //    * In that case we replace it with the placeholderMissingHashValue.
+  //    */
+  //  private def makeHashDiffObject(key: String, valueA: Option[Option[MetadataValue]], valueB: Option[Option[MetadataValue]]) = {
+  //    def makeFinalValue(value: Option[Option[MetadataValue]]) = value match {
+  //      case Some(Some(metadataValue)) => MetadataPrimitive(metadataValue)
+  //      case Some(None) => PlaceholderMissingHashValue
+  //      case None => MetadataNullComponent
+  //    }
+  //
+  //    MetadataObject(
+  //      "hashKey" -> MetadataPrimitive(MetadataValue(key.trim, MetadataString)),
+  //      "callA" -> makeFinalValue(valueA),
+  //      "callB" -> makeFinalValue(valueB)
+  //    )
+  //  }
+
+}
+
+
+object CallCacheDiffActor {
+  //  private val PlaceholderMissingHashValue = MetadataPrimitive(MetadataValue("Error: there is a hash entry for this key but the value is null !"))
+
+  final case class CachedCallNotFoundException(message: String) extends Exception {
+    override def getMessage = message
   }
 
-  /**
-    * Generates the "info" section of callA or callB
-    */
-  private def makeCallInfo(query: MetadataQuery, eventList: Seq[MetadataEvent]): MetadataComponent = {
-    val callKey = MetadataObject(Map(
-      "workflowId" -> MetadataPrimitive(MetadataValue(query.workflowId.toString)),
-      "callFqn" -> MetadataPrimitive(MetadataValue(query.jobKey.get.callFqn)),
-      "jobIndex" -> MetadataPrimitive(MetadataValue(query.jobKey.get.index.getOrElse(-1)))
-    ))
+  // Exceptions when calls exist but have no hashes in their metadata, indicating they were run pre-28
+  //  private val HashesForCallAAndBNotFoundException = new Exception("callA and callB have not finished yet, or were run on a previous version of Cromwell on which this endpoint was not supported.")
+  //  private val HashesForCallANotFoundException = new Exception("callA has not finished yet, or was run on a previous version of Cromwell on which this endpoint was not supported.")
+  //  private val HashesForCallBNotFoundException = new Exception("callB has not finished yet, or was run on a previous version of Cromwell on which this endpoint was not supported.")
 
-    val allowResultReuse = attributeToComponent(eventList, { _ == CallCachingKeys.AllowReuseMetadataKey }, { _ => "allowResultReuse" })
-    val executionStatus = attributeToComponent(eventList, { _ == CallMetadataKeys.ExecutionStatus })
+  sealed trait CallCacheDiffActorState
+  case object Idle extends CallCacheDiffActorState
+  case object WaitingForMetadata extends CallCacheDiffActorState
 
-    List(callKey, allowResultReuse, executionStatus) combineAll
-  }
+  sealed trait CallCacheDiffActorData
+  case object CallCacheDiffNoData extends CallCacheDiffActorData
+  case class CallCacheDiffWithRequest(queryA: MetadataQuery,
+                                      queryB: MetadataQuery,
+                                      responseA: Option[WorkflowMetadataJson],
+                                      responseB: Option[WorkflowMetadataJson],
+                                      replyTo: ActorRef
+                                     ) extends CallCacheDiffActorData
 
-  /**
-    * Collects events from the list for which the keys verify the keyFilter predicate
-    * and apply keyModifier to the event's key
-    */
-  private def collectEvents(events: Seq[MetadataEvent],
-                            keyFilter: (String  => Boolean),
-                            keyModifier: (String => String)) = events collect {
-    case event @ MetadataEvent(metadataKey @ MetadataKey(_, _, key), _, _) if keyFilter(key) =>
-      event.copy(key = metadataKey.copy(key = keyModifier(key)))
-  }
+  sealed abstract class CallCacheDiffActorResponse
+  case class BuiltCallCacheDiffResponse(response: JsObject) extends CallCacheDiffActorResponse
+  case class FailedCallCacheDiffResponse(reason: Throwable) extends CallCacheDiffActorResponse
 
-  /**
-    * Given a list of events, a keyFilter and a keyModifier, returns the associated MetadataComponent.
-    * Ensures that events are properly aggregated together (CRDTs and latest timestamp rule)
-    */
-  private def attributeToComponent(events: Seq[MetadataEvent], keyFilter: (String  => Boolean), keyModifier: (String => String) = identity[String]) = {
-    MetadataComponent(collectEvents(events, keyFilter, keyModifier))
-  }
 
-  /**
-    * Makes a diff object out of a key and a pair of values.
-    * Values are Option[Option[MetadataValue]] for the following reason:
-    *
-    * The outer option represents whether or not this key had a corresponding hash metadata entry for the given call
-    * If the above is true, the inner value is the metadata value for this entry, which is nullable, hence an Option.
-    * The first outer option will determine whether the resulting json value will be null (no hash entry for this key),
-    * or the actual value.
-    * If the metadata value (inner option) happens to be None, it's an error, as we don't expect to publish null hash values.
-    * In that case we replace it with the placeholderMissingHashValue.
-    */
-  private def makeHashDiffObject(key: String, valueA: Option[Option[MetadataValue]], valueB: Option[Option[MetadataValue]]) = {
-    def makeFinalValue(value: Option[Option[MetadataValue]]) = value match {
-      case Some(Some(metadataValue)) => MetadataPrimitive(metadataValue)
-      case Some(None) => PlaceholderMissingHashValue
-      case None => MetadataNullComponent
-    }
-
-    MetadataObject(
-      "hashKey" -> MetadataPrimitive(MetadataValue(key.trim, MetadataString)),
-      "callA" -> makeFinalValue(valueA),
-      "callB" -> makeFinalValue(valueB)
-    )
-  }
-
-  /**
-    * Creates the hash differential between 2 list of events
-    */
-  private def diffHashes(eventsA: Seq[MetadataEvent], eventsB: Seq[MetadataEvent]): Try[MetadataComponent] = {
-    val hashesKey = CallCachingKeys.HashesKey + MetadataKey.KeySeparator
-    // Collect hashes events and map their key to only keep the meaningful part of the key
-    // Then map the result to get a Map of hashKey -> Option[MetadataValue]. This will allow for fast lookup when
-    // comparing the 2 hash sets.
-    // Note that it's an Option[MetadataValue] because metadata values can be null, although for this particular
-    // case we don't expect it to be (we should never publish a hash metadata event with a null value)
-    // If that happens we will place a placeholder value in place of the hash to signify of the unexpected absence of it
-    def collectHashes(events: Seq[MetadataEvent]) = {
-      collectEvents(events, { _.startsWith(hashesKey) }, { _.stripPrefix(hashesKey) })  map {
-        case MetadataEvent(MetadataKey(_, _, keyA), valueA, _) => keyA -> valueA
-      } toMap
-    }
-
-    val hashesA: Map[String, Option[MetadataValue]] = collectHashes(eventsA)
-    val hashesB: Map[String, Option[MetadataValue]] = collectHashes(eventsB)
-
-    (hashesA.isEmpty, hashesB.isEmpty) match {
-      case (true, true) => Failure(HashesForCallAAndBNotFoundException)
-      case (true, false) => Failure(HashesForCallANotFoundException)
-      case (false, true) => Failure(HashesForCallBNotFoundException)
-      case (false, false) => Success(diffHashEvents(hashesA, hashesB))
-    }
-
-  }
-
-  private def diffHashEvents(hashesA: Map[String, Option[MetadataValue]], hashesB: Map[String, Option[MetadataValue]]) = {
-    val hashesUniqueToB: Map[String, Option[MetadataValue]] = hashesB.filterNot({ case (k, _) => hashesA.keySet.contains(k) })
-
-    val hashDiff: List[MetadataComponent] = {
-      // Start with all hashes in A
-      hashesA
-        // Try to find the corresponding pair in B.
-        // We end up with a 
-        // List[(Option[String, Option[MetadataValue], Option[String, Option[MetadataValue])]
-        //                ^               ^                     ^               ^
-        //             hashKey        hashValue              hashKey         hashValue
-        //               for             for                   for              for
-        //                A               A                     B                B
-        //      |____________________________________| |___________________________________|
-        //                  hashPair for A                        hashPair for B
-        // 
-        // HashPairs are Some or None depending on whether or not they have a metadata entry for the corresponding hashKey
-        // At this stage we only have Some(hashPair) for A, and either Some(hashPair) or None for B depending on if we found it in hashesB
-        .map({
-        hashPairA => Option(hashPairA) -> hashesB.find(_._1 == hashPairA._1)
-      })
-        // Add the missing hashes that are in B but not in A. The left hashPair is therefore None
-        .++(hashesUniqueToB.map(None -> Option(_)))
-        .collect({
-          // Both have a value but they're different. We can assume the keys are the same (if we did our job right until here)
-          case (Some((keyA, valueA)), Some((_, valueB))) if valueA != valueB =>
-            makeHashDiffObject(keyA, Option(valueA), Option(valueB))
-          // Key is in A but not in B
-          case (Some((keyA, valueA)), None) =>
-            makeHashDiffObject(keyA, Option(valueA), None)
-          // Key is in B but not in A
-          case (None, Some((keyB, valueB))) =>
-            makeHashDiffObject(keyB, None, Option(valueB))
-        })
-        .toList
-    }
-
-    MetadataList(hashDiff)
-  }
+  def props(serviceRegistryActor: ActorRef) = Props(new CallCacheDiffActor(serviceRegistryActor)).withDispatcher(EngineDispatcher)
 
   /**
     * Create a Metadata query from a CallCacheDiffQueryCall
     */
-  private def makeMetadataQuery(call: CallCacheDiffQueryCall) = MetadataQuery(
-    call.workflowId,
+  def makeMetadataQuery(call: CallCacheDiffQueryCall) = MetadataQuery(
+    workflowId = call.workflowId,
     // jobAttempt None will return keys for all attempts
-    Option(MetadataQueryJobKey(call.callFqn, call.jobIndex, None)),
-    None,
-    Option(NonEmptyList.of("callCaching", "executionStatus")),
-    None,
+    jobKey = Option(MetadataQueryJobKey(call.callFqn, call.jobIndex, None)),
+    key = None,
+    includeKeysOption = Option(NonEmptyList.of("callCaching", "executionStatus")),
+    excludeKeysOption = Option(NonEmptyList.of("callCaching:hitFailures")),
     expandSubWorkflows = false
   )
+
+  // These simple case classes are just to help apply a little type safety to input and output types:
+  final case class WorkflowMetadataJson(value: JsObject) extends AnyVal
+  final case class CallCachingMetadataJson(value: JsObject) extends AnyVal
+
+  /*
+   * Takes in the JsObject returned from a metadata query and filters out only the appropriate call's callCaching section
+   */
+  def extractCallCachingMetadata(query: MetadataQuery, response: WorkflowMetadataJson): ErrorOr[CallCachingMetadataJson] = {
+
+    for {
+      // Sanity Checks:
+      _ <- response.value.checkFieldValue("id", s""""${query.workflowId}"""")
+      jobKey <- query.jobKey.toErrorOr("Call is required in call cache diff query")
+
+      // Unpack the JSON:
+      allCalls <- response.value.fieldAsObject("calls")
+      callShards <- allCalls.fieldAsArray(jobKey.callFqn)
+      onlyShardElement <- callShards.exactlyOneValueAsObject
+      _ <- onlyShardElement.checkFieldValue("shardIndex", jobKey.index.getOrElse(-1).toString)
+      callCaching <- onlyShardElement.fieldAsObject(CallMetadataKeys.CallCaching)
+    } yield CallCachingMetadataJson(callCaching)
+  }
+
+  def extractHashes(callCachingMetadataJson: CallCachingMetadataJson): ErrorOr[Map[String, String]] = {
+    def processField(keyPrefix: String)(fieldValue: (String, JsValue)): ErrorOr[Map[String, String]] = fieldValue match {
+      case (key, hashString: JsString) => Map(keyPrefix + key -> hashString.value).validNel
+      case (key, subObject: JsObject) => extractHashEntries(key + ":")(subObject)
+      case other => s"Cannot extract hashes. Expected JsString or JsObject but got $other".invalidNel
+    }
+
+    def extractHashEntries(keyPrefix: String)(jsObject: JsObject): ErrorOr[Map[String, String]] = {
+      val traversed = jsObject.fields.toList.traverse(processField(keyPrefix))
+      traversed.map(_.flatten.toMap)
+    }
+
+    callCachingMetadataJson.value.fieldAsObject("hashes") flatMap extractHashEntries("")
+  }
+
+  def diffHashEvents(hashesA: Map[String, String], hashesB: Map[String, String]): Map[String, (Option[String], Option[String])] = {
+
+    val hashesInANotMatchedInB: Map[String, (Option[String], Option[String])] = hashesA collect {
+      case (key, value) if hashesB.get(key) != Option(value) => key -> (Option(value), hashesB.get(key))
+    }
+
+    val hashesUniqueToB: Map[String, String] = hashesB.filterNot({ case (k, _) => hashesA.keySet.contains(k) })
+
+    hashesInANotMatchedInB ++ hashesUniqueToB.map {
+      case (key, value) => key -> (None, Option(value))
+    }
+  }
+
+  implicit class EnhancedJsObject(val jsObject: JsObject) extends AnyVal {
+    def getField(field: String): ErrorOr[JsValue] = jsObject.fields.get(field).toErrorOr("No value provided")
+    def fieldAsObject(field: String): ErrorOr[JsObject] = jsObject.getField(field) flatMap { _.mapToJsObject }
+    def fieldAsArray(field: String): ErrorOr[JsArray] = jsObject.getField(field) flatMap { _.mapToJsArray }
+    def checkFieldValue(field: String, expectation: String): ErrorOr[Unit] = jsObject.getField(field) flatMap {
+      case v: JsValue if v.toString == expectation => ().validNel
+      case other => s"Unexpected metadata field '$field'. Expected '$expectation' but got ${other.toString}".invalidNel
+    }
+  }
+
+  implicit class EnhancedJsArray(val jsArray: JsArray) extends AnyVal {
+    def exactlyOneValueAsObject: ErrorOr[JsObject] = if (jsArray.elements.size == 1) {
+      jsArray.elements.head.mapToJsObject
+    } else {
+      s"Expected exactly 1 array element but got ${}".invalidNel
+    }
+  }
+
+  implicit class EnhancedJsValue(val jsValue: JsValue) extends AnyVal {
+    def mapToJsObject: ErrorOr[JsObject] = jsValue match {
+      case obj: JsObject => obj.validNel
+      case other => s"Invalid value type. Expected JsObject but got ${other.getClass.getSimpleName}: ${other.prettyPrint}".invalidNel
+    }
+    def mapToJsArray: ErrorOr[JsArray] = jsValue match {
+      case arr: JsArray => arr.validNel
+      case other => s"Invalid value type. Expected JsArray but got ${other.getClass.getSimpleName}: ${other.prettyPrint}".invalidNel
+    }
+  }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -12,9 +12,9 @@ import common.validation.Validation._
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallCacheDiffActorData, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
-import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataServiceKeyLookupFailed}
+import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
 import spray.json.{JsArray, JsBoolean, JsObject, JsString, JsValue}
 
 class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[CallCacheDiffActorState, CallCacheDiffActorData] {
@@ -44,7 +44,7 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
     // Response B
     case Event(BuiltMetadataResponse(GetMetadataAction(originalQuery), responseJson), CallCacheDiffWithRequest(queryA, queryB, Some(responseA), None, replyTo)) if queryB == originalQuery =>
       buildDiffAndRespond(queryA, queryB, responseA, WorkflowMetadataJson(responseJson), replyTo)
-    case Event(MetadataServiceKeyLookupFailed(_, failure), data: CallCacheDiffWithRequest) =>
+    case Event(FailedMetadataResponse(_, failure), data: CallCacheDiffWithRequest) =>
       data.replyTo ! FailedCallCacheDiffResponse(failure)
       context stop self
       stay()

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -90,7 +90,6 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[Call
 
 
 object CallCacheDiffActor {
-  //  private val PlaceholderMissingHashValue = MetadataPrimitive(MetadataValue("Error: there is a hash entry for this key but the value is null !"))
 
   final case class CachedCallNotFoundException(message: String) extends Exception {
     override def getMessage = message
@@ -162,7 +161,7 @@ object CallCacheDiffActor {
     def processField(keyPrefix: String)(fieldValue: (String, JsValue)): ErrorOr[Map[String, String]] = fieldValue match {
       case (key, hashString: JsString) => Map(keyPrefix + key -> hashString.value).validNel
       case (key, subObject: JsObject) => extractHashEntries(key + ":", subObject)
-      case other => s"Cannot extract hashes. Expected JsString or JsObject but got $other".invalidNel
+      case (key, otherValue) => s"Cannot extract hashes for $key. Expected JsString or JsObject but got ${otherValue.getClass.getSimpleName} $otherValue".invalidNel
     }
 
     def extractHashEntries(keyPrefix: String, jsObject: JsObject): ErrorOr[Map[String, String]] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
@@ -23,6 +23,5 @@ object CallCacheDiffActorJsonFormatting extends SprayJsonSupport with DefaultJso
       throw new NotImplementedException("Programmer Error: No reader for HashDifferentials written. It was not expected to be required")
   }
 
-  //jsonFormat3(HashDifference)
   implicit val successfulResponseJsonFormatter = jsonFormat3(SuccessfulCallCacheDiffResponse)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
@@ -1,0 +1,12 @@
+package cromwell.engine.workflow.lifecycle.execution.callcaching
+
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallDetails, HashDifference, SuccessfulCallCacheDiffResponse}
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json._
+
+object CallCacheDiffActorJsonFormatting extends SprayJsonSupport with DefaultJsonProtocol {
+
+  implicit val callDetailsJsonFormatter = jsonFormat5(CallDetails)
+  implicit val hashDifferenceJsonFormatter = jsonFormat3(HashDifference)
+  implicit val successfulResponseJsonFormatter = jsonFormat3(SuccessfulCallCacheDiffResponse)
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorJsonFormatting.scala
@@ -2,11 +2,27 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CallDetails, HashDifference, SuccessfulCallCacheDiffResponse}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import org.apache.commons.lang3.NotImplementedException
 import spray.json._
 
 object CallCacheDiffActorJsonFormatting extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val callDetailsJsonFormatter = jsonFormat5(CallDetails)
-  implicit val hashDifferenceJsonFormatter = jsonFormat3(HashDifference)
+
+  // Note: This json format is written out longform to get the non-standard Option behavior (the default omits 'None' fields altogether)
+  implicit val hashDifferenceJsonFormatter = new RootJsonFormat[HashDifference] {
+    override def write(hashDifference: HashDifference): JsValue = {
+      def fromOption(opt: Option[String]) = opt.map(JsString.apply).getOrElse(JsNull)
+      JsObject(Map(
+        "hashKey" -> JsString(hashDifference.hashKey),
+        "callA" -> fromOption(hashDifference.callA),
+        "callB" -> fromOption(hashDifference.callB)
+      ))
+    }
+    override def read(json: JsValue): HashDifference =
+      throw new NotImplementedException("Programmer Error: No reader for HashDifferentials written. It was not expected to be required")
+  }
+
+  //jsonFormat3(HashDifference)
   implicit val successfulResponseJsonFormatter = jsonFormat3(SuccessfulCallCacheDiffResponse)
 }

--- a/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
@@ -1,11 +1,11 @@
 package cromwell.webservice
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import common.collections.EnhancedCollections._
 import cromwell.core._
-import cromwell.core.labels.Labels
+import cromwell.core.labels.{Label, Labels}
 import cromwell.services.metadata.MetadataEvent
 import cromwell.services.metadata.MetadataService._
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
 import cromwell.webservice.LabelsManagerActor._
 import spray.json.{DefaultJsonProtocol, JsObject, JsString}
 
@@ -23,13 +23,6 @@ object LabelsManagerActor {
   final case class LabelsAddition(data: LabelsData) extends LabelsAction
 
   sealed trait LabelsResponse extends LabelsMessage
-
-  def processLabelsResponse(workflowId: WorkflowId, labels: Map[String, String]): JsObject = {
-    JsObject(Map(
-      WorkflowMetadataKeys.Id -> JsString(workflowId.toString),
-      WorkflowMetadataKeys.Labels -> JsObject(labels safeMapValues JsString.apply)
-    ))
-  }
 
   sealed abstract class LabelsManagerActorResponse
   final case class BuiltLabelsManagerResponse(response: JsObject) extends LabelsManagerActorResponse
@@ -59,7 +52,7 @@ class LabelsManagerActor(serviceRegistryActor: ActorRef) extends Actor with Acto
         At this point in the actor lifecycle, wfId has already been filled out so the .get is safe
       */
       serviceRegistryActor ! GetLabels(wfId.get)
-    case LabelLookupResponse(id, origLabels) =>
+    case BuiltMetadataResponse(_, jsObject) =>
       /*
         There's some trickery going on here. We've updated the labels in the metadata store but almost certainly when
         the store received the GetLabels request above the summarizer will not have been run so our new values are
@@ -73,8 +66,16 @@ class LabelsManagerActor(serviceRegistryActor: ActorRef) extends Actor with Acto
 
         At this point in the actor lifecycle, newLabels will have been filled in so the .get is safe
       */
-      val updated = origLabels ++ newLabels.get.asMap
-      target ! BuiltLabelsManagerResponse(processLabelsResponse(id, updated))
+
+      def replaceOrAddLabel(originalJson: JsObject, label: Label): JsObject = {
+        val labels = originalJson.fields.get("labels").map(_.asJsObject.fields).getOrElse(Map.empty)
+        val updatedLabels = labels + (label.key -> JsString(label.value))
+
+        JsObject(originalJson.fields + ("labels" -> JsObject(updatedLabels)))
+      }
+
+      val updatedJson = newLabels.get.value.foldLeft(jsObject)(replaceOrAddLabel)
+      target ! BuiltLabelsManagerResponse(updatedJson)
       context stop self
     case f: MetadataServiceFailure =>
       /*

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -10,7 +10,6 @@ import cromwell.engine._
 import cromwell.services.healthmonitor.ProtoHealthMonitorServiceActor.{StatusCheckResponse, SubsystemStatus}
 import cromwell.services.metadata.MetadataService._
 import cromwell.util.JsonFormatting.WomValueJsonFormatter._
-import cromwell.webservice.metadata.MetadataBuilderActor.BuiltMetadataResponse
 import cromwell.webservice.routes.CromwellApiService.BackendResponse
 import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, RootJsonFormat}
 
@@ -22,7 +21,6 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val callOutputResponseProtocol = jsonFormat3(CallOutputResponse)
   implicit val engineStatsProtocol = jsonFormat2(EngineStatsActor.EngineStats)
   implicit val BackendResponseFormat = jsonFormat2(BackendResponse)
-  implicit val BuiltStatusResponseFormat = jsonFormat1(BuiltMetadataResponse)
   implicit val callAttempt = jsonFormat2(CallAttempt)
 
   implicit val workflowOptionsFormatter: JsonFormat[WorkflowOptions] = new JsonFormat[WorkflowOptions]  {

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -168,8 +168,6 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport w
     onComplete(metadataResponse) {
       case Success(r: BuiltMetadataResponse) =>
 
-        println("Got BuiltMetadataResponse!")
-
         Try(Source.fromResource("workflowTimings/workflowTimings.html").mkString) match {
           case Success(wfTimingsContent) =>
             val response = HttpResponse(entity = wfTimingsContent.replace("\"{{REPLACE_THIS_WITH_METADATA}}\"", r.response.toString))

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -170,7 +170,7 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport w
 
         Try(Source.fromResource("workflowTimings/workflowTimings.html").mkString) match {
           case Success(wfTimingsContent) =>
-            val response = HttpResponse(entity = wfTimingsContent.replace("\"{{REPLACE_THIS_WITH_METADATA}}\"", r.response.toString))
+            val response = HttpResponse(entity = wfTimingsContent.replace("\"{{REPLACE_THIS_WITH_METADATA}}\"", r.responseJson.toString))
             complete(response.withEntity(response.entity.withContentType(`text/html(UTF-8)`)))
           case Failure(e) => completeResponse(StatusCodes.InternalServerError, APIResponse.fail(new RuntimeException("Error while loading workflowTimings.html", e)), Seq.empty)
         }

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -3,6 +3,7 @@ package cromwell.webservice.routes
 import java.util.UUID
 
 import akka.actor.{ActorRef, ActorRefFactory}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActorJsonFormatting.successfulResponseJsonFormatter
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model._
@@ -22,7 +23,7 @@ import cromwell.core.{path => _, _}
 import cromwell.engine.backend.BackendConfiguration
 import cromwell.engine.instrumentation.HttpInstrumentation
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{BuiltCallCacheDiffResponse, CachedCallNotFoundException, CallCacheDiffActorResponse, FailedCallCacheDiffResponse}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor.{CachedCallNotFoundException, CallCacheDiffActorResponse, FailedCallCacheDiffResponse, SuccessfulCallCacheDiffResponse}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheDiffActor, CallCacheDiffQueryParameter}
 import cromwell.engine.workflow.workflowstore.SqlWorkflowStore.NotInOnHoldStateException
 import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStoreEngineActor, WorkflowStoreSubmitActor}
@@ -88,7 +89,7 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport w
               case Valid(queryParameter) =>
                 val diffActor = actorRefFactory.actorOf(CallCacheDiffActor.props(serviceRegistryActor), "CallCacheDiffActor-" + UUID.randomUUID())
                 onComplete(diffActor.ask(queryParameter).mapTo[CallCacheDiffActorResponse]) {
-                  case Success(r: BuiltCallCacheDiffResponse) => complete(r.response)
+                  case Success(r: SuccessfulCallCacheDiffResponse) => complete(r)
                   case Success(r: FailedCallCacheDiffResponse) => r.reason.errorRequest(StatusCodes.InternalServerError)
                   case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
                   case Failure(e: CachedCallNotFoundException) => e.errorRequest(StatusCodes.NotFound)

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -167,6 +167,9 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport w
   private def completeTimingRouteResponse(metadataResponse: Future[MetadataBuilderActorResponse]) = {
     onComplete(metadataResponse) {
       case Success(r: BuiltMetadataResponse) =>
+
+        println("Got BuiltMetadataResponse!")
+
         Try(Source.fromResource("workflowTimings/workflowTimings.html").mkString) match {
           case Success(wfTimingsContent) =>
             val response = HttpResponse(entity = wfTimingsContent.replace("\"{{REPLACE_THIS_WITH_METADATA}}\"", r.response.toString))

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -131,7 +131,7 @@ trait MetadataRouteSupport extends HttpInstrumentation {
 
 object MetadataRouteSupport {
   def metadataLookup(possibleWorkflowId: String,
-                     request: WorkflowId => ReadAction,
+                     request: WorkflowId => MetadataReadAction,
                      serviceRegistryActor: ActorRef,
                      metadataBuilderRegulatorActor: ActorRef)
                     (implicit timeout: Timeout,
@@ -145,7 +145,7 @@ object MetadataRouteSupport {
   }
 
   def metadataBuilderActorRequest(possibleWorkflowId: String,
-                                  request: WorkflowId => ReadAction,
+                                  request: WorkflowId => MetadataReadAction,
                                   serviceRegistryActor: ActorRef,
                                   metadataBuilderRegulatorActor: ActorRef)
                                  (implicit timeout: Timeout,

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -149,7 +149,7 @@ object MetadataRouteSupport {
 
   def completeMetadataBuilderResponse(response: Future[MetadataBuilderActorResponse]): Route = {
     onComplete(response) {
-      case Success(r: BuiltMetadataResponse) => complete(r.response)
+      case Success(r: BuiltMetadataResponse) => complete(r.responseJson)
       case Success(r: FailedMetadataResponse) => r.reason.errorRequest(StatusCodes.InternalServerError)
       case Failure(_: AskTimeoutException) if CromwellShutdown.shutdownInProgress() => serviceShuttingDownResponse
       case Failure(e: UnrecognizedWorkflowException) => e.failRequest(StatusCodes.NotFound)

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -161,7 +161,7 @@ object MetadataRouteSupport {
 
   def metadataQueryRequest(parameters: Seq[(String, String)],
                            serviceRegistryActor: ActorRef)(implicit timeout: Timeout): Future[MetadataQueryResponse] = {
-    serviceRegistryActor.ask(WorkflowQuery(parameters)).mapTo[MetadataQueryResponse]
+    serviceRegistryActor.ask(QueryForWorkflowsMatchingParameters(parameters)).mapTo[MetadataQueryResponse]
   }
 
   def completeMetadataQueryResponse(response: Future[MetadataQueryResponse]): Route = {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -5,7 +5,7 @@ import cats.data.NonEmptyList
 import cromwell.core._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
-import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
+import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
 import cromwell.services.metadata._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
@@ -66,8 +66,8 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
 
     actor ! CallCacheDiffQueryParameter(callA, callB)
 
-    mockServiceRegistryActor.expectMsg(GetMetadataQueryAction(queryA))
-    mockServiceRegistryActor.expectMsg(GetMetadataQueryAction(queryB))
+    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryA))
+    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryB))
   }
 
   it should "save response for callA and wait for callB" in {

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -223,63 +223,47 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
     expectTerminated(actor)
   }
 
-//  it should "Respond with an appropriate message if hashes are missing" in {
-//    import scala.concurrent.duration._
-//    import scala.language.postfixOps
-//
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
-//
-//    actor ! MetadataLookupResponse(queryA, eventsA.filterNot(_.key.key.contains("hashes")))
-//
-//    expectMsgPF(1 second) {
-//      case FailedCallCacheDiffResponse(e) =>
-//         e.getMessage shouldBe "callA and callB have not finished yet, or were run on a previous version of Cromwell on which this endpoint was not supported."
-//    }
-//    expectTerminated(actor)
-//  }
-//
-//  it should "Respond with CachedCallNotFoundException if a call is missing" in {
-//    import scala.concurrent.duration._
-//    import scala.language.postfixOps
-//
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
-//
-//    actor ! MetadataLookupResponse(queryA, List.empty)
-//
-//    expectMsgPF(1 second) {
-//      case FailedCallCacheDiffResponse(e) =>
-//        e.getMessage shouldBe "Cannot find call 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1"
-//    }
-//    expectTerminated(actor)
-//  }
-//
-//  it should "Respond with CachedCallNotFoundException if both calls are missing" in {
-//    import scala.concurrent.duration._
-//    import scala.language.postfixOps
-//
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val responseB = MetadataLookupResponse(queryB, List.empty)
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
-//
-//    actor ! MetadataLookupResponse(queryA, List.empty)
-//
-//    expectMsgPF(1 second) {
-//      case FailedCallCacheDiffResponse(e) =>
-//        e.getMessage shouldBe "Cannot find calls 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1, bb85b3ec-e179-4f12-b90f-5191216da598:callFqnB:-1"
-//    }
-//    expectTerminated(actor)
-//  }
+  it should "respond with an appropriate error if calls' hashes are missing" in {
+    testExpectedErrorForModifiedMetadata(
+      metadataFilter = _.key.key.contains("hashes"),
+      error = s"""Failed to calculate diff for call A and call B:
+                 |Failed to extract relevant metadata for call A (971652a6-139c-4ef3-96b5-aeb611a40dbf / callFqnA:1) (reason 1 of 1): No 'hashes' field found
+                 |Failed to extract relevant metadata for call B (bb85b3ec-e179-4f12-b90f-5191216da598 / callFqnB:-1) (reason 1 of 1): No 'hashes' field found""".stripMargin
+    )
+  }
+
+  it should "respond with an appropriate error if both calls are missing" in {
+    testExpectedErrorForModifiedMetadata(
+      metadataFilter = _.key.jobKey.nonEmpty,
+      error = s"""Failed to calculate diff for call A and call B:
+                 |Failed to extract relevant metadata for call A (971652a6-139c-4ef3-96b5-aeb611a40dbf / callFqnA:1) (reason 1 of 1): No 'calls' field found
+                 |Failed to extract relevant metadata for call B (bb85b3ec-e179-4f12-b90f-5191216da598 / callFqnB:-1) (reason 1 of 1): No 'calls' field found""".stripMargin
+    )
+  }
+
+  def testExpectedErrorForModifiedMetadata(metadataFilter: MetadataEvent => Boolean, error: String) = {
+    import scala.concurrent.duration._
+    import scala.language.postfixOps
+
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+
+    def getModifiedResponse(workflowId: WorkflowId, query: MetadataQuery, events: Seq[MetadataEvent]): BuiltMetadataResponse = {
+      val modifiedEvents = events.filterNot(metadataFilter) // filters out any "call" level metadata
+      val modifiedWorkflowMetadata = MetadataBuilderActor.workflowMetadataResponse(workflowId, modifiedEvents, includeCallsIfEmpty = false, Map.empty)
+      BuiltMetadataResponse(MetadataService.GetMetadataAction(query), modifiedWorkflowMetadata)
+    }
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+
+    actor ! getModifiedResponse(workflowIdA, queryA, eventsA)
+    actor ! getModifiedResponse(workflowIdB, queryB, eventsB)
+
+    expectMsgPF(1 second) {
+      case FailedCallCacheDiffResponse(e) => e.getMessage shouldBe error
+    }
+    expectTerminated(actor)
+  }
+
 }

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -8,7 +8,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQue
 import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata.{MetadataService, _}
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
 import spray.json.JsObject
@@ -200,29 +200,29 @@ class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matcher
     }
     expectTerminated(actor)
   }
-//
-//  it should "fail properly" in {
-//    import scala.concurrent.duration._
-//    import scala.language.postfixOps
-//
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val exception = new Exception("Query lookup failed - but it's ok ! this is a test !")
-//    val responseA = MetadataServiceKeyLookupFailed(queryA, exception)
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-//
-//    actor ! responseA
-//
-//    expectMsgPF(1 second) {
-//      case FailedCallCacheDiffResponse(e: Throwable) =>
-//        e.getMessage shouldBe "Query lookup failed - but it's ok ! this is a test !"
-//    }
-//
-//    expectTerminated(actor)
-//  }
-//
+
+  it should "fail properly" in {
+    import scala.concurrent.duration._
+    import scala.language.postfixOps
+
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+    val exception = new Exception("Query lookup failed - but it's ok ! this is a test !")
+    val responseA = FailedMetadataResponse(GetMetadataAction(queryA), exception)
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+
+    actor ! responseA
+
+    expectMsgPF(1 second) {
+      case FailedCallCacheDiffResponse(e: Throwable) =>
+        e.getMessage shouldBe "Query lookup failed - but it's ok ! this is a test !"
+    }
+
+    expectTerminated(actor)
+  }
+
 //  it should "Respond with an appropriate message if hashes are missing" in {
 //    import scala.concurrent.duration._
 //    import scala.language.postfixOps

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -1,267 +1,267 @@
-package cromwell.engine.workflow.lifecycle.execution.callcaching
-
-import akka.testkit.{ImplicitSender, TestFSMRef, TestProbe}
-import cats.data.NonEmptyList
-import cromwell.core._
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor._
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
-import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
-import cromwell.services.metadata._
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{FlatSpecLike, Matchers}
-
-class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
-
-  behavior of "CallCacheDiffActor"
-
-  val workflowIdA = WorkflowId.fromString("971652a6-139c-4ef3-96b5-aeb611a40dbf")
-  val workflowIdB = WorkflowId.fromString("bb85b3ec-e179-4f12-b90f-5191216da598")
-
-  val callFqnA = "callFqnA"
-  val callFqnB = "callFqnB"
-  
-  val metadataJobKeyA = Option(MetadataJobKey(callFqnA, Option(1), 1))
-  val metadataJobKeyB = Option(MetadataJobKey(callFqnB, None, 1))
-  
-  val callA = CallCacheDiffQueryCall(workflowIdA, callFqnA, Option(1))
-  val callB = CallCacheDiffQueryCall(workflowIdB, callFqnB, None)
-
-  val queryA = MetadataQuery(
-    workflowIdA,
-    Option(MetadataQueryJobKey(callFqnA, Option(1), None)),
-    None,
-    Option(NonEmptyList.of("callCaching", "executionStatus")),
-    None,
-    expandSubWorkflows = false
-  )
-
-  val queryB = MetadataQuery(
-    workflowIdB,
-    Option(MetadataQueryJobKey(callFqnB, None, None)),
-    None,
-    Option(NonEmptyList.of("callCaching", "executionStatus")),
-    None,
-    expandSubWorkflows = false
-  )
-  
-  val eventsA = List(
-      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "executionStatus"), MetadataValue("Done")),
-      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:allowResultReuse"), MetadataValue(true)),
-      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in only in A"), MetadataValue("hello")),
-      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
-      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for A !"))
-  )
-
-  val eventsB = List(
-    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "executionStatus"), MetadataValue("Failed")),
-    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:allowResultReuse"), MetadataValue(false)),
-    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in only in B"), MetadataValue("hello")),
-    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
-    MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for B !"))
-  )
-  
-  it should "send correct queries to MetadataService when receiving a CallCacheDiffRequest" in {
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-
-    actor ! CallCacheDiffQueryParameter(callA, callB)
-
-    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryA))
-    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryB))
-  }
-
-  it should "save response for callA and wait for callB" in {
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-
-    val response = MetadataLookupResponse(queryA, eventsA)
-    actor ! response
-   
-    eventually {
-      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, Some(response), None, self)
-      actor.stateName shouldBe WaitingForMetadata
-    }
-  }
-
-  it should "save response for callB and wait for callA" in {
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-
-    val response = MetadataLookupResponse(queryB, eventsB)
-    actor ! response
-
-    eventually {
-      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, None, Some(response), self)
-      actor.stateName shouldBe WaitingForMetadata
-    }
-  }
-
-  it should "build the response when receiving response for A and already has B" in {
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val responseB = MetadataLookupResponse(queryB, eventsB)
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
-
-    actor ! MetadataLookupResponse(queryA, eventsA)
-
-    expectMsgClass(classOf[CallCacheDiffActorResponse])
-    expectTerminated(actor)
-  }
-
-  it should "build the response when receiving response for B and already has A" in {
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val responseA = MetadataLookupResponse(queryA, eventsA)
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, Option(responseA), None, self))
-
-    actor ! MetadataLookupResponse(queryB, eventsB)
-
-    expectMsgClass(classOf[CallCacheDiffActorResponse])
-    expectTerminated(actor)
-  }
-
-  it should "build a correct response" in {
-    import cromwell.services.metadata.MetadataService.MetadataLookupResponse
-    import spray.json._
-    
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-
-    actor ! MetadataLookupResponse(queryB, eventsB)
-    actor ! MetadataLookupResponse(queryA, eventsA)
-
-    val expectedJson: JsObject =
-      s"""
-         |{  
-         |   "callA":{  
-         |      "executionStatus": "Done",
-         |      "allowResultReuse": true,
-         |      "callFqn": "callFqnA",
-         |      "jobIndex": 1,
-         |      "workflowId": "971652a6-139c-4ef3-96b5-aeb611a40dbf"
-         |   },
-         |   "callB":{  
-         |      "executionStatus": "Failed",
-         |      "allowResultReuse": false,
-         |      "callFqn": "callFqnB",
-         |      "jobIndex": -1,
-         |      "workflowId": "bb85b3ec-e179-4f12-b90f-5191216da598"
-         |   },
-         |   "hashDifferential":[  
-         |      {  
-         |         "hashKey": "hash in only in A",
-         |         "callA":"hello",
-         |         "callB":null
-         |      },
-         |      {  
-         |         "hashKey": "hash in A and B with different value",
-         |         "callA":"I'm the hash for A !",
-         |         "callB":"I'm the hash for B !"
-         |      },
-         |      {  
-         |         "hashKey": "hash in only in B",
-         |         "callA":null,
-         |         "callB":"hello"
-         |      }
-         |   ]
-         |}
-       """.stripMargin.parseJson.asJsObject
-    
-    val expectedResponse = BuiltCallCacheDiffResponse(expectedJson)
-    
-    expectMsg(expectedResponse)
-    expectTerminated(actor)
-  }
-
-  it should "fail properly" in {
-    import scala.concurrent.duration._
-    import scala.language.postfixOps
-
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val exception = new Exception("Query lookup failed - but it's ok ! this is a test !")
-    val responseA = MetadataServiceKeyLookupFailed(queryA, exception)
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-
-    actor ! responseA
-
-    expectMsgPF(1 second) {
-      case FailedCallCacheDiffResponse(e: Throwable) =>
-        e.getMessage shouldBe "Query lookup failed - but it's ok ! this is a test !"
-    }
-    
-    expectTerminated(actor)
-  }
-
-  it should "Respond with an appropriate message if hashes are missing" in {
-    import scala.concurrent.duration._
-    import scala.language.postfixOps
-
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
-
-    actor ! MetadataLookupResponse(queryA, eventsA.filterNot(_.key.key.contains("hashes")))
-
-    expectMsgPF(1 second) {
-      case FailedCallCacheDiffResponse(e) =>
-         e.getMessage shouldBe "callA and callB have not finished yet, or were run on a previous version of Cromwell on which this endpoint was not supported."
-    }
-    expectTerminated(actor)
-  }
-
-  it should "Respond with CachedCallNotFoundException if a call is missing" in {
-    import scala.concurrent.duration._
-    import scala.language.postfixOps
-
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
-
-    actor ! MetadataLookupResponse(queryA, List.empty)
-
-    expectMsgPF(1 second) {
-      case FailedCallCacheDiffResponse(e) =>
-        e.getMessage shouldBe "Cannot find call 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1"
-    }
-    expectTerminated(actor)
-  }
-
-  it should "Respond with CachedCallNotFoundException if both calls are missing" in {
-    import scala.concurrent.duration._
-    import scala.language.postfixOps
-
-    val mockServiceRegistryActor = TestProbe()
-    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-    watch(actor)
-    val responseB = MetadataLookupResponse(queryB, List.empty)
-
-    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
-
-    actor ! MetadataLookupResponse(queryA, List.empty)
-
-    expectMsgPF(1 second) {
-      case FailedCallCacheDiffResponse(e) =>
-        e.getMessage shouldBe "Cannot find calls 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1, bb85b3ec-e179-4f12-b90f-5191216da598:callFqnB:-1"
-    }
-    expectTerminated(actor)
-  }
-}
+//package cromwell.engine.workflow.lifecycle.execution.callcaching
+//
+//import akka.testkit.{ImplicitSender, TestFSMRef, TestProbe}
+//import cats.data.NonEmptyList
+//import cromwell.core._
+//import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor._
+//import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
+//import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
+//import cromwell.services.metadata._
+//import org.scalatest.concurrent.Eventually
+//import org.scalatest.{FlatSpecLike, Matchers}
+//
+//class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
+//
+//  behavior of "CallCacheDiffActor"
+//
+//  val workflowIdA = WorkflowId.fromString("971652a6-139c-4ef3-96b5-aeb611a40dbf")
+//  val workflowIdB = WorkflowId.fromString("bb85b3ec-e179-4f12-b90f-5191216da598")
+//
+//  val callFqnA = "callFqnA"
+//  val callFqnB = "callFqnB"
+//
+//  val metadataJobKeyA = Option(MetadataJobKey(callFqnA, Option(1), 1))
+//  val metadataJobKeyB = Option(MetadataJobKey(callFqnB, None, 1))
+//
+//  val callA = CallCacheDiffQueryCall(workflowIdA, callFqnA, Option(1))
+//  val callB = CallCacheDiffQueryCall(workflowIdB, callFqnB, None)
+//
+//  val queryA = MetadataQuery(
+//    workflowIdA,
+//    Option(MetadataQueryJobKey(callFqnA, Option(1), None)),
+//    None,
+//    Option(NonEmptyList.of("callCaching", "executionStatus")),
+//    None,
+//    expandSubWorkflows = false
+//  )
+//
+//  val queryB = MetadataQuery(
+//    workflowIdB,
+//    Option(MetadataQueryJobKey(callFqnB, None, None)),
+//    None,
+//    Option(NonEmptyList.of("callCaching", "executionStatus")),
+//    None,
+//    expandSubWorkflows = false
+//  )
+//
+//  val eventsA = List(
+//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "executionStatus"), MetadataValue("Done")),
+//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:allowResultReuse"), MetadataValue(true)),
+//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in only in A"), MetadataValue("hello")),
+//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
+//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for A !"))
+//  )
+//
+//  val eventsB = List(
+//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "executionStatus"), MetadataValue("Failed")),
+//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:allowResultReuse"), MetadataValue(false)),
+//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in only in B"), MetadataValue("hello")),
+//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
+//    MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for B !"))
+//  )
+//
+//  it should "send correct queries to MetadataService when receiving a CallCacheDiffRequest" in {
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//
+//    actor ! CallCacheDiffQueryParameter(callA, callB)
+//
+//    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryA))
+//    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryB))
+//  }
+//
+//  it should "save response for callA and wait for callB" in {
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+//
+//    val response = MetadataLookupResponse(queryA, eventsA)
+//    actor ! response
+//
+//    eventually {
+//      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, Some(response), None, self)
+//      actor.stateName shouldBe WaitingForMetadata
+//    }
+//  }
+//
+//  it should "save response for callB and wait for callA" in {
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+//
+//    val response = MetadataLookupResponse(queryB, eventsB)
+//    actor ! response
+//
+//    eventually {
+//      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, None, Some(response), self)
+//      actor.stateName shouldBe WaitingForMetadata
+//    }
+//  }
+//
+//  it should "build the response when receiving response for A and already has B" in {
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val responseB = MetadataLookupResponse(queryB, eventsB)
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//
+//    actor ! MetadataLookupResponse(queryA, eventsA)
+//
+//    expectMsgClass(classOf[CallCacheDiffActorResponse])
+//    expectTerminated(actor)
+//  }
+//
+//  it should "build the response when receiving response for B and already has A" in {
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val responseA = MetadataLookupResponse(queryA, eventsA)
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, Option(responseA), None, self))
+//
+//    actor ! MetadataLookupResponse(queryB, eventsB)
+//
+//    expectMsgClass(classOf[CallCacheDiffActorResponse])
+//    expectTerminated(actor)
+//  }
+//
+//  it should "build a correct response" in {
+//    import cromwell.services.metadata.MetadataService.MetadataLookupResponse
+//    import spray.json._
+//
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+//
+//    actor ! MetadataLookupResponse(queryB, eventsB)
+//    actor ! MetadataLookupResponse(queryA, eventsA)
+//
+//    val expectedJson: JsObject =
+//      s"""
+//         |{
+//         |   "callA":{
+//         |      "executionStatus": "Done",
+//         |      "allowResultReuse": true,
+//         |      "callFqn": "callFqnA",
+//         |      "jobIndex": 1,
+//         |      "workflowId": "971652a6-139c-4ef3-96b5-aeb611a40dbf"
+//         |   },
+//         |   "callB":{
+//         |      "executionStatus": "Failed",
+//         |      "allowResultReuse": false,
+//         |      "callFqn": "callFqnB",
+//         |      "jobIndex": -1,
+//         |      "workflowId": "bb85b3ec-e179-4f12-b90f-5191216da598"
+//         |   },
+//         |   "hashDifferential":[
+//         |      {
+//         |         "hashKey": "hash in only in A",
+//         |         "callA":"hello",
+//         |         "callB":null
+//         |      },
+//         |      {
+//         |         "hashKey": "hash in A and B with different value",
+//         |         "callA":"I'm the hash for A !",
+//         |         "callB":"I'm the hash for B !"
+//         |      },
+//         |      {
+//         |         "hashKey": "hash in only in B",
+//         |         "callA":null,
+//         |         "callB":"hello"
+//         |      }
+//         |   ]
+//         |}
+//       """.stripMargin.parseJson.asJsObject
+//
+//    val expectedResponse = BuiltCallCacheDiffResponse(expectedJson)
+//
+//    expectMsg(expectedResponse)
+//    expectTerminated(actor)
+//  }
+//
+//  it should "fail properly" in {
+//    import scala.concurrent.duration._
+//    import scala.language.postfixOps
+//
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val exception = new Exception("Query lookup failed - but it's ok ! this is a test !")
+//    val responseA = MetadataServiceKeyLookupFailed(queryA, exception)
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+//
+//    actor ! responseA
+//
+//    expectMsgPF(1 second) {
+//      case FailedCallCacheDiffResponse(e: Throwable) =>
+//        e.getMessage shouldBe "Query lookup failed - but it's ok ! this is a test !"
+//    }
+//
+//    expectTerminated(actor)
+//  }
+//
+//  it should "Respond with an appropriate message if hashes are missing" in {
+//    import scala.concurrent.duration._
+//    import scala.language.postfixOps
+//
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//
+//    actor ! MetadataLookupResponse(queryA, eventsA.filterNot(_.key.key.contains("hashes")))
+//
+//    expectMsgPF(1 second) {
+//      case FailedCallCacheDiffResponse(e) =>
+//         e.getMessage shouldBe "callA and callB have not finished yet, or were run on a previous version of Cromwell on which this endpoint was not supported."
+//    }
+//    expectTerminated(actor)
+//  }
+//
+//  it should "Respond with CachedCallNotFoundException if a call is missing" in {
+//    import scala.concurrent.duration._
+//    import scala.language.postfixOps
+//
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//
+//    actor ! MetadataLookupResponse(queryA, List.empty)
+//
+//    expectMsgPF(1 second) {
+//      case FailedCallCacheDiffResponse(e) =>
+//        e.getMessage shouldBe "Cannot find call 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1"
+//    }
+//    expectTerminated(actor)
+//  }
+//
+//  it should "Respond with CachedCallNotFoundException if both calls are missing" in {
+//    import scala.concurrent.duration._
+//    import scala.language.postfixOps
+//
+//    val mockServiceRegistryActor = TestProbe()
+//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+//    watch(actor)
+//    val responseB = MetadataLookupResponse(queryB, List.empty)
+//
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//
+//    actor ! MetadataLookupResponse(queryA, List.empty)
+//
+//    expectMsgPF(1 second) {
+//      case FailedCallCacheDiffResponse(e) =>
+//        e.getMessage shouldBe "Cannot find calls 971652a6-139c-4ef3-96b5-aeb611a40dbf:callFqnA:1, bb85b3ec-e179-4f12-b90f-5191216da598:callFqnB:-1"
+//    }
+//    expectTerminated(actor)
+//  }
+//}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -1,187 +1,205 @@
-//package cromwell.engine.workflow.lifecycle.execution.callcaching
-//
-//import akka.testkit.{ImplicitSender, TestFSMRef, TestProbe}
-//import cats.data.NonEmptyList
-//import cromwell.core._
-//import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor._
-//import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
-//import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse, MetadataServiceKeyLookupFailed}
-//import cromwell.services.metadata._
-//import org.scalatest.concurrent.Eventually
-//import org.scalatest.{FlatSpecLike, Matchers}
-//
-//class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
-//
-//  behavior of "CallCacheDiffActor"
-//
-//  val workflowIdA = WorkflowId.fromString("971652a6-139c-4ef3-96b5-aeb611a40dbf")
-//  val workflowIdB = WorkflowId.fromString("bb85b3ec-e179-4f12-b90f-5191216da598")
-//
-//  val callFqnA = "callFqnA"
-//  val callFqnB = "callFqnB"
-//
-//  val metadataJobKeyA = Option(MetadataJobKey(callFqnA, Option(1), 1))
-//  val metadataJobKeyB = Option(MetadataJobKey(callFqnB, None, 1))
-//
-//  val callA = CallCacheDiffQueryCall(workflowIdA, callFqnA, Option(1))
-//  val callB = CallCacheDiffQueryCall(workflowIdB, callFqnB, None)
-//
-//  val queryA = MetadataQuery(
-//    workflowIdA,
-//    Option(MetadataQueryJobKey(callFqnA, Option(1), None)),
-//    None,
-//    Option(NonEmptyList.of("callCaching", "executionStatus")),
-//    None,
-//    expandSubWorkflows = false
-//  )
-//
-//  val queryB = MetadataQuery(
-//    workflowIdB,
-//    Option(MetadataQueryJobKey(callFqnB, None, None)),
-//    None,
-//    Option(NonEmptyList.of("callCaching", "executionStatus")),
-//    None,
-//    expandSubWorkflows = false
-//  )
-//
-//  val eventsA = List(
-//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "executionStatus"), MetadataValue("Done")),
-//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:allowResultReuse"), MetadataValue(true)),
-//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in only in A"), MetadataValue("hello")),
-//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
-//      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for A !"))
-//  )
-//
-//  val eventsB = List(
-//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "executionStatus"), MetadataValue("Failed")),
-//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:allowResultReuse"), MetadataValue(false)),
-//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in only in B"), MetadataValue("hello")),
-//    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes: hash in A and B with same value"), MetadataValue(1)),
-//    MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes: hash in A and B with different value"), MetadataValue("I'm the hash for B !"))
-//  )
-//
-//  it should "send correct queries to MetadataService when receiving a CallCacheDiffRequest" in {
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//
-//    actor ! CallCacheDiffQueryParameter(callA, callB)
-//
-//    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryA))
-//    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryB))
-//  }
-//
-//  it should "save response for callA and wait for callB" in {
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-//
-//    val response = MetadataLookupResponse(queryA, eventsA)
-//    actor ! response
-//
-//    eventually {
-//      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, Some(response), None, self)
-//      actor.stateName shouldBe WaitingForMetadata
-//    }
-//  }
-//
-//  it should "save response for callB and wait for callA" in {
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-//
-//    val response = MetadataLookupResponse(queryB, eventsB)
-//    actor ! response
-//
-//    eventually {
-//      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, None, Some(response), self)
-//      actor.stateName shouldBe WaitingForMetadata
-//    }
-//  }
-//
-//  it should "build the response when receiving response for A and already has B" in {
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val responseB = MetadataLookupResponse(queryB, eventsB)
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
-//
-//    actor ! MetadataLookupResponse(queryA, eventsA)
-//
-//    expectMsgClass(classOf[CallCacheDiffActorResponse])
-//    expectTerminated(actor)
-//  }
-//
-//  it should "build the response when receiving response for B and already has A" in {
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    val responseA = MetadataLookupResponse(queryA, eventsA)
-//
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, Option(responseA), None, self))
-//
-//    actor ! MetadataLookupResponse(queryB, eventsB)
-//
-//    expectMsgClass(classOf[CallCacheDiffActorResponse])
-//    expectTerminated(actor)
-//  }
-//
-//  it should "build a correct response" in {
-//    import cromwell.services.metadata.MetadataService.MetadataLookupResponse
-//    import spray.json._
-//
-//    val mockServiceRegistryActor = TestProbe()
-//    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
-//    watch(actor)
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
-//
-//    actor ! MetadataLookupResponse(queryB, eventsB)
-//    actor ! MetadataLookupResponse(queryA, eventsA)
-//
-//    val expectedJson: JsObject =
-//      s"""
-//         |{
-//         |   "callA":{
-//         |      "executionStatus": "Done",
-//         |      "allowResultReuse": true,
-//         |      "callFqn": "callFqnA",
-//         |      "jobIndex": 1,
-//         |      "workflowId": "971652a6-139c-4ef3-96b5-aeb611a40dbf"
-//         |   },
-//         |   "callB":{
-//         |      "executionStatus": "Failed",
-//         |      "allowResultReuse": false,
-//         |      "callFqn": "callFqnB",
-//         |      "jobIndex": -1,
-//         |      "workflowId": "bb85b3ec-e179-4f12-b90f-5191216da598"
-//         |   },
-//         |   "hashDifferential":[
-//         |      {
-//         |         "hashKey": "hash in only in A",
-//         |         "callA":"hello",
-//         |         "callB":null
-//         |      },
-//         |      {
-//         |         "hashKey": "hash in A and B with different value",
-//         |         "callA":"I'm the hash for A !",
-//         |         "callB":"I'm the hash for B !"
-//         |      },
-//         |      {
-//         |         "hashKey": "hash in only in B",
-//         |         "callA":null,
-//         |         "callB":"hello"
-//         |      }
-//         |   ]
-//         |}
-//       """.stripMargin.parseJson.asJsObject
-//
-//    val expectedResponse = BuiltCallCacheDiffResponse(expectedJson)
-//
-//    expectMsg(expectedResponse)
-//    expectTerminated(actor)
-//  }
+package cromwell.engine.workflow.lifecycle.execution.callcaching
+
+import akka.testkit.{ImplicitSender, TestFSMRef, TestProbe}
+import cats.data.NonEmptyList
+import cromwell.core._
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActor._
+import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
+import cromwell.services.metadata.MetadataService.GetMetadataAction
+import cromwell.services.metadata.{MetadataService, _}
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{FlatSpecLike, Matchers}
+import spray.json.JsObject
+
+class CallCacheDiffActorSpec extends TestKitSuite with FlatSpecLike with Matchers with ImplicitSender with Eventually {
+
+  behavior of "CallCacheDiffActor"
+
+  val workflowIdA = WorkflowId.fromString("971652a6-139c-4ef3-96b5-aeb611a40dbf")
+  val workflowIdB = WorkflowId.fromString("bb85b3ec-e179-4f12-b90f-5191216da598")
+
+  val callFqnA = "callFqnA"
+  val callFqnB = "callFqnB"
+
+  val metadataJobKeyA = Option(MetadataJobKey(callFqnA, Option(1), 1))
+  val metadataJobKeyB = Option(MetadataJobKey(callFqnB, None, 1))
+
+  val callA = CallCacheDiffQueryCall(workflowIdA, callFqnA, Option(1))
+  val callB = CallCacheDiffQueryCall(workflowIdB, callFqnB, None)
+
+  val queryA = MetadataQuery(
+    workflowId = workflowIdA,
+    jobKey = Option(MetadataQueryJobKey(callFqnA, Option(1), None)),
+    key = None,
+    includeKeysOption = Option(NonEmptyList.of("callCaching", "executionStatus")),
+    excludeKeysOption = Option(NonEmptyList.of("callCaching:hitFailures")),
+    expandSubWorkflows = false
+  )
+
+  val queryB = MetadataQuery(
+    workflowId = workflowIdB,
+    jobKey = Option(MetadataQueryJobKey(callFqnB, None, None)),
+    key = None,
+    includeKeysOption = Option(NonEmptyList.of("callCaching", "executionStatus")),
+    excludeKeysOption = Option(NonEmptyList.of("callCaching:hitFailures")),
+    expandSubWorkflows = false
+  )
+
+  val eventsA = List(
+      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "executionStatus"), MetadataValue("Done")),
+      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:allowResultReuse"), MetadataValue(true)),
+      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes:hash in only in A"), MetadataValue("hello from A")),
+      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes:hash in A and B with same value"), MetadataValue("we are thinking the same thought")),
+      MetadataEvent(MetadataKey(workflowIdA, metadataJobKeyA, "callCaching:hashes:hash in A and B with different value"), MetadataValue("I'm the hash for A !"))
+  )
+  val workflowMetadataA: JsObject = MetadataBuilderActor.workflowMetadataResponse(workflowIdA, eventsA, includeCallsIfEmpty = false, Map.empty)
+  val responseForA = BuiltMetadataResponse(MetadataService.GetMetadataAction(queryA), workflowMetadataA)
+
+  val eventsB = List(
+    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "executionStatus"), MetadataValue("Failed")),
+    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:allowResultReuse"), MetadataValue(false)),
+    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes:hash in only in B"), MetadataValue("hello from B")),
+    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes:hash in A and B with same value"), MetadataValue("we are thinking the same thought")),
+    MetadataEvent(MetadataKey(workflowIdB, metadataJobKeyB, "callCaching:hashes:hash in A and B with different value"), MetadataValue("I'm the hash for B !"))
+  )
+  val workflowMetadataB: JsObject = MetadataBuilderActor.workflowMetadataResponse(workflowIdB, eventsB, includeCallsIfEmpty = false, Map.empty)
+  val responseForB = BuiltMetadataResponse(MetadataService.GetMetadataAction(queryB), workflowMetadataB)
+
+  it should "send correct queries to MetadataService when receiving a CallCacheDiffRequest" in {
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+
+    actor ! CallCacheDiffQueryParameter(callA, callB)
+
+    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryA))
+    mockServiceRegistryActor.expectMsg(GetMetadataAction(queryB))
+
+    system.stop(actor)
+  }
+
+  it should "save response for callA and wait for callB" in {
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+
+    actor ! responseForA
+
+    eventually {
+      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, Some(WorkflowMetadataJson(workflowMetadataA)), None, self)
+      actor.stateName shouldBe WaitingForMetadata
+    }
+
+    system.stop(actor)
+  }
+
+  it should "save response for callB and wait for callA" in {
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+
+    actor ! responseForB
+
+    eventually {
+      actor.stateData shouldBe CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self)
+      actor.stateName shouldBe WaitingForMetadata
+    }
+
+    system.stop(actor)
+  }
+
+  it should "build the response when receiving response for A and already has B" in {
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
+
+    actor ! responseForA
+
+    expectMsgClass(classOf[CallCacheDiffActorResponse])
+    expectTerminated(actor)
+  }
+
+  it should "build the response when receiving response for B and already has A" in {
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, Some(WorkflowMetadataJson(workflowMetadataA)), None, self))
+
+    actor ! responseForB
+
+    expectMsgClass(classOf[CallCacheDiffActorResponse])
+    expectTerminated(actor)
+  }
+
+  it should "build a correct response" in {
+    import spray.json._
+    import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffActorJsonFormatting.successfulResponseJsonFormatter
+
+    val mockServiceRegistryActor = TestProbe()
+    val actor = TestFSMRef(new CallCacheDiffActor(mockServiceRegistryActor.ref))
+    watch(actor)
+    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, None, self))
+
+    actor ! responseForB
+    actor ! responseForA
+
+    val expectedJson: JsObject =
+      s"""
+         |{
+         |   "callA":{
+         |      "executionStatus": "Done",
+         |      "allowResultReuse": true,
+         |      "callFqn": "callFqnA",
+         |      "jobIndex": 1,
+         |      "workflowId": "971652a6-139c-4ef3-96b5-aeb611a40dbf"
+         |   },
+         |   "callB":{
+         |      "executionStatus": "Failed",
+         |      "allowResultReuse": false,
+         |      "callFqn": "callFqnB",
+         |      "jobIndex": -1,
+         |      "workflowId": "bb85b3ec-e179-4f12-b90f-5191216da598"
+         |   },
+         |   "hashDifferential":[
+         |      {
+         |         "hashKey": "hash in only in A",
+         |         "callA":"hello from A",
+         |         "callB":null
+         |      },
+         |      {
+         |         "hashKey": "hash in A and B with different value",
+         |         "callA":"I'm the hash for A !",
+         |         "callB":"I'm the hash for B !"
+         |      },
+         |      {
+         |         "hashKey": "hash in only in B",
+         |         "callA":null,
+         |         "callB":"hello from B"
+         |      }
+         |   ]
+         |}
+       """.stripMargin.parseJson.asJsObject
+
+    expectMsgPF() {
+      case r: SuccessfulCallCacheDiffResponse =>
+        withClue(s"""
+             |Expected:
+             |${expectedJson.prettyPrint}
+             |
+             |Actual:
+             |${r.toJson.prettyPrint}""".stripMargin) {
+          r.toJson should be(expectedJson)
+        }
+      case other => fail(s"Expected SuccessfulCallCacheDiffResponse but got $other")
+    }
+    expectTerminated(actor)
+  }
 //
 //  it should "fail properly" in {
 //    import scala.concurrent.duration._
@@ -214,7 +232,7 @@
 //    watch(actor)
 //    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
 //
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
 //
 //    actor ! MetadataLookupResponse(queryA, eventsA.filterNot(_.key.key.contains("hashes")))
 //
@@ -234,7 +252,7 @@
 //    watch(actor)
 //    val responseB = MetadataLookupResponse(queryB, eventsB.filterNot(_.key.key.contains("hashes")))
 //
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
 //
 //    actor ! MetadataLookupResponse(queryA, List.empty)
 //
@@ -254,7 +272,7 @@
 //    watch(actor)
 //    val responseB = MetadataLookupResponse(queryB, List.empty)
 //
-//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Option(responseB), self))
+//    actor.setState(WaitingForMetadata, CallCacheDiffWithRequest(queryA, queryB, None, Some(WorkflowMetadataJson(workflowMetadataB)), self))
 //
 //    actor ! MetadataLookupResponse(queryA, List.empty)
 //
@@ -264,4 +282,4 @@
 //    }
 //    expectTerminated(actor)
 //  }
-//}
+}

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -43,7 +43,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, action)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryReply, events))
     response map { r => r shouldBe a [BuiltMetadataResponse] }
-    response.mapTo[BuiltMetadataResponse] map { b => b.response shouldBe expectedRes.parseJson}
+    response.mapTo[BuiltMetadataResponse] map { b => b.responseJson shouldBe expectedRes.parseJson}
   }
 
   it should "build workflow scope tree from metadata events" in {
@@ -499,7 +499,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
 
     response map { r => r shouldBe a [BuiltMetadataResponse] }
     val bmr = response.mapTo[BuiltMetadataResponse]
-    bmr map { b => b.response shouldBe expandedRes.parseJson}
+    bmr map { b => b.responseJson shouldBe expandedRes.parseJson}
   }
   
   it should "NOT expand sub workflow metadata when NOT asked for" in {
@@ -542,7 +542,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
 
     response map { r => r shouldBe a [BuiltMetadataResponse] }
     val bmr = response.mapTo[BuiltMetadataResponse]
-    bmr map { b => b.response shouldBe nonExpandedRes.parseJson}
+    bmr map { b => b.responseJson shouldBe nonExpandedRes.parseJson}
 
   }
 

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -9,12 +9,13 @@ import akka.util.Timeout
 import cromwell.core._
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
-import cromwell.webservice.metadata.MetadataBuilderActor
-import cromwell.webservice.metadata.MetadataBuilderActor.{BuiltMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, MetadataBuilderActorResponse}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Assertion, AsyncFlatSpecLike, Matchers, Succeeded}
 import org.specs2.mock.Mockito
 import spray.json._
+import cromwell.util.AkkaTestUtil.EnhancedTestProbe
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -33,11 +34,14 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
                              queryReply: MetadataQuery,
                              events: Seq[MetadataEvent],
                              expectedRes: String): Future[Assertion] = {
-    val mockServiceRegistry = TestProbe()
-    val mba = system.actorOf(MetadataBuilderActor.props(mockServiceRegistry.ref))
+    val mockReadMetadataWorkerActor = TestProbe()
+    def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
+
+
+    val mba = system.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker))
     val response = mba.ask(action).mapTo[MetadataBuilderActorResponse]
-    mockServiceRegistry.expectMsg(defaultTimeout, action)
-    mockServiceRegistry.reply(MetadataLookupResponse(queryReply, events))
+    mockReadMetadataWorkerActor.expectMsg(defaultTimeout, action)
+    mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryReply, events))
     response map { r => r shouldBe a [BuiltMetadataResponse] }
     response.mapTo[BuiltMetadataResponse] map { b => b.response shouldBe expectedRes.parseJson}
   }
@@ -96,7 +100,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
       |}""".stripMargin
 
     val mdQuery = MetadataQuery(workflowA, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, workflowAEvents, expectedRes)
   }
 
@@ -350,7 +354,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
       """.stripMargin
 
     val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
 
@@ -371,7 +375,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
       """.stripMargin
 
     val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
 
@@ -391,14 +395,14 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
       """.stripMargin
 
     val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, events, expectedResponse)
   }
 
   it should "render empty Json" in {
     val workflowId = WorkflowId.randomId()
     val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     val expectedEmptyResponse = """{}"""
     assertMetadataResponse(queryAction, mdQuery, List.empty, expectedEmptyResponse)
   }
@@ -428,7 +432,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
       """.stripMargin
 
     val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryAction = GetMetadataQueryAction(mdQuery)
+    val queryAction = GetMetadataAction(mdQuery)
     assertMetadataResponse(queryAction, mdQuery, emptyEvents, expectedEmptyResponse)
 
     val expectedNonEmptyResponse =
@@ -456,20 +460,22 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     )
     
     val mainQuery = MetadataQuery(mainWorkflowId, None, None, None, None, expandSubWorkflows = true)
-    val mainQueryAction = GetMetadataQueryAction(mainQuery)
+    val mainQueryAction = GetMetadataAction(mainQuery)
     
     val subQuery = MetadataQuery(subWorkflowId, None, None, None, None, expandSubWorkflows = true)
-    val subQueryAction = GetMetadataQueryAction(subQuery)
+    val subQueryAction = GetMetadataAction(subQuery)
     
     val parentProbe = TestProbe()
-    val mockServiceRegistry = TestProbe()
 
-    val metadataBuilder = TestActorRef(MetadataBuilderActor.props(mockServiceRegistry.ref), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
+    val mockReadMetadataWorkerActor = TestProbe()
+    def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
+
+    val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
     val response = metadataBuilder.ask(mainQueryAction).mapTo[MetadataBuilderActorResponse]
-    mockServiceRegistry.expectMsg(defaultTimeout, mainQueryAction)
-    mockServiceRegistry.reply(MetadataLookupResponse(mainQuery, mainEvents))
-    mockServiceRegistry.expectMsg(defaultTimeout, subQueryAction)
-    mockServiceRegistry.reply(MetadataLookupResponse(subQuery, subEvents))
+    mockReadMetadataWorkerActor.expectMsg(defaultTimeout, mainQueryAction)
+    mockReadMetadataWorkerActor.reply(MetadataLookupResponse(mainQuery, mainEvents))
+    mockReadMetadataWorkerActor.expectMsg(defaultTimeout, subQueryAction)
+    mockReadMetadataWorkerActor.reply(MetadataLookupResponse(subQuery, subEvents))
     
     val expandedRes =
       s"""
@@ -505,15 +511,17 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     )
 
     val queryNoExpand = MetadataQuery(mainWorkflowId, None, None, None, None, expandSubWorkflows = false)
-    val queryNoExpandAction = GetMetadataQueryAction(queryNoExpand)
+    val queryNoExpandAction = GetMetadataAction(queryNoExpand)
     
     val parentProbe = TestProbe()
-    val mockServiceRegistry = TestProbe()
 
-    val metadataBuilder = TestActorRef(MetadataBuilderActor.props(mockServiceRegistry.ref), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
+    val mockReadMetadataWorkerActor = TestProbe()
+    def readMetadataWorkerMaker= () => mockReadMetadataWorkerActor.props
+
+    val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
     val response = metadataBuilder.ask(queryNoExpandAction).mapTo[MetadataBuilderActorResponse]
-    mockServiceRegistry.expectMsg(defaultTimeout, queryNoExpandAction)
-    mockServiceRegistry.reply(MetadataLookupResponse(queryNoExpand, mainEvents))
+    mockReadMetadataWorkerActor.expectMsg(defaultTimeout, queryNoExpandAction)
+    mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryNoExpand, mainEvents))
 
 
     val nonExpandedRes =

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -19,6 +19,8 @@ import cromwell.services.healthmonitor.ProtoHealthMonitorServiceActor.{GetCurren
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
 import cromwell.services.womtool.WomtoolServiceMessages.{DescribeFailure, DescribeRequest, DescribeSuccess}
 import cromwell.services.womtool.models.WorkflowDescription
 import cromwell.util.SampleWdl.HelloWorld
@@ -543,11 +545,13 @@ object CromwellApiServiceSpec {
       )
     }
 
-    def responseMetadataValues(workflowId: WorkflowId, withKeys: List[String], withoutKeys: List[String]) = {
+    def responseMetadataValues(workflowId: WorkflowId, withKeys: List[String], withoutKeys: List[String]): JsObject = {
       def keyFilter(keys: List[String])(m: MetadataEvent) = keys.exists(k => m.key.key.startsWith(k))
-      fullMetadataResponse(workflowId)
+      val events = fullMetadataResponse(workflowId)
         .filter(m => withKeys.isEmpty || keyFilter(withKeys)(m))
         .filter(m => withoutKeys.isEmpty || !keyFilter(withoutKeys)(m))
+
+      MetadataBuilderActor.workflowMetadataResponse(workflowId, events, includeCallsIfEmpty = false, Map.empty)
     }
 
     def metadataQuery(workflowId: WorkflowId) =
@@ -585,22 +589,28 @@ object CromwellApiServiceSpec {
           ok = true,
           systems = Map(
             "Engine Database" -> SubsystemStatus(ok = true, messages = None)))
-      case GetStatus(id) if id == OnHoldWorkflowId => sender ! StatusLookupResponse(id, WorkflowOnHold)
-      case GetStatus(id) if id == RunningWorkflowId => sender ! StatusLookupResponse(id, WorkflowRunning)
-      case GetStatus(id) if id == AbortingWorkflowId => sender ! StatusLookupResponse(id, WorkflowAborting)
-      case GetStatus(id) if id == AbortedWorkflowId => sender ! StatusLookupResponse(id, WorkflowAborted)
-      case GetStatus(id) if id == SucceededWorkflowId => sender ! StatusLookupResponse(id, WorkflowSucceeded)
-      case GetStatus(id) if id == FailedWorkflowId => sender ! StatusLookupResponse(id, WorkflowFailed)
-      case GetStatus(id) => sender ! StatusLookupResponse(id, WorkflowSubmitted)
-      case GetLabels(id) => sender ! LabelLookupResponse(id, Map("key1" -> "label1", "key2" -> "label2"))
-      case WorkflowOutputs(id) =>
+      case request @ GetStatus(id) =>
+        val status = id match {
+          case OnHoldWorkflowId => WorkflowOnHold
+          case RunningWorkflowId => WorkflowRunning
+          case AbortingWorkflowId => WorkflowAborting
+          case AbortedWorkflowId => WorkflowAborted
+          case SucceededWorkflowId => WorkflowSucceeded
+          case FailedWorkflowId => WorkflowFailed
+          case _ => WorkflowSubmitted
+        }
+        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processStatusResponse(id, status))
+      case request @ GetLabels(id) =>
+        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processLabelsResponse(id, Map("key1" -> "label1", "key2" -> "label2")))
+      case request @ WorkflowOutputs(id) =>
         val event = Vector(MetadataEvent(MetadataKey(id, None, "outputs:test.hello.salutation"), MetadataValue("Hello foo!", MetadataString)))
-        sender ! WorkflowOutputsResponse(id, event)
-      case GetLogs(id) => sender ! LogsResponse(id, logsEvents(id))
-      case GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _)) =>
+        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processOutputsResponse(id, event))
+      case request @ GetLogs(id) =>
+        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.workflowMetadataResponse(id, logsEvents(id), includeCallsIfEmpty = false, Map.empty))
+      case request @ GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _)) =>
         val withKeysList = withKeys.map(_.toList).getOrElse(List.empty)
         val withoutKeysList = withoutKeys.map(_.toList).getOrElse(List.empty)
-        sender ! MetadataLookupResponse(metadataQuery(id), responseMetadataValues(id, withKeysList, withoutKeysList))
+        sender ! BuiltMetadataResponse(request, responseMetadataValues(id, withKeysList, withoutKeysList))
       case PutMetadataActionAndRespond(events, _, _) =>
         events.head.key.workflowId match {
           case CromwellApiServiceSpec.ExistingWorkflowId => sender ! MetadataWriteSuccess(events)

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -565,7 +565,7 @@ object CromwellApiServiceSpec {
     import MockServiceRegistryActor._
 
     override def receive = {
-      case WorkflowQuery(parameters) =>
+      case QueryForWorkflowsMatchingParameters(parameters) =>
         val labels: Option[Map[String, String]] = {
           parameters.contains(("additionalQueryResultFields", "labels")).option(
             Map("key1" -> "label1", "key2" -> "label2"))
@@ -597,6 +597,10 @@ object CromwellApiServiceSpec {
         val event = Vector(MetadataEvent(MetadataKey(id, None, "outputs:test.hello.salutation"), MetadataValue("Hello foo!", MetadataString)))
         sender ! WorkflowOutputsResponse(id, event)
       case GetLogs(id) => sender ! LogsResponse(id, logsEvents(id))
+      case GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _)) =>
+        val withKeysList = withKeys.map(_.toList).getOrElse(List.empty)
+        val withoutKeysList = withoutKeys.map(_.toList).getOrElse(List.empty)
+        sender ! MetadataLookupResponse(metadataQuery(id), responseMetadataValues(id, withKeysList, withoutKeysList))
       case PutMetadataActionAndRespond(events, _, _) =>
         events.head.key.workflowId match {
           case CromwellApiServiceSpec.ExistingWorkflowId => sender ! MetadataWriteSuccess(events)

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -597,10 +597,6 @@ object CromwellApiServiceSpec {
         val event = Vector(MetadataEvent(MetadataKey(id, None, "outputs:test.hello.salutation"), MetadataValue("Hello foo!", MetadataString)))
         sender ! WorkflowOutputsResponse(id, event)
       case GetLogs(id) => sender ! LogsResponse(id, logsEvents(id))
-      case GetSingleWorkflowMetadataAction(id, withKeys, withoutKeys, _) =>
-        val withKeysList = withKeys.map(_.toList).getOrElse(List.empty)
-        val withoutKeysList = withoutKeys.map(_.toList).getOrElse(List.empty)
-        sender ! MetadataLookupResponse(metadataQuery(id), responseMetadataValues(id, withKeysList, withoutKeysList))
       case PutMetadataActionAndRespond(events, _, _) =>
         events.head.key.workflowId match {
           case CromwellApiServiceSpec.ExistingWorkflowId => sender ! MetadataWriteSuccess(events)

--- a/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -46,6 +46,7 @@ case class OutputNotFoundException(outputFqn: String, actualOutputs: String) ext
 case class LogNotFoundException(log: String) extends RuntimeException(s"Expected log $log was not found")
 
 object CromwellTestKitSpec {
+
   val ConfigText =
     """
       |akka {

--- a/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -158,6 +158,7 @@ object CromwellTestKitSpec {
     }
   }
 
+
   /**
     * Special case for validating outputs. Used when the test wants to check that an output exists, but doesn't care what
     * the actual value was.

--- a/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -21,7 +21,7 @@ import cromwell.services.EngineServicesStore
 import cromwell.services.ServicesStore.EnhancedSqlDatabase
 import cromwell.services.metadata.MetadataQuery
 import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, MetadataLookupResponse}
-import cromwell.services.metadata.impl.ReadMetadataActor
+import cromwell.services.metadata.impl.ReadDatabaseMetadataWorkerActor
 import cromwell.util.EncryptionSpec
 import cromwell.util.SampleWdl.HelloWorld
 import cromwell.{CromwellTestKitSpec, CromwellTestKitWordSpec}
@@ -186,7 +186,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
         "WorkflowStoreActor-FetchEncryptedWorkflowOptions"
       )
       val readMetadataActor = system.actorOf(
-        ReadMetadataActor.props(metadataReadTimeout = 30 seconds),
+        ReadDatabaseMetadataWorkerActor.props(metadataReadTimeout = 30 seconds),
         "ReadMetadataActor-FetchEncryptedOptions"
       )
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(optionedSourceFiles))

--- a/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -20,7 +20,7 @@ import cromwell.engine.workflow.workflowstore._
 import cromwell.services.EngineServicesStore
 import cromwell.services.ServicesStore.EnhancedSqlDatabase
 import cromwell.services.metadata.MetadataQuery
-import cromwell.services.metadata.MetadataService.{GetMetadataQueryAction, MetadataLookupResponse}
+import cromwell.services.metadata.MetadataService.{GetMetadataAction, MetadataLookupResponse}
 import cromwell.services.metadata.impl.ReadDatabaseMetadataWorkerActor
 import cromwell.util.EncryptionSpec
 import cromwell.util.SampleWdl.HelloWorld
@@ -214,7 +214,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
 
               // We need to wait for workflow metadata to be flushed before we can successfully query for it
               eventually(timeout(15 seconds), interval(5 seconds)) {
-                readMetadataActor ! GetMetadataQueryAction(MetadataQuery.forWorkflow(id))
+                readMetadataActor ! GetMetadataAction(MetadataQuery.forWorkflow(id))
                 expectMsgPF(10 seconds) {
                   case MetadataLookupResponse(_, eventList) =>
                     val optionsEvent = eventList.find(_.key.key == "submittedFiles:options").get

--- a/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataQuery.scala
@@ -94,7 +94,9 @@ object MetadataQueryJobKey {
   def forMetadataJobKey(jobKey: MetadataJobKey) = MetadataQueryJobKey(jobKey.callFqn, jobKey.index, Option(jobKey.attempt))
 }
 
-case class MetadataQuery(workflowId: WorkflowId, jobKey: Option[MetadataQueryJobKey], key: Option[String],
+case class MetadataQuery(workflowId: WorkflowId,
+                         jobKey: Option[MetadataQueryJobKey],
+                         key: Option[String],
                          includeKeysOption: Option[NonEmptyList[String]],
                          excludeKeysOption: Option[NonEmptyList[String]],
                          expandSubWorkflows: Boolean)

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -116,20 +116,20 @@ object MetadataService {
   final case class MetadataLookupJsonResponse(query: MetadataQuery, result: Json) extends MetadataServiceResponse
   final case class MetadataLookupFailed(query: MetadataQuery, reason: Throwable)
 
-//  final case class MetadataLookupResponse(query: MetadataQuery, eventList: Seq[MetadataEvent]) extends MetadataServiceResponse
-//  final case class MetadataServiceKeyLookupFailed(query: MetadataQuery, reason: Throwable) extends MetadataServiceFailure
+  final case class MetadataLookupResponse(query: MetadataQuery, eventList: Seq[MetadataEvent]) extends MetadataServiceResponse
+  final case class MetadataServiceKeyLookupFailed(query: MetadataQuery, reason: Throwable) extends MetadataServiceFailure
 
-//  final case class StatusLookupResponse(workflowId: WorkflowId, status: WorkflowState) extends MetadataServiceResponse
-//  final case class StatusLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+  final case class StatusLookupResponse(workflowId: WorkflowId, status: WorkflowState) extends MetadataServiceResponse
+  final case class StatusLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-//  final case class LabelLookupResponse(workflowId: WorkflowId, labels: Map[String, String]) extends MetadataServiceResponse
-//  final case class LabelLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+  final case class LabelLookupResponse(workflowId: WorkflowId, labels: Map[String, String]) extends MetadataServiceResponse
+  final case class LabelLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-//  final case class WorkflowOutputsResponse(id: WorkflowId, outputs: Seq[MetadataEvent]) extends MetadataServiceResponse
-//  final case class WorkflowOutputsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+  final case class WorkflowOutputsResponse(id: WorkflowId, outputs: Seq[MetadataEvent]) extends MetadataServiceResponse
+  final case class WorkflowOutputsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-//  final case class LogsResponse(id: WorkflowId, logs: Seq[MetadataEvent]) extends MetadataServiceResponse
-//  final case class LogsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+  final case class LogsResponse(id: WorkflowId, logs: Seq[MetadataEvent]) extends MetadataServiceResponse
+  final case class LogsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
   final case class MetadataWriteSuccess(events: Iterable[MetadataEvent]) extends MetadataServiceResponse
   final case class MetadataWriteFailure(reason: Throwable, events: Iterable[MetadataEvent]) extends MetadataServiceFailure

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -2,6 +2,7 @@ package cromwell.services.metadata
 
 import java.time.OffsetDateTime
 
+import io.circe.Json
 import akka.actor.ActorRef
 import cats.data.NonEmptyList
 import cromwell.core._
@@ -38,7 +39,7 @@ object MetadataService {
   trait MetadataServiceAction extends MetadataServiceMessage with ServiceRegistryMessage {
     def serviceName = MetadataServiceName
   }
-  trait ReadAction extends MetadataServiceAction
+  trait MetadataReadAction extends MetadataServiceAction
   object PutMetadataAction {
     def apply(event: MetadataEvent, others: MetadataEvent*) = new PutMetadataAction(List(event) ++ others)
   }
@@ -86,13 +87,13 @@ object MetadataService {
                                                    includeKeysOption: Option[NonEmptyList[String]],
                                                    excludeKeysOption: Option[NonEmptyList[String]],
                                                    expandSubWorkflows: Boolean)
-    extends ReadAction
-  final case class GetMetadataQueryAction(key: MetadataQuery) extends ReadAction
-  final case class GetStatus(workflowId: WorkflowId) extends ReadAction
-  final case class GetLabels(workflowId: WorkflowId) extends ReadAction
-  final case class WorkflowQuery(parameters: Seq[(String, String)]) extends ReadAction
-  final case class WorkflowOutputs(workflowId: WorkflowId) extends ReadAction
-  final case class GetLogs(workflowId: WorkflowId) extends ReadAction
+    extends MetadataReadAction
+  final case class GetMetadataQueryAction(key: MetadataQuery) extends MetadataReadAction
+  final case class GetStatus(workflowId: WorkflowId) extends MetadataReadAction
+  final case class GetLabels(workflowId: WorkflowId) extends MetadataReadAction
+  final case class WorkflowQuery(parameters: Seq[(String, String)]) extends MetadataReadAction
+  final case class WorkflowOutputs(workflowId: WorkflowId) extends MetadataReadAction
+  final case class GetLogs(workflowId: WorkflowId) extends MetadataReadAction
   case object RefreshSummary extends MetadataServiceAction
   trait ValidationCallback {
     def onMalformed(possibleWorkflowId: String): Unit
@@ -112,20 +113,23 @@ object MetadataService {
     def reason: Throwable
   }
 
-  final case class MetadataLookupResponse(query: MetadataQuery, eventList: Seq[MetadataEvent]) extends MetadataServiceResponse
-  final case class MetadataServiceKeyLookupFailed(query: MetadataQuery, reason: Throwable) extends MetadataServiceFailure
+  final case class MetadataLookupJsonResponse(query: MetadataQuery, result: Json) extends MetadataServiceResponse
+  final case class MetadataLookupFailed(query: MetadataQuery, reason: Throwable)
 
-  final case class StatusLookupResponse(workflowId: WorkflowId, status: WorkflowState) extends MetadataServiceResponse
-  final case class StatusLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+//  final case class MetadataLookupResponse(query: MetadataQuery, eventList: Seq[MetadataEvent]) extends MetadataServiceResponse
+//  final case class MetadataServiceKeyLookupFailed(query: MetadataQuery, reason: Throwable) extends MetadataServiceFailure
 
-  final case class LabelLookupResponse(workflowId: WorkflowId, labels: Map[String, String]) extends MetadataServiceResponse
-  final case class LabelLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+//  final case class StatusLookupResponse(workflowId: WorkflowId, status: WorkflowState) extends MetadataServiceResponse
+//  final case class StatusLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-  final case class WorkflowOutputsResponse(id: WorkflowId, outputs: Seq[MetadataEvent]) extends MetadataServiceResponse
-  final case class WorkflowOutputsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+//  final case class LabelLookupResponse(workflowId: WorkflowId, labels: Map[String, String]) extends MetadataServiceResponse
+//  final case class LabelLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-  final case class LogsResponse(id: WorkflowId, logs: Seq[MetadataEvent]) extends MetadataServiceResponse
-  final case class LogsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+//  final case class WorkflowOutputsResponse(id: WorkflowId, outputs: Seq[MetadataEvent]) extends MetadataServiceResponse
+//  final case class WorkflowOutputsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
+
+//  final case class LogsResponse(id: WorkflowId, logs: Seq[MetadataEvent]) extends MetadataServiceResponse
+//  final case class LogsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
   final case class MetadataWriteSuccess(events: Iterable[MetadataEvent]) extends MetadataServiceResponse
   final case class MetadataWriteFailure(reason: Throwable, events: Iterable[MetadataEvent]) extends MetadataServiceFailure

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -103,7 +103,7 @@ object MetadataService {
   }
   final case class GetStatus(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   final case class GetLabels(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class WorkflowQuery(parameters: Seq[(String, String)]) extends MetadataReadAction
+  final case class QueryForWorkflowsMatchingParameters(parameters: Seq[(String, String)]) extends MetadataReadAction
   final case class WorkflowOutputs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   final case class GetLogs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   case object RefreshSummary extends MetadataServiceAction

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -25,7 +25,7 @@ object MetadataServiceActor {
   def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = Props(MetadataServiceActor(serviceConfig, globalConfig, serviceRegistryActor)).withDispatcher(ServiceDispatcher)
 }
 
-final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
+case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef)
   extends Actor with ActorLogging with MetadataDatabaseAccess with MetadataServicesStore with GracefulShutdownHelper {
 
   private val decider: Decider = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -109,7 +109,7 @@ final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Confi
     case listen: Listen => writeActor forward listen
     case v: ValidateWorkflowIdInMetadata => validateWorkflowIdInMetadata(v.possibleWorkflowId, sender())
     case v: ValidateWorkflowIdInMetadataSummaries => validateWorkflowIdInMetadataSummaries(v.possibleWorkflowId, sender())
-    case action: ReadAction => readActor forward action
+    case action: MetadataReadAction => readActor forward action
     case RefreshSummary => summaryActor foreach { _ ! SummarizeMetadata(metadataSummaryRefreshLimit, sender()) }
     case MetadataSummarySuccess => scheduleSummary()
     case MetadataSummaryFailure(t) =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -49,7 +49,8 @@ final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Confi
   private val metadataReadTimeout: Duration =
     serviceConfig.getOrElse[Duration]("metadata-read-query-timeout", Duration.Inf)
 
-  val readActor = context.actorOf(ReadMetadataActor.props(metadataReadTimeout), "read-metadata-actor")
+  def readMetadataWorkerActorMaker() = ReadDatabaseMetadataWorkerActor.props(metadataReadTimeout)
+  val readActor = context.actorOf(ReadMetadataRegulatorActor.props(readMetadataWorkerActorMaker), "read-metadata-actor")
 
   val dbFlushRate = serviceConfig.getOrElse("db-flush-rate", 5.seconds)
   val dbBatchSize = serviceConfig.getOrElse("db-batch-size", 200)

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -36,7 +36,7 @@ final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Confi
   override val supervisorStrategy = new OneForOneStrategy()(decider) {
     override def logFailure(context: ActorContext, child: ActorRef, cause: Throwable, decision: Directive) = {
       val childName = if (child == readActor) "Read" else "Write"
-      log.error(s"The $childName Metadata Actor died unexpectedly, metadata events might have been lost. Restarting it...", cause)
+      log.error(cause, s"The $childName Metadata Actor died unexpectedly, metadata events might have been lost. Restarting it...")
     }
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -53,7 +53,7 @@ final case class MetadataServiceActor(serviceConfig: Config, globalConfig: Confi
   def readMetadataWorkerActorProps(): Props = ReadDatabaseMetadataWorkerActor.props(metadataReadTimeout).withDispatcher(ServiceDispatcher)
   def metadataBuilderActorProps(): Props = MetadataBuilderActor.props(readMetadataWorkerActorProps).withDispatcher(ServiceDispatcher)
 
-  val readActor = context.actorOf(ReadMetadataRegulatorActor.props(metadataBuilderActorProps), "read-metadata-actor")
+  val readActor = context.actorOf(ReadMetadataRegulatorActor.props(metadataBuilderActorProps, readMetadataWorkerActorProps), "singleton-ReadMetadataRegulatorActor")
 
   val dbFlushRate = serviceConfig.getOrElse("db-flush-rate", 5.seconds)
   val dbBatchSize = serviceConfig.getOrElse("db-batch-size", 200)

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -34,7 +34,7 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
     } andThen {
       case _ => self ! PoisonPill
     } recover {
-      case t => log.error(s"Programmer Error! Unexpected error fall-through to 'evaluateRespondAndStop in ${getClass.getSimpleName}'")
+      case t => log.error(t, s"Programmer Error! Unexpected error fall-through to 'evaluateRespondAndStop in ${getClass.getSimpleName}'")
     }
     ()
   }

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -1,18 +1,18 @@
 package cromwell.services.metadata.impl
 
-import akka.actor.{Actor, ActorLogging, Props}
-import cromwell.core.Dispatcher.ApiDispatcher
+import akka.actor.{Actor, ActorLogging, ActorRef, PoisonPill, Props}
+import cromwell.core.Dispatcher.ServiceDispatcher
 import cromwell.core.{WorkflowId, WorkflowSubmitted}
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.{MetadataQuery, WorkflowQueryParameters}
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 object ReadDatabaseMetadataWorkerActor {
-  def props(metadataReadTimeout: Duration) = Props(new ReadDatabaseMetadataWorkerActor(metadataReadTimeout)).withDispatcher(ApiDispatcher)
+  def props(metadataReadTimeout: Duration) = Props(new ReadDatabaseMetadataWorkerActor(metadataReadTimeout)).withDispatcher(ServiceDispatcher)
 }
 
 class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Actor with ActorLogging with MetadataDatabaseAccess with MetadataServicesStore {
@@ -20,42 +20,56 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
   implicit val ec = context.dispatcher
 
   def receive = {
-    case GetMetadataAction(query@MetadataQuery(_, _, _, _, _, _)) => queryAndRespond(query)
-    case GetStatus(workflowId) => queryStatusAndRespond(workflowId)
-    case GetLabels(workflowId) => queryLabelsAndRespond(workflowId)
-    case GetLogs(workflowId) => queryLogsAndRespond(workflowId)
-    case query: QueryForWorkflowsMatchingParameters => queryWorkflowsAndRespond(query.parameters)
-    case WorkflowOutputs(id) => queryWorkflowOutputsAndRespond(id)
+    case GetMetadataAction(query@MetadataQuery(_, _, _, _, _, _)) => evaluateRespondAndStop(sender(), getMetadata(query))
+    case GetStatus(workflowId) => evaluateRespondAndStop(sender(), getStatus(workflowId))
+    case GetLabels(workflowId) => evaluateRespondAndStop(sender(), queryLabelsAndRespond(workflowId))
+    case GetLogs(workflowId) => evaluateRespondAndStop(sender(), queryLogsAndRespond(workflowId))
+    case query: QueryForWorkflowsMatchingParameters => evaluateRespondAndStop(sender(), queryWorkflowsAndRespond(query.parameters))
+    case WorkflowOutputs(id) => evaluateRespondAndStop(sender(), queryWorkflowOutputsAndRespond(id))
   }
 
-  private def queryAndRespond(query: MetadataQuery): Unit = {
-    val sndr = sender()
-    queryMetadataEvents(query, metadataReadTimeout) onComplete {
-      case Success(m) => sndr ! MetadataLookupResponse(query, m)
-      case Failure(t) => sndr ! MetadataServiceKeyLookupFailed(query, t)
+  private def evaluateRespondAndStop(sndr: ActorRef, f: Future[Any]) = {
+    f map { result =>
+      sndr ! result
+    } andThen {
+      case _ => self ! PoisonPill
+    } recover {
+      case t => log.error(s"Programmer Error! Unexpected error fall-through to 'evaluateRespondAndStop in ${getClass.getSimpleName}'")
+    }
+    ()
+  }
+
+  private def getMetadata(query: MetadataQuery): Future[MetadataServiceResponse] = {
+
+    queryMetadataEvents(query, metadataReadTimeout) map {
+      m => MetadataLookupResponse(query, m)
+    } recover {
+      case t => MetadataServiceKeyLookupFailed(query, t)
     }
   }
 
-  private def queryStatusAndRespond(id: WorkflowId): Unit = {
-    val sndr = sender()
-    getWorkflowStatus(id) onComplete {
-      case Success(Some(s)) => sndr ! StatusLookupResponse(id, s)
+  private def getStatus(id: WorkflowId): Future[MetadataServiceResponse] = {
+
+    getWorkflowStatus(id) map {
+      case Some(s) => StatusLookupResponse(id, s)
       // There's a workflow existence check at the API layer.  If the request has made it this far in the system
       // then the workflow exists but it must not have generated a status yet.
-      case Success(None) => sndr ! StatusLookupResponse(id, WorkflowSubmitted)
-      case Failure(t) => sndr ! StatusLookupFailed(id, t)
+      case None => StatusLookupResponse(id, WorkflowSubmitted)
+    } recover {
+      case t => StatusLookupFailed(id, t)
     }
   }
 
-  private def queryLabelsAndRespond(id: WorkflowId): Unit = {
-    val sndr = sender()
-    getWorkflowLabels(id) onComplete {
-      case Success(ls) => sndr ! LabelLookupResponse(id, ls)
-      case Failure(t) => sndr ! LabelLookupFailed(id, t)
+  private def queryLabelsAndRespond(id: WorkflowId): Future[MetadataServiceResponse] = {
+
+    getWorkflowLabels(id) map {
+      ls => LabelLookupResponse(id, ls)
+    } recover {
+      case t => LabelLookupFailed(id, t)
     }
   }
 
-  private def queryWorkflowsAndRespond(rawParameters: Seq[(String, String)]): Unit = {
+  private def queryWorkflowsAndRespond(rawParameters: Seq[(String, String)]): Future[MetadataServiceResponse] = {
     def queryWorkflows: Future[(WorkflowQueryResponse, Option[QueryMetadata])] = {
       for {
       // Future/Try to wrap the exception that might be thrown from WorkflowQueryParameters.apply.
@@ -64,27 +78,26 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
       } yield response
     }
 
-    val sndr = sender()
-
-    queryWorkflows onComplete {
-      case Success((response, metadata)) => sndr ! WorkflowQuerySuccess(response, metadata)
-      case Failure(t) => sndr ! WorkflowQueryFailure(t)
+    queryWorkflows map {
+      case (response, metadata) => WorkflowQuerySuccess(response, metadata)
+    } recover {
+      case t => WorkflowQueryFailure(t)
     }
   }
 
-  private def queryWorkflowOutputsAndRespond(id: WorkflowId): Unit = {
-    val replyTo = sender()
-    queryWorkflowOutputs(id, metadataReadTimeout) onComplete {
-      case Success(o) => replyTo ! WorkflowOutputsResponse(id, o)
-      case Failure(t) => replyTo ! WorkflowOutputsFailure(id, t)
+  private def queryWorkflowOutputsAndRespond(id: WorkflowId): Future[MetadataServiceResponse] = {
+    queryWorkflowOutputs(id, metadataReadTimeout) map {
+      o => WorkflowOutputsResponse(id, o)
+    } recover {
+      case t => WorkflowOutputsFailure(id, t)
     }
   }
 
-  private def queryLogsAndRespond(id: WorkflowId): Unit = {
-    val replyTo = sender()
-    queryLogs(id, metadataReadTimeout) onComplete {
-      case Success(s) => replyTo ! LogsResponse(id, s)
-      case Failure(t) => replyTo ! LogsFailure(id, t)
+  private def queryLogsAndRespond(id: WorkflowId): Future[MetadataServiceResponse] = {
+    queryLogs(id, metadataReadTimeout) map {
+      s => LogsResponse(id, s)
+    } recover {
+      case t => LogsFailure(id, t)
     }
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -11,11 +11,11 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
-object ReadMetadataActor {
-  def props(metadataReadTimeout: Duration) = Props(new ReadMetadataActor(metadataReadTimeout)).withDispatcher(ApiDispatcher)
+object ReadDatabaseMetadataWorkerActor {
+  def props(metadataReadTimeout: Duration) = Props(new ReadDatabaseMetadataWorkerActor(metadataReadTimeout)).withDispatcher(ApiDispatcher)
 }
 
-class ReadMetadataActor(metadataReadTimeout: Duration) extends Actor with ActorLogging with MetadataDatabaseAccess with MetadataServicesStore {
+class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Actor with ActorLogging with MetadataDatabaseAccess with MetadataServicesStore {
 
   implicit val ec = context.dispatcher
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -5,7 +5,7 @@ import cromwell.core.Dispatcher.ApiDispatcher
 import cromwell.core.{WorkflowId, WorkflowSubmitted}
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.metadata.{CallMetadataKeys, MetadataQuery, WorkflowQueryParameters}
+import cromwell.services.metadata.{MetadataQuery, WorkflowQueryParameters}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.Future
@@ -20,12 +20,7 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
   implicit val ec = context.dispatcher
 
   def receive = {
-    case GetSingleWorkflowMetadataAction(workflowId, includeKeysOption, excludeKeysOption, expandSubWorkflows) =>
-      val includeKeys = if (expandSubWorkflows) {
-        includeKeysOption map { _ :+ CallMetadataKeys.SubWorkflowId }
-      } else includeKeysOption
-      queryAndRespond(MetadataQuery(workflowId, None, None, includeKeys, excludeKeysOption, expandSubWorkflows))
-    case GetMetadataQueryAction(query@MetadataQuery(_, _, _, _, _, _)) => queryAndRespond(query)
+    case GetMetadataAction(query@MetadataQuery(_, _, _, _, _, _)) => queryAndRespond(query)
     case GetStatus(workflowId) => queryStatusAndRespond(workflowId)
     case GetLabels(workflowId) => queryLabelsAndRespond(workflowId)
     case GetLogs(workflowId) => queryLogsAndRespond(workflowId)

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -24,7 +24,7 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
     case GetStatus(workflowId) => queryStatusAndRespond(workflowId)
     case GetLabels(workflowId) => queryLabelsAndRespond(workflowId)
     case GetLogs(workflowId) => queryLogsAndRespond(workflowId)
-    case query: WorkflowQuery => queryWorkflowsAndRespond(query.parameters)
+    case query: QueryForWorkflowsMatchingParameters => queryWorkflowsAndRespond(query.parameters)
     case WorkflowOutputs(id) => queryWorkflowOutputsAndRespond(id)
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.core.Dispatcher.ApiDispatcher
 import cromwell.services.metadata.MetadataService
-import cromwell.services.metadata.MetadataService.{MetadataQueryResponse, MetadataReadAction, MetadataServiceAction, WorkflowMetadataReadAction}
+import cromwell.services.metadata.MetadataService.{MetadataQueryResponse, MetadataReadAction, MetadataServiceAction, MetadataServiceResponse, WorkflowMetadataReadAction}
 import cromwell.services.metadata.impl.ReadMetadataRegulatorActor.ReadMetadataWorkerMaker
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor.MetadataBuilderActorResponse
@@ -46,8 +46,11 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
             readMetadataActor ! crossWorkflowAction
           }
       }
-    case response: MetadataBuilderActorResponse => handleResponseFromMetadataWorker(response)
-    case response: MetadataQueryResponse => handleResponseFromMetadataWorker(response)
+    case serviceResponse: MetadataServiceResponse =>
+      serviceResponse match {
+        case response: MetadataBuilderActorResponse => handleResponseFromMetadataWorker(response)
+        case response: MetadataQueryResponse => handleResponseFromMetadataWorker(response)
+      }
     case other => log.error(s"Programmer Error: Unexpected message $other received from $sender")
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
@@ -42,7 +42,7 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
             builderRequests.put(builderActor, singleWorkflowAction)
             builderActor ! singleWorkflowAction
           }
-        case crossWorkflowAction: MetadataService.WorkflowQuery =>
+        case crossWorkflowAction: MetadataService.QueryForWorkflowsMatchingParameters =>
           val currentRequesters = apiRequests.getOrElse(crossWorkflowAction, Set.empty)
           apiRequests.put(crossWorkflowAction, currentRequesters + sender())
           if (currentRequesters.isEmpty) {

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
@@ -29,14 +29,9 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
     case action: MetadataReadAction =>
       action match {
         case singleWorkflowAction: WorkflowMetadataReadAction =>
-          // If I've still left this log in at PR time, you have permission to call me a fool:
-          log.info(s"Received $singleWorkflowAction")
-
           val currentRequesters = apiRequests.getOrElse(singleWorkflowAction, Set.empty)
           apiRequests.put(singleWorkflowAction, currentRequesters + sender())
           if (currentRequesters.isEmpty) {
-            // If I've still left this log in at PR time, you have permission to call me a fool:
-            log.info(s"Creating new builder actor to handle $singleWorkflowAction")
 
             val builderActor = context.actorOf(metadataBuilderActorProps().withDispatcher(ApiDispatcher), MetadataBuilderActor.uniqueActorName(singleWorkflowAction.workflowId.toString))
             builderRequests.put(builderActor, singleWorkflowAction)
@@ -52,9 +47,6 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
           }
       }
     case response: MetadataBuilderActorResponse =>
-      // If I've still left this log in at PR time, you have permission to call me a fool:
-      log.info(s"Received response for ${response.originalRequest}. Forwarding response back to requester.")
-
       val sndr = sender()
       builderRequests.get(sndr) match {
         case Some(action) =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -281,7 +281,6 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props)
       allDone()
     case Event(MetadataLookupResponse(query, metadata), HasWorkData(target, originalRequest)) =>
       processMetadataResponse(query, metadata, target, originalRequest)
-
     case Event(failure: MetadataServiceFailure, HasWorkData(target, originalRequest)) =>
       target ! FailedMetadataResponse(originalRequest, failure.reason)
       allDone()

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -1,4 +1,4 @@
-package cromwell.webservice.metadata
+package cromwell.services.metadata.impl.builder
 
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -20,7 +20,7 @@ import scala.language.postfixOps
 
 object MetadataBuilderActor {
   sealed trait MetadataBuilderActorResponse extends MetadataServiceResponse { def originalRequest: MetadataReadAction }
-  final case class BuiltMetadataResponse(originalRequest: MetadataReadAction, response: JsObject) extends MetadataBuilderActorResponse
+  final case class BuiltMetadataResponse(originalRequest: MetadataReadAction, responseJson: JsObject) extends MetadataBuilderActorResponse
   final case class FailedMetadataResponse(originalRequest: MetadataReadAction, reason: Throwable) extends MetadataBuilderActorResponse
 
   sealed trait MetadataBuilderActorState

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -206,6 +206,9 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props)
   startWith(Idle, IdleData)
   val tag = self.path.name
 
+  // If I've still left this log in at PR time, you have permission to call me a fool:
+  log.info(s"New ${getClass.getSimpleName} created as $tag")
+
   when(Idle) {
     case Event(action: MetadataReadAction, IdleData) =>
 
@@ -264,6 +267,12 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props)
       log.error(s"Received unexpected message $message in state $stateName with target: $target")
       self ! PoisonPill
       stay
+  }
+
+  onTransition {
+    case (from, to) =>
+      // If I've still left this log in at PR time, you have permission to call me a fool:
+      log.info(s"${getClass.getSimpleName} transitioning from $from (using $stateData) to $to (using $nextStateData)")
   }
 
   def processSubWorkflowMetadata(metadataResponse: MetadataBuilderActorResponse, data: HasReceivedEventsData) = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -252,9 +252,6 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props)
   startWith(Idle, IdleData)
   val tag = self.path.name
 
-  // If I've still left this log in at PR time, you have permission to call me a fool:
-  log.info(s"New ${getClass.getSimpleName} created as $tag")
-
   when(Idle) {
     case Event(action: MetadataReadAction, IdleData) =>
 
@@ -310,12 +307,6 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props)
       log.error(s"Received unexpected message $message in state $stateName with target: $target")
       self ! PoisonPill
       stay
-  }
-
-  onTransition {
-    case (from, to) =>
-      // If I've still left this log in at PR time, you have permission to call me a fool:
-      log.info(s"${getClass.getSimpleName} transitioning from $from (using $stateData) to $to (using $nextStateData)")
   }
 
   def processSubWorkflowMetadata(metadataResponse: MetadataBuilderActorResponse, data: HasReceivedEventsData) = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -1,6 +1,7 @@
 package cromwell.services.metadata.impl.builder
 
 import java.time.OffsetDateTime
+import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.{ActorRef, LoggingFSM, PoisonPill, Props}
 import common.collections.EnhancedCollections._
@@ -139,7 +140,9 @@ object MetadataBuilderActor {
     JsObject(events.groupBy(_.key.workflowId.toString) safeMapValues parseWorkflowEvents(includeCallsIfEmpty = true, expandedValues))
   }
 
-  def uniqueActorName(workflowId: String): String = s"${getClass.getSimpleName}-for-$workflowId"
+  val actorIdIterator = new AtomicLong(0)
+
+  def uniqueActorName(workflowId: String): String = s"${getClass.getSimpleName}.${actorIdIterator.getAndIncrement()}-for-$workflowId"
 
   case class JobKeyAndGrouping(jobKey: MetadataJobKey, grouping: String)
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderRegulatorActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderRegulatorActor.scala
@@ -1,4 +1,4 @@
-package cromwell.webservice.metadata
+package cromwell.services.metadata.impl.builder
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.core.Dispatcher.ApiDispatcher

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataComponent.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataComponent.scala
@@ -1,4 +1,4 @@
-package cromwell.webservice.metadata
+package cromwell.services.metadata.impl.builder
 
 import cats.instances.list._
 import cats.instances.map._

--- a/services/src/test/scala/cromwell/services/metadata/MetadataQuerySpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataQuerySpec.scala
@@ -1,0 +1,58 @@
+package cromwell.services.metadata
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.testkit.TestProbe
+import com.typesafe.config.{Config, ConfigFactory}
+import cromwell.core.TestKitSuite
+import cromwell.services.metadata.MetadataQuerySpec.{CannedResponseReadMetadataWorker, MetadataServiceActor_CustomizeRead}
+import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse, QueryForWorkflowsMatchingParameters, WorkflowQueryResponse, WorkflowQuerySuccess}
+import cromwell.services.metadata.impl.{MetadataServiceActor, MetadataServiceActorSpec}
+import org.scalatest.{FlatSpecLike, Matchers}
+
+class MetadataQuerySpec extends TestKitSuite("MetadataQuerySpec") with FlatSpecLike with Matchers  {
+
+  it should "correctly forward requests to read workers and responses back to requesters" in {
+
+    val request = QueryForWorkflowsMatchingParameters(
+      parameters = List(("paramName1", "paramValue1"))
+    )
+
+    val response = WorkflowQuerySuccess(
+      response = WorkflowQueryResponse(Seq.empty, 0),
+      meta = None
+    )
+
+    val requester = TestProbe("MetadataServiceClientProbe")
+    def readWorkerProps() = Props(new CannedResponseReadMetadataWorker(Map(request -> response)))
+    val serviceRegistry = TestProbe("ServiceRegistryProbe")
+    val metadataService = system.actorOf(MetadataServiceActor_CustomizeRead.props(readWorkerProps, serviceRegistry), "MetadataServiceUnderTest")
+
+    requester.send(metadataService, request)
+    requester.expectMsg(response)
+
+  }
+
+}
+
+
+object MetadataQuerySpec {
+  final class MetadataServiceActor_CustomizeRead(config: Config, serviceRegistryActor: ActorRef, readWorkerMaker: () => Props)
+    extends MetadataServiceActor(MetadataServiceActorSpec.globalConfigToMetadataServiceConfig(config), config, serviceRegistryActor) {
+
+    override def readMetadataWorkerActorProps(): Props = readWorkerMaker.apply.withDispatcher(cromwell.core.Dispatcher.ServiceDispatcher)
+  }
+
+  object MetadataServiceActor_CustomizeRead {
+    val config = ConfigFactory.parseString(MetadataServiceActorSpec.ConfigWithoutSummarizer)
+
+    def props(readActorProps: () => Props, serviceRegistryProbe: TestProbe) =
+      Props(new MetadataServiceActor_CustomizeRead(config, serviceRegistryProbe.ref, readActorProps))
+  }
+
+
+  final class CannedResponseReadMetadataWorker(cannedResponses: Map[MetadataReadAction, MetadataServiceResponse]) extends Actor {
+    override def receive = {
+      case msg: MetadataReadAction => sender ! cannedResponses.getOrElse(msg, throw new Exception(s"Unexpected inbound message: $msg"))
+    }
+  }
+}

--- a/services/src/test/scala/cromwell/services/metadata/QueryForWorkflowsMatchingParametersSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/QueryForWorkflowsMatchingParametersSpec.scala
@@ -7,7 +7,7 @@ import cromwell.core.labels.Label
 import cromwell.services.metadata.WorkflowQueryKey._
 import org.scalatest.{Matchers, WordSpec}
 
-class WorkflowQueryParametersSpec extends WordSpec with Matchers {
+class QueryForWorkflowsMatchingParametersSpec extends WordSpec with Matchers {
 
   val StartDateString = "2015-11-01T11:11:11Z"
   val EndDateString = "2015-11-01T12:12:12Z"

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -55,19 +55,19 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
 
       eventually(Timeout(10.seconds), Interval(2.seconds)) {
         (for {
-          response1 <- (actor ? GetMetadataQueryAction(query1)).mapTo[MetadataServiceResponse]
+          response1 <- (actor ? GetMetadataAction(query1)).mapTo[MetadataServiceResponse]
           _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
 
-          response2 <- (actor ? GetMetadataQueryAction(query2)).mapTo[MetadataServiceResponse]
+          response2 <- (actor ? GetMetadataAction(query2)).mapTo[MetadataServiceResponse]
           _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
 
-          response3 <- (actor ? GetMetadataQueryAction(query3)).mapTo[MetadataServiceResponse]
+          response3 <- (actor ? GetMetadataAction(query3)).mapTo[MetadataServiceResponse]
           _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
 
-          response4 <- (actor ? GetMetadataQueryAction(query4)).mapTo[MetadataServiceResponse]
+          response4 <- (actor ? GetMetadataAction(query4)).mapTo[MetadataServiceResponse]
           _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
 
-          response5 <- (actor ? GetMetadataQueryAction(query5)).mapTo[MetadataServiceResponse]
+          response5 <- (actor ? GetMetadataAction(query5)).mapTo[MetadataServiceResponse]
           _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
 
         } yield ()).futureValue

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -123,52 +123,6 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
 
     }
   }
-
-//      eventually(Timeout(10.seconds), Interval(2.seconds)) {
-//        val response1 = Await.result((actor ? GetMetadataAction(query1)).mapTo[BuiltMetadataResponse], 1.seconds)
-//        response1.response.prettyPrint shouldBe
-//          s"""{
-//             |  "${event1_2.key.key}": "${event1_2.value.map(_.value).get}",
-//             |  "calls": {
-//             |
-//             |  },
-//             |  "id": "$workflowId"
-//             |}""".stripMargin
-//      }
-//
-//      val response2 = Await.result((actor ? GetMetadataAction(query2)).mapTo[BuiltMetadataResponse], 10.seconds)
-//      response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
-//
-//      val response3 = Await.result((actor ? GetMetadataAction(query3)).mapTo[BuiltMetadataResponse], 10.seconds)
-//      response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
-//
-//      val response4 = Await.result((actor ? GetMetadataAction(query4)).mapTo[BuiltMetadataResponse], 10.seconds)
-//      response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
-//
-//      val response5 = Await.result((actor ? GetMetadataAction(query5)).mapTo[BuiltMetadataResponse], 10.seconds)
-//      response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
-
-//      eventually(Timeout(10.seconds), Interval(2.seconds)) {
-//      {
-//        (for {
-//          response1 <- (actor ? GetMetadataAction(query1)).mapTo[MetadataServiceResponse]
-//          _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
-//
-//          response2 <- (actor ? GetMetadataAction(query2)).mapTo[MetadataServiceResponse]
-//          _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
-//
-//          response3 <- (actor ? GetMetadataAction(query3)).mapTo[MetadataServiceResponse]
-//          _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
-//
-//          response4 <- (actor ? GetMetadataAction(query4)).mapTo[MetadataServiceResponse]
-//          _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
-//
-//          response5 <- (actor ? GetMetadataAction(query5)).mapTo[MetadataServiceResponse]
-//          _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
-//
-//        } yield ()).futureValue
-//      }
-
 }
 
 object MetadataServiceActorSpec {

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -9,15 +9,20 @@ import cromwell.core._
 import cromwell.services.ServicesSpec
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+
+import scala.concurrent.Await
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
+
+import spray.json._
 
 import scala.concurrent.duration._
 
 class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
   import MetadataServiceActorSpec.Config
   val config = ConfigFactory.parseString(Config)
-  val actor = system.actorOf(MetadataServiceActor.props(config, config, TestProbe().ref))
+  val actor = system.actorOf(MetadataServiceActor.props(config, config, TestProbe().ref), "MetadataServiceActor-for-MetadataServiceActorSpec")
 
     val workflowId = WorkflowId.randomId()
 
@@ -37,43 +42,133 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
   val event3_1 = MetadataEvent(key3, Option(MetadataValue("value3")), moment.plusSeconds(4))
   val event3_2 = MetadataEvent(key3, None, moment.plusSeconds(5))
 
+  override def beforeAll: Unit = {
+
+    // Even though event1_1 arrives second, the older timestamp should mean it does not replace event1_2:
+    val putAction2 = PutMetadataAction(event1_2)
+    val putAction1 = PutMetadataAction(event1_1)
+    val putAction3 = PutMetadataAction(event2_1, event3_1, event3_2)
+
+    actor ! putAction1
+    actor ! putAction2
+    actor ! putAction3
+  }
+
+  val query1 = MetadataQuery.forKey(key1)
+  val query2 = MetadataQuery.forKey(key2)
+  val query3 = MetadataQuery.forKey(key3)
+  val query4 = MetadataQuery.forWorkflow(workflowId)
+  val query5 = MetadataQuery.forJob(workflowId, supJob)
+
+  def expectConstructedMetadata(query: MetadataQuery, expectation: String) = {
+
+  }
+
+  val testCases = List[(String, MetadataQuery, String)] (
+    ("query1", query1, s"""{
+                          |  "key1": "value2",
+                          |  "calls": {},
+                          |  "id": "$workflowId"
+                          |}""".stripMargin),
+    ("query2", query2, s"""{
+                          |  "key2": "value1",
+                          |  "calls": {},
+                          |  "id": "$workflowId"
+                          |}""".stripMargin),
+    ("query3", query3, s"""{
+                          |  "calls": {
+                          |    "sup.sup": [{
+                          |      "dog": {},
+                          |      "attempt": 1,
+                          |      "shardIndex": -1
+                          |    }]
+                          |  },
+                          |  "id": "$workflowId"
+                          |}""".stripMargin),
+    ("query4", query4, s"""{
+                          |  "key1": "value2",
+                          |  "key2": "value1",
+                          |  "calls": {
+                          |    "sup.sup": [{
+                          |      "dog": {},
+                          |      "attempt": 1,
+                          |      "shardIndex": -1
+                          |    }]
+                          |  },
+                          |  "id": "$workflowId"
+                          |}""".stripMargin),
+    ("query5", query5, s"""{
+                          |  "calls": {
+                          |    "sup.sup": [{
+                          |      "dog": {},
+                          |      "attempt": 1,
+                          |      "shardIndex": -1
+                          |    }]
+                          |  },
+                          |  "id": "$workflowId"
+                          |}""".stripMargin)
+  )
+
   "MetadataServiceActor" should {
-    "Store values for different keys and then retrieve those values" in {
-      val putAction1 = PutMetadataAction(event1_1)
-      val putAction2 = PutMetadataAction(event1_2)
-      val putAction3 = PutMetadataAction(event2_1, event3_1, event3_2)
 
-      actor ! putAction1
-      actor ! putAction2
-      actor ! putAction3
+    testCases foreach { case (name, query, expectation) =>
 
-      val query1 = MetadataQuery.forKey(key1)
-      val query2 = MetadataQuery.forKey(key2)
-      val query3 = MetadataQuery.forKey(key3)
-      val query4 = MetadataQuery.forWorkflow(workflowId)
-      val query5 = MetadataQuery.forJob(workflowId, supJob)
+      s"perform $name correctly" in {
+        eventually(Timeout(10.seconds), Interval(2.seconds)) {
+          val response = Await.result((actor ? GetMetadataAction(query)).mapTo[BuiltMetadataResponse], 1.seconds)
 
-      eventually(Timeout(10.seconds), Interval(2.seconds)) {
-        (for {
-          response1 <- (actor ? GetMetadataAction(query1)).mapTo[MetadataServiceResponse]
-          _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
-
-          response2 <- (actor ? GetMetadataAction(query2)).mapTo[MetadataServiceResponse]
-          _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
-
-          response3 <- (actor ? GetMetadataAction(query3)).mapTo[MetadataServiceResponse]
-          _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
-
-          response4 <- (actor ? GetMetadataAction(query4)).mapTo[MetadataServiceResponse]
-          _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
-
-          response5 <- (actor ? GetMetadataAction(query5)).mapTo[MetadataServiceResponse]
-          _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
-
-        } yield ()).futureValue
+          response.response shouldBe expectation.parseJson
+        }
       }
+
     }
   }
+
+//      eventually(Timeout(10.seconds), Interval(2.seconds)) {
+//        val response1 = Await.result((actor ? GetMetadataAction(query1)).mapTo[BuiltMetadataResponse], 1.seconds)
+//        response1.response.prettyPrint shouldBe
+//          s"""{
+//             |  "${event1_2.key.key}": "${event1_2.value.map(_.value).get}",
+//             |  "calls": {
+//             |
+//             |  },
+//             |  "id": "$workflowId"
+//             |}""".stripMargin
+//      }
+//
+//      val response2 = Await.result((actor ? GetMetadataAction(query2)).mapTo[BuiltMetadataResponse], 10.seconds)
+//      response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
+//
+//      val response3 = Await.result((actor ? GetMetadataAction(query3)).mapTo[BuiltMetadataResponse], 10.seconds)
+//      response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
+//
+//      val response4 = Await.result((actor ? GetMetadataAction(query4)).mapTo[BuiltMetadataResponse], 10.seconds)
+//      response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
+//
+//      val response5 = Await.result((actor ? GetMetadataAction(query5)).mapTo[BuiltMetadataResponse], 10.seconds)
+//      response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
+
+//      eventually(Timeout(10.seconds), Interval(2.seconds)) {
+//      {
+//        (for {
+//          response1 <- (actor ? GetMetadataAction(query1)).mapTo[MetadataServiceResponse]
+//          _ = response1 shouldBe MetadataLookupResponse(query1, Seq(event1_1, event1_2))
+//
+//          response2 <- (actor ? GetMetadataAction(query2)).mapTo[MetadataServiceResponse]
+//          _ = response2 shouldBe MetadataLookupResponse(query2, Seq(event2_1))
+//
+//          response3 <- (actor ? GetMetadataAction(query3)).mapTo[MetadataServiceResponse]
+//          _ = response3 shouldBe MetadataLookupResponse(query3, Seq(event3_1, event3_2))
+//
+//          response4 <- (actor ? GetMetadataAction(query4)).mapTo[MetadataServiceResponse]
+//          _ = response4 shouldBe MetadataLookupResponse(query4, Seq(event1_1, event1_2, event2_1, event3_1, event3_2))
+//
+//          response5 <- (actor ? GetMetadataAction(query5)).mapTo[MetadataServiceResponse]
+//          _ = response5 shouldBe MetadataLookupResponse(query5, Seq(event3_1, event3_2))
+//
+//        } yield ()).futureValue
+//      }
+
 }
 
 object MetadataServiceActorSpec {

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -117,7 +117,7 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
         eventually(Timeout(10.seconds), Interval(2.seconds)) {
           val response = Await.result((actor ? GetMetadataAction(query)).mapTo[BuiltMetadataResponse], 1.seconds)
 
-          response.response shouldBe expectation.parseJson
+          response.responseJson shouldBe expectation.parseJson
         }
       }
 


### PR DESCRIPTION
### Motivation:

For motivation see the [metadata design doc](https://docs.google.com/document/d/1VYnzk97yTtllozO9ivZpZQTwrsY5T0wGqxlvAbrEQgg/edit?ts=5d5d601c#heading=h.iqo65dknl60s). 

Briefly, the intention is to move the "rendering" process inside the `ServiceRegistryActor` so that in the future calls to the ServiceRegistry return JSON rather than event lists. This allows the "pre-rendered JSON" metadata service to fulfil the same service interface as the "database-event driven"  metadata service.

### PR Review Guidance

Most of the PR is noise but the "signal" is very important to get right!

Things to consider when reviewing this (perhaps otherwise unwieldy) PR:

- Does the actor structure in the diagrams below make sense?
  - ... and does it match reality as implemented in this PR?
- Have the newly introduced actors been implemented well? (ie please review these as though they were brand new actors)
  - `ReadMetadataRegulatorActor`
  - `MetadataBuilderActor`
  - `ReadDatabaseMetadataWorkerActor`
- Have the responsibilities of the replaced actors been taken care of appropriately?
- Has the API of Cromwell changed inappropriately?
- I had to refactor the `CallCacheDiffActor` because it was using the metadata service directly. Did I do a good job? And are its new tests appropriately equivalent to its old ones?
- Are there sufficient tests between unit, CI and "perf" to make you feel good about me merging this PR?
- Am I forgetting anything?

### Structure before the changes:

![Before BA-5842_ Metadata Service Actor (3)](https://user-images.githubusercontent.com/13006282/64040517-426d4380-cb2b-11e9-8a40-fa11edd33b58.png)

### Structure after the changes:

![After BA-5842_ Metadata Service Actor](https://user-images.githubusercontent.com/13006282/64040066-24531380-cb2a-11e9-8a74-98d7c976e6ec.png)

### Concerns

This feels slightly more risky than normal because the refactor was pretty fiddly and I was "test driven" for a significant portion of the refactor - mainly because actors are not typed and thus it was very tricky to make sure I found everywhere using the old object set which should now be using the new object set. 