### PR TITLE
Reintroduce "Cromwell Polling Interval" timing event. Response to BA-6040

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -107,7 +107,6 @@ trait GetRequestHandler { this: RequestHandler =>
             case None => Success(executionEvents, machineType, zone, instanceName)
           }
         } else if (operation.hasStarted) {
-          println(s"[${OffsetDateTime.now()}] ${operation.getName}: Running")
           Running
         } else {
           Initializing
@@ -130,7 +129,7 @@ trait GetRequestHandler { this: RequestHandler =>
     }
 
     val completionEvent: Option[ExecutionEvent] = {
-      metadata.get("endTime") map { time => ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse(time.toString)) }
+      metadata.get("endTime") map { time => ExecutionEvent("Complete in GCE / Cromwell Poll Interval", OffsetDateTime.parse(time.toString)) }
     }
 
     // Map action indexes to event types. Action indexes are 1-based for some reason.

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -128,6 +128,10 @@ trait GetRequestHandler { this: RequestHandler =>
       metadata.get("createTime") map { time => ExecutionEvent("waiting for quota", OffsetDateTime.parse(time.toString)) }
     }
 
+    val completionEvent: Option[ExecutionEvent] = {
+      metadata.get("endTime") map { time => ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse(time.toString)) }
+    }
+
     // Map action indexes to event types. Action indexes are 1-based for some reason.
     val actionIndexToEventType: Map[Int, String] = List(Key.Logging, Key.Tag).flatMap { k =>
       actions.zipWithIndex collect { case (a, i) if a.getLabels.containsKey(k) => (i + 1) -> a.getLabels.get(k) } } toMap
@@ -151,6 +155,6 @@ trait GetRequestHandler { this: RequestHandler =>
         executionEvents filterNot { e => (e.name.startsWith("Started pulling ") || e.name.startsWith("Stopped pulling ")) && e.offsetDateTime.compareTo(start.offsetDateTime) > 0 }
     }
 
-    starterEvent.toList ++ filteredExecutionEvents
+    starterEvent.toList ++ filteredExecutionEvents ++ completionEvent
   }
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandler.scala
@@ -107,6 +107,7 @@ trait GetRequestHandler { this: RequestHandler =>
             case None => Success(executionEvents, machineType, zone, instanceName)
           }
         } else if (operation.hasStarted) {
+          println(s"[${OffsetDateTime.now()}] ${operation.getName}: Running")
           Running
         } else {
           Initializing

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
@@ -189,7 +189,7 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
         Nil,
         List(
           ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None),
-          ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
+          ExecutionEvent("Complete in GCE / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
         ),
         Some("custom-2-7168"),
         None,
@@ -299,7 +299,9 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
       val operation =
       Option(json).map(GoogleAuthMode.jsonFactory.createJsonParser).map(_.parse(classOf[Operation])).orNull
       val runStatus = requestHandler.interpretOperationStatus(operation, pollingRequest)
+
       runStatus should be(expectedStatus)
+
     }
   }
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
@@ -283,7 +283,7 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
         Nil,
         List(
           ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None),
-          ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
+          ExecutionEvent("Complete in GCE / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
         ),
         Some("custom-2-7168"),
         None,

--- a/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/test/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/GetRequestHandlerSpec.scala
@@ -101,7 +101,7 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
          |""".stripMargin,
       Failed(Status.UNAVAILABLE, None, Nil, Nil, None, None, None)
     ),
-    ("Check that we classify error code 10 as a preemption on a preemptible VM",
+    ("check that we classify error code 10 as a preemption on a preemptible VM",
       """{
         |  "done": true,
         |  "error": {
@@ -182,9 +182,20 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
         |    "startTime": "2019-08-18T12:04:39.192909594Z"
         |  },
         |  "name": "asdfasdf"
-        |}""".stripMargin, Preempted(Status.ABORTED, None, Nil, List(ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None)), Some("custom-2-7168"), None, None)
+        |}""".stripMargin,
+      Preempted(
+        Status.ABORTED,
+        None,
+        Nil,
+        List(
+          ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None),
+          ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
+        ),
+        Some("custom-2-7168"),
+        None,
+        None)
     ),
-    ("Check that we classify error code 10 as a failure on a non-preemptible VM",
+    ("check that we classify error code 10 as a failure on a non-preemptible VM",
       """{
         |  "done": true,
         |  "error": {
@@ -265,7 +276,19 @@ class GetRequestHandlerSpec extends FlatSpec with Matchers with TableDrivenPrope
         |    "startTime": "2019-08-18T12:04:39.192909594Z"
         |  },
         |  "name": "asdfasdf"
-        |}""".stripMargin, Failed(Status.ABORTED, None, Nil, List(ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None)), Some("custom-2-7168"), None, None)
+        |}""".stripMargin,
+      Failed(
+        Status.ABORTED,
+        None,
+        Nil,
+        List(
+          ExecutionEvent("waiting for quota", OffsetDateTime.parse("2019-08-18T12:04:38.082650Z"),None),
+          ExecutionEvent("Complete in GCS / Cromwell Poll Interval", OffsetDateTime.parse("2019-08-18T15:58:26.659602622Z"),None),
+        ),
+        Some("custom-2-7168"),
+        None,
+        None
+      )
     )
   )
 


### PR DESCRIPTION
Rather than having very long "Worker released" events which don't mean very much, re-introduce "Cromwell Polling Interval" to fill the gap between "GCS is done" and "Cromwell notices it"

![Screen Shot 2019-10-09 at 5 02 36 PM](https://user-images.githubusercontent.com/13006282/66520194-b6015980-eab6-11e9-887c-7ee27f288d3b.png)
