### PR TITLE
Minor updates to track Java 9 and Java 12 STDLIB updates that conflic… BA-5976

### DIFF
--- a/cwl/src/main/scala/cwl/CwltoolRunner.scala
+++ b/cwl/src/main/scala/cwl/CwltoolRunner.scala
@@ -18,7 +18,7 @@ object CwltoolRunner {
 
   lazy val instance: CwltoolRunner = {
     val runnerClass = config.getString("cwltool-runner.class")
-    Class.forName(runnerClass).newInstance().asInstanceOf[CwltoolRunner]
+    Class.forName(runnerClass).getDeclaredConstructor().newInstance().asInstanceOf[CwltoolRunner]
   }
 }
 

--- a/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
+++ b/languageFactories/cwl-v1-0/src/main/scala/languages/cwl/CwlV1_0LanguageFactory.scala
@@ -66,7 +66,7 @@ class CwlV1_0LanguageFactory(override val config: Config) extends LanguageFactor
   override def createExecutable(womBundle: WomBundle, inputs: WorkflowJson, ioFunctions: IoFunctionSet): Checked[ValidatedWomNamespace] =
     enabledCheck flatMap { _ => "No createExecutable method implemented in CWL v1".invalidNelCheck }
 
-  override def looksParsable(content: String): Boolean = content.lines.exists { l =>
+  override def looksParsable(content: String): Boolean = content.linesIterator.exists { l =>
     val trimmed = l.trim.stripSuffix(",")
     trimmed == """"cwlVersion": "v1.0"""" || trimmed == "cwlVersion: v1.0"
   }

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -89,7 +89,7 @@ object LanguageFactoryUtil {
   }
 
   def simpleLooksParseable(startsWithOptions: List[String], commentIndicators: List[String])(content: String): Boolean = {
-    val fileWithoutInitialWhitespace = content.lines.toList.dropWhile { l =>
+    val fileWithoutInitialWhitespace = content.linesIterator.toList.dropWhile { l =>
       l.forall(_.isWhitespace) || commentIndicators.exists(l.dropWhile(_.isWhitespace).startsWith(_))
     }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/Deserialization.scala
@@ -106,7 +106,7 @@ private [api] object Deserialization {
     */
   private [api] def deserializeTo[T <: GenericJson](attributes: JMap[String, Object])(implicit tag: ClassTag[T]): Try[T] = Try {
     // Create a new instance, because it's a GenericJson there's always a 0-arg constructor
-    val newT = tag.runtimeClass.asInstanceOf[Class[T]].newInstance()
+    val newT = tag.runtimeClass.asInstanceOf[Class[T]].getConstructor().newInstance()
 
     // Optionally returns the field with the given name
     def field(name: String) = Option(newT.getClassInfo.getField(name))

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/graph/LinkedGraphMaker.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/graph/LinkedGraphMaker.scala
@@ -41,7 +41,7 @@ object LinkedGraphMaker {
 
   def getOrdering(linkedGraph: LinkedGraph): ErrorOr[List[WorkflowGraphElement]] = {
 
-    def nodeName(workflowGraphElement: WorkflowGraphElement): String = workflowGraphElement.toWdlV1.lines.toList.headOption.getOrElse("Unnamed Element").replace("\"", "")
+    def nodeName(workflowGraphElement: WorkflowGraphElement): String = workflowGraphElement.toWdlV1.linesIterator.toList.headOption.getOrElse("Unnamed Element").replace("\"", "")
 
     // Find the topological order in which we must create the graph nodes:
     val edges = linkedGraph.edges map { case LinkedGraphEdge(from, to) => DiEdge(from, to) }

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wdl/WdlWriter.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wdl/WdlWriter.scala
@@ -10,7 +10,7 @@ trait WdlWriter[A] {
 
 object WdlWriter {
   // Stolen from WomGraph.scala
-  def indent(s: String) = s.lines.map(x => s"  $x").mkString(System.lineSeparator)
+  def indent(s: String) = s.linesIterator.map(x => s"  $x").mkString(System.lineSeparator)
   def combine(ss: Iterable[String]) = ss.mkString(start="", sep=System.lineSeparator, end=System.lineSeparator)
   def indentAndCombine(ss: Iterable[String]) = combine(ss.map(indent))
 }

--- a/womtool/src/main/scala/womtool/graph/WomGraph.scala
+++ b/womtool/src/main/scala/womtool/graph/WomGraph.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 
 class WomGraph(graphName: String, graph: Graph) {
 
-  def indent(s: String) = s.lines.map(x => s"  $x").mkString(System.lineSeparator)
+  def indent(s: String) = s.linesIterator.map(x => s"  $x").mkString(System.lineSeparator)
   def combine(ss: Iterable[String]) = ss.mkString(start="", sep=System.lineSeparator, end=System.lineSeparator)
   def indentAndCombine(ss: Iterable[String]) = combine(ss.map(indent))
   implicit val monoid = cats.derived.MkMonoid[NodesAndLinks]


### PR DESCRIPTION
The `newInstance()` call on class now needs to go via a constructor object due to deprecation. This change is backwards-compatible with Java versions.

Java added a `lines` op to files that clashes with the scala one. The fix is to use `linesIterator`. This should be backwards-compatible in scala.