### PR TITLE
Reading bytes from file stream without unnecessary cast to chars  [BA-6097]

### DIFF
--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -105,15 +105,20 @@ trait EvenBetterPathMethods {
     case ex: Throwable => Failure(new IOException(s"Could not read from ${this.pathAsString}: ${ex.getMessage}", ex))
   }
 
-  /*
-   * The input stream will be closed when this method returns, which means the f function
-   * cannot leak an open stream.
-   */
+  /**
+    * BufferedReader can be used to read UTF-8 characters from the input stream.
+    * The input stream will be closed when this method returns, which means the f function
+    * cannot leak an open stream.
+    */
   def withReader[A](f: BufferedReader => A)(implicit ec: ExecutionContext): A = {
     // Use an input reader to convert the byte stream to character stream. Buffered reader for efficiency.
     tryWithResource(() => new BufferedReader(new InputStreamReader(this.mediaInputStream, Codec.UTF8.name)))(f).recoverWith(fileIoErrorPf).get
   }
 
+  /**
+    * InputStream's read method reads bytes, whereas InputStreamReader's read method reads characters.
+    * BufferedInputStream can be used to read bytes directly from input stream, without conversion to characters.
+    */
   def withBufferedStream[A](f: BufferedInputStream => A)(implicit ec: ExecutionContext): A = {
     tryWithResource(() => new BufferedInputStream(this.mediaInputStream))(f).recoverWith(fileIoErrorPf).get
   }

--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -1,6 +1,6 @@
 package cromwell.core.path
 
-import java.io.{BufferedReader, IOException, InputStream, InputStreamReader}
+import java.io.{BufferedInputStream, BufferedReader, IOException, InputStream, InputStreamReader}
 import java.nio.file.{FileAlreadyExistsException, Files}
 import java.nio.file.attribute.{PosixFilePermission, PosixFilePermissions}
 
@@ -10,7 +10,7 @@ import cromwell.util.TryWithResource.tryWithResource
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.io.Codec
-import scala.util.Failure
+import scala.util.{Failure, Try}
 
 /**
   * Implements methods beyond those implemented in NioPathMethods and BetterFileMethods
@@ -101,24 +101,29 @@ trait EvenBetterPathMethods {
     write(content)(openOptions, Codec.UTF8)
   }
 
+  private def fileIoErrorPf[A]: PartialFunction[Throwable, Try[A]] = {
+    case ex: Throwable => Failure(new IOException(s"Could not read from ${this.pathAsString}: ${ex.getMessage}", ex))
+  }
+
   /*
    * The input stream will be closed when this method returns, which means the f function
    * cannot leak an open stream.
    */
   def withReader[A](f: BufferedReader => A)(implicit ec: ExecutionContext): A = {
-
     // Use an input reader to convert the byte stream to character stream. Buffered reader for efficiency.
-    tryWithResource(() => new BufferedReader(new InputStreamReader(this.mediaInputStream, Codec.UTF8.name)))(f).recoverWith({
-      case failure => Failure(new IOException(s"Could not read from ${this.pathAsString}: ${failure.getMessage}", failure))
-    }).get
+    tryWithResource(() => new BufferedReader(new InputStreamReader(this.mediaInputStream, Codec.UTF8.name)))(f).recoverWith(fileIoErrorPf).get
+  }
+
+  def withBufferedStream[A](f: BufferedInputStream => A)(implicit ec: ExecutionContext): A = {
+    tryWithResource(() => new BufferedInputStream(this.mediaInputStream))(f).recoverWith(fileIoErrorPf).get
   }
 
   /**
     * Returns an Array[Byte] from a Path. Limit the array size to "limit" byte if defined.
     * @throws IOException if failOnOverflow is true and the file is larger than limit
     */
-  def limitFileContent(limit: Option[Int], failOnOverflow: Boolean)(implicit ec: ExecutionContext) = withReader { reader =>
-    val bytesIterator = Iterator.continually(reader.read).takeWhile(_ != -1).map(_.toByte)
+  def limitFileContent(limit: Option[Int], failOnOverflow: Boolean)(implicit ec: ExecutionContext) = withBufferedStream { bufferedStream =>
+    val bytesIterator = Iterator.continually(bufferedStream.read).takeWhile(_ != -1).map(_.toByte)
     // Take 1 more than the limit so that we can look at the size and know if it's overflowing
     val bytesArray = limit.map(l => bytesIterator.take(l + 1)).getOrElse(bytesIterator).toArray
 


### PR DESCRIPTION
`InputStream's` `read` method reads bytes, whereas `InputStreamReader's` `read` method reads characters. So, we can use `BufferedInputStream` to read bytes directly from input stream, without conversion to characters.