### PR TITLE
Use AwsCredentialProviders for as long as possible before materialising AwsCredentials

### DIFF
--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
@@ -114,9 +114,7 @@ final case class CustomKeyMode(override val name: String,
     // Validate credentials synchronously here, without retry.
     // It's very unlikely to fail as it should not happen more than a few times
     // (one for the engine and for each backend using it) per Cromwell instance.
-    var creds = validateCredential(AwsBasicCredentials.create(accessKey, secretKey), region)
-
-    StaticCredentialsProvider.create(creds)
+    StaticCredentialsProvider.create(validateCredential(AwsBasicCredentials.create(accessKey, secretKey), region))
   }
 
   override def provider(): AwsCredentialsProvider = _provider

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
@@ -32,7 +32,7 @@ package cromwell.cloudsupport.aws.s3
 
 import com.typesafe.config.ConfigFactory
 import net.ceedubs.ficus.Ficus._
-import software.amazon.awssdk.auth.credentials.{AwsCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 
@@ -49,16 +49,16 @@ object S3Storage {
       .build
   }
 
-  def s3Client(configuration: S3Configuration, credentials: AwsCredentials, region: Option[Region]): S3Client = {
+  def s3Client(configuration: S3Configuration, provider: AwsCredentialsProvider, region: Option[Region]): S3Client = {
     val builder = S3Client.builder
       .serviceConfiguration(configuration)
-      .credentialsProvider(StaticCredentialsProvider.create(credentials))
+      .credentialsProvider(provider)
     region.foreach(builder.region)
     builder.build
   }
 
-  def s3Client(credentials: AwsCredentials, region: Option[Region]): S3Client = {
-    s3Client(s3Configuration(), credentials, region)
+  def s3Client(provider: AwsCredentialsProvider, region: Option[Region]): S3Client = {
+    s3Client(s3Configuration(), provider, region)
   }
 
   def s3Configuration(accelerateModeEnabled: Boolean = false,

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/s3/S3StorageSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/s3/S3StorageSpec.scala
@@ -53,7 +53,7 @@ class S3StorageSpec extends FlatSpec with Matchers {
 
   it should "build s3 client with credentials" taggedAs S3StorageSpecUtils.AwsTest in {
     S3Storage.s3Client(
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       Option(Region.US_EAST_1)
     )
   }

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -33,8 +33,6 @@ package cromwell.filesystems.s3
 import java.net.URI
 
 import com.google.common.net.UrlEscapers
-import software.amazon.awssdk.auth.credentials.AwsCredentials
-import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 import cromwell.cloudsupport.aws.auth.AwsAuthMode
 import cromwell.cloudsupport.aws.s3.S3Storage
 import cromwell.core.WorkflowOptions
@@ -42,7 +40,9 @@ import cromwell.core.path.{NioPath, Path, PathBuilder}
 import cromwell.filesystems.s3.S3PathBuilder._
 import org.lerch.s3fs.S3FileSystemProvider
 import org.lerch.s3fs.util.S3Utils
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -115,22 +115,22 @@ object S3PathBuilder {
                    configuration: S3Configuration,
                    options: WorkflowOptions,
                    storageRegion: Option[Region])(implicit ec: ExecutionContext): Future[S3PathBuilder] = {
-    val credentials = authMode.provider().resolveCredentials
+    val provider = authMode.provider()
 
     // Other backends needed retry here. In case we need retry, we'll return
     // a future. This will allow us to add capability without changing signature
-    Future(fromCredentials(credentials,
+    Future(fromProvider(provider,
       configuration,
       options,
       storageRegion
     ))
   }
 
-  def fromCredentials(credentials: AwsCredentials,
-                      configuration: S3Configuration,
-                      options: WorkflowOptions,
-                      storageRegion: Option[Region]): S3PathBuilder = {
-    new S3PathBuilder(S3Storage.s3Client(credentials, storageRegion), configuration)
+  def fromProvider(provider: AwsCredentialsProvider,
+                   configuration: S3Configuration,
+                   options: WorkflowOptions,
+                   storageRegion: Option[Region]): S3PathBuilder = {
+    new S3PathBuilder(S3Storage.s3Client(provider, storageRegion), configuration)
   }
 }
 

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -115,7 +115,7 @@ object S3PathBuilder {
                    configuration: S3Configuration,
                    options: WorkflowOptions,
                    storageRegion: Option[Region])(implicit ec: ExecutionContext): Future[S3PathBuilder] = {
-    val credentials = authMode.credential((key: String) => options.get(key).get)
+    val credentials = authMode.provider().resolveCredentials
 
     // Other backends needed retry here. In case we need retry, we'll return
     // a future. This will allow us to add capability without changing signature

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilderFactory.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilderFactory.scala
@@ -37,12 +37,12 @@ import common.validation.Validation._
 import cromwell.cloudsupport.aws.AwsConfiguration
 import cromwell.cloudsupport.aws.auth.AwsAuthMode
 import cromwell.cloudsupport.aws.s3.S3Storage
-import cromwell.core.path.PathBuilderFactory
 import cromwell.core.WorkflowOptions
+import cromwell.core.path.PathBuilderFactory
 import net.ceedubs.ficus.Ficus._
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 import scala.concurrent.{ExecutionContext, Future}
-import software.amazon.awssdk.auth.credentials.AwsCredentials
 
 // The constructor of this class is required to be Config, Config by cromwell
 // So, we need to take this config and get the AuthMode out of it
@@ -61,8 +61,8 @@ final case class S3PathBuilderFactory private(globalConfig: Config, instanceConf
 
   // Ignores the authMode and creates an S3PathBuilder using the passed credentials directly.
   // Can be used when the Credentials are already available.
-  def fromCredentials(options: WorkflowOptions, credentials: AwsCredentials): S3PathBuilder = {
-    S3PathBuilder.fromCredentials(credentials, S3Storage.DefaultConfiguration, options, conf.region)
+  def fromProvider(options: WorkflowOptions, provider: AwsCredentialsProvider): S3PathBuilder = {
+    S3PathBuilder.fromProvider(provider, S3Storage.DefaultConfiguration, options, conf.region)
   }
 }
 

--- a/filesystems/s3/src/test/scala/cromwell/filesystems/s3/S3PathBuilderSpec.scala
+++ b/filesystems/s3/src/test/scala/cromwell/filesystems/s3/S3PathBuilderSpec.scala
@@ -47,8 +47,8 @@ class S3PathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wit
     // We aren't using workflow options...yet
     val wfOptionsWithProject = WorkflowOptions.empty
 
-    S3PathBuilder.fromCredentials(
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+    S3PathBuilder.fromProvider(
+      AnonymousCredentialsProvider.create,
       S3Storage.s3Configuration(),
       wfOptionsWithProject,
       Option(Region.US_EAST_1)
@@ -381,8 +381,8 @@ class S3PathBuilderSpec extends TestKitSuite with FlatSpecLike with Matchers wit
   )
 
   private lazy val pathBuilder = {
-    S3PathBuilder.fromCredentials(
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+    S3PathBuilder.fromProvider(
+      AnonymousCredentialsProvider.create,
       S3Storage.s3Configuration(),
       WorkflowOptions.empty,
       Option(Region.US_EAST_1)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchBackendInitializationData.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchBackendInitializationData.scala
@@ -31,15 +31,15 @@
 
 package cromwell.backend.impl.aws
 
-import software.amazon.awssdk.auth.credentials.AwsCredentials
 import cromwell.backend.standard.{StandardInitializationData, StandardValidatedRuntimeAttributesBuilder}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 case class AwsBatchBackendInitializationData
 (
   override val workflowPaths: AwsBatchWorkflowPaths,
   override val runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder,
   configuration: AwsBatchConfiguration,
-  credentials: AwsCredentials,
+  provider: AwsCredentialsProvider,
   // TODO: We'll need something specific for batch probably, but I need to
   //       understand more about the genomics node first
   //genomics: Genomics

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchInitializationActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchInitializationActor.scala
@@ -75,7 +75,7 @@ class AwsBatchInitializationActor(params: AwsBatchInitializationActorParams)
     AwsBatchRuntimeAttributes.runtimeAttributesBuilder(configuration)
 
   private lazy val credentials: Future[AwsCredentials] =
-    Future { configuration.awsAuth.credential(_ => "") }
+    Future { configuration.awsAuth.provider().resolveCredentials() }
 
   override lazy val workflowPaths: Future[AwsBatchWorkflowPaths] = for {
     creds <- credentials

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchInitializationActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchInitializationActor.scala
@@ -34,17 +34,15 @@ package cromwell.backend.impl.aws
 import java.io.IOException
 
 import akka.actor.ActorRef
-import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import cromwell.filesystems.s3.batch.S3BatchCommandBuilder
-import cromwell.backend.standard.{StandardInitializationActor,
-                                  StandardInitializationActorParams,
-                                  StandardValidatedRuntimeAttributesBuilder}
-import cromwell.backend.{BackendConfigurationDescriptor,
-                         BackendWorkflowDescriptor}
+import cromwell.backend.standard.{StandardInitializationActor, StandardInitializationActorParams, StandardValidatedRuntimeAttributesBuilder}
+import cromwell.backend.{BackendConfigurationDescriptor, BackendWorkflowDescriptor}
 import cromwell.core.io.DefaultIoCommandBuilder
 import cromwell.core.io.AsyncIoActorClient
 import cromwell.core.path.Path
 import wom.graph.CommandCallNode
+
 import scala.concurrent.Future
 
 case class AwsBatchInitializationActorParams
@@ -74,17 +72,17 @@ class AwsBatchInitializationActor(params: AwsBatchInitializationActorParams)
   override lazy val runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder =
     AwsBatchRuntimeAttributes.runtimeAttributesBuilder(configuration)
 
-  private lazy val credentials: Future[AwsCredentials] =
-    Future { configuration.awsAuth.provider().resolveCredentials() }
+  private lazy val provider: Future[AwsCredentialsProvider] =
+    Future { configuration.awsAuth.provider() }
 
   override lazy val workflowPaths: Future[AwsBatchWorkflowPaths] = for {
-    creds <- credentials
-  } yield new AwsBatchWorkflowPaths(workflowDescriptor, creds, configuration)
+    prov <- provider
+  } yield new AwsBatchWorkflowPaths(workflowDescriptor, prov, configuration)
 
   override lazy val initializationData: Future[AwsBatchBackendInitializationData] = for {
     workflowPaths <- workflowPaths
-    creds <- credentials
-  } yield AwsBatchBackendInitializationData(workflowPaths, runtimeAttributesBuilder, configuration, creds)
+    prov <- provider
+  } yield AwsBatchBackendInitializationData(workflowPaths, runtimeAttributesBuilder, configuration, prov)
 
   override lazy val ioCommandBuilder =  {
     val conf = Option(configuration) match {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -49,7 +49,6 @@ import cromwell.backend.io.JobPaths
 import cromwell.cloudsupport.aws.auth.AwsAuthMode
 import org.slf4j.LoggerFactory
 import fs2.Stream
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 
 import scala.collection.JavaConverters._
@@ -85,7 +84,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
   lazy val client = {
     val builder = BatchClient.builder()
     optAwsAuthMode.foreach { awsAuthMode =>
-      builder.credentialsProvider(StaticCredentialsProvider.create(awsAuthMode.credential(_ => "")))
+      builder.credentialsProvider(awsAuthMode.provider())
     }
     configRegion.foreach(builder.region)
     builder.build

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPaths.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPaths.scala
@@ -31,7 +31,7 @@
 
 package cromwell.backend.impl.aws
 
-import software.amazon.awssdk.auth.credentials.AwsCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import cromwell.backend.io.WorkflowPaths
@@ -45,8 +45,8 @@ object AwsBatchWorkflowPaths {
 }
 
 case class AwsBatchWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
-                            credentials: AwsCredentials,
-                            configuration: AwsBatchConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
+                                 provider: AwsCredentialsProvider,
+                                 configuration: AwsBatchConfiguration)(implicit actorSystem: ActorSystem) extends WorkflowPaths {
 
   override lazy val executionRootString: String =  configuration.fileSystem match {
     case AWSBatchStorageSystems.s3  => workflowDescriptor.workflowOptions.getOrElse(AwsBatchWorkflowPaths.RootOptionKey, configuration.root)
@@ -63,7 +63,7 @@ case class AwsBatchWorkflowPaths(workflowDescriptor: BackendWorkflowDescriptor,
   override def config: Config = configuration.configurationDescriptor.backendConfig
   override def pathBuilders: List[PathBuilder] = {
     if (configuration.fileSystem == "s3") {
-      List(configuration.pathBuilderFactory.asInstanceOf[S3PathBuilderFactory].fromCredentials(workflowOptions, credentials))
+      List(configuration.pathBuilderFactory.asInstanceOf[S3PathBuilderFactory].fromProvider(workflowOptions, provider))
     } else {
       WorkflowPaths.DefaultPathBuilders}
   }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/OccasionalStatusPollingActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/OccasionalStatusPollingActor.scala
@@ -4,7 +4,6 @@ import akka.actor.{Actor, ActorLogging, Props}
 import cromwell.backend.impl.aws.OccasionalStatusPollingActor._
 import cromwell.backend.impl.aws.RunStatus.{Initializing, Running}
 import cromwell.cloudsupport.aws.auth.AwsAuthMode
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.batch.BatchClient
 import software.amazon.awssdk.services.batch.model.ListJobsRequest
@@ -35,8 +34,9 @@ class OccasionalStatusPollingActor(configRegion: Option[Region], optAwsAuthMode:
 
   lazy val client = {
     val builder = BatchClient.builder()
+    Console.out.println("XXXXXX Made new client")
     optAwsAuthMode.foreach { awsAuthMode =>
-      builder.credentialsProvider(StaticCredentialsProvider.create(awsAuthMode.credential(_ => "")))
+      builder.credentialsProvider(awsAuthMode.provider())
     }
     configRegion.foreach(builder.region)
     builder.build
@@ -85,6 +85,7 @@ class OccasionalStatusPollingActor(configRegion: Option[Region], optAwsAuthMode:
 
       val request = requestBuilder.build()
 
+      Console.out.println("YYYYY Using client")
       val response = client.listJobs(request)
       val jobIds = response.jobSummaryList().asScala.map(_.jobId()).toVector
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/OccasionalStatusPollingActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/OccasionalStatusPollingActor.scala
@@ -34,7 +34,6 @@ class OccasionalStatusPollingActor(configRegion: Option[Region], optAwsAuthMode:
 
   lazy val client = {
     val builder = BatchClient.builder()
-    Console.out.println("XXXXXX Made new client")
     optAwsAuthMode.foreach { awsAuthMode =>
       builder.credentialsProvider(awsAuthMode.provider())
     }
@@ -85,7 +84,6 @@ class OccasionalStatusPollingActor(configRegion: Option[Region], optAwsAuthMode:
 
       val request = requestBuilder.build()
 
-      Console.out.println("YYYYY Using client")
       val response = client.listJobs(request)
       val jobIds = response.jobSummaryList().asScala.map(_.jobId()).toVector
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActorSpec.scala
@@ -80,8 +80,8 @@ import scala.util.Success
 
 class AwsBatchAsyncBackendJobExecutionActorSpec extends TestKitSuite("AwsBatchAsyncBackendJobExecutionActorSpec")
   with FlatSpecLike with Matchers with ImplicitSender with Mockito with BackendSpec with BeforeAndAfter with DefaultJsonProtocol {
-  lazy val mockPathBuilder: S3PathBuilder = S3PathBuilder.fromCredentials(
-    AnonymousCredentialsProvider.create.resolveCredentials(),
+  lazy val mockPathBuilder: S3PathBuilder = S3PathBuilder.fromProvider(
+    AnonymousCredentialsProvider.create,
     S3Storage.DefaultConfiguration,
     WorkflowOptions.empty,
     Option(Region.US_EAST_1)
@@ -135,7 +135,7 @@ class AwsBatchAsyncBackendJobExecutionActorSpec extends TestKitSuite("AwsBatchAs
   private def buildInitializationData(jobDescriptor: BackendJobDescriptor, configuration: AwsBatchConfiguration) = {
     val workflowPaths = AwsBatchWorkflowPaths(
       jobDescriptor.workflowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
     val runtimeAttributesBuilder = AwsBatchRuntimeAttributes.runtimeAttributesBuilder(configuration)

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchCallPathsSpec.scala
@@ -61,7 +61,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
     val workflowPaths = AwsBatchWorkflowPaths(
       workflowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
 
@@ -83,7 +83,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
     val workflowPaths = AwsBatchWorkflowPaths(
       workflowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
 
@@ -108,7 +108,7 @@ class AwsBatchCallPathsSpec extends TestKitSuite with FlatSpecLike with Matchers
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
     val workflowPaths = AwsBatchWorkflowPaths(
       workflowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -129,7 +129,7 @@ class AwsBatchJobSpec extends TestKitSuite with FlatSpecLike with Matchers with 
     val configuration = new AwsBatchConfiguration(AwsBatchBackendConfigurationDescriptor)
     val workflowPaths = AwsBatchWorkflowPaths(
       workFlowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchWorkflowPathsSpec.scala
@@ -59,7 +59,7 @@ class AwsBatchWorkflowPathsSpec extends TestKitSuite with FlatSpecLike with Matc
 
     val workflowPaths = AwsBatchWorkflowPaths(
       workflowDescriptor,
-      AnonymousCredentialsProvider.create.resolveCredentials(),
+      AnonymousCredentialsProvider.create,
       configuration
     )
     workflowPaths.executionRoot.pathAsString should be("s3://my-cromwell-workflows-bucket/")


### PR DESCRIPTION
For any AWS backend config using temporary credentials (fargate, assume-roles, ec2 instances?) - obtaining the actual credentials needs to be delayed as long as possible so that long running tasks will use the providers ability to refresh.

This PR just converts AwsAuthModes to hand out AwsCredentialProviders rather than AwsCredentials. 

All the AWS Java SDK builders take credential providers as the basis for their client anyhow (builder.credentialsProvider(xxx)) 

Unresolved in this PR is the use of 'options' as a parameter to the auth modes credentials() call - I could not work out what they were intended for. In general they were just passed in as (_ => "") but there may be some loss of functionality?
