### PR TITLE
Enable several Centaur tests that now pass on the AWS backend. [No JIRA]

### DIFF
--- a/src/ci/bin/testCentaurAws.sh
+++ b/src/ci/bin/testCentaurAws.sh
@@ -19,30 +19,12 @@ export AWS_CONFIG_FILE="${CROMWELL_BUILD_RESOURCES_DIRECTORY}"/aws_config
 
 cromwell::build::run_centaur \
     -p 100 \
-    -e smartseq2singlesample \
-    -e arrays \
-    -e haplotypecaller \
-    -e jointdiscovery \
-    -e mutect2 \
-    -e singlesample \
-    -e singlesample_production \
-    -e cnv_somatic_pair \
-    -e cnv_somatic_panel \
     -e localdockertest \
-    -e inline_file \
-    -e iwdr_input_string_function \
     -e non_root_default_user \
-    -e cwl_interpolated_strings \
     -e non_root_specified_user \
-    -e space \
-    -e draft3_optional_input_from_scatter \
-    -e iwdr_input_string \
-    -e cwl_cache_between_workflows \
     -e abort.scheduled_abort \
-    -e cwl_cache_within_workflow \
-    -e inline_file_custom_entryname \
     -e relative_output_paths \
     -e relative_output_paths_colliding \
-    -e standard_output_paths_colliding_prevented \
+    -e standard_output_paths_colliding_prevented
 
 cromwell::build::generate_code_coverage


### PR DESCRIPTION
While poking at #5216 I found that several Centaur tests that had been excluded for AWS are now passing. 🎉 