### PR TITLE
Round to nearest integer GiB of total memory. [force ci]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/monitoring_log/monitoring_log.options
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log/monitoring_log.options
@@ -1,3 +1,3 @@
 {
-    "monitoring_script": "gs://cloud-cromwell-dev/some/simple_script.sh"
+    "monitoring_script": "gs://cloud-cromwell-dev/some/rounding_script.sh"
 }

--- a/centaur/src/main/resources/standardTestCases/monitoring_log_papiv1.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log_papiv1.test
@@ -10,9 +10,9 @@ files {
 }
 
 metadata {
-  "calls.monitoring_log.get_stats.jes.monitoringScript": "gs://cloud-cromwell-dev/some/simple_script.sh"
+  "calls.monitoring_log.get_stats.jes.monitoringScript": "gs://cloud-cromwell-dev/some/rounding_script.sh"
   "calls.monitoring_log.get_stats.monitoringLog": "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/monitoring_log/<<UUID>>/call-get_stats/monitoring.log"
   "outputs.monitoring_log.get_stats.stats.0": "CPU: 1"
-  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 3.6G"
+  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 4G"
   "outputs.monitoring_log.get_stats.stats.2": "Total Disk space: 9.8G"
 }

--- a/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
@@ -10,9 +10,9 @@ files {
 }
 
 metadata {
-  "calls.monitoring_log.get_stats.jes.monitoringScript": "gs://cloud-cromwell-dev/some/simple_script.sh"
+  "calls.monitoring_log.get_stats.jes.monitoringScript": "gs://cloud-cromwell-dev/some/rounding_script.sh"
   "calls.monitoring_log.get_stats.monitoringLog": "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/monitoring_log/<<UUID>>/call-get_stats/monitoring.log"
   "outputs.monitoring_log.get_stats.stats.0": "CPU: 1"
-  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 1.9G"
+  "outputs.monitoring_log.get_stats.stats.1": "Total Memory: 2G"
   "outputs.monitoring_log.get_stats.stats.2": "Total Disk space: 9.8G"
 }


### PR DESCRIPTION
A rougher GiB-in-integer measure of total memory on the GCE VM due to unexplained but not particularly interesting fluctuations.

diffs in the monitoring script:
```
cromwell mcovarr$ diff <(gsutil cat gs://cloud-cromwell-dev/some/simple_script.sh) <(gsutil cat gs://cloud-cromwell-dev/some/rounding_script.sh)
3,4c3,4
< echo Total Memory: $(free -h | grep Mem | awk '{ print $2 }')
< echo Total Disk space: $(df -h | grep cromwell_root | awk '{ print $2}')
\ No newline at end of file
---
> cat /proc/meminfo | grep MemTotal | sed -E 's/[^0-9]+([0-9]+).*/\1/' | awk '{printf "Total Memory: %1.0fG\n", $0 / (1024 * 1024)}'
> echo Total Disk space: $(df -h | grep cromwell_root | awk '{ print $2}')
```

the new bits in action (bash arithmetic is integer only, hence the "19 ... / 10" and "20 .. / 10"):
```
# 1.9 GiB
cromwell mcovarr$ echo $((19 * 1024 * 1024 / 10)) | awk '{printf "Total Memory: %1.0fG\n", $0 / (1024 * 1024)}'
Total Memory: 2G
# 2.0 GiB
cromwell mcovarr$ echo $((20 * 1024 * 1024 / 10)) | awk '{printf "Total Memory: %1.0fG\n", $0 / (1024 * 1024)}'
Total Memory: 2G
```