### PR TITLE
Better "no metadata found" errors for call cache diffs [BA-6106]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -146,6 +146,7 @@ object CallCacheDiffActor {
 
     for {
       // Sanity Checks:
+      _ <- response.value.validateNonEmptyResponse()
       _ <- response.value.checkFieldValue("id", s""""${query.workflowId}"""")
       jobKey <- query.jobKey.toErrorOr("Call is required in call cache diff query")
 
@@ -212,6 +213,10 @@ object CallCacheDiffActor {
     def checkFieldValue(field: String, expectation: String): ErrorOr[Unit] = jsObject.getField(field) flatMap {
       case v: JsValue if v.toString == expectation => ().validNel
       case other => s"Unexpected metadata field '$field'. Expected '$expectation' but got ${other.toString}".invalidNel
+    }
+
+    def validateNonEmptyResponse(): ErrorOr[Unit] = if (jsObject.fields.nonEmpty) { ().validNel } else {
+      "No metadata was found for that workflow/call/index combination. Check that the workflow ID is correct, that the call name is formatted like 'workflowname.callname' and that an index is provided if this was a scattered task. (NOTE: the default index is -1, ie non-scattered)".invalidNel
     }
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -216,7 +216,7 @@ object CallCacheDiffActor {
     }
 
     def validateNonEmptyResponse(): ErrorOr[Unit] = if (jsObject.fields.nonEmpty) { ().validNel } else {
-      "No metadata was found for that workflow/call/index combination. Check that the workflow ID is correct, that the call name is formatted like 'workflowname.callname' and that an index is provided if this was a scattered task. (NOTE: the default index is -1, ie non-scattered)".invalidNel
+      "No metadata was found for that workflow/call/index combination. Check that the workflow ID is correct, that the call name is formatted like 'workflowname.callname' and that an index is provided if this was a scattered task. (NOTE: the default index is -1, i.e. non-scattered)".invalidNel
     }
   }
 

--- a/engine/src/main/scala/cromwell/webservice/ApiDataModels.scala
+++ b/engine/src/main/scala/cromwell/webservice/ApiDataModels.scala
@@ -24,9 +24,11 @@ object APIResponse {
   private def constructFailureResponse(status: String, ex: Throwable) = {
     ex match {
       case exceptionWithErrors: MessageAggregation =>
-        FailureResponse(status, exceptionWithErrors.getMessage,
-          Option(JsArray(exceptionWithErrors.errorMessages.toList.map(JsString(_)).toVector)))
-      case e: Throwable => FailureResponse(status, e.getMessage, Option(e.getCause).map(c => JsArray(JsString(ExceptionUtils.getMessage(c)))))
+        FailureResponse(
+          status,
+          exceptionWithErrors.exceptionContext,
+          Option(exceptionWithErrors.errorMessages.toVector))
+      case e: Throwable => FailureResponse(status, e.getMessage, Option(e.getCause).map(c => Vector(ExceptionUtils.getMessage(c))))
     }
   }
 
@@ -41,4 +43,4 @@ object APIResponse {
 }
 
 case class SuccessResponse(status: String, message: String, data: Option[JsValue])
-case class FailureResponse(status: String, message: String, errors: Option[JsValue])
+case class FailureResponse(status: String, message: String, errors: Option[Vector[String]])

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -54,8 +54,6 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   }
   implicit val successResponse = jsonFormat3(SuccessResponse)
 
-    jsonFormat3(SuccessResponse)
-
   implicit object DateJsonFormat extends RootJsonFormat[OffsetDateTime] {
     override def write(offsetDateTime: OffsetDateTime) = JsString(offsetDateTime.toUtcMilliString)
 

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -48,6 +48,8 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val workflowSourceDataWithImports = jsonFormat11(WorkflowSourceFilesWithDependenciesZip)
   implicit val errorResponse = jsonFormat3(FailureResponse)
 
+  // By default the formatter for JsValues prints them out ADT-style.
+  // In the case of SuccessResponses, we just want raw JsValues to be included in our output verbatim.
   private implicit val identityJsValueFormatter = new RootJsonFormat[JsValue] {
     override def read(json: JsValue): JsValue = json
     override def write(obj: JsValue): JsValue = obj

--- a/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/WorkflowJsonSupport.scala
@@ -13,9 +13,7 @@ import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService._
 import cromwell.util.JsonFormatting.WomValueJsonFormatter._
 import cromwell.webservice.routes.CromwellApiService.BackendResponse
-import spray.json.{DefaultJsonProtocol, DeserializationException, JsObject, JsString, JsValue, JsonFormat, RootJsonFormat}
-
-import scala.util.{Failure, Success, Try}
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, RootJsonFormat}
 
 object WorkflowJsonSupport extends DefaultJsonProtocol {
   implicit val workflowStatusResponseProtocol = jsonFormat2(WorkflowStatusResponse)
@@ -49,29 +47,12 @@ object WorkflowJsonSupport extends DefaultJsonProtocol {
 
   implicit val workflowSourceDataWithImports = jsonFormat11(WorkflowSourceFilesWithDependenciesZip)
   implicit val errorResponse = jsonFormat3(FailureResponse)
-  implicit val successResponse = new RootJsonFormat[SuccessResponse] {
-    override def read(json: JsValue): SuccessResponse = Try {
-        val obj = json.asJsObject
-        val status = obj.fields("status").convertTo[String]
-        val message =  obj.fields("message").convertTo[String]
-        val data = obj.fields.get("data")
 
-      SuccessResponse(status, message, data)
-    } match {
-      case Success(value) => value
-      case Failure(error) => throw DeserializationException(s"Failed to deserialize SuccessResponse", error)
-    }
-    override def write(obj: SuccessResponse): JsValue = {
-      val base = Map[String, JsValue](
-          "status" -> JsString(obj.status),
-          "message" -> JsString(obj.message)
-        )
-      obj.data match {
-        case None => JsObject(base)
-        case Some(data) => JsObject(base + ("data" -> data))
-      }
-    }
+  private implicit val identityJsValueFormatter = new RootJsonFormat[JsValue] {
+    override def read(json: JsValue): JsValue = json
+    override def write(obj: JsValue): JsValue = obj
   }
+  implicit val successResponse = jsonFormat3(SuccessResponse)
 
     jsonFormat3(SuccessResponse)
 

--- a/engine/src/test/scala/cromwell/webservice/WorkflowJsonSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/WorkflowJsonSupportSpec.scala
@@ -1,0 +1,49 @@
+package cromwell.webservice
+
+import org.scalatest.{FlatSpec, Matchers}
+import spray.json._
+import WorkflowJsonSupport._
+
+class WorkflowJsonSupportSpec extends FlatSpec with Matchers {
+
+  val sampleSuccessResponse1 = SuccessResponse("good", "msg", Option(JsArray(Vector(JsString("data1"), JsString("data2")))))
+  val sampleSuccessResponse2 = SuccessResponse("good", "msg", None)
+  val sampleSuccessResponseJson1 =
+    """{
+      |  "status": "good",
+      |  "message": "msg",
+      |  "data": [ "data1", "data2" ]
+      |}""".stripMargin.parseJson
+  val sampleSuccessResponseJson2 =
+    """{
+      |  "status": "good",
+      |  "message": "msg"
+      |}""".stripMargin.parseJson
+
+  it should "correctly JSON-ify success messages" in {
+    sampleSuccessResponse1.toJson should be(sampleSuccessResponseJson1)
+    sampleSuccessResponse2.toJson should be(sampleSuccessResponseJson2)
+  }
+
+  it should "correctly parse success response JSONs" in {
+    sampleSuccessResponseJson1.convertTo[SuccessResponse] should be(sampleSuccessResponse1)
+    sampleSuccessResponseJson2.convertTo[SuccessResponse] should be(sampleSuccessResponse2)
+  }
+
+  val sampleFailureResponse = FailureResponse("bad", "msg", Option(Vector("error1", "error2")))
+  val sampleFailureResponseJson =
+    """{
+      |  "status": "bad",
+      |  "message": "msg",
+      |  "errors": [ "error1", "error2" ]
+      |}""".stripMargin.parseJson
+
+  it should "correctly JSON-ify a failure message" in {
+    sampleFailureResponse.toJson should be(sampleFailureResponseJson)
+  }
+
+  it should "correctly parse failure response JSON" in {
+    sampleFailureResponseJson.convertTo[FailureResponse] should be(sampleFailureResponse)
+  }
+
+}


### PR DESCRIPTION
#### What's changed?

Updates the error message format and content if a call cache diff fails to find a set of metadata.

#### Old Format and Content
```
{
  "status": "error",
  "message": "Failed to calculate diff for call A and call B:\nFailed to extract relevant metadata for call A (<<workflow ID>> / <<call name>>:<<index>>) (reason 1 of 1): No 'id' field found",
  "errors": {
    "JsArray": {
      "elements": [
        {
          "JsString": {
            "value": "Failed to calculate diff for call A and call B:\nFailed to extract relevant metadata for call A (<<workflow ID>> / <<call name>>:<<index>>) (reason 1 of 1): No 'id' field found"
          }
        }
      ]
    }
  }
}
```

### New Format and Content
```
{
  "status": "error",
  "message": "Failed to calculate diff for call A and call B",
  "errors": [
    "Failed to extract relevant metadata for call A (<<workflow ID>> / <<call name>>:<<index>>) (reason 1 of 1): No metadata was found for that workflow/call/index combination. Check that the workflow ID is correct, that the call name is formatted like 'workflowname.callname' and that an index is provided if this was a scattered task. (NOTE: the default index is -1, ie non-scattered)"
  ]
}
```

#### Commentary

~~I'm not convinced the "roll my own" Json formatter is needed... if only there were an "identity" formatter for JsValue, rather than the default - which interprets the value more like a ADT.~~

~~I'm open to suggestions.~~

UPDATE: it turns out rolling my own "identity formatter" was easier than rolling my own case class formatter.