### PR TITLE
Carbonite queries with includeKey/excludeKey parameters

### DIFF
--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -19,6 +19,7 @@ object JsonEditor {
 
   private val subWorkflowMetadataKey = "subWorkflowMetadata"
   private val subWorkflowIdKey = "subWorkflowId"
+  private val keysToIncludeInCallsOrWorkflows = NonEmptyList.of("id", "shardIndex", "attempt")
 
   def includeExcludeJson(json: Json, includeKeys: Option[NonEmptyList[String]], excludeKeys: Option[NonEmptyList[String]]): Json =
     (includeKeys, excludeKeys) match {
@@ -30,7 +31,7 @@ object JsonEditor {
     }
 
   def includeJson(json: Json, keys: NonEmptyList[String]): Json = {
-    val keysWithId = "id" :: "shardIndex" :: "attempt" :: keys
+    val keysWithId = keysToIncludeInCallsOrWorkflows ::: keys
     def folder: Folder[(Json, Boolean)] = new Folder[(Json, Boolean)] {
       override def onNull: (Json, Boolean) = (Json.Null, false)
       override def onBoolean(value: Boolean): (Json, Boolean) = (Json.fromBoolean(value), false)

--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -30,7 +30,7 @@ object JsonEditor {
     }
 
   def includeJson(json: Json, keys: NonEmptyList[String]): Json = {
-    val keysWithId = "id" :: keys
+    val keysWithId = "id" :: "shardIndex" :: "attempt" :: keys
     def folder: Folder[(Json, Boolean)] = new Folder[(Json, Boolean)] {
       override def onNull: (Json, Boolean) = (Json.Null, false)
       override def onBoolean(value: Boolean): (Json, Boolean) = (Json.fromBoolean(value), false)
@@ -45,7 +45,7 @@ object JsonEditor {
       override def onObject(value: JsonObject): (Json, Boolean) = {
         val modified: immutable.List[(String, Json)] = value.toList.flatMap{
           case (key, value) =>
-            val keep = keysWithId.foldLeft(false)(_ || key.startsWith(_))
+            val keep = keysWithId.foldLeft(false)(_ || key.equals(_))
             if (keep)
               List[(String,Json)]((key,value))
             else {

--- a/core/src/test/scala/cromwell/util/JsonEditorSpec.scala
+++ b/core/src/test/scala/cromwell/util/JsonEditorSpec.scala
@@ -136,6 +136,29 @@ class JsonEditorSpec extends FlatSpec with Matchers{
     assert(keys_nested2.get.toSet.contains("keepme") === true) // simple nested key "deep" removed
     assert(keys_nested2.get.size === 1) // simple nested key "deep" removed
   }
+
+  it should "start including and excluding keys from both (but only!) workflow- and call-roots" in {
+    val newJson = realJson.map(includeJson(_, NonEmptyList.of("start"))).right.get
+    val expectedJsonRaw =
+      """
+        |{
+        |  "calls": {
+        |    "main_workflow.wf_hello": [
+        |      {
+        |        "shardIndex": -1,
+        |        "attempt": 1,
+        |        "start": "2019-07-22T13:32:24.133-04:00"
+        |      }
+        |    ]
+        |  },
+        |  "id": "757d0bcc-b636-4658-99d4-9b4b3767f1d1",
+        |  "start": "2019-07-22T13:32:20.434-04:00"
+        |}
+      """.stripMargin
+    val expectedJson = parse(expectedJsonRaw)
+
+    newJson should be(expectedJson.right.get)
+  }
 }
 
 object JsonEditorSpec {


### PR DESCRIPTION
This passes the test from Chris' branch with some limited (though perhaps alarming) changes. However this PR and #5292 have shed light on nearly complete lack of semantic understanding of Cromwell metadata in the Carbonite JSON editing code. i.e. I can imagine valid workflows that would completely break the Carbonited metadata endpoints and will likely require a significant rethink of how the JSON editor works with metadata.