### PR TITLE
Add a case for 504 error in GCS IoActor

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -189,6 +189,11 @@ object IoActor {
     Option(failure.getMessage).exists(_.matches(serverErrorPattern))
   }
 
+  def isGcs504(failure: Throwable): Boolean = {
+    val serverErrorPattern = ".*Could not read from gs.+504 Gateway Timeout.*"
+    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
+  }
+
   val AdditionalRetryableHttpCodes = List(
     // HTTP 410: Gone
     // From Google doc (https://cloud.google.com/storage/docs/json_api/v1/status-codes):
@@ -221,7 +226,7 @@ object IoActor {
     case _: SocketException => true
     case _: SocketTimeoutException => true
     case ioE: IOException if Option(ioE.getMessage).exists(_.contains("Error getting access token for service account")) => true
-    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE)
+    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE) || isGcs504(ioE)
     case other => isTransient(other)
   }
 

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -226,7 +226,8 @@ class IoActorSpec extends TestKitSuite with FlatSpecLike with Matchers with Impl
       new IOException("text Error getting access token for service account some other text"),
       new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 500 Internal Server Error Backend Error"),
       new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 503 Service Unavailable Backend Error"),
-      new IOException("Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 503 Service Unavailable")
+      new IOException("Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 503 Service Unavailable"),
+      new IOException("Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 504 Gateway Timeout"),
     )
 
     retryables foreach { IoActor.isRetryable(_) shouldBe true }


### PR DESCRIPTION
Following up on https://github.com/broadinstitute/cromwell/pull/5321, this is another case when GCS IoActor fails with a retryable error.