### PR TITLE
Retrieve list of intermediate output files (approach 2) [WA-39]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
@@ -77,7 +77,6 @@ class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
       }
     }
 
-
     allOutputs.collect {
       case o if checkOutputIsFile(o._1, o._2) => getFilePath(o._2.valueString)
     }.flatten.toSet

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
@@ -1,0 +1,111 @@
+package cromwell.engine.workflow.lifecycle.deletion
+
+import akka.actor.{LoggingFSM, Props}
+import cromwell.core.path.{DefaultPathBuilder, Path, PathBuilder, PathFactory}
+import cromwell.core.{CallOutputs, RootWorkflowId}
+import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor._
+import cromwell.util.GracefulShutdownHelper.ShutdownCommand
+import wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
+import wom.values.{WomSingleFile, WomValue}
+
+import scala.util.Try
+
+class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
+                               workflowFinalOutputs: CallOutputs,
+                               workflowAllOutputs: CallOutputs,
+                               pathBuilders: List[PathBuilder]) extends LoggingFSM[DeleteWorkflowFilesActorState, DeleteWorkflowFilesActorStateData] {
+
+  /*
+  building a path for a string output such as 'Hello World' satisfies the conditions of a
+  being a relative file path for a DefaultPath which we don't want, so remove DefaultPathBuilder
+  (this is because we only want cloud backend paths like gs://, s3://, etc.)
+   */
+  val pathBuildersWithoutDefault = pathBuilders.filterNot(_ == DefaultPathBuilder)
+
+  startWith(Pending, NoData)
+
+  when(Pending) {
+    case Event(StartWorkflowFilesDeletion, NoData) =>
+      val intermediateOutputs = gatherIntermediateOutputFiles(workflowAllOutputs.outputs, workflowFinalOutputs.outputs)
+      if (intermediateOutputs.nonEmpty) goto(DeletingIntermediateFiles) using DeletingIntermediateFilesData(intermediateOutputs)
+      else {
+        log.info(s"Root workflow ${rootWorkflowId.id} does not have any intermediate output files to delete.")
+        stopSelf()
+      }
+  }
+
+
+  //TODO: To be done as part of WA-41 (https://broadworkbench.atlassian.net/browse/WA-41)
+  when(DeletingIntermediateFiles) {
+    case Event(_, _) => stopSelf()
+  }
+
+  whenUnhandled {
+    case Event(ShutdownCommand, _) => stopSelf()
+    case other =>
+      log.error(s"Programmer Error: Unexpected message to ${getClass.getSimpleName} ${self.path.name} in state $stateName with $stateData: $other")
+      stay()
+  }
+
+
+  private def stopSelf() = {
+    context stop self
+    stay()
+  }
+
+  def gatherIntermediateOutputFiles(allOutputs: Map[OutputPort, WomValue], finalOutputs: Map[OutputPort, WomValue]): Set[Path] = {
+    val isFinalOutputsNonEmpty = finalOutputs.nonEmpty
+
+    def existsInFinalOutputs(value: String): Option[Boolean] = {
+      finalOutputs.map(p => value.equals(p._2.valueString)).reduceOption(_ || _)
+    }
+
+    def getFilePath(value: String): Option[Path] = {
+      //if workflow has final outputs check if this output value does not exist in final outputs
+      (isFinalOutputsNonEmpty, existsInFinalOutputs(value)) match {
+        case (true, Some(true)) => None
+        case (true, Some(false)) | (true, None) | (false, _) =>
+          // eliminate outputs which are not files
+          Try(PathFactory.buildPath(value, pathBuildersWithoutDefault)).toOption
+      }
+    }
+
+    def checkOutputIsFile(port: OutputPort, value: WomValue): Boolean = {
+      (port, value) match {
+        case (_: GraphNodeOutputPort, _: WomSingleFile) => true
+        case _ => false
+      }
+    }
+
+
+    allOutputs.collect {
+      case o if checkOutputIsFile(o._1, o._2) => getFilePath(o._2.valueString)
+    }.flatten.toSet
+  }
+}
+
+
+object DeleteWorkflowFilesActor {
+
+  // Commands
+  sealed trait DeleteWorkflowFilesActorMessage
+  object StartWorkflowFilesDeletion extends DeleteWorkflowFilesActorMessage
+
+  // Actor states
+  sealed trait DeleteWorkflowFilesActorState
+  object Pending extends DeleteWorkflowFilesActorState
+  object DeletingIntermediateFiles extends DeleteWorkflowFilesActorState
+
+  // State data
+  sealed trait DeleteWorkflowFilesActorStateData
+  object NoData extends DeleteWorkflowFilesActorStateData
+  case class DeletingIntermediateFilesData(intermediateFiles: Set[Path]) extends DeleteWorkflowFilesActorStateData
+
+
+  def props(rootWorkflowId: RootWorkflowId,
+            workflowFinalOutputs: CallOutputs,
+            workflowAllOutputs: CallOutputs,
+            pathBuilders: List[PathBuilder]): Props = {
+    Props(new DeleteWorkflowFilesActor(rootWorkflowId, workflowFinalOutputs, workflowAllOutputs, pathBuilders))
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
@@ -58,7 +58,7 @@ class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
     val isFinalOutputsNonEmpty = finalOutputs.nonEmpty
 
     def existsInFinalOutputs(value: String): Option[Boolean] = {
-      finalOutputs.map(p => value.equals(p._2.valueString)).reduceOption(_ || _)
+      finalOutputs.map{ case (_, output) => value.equals(output.valueString)}.reduceOption(_ || _)
     }
 
     def getFilePathForSingleFile(value: String): Option[Path] = {
@@ -74,7 +74,7 @@ class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
     def getFilePath(value: WomValue): Seq[Path] = {
       val seqOfPaths = value match {
         case v: WomArray => v.value.map(a => getFilePathForSingleFile(a.valueString))
-        case a => Seq(getFilePathForSingleFile(a.valueString))
+        case s => Seq(getFilePathForSingleFile(s.valueString))
       }
       seqOfPaths.flatten
     }
@@ -89,7 +89,7 @@ class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
     }
 
     allOutputs.collect {
-      case o if checkOutputIsFile(o._1, o._2) => getFilePath(o._2)
+      case (port, output) if checkOutputIsFile(port, output) => getFilePath(output)
     }.flatten.toSet
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -110,8 +110,8 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   }
 
   when(SubWorkflowRunningState) {
-    case Event(WorkflowExecutionSucceededResponse(executedJobKeys, outputs), _) =>
-      context.parent ! SubWorkflowSucceededResponse(key, executedJobKeys, outputs)
+    case Event(WorkflowExecutionSucceededResponse(executedJobKeys, outputs, cumulativeOutputs), _) =>
+      context.parent ! SubWorkflowSucceededResponse(key, executedJobKeys, outputs, cumulativeOutputs)
       goto(SubWorkflowSucceededState)
     case Event(WorkflowExecutionFailedResponse(executedJobKeys, reason), _) =>
       context.parent ! SubWorkflowFailedResponse(key, executedJobKeys, reason)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -210,7 +210,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       }
       handleCallSuccessful(r.jobKey, r.jobOutputs, r.returnCode, stateData, Map.empty)
     // Sub Workflow
-    case Event(SubWorkflowSucceededResponse(jobKey, descendantJobKeys, callOutputs), currentStateData) =>
+    case Event(SubWorkflowSucceededResponse(jobKey, descendantJobKeys, callOutputs, cumulativeOutputs), currentStateData) =>
       // Update call outputs to come from sub-workflow output ports:
       val subworkflowOutputs: Map[OutputPort, WomValue] = callOutputs.outputs flatMap { case (port, value) =>
         jobKey.node.subworkflowCallOutputPorts collectFirst {
@@ -219,7 +219,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       }
 
       if(subworkflowOutputs.size == callOutputs.outputs.size) {
-        handleCallSuccessful(jobKey, CallOutputs(subworkflowOutputs), None, currentStateData, descendantJobKeys)
+        handleCallSuccessful(jobKey, CallOutputs(subworkflowOutputs), None, currentStateData, descendantJobKeys, cumulativeOutputs)
       } else {
         handleNonRetryableFailure(currentStateData, jobKey, new Exception(s"Subworkflow produced outputs: [${callOutputs.outputs.keys.mkString(", ")}], but we expected all of [${jobKey.node.subworkflowCallOutputPorts.map(_.internalName)}]"))
       }
@@ -334,7 +334,11 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
         case (outputNode, value) => outputNode.graphOutputPort -> value
       })
 
-      context.parent ! WorkflowExecutionSucceededResponse(data.jobExecutionMap, localOutputs)
+      val currentCumulativeOutputs = data.cumulativeOutputs.copy(
+        outputs = data.cumulativeOutputs.outputs ++ localOutputs.outputs
+      )
+
+      context.parent ! WorkflowExecutionSucceededResponse(data.jobExecutionMap, localOutputs, currentCumulativeOutputs)
       goto(WorkflowExecutionSuccessfulState) using data
     }
 
@@ -457,9 +461,14 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
     stay() using stateData.mergeExecutionDiff(executionDiff)
   }
 
-  private def handleCallSuccessful(jobKey: JobKey, outputs: CallOutputs, returnCode: Option[Int], data: WorkflowExecutionActorData, jobExecutionMap: JobExecutionMap) = {
+  private def handleCallSuccessful(jobKey: JobKey,
+                                   outputs: CallOutputs,
+                                   returnCode: Option[Int],
+                                   data: WorkflowExecutionActorData,
+                                   jobExecutionMap: JobExecutionMap,
+                                   cumulativeOutputs: CallOutputs = CallOutputs.empty) = {
     pushSuccessfulCallMetadata(jobKey, returnCode, outputs)
-    stay() using data.callExecutionSuccess(jobKey, outputs).addExecutions(jobExecutionMap)
+    stay() using data.callExecutionSuccess(jobKey, outputs, cumulativeOutputs).addExecutions(jobExecutionMap)
   }
 
   private def handleDeclarationEvaluationSuccessful(key: ExpressionKey, values: Map[OutputPort, WomValue], data: WorkflowExecutionActorData) = {
@@ -726,7 +735,7 @@ object WorkflowExecutionActor {
     def jobExecutionMap: JobExecutionMap
   }
 
-  case class WorkflowExecutionSucceededResponse(jobExecutionMap: JobExecutionMap, outputs: CallOutputs)
+  case class WorkflowExecutionSucceededResponse(jobExecutionMap: JobExecutionMap, outputs: CallOutputs, cumulativeOutputs: CallOutputs = CallOutputs.empty)
     extends WorkflowExecutionActorResponse {
     override def toString = "WorkflowExecutionSucceededResponse"
   }
@@ -758,7 +767,7 @@ object WorkflowExecutionActor {
     */
   private case object ExecutionHeartBeatKey
 
-  case class SubWorkflowSucceededResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap, outputs: CallOutputs)
+  case class SubWorkflowSucceededResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap, outputs: CallOutputs, cumulativeOutputs: CallOutputs = CallOutputs.empty)
 
   case class SubWorkflowFailedResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap, reason: Throwable)
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActorSpec.scala
@@ -1,0 +1,215 @@
+package cromwell.engine.workflow.lifecycle.deletion
+
+import akka.testkit.{TestFSMRef, TestProbe}
+import cromwell.core.path.Path
+import cromwell.core.path.PathFactory.PathBuilders
+import cromwell.core.{CallOutputs, RootWorkflowId, TestKitSuite, WorkflowId}
+import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor.{DeletingIntermediateFiles, DeletingIntermediateFilesData, StartWorkflowFilesDeletion}
+import cromwell.filesystems.gcs.{GcsPathBuilder, MockGcsPathBuilder}
+import org.scalatest.concurrent.Eventually.eventually
+import org.scalatest.{FlatSpecLike, Matchers}
+import wom.graph.GraphNodePort.{ExpressionBasedOutputPort, GraphNodeOutputPort}
+import wom.graph.{FullyQualifiedName, LocalName, WomIdentifier}
+import wom.types.{WomSingleFileType, WomStringType}
+import wom.values.{WomSingleFile, WomString}
+
+import scala.concurrent.duration._
+
+class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActorSpec") with FlatSpecLike with Matchers {
+
+  val mockPathBuilder: GcsPathBuilder = MockGcsPathBuilder.instance
+  val mockPathBuilders = List(mockPathBuilder)
+
+  it should "follow the expected golden-path lifecycle" in {
+    val rootWorkflowId = RootWorkflowId(WorkflowId.randomId().id)
+    val subworkflowId = WorkflowId.randomId()
+
+    val allOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_2"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_2")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("first_output_file"),FullyQualifiedName("first_sub_workflow.first_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_1"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_1")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("second_output_file"),FullyQualifiedName("first_sub_workflow.second_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val finalOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val testDeleteWorkflowFilesActor = TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId, finalOutputs, allOutputs, mockPathBuilders))
+
+    val gcsFilePath: Path = mockPathBuilder.build(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt").get
+    val intermediateFileList = Set(gcsFilePath)
+
+    testDeleteWorkflowFilesActor ! StartWorkflowFilesDeletion
+
+    eventually {
+      testDeleteWorkflowFilesActor.stateName shouldBe DeletingIntermediateFiles
+      testDeleteWorkflowFilesActor.stateData shouldBe DeletingIntermediateFilesData(intermediateFileList)
+    }
+
+    //TODO: add tests as needed for deleting files step as part of WA-41 (https://broadworkbench.atlassian.net/browse/WA-41)
+  }
+
+
+  it should "remove any non-file intermediate outputs" in {
+    val rootWorkflowId = RootWorkflowId(WorkflowId.randomId().id)
+    val subworkflowId = WorkflowId.randomId()
+
+    val allOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_2"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_2")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("first_output_file"),FullyQualifiedName("first_sub_workflow.first_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_1"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_1")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("second_output_file"),FullyQualifiedName("first_sub_workflow.second_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt") ,
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_string_output"),FullyQualifiedName("main_workflow.main_string_output")), WomStringType, null)
+        -> WomString("Hello World!"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("string_output"),FullyQualifiedName("first_sub_workflow.string_output")), WomStringType, null)
+        -> WomString("Hello World!")
+    ))
+
+    val finalOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_string_output"),FullyQualifiedName("main_workflow.main_string_output")), WomStringType, null)
+        -> WomString("Hello World!")
+    ))
+
+    val gcsFilePath: Path = mockPathBuilder.build(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt").get
+    val expectedIntermediateFileList = Set(gcsFilePath)
+
+    val testDeleteWorkflowFilesActor = TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId, finalOutputs, allOutputs, mockPathBuilders))
+
+    val actualIntermediateFileList = testDeleteWorkflowFilesActor.underlyingActor.gatherIntermediateOutputFiles(allOutputs.outputs, finalOutputs.outputs)
+
+    actualIntermediateFileList shouldBe expectedIntermediateFileList
+  }
+
+
+  it should "delete all file outputs if there are no final outputs" in {
+    val rootWorkflowId = RootWorkflowId(WorkflowId.randomId().id)
+    val subworkflowId = WorkflowId.randomId()
+
+    val allOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_2"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_2")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("first_output_file"),FullyQualifiedName("first_sub_workflow.first_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_1"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_1")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("second_output_file"),FullyQualifiedName("first_sub_workflow.second_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val finalOutputs = CallOutputs.empty
+
+    val testDeleteWorkflowFilesActor = TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId, finalOutputs, allOutputs, mockPathBuilders))
+
+    val gcsFilePath1: Path = mockPathBuilder.build(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt").get
+    val gcsFilePath2: Path = mockPathBuilder.build(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt").get
+    val intermediateFileList = Set(gcsFilePath1, gcsFilePath2)
+
+    testDeleteWorkflowFilesActor ! StartWorkflowFilesDeletion
+
+    eventually {
+      testDeleteWorkflowFilesActor.stateName shouldBe DeletingIntermediateFiles
+      testDeleteWorkflowFilesActor.stateData shouldBe DeletingIntermediateFilesData(intermediateFileList)
+    }
+  }
+
+
+  it should "terminate if root workflow has no intermediate outputs to delete" in {
+    val testProbe = TestProbe()
+    val rootWorkflowId = RootWorkflowId(WorkflowId.randomId().id)
+    val subworkflowId = WorkflowId.randomId()
+
+    val allOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output_1"),FullyQualifiedName("main_workflow.main_output_1")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_2"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_2")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("first_output_file"),FullyQualifiedName("first_sub_workflow.first_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_1"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_1")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("second_output_file"),FullyQualifiedName("first_sub_workflow.second_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt") ,
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output_2"),FullyQualifiedName("main_workflow.main_output_2")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val finalOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output_1"),FullyQualifiedName("main_workflow.main_output_1")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt") ,
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output_2"),FullyQualifiedName("main_workflow.main_output_2")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val testDeleteWorkflowFilesActor = TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId, finalOutputs, allOutputs, mockPathBuilders))
+
+
+    testProbe watch testDeleteWorkflowFilesActor
+
+    testDeleteWorkflowFilesActor ! StartWorkflowFilesDeletion
+
+    testProbe.expectTerminated(testDeleteWorkflowFilesActor, 10.seconds)
+  }
+
+
+  it should "remove values that are file names in form of string" in {
+    val rootWorkflowId = RootWorkflowId(WorkflowId.randomId().id)
+        val subworkflowId = WorkflowId.randomId()
+
+    val allOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_2"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_2")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("first_output_file"),FullyQualifiedName("first_sub_workflow.first_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_output_1"),FullyQualifiedName("first_sub_workflow.first_task.first_task_output_1")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("second_output_file"),FullyQualifiedName("first_sub_workflow.second_output_file")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt"),
+      GraphNodeOutputPort(WomIdentifier(LocalName("file_with_file_path_string_output"),FullyQualifiedName("first_sub_workflow.file_with_file_path_string_output")), WomStringType, null)
+        -> WomString(s"gs://my_bucket/non_existent_file.txt"),
+      ExpressionBasedOutputPort(WomIdentifier(LocalName("first_task.first_task_file_with_file_path_output"),FullyQualifiedName("first_sub_workflow.first_task.first_task_file_with_file_path_output")), WomSingleFileType, null, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/file_with_file_path.txt")
+    ))
+
+    val finalOutputs = CallOutputs(Map(
+      GraphNodeOutputPort(WomIdentifier(LocalName("main_output"),FullyQualifiedName("main_workflow.main_output")), WomSingleFileType, null)
+        -> WomSingleFile(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file2.txt")
+    ))
+
+    val testDeleteWorkflowFilesActor = TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId, finalOutputs, allOutputs, mockPathBuilders))
+
+    val gcsFilePath: Path = mockPathBuilder.build(s"gs://my_bucket/main_workflow/$rootWorkflowId/call-first_sub_workflow/firstSubWf.first_sub_workflow/$subworkflowId/call-first_task/intermediate_file1.txt").get
+    val intermediateFileList = Set(gcsFilePath)
+
+    testDeleteWorkflowFilesActor ! StartWorkflowFilesDeletion
+
+    eventually {
+      testDeleteWorkflowFilesActor.stateName shouldBe DeletingIntermediateFiles
+      testDeleteWorkflowFilesActor.stateData shouldBe DeletingIntermediateFilesData(intermediateFileList)
+    }
+  }
+}
+
+
+class MockDeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId, workflowFinalOutputs: CallOutputs,
+                                   workflowAllOutputs: CallOutputs, pathBuilders: PathBuilders) extends
+  DeleteWorkflowFilesActor(rootWorkflowId, workflowFinalOutputs, workflowAllOutputs, pathBuilders) { }


### PR DESCRIPTION
The approach here is to accumulate root and subworkflow outputs as they are produced. This approach addresses the below problems from [first approach](https://github.com/broadinstitute/cromwell/pull/5294) which talked to the database:

- possible performance issue arising due to running filter query on `METADATA_KEY` and `METADATA_VALUE` columns to find subworkflow ids
- the scenario where the `DeleteWorkflowFilesActor` is gathering outputs from metadata table but the metadata events containing output details has not been published to the table yet 
- output is a string containing a file path: This gets eliminated during filtering because such a value is stored as `WomString` instead of `WomSingleFile`