### PR TITLE
Add support for running tasks with fuse being enabled in papi

### DIFF
--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -280,6 +280,28 @@ backend.providers.PAPIv2.config {
 }
 ```
 
+**Enabling fuse capabilities**
+
+By default cromwell task containers doesn't allow to mount any fuses. It happens because containers are launched without specific linux capabilities being enabled. 
+Google pipelines backend supports running containers with the enabled capabilities and so does cromwell. 
+
+If you need to use fuses within task containers then you can set `enable_fuse` workflow option. 
+
+```
+{
+    "enable_fuse": true
+}
+```
+
+Differently you can enable support for fuses right in your backend configuration.
+
+```
+backend.providers.Papiv2.config {
+    genomics {
+        enable-fuse = true
+    }
+}
+```
 
 #### Google Labels
 

--- a/docs/backends/Google.md
+++ b/docs/backends/Google.md
@@ -280,10 +280,11 @@ backend.providers.PAPIv2.config {
 }
 ```
 
-**Enabling fuse capabilities**
+**Enabling FUSE capabilities**
 
-By default cromwell task containers doesn't allow to mount any fuses. It happens because containers are launched without specific linux capabilities being enabled. 
-Google pipelines backend supports running containers with the enabled capabilities and so does cromwell. 
+*This is a community contribution and not officially supported by the Cromwell team.*
+By default Cromwell task containers doesn't allow to mount any FUSE filesystems. It happens because containers are launched without specific linux capabilities being enabled. 
+Google pipelines backend supports running containers with the enabled capabilities and so does Cromwell. 
 
 If you need to use fuses within task containers then you can set `enable_fuse` workflow option. 
 
@@ -302,6 +303,12 @@ backend.providers.Papiv2.config {
     }
 }
 ```
+
+There is a list of limitations regarding the usage of FUSE filesystems:
+
++ Any inputs brought in via a FUSE filesystem will not be considered for call caching.
++ Any outputs stored via a FUSE filesystem will not be recreated if a task is replayed from a call-cache hit.
++ If the filesystem is writable, your job is potentially no longer idempotent - Cromwell may decide to retry your job for you, and you might get unforeseen file collisions or even incorrect results if that happens.
 
 #### Google Labels
 

--- a/docs/wf_options/Google.md
+++ b/docs/wf_options/Google.md
@@ -16,6 +16,7 @@ These workflow options provide Google-specific information for workflows running
 | `google_labels`                    | `object`        | An object containing only string values. Represent custom labels to send with PAPI job requests. Per the PAPI specification, each key and value must conform to the regex `[a-z]([-a-z0-9]*[a-z0-9])?`.                                                                                                                                                                                                                                                                                                       |
 | `enable_ssh_access`                | `boolean`       | If set to true, will enable SSH access to the Google Genomics worker machines. Please note that this is a community contribution and is not officially supported by the Cromwell development team.
 | `delete_intermediate_output_files` | `boolean`       | **Experimental:** Any `File` variables referenced in call `output` sections that are not found in the workflow `output` section will be considered an intermediate `File`. When the workflow finishes and this option is set to `true`, all intermediate `File` objects will be deleted from GCS. Cromwell must be run with the configuration value `system.delete-workflow-files` set to `true`. The default for both values is `false`. NOTE: The behavior of this option on other backends is unspecified. |
+| `enable_fuse`                      | `boolean`       | Specifies if workflow tasks should be submitted to Google Pipelines with an additional `ENABLE_FUSE` flag. It causes container to be executed with `CAP_SYS_ADMIN`. Use it only for trusted containers. Please note that this is a community contribution and is not officially supported by the Cromwell development team.                                                                                                                                                                                   |
 
 <!-- Pasted into then regenerated at https://www.tablesgenerator.com/markdown_tables -->
 
@@ -33,6 +34,7 @@ These workflow options provide Google-specific information for workflows running
   "google_labels": {
     "custom-label": "custom-value"
   },
-  "delete_intermediate_output_files": false
+  "delete_intermediate_output_files": false,
+  "enable_fuse": false
 }
 ```

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -394,6 +394,10 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
     descriptor.workflowOptions.getOrElse(WorkflowOptionKeys.GoogleComputeServiceAccount, jesAttributes.computeServiceAccount)
   }
 
+  protected def fuseEnabled(descriptor: BackendWorkflowDescriptor): Boolean = {
+    descriptor.workflowOptions.getBoolean(WorkflowOptionKeys.EnableFuse).toOption.getOrElse(jesAttributes.enableFuse)
+  }
+
   override def isTerminal(runStatus: RunStatus): Boolean = {
     runStatus match {
       case _: TerminalRunStatus => true
@@ -449,6 +453,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           adjustedSizeDisks = adjustedSizeDisks,
           virtualPrivateCloudConfiguration = jesAttributes.virtualPrivateCloudConfiguration,
           retryWithMoreMemoryKeys = jesAttributes.memoryRetryConfiguration.map(_.errorKeys),
+          fuseEnabled = fuseEnabled(jobDescriptor.workflowDescriptor),
         )
       case Some(other) =>
         throw new RuntimeException(s"Unexpected initialization data: $other")

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -30,6 +30,7 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                computeServiceAccount: String,
                                                auths: PipelinesApiAuths,
                                                restrictMetadataAccess: Boolean,
+                                               enableFuse: Boolean,
                                                executionBucket: String,
                                                endpointUrl: URL,
                                                location: String,
@@ -72,6 +73,7 @@ object PipelinesApiConfigurationAttributes {
     "genomics.compute-service-account",
     "genomics.auth",
     "genomics.restrict-metadata-access",
+    "genomics.enable-fuse",
     "genomics.endpoint-url",
     "genomics-api-queries-per-100-seconds",
     "genomics.localization-attempts",
@@ -146,6 +148,7 @@ object PipelinesApiConfigurationAttributes {
     val computeServiceAccount: String = backendConfig.as[Option[String]]("genomics.compute-service-account").getOrElse("default")
     val genomicsAuthName: ErrorOr[String] = validate { backendConfig.as[String]("genomics.auth") }
     val genomicsRestrictMetadataAccess: ErrorOr[Boolean] = validate { backendConfig.as[Option[Boolean]]("genomics.restrict-metadata-access").getOrElse(false) }
+    val genomicsEnableFuse: ErrorOr[Boolean] = validate { backendConfig.as[Option[Boolean]]("genomics.enable-fuse").getOrElse(false) }
     val gcsFilesystemAuthName: ErrorOr[String] = validate { backendConfig.as[String]("filesystems.gcs.auth") }
     val qpsValidation = validateQps(backendConfig)
     val duplicationStrategy = validate { backendConfig.as[Option[String]]("filesystems.gcs.caching.duplication-strategy").getOrElse("copy") match {
@@ -206,6 +209,7 @@ object PipelinesApiConfigurationAttributes {
                                                        genomicsName: String,
                                                        location: String,
                                                        restrictMetadata: Boolean,
+                                                       enableFuse: Boolean,
                                                        gcsName: String,
                                                        qps: Int Refined Positive,
                                                        cacheHitDuplicationStrategy: PipelinesCacheHitDuplicationStrategy,
@@ -221,6 +225,7 @@ object PipelinesApiConfigurationAttributes {
             computeServiceAccount = computeServiceAccount,
             auths = PipelinesApiAuths(genomicsAuth, gcsAuth),
             restrictMetadataAccess = restrictMetadata,
+            enableFuse = enableFuse,
             executionBucket = bucket,
             endpointUrl = endpointUrl,
             location = location,
@@ -243,6 +248,7 @@ object PipelinesApiConfigurationAttributes {
       genomicsAuthName,
       location,
       genomicsRestrictMetadataAccess,
+      genomicsEnableFuse,
       gcsFilesystemAuthName,
       qpsValidation,
       duplicationStrategy,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/WorkflowOptionKeys.scala
@@ -6,4 +6,5 @@ object WorkflowOptionKeys {
   val EnableSSHAccess = "enable_ssh_access"
   val GoogleProject = "google_project"
   val GoogleComputeServiceAccount = "google_compute_service_account"
+  val EnableFuse = "enable_fuse"
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -81,7 +81,8 @@ object PipelinesApiRequestFactory {
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],
                                       adjustedSizeDisks: Seq[PipelinesApiAttachedDisk],
                                       virtualPrivateCloudConfiguration: Option[VirtualPrivateCloudConfiguration],
-                                      retryWithMoreMemoryKeys: Option[List[String]]) {
+                                      retryWithMoreMemoryKeys: Option[List[String]],
+                                      fuseEnabled: Boolean) {
     def literalInputs = inputOutputParameters.literalInputParameters
     def inputParameters = inputOutputParameters.fileInputParameters
     def outputParameters = inputOutputParameters.fileOutputParameters

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -97,7 +97,8 @@ object ActionBuilder {
                  scriptContainerPath: String,
                  mounts: List[Mount],
                  jobShell: String,
-                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken]): Action = {
+                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
+                 fuseEnabled: Boolean): Action = {
 
     val dockerImageIdentifier = DockerImageIdentifier.fromString(docker)
 
@@ -115,7 +116,7 @@ object ActionBuilder {
       .setEntrypoint("")
       .setLabels(Map(Key.Tag -> Value.UserAction).asJava)
       .setCredentials(secret.orNull)
-      .setFlags(List(ActionFlag.EnableFuse.toString).asJava)
+      .setFlags((if (fuseEnabled) List(ActionFlag.EnableFuse.toString) else List.empty).asJava)
   }
 
   def checkForMemoryRetryAction(retryLookupKeys: List[String], mounts: List[Mount]): Action = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -115,6 +115,7 @@ object ActionBuilder {
       .setEntrypoint("")
       .setLabels(Map(Key.Tag -> Value.UserAction).asJava)
       .setCredentials(secret.orNull)
+      .setFlags(List(ActionFlag.EnableFuse.toString).asJava)
   }
 
   def checkForMemoryRetryAction(retryLookupKeys: List[String], mounts: List[Mount]): Action = {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/UserAction.scala
@@ -10,7 +10,8 @@ trait UserAction {
       createPipelineParameters.commandScriptContainerPath.pathAsString,
       mounts,
       createPipelineParameters.jobShell,
-      createPipelineParameters.privateDockerKeyAndEncryptedToken
+      createPipelineParameters.privateDockerKeyAndEncryptedToken,
+      createPipelineParameters.fuseEnabled
     )
 
     val describeAction = ActionBuilder.describeDocker("user action", userAction)

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionBuilder.scala
@@ -98,7 +98,8 @@ object ActionBuilder {
                  scriptContainerPath: String,
                  mounts: List[Mount],
                  jobShell: String,
-                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken]): Action = {
+                 privateDockerKeyAndToken: Option[CreatePipelineDockerKeyAndToken],
+                 fuseEnabled: Boolean): Action = {
 
     val dockerImageIdentifier = DockerImageIdentifier.fromString(docker)
 
@@ -116,6 +117,7 @@ object ActionBuilder {
       .setEntrypoint("")
       .setLabels(Map(Key.Tag -> Value.UserAction).asJava)
       .setCredentials(secret.orNull)
+      .setEnableFuse(fuseEnabled)
   }
 
   def checkForMemoryRetryAction(retryLookupKeys: List[String], mounts: List[Mount]): Action = {

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/UserAction.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/UserAction.scala
@@ -10,7 +10,8 @@ trait UserAction {
       createPipelineParameters.commandScriptContainerPath.pathAsString,
       mounts,
       createPipelineParameters.jobShell,
-      createPipelineParameters.privateDockerKeyAndEncryptedToken
+      createPipelineParameters.privateDockerKeyAndEncryptedToken,
+      createPipelineParameters.fuseEnabled
     )
 
     val describeAction = ActionBuilder.describeDocker("user action", userAction)


### PR DESCRIPTION
By default all cromwell task containers submitted by Google Cloud backend doesn't allow user to mount any filesystems within a container. It happens because containers are launched without specific linux capabilities being enabled. 

Nevertheless filesystem mounts can be of help in some workflows because it doesn't require all the task resources to be localized or to be embedded in docker images.

Google pipelines api allows to set `ENABLE_FUSE` flag for all submitted action. Once specified it forces Google pipelines engine to launch action containers with additional linux capabilities such as `CAP_SYS_ADMIN` being enabled.

The pull request adds support for launching cromwell task containers with an enabled support for fuses in Google Cloud.

Fuses support can be enabled via a workflow option `enable_fuse` or via a Google Cloud backend configuration attribute `backend.providers.Papiv2.config.genomics.enable-fuse`.