### PR TITLE
Configurable Carbonite freeze scanning parameters [BA-6109]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -532,6 +532,16 @@ services {
     #         auth = "application-default"
     #       }
     #     }
+    #
+    #     # Freeze scan configuration. This controls the intervals at which the `CarboniteWorkerActor` looks for terminal
+    #     # workflows to carbonite. All of these entries are optional and default to the values shown below. Any supplied
+    #     # values will be sanity checked: intervals must be durations, max greater than initial, multiplier must
+    #     # be a number greater than 1.
+    #     freeze-scan {
+    #       initial-interval = 5 seconds,
+    #       max-interval = 5 minutes,
+    #       multiplier = 1.1
+    #     }
     #   }
     # }
   }

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarboniteWorkerActor.scala
@@ -28,12 +28,15 @@ class CarboniteWorkerActor(carboniterConfig: HybridCarboniteConfig,
 
   val carboniteFreezerActor = context.actorOf(CarbonitingMetadataFreezerActor.props(carboniterConfig, self, serviceRegistryActor, ioActor))
 
-  val backOff = SimpleExponentialBackoff(
-    initialInterval = 5.seconds,
-    maxInterval = 5.minutes,
-    multiplier = 1.1,
-    randomizationFactor = 0.0
-  )
+  val backOff = {
+    val scanConfig = carboniterConfig.freezeScanConfig
+    SimpleExponentialBackoff(
+      initialInterval = scanConfig.initialInterval,
+      maxInterval = scanConfig.maxInterval,
+      multiplier = scanConfig.multiplier,
+      randomizationFactor = 0.0
+    )
+  }
 
   scheduleNextCarbonitingQuery()
 

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfig.scala
@@ -3,6 +3,7 @@ package cromwell.services.metadata.hybridcarbonite
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import common.Checked
+import common.validation.Checked._
 import common.validation.Validation._
 import cromwell.core.filesystem.CromwellFileSystems
 import cromwell.core.path.PathFactory.PathBuilders
@@ -12,19 +13,46 @@ import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.Try
 
-final case class HybridCarboniteConfig(enabled: Boolean, debugLogging: Boolean, pathBuilders: PathBuilders, bucket: String) {
+final case class HybridCarboniteConfig(enabled: Boolean, debugLogging: Boolean, pathBuilders: PathBuilders, bucket: String, freezeScanConfig: HybridCarboniteFreezeScanConfig) {
   def makePath(workflowId: WorkflowId)= PathFactory.buildPath(HybridCarboniteConfig.pathForWorkflow(workflowId, bucket), pathBuilders)
 }
+
+final case class HybridCarboniteFreezeScanConfig(initialInterval: FiniteDuration = 5 seconds, maxInterval: FiniteDuration = 5 minutes, multiplier: Double = 1.1)
 
 object HybridCarboniteConfig {
 
   def pathForWorkflow(id: WorkflowId, bucket: String) = s"gs://$bucket/$id/$id.json"
   
   def parseConfig(carboniterConfig: Config)(implicit system: ActorSystem): Checked[HybridCarboniteConfig] = {
-    val enable = carboniterConfig.as[Option[Boolean]]("enabled").getOrElse(false)
-    val carboniteDebugLogging = carboniterConfig.as[Option[Boolean]](path = "debug-logging").getOrElse(true)
+    val enable = carboniterConfig.getOrElse("enabled", false)
+    val carboniteDebugLogging = carboniterConfig.getOrElse("debug-logging", true)
+
+    def freezeScanConfig: Checked[HybridCarboniteFreezeScanConfig] = {
+      if (carboniterConfig.hasPath("freeze-scan")) {
+        val freeze = carboniterConfig.getConfig("freeze-scan")
+
+        val initialInterval = Try { freeze.getOrElse("initial-interval", 5 seconds) }
+        val maxInterval = Try { freeze.getOrElse("max-interval", default = 5 minutes) }
+        val multiplier = Try { freeze.getOrElse("multiplier", 1.1) }
+
+        import cats.instances.try_._
+        import cats.syntax.apply._
+
+        val tryImx = (initialInterval, maxInterval, multiplier) mapN { case (i, m, x) => (i, m, x) }
+
+        for {
+          imx <- tryImx.toCheckedWithContext("parse Carboniter 'freeze-scan' stanza")
+          (initial, max, multi) = imx
+          _ <- if (max > initial) "".validNelCheck else "max-interval must be greater than or equal to initial-interval in Carboniter 'freeze-scan' stanza".invalidNelCheck
+          _ <- if (multi > 1) "".validNelCheck else "'multiplier' must be greater than 1 in Carboniter 'freeze-scan' stanza".invalidNelCheck
+        } yield HybridCarboniteFreezeScanConfig(initialInterval = initial, maxInterval = max, multiplier = multi)
+      } else {
+        HybridCarboniteFreezeScanConfig().validNelCheck
+      }
+    }
 
     for {
       _ <- Try(carboniterConfig.getConfig("filesystems.gcs")).toCheckedWithContext("parse Carboniter 'filesystems.gcs' field from config")
@@ -32,6 +60,7 @@ object HybridCarboniteConfig {
       pathBuilders <- Try(Await.result(PathBuilderFactory.instantiatePathBuilders(pathBuilderFactories.values.toList, WorkflowOptions.empty), 10.seconds))
         .toCheckedWithContext("construct Carboniter path builders from factories")
       bucket <- Try(carboniterConfig.getString("bucket")).toCheckedWithContext("parse Carboniter 'bucket' field from config")
-    } yield HybridCarboniteConfig(enable, carboniteDebugLogging, pathBuilders, bucket)
+      freezeScan <- freezeScanConfig
+    } yield HybridCarboniteConfig(enable, carboniteDebugLogging, pathBuilders, bucket, freezeScan)
   }
 }

--- a/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfigSpec.scala
+++ b/hybridCarboniteMetadataService/src/test/scala/cromwell/services/metadata/hybridcarbonite/HybridCarboniteConfigSpec.scala
@@ -5,6 +5,9 @@ import com.typesafe.config.ConfigFactory
 import cromwell.core.TestKitSuite
 import org.scalatest.{FlatSpecLike, Matchers}
 
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
 class HybridCarboniteConfigSpec extends TestKitSuite("HybridCarboniteConfigSpec") with FlatSpecLike with Matchers {
 
   behavior of "HybridCarboniteConfig"
@@ -29,11 +32,17 @@ class HybridCarboniteConfigSpec extends TestKitSuite("HybridCarboniteConfigSpec"
 
     carboniteConfig match {
       case Left(e) => fail(s"Expected to parse correctly but got failure. Reason: $e")
-      case Right(c) => {
+      case Right(c) =>
         c.enabled shouldBe true
         c.bucket shouldBe "my_test_bucket"
         c.pathBuilders.head.name shouldBe "Google Cloud Storage"
-      }
+        //noinspection RedundantDefaultArgument
+        val defaultFreezeScanConfig = HybridCarboniteFreezeScanConfig(
+          initialInterval = 5 seconds,
+          maxInterval = 5 minutes,
+          multiplier = 1.1
+        )
+        c.freezeScanConfig shouldBe defaultFreezeScanConfig
     }
   }
 
@@ -54,11 +63,10 @@ class HybridCarboniteConfigSpec extends TestKitSuite("HybridCarboniteConfigSpec"
 
     carboniteConfig match {
       case Left(e) => fail(s"Expected to parse correctly but got failure. Reason: $e")
-      case Right(c) => {
+      case Right(c) =>
         c.enabled shouldBe false
         c.bucket shouldBe "my_test_bucket"
         c.pathBuilders.head.name shouldBe "Google Cloud Storage"
-      }
     }
   }
 
@@ -114,6 +122,95 @@ class HybridCarboniteConfigSpec extends TestKitSuite("HybridCarboniteConfigSpec"
 
     carboniteConfig match {
       case Left(e) => e.head shouldBe "No configuration setting found for key 'auth'"
+      case Right(_) => fail(s"Expected to fail but the config was parsed correctly!")
+    }
+  }
+
+  it should "respect valid freeze-scan config settings" in {
+    val config = ConfigFactory.parseString(
+      """{
+        |   enabled = true
+        |   bucket = "my_test_bucket"
+        |   filesystems {
+        |     gcs {
+        |       auth = "application-default"
+        |     }
+        |   }
+        |   freeze-scan {
+        |     initial-interval = 1 second
+        |     max-interval = 5 seconds
+        |     multiplier = 1.2
+        |   }
+        |}
+      """.stripMargin
+    )
+
+    val carboniteConfig = HybridCarboniteConfig.parseConfig(config)
+
+    carboniteConfig match {
+      case Left(e) => fail(s"Expected to parse correctly but got failure. Reason: $e")
+      case Right(c) =>
+        val expectedConfig = HybridCarboniteFreezeScanConfig(
+          initialInterval = 1 second,
+          maxInterval = 5 seconds,
+          multiplier = 1.2
+        )
+        c.freezeScanConfig shouldBe expectedConfig
+    }
+  }
+
+  it should "reject max interval < initial interval in freeze-scan config settings" in {
+    val config = ConfigFactory.parseString(
+      """{
+        |   enabled = true
+        |   bucket = "my_test_bucket"
+        |   filesystems {
+        |     gcs {
+        |       auth = "application-default"
+        |     }
+        |   }
+        |   freeze-scan {
+        |     max-interval = 1 second
+        |     initial-interval = 5 seconds
+        |     multiplier = 1.2
+        |   }
+        |}
+      """.stripMargin
+    )
+
+    val carboniteConfig = HybridCarboniteConfig.parseConfig(config)
+
+    carboniteConfig match {
+      case Left(e) =>
+        e.head shouldBe "max-interval must be greater than or equal to initial-interval in Carboniter 'freeze-scan' stanza"
+      case Right(_) => fail(s"Expected to fail but the config was parsed correctly!")
+    }
+  }
+
+  it should "reject intervals that are not durations in freeze-scan config settings" in {
+    val config = ConfigFactory.parseString(
+      """{
+        |   enabled = true
+        |   bucket = "my_test_bucket"
+        |   filesystems {
+        |     gcs {
+        |       auth = "application-default"
+        |     }
+        |   }
+        |   freeze-scan {
+        |     initial-interval = I
+        |     max-interval = like
+        |     multiplier = turtles
+        |   }
+        |}
+      """.stripMargin
+    )
+
+    val carboniteConfig = HybridCarboniteConfig.parseConfig(config)
+
+    carboniteConfig match {
+      case Left(e) =>
+        e.head shouldBe "Failed to parse Carboniter 'freeze-scan' stanza (reason 1 of 1): String: 10: Invalid value at 'initial-interval': No number in duration value 'I'"
       case Right(_) => fail(s"Expected to fail but the config was parsed correctly!")
     }
   }

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -27,6 +27,14 @@ services {
             auth = "service_account"
           }
         }
+
+        # The current Centaur Carbonite times out at 30 seconds waiting for terminal workflows to be
+        # Carbonited, so set the backoff max interval for freeze scanning to 15 seconds.
+        freeze-scan {
+          initial-interval = 2 seconds,
+          max-interval = 15 seconds,
+          multiplier = 1.1
+        }
       }
     }
   }

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -29,7 +29,7 @@ services {
         }
 
         # The current Centaur Carbonite logic times out at 30 seconds waiting for terminal workflows to be Carbonited.
-        # Set the backoff max interval for Carbonite freeze scanning to 15 seconds to be under that limit.
+        # Set the backoff max interval for Carbonite freeze scanning below that limit.
         freeze-scan {
           initial-interval = 2 seconds,
           max-interval = 15 seconds,

--- a/src/ci/resources/papi_v2_application.conf
+++ b/src/ci/resources/papi_v2_application.conf
@@ -28,8 +28,8 @@ services {
           }
         }
 
-        # The current Centaur Carbonite times out at 30 seconds waiting for terminal workflows to be
-        # Carbonited, so set the backoff max interval for freeze scanning to 15 seconds.
+        # The current Centaur Carbonite logic times out at 30 seconds waiting for terminal workflows to be Carbonited.
+        # Set the backoff max interval for Carbonite freeze scanning to 15 seconds to be under that limit.
         freeze-scan {
           initial-interval = 2 seconds,
           max-interval = 15 seconds,


### PR DESCRIPTION
Should address the cron failures by setting the maximum freeze scan interval to be less than the Carbonite-flavored Centaur's limit of patience.