### PR TITLE
Use Cloud SDK image for monitoringTerminationAction in PAPIv2 backend [BA-6117]

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -85,12 +85,10 @@ object ActionBuilder {
     * A fixed timeout is used to avoid hunting for monitoring PID.
     */
 
-  private val monitoringTerminationImage = "alpine"
   private val monitoringTerminationGraceTime = 10
 
   def monitoringTerminationAction(): Action =
-    new Action()
-      .setImageUri(monitoringTerminationImage)
+    cloudSdkAction
       .withCommand(s"/bin/sh", "-c", s"kill -TERM -1 && sleep $monitoringTerminationGraceTime")
       .withFlags(List(ActionFlag.AlwaysRun))
       .setPidNamespace(monitoringPidNamespace)


### PR DESCRIPTION
This PR changes Docker image for `monitoringTerminationAction()` in PAPIv2 backend, from `alpine` to `CloudSdkImage`. This is done to remove dependency on Docker Hub, and to re-use a Cloud SDK GCR image that's already present on the system, instead of fetching a fresh one.

JIRA: https://broadworkbench.atlassian.net/browse/BA-6117

Thanks!

Note: re-submitted this PR in place of #5276 