### PR TITLE
Make it easier to create PR branches. Make those branches work in travis [BA-6160]

### DIFF
--- a/processes/external-contributions/README.MD
+++ b/processes/external-contributions/README.MD
@@ -42,12 +42,16 @@ Note: inspired by the community answer [here](https://github.community/t5/How-to
 
 - Problem: our CI will only run against branches of the `broadinstitute/cromwell` repo submitted by team members.
 - To turn a community contribution into a PR that travis will run against:
-  - Identify a reference to use for the remote branch and check it out. 
-    - Example: for pull request 938 there will be a reference `refs/pull/938/head`
-    - We can fetch that reference to a new branch using: `git fetch -f origin refs/pull/938/head:938_pr_clone`
+  - Run the `scripts/make_pr_clone_branch.sh` script, providing the github PR number of the external PR as the command line argument
+    - Eg: `scripts/make_pr_clone_branch.sh 5333` to make a PR clone branch for PR #5333.  
   - Push the branch to github
+    - Note: The final `git push` command may not work as-is, depending on your ~/.gitconfig value of `push.default`. If it doesn't work then one of the following solutions may work:
+      - Setting `git`'s `push.default` config value to be '`current`'.
+      - Using `git push --set-upstream origin 5070_pr_clone` instead
+      - Using `git push origin HEAD` instead
   - Create a new PR for the clone branch. Indicate that it only exists to test a community contribution. 
-    - Example title: `[PR 938 Clone] PR for CI only`
+    - Example title: `[PR 5333 Clone] PR for CI only`
+- If you need to re-sync the clone PR against changes on the remote branch, the same script will *update* your local reference allowing you to force-push changes to the same github branch!  
 
 ### Cycle through Review and CI
 
@@ -62,35 +66,3 @@ Note: inspired by the community answer [here](https://github.community/t5/How-to
 - Once the tests have completed successfully and the PR has two approvals, it can be merged.
 - Remember to delete your branch clone PR (and the cloned branch itself too!)
 
-## Shortcuts
-
-### Git Command Shortcut
-
-Note: also inspired by the community answer [here](https://github.community/t5/How-to-use-Git-and-GitHub/Checkout-a-branch-from-a-fork/td-p/77 and the reference gitconfig file [here](https://github.com/lee-dohm/dotfiles/blob/8d3c59004154571578c2b32df2cdebb013517630/gitconfig#L8)).
-
-It's tedious to have to remember the syntax for `git fetch -f origin refs/pull/938/head:938_pr_clone` isn't it? Well
-luckily you don't have to!
-
-**Step 1:** add this line into your `~/.gitconfig` file under the `[alias]` section:
-```
-clone-pr = !sh -c 'git fetch -f origin pull/$1/head:$1_pr_clone && git checkout $1_pr_clone' -
-```
-
-**Step 2:** Your regular `git` command line now has new superpowers:
-```
-[develop] $ git clone-pr 938
-From https://github.com/broadinstitute/cromwell
- * [new ref]             refs/pull/938/head -> 938_pr_clone
-Switched to branch '938_pr_clone'
-
-[938_pr_clone] $ git push
-```
-
-Note: The final `git push` command may not work as-is, depending on your ~/.gitconfig value of `push.default`. 
-If it doesn't work then one of the following solutions may work:
-  * Setting `git`'s `push.default` config value to be '`current`'.
-  * Using `git push --set-upstream origin 5070_pr_clone` instead
-  * Using `git push origin HEAD` instead
-
-**Step 3:** If you need to re-sync your cloned PR against changes on their remote branch - no problem! The
-exact same `git clone-pr 938` will *update* your local reference allowing you to push changes up to github easily!  

--- a/scripts/make_pr_clone_branch.sh
+++ b/scripts/make_pr_clone_branch.sh
@@ -7,7 +7,7 @@ export PR_TO_CLONE="$1"
 git fetch -f origin "pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone"
 git checkout "${PR_TO_CLONE}_pr_clone"
 
-cat "PR for hash $(rev-parse --verify HEAD)" > pr_salt
+echo "PR for hash $(rev-parse --verify HEAD)" > pr_salt
 git add pr_salt
 git commit -m "Salting PR branch"
 

--- a/scripts/make_pr_clone_branch.sh
+++ b/scripts/make_pr_clone_branch.sh
@@ -13,5 +13,6 @@ git commit -m "Salting PR branch"
 
 echo "Created (or updated) pr-able branch for PR ${PR_TO_CLONE}."
 echo "You can now force push this branch to run the CI suite for the changes in that PR."
-
+echo "NOTE: Do NOT merge this branch into develop, merge the original"
+echo
 

--- a/scripts/make_pr_clone_branch.sh
+++ b/scripts/make_pr_clone_branch.sh
@@ -2,16 +2,16 @@
 
 set -euo pipefail
 
-export PR_TO_CLONE=$1
+export PR_TO_CLONE="$1"
 
-git fetch -f origin pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone 
-git checkout ${PR_TO_CLONE}_pr_clone
+git fetch -f "origin pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone"
+git checkout "${PR_TO_CLONE}_pr_clone"
 
 cat "PR for hash $(rev-parse --verify HEAD)" > pr_salt
 git add pr_salt
 git commit -m "Salting PR branch"
 
-echo "Created (or updated) pr-able branch for PR $1."
-echo "You can now force push this branch to run the CI suite for the changes in that PR.
+echo "Created (or updated) pr-able branch for PR ${PR_TO_CLONE}."
+echo "You can now force push this branch to run the CI suite for the changes in that PR."
 
 

--- a/scripts/make_pr_clone_branch.sh
+++ b/scripts/make_pr_clone_branch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export PR_TO_CLONE=$1
+
+git fetch -f origin pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone 
+git checkout ${PR_TO_CLONE}_pr_clone
+
+cat "PR for hash $(rev-parse --verify HEAD)" > pr_salt
+git add pr_salt
+git commit -m "Salting PR branch"
+
+echo "Created (or updated) pr-able branch for PR $1."
+echo "You can now force push this branch to run the CI suite for the changes in that PR.
+
+

--- a/scripts/make_pr_clone_branch.sh
+++ b/scripts/make_pr_clone_branch.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 export PR_TO_CLONE="$1"
 
-git fetch -f "origin pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone"
+git fetch -f origin "pull/${PR_TO_CLONE}/head:${PR_TO_CLONE}_pr_clone"
 git checkout "${PR_TO_CLONE}_pr_clone"
 
 cat "PR for hash $(rev-parse --verify HEAD)" > pr_salt


### PR DESCRIPTION
Travis doesn't seem to work quite right with PRs with identical hashes matching the external contributors.

Scriptify the experience of creating or updating a PR branch, and salting it so that the hash is different (and so that Travis will pick it up correctly).