### PR TITLE
Metadata plumbing fixes, some working metadata endpoints [BA-6069]

### DIFF
--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -22,6 +22,7 @@ object JsonEditor {
     }
 
   def includeJson(json: Json, keys: NonEmptyList[String]): Json = {
+    val keysWithId = "id" :: keys
     def folder: Folder[(Json, Boolean)] = new Folder[(Json, Boolean)] {
       override def onNull: (Json, Boolean) = (Json.Null, false)
       override def onBoolean(value: Boolean): (Json, Boolean) = (Json.fromBoolean(value), false)
@@ -36,7 +37,7 @@ object JsonEditor {
       override def onObject(value: JsonObject): (Json, Boolean) = {
         val modified: immutable.List[(String, Json)] = value.toList.flatMap{
           case (key, value) =>
-            val keep =  keys.foldLeft(false)(_ || key.startsWith(_))
+            val keep = keysWithId.foldLeft(false)(_ || key.startsWith(_))
             if (keep)
               List[(String,Json)]((key,value))
             else {
@@ -74,9 +75,9 @@ object JsonEditor {
 
   def removeSubworkflowMetadata(json: Json): Json = json // ??? // FIXME
 
-  def outputs(json: Json): Json = includeJson(json, NonEmptyList.of("outputs", "id")) |> (excludeJson(_, NonEmptyList.one("calls")))
+  def outputs(json: Json): Json = includeJson(json, NonEmptyList.of("outputs")) |> (excludeJson(_, NonEmptyList.one("calls")))
 
-  def logs(json: Json): Json = includeJson(json, NonEmptyList.of("stdout", "stderr", "backendLogs", "id"))
+  def logs(json: Json): Json = includeJson(json, NonEmptyList.of("stdout", "stderr", "backendLogs"))
 
   implicit class EnhancedJson(val json: Json) extends AnyVal {
     def rootWorkflowId: Option[WorkflowId] = {

--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -70,6 +70,10 @@ object JsonEditor {
     }
   }
 
+  def extractCall(json: Json, callFqn: String, index: Option[Int], attempt: Option[Int]): Json = json // ??? // FIXME
+
+  def removeSubworkflowMetadata(json: Json): Json = json // ??? // FIXME
+
   def outputs(json: Json): Json = includeJson(json, NonEmptyList.of("outputs", "id")) |> (excludeJson(_, NonEmptyList.one("calls")))
 
   def logs(json: Json): Json = includeJson(json, NonEmptyList.of("stdout", "stderr", "backendLogs", "id"))

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -20,7 +20,7 @@ import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreSubmitActor}
 import cromwell.jobstore.EmptyJobStoreActor
 import cromwell.server.CromwellRootActor
-import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
+import cromwell.services.{SuccessfulMetadataJsonResponse, FailedMetadataJsonResponse}
 import cromwell.services.metadata.MetadataService.{GetSingleWorkflowMetadataAction, GetStatus, ListenToMetadataWriteActor, WorkflowOutputs}
 import cromwell.subworkflowstore.EmptySubWorkflowStoreActor
 import spray.json._
@@ -76,18 +76,18 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
     case Event(IssuePollRequest, RunningSwraData(_, id)) =>
       requestStatus(id)
       stay()
-    case Event(BuiltMetadataResponse(_, jsObject: JsObject), RunningSwraData(_, _)) if !jsObject.state.isTerminal =>
+    case Event(SuccessfulMetadataJsonResponse(_, jsObject: JsObject), RunningSwraData(_, _)) if !jsObject.state.isTerminal =>
       schedulePollRequest()
       stay()
-    case Event(BuiltMetadataResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowSucceeded =>
+    case Event(SuccessfulMetadataJsonResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowSucceeded =>
       log.info(s"$Tag workflow finished with status '$WorkflowSucceeded'.")
       serviceRegistryActor ! ListenToMetadataWriteActor
       goto(WaitingForFlushedMetadata) using SucceededSwraData(replyTo, id)
-    case Event(BuiltMetadataResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowFailed =>
+    case Event(SuccessfulMetadataJsonResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowFailed =>
       log.info(s"$Tag workflow finished with status '$WorkflowFailed'.")
       serviceRegistryActor ! ListenToMetadataWriteActor
       goto(WaitingForFlushedMetadata) using FailedSwraData(replyTo, id, new RuntimeException(s"Workflow $id transitioned to state $WorkflowFailed"))
-    case Event(BuiltMetadataResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowAborted =>
+    case Event(SuccessfulMetadataJsonResponse(_, jsObject: JsObject), RunningSwraData(replyTo, id)) if jsObject.state == WorkflowAborted =>
       log.info(s"$Tag workflow finished with status '$WorkflowAborted'.")
       serviceRegistryActor ! ListenToMetadataWriteActor
       goto(WaitingForFlushedMetadata) using AbortedSwraData(replyTo, id)
@@ -104,13 +104,13 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
   }
 
   when (RequestingOutputs) {
-    case Event(BuiltMetadataResponse(_, outputs: JsObject), data: TerminalSwraData) =>
+    case Event(SuccessfulMetadataJsonResponse(_, outputs: JsObject), data: TerminalSwraData) =>
       outputOutputs(outputs)
       requestMetadataOrIssueReply(data)
   }
 
   when (RequestingMetadata) {
-    case Event(BuiltMetadataResponse(_, metadata: JsObject), data: TerminalSwraData) =>
+    case Event(SuccessfulMetadataJsonResponse(_, metadata: JsObject), data: TerminalSwraData) =>
       outputMetadata(metadata)
       issueReply(data)
   }
@@ -124,7 +124,7 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
     case Event(r: WorkflowAbortFailureResponse, data) => failAndFinish(r.failure, data)
     case Event(Failure(e), data) => failAndFinish(e, data)
     case Event(Status.Failure(e), data) => failAndFinish(e, data)
-    case Event(FailedMetadataResponse(_, e), data) => failAndFinish(e, data)
+    case Event(FailedMetadataJsonResponse(_, e), data) => failAndFinish(e, data)
     case Event(CurrentState(_, _) | Transition(_, _, _), _) =>
       // ignore uninteresting current state and transition messages
       stay()

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -20,8 +20,8 @@ import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.SubmitWorkflow
 import cromwell.engine.workflow.workflowstore.{InMemoryWorkflowStore, WorkflowStoreSubmitActor}
 import cromwell.jobstore.EmptyJobStoreActor
 import cromwell.server.CromwellRootActor
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import cromwell.services.metadata.MetadataService.{GetSingleWorkflowMetadataAction, GetStatus, ListenToMetadataWriteActor, WorkflowOutputs}
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
 import cromwell.subworkflowstore.EmptySubWorkflowStoreActor
 import spray.json._
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -14,7 +14,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffAct
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQueryParameter.CallCacheDiffQueryCall
 import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import spray.json.{JsArray, JsBoolean, JsNumber, JsObject, JsString, JsValue}
 
 class CallCacheDiffActor(serviceRegistryActor: ActorRef) extends LoggingFSM[CallCacheDiffActorState, CallCacheDiffActorData] {

--- a/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
@@ -5,7 +5,7 @@ import cromwell.core._
 import cromwell.core.labels.{Label, Labels}
 import cromwell.services.metadata.MetadataEvent
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services.BuiltMetadataResponse
 import cromwell.webservice.LabelsManagerActor._
 import spray.json.{DefaultJsonProtocol, JsObject, JsString}
 
@@ -21,8 +21,6 @@ object LabelsManagerActor {
 
   sealed trait LabelsAction extends LabelsMessage
   final case class LabelsAddition(data: LabelsData) extends LabelsAction
-
-  sealed trait LabelsResponse extends LabelsMessage
 
   sealed abstract class LabelsManagerActorResponse
   final case class BuiltLabelsManagerResponse(response: JsObject) extends LabelsManagerActorResponse

--- a/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
+++ b/engine/src/main/scala/cromwell/webservice/LabelsManagerActor.scala
@@ -5,7 +5,7 @@ import cromwell.core._
 import cromwell.core.labels.{Label, Labels}
 import cromwell.services.metadata.MetadataEvent
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.BuiltMetadataResponse
+import cromwell.services.SuccessfulMetadataJsonResponse
 import cromwell.webservice.LabelsManagerActor._
 import spray.json.{DefaultJsonProtocol, JsObject, JsString}
 
@@ -50,7 +50,7 @@ class LabelsManagerActor(serviceRegistryActor: ActorRef) extends Actor with Acto
         At this point in the actor lifecycle, wfId has already been filled out so the .get is safe
       */
       serviceRegistryActor ! GetLabels(wfId.get)
-    case BuiltMetadataResponse(_, jsObject) =>
+    case SuccessfulMetadataJsonResponse(_, jsObject) =>
       /*
         There's some trickery going on here. We've updated the labels in the metadata store but almost certainly when
         the store received the GetLabels request above the summarizer will not have been run so our new values are

--- a/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/CromwellApiService.scala
@@ -31,7 +31,7 @@ import cromwell.server.CromwellShutdown
 import cromwell.services.healthmonitor.ProtoHealthMonitorServiceActor.{GetCurrentStatus, StatusCheckResponse}
 import cromwell.services.metadata.MetadataService._
 import cromwell.webservice._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.services._
 import cromwell.webservice.WorkflowJsonSupport._
 import cromwell.webservice.WebServiceUtils
 import cromwell.webservice.WebServiceUtils.EnhancedThrowable
@@ -158,14 +158,14 @@ trait CromwellApiService extends HttpInstrumentation with MetadataRouteSupport w
   } ~ metadataRoutes
 
 
-  private def metadataLookupForTimingRoute(workflowId: WorkflowId): Future[MetadataBuilderActorResponse] = {
+  private def metadataLookupForTimingRoute(workflowId: WorkflowId): Future[BuildMetadataResponse] = {
     val includeKeys = NonEmptyList.of("start", "end", "executionStatus", "executionEvents", "subWorkflowMetadata")
     val readMetadataRequest = (w: WorkflowId) => GetSingleWorkflowMetadataAction(w, Option(includeKeys), None, expandSubWorkflows = true)
 
-    serviceRegistryActor.ask(readMetadataRequest(workflowId)).mapTo[MetadataBuilderActorResponse]
+    serviceRegistryActor.ask(readMetadataRequest(workflowId)).mapTo[BuildMetadataResponse]
   }
 
-  private def completeTimingRouteResponse(metadataResponse: Future[MetadataBuilderActorResponse]) = {
+  private def completeTimingRouteResponse(metadataResponse: Future[BuildMetadataResponse]) = {
     onComplete(metadataResponse) {
       case Success(r: BuiltMetadataResponse) =>
 

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -16,7 +16,7 @@ import cromwell.core.{WorkflowId, path => _}
 import cromwell.engine.instrumentation.HttpInstrumentation
 import cromwell.server.CromwellShutdown
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.services._
 import cromwell.webservice.LabelsManagerActor
 import cromwell.webservice.LabelsManagerActor._
 import cromwell.webservice.routes.CromwellApiService.{InvalidWorkflowException, UnrecognizedWorkflowException, serviceShuttingDownResponse, validateWorkflowIdInMetadata, validateWorkflowIdInMetadataSummaries}
@@ -143,11 +143,11 @@ object MetadataRouteSupport {
                                   request: WorkflowId => MetadataReadAction,
                                   serviceRegistryActor: ActorRef)
                                  (implicit timeout: Timeout,
-                                  ec: ExecutionContext): Future[MetadataBuilderActorResponse] = {
-    validateWorkflowIdInMetadata(possibleWorkflowId, serviceRegistryActor) flatMap { w => serviceRegistryActor.ask(request(w)).mapTo[MetadataBuilderActorResponse] }
+                                  ec: ExecutionContext): Future[BuildMetadataResponse] = {
+    validateWorkflowIdInMetadata(possibleWorkflowId, serviceRegistryActor) flatMap { w => serviceRegistryActor.ask(request(w)).mapTo[BuildMetadataResponse] }
   }
 
-  def completeMetadataBuilderResponse(response: Future[MetadataBuilderActorResponse]): Route = {
+  def completeMetadataBuilderResponse(response: Future[BuildMetadataResponse]): Route = {
     onComplete(response) {
       case Success(r: BuiltMetadataResponse) => complete(r.responseJson)
       case Success(r: FailedMetadataResponse) => r.reason.errorRequest(StatusCodes.InternalServerError)

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -19,7 +19,7 @@ import WesRouteSupport._
 import cromwell.core.abort.SuccessfulAbortResponse
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.server.CromwellShutdown
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services.BuiltMetadataResponse
 import cromwell.webservice.routes.CromwellApiService
 
 trait WesRouteSupport extends HttpInstrumentation {

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -19,7 +19,7 @@ import WesRouteSupport._
 import cromwell.core.abort.SuccessfulAbortResponse
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.server.CromwellShutdown
-import cromwell.services.BuiltMetadataResponse
+import cromwell.services.SuccessfulMetadataJsonResponse
 import cromwell.webservice.routes.CromwellApiService
 
 trait WesRouteSupport extends HttpInstrumentation {
@@ -57,7 +57,7 @@ trait WesRouteSupport extends HttpInstrumentation {
                   val response = validateWorkflowIdInMetadata(possibleWorkflowId, serviceRegistryActor).flatMap(w => serviceRegistryActor.ask(GetStatus(w)).mapTo[MetadataServiceResponse])
                   // WES can also return a 401 or a 403 but that requires user auth knowledge which Cromwell doesn't currently have
                   onComplete(response) {
-                    case Success(BuiltMetadataResponse(_, jsObject)) =>
+                    case Success(SuccessfulMetadataJsonResponse(_, jsObject)) =>
                       val wesState = WesState.fromCromwellStatusJson(jsObject)
                       complete(WesRunStatus(possibleWorkflowId, wesState))
                     case Success(r: StatusLookupFailed) => r.reason.errorRequest(StatusCodes.InternalServerError)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActorSpec.scala
@@ -8,7 +8,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheDiffQue
 import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata.{MetadataService, _}
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
 import spray.json.JsObject

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -7,19 +7,19 @@ import akka.pattern.ask
 import akka.testkit._
 import akka.util.Timeout
 import cromwell.core._
+import cromwell.services._
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.util.AkkaTestUtil.EnhancedTestProbe
+import cromwell.webservice.MetadataBuilderActorSpec._
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{Assertion, AsyncFlatSpecLike, Matchers, Succeeded}
 import org.specs2.mock.Mockito
 import spray.json._
-import cromwell.util.AkkaTestUtil.EnhancedTestProbe
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import cromwell.webservice.MetadataBuilderActorSpec._
 
 
 class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSpecLike with Matchers with Mockito
@@ -39,7 +39,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
 
 
     val mba = system.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker))
-    val response = mba.ask(action).mapTo[MetadataBuilderActorResponse]
+    val response = mba.ask(action).mapTo[BuildMetadataResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, action)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryReply, events))
     response map { r => r shouldBe a [BuiltMetadataResponse] }
@@ -471,7 +471,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
-    val response = metadataBuilder.ask(mainQueryAction).mapTo[MetadataBuilderActorResponse]
+    val response = metadataBuilder.ask(mainQueryAction).mapTo[BuildMetadataResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, mainQueryAction)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(mainQuery, mainEvents))
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, subQueryAction)
@@ -519,7 +519,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     def readMetadataWorkerMaker= () => mockReadMetadataWorkerActor.props
 
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
-    val response = metadataBuilder.ask(queryNoExpandAction).mapTo[MetadataBuilderActorResponse]
+    val response = metadataBuilder.ask(queryNoExpandAction).mapTo[BuildMetadataResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, queryNoExpandAction)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryNoExpand, mainEvents))
 

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -39,11 +39,11 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
 
 
     val mba = system.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker))
-    val response = mba.ask(action).mapTo[BuildMetadataResponse]
+    val response = mba.ask(action).mapTo[MetadataJsonResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, action)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryReply, events))
-    response map { r => r shouldBe a [BuiltMetadataResponse] }
-    response.mapTo[BuiltMetadataResponse] map { b => b.responseJson shouldBe expectedRes.parseJson}
+    response map { r => r shouldBe a [SuccessfulMetadataJsonResponse] }
+    response.mapTo[SuccessfulMetadataJsonResponse] map { b => b.responseJson shouldBe expectedRes.parseJson}
   }
 
   it should "build workflow scope tree from metadata events" in {
@@ -471,7 +471,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
-    val response = metadataBuilder.ask(mainQueryAction).mapTo[BuildMetadataResponse]
+    val response = metadataBuilder.ask(mainQueryAction).mapTo[MetadataJsonResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, mainQueryAction)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(mainQuery, mainEvents))
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, subQueryAction)
@@ -497,8 +497,8 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
          |}
        """.stripMargin
 
-    response map { r => r shouldBe a [BuiltMetadataResponse] }
-    val bmr = response.mapTo[BuiltMetadataResponse]
+    response map { r => r shouldBe a [SuccessfulMetadataJsonResponse] }
+    val bmr = response.mapTo[SuccessfulMetadataJsonResponse]
     bmr map { b => b.responseJson shouldBe expandedRes.parseJson}
   }
   
@@ -519,7 +519,7 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
     def readMetadataWorkerMaker= () => mockReadMetadataWorkerActor.props
 
     val metadataBuilder = TestActorRef(MetadataBuilderActor.props(readMetadataWorkerMaker), parentProbe.ref, s"MetadataActor-${UUID.randomUUID()}")
-    val response = metadataBuilder.ask(queryNoExpandAction).mapTo[BuildMetadataResponse]
+    val response = metadataBuilder.ask(queryNoExpandAction).mapTo[MetadataJsonResponse]
     mockReadMetadataWorkerActor.expectMsg(defaultTimeout, queryNoExpandAction)
     mockReadMetadataWorkerActor.reply(MetadataLookupResponse(queryNoExpand, mainEvents))
 
@@ -540,8 +540,8 @@ class MetadataBuilderActorSpec extends TestKitSuite("Metadata") with AsyncFlatSp
          |}
        """.stripMargin
 
-    response map { r => r shouldBe a [BuiltMetadataResponse] }
-    val bmr = response.mapTo[BuiltMetadataResponse]
+    response map { r => r shouldBe a [SuccessfulMetadataJsonResponse] }
+    val bmr = response.mapTo[SuccessfulMetadataJsonResponse]
     bmr map { b => b.responseJson shouldBe nonExpandedRes.parseJson}
 
   }

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -21,7 +21,7 @@ import cromwell.services.metadata.MetadataArchiveStatus.Unarchived
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services._
 import cromwell.services.womtool.WomtoolServiceMessages.{DescribeFailure, DescribeRequest, DescribeSuccess}
 import cromwell.services.womtool.models.WorkflowDescription
 import cromwell.util.SampleWdl.HelloWorld

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -600,18 +600,18 @@ object CromwellApiServiceSpec {
           case FailedWorkflowId => WorkflowFailed
           case _ => WorkflowSubmitted
         }
-        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processStatusResponse(id, status))
+        sender ! SuccessfulMetadataJsonResponse(request, MetadataBuilderActor.processStatusResponse(id, status))
       case request @ GetLabels(id) =>
-        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processLabelsResponse(id, Map("key1" -> "label1", "key2" -> "label2")))
+        sender ! SuccessfulMetadataJsonResponse(request, MetadataBuilderActor.processLabelsResponse(id, Map("key1" -> "label1", "key2" -> "label2")))
       case request @ WorkflowOutputs(id) =>
         val event = Vector(MetadataEvent(MetadataKey(id, None, "outputs:test.hello.salutation"), MetadataValue("Hello foo!", MetadataString)))
-        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.processOutputsResponse(id, event))
+        sender ! SuccessfulMetadataJsonResponse(request, MetadataBuilderActor.processOutputsResponse(id, event))
       case request @ GetLogs(id) =>
-        sender ! BuiltMetadataResponse(request, MetadataBuilderActor.workflowMetadataResponse(id, logsEvents(id), includeCallsIfEmpty = false, Map.empty))
+        sender ! SuccessfulMetadataJsonResponse(request, MetadataBuilderActor.workflowMetadataResponse(id, logsEvents(id), includeCallsIfEmpty = false, Map.empty))
       case request @ GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _)) =>
         val withKeysList = withKeys.map(_.toList).getOrElse(List.empty)
         val withoutKeysList = withoutKeys.map(_.toList).getOrElse(List.empty)
-        sender ! BuiltMetadataResponse(request, responseMetadataValues(id, withKeysList, withoutKeysList))
+        sender ! SuccessfulMetadataJsonResponse(request, responseMetadataValues(id, withKeysList, withoutKeysList))
       case PutMetadataActionAndRespond(events, _, _) =>
         events.head.key.workflowId match {
           case CromwellApiServiceSpec.ExistingWorkflowId => sender ! MetadataWriteSuccess(events)

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteMetadataServiceActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteMetadataServiceActor.scala
@@ -2,9 +2,9 @@ package cromwell.services.metadata.hybridcarbonite
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
-import cromwell.services.FailedMetadataResponse
+import cromwell.services.FailedMetadataJsonResponse
 import cromwell.services.ServiceRegistryActor.{IoActorRef, NoIoActorRefAvailable, RequestIoActorRef}
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataWriteAction, MetadataWriteFailure}
+import cromwell.services.metadata.MetadataService.{BuildMetadataJsonAction, MetadataWriteAction, MetadataWriteFailure}
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import mouse.boolean._
@@ -24,13 +24,13 @@ class CarboniteMetadataServiceActor(carboniteConfig: HybridCarboniteConfig, serv
   var carboniteWorker: Option[ActorRef] = None
 
   override def receive: Receive = {
-    case read: MetadataReadAction =>
+    case read: BuildMetadataJsonAction =>
       ioActorOption match {
         case Some(ioActor) =>
           val worker = context.actorOf(thawingActorProps(ioActor))
           worker forward read
         case None =>
-          sender ! FailedMetadataResponse(read, new Exception("Cannot create CarbonitedMetadataThawingActor: no IoActor reference available"))
+          sender ! FailedMetadataJsonResponse(read, new Exception("Cannot create CarbonitedMetadataThawingActor: no IoActor reference available"))
       }
     case write: MetadataWriteAction =>
       val error = new UnsupportedOperationException(s"Programmer Error! Carboniter Worker should never be sent write requests (but got $write from $sender)")

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteMetadataServiceActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteMetadataServiceActor.scala
@@ -2,9 +2,9 @@ package cromwell.services.metadata.hybridcarbonite
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cats.data.NonEmptyList
+import cromwell.services.FailedMetadataResponse
 import cromwell.services.ServiceRegistryActor.{IoActorRef, NoIoActorRefAvailable, RequestIoActorRef}
 import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataWriteAction, MetadataWriteFailure}
-import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor.ThawCarboniteFailed
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import mouse.boolean._
@@ -30,7 +30,7 @@ class CarboniteMetadataServiceActor(carboniteConfig: HybridCarboniteConfig, serv
           val worker = context.actorOf(thawingActorProps(ioActor))
           worker forward read
         case None =>
-          sender ! ThawCarboniteFailed(new Exception("Cannot create CarbonitedMetadataThawingActor: no IoActor reference available"))
+          sender ! FailedMetadataResponse(read, new Exception("Cannot create CarbonitedMetadataThawingActor: no IoActor reference available"))
       }
     case write: MetadataWriteAction =>
       val error = new UnsupportedOperationException(s"Programmer Error! Carboniter Worker should never be sent write requests (but got $write from $sender)")

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
@@ -2,72 +2,86 @@ package cromwell.services.metadata.hybridcarbonite
 
 import akka.actor.{ActorRef, LoggingFSM, Props, Status}
 import akka.pattern.pipe
+import cats.data.NonEmptyList
+import cromwell.core.WorkflowId
 import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
-import cromwell.core.{RootWorkflowId, WorkflowId}
-import cromwell.services.metadata.MetadataService.{GetRootAndSubworkflowLabels, RootAndSubworkflowLabelsLookupFailed, RootAndSubworkflowLabelsLookupResponse}
+import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor._
+import cromwell.services.metadata.{MetadataQuery, MetadataQueryJobKey}
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import cromwell.util.JsonEditor
 import io.circe.parser._
 import io.circe.{Json, Printer}
+import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConfig, serviceRegistry: ActorRef, ioActor: ActorRef) extends LoggingFSM[CarbonitedMetadataThawingState, CarbonitedMetadataThawingData] {
+final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConfig, serviceRegistry: ActorRef, ioActor: ActorRef) extends LoggingFSM[ThawingState, ThawingData] {
 
   implicit val ec: ExecutionContext = context.dispatcher
 
   val asyncIo = new AsyncIo(ioActor, DefaultIoCommandBuilder)
 
-  startWith(CarbonitedMetadataThawingActorPendingState, CarbonitedMetadataThawingActorPendingData)
+  startWith(PendingState, PendingData)
 
-  when(CarbonitedMetadataThawingActorPendingState) {
-    case Event(ThawCarbonitedMetadata(rootWorkflowId), CarbonitedMetadataThawingActorPendingData) =>
-
-      val response = for {
-        rawResponseFromIoActor <- asyncIo.contentAsStringAsync(carboniterConfig.makePath(rootWorkflowId), maxBytes = Option(30 * 1024 * 1024), failOnOverflow = true)
+  when(PendingState) {
+    case Event(action: WorkflowMetadataReadAction, PendingData) =>
+      val gcsResponse = for {
+        rawResponseFromIoActor <- asyncIo.contentAsStringAsync(carboniterConfig.makePath(action.workflowId), maxBytes = Option(30 * 1024 * 1024), failOnOverflow = true)
         parsedResponse <- Future.fromTry(parse(rawResponseFromIoActor).toTry.map(GcsMetadataResponse.apply))
       } yield parsedResponse
 
-      response pipeTo self
-      serviceRegistry ! GetRootAndSubworkflowLabels(rootWorkflowId)
+      gcsResponse pipeTo self
 
-      goto(CarbonitedMetadataThawingActorRunningState) using CarbonitedMetadataThawingActorDataNothingYet(sender())
+      val targetState = if (action.requiresLabels) {
+        serviceRegistry ! GetRootAndSubworkflowLabels(action.workflowId)
+        NeedsGcsAndLabelsState
+      } else {
+        NeedsOnlyGcsState
+      }
+
+      goto(targetState) using WorkingNoData(sender(), action)
   }
 
-  when(CarbonitedMetadataThawingActorRunningState) {
+  when(NeedsOnlyGcsState) {
+    case Event(GcsMetadataResponse(gcsResponse), WorkingNoData(requester, action)) =>
+      val responseJson = gcsResponse.editFor(action).toSpray
+      requester ! BuiltMetadataResponse(action, responseJson)
+      stop()
+  }
 
+  when(NeedsGcsAndLabelsState) {
     // Successful Responses:
-    case Event(GcsMetadataResponse(response), CarbonitedMetadataThawingActorDataNothingYet(requester)) =>
-      stay() using CarbonitedMetadataThawingActorDataWithGcsResponse(requester, response)
-
-    case Event(GcsMetadataResponse(response), CarbonitedMetadataThawingActorDataWithLabels(requester, labels)) =>
-      requester ! ThawCarboniteSucceeded(mergeResponses(response, labels))
+    case Event(GcsMetadataResponse(gcsResponse), WorkingSomeData(requester, action, _ , Some(labels))) =>
+      val responseJson = gcsResponse.editFor(action).updateLabels(labels).toSpray
+      requester ! BuiltMetadataResponse(action, responseJson)
       stop()
 
-    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), CarbonitedMetadataThawingActorDataNothingYet(requester)) =>
-      stay() using CarbonitedMetadataThawingActorDataWithLabels(requester, labels)
-
-    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), CarbonitedMetadataThawingActorDataWithGcsResponse(requester, gcsResponse)) =>
-      requester ! ThawCarboniteSucceeded(mergeResponses(gcsResponse, labels))
+    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), WorkingSomeData(requester, action, Some(gcsResponse), _)) =>
+      val responseJson = gcsResponse.editFor(action).updateLabels(labels).toSpray
+      requester ! BuiltMetadataResponse(action, responseJson)
       stop()
+
+    case Event(GcsMetadataResponse(gcsResponse), WorkingNoData(requester, action)) =>
+      stay() using WorkingSomeData(requester, action, gcsResponse = Option(gcsResponse))
+
+    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), WorkingNoData(requester, action)) =>
+      stay() using WorkingSomeData(requester, action, labels = Option(labels))
 
     // Failures:
-    case Event(Status.Failure(failure), data: CarbonitedMetadataThawingActorWorkingData) =>
-      data.requester ! ThawCarboniteFailed(failure)
-      stop()
-    case Event(RootAndSubworkflowLabelsLookupFailed(_, failure), data: CarbonitedMetadataThawingActorWorkingData) =>
-      data.requester ! ThawCarboniteFailed(failure)
+    case Event(RootAndSubworkflowLabelsLookupFailed(_, failure), data: WorkingData) =>
+      data.requester ! FailedMetadataResponse(data.action, failure)
       stop()
   }
 
   whenUnhandled {
+    case Event(Status.Failure(failure), data: WorkingData) =>
+      data.requester ! FailedMetadataResponse(data.action, failure)
+      stop()
     case other =>
       log.error(s"Programmer Error: Unexpected message to ${self.path.name}: $other")
       stay()
   }
-
-  def mergeResponses(metadata: Json, labels: Map[WorkflowId, Map[String, String]]): String = JsonEditor.updateLabels(metadata, labels).printWith(Printer.spaces2)
-
 }
 
 object CarbonitedMetadataThawingActor {
@@ -75,23 +89,61 @@ object CarbonitedMetadataThawingActor {
   def props(carboniterConfig: HybridCarboniteConfig, serviceRegistry: ActorRef, ioActor: ActorRef): Props =
     Props(new CarbonitedMetadataThawingActor(carboniterConfig, serviceRegistry, ioActor))
 
-  sealed trait ThawCarboniteMessage
-
-  final case class ThawCarbonitedMetadata(workflowId: RootWorkflowId) extends ThawCarboniteMessage
-  final case class ThawCarboniteSucceeded(value: String) extends ThawCarboniteMessage
-  final case class ThawCarboniteFailed(reason: Throwable) extends ThawCarboniteMessage
-
   final case class GcsMetadataResponse(response: Json)
 
-  sealed trait CarbonitedMetadataThawingState
-  case object CarbonitedMetadataThawingActorPendingState extends CarbonitedMetadataThawingState
-  case object CarbonitedMetadataThawingActorRunningState extends CarbonitedMetadataThawingState
+  sealed trait ThawingState
+  case object PendingState extends ThawingState
+  case object NeedsGcsAndLabelsState extends ThawingState
+  case object NeedsOnlyGcsState extends ThawingState
 
-  sealed trait CarbonitedMetadataThawingData
-  case object CarbonitedMetadataThawingActorPendingData extends CarbonitedMetadataThawingData
-  sealed trait CarbonitedMetadataThawingActorWorkingData extends CarbonitedMetadataThawingData { def requester: ActorRef }
-  final case class CarbonitedMetadataThawingActorDataNothingYet(requester: ActorRef) extends CarbonitedMetadataThawingActorWorkingData
-  final case class CarbonitedMetadataThawingActorDataWithGcsResponse(requester: ActorRef, gcsResponse: Json) extends CarbonitedMetadataThawingActorWorkingData
-  final case class CarbonitedMetadataThawingActorDataWithLabels(requester: ActorRef, labels: Map[WorkflowId, Map[String, String]]) extends CarbonitedMetadataThawingActorWorkingData
+  sealed trait ThawingData
+  case object PendingData extends ThawingData
+  sealed trait WorkingData extends ThawingData {
+    def requester: ActorRef
+    def action: WorkflowMetadataReadAction
+  }
+  final case class WorkingNoData(requester: ActorRef, action: WorkflowMetadataReadAction) extends WorkingData
+  final case class WorkingSomeData(requester: ActorRef, action: WorkflowMetadataReadAction, gcsResponse: Option[Json] = None, labels: Option[Map[WorkflowId, Map[String, String]]] = None) extends WorkingData
 
+  implicit class EnhancedJson(val json: Json) extends AnyVal {
+    def editFor(action: WorkflowMetadataReadAction): Json = action match {
+      case _: GetLogs => JsonEditor.logs(json)
+      case _: WorkflowOutputs => JsonEditor.outputs(json)
+      case get: GetMetadataAction =>
+        val intermediate = get.key match {
+          case MetadataQuery(_, None, None, None, None, _) => json
+          case MetadataQuery(_, None, Some(key), None, None, _) => JsonEditor.includeJson(json, NonEmptyList.of(key))
+          case MetadataQuery(_, Some(jobKey), None, None, None, _) => JsonEditor.extractCall(json, jobKey.callFqn, jobKey.index, jobKey.attempt)
+          case MetadataQuery(_, Some(MetadataQueryJobKey(callFqn, index, attempt)), Some(key), None, None, _) =>
+            val callJson = JsonEditor.extractCall(json, callFqn, index, attempt)
+            JsonEditor.includeJson(callJson, NonEmptyList.of(key))
+          case MetadataQuery(_, None, None, includeKeys, excludeKeys, _) =>
+            JsonEditor.includeExcludeJson(json, includeKeys, excludeKeys)
+          case MetadataQuery(_, Some(MetadataQueryJobKey(callFqn, index, attempt)), None, includeKeys, excludeKeys, _) =>
+            val callJson = JsonEditor.extractCall(json, callFqn, index, attempt)
+            JsonEditor.includeExcludeJson(callJson, includeKeys, excludeKeys)
+          case wrong => throw new RuntimeException(s"Programmer Error: Invalid MetadataQuery: $wrong")
+        }
+        // For carbonited metadata, "expanded" subworkflows translates to not deleting subworkflows out of the root workflow that already
+        // contains them. So `identity` for expanded subworkflows and `JsonEditor.removeSubworkflowMetadata` for unexpanded subworkflows.
+        val processSubworkflowMetadata: Json => Json = if (get.key.expandSubWorkflows) identity else JsonEditor.removeSubworkflowMetadata
+        processSubworkflowMetadata(intermediate)
+      case other =>
+        throw new RuntimeException(s"Programmer Error: Unexpected WorkflowMetadataReadAction message of type '${other.getClass.getSimpleName}': $other")
+    }
+
+    def updateLabels(labels: Map[WorkflowId, Map[String, String]]): Json = JsonEditor.updateLabels(json, labels)
+
+    def toSpray: JsObject = json.printWith(Printer.spaces2).parseJson.asJsObject
+  }
+
+  implicit class EnhancedWorkflowMetadataReadAction(val action: WorkflowMetadataReadAction) extends AnyVal {
+    def requiresLabels: Boolean = action match {
+      case _: GetLogs | _: WorkflowOutputs => false
+      case q: GetMetadataAction if q.key.excludeKeysOption.exists { _.toList.contains("labels") } => false
+      case q: GetMetadataAction if q.key.includeKeysOption.exists { _.toList.contains("labels") } => true
+      case q: GetMetadataAction if q.key.includeKeysOption.isDefined => false
+      case _ => true
+    }
+  }
 }

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
@@ -8,7 +8,7 @@ import cromwell.core.io.{AsyncIo, DefaultIoCommandBuilder}
 import cromwell.services.metadata.MetadataQuery
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor._
-import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
+import cromwell.services.{SuccessfulMetadataJsonResponse, FailedMetadataJsonResponse}
 import cromwell.util.JsonEditor
 import io.circe.parser._
 import io.circe.{Json, Printer}
@@ -25,7 +25,7 @@ final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConf
   startWith(PendingState, PendingData)
 
   when(PendingState) {
-    case Event(action: WorkflowMetadataReadAction, PendingData) =>
+    case Event(action: BuildWorkflowMetadataJsonAction, PendingData) =>
       val gcsResponse = for {
         rawResponseFromIoActor <- asyncIo.contentAsStringAsync(carboniterConfig.makePath(action.workflowId), maxBytes = Option(30 * 1024 * 1024), failOnOverflow = true)
         parsedResponse <- Future.fromTry(parse(rawResponseFromIoActor).toTry.map(GcsMetadataResponse.apply))
@@ -33,12 +33,8 @@ final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConf
 
       gcsResponse pipeTo self
 
-      val targetState = if (action.requiresLabels) {
-        serviceRegistry ! GetRootAndSubworkflowLabels(action.workflowId)
-        NeedsGcsAndLabelsState
-      } else {
-        NeedsOnlyGcsState
-      }
+      if (action.requiresLabels) { serviceRegistry ! GetRootAndSubworkflowLabels(action.workflowId) }
+      val targetState = if (action.requiresLabels) NeedsGcsAndLabelsState else NeedsOnlyGcsState
 
       goto(targetState) using WorkingNoData(sender(), action)
   }
@@ -46,37 +42,37 @@ final class CarbonitedMetadataThawingActor(carboniterConfig: HybridCarboniteConf
   when(NeedsOnlyGcsState) {
     case Event(GcsMetadataResponse(gcsResponse), WorkingNoData(requester, action)) =>
       val responseJson = gcsResponse.editFor(action).toSpray
-      requester ! BuiltMetadataResponse(action, responseJson)
+      requester ! SuccessfulMetadataJsonResponse(action, responseJson)
       stop()
   }
 
   when(NeedsGcsAndLabelsState) {
     // Successful Responses:
-    case Event(GcsMetadataResponse(gcsResponse), WorkingSomeData(requester, action, _ , Some(labels))) =>
+    case Event(GcsMetadataResponse(gcsResponse), WorkingWithLabelsData(requester, action, labels)) =>
       val responseJson = gcsResponse.editFor(action).updateLabels(labels).toSpray
-      requester ! BuiltMetadataResponse(action, responseJson)
+      requester ! SuccessfulMetadataJsonResponse(action, responseJson)
       stop()
 
-    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), WorkingSomeData(requester, action, Some(gcsResponse), _)) =>
+    case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), WorkingWithGcsData(requester, action, gcsResponse)) =>
       val responseJson = gcsResponse.editFor(action).updateLabels(labels).toSpray
-      requester ! BuiltMetadataResponse(action, responseJson)
+      requester ! SuccessfulMetadataJsonResponse(action, responseJson)
       stop()
 
     case Event(GcsMetadataResponse(gcsResponse), WorkingNoData(requester, action)) =>
-      stay() using WorkingSomeData(requester, action, gcsResponse = Option(gcsResponse))
+      stay() using WorkingWithGcsData(requester, action, gcsResponse = gcsResponse)
 
     case Event(RootAndSubworkflowLabelsLookupResponse(_, labels), WorkingNoData(requester, action)) =>
-      stay() using WorkingSomeData(requester, action, labels = Option(labels))
+      stay() using WorkingWithLabelsData(requester, action, labels = labels)
 
     // Failures:
     case Event(RootAndSubworkflowLabelsLookupFailed(_, failure), data: WorkingData) =>
-      data.requester ! FailedMetadataResponse(data.action, failure)
+      data.requester ! FailedMetadataJsonResponse(data.action, failure)
       stop()
   }
 
   whenUnhandled {
     case Event(Status.Failure(failure), data: WorkingData) =>
-      data.requester ! FailedMetadataResponse(data.action, failure)
+      data.requester ! FailedMetadataJsonResponse(data.action, failure)
       stop()
     case other =>
       log.error(s"Programmer Error: Unexpected message to ${getClass.getSimpleName} ${self.path.name}: $other")
@@ -100,13 +96,14 @@ object CarbonitedMetadataThawingActor {
   case object PendingData extends ThawingData
   sealed trait WorkingData extends ThawingData {
     def requester: ActorRef
-    def action: WorkflowMetadataReadAction
+    def action: BuildWorkflowMetadataJsonAction
   }
-  final case class WorkingNoData(requester: ActorRef, action: WorkflowMetadataReadAction) extends WorkingData
-  final case class WorkingSomeData(requester: ActorRef, action: WorkflowMetadataReadAction, gcsResponse: Option[Json] = None, labels: Option[Map[WorkflowId, Map[String, String]]] = None) extends WorkingData
+  final case class WorkingNoData(requester: ActorRef, action: BuildWorkflowMetadataJsonAction) extends WorkingData
+  final case class WorkingWithLabelsData(requester: ActorRef, action: BuildWorkflowMetadataJsonAction, labels: Map[WorkflowId, Map[String, String]]) extends WorkingData
+  final case class WorkingWithGcsData(requester: ActorRef, action: BuildWorkflowMetadataJsonAction, gcsResponse: Json) extends WorkingData
 
   implicit class EnhancedJson(val json: Json) extends AnyVal {
-    def editFor(action: WorkflowMetadataReadAction): Json = action match {
+    def editFor(action: BuildWorkflowMetadataJsonAction): Json = action match {
       case _: GetLogs => JsonEditor.logs(json)
       case _: WorkflowOutputs => JsonEditor.outputs(json)
       case get: GetMetadataAction =>
@@ -126,7 +123,7 @@ object CarbonitedMetadataThawingActor {
         val processSubworkflowMetadata: Json => Json = if (get.key.expandSubWorkflows) identity else JsonEditor.removeSubworkflowMetadata
         processSubworkflowMetadata(intermediate)
       case other =>
-        throw new RuntimeException(s"Programmer Error: Unexpected WorkflowMetadataReadAction message of type '${other.getClass.getSimpleName}': $other")
+        throw new RuntimeException(s"Programmer Error: Unexpected BuildWorkflowMetadataJsonAction message of type '${other.getClass.getSimpleName}': $other")
     }
 
     def updateLabels(labels: Map[WorkflowId, Map[String, String]]): Json = JsonEditor.updateLabels(json, labels)
@@ -134,9 +131,10 @@ object CarbonitedMetadataThawingActor {
     def toSpray: JsObject = json.printWith(Printer.spaces2).parseJson.asJsObject
   }
 
-  implicit class EnhancedWorkflowMetadataReadAction(val action: WorkflowMetadataReadAction) extends AnyVal {
+  implicit class EnhancedBuildWorkflowMetadataJsonAction(val action: BuildWorkflowMetadataJsonAction) extends AnyVal {
     def requiresLabels: Boolean = action match {
       case _: GetLogs | _: WorkflowOutputs => false
+      case q: GetMetadataAction if q.key.key.isDefined && !q.key.key.contains("labels") => false
       case q: GetMetadataAction if q.key.excludeKeysOption.exists { _.toList.contains("labels") } => false
       case q: GetMetadataAction if q.key.includeKeysOption.exists { _.toList.contains("labels") } => true
       case q: GetMetadataAction if q.key.includeKeysOption.isDefined => false

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActor.scala
@@ -12,7 +12,7 @@ import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata.hybridcarbonite.CarboniteWorkerActor.CarboniteWorkflowComplete
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActor._
 import cromwell.services.metadata.impl.MetadataDatabaseAccess
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse}
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import cromwell.services.metadata.{MetadataArchiveStatus, MetadataQuery}
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridMetadataServiceActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridMetadataServiceActor.scala
@@ -7,7 +7,7 @@ import common.exception.AggregatedMessageException
 import common.validation.Checked._
 import common.validation.Validation._
 import cromwell.core.Dispatcher.ServiceDispatcher
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceAction, MetadataWriteAction, ValidateWorkflowIdInMetadata}
+import cromwell.services.metadata.MetadataService.{BuildMetadataJsonAction, MetadataServiceAction, MetadataWriteAction, ValidateWorkflowIdInMetadata}
 import cromwell.services.metadata.impl.{MetadataServiceActor, ReadMetadataRegulatorActor}
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
@@ -43,7 +43,7 @@ class HybridMetadataServiceActor(serviceConfig: Config, globalConfig: Config, se
 
   override def receive = {
     case action: MetadataServiceAction => action match {
-      case read: MetadataReadAction => readRegulatorActor forward read
+      case read: BuildMetadataJsonAction => readRegulatorActor forward read
       case write: MetadataWriteAction => classicMetadataService.forward(write)
       case validate: ValidateWorkflowIdInMetadata => classicMetadataService forward validate
     }

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActor.scala
@@ -1,9 +1,9 @@
 package cromwell.services.metadata.hybridcarbonite
 
 import akka.actor.{ActorRef, FSM, LoggingFSM, Props}
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse, QueryForWorkflowsMatchingParameters, WorkflowMetadataReadAction, WorkflowQueryFailure, WorkflowQuerySuccess}
+import cromwell.services.FailedMetadataResponse
+import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.hybridcarbonite.HybridReadDeciderActor._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.FailedMetadataResponse
 import cromwell.services.metadata.{MetadataArchiveStatus, WorkflowQueryKey}
 
 import scala.concurrent.ExecutionContext
@@ -15,33 +15,25 @@ class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMet
   implicit val ec: ExecutionContext = context.dispatcher
 
   when(Pending) {
-    case Event(read: MetadataReadAction, NoData) =>
-      read match {
-        case wmra: WorkflowMetadataReadAction =>
-          classicMetadataServiceActor ! QueryForWorkflowsMatchingParameters(Vector(WorkflowQueryKey.Id.name -> wmra.workflowId.toString))
-          goto(RequestingMetadataArchiveStatus) using WorkingData(sender(), read)
-
-        case query: QueryForWorkflowsMatchingParameters =>
-          classicMetadataServiceActor ! query
-          goto(WaitingForMetadataResponse) using WorkingData(sender(), read)
-      }
+    case Event(action: MetadataReadAction, NoData) if action.requiresOnlyClassicMetadata =>
+      classicMetadataServiceActor ! action
+      goto(WaitingForMetadataResponse) using WorkingData(sender(), action)
+    case Event(action: WorkflowMetadataReadAction, NoData) =>
+      classicMetadataServiceActor ! QueryForWorkflowsMatchingParameters(Vector(WorkflowQueryKey.Id.name -> action.workflowId.toString))
+      goto(RequestingMetadataArchiveStatus) using WorkingData(sender(), action)
   }
 
   when(RequestingMetadataArchiveStatus) {
-    case Event(WorkflowQuerySuccess(response, _), wd: WorkingData) =>
-      if (response.results.size > 1) {
-        val errorMsg = s"Programmer Error: Got more than one status row back looking up metadata archive status for ${wd.request}: $response"
-        wd.actor ! makeAppropriateFailureForRequest(errorMsg, wd.request)
-        stop(FSM.Failure(errorMsg))
-      } else if (response.results.headOption.exists(_.metadataArchiveStatus == MetadataArchiveStatus.Archived)) {
-        carboniteMetadataServiceActor ! wd.request
-        goto(WaitingForMetadataResponse)
-      } else {
-        classicMetadataServiceActor ! wd.request
-        goto(WaitingForMetadataResponse)
-      }
-
-
+    case Event(s: WorkflowQuerySuccess, wd: WorkingData) if s.hasMultipleSummaryRows =>
+      val errorMsg = s"Programmer Error: Found multiple summary rows looking up metadata archive status for ${wd.request}: ${s.response}"
+      wd.requester ! makeAppropriateFailureForRequest(errorMsg, wd.request)
+      stop(FSM.Failure(errorMsg))
+    case Event(s: WorkflowQuerySuccess, wd: WorkingData) if s.isCarbonited =>
+      carboniteMetadataServiceActor ! wd.request
+      goto(WaitingForMetadataResponse)
+    case Event(_: WorkflowQuerySuccess, wd: WorkingData) => // this is an uncarbonited workflow
+      classicMetadataServiceActor ! wd.request
+      goto(WaitingForMetadataResponse)
     case Event(WorkflowQueryFailure(reason), wd: WorkingData) =>
       log.error(reason, s"Programmer Error: Failed to determine how to route ${wd.request.getClass.getSimpleName}. Falling back to classic.")
       classicMetadataServiceActor ! wd.request
@@ -49,21 +41,21 @@ class HybridReadDeciderActor(classicMetadataServiceActor: ActorRef, carboniteMet
   }
 
   when(WaitingForMetadataResponse) {
-    case Event(response: MetadataServiceResponse , wd: WorkingData) =>
-      wd.actor ! response
+    case Event(response: MetadataServiceResponse, wd: WorkingData) =>
+      wd.requester ! response
       stop(FSM.Normal)
   }
 
   whenUnhandled {
-    case Event(msg, data) =>
-      val errorMsg = s"Programmer Error: Unexpected message '$msg' sent to ${getClass.getSimpleName} in state $stateName with data $stateData from $sender()"
-      log.error(errorMsg)
+    case Event(akkaMessage, data) =>
+      val logMessage = s"Programmer Error: Unexpected message '$akkaMessage' sent to ${getClass.getSimpleName} in state $stateName with data $stateData from $sender()"
+      log.error(logMessage)
       data match {
-        case NoData => stop(FSM.Failure(errorMsg))
+        case NoData =>
+          stop(FSM.Failure(logMessage))
         case WorkingData(actor, request) =>
-          actor ! makeAppropriateFailureForRequest(errorMsg, request)
-
-          stop(FSM.Failure(msg))
+          actor ! makeAppropriateFailureForRequest(logMessage, request)
+          stop(FSM.Failure(logMessage))
       }
   }
 
@@ -85,5 +77,17 @@ object HybridReadDeciderActor {
 
   sealed trait HybridReadDeciderData
   case object NoData extends HybridReadDeciderData
-  final case class WorkingData(actor: ActorRef, request: MetadataReadAction) extends HybridReadDeciderData
+  final case class WorkingData(requester: ActorRef, request: MetadataReadAction) extends HybridReadDeciderData
+
+  implicit class EnhancedWorkflowQuerySuccess(val success: WorkflowQuerySuccess) extends AnyVal {
+    def hasMultipleSummaryRows: Boolean = success.response.results.size > 1
+    def isCarbonited: Boolean = success.response.results.headOption.exists(_.metadataArchiveStatus == MetadataArchiveStatus.Archived)
+  }
+
+  implicit class EnhancedMetadataReadAction(val action: MetadataReadAction) extends AnyVal {
+    def requiresOnlyClassicMetadata: Boolean = action match {
+      case _: GetLabels | _: GetRootAndSubworkflowLabels | _: GetStatus | _: QueryForWorkflowsMatchingParameters => true
+      case _ => false // GetLogs, WorkflowOutputs, GetMetadataAction
+    }
+  }
 }

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActorSpec.scala
@@ -1,7 +1,5 @@
 package cromwell.services.metadata.hybridcarbonite
 
-import java.util.UUID
-
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestActorRef, TestProbe}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
@@ -9,20 +7,21 @@ import com.typesafe.config.ConfigFactory
 import common.validation.Validation._
 import cromwell.core.io.IoContentAsStringCommand
 import cromwell.core.io.IoPromiseProxyActor.IoCommandWithPromise
-import cromwell.core.{RootWorkflowId, TestKitSuite, WorkflowId}
-import cromwell.services.metadata.MetadataService.{GetRootAndSubworkflowLabels, RootAndSubworkflowLabelsLookupResponse}
-import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActor.{ThawCarboniteFailed, ThawCarboniteSucceeded, ThawCarbonitedMetadata}
+import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.services.metadata.MetadataQuery
+import cromwell.services.metadata.MetadataService.{GetMetadataAction, GetRootAndSubworkflowLabels, RootAndSubworkflowLabelsLookupResponse}
 import cromwell.services.metadata.hybridcarbonite.CarbonitedMetadataThawingActorSpec.{workflowId, _}
+import cromwell.services.{BuiltMetadataResponse, FailedMetadataResponse}
 import io.circe.parser._
-import net.thisptr.jackson.jq.{BuiltinFunctionLoader, JsonQuery, Output, Scope, Versions}
+import net.thisptr.jackson.jq._
 import org.scalatest.{FlatSpecLike, Matchers}
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.language.postfixOps
-import scala.collection.JavaConverters._
 
 
 class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadataThawingActorSpec") with FlatSpecLike with Matchers {
@@ -46,10 +45,16 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
   it should "receive a message from GCS" in {
 
     val clientProbe = TestProbe()
-
     val actorUnderTest = TestActorRef(new CarbonitedMetadataThawingActor(carboniterConfig, serviceRegistryActor.ref, ioActor.ref), "ThawingActor")
-
-    clientProbe.send(actorUnderTest, ThawCarbonitedMetadata(workflowId))
+    clientProbe.send(actorUnderTest, GetMetadataAction(
+      MetadataQuery(
+        workflowId = workflowId,
+        jobKey = None,
+        key = None,
+        includeKeysOption = None,
+        excludeKeysOption = None,
+        expandSubWorkflows = true
+      )))
 
     serviceRegistryActor.expectMsg(GetRootAndSubworkflowLabels(workflowId))
     serviceRegistryActor.send(actorUnderTest, RootAndSubworkflowLabelsLookupResponse(workflowId, Map(WorkflowId(workflowId.id) -> Map("bob loblaw" -> "law blog"))))
@@ -60,14 +65,14 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
     }
 
     clientProbe.expectMsgPF(max = 5.seconds) {
-      case ThawCarboniteSucceeded(str) => parse(str) should be(parse(augmentedMetadataSample))
-      case ThawCarboniteFailed(reason) => fail(reason)
+      case BuiltMetadataResponse(_, jsObject) => parse(jsObject.compactPrint) should be(parse(augmentedMetadataSample))
+      case FailedMetadataResponse(_, reason) => fail(reason)
     }
   }
 
   it should "add labels to subworkflows" in {
 
-    val rootWorkflowId = RootWorkflowId(UUID.fromString("e0c918bb-695e-458a-ab37-be33db7bf721"))
+    val rootWorkflowId = WorkflowId.fromString("e0c918bb-695e-458a-ab37-be33db7bf721")
     // The subworkflow IDs in the order they appear in the metadata JSON.
     val subWorkflowIds = List(
       "be186a2f-b52c-4c6d-96dd-b9a7f16ac526",
@@ -85,13 +90,22 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
       "0571a73e-1485-4b28-9320-e87036685d61",
       "d9ce3320-727f-42f5-a946-e11177ebd7dd") map WorkflowId.fromString
 
-    // The root workflow ID has to be a WorkflowId and not a RootWorkflowId in this Map.
-    val labelsForUpdate: Map[WorkflowId, Map[String, String]] = (WorkflowId.fromString(rootWorkflowId.toString) :: subWorkflowIds) map { id => id -> Map("short_id" -> id.shortString) } toMap
+    val labelsForUpdate: Map[WorkflowId, Map[String, String]] = (rootWorkflowId :: subWorkflowIds) map { id => id -> Map("short_id" -> id.shortString) } toMap
+
+    val action = GetMetadataAction(
+      MetadataQuery(
+        workflowId = rootWorkflowId,
+        jobKey = None,
+        key = None,
+        includeKeysOption = None,
+        excludeKeysOption = None,
+        expandSubWorkflows = true
+      ))
 
     val clientProbe = TestProbe()
     val actorUnderTest = TestActorRef(new CarbonitedMetadataThawingActor(carboniterConfig, serviceRegistryActor.ref, ioActor.ref), "ThawingActor")
 
-    clientProbe.send(actorUnderTest, ThawCarbonitedMetadata(rootWorkflowId))
+    clientProbe.send(actorUnderTest, action)
     serviceRegistryActor.expectMsg(GetRootAndSubworkflowLabels(rootWorkflowId))
     serviceRegistryActor.send(actorUnderTest, RootAndSubworkflowLabelsLookupResponse(rootWorkflowId, labelsForUpdate))
 
@@ -121,11 +135,11 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
     }
 
     clientProbe.expectMsgPF(max = 5.seconds) {
-      case ThawCarboniteSucceeded(metadataAfterThawing) =>
+      case BuiltMetadataResponse(_, metadataAfterThawing) =>
         val rootNodesAfterUpdate = new ArrayBuffer[JsonNode]()
         val rootOutputAfterUpdate = outputBuilder(rootNodesAfterUpdate)
 
-        val jsonNodeAfterUpdate = objectMapper.readTree(metadataAfterThawing)
+        val jsonNodeAfterUpdate = objectMapper.readTree(metadataAfterThawing.compactPrint)
         rootWorkflowLabelsQuery.apply(scope, jsonNodeAfterUpdate, rootOutputAfterUpdate)
         val actualRootLabelsAfterUpdate = rootNodesAfterUpdate.head.fields().asScala.toList map { e => e.getKey -> e.getValue.textValue() } toMap
         val expectedRootLabelsAfterUpdate = Map(
@@ -144,13 +158,13 @@ class CarbonitedMetadataThawingActorSpec extends TestKitSuite("CarbonitedMetadat
         val expected = subWorkflowIds map { _.shortString }
         actual shouldEqual expected
 
-      case ThawCarboniteFailed(reason) => fail(reason)
+      case FailedMetadataResponse(_, reason) => fail(reason)
     }
   }
 }
 
 object CarbonitedMetadataThawingActorSpec {
-  val workflowId = RootWorkflowId(UUID.fromString("2ce544a0-4c0d-4cc9-8a0b-b412bb1e5f82"))
+  val workflowId = WorkflowId.fromString("2ce544a0-4c0d-4cc9-8a0b-b412bb1e5f82")
 
   val rawMetadataSample = sampleMetadataContent("")
   val augmentedMetadataSample = sampleMetadataContent("""

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActorSpec.scala
@@ -11,7 +11,7 @@ import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActor.{Fetching, FreezeMetadata, Freezing, Pending, UpdatingDatabase}
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActorSpec.TestableCarbonitingMetadataFreezerActor
-import cromwell.services.BuiltMetadataResponse
+import cromwell.services.SuccessfulMetadataJsonResponse
 import org.scalatest.{FlatSpecLike, Matchers}
 import spray.json._
 import org.scalatest.concurrent.Eventually._
@@ -56,7 +56,7 @@ class CarbonitingMetadataFreezerActorSpec extends TestKitSuite("CarbonitedMetada
          |  "status": "Successful"
          |}""".stripMargin.parseJson
 
-    serviceRegistryActor.send(actor, BuiltMetadataResponse(null, jsonValue.asJsObject))
+    serviceRegistryActor.send(actor, SuccessfulMetadataJsonResponse(null, jsonValue.asJsObject))
 
     var ioCommandPromise: Promise[Any] = null
     ioActor.expectMsgPF(10.seconds) {

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/CarbonitingMetadataFreezerActorSpec.scala
@@ -11,7 +11,7 @@ import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService.GetMetadataAction
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActor.{Fetching, FreezeMetadata, Freezing, Pending, UpdatingDatabase}
 import cromwell.services.metadata.hybridcarbonite.CarbonitingMetadataFreezerActorSpec.TestableCarbonitingMetadataFreezerActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
+import cromwell.services.BuiltMetadataResponse
 import org.scalatest.{FlatSpecLike, Matchers}
 import spray.json._
 import org.scalatest.concurrent.Eventually._

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
@@ -3,7 +3,7 @@ package cromwell.services.metadata.hybridcarbonite
 import akka.actor.ActorSystem
 import akka.testkit.{TestFSMRef, TestProbe}
 import cromwell.core.{TestKitSuite, WorkflowId}
-import cromwell.services.BuiltMetadataResponse
+import cromwell.services.SuccessfulMetadataJsonResponse
 import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataArchiveStatus._
 import cromwell.services.metadata.MetadataService._
@@ -56,7 +56,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
         |  "id": "${sampleWorkflowId.toString}"
         |}""".stripMargin
     val responseJson = responseJsonString.parseJson.asJsObject
-    val response = BuiltMetadataResponse(incomingQuery, responseJson)
+    val response = SuccessfulMetadataJsonResponse(incomingQuery, responseJson)
     decidedUponActor.send(hrda, response)
 
     client.expectMsg(response)

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridReadDeciderActorSpec.scala
@@ -3,11 +3,11 @@ package cromwell.services.metadata.hybridcarbonite
 import akka.actor.ActorSystem
 import akka.testkit.{TestFSMRef, TestProbe}
 import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.services.BuiltMetadataResponse
 import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataArchiveStatus._
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.hybridcarbonite.HybridReadDeciderActor._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
 import org.scalatest.{FlatSpecLike, Matchers}
 import spray.json._
 
@@ -35,7 +35,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
 
     hrda.stateName should be(Pending)
 
-    val incomingQuery = GetLabels(sampleWorkflowId)
+    val incomingQuery = WorkflowOutputs(sampleWorkflowId)
 
     // The HybridReadDeciderActor gets a workflow-specific query and looks up its archive status:
     client.send(hrda, incomingQuery)
@@ -52,7 +52,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
     // Send a basic response:
     val responseJsonString =
       s"""{
-        |  "labels": [],
+        |  "outputs": {},
         |  "id": "${sampleWorkflowId.toString}"
         |}""".stripMargin
     val responseJson = responseJsonString.parseJson.asJsObject
@@ -68,7 +68,7 @@ class HybridReadDeciderActorSpec extends TestKitSuite("HybridReadDeciderActorSpe
     carboniteMetadataActor.msgAvailable should be(false)
   }
 
-  it should "go straight to the classic metadata service for archive status for multi-workflow queries" in {
+  it should "go straight to the classic metadata service for summary table searches" in {
 
     val client = TestProbe("client")
     val classicMetadataActor = TestProbe("classic")

--- a/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -377,7 +377,7 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
 
   private def getWorkflowState(workflowId: WorkflowId, serviceRegistryActor: ActorRef)(implicit ec: ExecutionContext): WorkflowState = {
     val statusResponse = serviceRegistryActor.ask(GetStatus(workflowId))(TimeoutDuration).collect {
-      case BuiltMetadataResponse(_, jsObject) => WorkflowState.withName(jsObject.fields("status").asInstanceOf[JsString].value)
+      case SuccessfulMetadataJsonResponse(_, jsObject) => WorkflowState.withName(jsObject.fields("status").asInstanceOf[JsString].value)
       case f => throw new RuntimeException(s"Unexpected status response for $workflowId: $f")
     }
     Await.result(statusResponse, TimeoutDuration)
@@ -401,9 +401,9 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
 
   private def getWorkflowOutputsFromMetadata(id: WorkflowId, serviceRegistryActor: ActorRef): Map[FullyQualifiedName, WomValue] = {
 
-    val response = serviceRegistryActor.ask(WorkflowOutputs(id)).mapTo[BuildMetadataResponse] collect {
-      case BuiltMetadataResponse(_, r) => r
-      case FailedMetadataResponse(_, e) => throw e
+    val response = serviceRegistryActor.ask(WorkflowOutputs(id)).mapTo[MetadataJsonResponse] collect {
+      case SuccessfulMetadataJsonResponse(_, r) => r
+      case FailedMetadataJsonResponse(_, e) => throw e
     }
     val jsObject = Await.result(response, TimeoutDuration)
 

--- a/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
+++ b/server/src/test/scala/cromwell/CromwellTestKitSpec.scala
@@ -27,7 +27,7 @@ import cromwell.services.ServiceRegistryActor
 import cromwell.services.metadata.MetadataService._
 import cromwell.subworkflowstore.EmptySubWorkflowStoreActor
 import cromwell.util.SampleWdl
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.{BuiltMetadataResponse, FailedMetadataResponse, MetadataBuilderActorResponse}
+import cromwell.services._
 import org.scalactic.Equality
 import org.scalatest._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -37,6 +37,7 @@ import wom.core.FullyQualifiedName
 import wom.types._
 import wom.values._
 
+import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.language.postfixOps
@@ -269,6 +270,7 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
 
   // Allow to use shouldEqual between 2 WdlTypes while acknowledging for edge cases
   implicit val wdlTypeSoftEquality = new Equality[WomType] {
+    @tailrec
     override def areEqual(a: WomType, b: Any): Boolean = (a, b) match {
       case (WomStringType | WomSingleFileType, WomSingleFileType | WomStringType) => true
       case (arr1: WomArrayType, arr2: WomArrayType) => areEqual(arr1.memberType, arr2.memberType)
@@ -399,7 +401,7 @@ abstract class CromwellTestKitSpec(val twms: TestWorkflowManagerSystem = default
 
   private def getWorkflowOutputsFromMetadata(id: WorkflowId, serviceRegistryActor: ActorRef): Map[FullyQualifiedName, WomValue] = {
 
-    val response = serviceRegistryActor.ask(WorkflowOutputs(id)).mapTo[MetadataBuilderActorResponse] collect {
+    val response = serviceRegistryActor.ask(WorkflowOutputs(id)).mapTo[BuildMetadataResponse] collect {
       case BuiltMetadataResponse(_, r) => r
       case FailedMetadataResponse(_, e) => throw e
     }

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -39,9 +39,9 @@ object MetadataService {
   trait MetadataServiceAction extends MetadataServiceMessage with ServiceRegistryMessage {
     def serviceName = MetadataServiceName
   }
-  sealed trait MetadataReadAction extends MetadataServiceAction
+  sealed trait BuildMetadataJsonAction extends MetadataServiceAction
 
-  sealed trait WorkflowMetadataReadAction extends MetadataReadAction {
+  sealed trait BuildWorkflowMetadataJsonAction extends BuildMetadataJsonAction {
     def workflowId: WorkflowId
   }
 
@@ -93,21 +93,21 @@ object MetadataService {
     def apply(workflowId: WorkflowId,
               includeKeysOption: Option[NonEmptyList[String]],
               excludeKeysOption: Option[NonEmptyList[String]],
-              expandSubWorkflows: Boolean): WorkflowMetadataReadAction = {
+              expandSubWorkflows: Boolean): BuildWorkflowMetadataJsonAction = {
       GetMetadataAction(MetadataQuery(workflowId, None, None, includeKeysOption, excludeKeysOption, expandSubWorkflows))
     }
   }
 
 
-  final case class GetMetadataAction(key: MetadataQuery) extends WorkflowMetadataReadAction {
+  final case class GetMetadataAction(key: MetadataQuery) extends BuildWorkflowMetadataJsonAction {
     override def workflowId: WorkflowId = key.workflowId
   }
-  final case class GetStatus(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class GetLabels(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class GetRootAndSubworkflowLabels(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class QueryForWorkflowsMatchingParameters(parameters: Seq[(String, String)]) extends MetadataReadAction
-  final case class WorkflowOutputs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class GetLogs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
+  final case class GetStatus(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
+  final case class GetLabels(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
+  final case class GetRootAndSubworkflowLabels(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
+  final case class QueryForWorkflowsMatchingParameters(parameters: Seq[(String, String)]) extends BuildMetadataJsonAction
+  final case class WorkflowOutputs(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
+  final case class GetLogs(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
   case object RefreshSummary extends MetadataServiceAction
   trait ValidationCallback {
     def onMalformed(possibleWorkflowId: String): Unit

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -39,9 +39,9 @@ object MetadataService {
   trait MetadataServiceAction extends MetadataServiceMessage with ServiceRegistryMessage {
     def serviceName = MetadataServiceName
   }
-  trait MetadataReadAction extends MetadataServiceAction
+  sealed trait MetadataReadAction extends MetadataServiceAction
 
-  trait WorkflowMetadataReadAction extends MetadataReadAction {
+  sealed trait WorkflowMetadataReadAction extends MetadataReadAction {
     def workflowId: WorkflowId
   }
 
@@ -104,7 +104,7 @@ object MetadataService {
   }
   final case class GetStatus(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   final case class GetLabels(workflowId: WorkflowId) extends WorkflowMetadataReadAction
-  final case class GetRootAndSubworkflowLabels(workflowId: RootWorkflowId) extends WorkflowMetadataReadAction
+  final case class GetRootAndSubworkflowLabels(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   final case class QueryForWorkflowsMatchingParameters(parameters: Seq[(String, String)]) extends MetadataReadAction
   final case class WorkflowOutputs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
   final case class GetLogs(workflowId: WorkflowId) extends WorkflowMetadataReadAction
@@ -139,8 +139,8 @@ object MetadataService {
   final case class LabelLookupResponse(workflowId: WorkflowId, labels: Map[String, String]) extends MetadataServiceResponse
   final case class LabelLookupFailed(workflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
-  final case class RootAndSubworkflowLabelsLookupResponse(rootWorkflowId: RootWorkflowId, labels: Map[WorkflowId, Map[String, String]]) extends MetadataServiceResponse
-  final case class RootAndSubworkflowLabelsLookupFailed(rootWorkflowId: RootWorkflowId, reason: Throwable) extends MetadataServiceFailure
+  final case class RootAndSubworkflowLabelsLookupResponse(rootWorkflowId: WorkflowId, labels: Map[WorkflowId, Map[String, String]]) extends MetadataServiceResponse
+  final case class RootAndSubworkflowLabelsLookupFailed(rootWorkflowId: WorkflowId, reason: Throwable) extends MetadataServiceFailure
 
   final case class WorkflowOutputsResponse(id: WorkflowId, outputs: Seq[MetadataEvent]) extends MetadataServiceResponse
   final case class WorkflowOutputsFailure(id: WorkflowId, reason: Throwable) extends MetadataServiceFailure

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -210,7 +210,7 @@ trait MetadataDatabaseAccess {
     metadataDatabaseInterface.getWorkflowLabels(id.toString)
   }
 
-  def getRootAndSubworkflowLabels(rootWorkflowId: RootWorkflowId)(implicit ec: ExecutionContext): Future[Map[WorkflowId, Map[String, String]]] = {
+  def getRootAndSubworkflowLabels(rootWorkflowId: WorkflowId)(implicit ec: ExecutionContext): Future[Map[WorkflowId, Map[String, String]]] = {
     metadataDatabaseInterface.getRootAndSubworkflowLabels(rootWorkflowId.toString) map {
       _ map { case (id, labelsForId) => WorkflowId.fromString(id) -> labelsForId }
     }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -121,7 +121,7 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
     case listen: Listen => writeActor forward listen
     case v: ValidateWorkflowIdInMetadata => validateWorkflowIdInMetadata(v.possibleWorkflowId, sender())
     case v: ValidateWorkflowIdInMetadataSummaries => validateWorkflowIdInMetadataSummaries(v.possibleWorkflowId, sender())
-    case action: MetadataReadAction => readActor forward action
+    case action: BuildMetadataJsonAction => readActor forward action
 
   }
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -27,7 +27,7 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration) extends Act
     case GetLogs(workflowId) => evaluateRespondAndStop(sender(), queryLogsAndRespond(workflowId))
     case query: QueryForWorkflowsMatchingParameters => evaluateRespondAndStop(sender(), queryWorkflowsAndRespond(query.parameters))
     case WorkflowOutputs(id) => evaluateRespondAndStop(sender(), queryWorkflowOutputsAndRespond(id))
-    case unexpected => log.warning(s"Unexpected message received by ${getClass.getSimpleName}: $unexpected")
+    case unexpected => log.warning(s"Programmer Error! Unexpected message received by ${getClass.getSimpleName}: $unexpected")
   }
 
   private def evaluateRespondAndStop(sndr: ActorRef, f: Future[Any]) = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadMetadataRegulatorActor.scala
@@ -4,15 +4,15 @@ import java.util.UUID
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import cromwell.core.Dispatcher.ApiDispatcher
+import cromwell.services.BuildMetadataResponse
 import cromwell.services.metadata.MetadataService
-import cromwell.services.metadata.MetadataService.{MetadataQueryResponse, MetadataReadAction, MetadataServiceAction, MetadataServiceResponse, WorkflowMetadataReadAction}
-import cromwell.services.metadata.impl.ReadMetadataRegulatorActor.ReadMetadataWorkerMaker
+import cromwell.services.metadata.MetadataService.{MetadataQueryResponse, MetadataReadAction, MetadataServiceAction, MetadataServiceResponse, RootAndSubworkflowLabelsLookupResponse, WorkflowMetadataReadAction}
+import cromwell.services.metadata.impl.ReadMetadataRegulatorActor.PropsMaker
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.MetadataBuilderActorResponse
 
 import scala.collection.mutable
 
-class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMaker, readMetadataWorkerProps: ReadMetadataWorkerMaker) extends Actor with ActorLogging {
+class ReadMetadataRegulatorActor(metadataBuilderActorProps: PropsMaker, readMetadataWorkerProps: PropsMaker) extends Actor with ActorLogging {
   // This actor tracks all requests coming in from the API service and spins up new builders as needed to service them.
   // If the processing of an identical request is already in flight the requester will be added to a set of requesters
   // to notify when the response from the first request becomes available.
@@ -48,8 +48,8 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
       }
     case serviceResponse: MetadataServiceResponse =>
       serviceResponse match {
-        case response: MetadataBuilderActorResponse => handleResponseFromMetadataWorker(response)
-        case response: MetadataQueryResponse => handleResponseFromMetadataWorker(response)
+        case response @ (_: BuildMetadataResponse | _: MetadataQueryResponse | _: RootAndSubworkflowLabelsLookupResponse) =>
+          handleResponseFromMetadataWorker(response)
       }
     case other => log.error(s"Programmer Error: Unexpected message $other received from $sender")
   }
@@ -76,10 +76,9 @@ class ReadMetadataRegulatorActor(metadataBuilderActorProps: ReadMetadataWorkerMa
 }
 
 object ReadMetadataRegulatorActor {
+  type PropsMaker = () => Props
 
-  type ReadMetadataWorkerMaker = () => Props
-
-  def props(metadataBuilderActorProps: ReadMetadataWorkerMaker, readMetadataWorkerProps: ReadMetadataWorkerMaker): Props = {
-    Props(new ReadMetadataRegulatorActor(metadataBuilderActorProps, readMetadataWorkerProps))
+  def props(singleWorkflowMetadataBuilderProps: PropsMaker, summarySearcherProps: PropsMaker): Props = {
+    Props(new ReadMetadataRegulatorActor(singleWorkflowMetadataBuilderProps, summarySearcherProps))
   }
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -85,7 +85,7 @@ object MetadataBuilderActor {
      *    ...
      * )
      * Note that groupBy will preserve the ordering of the events in the Seq, which means that as long as the DB sorts them by timestamp, we can always assume the last one is the newest one.
-     * This is guaranteed by the groupBy invariant and the fact that filter preservers the ordering. (See scala doc for groupBy and filter)
+     * This is guaranteed by the groupBy invariant and the fact that filter preserves the ordering. (See scala doc for groupBy and filter)
      */
     val callsGroupedByFQN = callLevel groupBy { _.key.jobKey.get.callFqn }
     /*

--- a/services/src/main/scala/cromwell/services/metadata/package.scala
+++ b/services/src/main/scala/cromwell/services/metadata/package.scala
@@ -1,12 +1,12 @@
 package cromwell.services
 
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse}
+import cromwell.services.metadata.MetadataService.{BuildMetadataJsonAction, MetadataServiceResponse}
 import spray.json.JsObject
 
 package object metadata {
   type QueryParameters = Seq[QueryParameter]
 }
 
-sealed trait BuildMetadataResponse extends MetadataServiceResponse { def originalRequest: MetadataReadAction }
-final case class BuiltMetadataResponse(originalRequest: MetadataReadAction, responseJson: JsObject) extends BuildMetadataResponse
-final case class FailedMetadataResponse(originalRequest: MetadataReadAction, reason: Throwable) extends BuildMetadataResponse
+sealed trait MetadataJsonResponse extends MetadataServiceResponse { def originalRequest: BuildMetadataJsonAction }
+final case class SuccessfulMetadataJsonResponse(originalRequest: BuildMetadataJsonAction, responseJson: JsObject) extends MetadataJsonResponse
+final case class FailedMetadataJsonResponse(originalRequest: BuildMetadataJsonAction, reason: Throwable) extends MetadataJsonResponse

--- a/services/src/main/scala/cromwell/services/metadata/package.scala
+++ b/services/src/main/scala/cromwell/services/metadata/package.scala
@@ -1,5 +1,12 @@
 package cromwell.services
 
+import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse}
+import spray.json.JsObject
+
 package object metadata {
   type QueryParameters = Seq[QueryParameter]
 }
+
+sealed trait BuildMetadataResponse extends MetadataServiceResponse { def originalRequest: MetadataReadAction }
+final case class BuiltMetadataResponse(originalRequest: MetadataReadAction, responseJson: JsObject) extends BuildMetadataResponse
+final case class FailedMetadataResponse(originalRequest: MetadataReadAction, reason: Throwable) extends BuildMetadataResponse

--- a/services/src/test/scala/cromwell/services/metadata/MetadataQuerySpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataQuerySpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core.TestKitSuite
 import cromwell.services.metadata.MetadataQuerySpec.{CannedResponseReadMetadataWorker, MetadataServiceActor_CustomizeRead}
-import cromwell.services.metadata.MetadataService.{MetadataReadAction, MetadataServiceResponse, QueryForWorkflowsMatchingParameters, WorkflowQueryResponse, WorkflowQuerySuccess}
+import cromwell.services.metadata.MetadataService.{BuildMetadataJsonAction, MetadataServiceResponse, QueryForWorkflowsMatchingParameters, WorkflowQueryResponse, WorkflowQuerySuccess}
 import cromwell.services.metadata.impl.{MetadataServiceActor, MetadataServiceActorSpec}
 import org.scalatest.{FlatSpecLike, Matchers}
 
@@ -50,9 +50,9 @@ object MetadataQuerySpec {
   }
 
 
-  final class CannedResponseReadMetadataWorker(cannedResponses: Map[MetadataReadAction, MetadataServiceResponse]) extends Actor {
+  final class CannedResponseReadMetadataWorker(cannedResponses: Map[BuildMetadataJsonAction, MetadataServiceResponse]) extends Actor {
     override def receive = {
-      case msg: MetadataReadAction => sender ! cannedResponses.getOrElse(msg, throw new Exception(s"Unexpected inbound message: $msg"))
+      case msg: BuildMetadataJsonAction => sender ! cannedResponses.getOrElse(msg, throw new Exception(s"Unexpected inbound message: $msg"))
     }
   }
 }

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -6,10 +6,9 @@ import akka.pattern._
 import akka.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core._
-import cromwell.services.ServicesSpec
+import cromwell.services.{BuiltMetadataResponse, ServicesSpec}
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
-import cromwell.services.metadata.impl.builder.MetadataBuilderActor.BuiltMetadataResponse
 import cromwell.services.metadata.impl.MetadataServiceActorSpec._
 
 import scala.concurrent.Await

--- a/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/MetadataServiceActorSpec.scala
@@ -6,7 +6,7 @@ import akka.pattern._
 import akka.testkit.TestProbe
 import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.core._
-import cromwell.services.{BuiltMetadataResponse, ServicesSpec}
+import cromwell.services.{SuccessfulMetadataJsonResponse, ServicesSpec}
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.services.metadata.impl.MetadataServiceActorSpec._
@@ -118,7 +118,7 @@ class MetadataServiceActorSpec extends ServicesSpec("Metadata") {
 
       s"perform $name correctly" in {
         eventually(Timeout(10.seconds), Interval(2.seconds)) {
-          val response = Await.result((actor ? GetMetadataAction(query)).mapTo[BuiltMetadataResponse], 1.seconds)
+          val response = Await.result((actor ? GetMetadataAction(query)).mapTo[SuccessfulMetadataJsonResponse], 1.seconds)
 
           response.responseJson shouldBe expectation.parseJson
         }


### PR DESCRIPTION
Completely punted on unexpanding subworkflows and call-level queries. The latter shortcoming surprisingly appears to at least one of the causes of 19 tests still failing in Chris' #5237 PR. But the basic metadata endpoint with include / exclude does appear to work on a Carboniting Cromwell.