### PR TITLE
Remove DRS uuids that fail to resolve [BA-6022]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
@@ -14,8 +14,8 @@ metadata {
 
   "outputs.drs_usa_hca.hash1" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
   "outputs.drs_usa_hca.hash2" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
-  "outputs.drs_usa_hca.hash3" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
+  "outputs.drs_usa_hca.hash3" = "a34f51039b67d4bf3418c5ad1b94a1ea"
   "outputs.drs_usa_hca.size1" = 36895.0
   "outputs.drs_usa_hca.size2" = 36895.0
-  "outputs.drs_usa_hca.size3" = 36895.0
+  "outputs.drs_usa_hca.size3" = 22403106
 }

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
@@ -15,11 +15,7 @@ metadata {
   "outputs.drs_usa_hca.hash1" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
   "outputs.drs_usa_hca.hash2" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
   "outputs.drs_usa_hca.hash3" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
-  "outputs.drs_usa_hca.hash4" = "0f9e425404d1ffda8e9ecd313c7d7ecb"
-  "outputs.drs_usa_hca.hash5" = "a34f51039b67d4bf3418c5ad1b94a1ea"
   "outputs.drs_usa_hca.size1" = 36895.0
   "outputs.drs_usa_hca.size2" = 36895.0
   "outputs.drs_usa_hca.size3" = 36895.0
-  "outputs.drs_usa_hca.size4" = 36895.0
-  "outputs.drs_usa_hca.size5" = 22403106
 }

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca/drs_usa_hca.inputs
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca/drs_usa_hca.inputs
@@ -1,8 +1,6 @@
 {
     # For all below 5 HCA uuids, Martha does not return a service account
-    "drs_usa_hca.localize_drs_with_usa.file1": "drs://service.staging.explore.data.humancellatlas.org/033c9840-c5cd-438b-b0e4-8e4cd8fc8dc6?version=2019-07-04T104122.106166Z",
-    "drs_usa_hca.localize_drs_with_usa.file2": "drs://service.staging.explore.data.humancellatlas.org/4defa7b0-46c2-4053-8e99-b827eed1bc96?version=2019-07-04T104122.100969Z",
-    "drs_usa_hca.localize_drs_with_usa.file3": "drs://service.staging.explore.data.humancellatlas.org/de5dcfc1-5aea-41ba-a7ae-e72c416cb450?version=2019-07-04T104122.092788Z",
-    "drs_usa_hca.localize_drs_with_usa.file4": "drs://service.staging.explore.data.humancellatlas.org/16dea2c5-e2bd-45bc-b2fd-fcac0daafc48?version=2019-07-04T104122.060634Z",
-    "drs_usa_hca.localize_drs_with_usa.file5": "drs://service.dev.explore.data.humancellatlas.org/7c800467-9143-402f-b965-4e7cad75c1e6?version=2019-05-26T130511.722646Z"
+    "drs_usa_hca.localize_drs_with_usa.file1": "drs://service.staging.explore.data.humancellatlas.org/4defa7b0-46c2-4053-8e99-b827eed1bc96?version=2019-07-04T104122.100969Z",
+    "drs_usa_hca.localize_drs_with_usa.file2": "drs://service.staging.explore.data.humancellatlas.org/de5dcfc1-5aea-41ba-a7ae-e72c416cb450?version=2019-07-04T104122.092788Z",
+    "drs_usa_hca.localize_drs_with_usa.file3": "drs://service.dev.explore.data.humancellatlas.org/7c800467-9143-402f-b965-4e7cad75c1e6?version=2019-05-26T130511.722646Z"
 }

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca/drs_usa_hca.wdl
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca/drs_usa_hca.wdl
@@ -7,13 +7,9 @@ workflow drs_usa_hca {
         String hash1 = localize_drs_with_usa.hash1
         String hash2 = localize_drs_with_usa.hash2
         String hash3 = localize_drs_with_usa.hash3
-        String hash4 = localize_drs_with_usa.hash4
-        String hash5 = localize_drs_with_usa.hash5
         Float size1 = localize_drs_with_usa.size1
         Float size2 = localize_drs_with_usa.size2
         Float size3 = localize_drs_with_usa.size3
-        Float size4 = localize_drs_with_usa.size4
-        Float size5 = localize_drs_with_usa.size5
     }
 }
 
@@ -22,29 +18,21 @@ task localize_drs_with_usa {
        File file1
        File file2
        File file3
-       File file4
-       File file5
     }
 
     command <<<
        md5sum ~{file1} | cut -c1-32 > hash1
        md5sum ~{file2} | cut -c1-32 > hash2
        md5sum ~{file3} | cut -c1-32 > hash3
-       md5sum ~{file4} | cut -c1-32 > hash4
-       md5sum ~{file5} | cut -c1-32 > hash5
     >>>
 
     output {
         String hash1 = read_string("hash1")
         String hash2 = read_string("hash2")
         String hash3 = read_string("hash3")
-        String hash4 = read_string("hash4")
-        String hash5 = read_string("hash5")
         Float size1 = size(file1)
         Float size2 = size(file2)
         Float size3 = size(file3)
-        Float size4 = size(file4)
-        Float size5 = size(file5)
     }
 
     runtime {


### PR DESCRIPTION
2 out of 5 drs uuids are failing to resolve due to some issues with HCA's resolution server. This PR removes them until a fix for them is found.

JIRA [issue](https://broadworkbench.atlassian.net/browse/BA-6022)