### PR TITLE
Add init script for papi backend

### DIFF
--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -215,6 +215,18 @@ In order to monitor metrics (CPU, Memory, Disk usage...) about the VM during Cal
 
 The output of this script will be written to a `monitoring.log` file that will be available in the call gcs bucket when the call completes.  This feature is meant to run a script in the background during long-running processes.  It's possible that if the task is very short that the log file does not flush before de-localization happens and you will end up with a zero byte file.
 
+**Common initialization**
+
+In order to add common initialization script for all submitted calls the corresponding workflow option can be used. If specified then the initialization script will be executed exactly after the monitoring script was invoked and before the task commands. It is guaranteed that a task command execution won't start until the init script has not finished or failed.
+
+```
+{
+  "init_script": "gs://cromwell/initialization/script.sh"
+}
+```
+
+The output of the initialization script will be written to an `init.log` file which will be delocalized just like the monitoring script log file. 
+
 **Google Cloud Storage Filesystem**
 
 On the Google Pipelines backend the GCS (Google Cloud Storage) filesystem is used for the root of the workflow execution.

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -9,7 +9,8 @@ Keys | Possible Values | Description
 `google_project` | `string` |  Google project used to execute this workflow.
 `refresh_token` |`string` |   Only used if `localizeWithRefreshToken` is specified in the [Configuration](../Configuring).
 `auth_bucket` |`string` |     A GCS URL that only Cromwell can write to.  The Cromwell account is determined by the `google.authScheme` (and the corresponding `google.userAuth` and `google.serviceAuth`). Defaults to the the value in [jes_gcs_root](#jes_gcs_root).
-`monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/script.sh"`, it will be invoked as `./script.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
+`monitoring_script` |`string` |   Specifies a GCS URL to a script that will be invoked prior to the user command being run.  For example, if the value for monitoring_script is `"gs://bucket/monitor.sh"`, it will be invoked as `./monitor.sh > monitoring.log &`.  The value `monitoring.log` file will be automatically de-localized.
+`init_script` |`string` |   Specifies a GCS URL to a script that will be executed prior to the user command. The difference between monitoring_script and init_script lies in the fact that user command won't start until init_script is finished. Corresponding log file `init.log` will be automatically de-localized.
 `monitoring_image` |`string` |   Specifies a Docker image to monitor the task. This image will run concurrently with the task container, and provides an alternative mechanism to `monitoring_script` (the latter runs *inside* the task container). For example, one can use `quay.io/broadinstitute/cromwell-monitor`, which reports cpu/memory/disk utilization metrics to [Stackdriver](https://cloud.google.com/monitoring/).
 `google_labels` | `object` | An object containing only string values. Represent custom labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `[a-z]([-a-z0-9]*[a-z0-9])?`.
 
@@ -19,9 +20,10 @@ Keys | Possible Values | Description
   "jes_gcs_root": "gs://my-bucket/workflows",
   "google_project": "my_google_project",
   "refresh_token": "1/Fjf8gfJr5fdfNf9dk26fdn23FDm4x",
-  "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com"
+  "google_compute_service_account": " my-new-svcacct@my-google-project.iam.gserviceaccount.com",
   "auth_bucket": "gs://my-auth-bucket/private",
-  "monitoring_script": "gs://bucket/script.sh",
+  "monitoring_script": "gs://bucket/monitor.sh",
+  "init_script": "gs://bucket/init.sh",
   "monitoring_image": "quay.io/broadinstitute/cromwell-monitor",
   "google_labels": {
     "custom-label": "custom-value"

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -351,6 +351,22 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     )
   }
 
+  lazy val jesInitParamName: String = PipelinesApiJobPaths.JesInitKey
+  lazy val localInitLogPath: Path = DefaultPathBuilder.get(pipelinesApiCallPaths.jesInitLogFilename)
+  lazy val localInitScriptPath: Path = DefaultPathBuilder.get(pipelinesApiCallPaths.jesInitScriptFilename)
+
+  lazy val initScript: Option[PipelinesApiFileInput] = {
+    pipelinesApiCallPaths.workflowPaths.initScriptPath map { path =>
+      PipelinesApiFileInput(s"$jesInitParamName-in", path, localInitScriptPath, workingDisk)
+    }
+  }
+
+  lazy val initOutput: Option[PipelinesApiFileOutput] = initScript map { _ =>
+    PipelinesApiFileOutput(s"$jesInitParamName-out",
+      pipelinesApiCallPaths.jesInitLogPath, localInitLogPath, workingDisk, optional = false, secondary = false,
+      contentType = plainTextContentType)
+  }
+
   lazy val jesMonitoringParamName: String = PipelinesApiJobPaths.JesMonitoringKey
   lazy val localMonitoringLogPath: Path = DefaultPathBuilder.get(pipelinesApiCallPaths.jesMonitoringLogFilename)
   lazy val localMonitoringScriptPath: Path = DefaultPathBuilder.get(pipelinesApiCallPaths.jesMonitoringScriptFilename)
@@ -369,16 +385,28 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
 
   override lazy val commandDirectory: Path = PipelinesApiWorkingDisk.MountPoint
 
+  private val DockerInitLogPath: Path = PipelinesApiWorkingDisk.MountPoint.resolve(pipelinesApiCallPaths.jesInitLogFilename)
+  private val DockerInitScriptPath: Path = PipelinesApiWorkingDisk.MountPoint.resolve(pipelinesApiCallPaths.jesInitScriptFilename)
   private val DockerMonitoringLogPath: Path = PipelinesApiWorkingDisk.MountPoint.resolve(pipelinesApiCallPaths.jesMonitoringLogFilename)
   private val DockerMonitoringScriptPath: Path = PipelinesApiWorkingDisk.MountPoint.resolve(pipelinesApiCallPaths.jesMonitoringScriptFilename)
   private var hasDockerCredentials: Boolean = false
 
   override def scriptPreamble: String = {
+    var preamble = ""
     if (monitoringOutput.isDefined) {
-      s"""|touch $DockerMonitoringLogPath
-          |chmod u+x $DockerMonitoringScriptPath
-          |$DockerMonitoringScriptPath > $DockerMonitoringLogPath &""".stripMargin
-    } else ""
+      preamble += s"""|touch $DockerMonitoringLogPath
+                      |chmod u+x $DockerMonitoringScriptPath
+                      |$DockerMonitoringScriptPath > $DockerMonitoringLogPath &""".stripMargin
+    }
+    if (initOutput.isDefined) {
+      if (monitoringOutput.isDefined) {
+        preamble += "\n"
+      }
+      preamble += s"""|touch $DockerInitLogPath
+                      |chmod u+x $DockerInitScriptPath
+                      |$DockerInitScriptPath > $DockerInitLogPath""".stripMargin
+    }
+    preamble
   }
 
   override def globParentDirectory(womGlobFile: WomGlobFile): Path = {
@@ -520,12 +548,14 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
       InputOutputParameters(
         DetritusInputParameters(
           executionScriptInputParameter = cmdInput,
-          monitoringScriptInputParameter = monitoringScript
+          monitoringScriptInputParameter = monitoringScript,
+          initScriptInputParameter = initScript
         ),
         generateInputs(jobDescriptor).toList,
         standardStreams ++ generateOutputs(jobDescriptor).toList,
         DetritusOutputParameters(
           monitoringScriptOutputParameter = monitoringOutput,
+          initScriptOutputParameter = initOutput,
           rcFileOutputParameter = rcFileOutput,
           memoryRetryRCFileOutputParameter = memoryRetryRCFileOutput
         ),

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiJobPaths.scala
@@ -8,6 +8,7 @@ import cromwell.services.metadata.CallMetadataKeys
 object PipelinesApiJobPaths {
   val JesLogPathKey = "jesLog"
   val JesMonitoringKey = "monitoring"
+  val JesInitKey = "init"
   val JesExecParamName = "exec"
   val GcsTransferLibraryName = "gcs_transfer.sh"
   val GcsLocalizationScriptName = "gcs_localization.sh"
@@ -27,6 +28,11 @@ final case class PipelinesApiJobPaths(override val workflowPaths: PipelinesApiWo
   val jesLogFilename: String = s"$jesLogBasename.log"
   lazy val jesLogPath: Path = callExecutionRoot.resolve(jesLogFilename)
 
+  val jesInitLogFilename: String = s"${PipelinesApiJobPaths.JesInitKey}.log"
+  lazy val jesInitLogPath: Path = callExecutionRoot.resolve(jesInitLogFilename)
+
+  val jesInitScriptFilename: String = s"${PipelinesApiJobPaths.JesInitKey}.sh"
+
   val jesMonitoringLogFilename: String = s"${PipelinesApiJobPaths.JesMonitoringKey}.log"
   lazy val jesMonitoringLogPath: Path = callExecutionRoot.resolve(jesMonitoringLogFilename)
 
@@ -37,6 +43,9 @@ final case class PipelinesApiJobPaths(override val workflowPaths: PipelinesApiWo
   ) ++ (
     workflowPaths.monitoringScriptPath map { p => Map(PipelinesApiMetadataKeys.MonitoringScript -> p,
                                                       PipelinesApiMetadataKeys.MonitoringLog -> jesMonitoringLogPath) } getOrElse Map.empty
+  ) ++ (
+    workflowPaths.initScriptPath map { p => Map(PipelinesApiMetadataKeys.InitScript -> p,
+                                                PipelinesApiMetadataKeys.InitLog -> jesInitLogPath) } getOrElse Map.empty
   )
 
   override lazy val customDetritusPaths: Map[String, Path] = Map(

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiMetadataKeys.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiMetadataKeys.scala
@@ -4,9 +4,11 @@ object PipelinesApiMetadataKeys {
   val GoogleProject = "jes:googleProject"
   val ExecutionBucket = "jes:executionBucket"
   val EndpointUrl = "jes:endpointUrl"
+  val InitScript = "jes:initScript"
   val MonitoringScript = "jes:monitoringScript"
   val MachineType = "jes:machineType"
   val Zone = "jes:zone"
   val InstanceName = "jes:instanceName"
+  val InitLog = "initLog"
   val MonitoringLog = "monitoringLog"
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiWorkflowPaths.scala
@@ -69,6 +69,11 @@ case class PipelinesApiWorkflowPaths(workflowDescriptor: BackendWorkflowDescript
     authBucket.resolve(s"${workflowDescriptor.rootWorkflowId}_auth.json")
   }
 
+  val initScriptPath: Option[Path] = workflowOptions.get(WorkflowOptionKeys.InitScript).toOption map { path =>
+    // Fail here if the path exists but can't be built
+    getPath(path).get
+  }
+
   val monitoringScriptPath: Option[Path] = workflowOptions.get(WorkflowOptionKeys.MonitoringScript).toOption map { path =>
     // Fail here if the path exists but can't be built
     getPath(path).get

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.google.pipelines.common
 
 object WorkflowOptionKeys {
+  val InitScript = "init_script"
   val MonitoringScript = "monitoring_script"
   val MonitoringImage = "monitoring_image"
   val GoogleProject = "google_project"

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -27,9 +27,10 @@ object PipelinesApiRequestFactory {
     */
   case class DetritusInputParameters(
                                       executionScriptInputParameter: PipelinesApiFileInput,
-                                      monitoringScriptInputParameter: Option[PipelinesApiFileInput]
+                                      monitoringScriptInputParameter: Option[PipelinesApiFileInput],
+                                      initScriptInputParameter: Option[PipelinesApiFileInput]
                                     ) {
-    def all: List[PipelinesApiFileInput] = List(executionScriptInputParameter) ++ monitoringScriptInputParameter
+    def all: List[PipelinesApiFileInput] = List(executionScriptInputParameter) ++ monitoringScriptInputParameter ++ initScriptInputParameter
   }
 
   /**
@@ -37,10 +38,11 @@ object PipelinesApiRequestFactory {
     */
   case class DetritusOutputParameters(
                                        monitoringScriptOutputParameter: Option[PipelinesApiFileOutput],
+                                       initScriptOutputParameter: Option[PipelinesApiFileOutput],
                                        rcFileOutputParameter: PipelinesApiFileOutput,
                                        memoryRetryRCFileOutputParameter: PipelinesApiFileOutput
                                     ) {
-    def all: List[PipelinesApiFileOutput] = memoryRetryRCFileOutputParameter :: List(rcFileOutputParameter) ++ monitoringScriptOutputParameter
+    def all: List[PipelinesApiFileOutput] = memoryRetryRCFileOutputParameter :: List(rcFileOutputParameter) ++ monitoringScriptOutputParameter ++ initScriptOutputParameter
   }
 
   /**


### PR DESCRIPTION
Cromwell engine with Google Cloud backend provides support for so-called *monitoring script* that can be used to monitor virtual machine / container stats while cromwell task command is being executed. The monitoring script launches asynchronously right before the task command and ends right after the command has finished.

The monitoring scripts does help a lot in the monitoring processes but it cannot be used to add some common initialization for all cromwell tasks as long as it is launched asynchronously.

Nevertheless a possibility to have support for some common initialization logic for all cromwell tasks can be of help. For example, if most of the workflow tasks uses filesystem mounts then their initialization can be either specified in the beginning of each task or it can be specified in a single place, so-called *initialization script*.

The support for *initialization script* is inspired totally by the *monitoring script* and the implementation is pretty the same.

Initialization script can be specified using the `init_script` workflow option.