### PR TITLE
Carbonite metrics [BA-6043]

### DIFF
--- a/core/src/test/scala/cromwell/util/AkkaTestUtil.scala
+++ b/core/src/test/scala/cromwell/util/AkkaTestUtil.scala
@@ -3,7 +3,9 @@ package cromwell.util
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Kill, PoisonPill, Props, SupervisorStrategy}
 import akka.testkit.TestProbe
 
+import scala.annotation.tailrec
 import scala.util.control.NoStackTrace
+import scala.concurrent.duration._
 
 object AkkaTestUtil {
 
@@ -19,6 +21,18 @@ object AkkaTestUtil {
         case inbound => probe.ref forward inbound
       }
     })
+
+    @tailrec
+    final def expectMsgAmongstOthers(message: Any, maxWait: FiniteDuration = 10.seconds): Unit = {
+      val waitStart = System.currentTimeMillis()
+      val nextMessage = probe.expectMsgPF(10.seconds) { case anything => anything }
+      nextMessage match {
+        case `message` => () // success!
+        case _ =>
+          val waitedSoFar = System.currentTimeMillis() - waitStart
+          probe.expectMsgAmongstOthers(message, maxWait.minus(waitedSoFar.millis))
+      }
+    }
   }
 
   def actorDeathMethods(system: ActorSystem): List[(String, ActorRef => Unit)] = List(

--- a/core/src/test/scala/cromwell/util/AkkaTestUtil.scala
+++ b/core/src/test/scala/cromwell/util/AkkaTestUtil.scala
@@ -2,10 +2,7 @@ package cromwell.util
 
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Kill, PoisonPill, Props, SupervisorStrategy}
 import akka.testkit.TestProbe
-
-import scala.annotation.tailrec
 import scala.util.control.NoStackTrace
-import scala.concurrent.duration._
 
 object AkkaTestUtil {
 
@@ -21,18 +18,6 @@ object AkkaTestUtil {
         case inbound => probe.ref forward inbound
       }
     })
-
-    @tailrec
-    final def expectMsgAmongstOthers(message: Any, maxWait: FiniteDuration = 10.seconds): Unit = {
-      val waitStart = System.currentTimeMillis()
-      val nextMessage = probe.expectMsgPF(10.seconds) { case anything => anything }
-      nextMessage match {
-        case `message` => () // success!
-        case _ =>
-          val waitedSoFar = System.currentTimeMillis() - waitStart
-          probe.expectMsgAmongstOthers(message, maxWait.minus(waitedSoFar.millis))
-      }
-    }
   }
 
   def actorDeathMethods(system: ActorSystem): List[(String, ActorRef => Unit)] = List(

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActor.scala
@@ -70,9 +70,9 @@ class CarbonitingMetadataFreezerActor(carboniterConfig: HybridCarboniteConfig,
   }
 
   when(UpdatingDatabase) {
-    case Event(DatabaseUpdateCompleted(Success(_)), UpdatingDatabaseData(workflowId, _)) =>
+    case Event(DatabaseUpdateCompleted(Success(_)), UpdatingDatabaseData(workflowId, result)) =>
       // All set; send 'complete' to CarboniteWorkerActor; wait for next workflow to carbonite
-      carboniteWorkerActor ! CarboniteWorkflowComplete(workflowId)
+      carboniteWorkerActor ! CarboniteWorkflowComplete(workflowId, result)
       goto(Pending)
     case Event(DatabaseUpdateCompleted(Failure(reason)), UpdatingDatabaseData(workflowId, freezingResult)) =>
       log.error(reason, s"Unable to update workflow ID $workflowId's METADATA_ARCHIVE_STATUS to $freezingResult. Will try again in 1 minute")

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActorSpec.scala
@@ -7,7 +7,7 @@ import common.validation.Validation._
 import common.assertion.ManyTimes._
 import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.core.{TestKitSuite, WorkflowId}
-import cromwell.services.metadata.MetadataArchiveStatus.Unarchived
+import cromwell.services.metadata.MetadataArchiveStatus.{Archived, Unarchived}
 import cromwell.services.metadata.MetadataService.{QueryForWorkflowsMatchingParameters, QueryMetadata, WorkflowQueryResponse, WorkflowQueryResult, WorkflowQuerySuccess}
 import cromwell.services.metadata.hybridcarbonite.CarboniteWorkerActor.CarboniteWorkflowComplete
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActor.FreezeMetadata
@@ -63,7 +63,7 @@ class CarboniteWorkerActorSpec extends TestKitSuite("CarboniteWorkerActorSpec") 
 
       carboniteFreezerActor.expectMsg(FreezeMetadata(WorkflowId.fromString(workflowToCarbonite)))
 
-      carboniteFreezerActor.send(carboniteWorkerActor, CarboniteWorkflowComplete(WorkflowId.fromString(workflowToCarbonite)))
+      carboniteFreezerActor.send(carboniteWorkerActor, CarboniteWorkflowComplete(WorkflowId.fromString(workflowToCarbonite), Archived))
     }
   }
 }


### PR DESCRIPTION
Includes metrics for:

* Time to query for carbonite-able workflows
* Time to freeze workflows once they have been identified as carbonite-able
* Successful carbonite count
* Unsuccessful carbonite count
* Number of workflow remaining which are eligible for carbonite-ing