### PR TITLE
Allow GCP global pipeline timeout to be configurable

### DIFF
--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -58,8 +58,8 @@ backend {
         # }
 
         # Global pipeline timeout
-        # Defaults to 7 days
-        # pipeline-timeout = 3 days
+        # Defaults to 7 days; max 30 days
+        # pipeline-timeout = 7 days
 
         genomics {
           # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create

--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -57,6 +57,10 @@ backend {
         #  auth = "application-default"
         # }
 
+        # Global pipeline timeout
+        # Defaults to 7 days
+        # pipeline-timeout = 3 days
+
         genomics {
           # A reference to an auth defined in the `google` stanza at the top.  This auth is used to create
           # Pipelines and manipulate auth JSONs.

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -251,6 +251,16 @@ standards for memory for a VM. So it's possible that even though the request say
 Two environment variables called `${MEM_UNIT}` and `${MEM_SIZE}` are also available inside the command block of a task,
 making it easy to retrieve the new value of memory on the machine.
 
+**Pipeline timeout**
+
+Google sets a default pipeline timeout of 7 days, after which the pipeline will abort. Setting `pipeline-timeout` overrides this limit to a maximum of 30 days.
+
+```hocon
+backend.providers.PAPIv2.config {
+    pipeline-timeout: 14 days
+}
+```
+
 
 #### Google Labels
 

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -442,6 +442,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           computeServiceAccount = computeServiceAccount(jobDescriptor.workflowDescriptor),
           googleLabels = backendLabels ++ customLabels,
           preemptible = preemptible,
+          pipelineTimeout = pipelinesConfiguration.pipelineTimeout,
           jobShell = pipelinesConfiguration.jobShell,
           privateDockerKeyAndEncryptedToken = dockerKeyAndToken,
           womOutputRuntimeExtractor = jobDescriptor.workflowDescriptor.outputRuntimeExtractor,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfiguration.scala
@@ -15,6 +15,7 @@ class PipelinesApiConfiguration(val configurationDescriptor: BackendConfiguratio
 
   val jesAuths = papiAttributes.auths
   val root = configurationDescriptor.backendConfig.getString("root")
+  val pipelineTimeout = papiAttributes.pipelineTimeout
   val runtimeConfig = configurationDescriptor.backendRuntimeAttributesConfig
   val jesComputeServiceAccount = papiAttributes.computeServiceAccount
 

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -36,7 +36,7 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                qps: Int Refined Positive,
                                                cacheHitDuplicationStrategy: PipelinesCacheHitDuplicationStrategy,
                                                requestWorkers: Int Refined Positive,
-                                               pipelineTimeout: Option[FiniteDuration],
+                                               pipelineTimeout: FiniteDuration,
                                                logFlushPeriod: Option[FiniteDuration],
                                                gcsTransferConfiguration: GcsTransferConfiguration,
                                                virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration],
@@ -152,11 +152,7 @@ object PipelinesApiConfigurationAttributes {
     } }
     val requestWorkers: ErrorOr[Int Refined Positive] = validatePositiveInt(backendConfig.as[Option[Int]]("request-workers").getOrElse(3), "request-workers")
 
-    val pipelineTimeout: Option[FiniteDuration] = backendConfig.as[Option[FiniteDuration]]("pipeline-timeout") match {
-      case Some(duration) if duration.isFinite() => Option(duration)
-      // Defaults to Google's defined default (7d)
-      case None => Option(7.days)
-    }
+    val pipelineTimeout: FiniteDuration = backendConfig.getOrElse("pipeline-timeout", 7.days)
 
     val logFlushPeriod: Option[FiniteDuration] = backendConfig.as[Option[FiniteDuration]]("log-flush-period") match {
       case Some(duration) if duration.isFinite() => Option(duration)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -36,6 +36,7 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                qps: Int Refined Positive,
                                                cacheHitDuplicationStrategy: PipelinesCacheHitDuplicationStrategy,
                                                requestWorkers: Int Refined Positive,
+                                               pipelineTimeout: String,
                                                logFlushPeriod: Option[FiniteDuration],
                                                gcsTransferConfiguration: GcsTransferConfiguration,
                                                virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration],
@@ -80,6 +81,7 @@ object PipelinesApiConfigurationAttributes {
     "filesystems.gcs.caching.duplication-strategy",
     "concurrent-job-limit",
     "request-workers",
+    "pipeline-timeout",
     "batch-requests.timeouts.read",
     "batch-requests.timeouts.connect",
     "default-runtime-attributes.bootDiskSizeGb",
@@ -149,6 +151,13 @@ object PipelinesApiConfigurationAttributes {
       case other => throw new IllegalArgumentException(s"Unrecognized caching duplication strategy: $other. Supported strategies are copy and reference. See reference.conf for more details.")
     } }
     val requestWorkers: ErrorOr[Int Refined Positive] = validatePositiveInt(backendConfig.as[Option[Int]]("request-workers").getOrElse(3), "request-workers")
+
+    val pipelineTimeout: String = backendConfig.as[Option[FiniteDuration]]("pipeline-timeout") match {
+      case Some(duration) if (duration.isFinite() && duration > 0.seconds) => duration.toSeconds.toString() + "s"
+      // defaults to Google's defined default (7d)
+      case None => null
+    }
+
     val logFlushPeriod: Option[FiniteDuration] = backendConfig.as[Option[FiniteDuration]]("log-flush-period") match {
       case Some(duration) if duration.isFinite() => Option(duration)
       // "Inf" disables upload
@@ -218,6 +227,7 @@ object PipelinesApiConfigurationAttributes {
             qps = qps,
             cacheHitDuplicationStrategy = cacheHitDuplicationStrategy,
             requestWorkers = requestWorkers,
+            pipelineTimeout = pipelineTimeout,
             logFlushPeriod = logFlushPeriod,
             gcsTransferConfiguration = gcsTransferConfiguration,
             virtualPrivateCloudConfiguration = virtualPrivateCloudConfiguration,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -36,7 +36,7 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                qps: Int Refined Positive,
                                                cacheHitDuplicationStrategy: PipelinesCacheHitDuplicationStrategy,
                                                requestWorkers: Int Refined Positive,
-                                               pipelineTimeout: String,
+                                               pipelineTimeout: Option[FiniteDuration],
                                                logFlushPeriod: Option[FiniteDuration],
                                                gcsTransferConfiguration: GcsTransferConfiguration,
                                                virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration],
@@ -152,10 +152,10 @@ object PipelinesApiConfigurationAttributes {
     } }
     val requestWorkers: ErrorOr[Int Refined Positive] = validatePositiveInt(backendConfig.as[Option[Int]]("request-workers").getOrElse(3), "request-workers")
 
-    val pipelineTimeout: String = backendConfig.as[Option[FiniteDuration]]("pipeline-timeout") match {
-      case Some(duration) if (duration.isFinite() && duration > 0.seconds) => duration.toSeconds.toString() + "s"
-      // defaults to Google's defined default (7d)
-      case None => null
+    val pipelineTimeout: Option[FiniteDuration] = backendConfig.as[Option[FiniteDuration]]("pipeline-timeout") match {
+      case Some(duration) if duration.isFinite() => Option(duration)
+      // Defaults to Google's defined default (7d)
+      case None => Option(7.days)
     }
 
     val logFlushPeriod: Option[FiniteDuration] = backendConfig.as[Option[FiniteDuration]]("log-flush-period") match {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -11,6 +11,8 @@ import cromwell.core.logging.JobLogger
 import cromwell.core.path.Path
 import wom.runtime.WomOutputRuntimeExtractor
 
+import scala.concurrent.duration._
+
 /**
   * The PipelinesApiRequestFactory defines the HttpRequests needed to run jobs
   */
@@ -73,7 +75,7 @@ object PipelinesApiRequestFactory {
                                       computeServiceAccount: String,
                                       googleLabels: Seq[GoogleLabel],
                                       preemptible: Boolean,
-                                      pipelineTimeout: String,
+                                      pipelineTimeout: Option[FiniteDuration],
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -75,7 +75,7 @@ object PipelinesApiRequestFactory {
                                       computeServiceAccount: String,
                                       googleLabels: Seq[GoogleLabel],
                                       preemptible: Boolean,
-                                      pipelineTimeout: Option[FiniteDuration],
+                                      pipelineTimeout: FiniteDuration,
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -73,6 +73,7 @@ object PipelinesApiRequestFactory {
                                       computeServiceAccount: String,
                                       googleLabels: Seq[GoogleLabel],
                                       preemptible: Boolean,
+                                      pipelineTimeout: String,
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
@@ -77,6 +77,20 @@ class PipelinesApiConfigurationAttributesSpec extends FlatSpec with Matchers {
     pipelinesApiAttributes.batchRequestTimeoutConfiguration should be(BatchRequestTimeoutConfiguration(None, None))
   }
 
+  it should "parse pipeline-timeout" in {
+    val backendConfig = ConfigFactory.parseString(configString(customContent = "pipeline-timeout = 3 days")))
+    val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
+
+    pipelinesApiAttributes.pipelineTimeout should be("259200s")
+  }
+
+  it should "parse an undefined pipeline-timeout" in {
+    val backendConfig = ConfigFactory.parseString(configString())
+    val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
+
+    pipelinesApiAttributes.pipelineTimeout should be(null)
+  }
+
   it should "parse compute service account" in {
     val backendConfig = ConfigFactory.parseString(configString(genomics = """compute-service-account = "testing" """))
 

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
@@ -78,7 +78,7 @@ class PipelinesApiConfigurationAttributesSpec extends FlatSpec with Matchers {
   }
 
   it should "parse pipeline-timeout" in {
-    val backendConfig = ConfigFactory.parseString(configString(customContent = "pipeline-timeout = 3 days")))
+    val backendConfig = ConfigFactory.parseString(configString(customContent = "pipeline-timeout = 3 days"))
     val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
 
     pipelinesApiAttributes.pipelineTimeout should be("259200s")

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
@@ -81,14 +81,14 @@ class PipelinesApiConfigurationAttributesSpec extends FlatSpec with Matchers {
     val backendConfig = ConfigFactory.parseString(configString(customContent = "pipeline-timeout = 3 days"))
     val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
 
-    pipelinesApiAttributes.pipelineTimeout should be(Option(3.days))
+    pipelinesApiAttributes.pipelineTimeout should be(3.days)
   }
 
   it should "parse an undefined pipeline-timeout" in {
     val backendConfig = ConfigFactory.parseString(configString())
     val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
 
-    pipelinesApiAttributes.pipelineTimeout should be(Option(7.days))
+    pipelinesApiAttributes.pipelineTimeout should be(7.days)
   }
 
   it should "parse compute service account" in {

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributesSpec.scala
@@ -81,14 +81,14 @@ class PipelinesApiConfigurationAttributesSpec extends FlatSpec with Matchers {
     val backendConfig = ConfigFactory.parseString(configString(customContent = "pipeline-timeout = 3 days"))
     val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
 
-    pipelinesApiAttributes.pipelineTimeout should be("259200s")
+    pipelinesApiAttributes.pipelineTimeout should be(Option(3.days))
   }
 
   it should "parse an undefined pipeline-timeout" in {
     val backendConfig = ConfigFactory.parseString(configString())
     val pipelinesApiAttributes = PipelinesApiConfigurationAttributes(googleConfig, backendConfig, "papi")
 
-    pipelinesApiAttributes.pipelineTimeout should be(null)
+    pipelinesApiAttributes.pipelineTimeout should be(Option(7.days))
   }
 
   it should "parse compute service account" in {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -217,6 +217,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         .setResources(resources)
         .setActions(sortedActions.asJava)
         .setEnvironment(environment)
+        .setTimeout(createPipelineParameters.pipelineTimeout)
 
       val pipelineRequest = new RunPipelineRequest()
         .setPipeline(pipeline)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -217,7 +217,10 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         .setResources(resources)
         .setActions(sortedActions.asJava)
         .setEnvironment(environment)
-        .setTimeout(createPipelineParameters.pipelineTimeout)
+
+      createPipelineParameters.pipelineTimeout foreach {
+        timeout => pipeline.setTimeout(timeout.toSeconds.toString() + "s")
+      }
 
       val pipelineRequest = new RunPipelineRequest()
         .setPipeline(pipeline)

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -217,10 +217,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
         .setResources(resources)
         .setActions(sortedActions.asJava)
         .setEnvironment(environment)
-
-      createPipelineParameters.pipelineTimeout foreach {
-        timeout => pipeline.setTimeout(timeout.toSeconds.toString() + "s")
-      }
+        .setTimeout(createPipelineParameters.pipelineTimeout.toSeconds.toString() + "s")
 
       val pipelineRequest = new RunPipelineRequest()
         .setPipeline(pipeline)


### PR DESCRIPTION
If a timeout is not provided, GCP defaults to [setting a timeout of 7 days](https://developers.google.com/resources/api-libraries/documentation/genomics/v2alpha1/java/latest/com/google/api/services/genomics/v2alpha1/model/Pipeline.html), after which the pipeline will abort.

Occasionally pipelines genuinely need to run >7 days. These changes allow this value to be user-configured.