### PR TITLE
Implement recoverAsync for AWS backend [BA-4857]

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="TypeAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="TypeAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
-  </profile>
-</component>

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -395,6 +395,20 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     } yield PendingExecutionHandle(jobDescriptor, StandardAsyncJob(submitJobResponse.jobId), Option(batchJob), previousState = None)
   }
 
+
+  override def recoverAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] =  reconnectAsync(jobId)
+
+  override def reconnectAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] = {
+    val handle = PendingExecutionHandle[StandardAsyncJob, StandardAsyncRunInfo, StandardAsyncRunState](jobDescriptor, jobId, Option(batchJob), previousState = None)
+    Future.successful(handle)
+  }
+
+  override def reconnectToAbortAsync(jobId: StandardAsyncJob): Future[ExecutionHandle] = {
+    tryAbort(jobId)
+    reconnectAsync(jobId)
+  }
+
+
   val futureKvJobKey = KvJobKey(jobDescriptor.key.call.fullyQualifiedName, jobDescriptor.key.index, jobDescriptor.key.attempt + 1)
 
   // This is called by Cromwell after initial execution (see executeAsync above)


### PR DESCRIPTION
This is a small batch to fix #4857 by implementing recoverAsync in AwsBatchAsyncBackendJobExecutionActor.

I have tested this in our environment and it appears to work.
Implementation is based on pattern in other AsyncBackendJobExecutionActor classes