### PR TITLE
Metadata decider logic

### DIFF
--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
@@ -15,12 +15,6 @@ class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMet
 
   implicit val ec: ExecutionContext = context.dispatcher
 
-  // TODO: [CARBONITE] Decide which actor to send the read request to
-  // NOTE: the 'Future' return value was arbitrary to demonstrate the concept... feel free to refactor all this logic into something better
-  //  like (eg) sending a message to the summary table followed by some appropriate forwarding action when the response comes back
-  def decide(read: MetadataReadAction): Future[ActorRef] = Future.successful(classicMetadataServiceActor)
-
-
   when(Pending) {
     case Event(read: MetadataReadAction, NoData) =>
       val sndr = sender()

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
@@ -1,13 +1,15 @@
 package cromwell.services.metadata.hybridcarbonite
 
-import akka.actor.{Actor, ActorRef, PoisonPill, Props}
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse}
+import akka.actor.FSM.Normal
+import akka.actor.{ActorRef, FSM, LoggingFSM, Props}
+import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse, QueryForWorkflowsMatchingParameters, WorkflowMetadataReadAction, WorkflowQueryFailure, WorkflowQuerySuccess}
+import cromwell.services.metadata.hybridcarbonite.HybridReadDeciderActor._
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor.FailedMetadataResponse
+import cromwell.services.metadata.{MetadataArchiveStatus, WorkflowQueryKey}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 
-class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMetadataServiceActor: ActorRef) extends Actor {
+class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMetadataServiceActor: ActorRef) extends LoggingFSM[HybridReadDeciderState, HybridReadDeciderData] {
 
   implicit val ec: ExecutionContext = context.dispatcher
 
@@ -16,28 +18,73 @@ class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMet
   //  like (eg) sending a message to the summary table followed by some appropriate forwarding action when the response comes back
   def decide(read: MetadataReadAction): Future[ActorRef] = Future.successful(classicMetadataServiceActor)
 
-  var sndr: Option[ActorRef] = None
 
-  override def receive: Receive = {
-    case read: MetadataReadAction =>
-      sndr = Option(sender())
-      decide(read) onComplete {
-        case Success(forwardTo) =>
-          forwardTo ! read
-        case Failure(e) =>
-          respondAndStop(FailedMetadataResponse(read, new Exception("Failed to decide which metadata service to forward request to", e)))
+  when(Pending) {
+    case Event(read: MetadataReadAction, NoData) =>
+      val sndr = sender()
+
+      read match {
+        case _: WorkflowMetadataReadAction =>
+          classicMetadataServiceActor ! QueryForWorkflowsMatchingParameters(Vector(WorkflowQueryKey.Id.name -> ""))
+          goto(RequestingMetadataArchiveStatus) using WorkingData(sndr, read)
+
+        case query: QueryForWorkflowsMatchingParameters =>
+          classicMetadataServiceActor ! query
+          goto(WaitingForMetadataResponse) using WorkingData(sndr, read)
       }
-    case response: MetadataServiceResponse =>
-      respondAndStop(response)
   }
 
-  def respondAndStop(msg: Any) = {
-    sndr.foreach { _ ! msg }
-    self ! PoisonPill
+  when(RequestingMetadataArchiveStatus) {
+    case Event(WorkflowQuerySuccess(response, _), wd: WorkingData) =>
+      if (response.results.size == 1 && response.results.headOption.exists(_.metadataArchiveStatus == MetadataArchiveStatus.Archived)) {
+        carboniteMetadataServiceActor ! wd.request
+      } else {
+        classicMetadataServiceActor ! wd.request
+      }
+      goto(WaitingForMetadataResponse)
+
+    case Event(WorkflowQueryFailure(reason), wd: WorkingData) =>
+      log.error(reason, s"Failed to determine how to route ${wd.request.getClass.getSimpleName}. Falling back to classic.")
+      classicMetadataServiceActor ! wd.request
+      goto(WaitingForMetadataResponse)
   }
+
+  when(WaitingForMetadataResponse) {
+    case Event(response: MetadataServiceResponse , wd: WorkingData) =>
+      wd.actor ! response
+      stop(Normal)
+  }
+
+  whenUnhandled {
+    case Event(msg, data) =>
+      val errorMsg = s"Programmer Error: Unexpected message '$msg' sent to ${getClass.getSimpleName} in state $stateName with data $stateData from $sender()"
+      log.error(errorMsg)
+      data match {
+        case NoData => stop(FSM.Failure(errorMsg))
+        case WorkingData(actor, request) =>
+          actor ! makeAppropriateFailureForRequest(errorMsg, request)
+
+          stop(FSM.Failure(msg))
+      }
+  }
+
+  def makeAppropriateFailureForRequest(msg: String, request: MetadataReadAction) = request match {
+    case _: QueryForWorkflowsMatchingParameters => WorkflowQueryFailure(new Exception(msg))
+    case _ => FailedMetadataResponse(request, new Exception(msg))
+  }
+
 }
 
 object HybridReadDeciderActor {
   def props(classicMetadataServiceActor: ActorRef, carboniteMetadataServiceActor: ActorRef) =
     Props(new HybridReadDeciderActor(classicMetadataServiceActor, carboniteMetadataServiceActor))
+
+  sealed trait HybridReadDeciderState
+  case object Pending extends HybridReadDeciderState
+  case object RequestingMetadataArchiveStatus extends HybridReadDeciderState
+  case object WaitingForMetadataResponse extends HybridReadDeciderState
+
+  sealed trait HybridReadDeciderData
+  case object NoData extends HybridReadDeciderData
+  final case class WorkingData(actor: ActorRef, request: MetadataReadAction) extends HybridReadDeciderData
 }

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
@@ -7,7 +7,7 @@ import cromwell.services.metadata.hybridcarbonite.HybridReadDeciderActor._
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor.FailedMetadataResponse
 import cromwell.services.metadata.{MetadataArchiveStatus, WorkflowQueryKey}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMetadataServiceActor: ActorRef) extends LoggingFSM[HybridReadDeciderState, HybridReadDeciderData] {
 

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
@@ -11,6 +11,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMetadataServiceActor: ActorRef) extends LoggingFSM[HybridReadDeciderState, HybridReadDeciderData] {
 
+  startWith(Pending, NoData)
+
   implicit val ec: ExecutionContext = context.dispatcher
 
   // TODO: [CARBONITE] Decide which actor to send the read request to
@@ -24,8 +26,8 @@ class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMet
       val sndr = sender()
 
       read match {
-        case _: WorkflowMetadataReadAction =>
-          classicMetadataServiceActor ! QueryForWorkflowsMatchingParameters(Vector(WorkflowQueryKey.Id.name -> ""))
+        case wmra: WorkflowMetadataReadAction =>
+          classicMetadataServiceActor ! QueryForWorkflowsMatchingParameters(Vector(WorkflowQueryKey.Id.name -> wmra.workflowId.toString))
           goto(RequestingMetadataArchiveStatus) using WorkingData(sndr, read)
 
         case query: QueryForWorkflowsMatchingParameters =>

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
@@ -30,8 +30,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
 
     val decidedUponActor = if (shouldChooseCarboniter) carboniteMetadataActor else classicMetadataActor
 
-    val hrda: TestFSMRef[HybridReadDeciderState, HybridReadDeciderData, HybridReadDeciderActor] =
-      TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
+    val hrda = TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
     watch(hrda)
 
     hrda.stateName should be(Pending)
@@ -75,8 +74,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
     val classicMetadataActor = TestProbe("classic")
     val carboniteMetadataActor = TestProbe("carboniter")
 
-    val hrda: TestFSMRef[HybridReadDeciderState, HybridReadDeciderData, HybridReadDeciderActor] =
-      TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
+    val hrda = TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
     watch(hrda)
 
     hrda.stateName should be(Pending)

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
@@ -1,0 +1,103 @@
+package cromwell.services.metadata.hybridcarbonite
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestFSMRef, TestProbe}
+import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.services.metadata.MetadataArchiveStatus
+import cromwell.services.metadata.MetadataArchiveStatus._
+import cromwell.services.metadata.MetadataService._
+import cromwell.services.metadata.hybridcarbonite.HybridReadDeciderActor._
+import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import org.scalatest.{FlatSpecLike, Matchers}
+import spray.json._
+
+class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpec") with FlatSpecLike with Matchers {
+
+  behavior of "HybridReadDeciderActor"
+
+  implicit val as: ActorSystem = system
+
+  it should "pass messages correctly for not-yet-archived workflow queries" in { routingTest(Unarchived, shouldChooseCarboniter = false) }
+  it should "pass messages correctly for archived workflow queries" in { routingTest(Archived, shouldChooseCarboniter = true) }
+  it should "pass messages correctly for failed-archived workflow queries" in { routingTest(ArchiveFailed, shouldChooseCarboniter = false) }
+
+  def routingTest(archiveStatusToReturn: MetadataArchiveStatus, shouldChooseCarboniter: Boolean) = {
+    val sampleWorkflowId = WorkflowId.randomId()
+
+    val client = TestProbe("client")
+    val classicMetadataActor = TestProbe("classic")
+    val carboniteMetadataActor = TestProbe("carboniter")
+
+    val decidedUponActor = if (shouldChooseCarboniter) carboniteMetadataActor else classicMetadataActor
+
+    val hrda: TestFSMRef[HybridReadDeciderState, HybridReadDeciderData, HybridReadDeciderActor] =
+      TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
+    watch(hrda)
+
+    hrda.stateName should be(Pending)
+
+    val incomingQuery = GetLabels(sampleWorkflowId)
+
+    // The HybridReadDeciderActor gets a workflow-specific query and looks up its archive status:
+    client.send(hrda, incomingQuery)
+    classicMetadataActor.expectMsg(QueryForWorkflowsMatchingParameters(Vector("Id" -> sampleWorkflowId.toString)))
+    hrda.stateName should be(RequestingMetadataArchiveStatus)
+
+    // The classic metadata actor lets us know that the workflow is unarchived
+    classicMetadataActor.send(hrda, WorkflowQuerySuccess(WorkflowQueryResponse(Seq(WorkflowQueryResult(null, null, null, null, null, null, null, null, null, archiveStatusToReturn)), 1), None))
+
+    // We expect the classic metadata service to receive the original query now:
+    decidedUponActor.expectMsg(incomingQuery)
+    hrda.stateName should be(WaitingForMetadataResponse)
+
+    // Send a basic response:
+    val responseJsonString =
+      s"""{
+        |  "labels": [],
+        |  "id": "${sampleWorkflowId.toString}"
+        |}""".stripMargin
+    val responseJson = responseJsonString.parseJson.asJsObject
+    val response = BuiltMetadataResponse(incomingQuery, responseJson)
+    decidedUponActor.send(hrda, response)
+
+    client.expectMsg(response)
+
+    // Expect the HRDA to shut itself down now that its job is done:
+    expectTerminated(hrda)
+    client.msgAvailable should be(false)
+    classicMetadataActor.msgAvailable should be(false)
+    carboniteMetadataActor.msgAvailable should be(false)
+  }
+
+  it should "go straight to the classic metadata service for archive status for multi-workflow queries" in {
+
+    val client = TestProbe("client")
+    val classicMetadataActor = TestProbe("classic")
+    val carboniteMetadataActor = TestProbe("carboniter")
+
+    val hrda: TestFSMRef[HybridReadDeciderState, HybridReadDeciderData, HybridReadDeciderActor] =
+      TestFSMRef.apply(new HybridReadDeciderActor(classicMetadataActor.ref, carboniteMetadataActor.ref))
+    watch(hrda)
+
+    hrda.stateName should be(Pending)
+
+    val queryMsg = QueryForWorkflowsMatchingParameters(Vector("Includekey" -> "blah"))
+    client.send(hrda, queryMsg)
+    classicMetadataActor.expectMsg(queryMsg)
+    hrda.stateName should be(WaitingForMetadataResponse)
+
+    val response = WorkflowQuerySuccess(WorkflowQueryResponse(Seq(
+      WorkflowQueryResult("id1", null, null, null, null, null, null, null, null, null),
+      WorkflowQueryResult("id2", null, null, null, null, null, null, null, null, null)
+    ), 2), None)
+    classicMetadataActor.send(hrda, response)
+    client.expectMsg(response)
+
+    // Expect the HRDA to shut itself down now that its job is done:
+    expectTerminated(hrda)
+    client.msgAvailable should be(false)
+    classicMetadataActor.msgAvailable should be(false)
+    carboniteMetadataActor.msgAvailable should be(false)
+  }
+
+}

--- a/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
+++ b/services/src/main/scala/cromwell/services/metadata/WorkflowQueryKey.scala
@@ -110,7 +110,7 @@ object WorkflowQueryKey {
     override def validate(grouped: Map[String, Seq[(String, String)]]): ErrorOr[List[String]] = {
       val values = valuesFromMap(grouped).toList
       val nels = values map { v =>
-        if (Try(WorkflowId.fromString(v.toLowerCase.capitalize)).isSuccess) v.validNel[String] else v.invalidNel[String]
+        if (Try(WorkflowId.fromString(v.toLowerCase.capitalize)).isSuccess) v.validNel[String] else s"invalid Id value: '$v'".invalidNel[String]
       }
       sequenceListOfValidatedNels("Id values do match allowed workflow id pattern", nels)
     }


### PR DESCRIPTION
Implements HybridMetadataReadDecider logic from https://docs.google.com/document/d/1VYnzk97yTtllozO9ivZpZQTwrsY5T0wGqxlvAbrEQgg/edit#bookmark=id.mwkzc5gtae81

* Asks classic metadata service for archive status 
* Depending on the response, forwards the original query to either the classic or carbonite metadata service