### PR TITLE
Centaur test carbonite process [BA-6052]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/control_chars.test
+++ b/centaur/src/main/resources/standardTestCases/control_chars.test
@@ -1,0 +1,12 @@
+name: control_chars
+testFormat: workflowsuccess
+
+files {
+  workflow: control_chars/control_chars.wdl
+}
+
+metadata {
+  workflowName: control_chars
+  status: Succeeded
+  "calls.control_chars.control.executionStatus": Done
+}

--- a/centaur/src/main/resources/standardTestCases/control_chars/control_chars.wdl
+++ b/centaur/src/main/resources/standardTestCases/control_chars/control_chars.wdl
@@ -1,0 +1,17 @@
+version 1.0
+
+task control {
+  command {
+    echo "“Control characters should work with Carbonited metadata” — Cromwell"
+  }
+  output {
+    String salutation = read_string(stdout())
+  }
+  runtime {
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+  }
+}
+
+workflow control_chars {
+  call control
+}

--- a/centaur/src/main/scala/centaur/CentaurConfig.scala
+++ b/centaur/src/main/scala/centaur/CentaurConfig.scala
@@ -51,6 +51,7 @@ object CentaurConfig {
   lazy val conf = ConfigFactory.load().getConfig("centaur")
   
   lazy val runMode = CentaurRunMode(conf)
+  lazy val expectCarbonite = if (conf.hasPath("expectCarbonite")) conf.getBoolean("expectCarbonite") else false
   
   lazy val cromwellUrl = runMode.cromwellUrl
   lazy val sendReceiveTimeout = conf.getDuration("sendReceiveTimeout").toScala

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -94,6 +94,10 @@ object CentaurCromwellClient extends StrictLogging {
   def metadataWithId(id: WorkflowId, args: Option[Map[String, List[String]]] = defaultMetadataArgs): IO[WorkflowMetadata] = {
     sendReceiveFutureCompletion(() => cromwellClient.metadata(id, args))
   }
+
+  def archiveStatus(id: WorkflowId): IO[String] = {
+    sendReceiveFutureCompletion(() => cromwellClient.query(id)).map(_.results.head.metadataArchiveStatus)
+  }
   
   implicit private val timer = IO.timer(blockingEc)
   implicit private val contextShift = IO.contextShift(blockingEc)

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -487,7 +487,13 @@ object Operations extends StrictLogging {
       }
 
       override def run: IO[Unit] = {
-        eventuallyArchived().timeout(CentaurConfig.metadataConsistencyTimeout)
+        if (CentaurConfig.expectCarbonite) {
+          logger.info(s"Expecting carbonited status for $workflowId")
+          eventuallyArchived().timeout(CentaurConfig.metadataConsistencyTimeout)
+        } else {
+          logger.info(s"Not expecting carbonited status for $workflowId (because expectCarbonite is turned off)")
+          IO.pure(())
+        }
       }
     }
   }

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -29,7 +29,6 @@ import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
 import io.circe.parser._
 import spray.json.JsString
 
-import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.util.Failure

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -470,7 +470,7 @@ object Operations extends StrictLogging {
   def waitForArchive(workflowId: WorkflowId): Test[Unit] = {
     new Test[Unit] {
 
-      def validateMetadataArchiveStatus(status: String): IO[Unit] = if (status == "Archived") IO[Unit].apply(()) else IO.fromTry(Failure(new Exception(s"Expected Archived but got $status")))
+      def validateMetadataArchiveStatus(status: String): IO[Unit] = if (status == "Archived") IO.pure(()) else IO.fromTry(Failure(new Exception(s"Expected Archived but got $status")))
 
       def validateArchived(): IO[Unit] = for {
           archiveStatus <- CentaurCromwellClient.archiveStatus(workflowId)

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -470,12 +470,15 @@ object Operations extends StrictLogging {
   def waitForArchive(workflowId: WorkflowId): Test[Unit] = {
     new Test[Unit] {
 
-      def validateMetadataArchiveStatus(status: String): IO[Boolean] = if (status == "Archived") {
-        IO.pure(true)
-      }  else if (status == "Unarchived" ) {
-        IO.pure(false)
-      } else {
-        IO.fromTry(Failure(new Exception(s"Expected Archived but got $status")))
+      def validateMetadataArchiveStatus(status: String): IO[Boolean] = {
+        logger.info(s"Validating archive status '$status for workflow ID: $workflowId'")
+        if (status == "Archived") {
+          IO.pure(true)
+        }  else if (status == "Unarchived" ) {
+          IO.pure(false)
+        } else {
+          IO.fromTry(Failure(new Exception(s"Expected Archived but got $status")))
+        }
       }
 
       def checkArchived(): IO[Boolean] = for {

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -38,6 +38,7 @@ object TestFormulas {
     metadata <- validateMetadata(submittedWorkflow, workflowDefinition)
     _ = cromwellTracker.track(metadata)
     _ <- validateDirectoryContentsCounts(workflowDefinition, submittedWorkflow, metadata)
+    _ <- waitForArchive(submittedWorkflow.id)
   } yield SubmitResponse(submittedWorkflow)
 
   def runFailingWorkflowAndVerifyMetadata(workflowDefinition: Workflow)(implicit cromwellTracker: Option[CromwellTracker]): Test[SubmitResponse] = for {
@@ -45,6 +46,7 @@ object TestFormulas {
     metadata <- validateMetadata(submittedWorkflow, workflowDefinition)
     _ = cromwellTracker.track(metadata)
     _ <- validateDirectoryContentsCounts(workflowDefinition, submittedWorkflow, metadata)
+    _ <- waitForArchive(submittedWorkflow.id)
   } yield SubmitResponse(submittedWorkflow)
 
   def runWorkflowTwiceExpectingCaching(workflowDefinition: Workflow)(implicit cromwellTracker: Option[CromwellTracker]): Test[SubmitResponse] = {

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -39,6 +39,8 @@ object TestFormulas {
     _ = cromwellTracker.track(metadata)
     _ <- validateDirectoryContentsCounts(workflowDefinition, submittedWorkflow, metadata)
     _ <- waitForArchive(submittedWorkflow.id)
+    // Re-validate the metadata now that carboniting has completed
+    _ <- validateMetadata(submittedWorkflow, workflowDefinition)
   } yield SubmitResponse(submittedWorkflow)
 
   def runFailingWorkflowAndVerifyMetadata(workflowDefinition: Workflow)(implicit cromwellTracker: Option[CromwellTracker]): Test[SubmitResponse] = for {
@@ -47,6 +49,8 @@ object TestFormulas {
     _ = cromwellTracker.track(metadata)
     _ <- validateDirectoryContentsCounts(workflowDefinition, submittedWorkflow, metadata)
     _ <- waitForArchive(submittedWorkflow.id)
+    // Re-validate the metadata now that carboniting has completed
+    _ <- validateMetadata(submittedWorkflow, workflowDefinition)
   } yield SubmitResponse(submittedWorkflow)
 
   def runWorkflowTwiceExpectingCaching(workflowDefinition: Workflow)(implicit cromwellTracker: Option[CromwellTracker]): Test[SubmitResponse] = {

--- a/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.model.headers.{Authorization, HttpCredentials, HttpEnc
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
-import cats.data.NonEmptyList
 import cats.effect.IO
 import cromwell.api.CromwellClient._
 import cromwell.api.model._
@@ -64,6 +63,7 @@ class CromwellClient(val cromwellUrl: URL,
   import model.WorkflowLabelsJsonSupport._
   import model.WorkflowLogsJsonSupport._
   import model.WorkflowOutputsJsonSupport._
+  import model.CromwellQueryResultJsonSupport._
 
   def submit(workflow: WorkflowSubmission)
             (implicit ec: ExecutionContext): FailureResponseOrT[SubmittedWorkflow] = {

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
@@ -7,9 +7,9 @@ import cromwell.api.model.WorkflowStatusJsonFormatter._
 
 case class CromwellQueryResults(results: Seq[CromwellQueryResult])
 
-case class CromwellQueryResult(name: String, id: WorkflowId, status: WorkflowStatus, end: OffsetDateTime, start: OffsetDateTime)
+case class CromwellQueryResult(name: String, id: WorkflowId, status: WorkflowStatus, end: OffsetDateTime, start: OffsetDateTime, metadataArchiveStatus: String)
 
 object CromwellQueryResultJsonFormatter extends DefaultJsonProtocol {
-  implicit val CromwellQueryResultJsonFormat = jsonFormat5(CromwellQueryResult)
+  implicit val CromwellQueryResultJsonFormat = jsonFormat6(CromwellQueryResult)
   implicit val CromwellQueryResultsJsonFormat = jsonFormat1(CromwellQueryResults)
 }

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
@@ -9,7 +9,7 @@ case class CromwellQueryResults(results: Seq[CromwellQueryResult])
 
 case class CromwellQueryResult(name: String, id: WorkflowId, status: WorkflowStatus, end: OffsetDateTime, start: OffsetDateTime, metadataArchiveStatus: String)
 
-object CromwellQueryResultJsonFormatter extends DefaultJsonProtocol {
+object CromwellQueryResultJsonSupport extends DefaultJsonProtocol {
   implicit val CromwellQueryResultJsonFormat = jsonFormat6(CromwellQueryResult)
   implicit val CromwellQueryResultsJsonFormat = jsonFormat1(CromwellQueryResults)
 }

--- a/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/model/CromwellQueryResult.scala
@@ -7,7 +7,7 @@ import cromwell.api.model.WorkflowStatusJsonFormatter._
 
 case class CromwellQueryResults(results: Seq[CromwellQueryResult])
 
-case class CromwellQueryResult(name: String, id: WorkflowId, status: WorkflowStatus, end: OffsetDateTime, start: OffsetDateTime, metadataArchiveStatus: String)
+case class CromwellQueryResult(name: Option[String], id: WorkflowId, status: WorkflowStatus, end: Option[OffsetDateTime], start: Option[OffsetDateTime], metadataArchiveStatus: String)
 
 object CromwellQueryResultJsonSupport extends DefaultJsonProtocol {
   implicit val CromwellQueryResultJsonFormat = jsonFormat6(CromwellQueryResult)

--- a/cromwellApiClient/src/test/scala/cromwell/api/model/CromwellQueryResultJsonFormatterSpec.scala
+++ b/cromwellApiClient/src/test/scala/cromwell/api/model/CromwellQueryResultJsonFormatterSpec.scala
@@ -4,7 +4,7 @@ import java.time.OffsetDateTime
 
 import org.scalatest.{FlatSpec, Matchers}
 import spray.json._
-import cromwell.api.model.CromwellQueryResultJsonFormatter._
+import cromwell.api.model.CromwellQueryResultJsonSupport._
 
 class CromwellQueryResultJsonFormatterSpec extends FlatSpec with Matchers {
 
@@ -16,14 +16,16 @@ class CromwellQueryResultJsonFormatterSpec extends FlatSpec with Matchers {
       WorkflowId.fromString("bee51f36-396d-4e22-8a81-33dedff66bf6"),
       Failed,
       OffsetDateTime.parse("2017-07-24T14:44:34.010Z"),
-      OffsetDateTime.parse("2017-07-24T14:44:33.227Z")
+      OffsetDateTime.parse("2017-07-24T14:44:33.227Z"),
+      "Archived"
     ),
     CromwellQueryResult(
       "switcheroo",
       WorkflowId.fromString("0071495e-39eb-478e-bc98-8614b986c91e"),
       Succeeded,
       OffsetDateTime.parse("2017-07-24T15:06:45.940Z"),
-      OffsetDateTime.parse("2017-07-24T15:04:54.372Z")
+      OffsetDateTime.parse("2017-07-24T15:04:54.372Z"),
+      "Unarchived"
     ),
   ))
 
@@ -34,14 +36,16 @@ class CromwellQueryResultJsonFormatterSpec extends FlatSpec with Matchers {
                        |      "id": "bee51f36-396d-4e22-8a81-33dedff66bf6",
                        |      "status": "Failed",
                        |      "end": "2017-07-24T14:44:34.010Z",
-                       |      "start": "2017-07-24T14:44:33.227Z"
+                       |      "start": "2017-07-24T14:44:33.227Z",
+                       |      "metadataArchiveStatus": "Archived"
                        |    },
                        |    {
                        |      "name": "switcheroo",
                        |      "id": "0071495e-39eb-478e-bc98-8614b986c91e",
                        |      "status": "Succeeded",
                        |      "end": "2017-07-24T15:06:45.940Z",
-                       |      "start": "2017-07-24T15:04:54.372Z"
+                       |      "start": "2017-07-24T15:04:54.372Z",
+                       |      "metadataArchiveStatus": "Unarchived"
                        |    }
                        |  ]
                        |}""".stripMargin.parseJson.asJsObject

--- a/cromwellApiClient/src/test/scala/cromwell/api/model/CromwellQueryResultJsonFormatterSpec.scala
+++ b/cromwellApiClient/src/test/scala/cromwell/api/model/CromwellQueryResultJsonFormatterSpec.scala
@@ -12,19 +12,19 @@ class CromwellQueryResultJsonFormatterSpec extends FlatSpec with Matchers {
 
   val sampleQueryResult = CromwellQueryResults(results = List(
     CromwellQueryResult(
-      "switcheroo",
+      Option("switcheroo"),
       WorkflowId.fromString("bee51f36-396d-4e22-8a81-33dedff66bf6"),
       Failed,
-      OffsetDateTime.parse("2017-07-24T14:44:34.010Z"),
-      OffsetDateTime.parse("2017-07-24T14:44:33.227Z"),
+      Option(OffsetDateTime.parse("2017-07-24T14:44:34.010Z")),
+        Option(OffsetDateTime.parse("2017-07-24T14:44:33.227Z")),
       "Archived"
     ),
     CromwellQueryResult(
-      "switcheroo",
+      Option("switcheroo"),
       WorkflowId.fromString("0071495e-39eb-478e-bc98-8614b986c91e"),
       Succeeded,
-      OffsetDateTime.parse("2017-07-24T15:06:45.940Z"),
-      OffsetDateTime.parse("2017-07-24T15:04:54.372Z"),
+        Option(OffsetDateTime.parse("2017-07-24T15:06:45.940Z")),
+          Option(OffsetDateTime.parse("2017-07-24T15:04:54.372Z")),
       "Unarchived"
     ),
   ))

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActorSpec.scala
@@ -71,8 +71,6 @@ class CarboniteWorkerActorSpec extends TestKitSuite("CarboniteWorkerActorSpec") 
   }
 }
 
-
-
 class MockCarboniteWorkerActor(carboniterConfig: HybridCarboniteConfig,
                                serviceRegistryActor: ActorRef,
                                ioActor: ActorRef,

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -452,7 +452,12 @@ cromwell::private::create_centaur_variables() {
             ;;
         *)
             CROMWELL_BUILD_CENTAUR_TEST_DIRECTORY="${CROMWELL_BUILD_CENTAUR_RESOURCES}/${CROMWELL_BUILD_CENTAUR_TYPE}TestCases"
-            CROMWELL_BUILD_CENTAUR_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/centaur_application.conf"
+            if test "${CROMWELL_BUILD_BACKEND_TYPE}" = "papi_v2"
+            then
+              CROMWELL_BUILD_CENTAUR_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/papi_v2_centaur_application.conf"
+            else
+              CROMWELL_BUILD_CENTAUR_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/centaur_application.conf"
+            fi
             ;;
     esac
 

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -12,7 +12,7 @@ services {
       # The carbonite section contains carbonite-specific options
       carbonite-metadata-service {
         # enable carboniting
-        enabled = false
+        enabled = true
 
         # Which bucket to use for storing the generated metadata JSON
         bucket = "carbonite-test-bucket"

--- a/src/ci/resources/papi_v2_centaur_application.conf
+++ b/src/ci/resources/papi_v2_centaur_application.conf
@@ -1,0 +1,5 @@
+include "centaur_application.conf"
+
+centaur {
+  expectCarbonite: true
+}

--- a/wes2cromwell/src/main/scala/wes2cromwell/RunListResponse.scala
+++ b/wes2cromwell/src/main/scala/wes2cromwell/RunListResponse.scala
@@ -7,7 +7,7 @@ case class RunListResponse(runs: List[WesRunStatus], next_page_token: String)
 
 object RunListResponse {
   def fromJson(json: String): RunListResponse = {
-    import cromwell.api.model.CromwellQueryResultJsonFormatter._
+    import cromwell.api.model.CromwellQueryResultJsonSupport._
 
     val jsonAst = JsonParser(json)
     val queryResults = jsonAst.convertTo[CromwellQueryResults]


### PR DESCRIPTION
For workflow-success and workflow-failure type tests:

* Wait for the query results for the workflow to indicate carbonite complete
* Ensure that the metadata is as valid afterwards as it was beforehand