### PR TITLE
[PAPIv2] Delocalize detritusOutputParameters before jobOutputParameters [BA-6112]

### DIFF
--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -56,7 +56,7 @@ object PipelinesApiRequestFactory {
                                     literalInputParameters: List[PipelinesApiLiteralInput]
                                   ) {
     lazy val fileInputParameters: List[PipelinesApiInput] = jobInputParameters ++ detritusInputParameters.all
-    lazy val fileOutputParameters: List[PipelinesApiOutput] = jobOutputParameters ++ detritusOutputParameters.all
+    lazy val fileOutputParameters: List[PipelinesApiOutput] = detritusOutputParameters.all ++ jobOutputParameters
   }
 
   case class CreatePipelineDockerKeyAndToken(key: String, encryptedToken: String)


### PR DESCRIPTION
The current de-localization logic for PAPIv2 (which goes into `gcp_transfer.sh`) de-localizes "job" outputs (the ones declared in the `output {}` section of a task) _first_.

The problem with that is if the task command fails, then at least one of the "job" outputs never gets created, and so `gcp_transfer.sh` fails permanently (after a few unsuccessful retries to delocalize a "job" output), and never gets to de-localize "helper" files like `memory_retry_rc` (and `rc`) or `monitoring.log`. As a result, features like `memory-retry` or `monotiring_script` don't work when the task fails (for example, when it runs out of memory!), because they rely on the presence of those files in the GCS execution folder.

I propose moving de-localization of "helper" files in front of the "job" outputs. This way, the "helper" files will always be de-localized first, because they're supposed to be always present, unlike declared "outputs" of the task, which depend on the success of the task command.

JIRA reference: https://broadworkbench.atlassian.net/browse/BA-6112

Thanks!