### PR TITLE
Flatten subworkflow search for unexpansion [BA-6140]

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -526,7 +526,7 @@ object Operations extends StrictLogging {
           IO.unit
         } else {
           val message = (List("actual logs endpoint output did not equal filtered metadata", "flat logs: ") ++
-            flatLogs.toList :+ "flat filtered metadata: " ++ flatFilteredMetadata.toList).mkString("\n")
+            flatLogs.toList ++ List("flat filtered metadata: ") ++ flatFilteredMetadata.toList).mkString("\n")
           IO.raiseError(CentaurTestException(message, workflow, submittedWorkflow))
         }
 

--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -101,8 +101,7 @@ object JsonEditor {
 
     callsObject.toList.flatTraverse[ErrorOr, (String, Json)] {
       case (key, json) => isCallSubworkflow(json) map { isSubworkflow =>
-        // If the value is true return a single-element List containing the (key, json) pair,
-        // otherwise return an empty List.
+        // If the value is true return an empty List, otherwise return a single-element List containing the (key, json) pair.
         if (isSubworkflow) List.empty else List((key, json))
       }
     } map { Json.fromFields }

--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -90,6 +90,9 @@ object JsonEditor {
     val shardAttemptAndLogsFields = NonEmptyList.of("shardIndex", "attempt", "stdout", "stderr", "backendLogs")
 
     def removeSubworkflowCalls(calls: JsonObject): JsonObject = calls.filter {
+      // All calls within this array are assumed to have the same "shape": either they are subworkflows or regular jobs.
+      // So this only looks at the first element of the call array to determine whether this member of the containing
+      // object should be filtered as a subworkflow.
       case (_, json) => ! json.asArray.get.head.asObject.exists(_.contains(subWorkflowIdKey))
     }
 

--- a/core/src/main/scala/cromwell/util/JsonEditor.scala
+++ b/core/src/main/scala/cromwell/util/JsonEditor.scala
@@ -220,7 +220,10 @@ object JsonEditor {
         }
         updatedCallArray map Json.fromValues
       }
-      updatedCallsObject map Json.fromJsonObject
+
+      for {
+        updatedCallsJson <- updatedCallsObject map Json.fromJsonObject
+      } yield Json.fromJsonObject(workflowObject.add("calls", updatedCallsJson))
     }
 
     for {

--- a/core/src/test/scala/cromwell/util/JsonEditorSpec.scala
+++ b/core/src/test/scala/cromwell/util/JsonEditorSpec.scala
@@ -83,7 +83,7 @@ class JsonEditorSpec extends FlatSpec with Matchers{
           .getContextClassLoader
           .getResourceAsStream("metadata_with_subworkflows.json")
         ).mkString)
-    val newJson = metadataWithSubworkflows.map(replaceSubworkflowMetadataWithId).right.get
+    val newJson = metadataWithSubworkflows.map(unexpandSubworkflows).right.get
     val keys = newJson.get.hcursor.downField("calls").downField("wf.wf").downArray.keys
     assert(keys.exists(_.exists(_ == "subWorkflowMetadata")) === false)
 

--- a/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
+++ b/hybridCarboniteMetadataService/src/main/scala/cromwell/services/metadata/hybridcarbonite/CarbonitedMetadataThawingActor.scala
@@ -150,12 +150,9 @@ object CarbonitedMetadataThawingActor {
           case wrong => throw new RuntimeException(s"Programmer Error: Invalid MetadataQuery: $wrong")
         }
         // For carbonited metadata, "expanded" subworkflows translates to not deleting subworkflows out of the root workflow that already
-        // contains them. So `intermediate.validNel` for expanded subworkflows and `JsonEditor.replaceSubworkflowMetadataWithId` for unexpanded subworkflows.
-        if (get.key.expandSubWorkflows) {
-          intermediate.validNel
-        } else {
-          JsonEditor.replaceSubworkflowMetadataWithId(intermediate)
-        }
+        // contains them. So `intermediate.validNel` for expanded subworkflows and `JsonEditor.replaceSubworkflowMetadataWithId`
+        // for unexpanded subworkflows.
+        if (get.key.expandSubWorkflows) intermediate.validNel else JsonEditor.unexpandSubworkflows(intermediate)
       case other =>
         throw new RuntimeException(s"Programmer Error: Unexpected BuildWorkflowMetadataJsonAction message of type '${other.getClass.getSimpleName}': $other")
     }


### PR DESCRIPTION
Kind of related to BA-6087 (though maybe not as much as I originally thought when I started on this), only unexpand subworkflows in the root workflow. i.e. don't piggyback on the depth-first search logic used for label upserting as that may end up doing a lot of unnecessary unexpansions in lower-level subworkflows whose parents are later unexpanded.