### PR TITLE
Fix TES backend to load preemptible setting from configuration [BA-6004]

### DIFF
--- a/cromwell.example.backends/TES.conf
+++ b/cromwell.example.backends/TES.conf
@@ -26,6 +26,7 @@ backend {
           continueOnReturnCode: 0
           memory: "2 GB"
           disk: "2 GB"
+          preemptible: false
         }
       }
     }

--- a/docs/backends/TES.md
+++ b/docs/backends/TES.md
@@ -46,14 +46,14 @@ Currently this backend only works with files on a Local or Shared File System.
 
 **Docker**
 
-This backend supports the following optional [Runtime Attributes](RuntimeAttributes) and [Workflow Options](wf_options/Overview/) for working with Docker:
+This backend supports the following optional [Runtime Attributes](../RuntimeAttributes) and [Workflow Options](../wf_options/Overview/) for working with Docker:
 
 * `docker`: Docker image to use such as "Ubuntu".
 * `dockerWorkingDir`: defines the working directory in the container.
 
 **CPU, Memory and Disk** 
 
-This backend supports CPU, memory and disk size configuration through the use of the following [Runtime Attributes](RuntimeAttributes) and [Workflow Options](wf_options/Overview/):  
+This backend supports CPU, memory and disk size configuration through the use of the following [Runtime Attributes](../RuntimeAttributes) and [Workflow Options](../wf_options/Overview/):  
 
 * `cpu` defines the amount of CPU to use. 
     * Type: Integer (ex: 4)
@@ -61,6 +61,8 @@ This backend supports CPU, memory and disk size configuration through the use of
     * Type: String (ex: "4 GB" or "4096 MB")
 * `disk` defines the amount of disk to use. 
     * Type: String (ex: "1 GB" or "1024 MB")
+* `preemptible` defines whether or not to use preemptible VMs. 
+    * Type: Boolean (ex: "true" or "false")
 
 If they are not set, the TES backend may use default values.
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -223,7 +223,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
     cpu_cores = runtimeAttributes.cpu.map(_.value),
     ram_gb = ram,
     disk_gb = disk,
-    preemptible = Option(false),
+    preemptible = Option(runtimeAttributes.preemptible),
     zones = None
   )
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
@@ -59,6 +59,7 @@ class TesInitializationActorSpec extends TestKitSuite("TesInitializationActorSpe
       |    continueOnReturnCode: 0
       |    memory: "2 GB"
       |    disk: "2 GB"
+      |    preemptible: false
       |    # The keys below have been commented out as they are optional runtime attributes.
       |    # dockerWorkingDir
       |    # docker

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -21,7 +21,8 @@ class TesRuntimeAttributesSpec extends WordSpecLike with Matchers {
     false,
     None,
     None,
-    None
+    None,
+    false
   )
 
   val expectedDefaultsPlusUbuntuDocker = expectedDefaults.copy(dockerImage = "ubuntu:latest")
@@ -61,6 +62,17 @@ class TesRuntimeAttributesSpec extends WordSpecLike with Matchers {
       assertFailure(runtimeAttributes, "Expecting failOnStderr runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
     }
 
+    "validate a valid preemptible entry" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomBoolean(true))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(preemptible = true)
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "fail to validate an invalid preemptible entry" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomString("yes"))
+      assertFailure(runtimeAttributes, "Expecting preemptible runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+    }
+    
     "validate a valid continueOnReturnCode entry" in {
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "continueOnReturnCode" -> WomInteger(1))
       val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(continueOnReturnCode = ContinueOnReturnCodeSet(Set(1)))

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
@@ -16,6 +16,7 @@ object TesTestConfig {
       |  continueOnReturnCode: 0
       |  memory: "2 GB"
       |  disk: "2 GB"
+      |  preemptible: false
       |  # The keys below have been commented out as they are optional runtime attributes.
       |  # dockerWorkingDir
       |  # docker


### PR DESCRIPTION
The TES backend previously hardcoded the value of preemptible to false [[BA-6004](https://broadworkbench.atlassian.net/browse/BA-6004)]. This change reads the value in from either the backend runtime or workflow runtime config. 

I manually tested that the setting gets picked up from the config (workflow runtime setting of preemptible successfully overrides backend runtime setting; absence of preemptible setting uses default of false) and gets put in the task message sent to the TES API. 

I also made a few minor updates to the TES docs to describe preemptible and fix a couple broken links. 

A quick test was run as follows to view the TES task submission message sent by Cromwell:

-  In one window, listen on port 5000 and display anything sent to it

`ncat -l 5000 -k`

- In another window, submit workflow to Cromwell configured to talk to TES on port 5000 

`java -Dconfig.file=app.config -jar /c/git/cromwell/server/target/scala-2.12/cromwell-48-366e431-SNAP.jar run test.wdl  --inputs test.json
`
- Check that proper `"resources":{"preemptible":<value>}}` field is contained in the TES message. 

[app.config.txt](https://github.com/broadinstitute/cromwell/files/3822302/app.config.txt)
[test.json.txt](https://github.com/broadinstitute/cromwell/files/3822303/test.json.txt)
[test.wdl.txt](https://github.com/broadinstitute/cromwell/files/3822304/test.wdl.txt)
