### PR TITLE
Speed up processRunnableTaskCallInputExpression [BA-5988]

### DIFF
--- a/common/src/main/scala/common/validation/Validation.scala
+++ b/common/src/main/scala/common/validation/Validation.scala
@@ -94,11 +94,11 @@ object Validation {
   }
 
   implicit class OptionValidation[A](val o: Option[A]) extends AnyVal {
-    def toErrorOr(errorMessage: String): ErrorOr[A] = {
+    def toErrorOr(errorMessage: => String): ErrorOr[A] = {
       Validated.fromOption(o, NonEmptyList.of(errorMessage))
     }
 
-    def toChecked(errorMessage: String): Checked[A] = {
+    def toChecked(errorMessage: => String): Checked[A] = {
       Either.fromOption(o, NonEmptyList.of(errorMessage))
     }
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -543,10 +543,10 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
                                                      data: WorkflowExecutionActorData,
                                                      expressionNode: TaskCallInputExpressionNode): ErrorOr[WorkflowExecutionDiff] = {
     import cats.syntax.either._
-    val taskCallNode = expressionNode.taskCallNodeReceivingInput.get(())
+    val taskCallNode: CommandCallNode = expressionNode.taskCallNodeReceivingInput.get(())
 
     (for {
-      backendJobDescriptorKey <- data.executionStore.backendJobDescriptorKeyForNode(taskCallNode) toChecked s"No BackendJobDescriptorKey found for call node $taskCallNode"
+      backendJobDescriptorKey <- data.executionStore.backendJobDescriptorKeyForNode(taskCallNode) toChecked s"No BackendJobDescriptorKey found for call node ${taskCallNode.identifier.fullyQualifiedName}"
       factory <- backendFactoryForTaskCallNode(taskCallNode)
       backendInitializationData = params.initializationData.get(factory.name)
       functions = factory.expressionLanguageFunctions(workflowDescriptor.backendDescriptor, backendJobDescriptorKey, backendInitializationData, params.ioActor, ioEc)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -72,4 +72,30 @@ object ExecutionStoreBenchmark extends Bench[Double] with DefaultJsonProtocol {
       }
     }
   }
+
+  performance of "CommandCallNode" in {
+
+    measure method "default toString" in {
+
+      val sizes = Gen.range("size")(from = 10000, upto = 10000, hop = 10000)
+      using(sizes) in { size =>
+        1 to size foreach { _ =>
+          (scatterCall.toString, prepareCall.toString)
+        }
+      }
+
+    }
+
+    measure method "simple toString" in {
+
+      val sizes = Gen.range("size")(from = 10000, upto = 10000, hop = 10000)
+      using(sizes) in { size =>
+        1 to size foreach { _ =>
+          (scatterCall.identifier.fullyQualifiedName, prepareCall.identifier.fullyQualifiedName)
+        }
+      }
+
+    }
+
+  }
 }


### PR DESCRIPTION
The performance of method `processRunnableTaskCallInputExpression` first appeared on our radar in https://github.com/broadinstitute/cromwell/pull/5048.

It came up again yesterday when we had a high CPU event on all three runners.

I took a thread dump during the event and there were 44 threads busy with
```
at wom.graph.CommandCallNode.toString(CallNode.scala:68)
at java.lang.String.valueOf(String.java:2994)
at java.lang.StringBuilder.append(StringBuilder.java:131)
at cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.processRunnableTaskCallInputExpression(WorkflowExecutionActor.scala:549)
```

I think we are making the mistake of calculating a  potentially very large `toString` by using the default case class implementation.

I do have the full stack dump available in case anyone is curious.

![Screen Shot 2019-09-11 at 5 00 45 PM](https://user-images.githubusercontent.com/1087943/64735012-b60d3a00-d4b5-11e9-8f60-e9a55fd20f07.png)
