### PR TITLE
RootWorkflowFileHashCacheActor fixes [BA-6165]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -169,7 +169,7 @@ object WorkflowActor {
             serverMode: Boolean,
             workflowHeartbeatConfig: WorkflowHeartbeatConfig,
             totalJobsByRootWf: AtomicInteger,
-            fileHashCacheActor: Option[ActorRef],
+            fileHashCacheActorProps: Option[Props],
             blacklistCache: Option[BlacklistCache]): Props = {
     Props(
       new WorkflowActor(
@@ -191,7 +191,7 @@ object WorkflowActor {
         serverMode = serverMode,
         workflowHeartbeatConfig = workflowHeartbeatConfig,
         totalJobsByRootWf = totalJobsByRootWf,
-        fileHashCacheActor = fileHashCacheActor,
+        fileHashCacheActorProps = fileHashCacheActorProps,
         blacklistCache = blacklistCache)).withDispatcher(EngineDispatcher)
   }
 }
@@ -217,7 +217,10 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
                     serverMode: Boolean,
                     workflowHeartbeatConfig: WorkflowHeartbeatConfig,
                     totalJobsByRootWf: AtomicInteger,
-                    fileHashCacheActor: Option[ActorRef],
+                    // `Props` and not an `ActorRef` since the `RootWorkflowFileHashCacheActor` should be created as a
+                    // child of this actor. The package of the `RootWorkflowFileHashCacheActor` is not visible from the
+                    // package of this class so the `Props` are passed in.
+                    fileHashCacheActorProps: Option[Props],
                     blacklistCache: Option[BlacklistCache])
   extends LoggingFSM[WorkflowActorState, WorkflowActorData] with WorkflowLogging with WorkflowMetadataHelper
   with WorkflowInstrumentation with Timers {
@@ -228,7 +231,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
   override val rootWorkflowIdForLogging = workflowId.toRoot
 
   private val restarting = initialStartableState.restarted
-  
+
   private val startTime = System.currentTimeMillis()
 
   private val workflowDockerLookupActor = context.actorOf(
@@ -319,7 +322,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
         startState = data.effectiveStartableState,
         rootConfig = conf,
         totalJobsByRootWf = totalJobsByRootWf,
-        fileHashCacheActor = fileHashCacheActor,
+        fileHashCacheActor = fileHashCacheActorProps map context.system.actorOf,
         blacklistCache = blacklistCache), name = s"WorkflowExecutionActor-$workflowId")
 
       executionActor ! ExecuteWorkflowCommand

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -218,8 +218,8 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
                     workflowHeartbeatConfig: WorkflowHeartbeatConfig,
                     totalJobsByRootWf: AtomicInteger,
                     // `Props` and not an `ActorRef` since the `RootWorkflowFileHashCacheActor` should be created as a
-                    // child of this actor. The package of the `RootWorkflowFileHashCacheActor` is not visible from the
-                    // package of this class so the `Props` are passed in.
+                    // child of this actor. The sbt subproject of `RootWorkflowFileHashCacheActor` is not visible from
+                    // the subproject this class belongs to so the `Props` are passed in.
                     fileHashCacheActorProps: Option[Props],
                     blacklistCache: Option[BlacklistCache])
   extends LoggingFSM[WorkflowActorState, WorkflowActorData] with WorkflowLogging with WorkflowMetadataHelper

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -19,6 +19,7 @@ import cromwell.engine.workflow.WorkflowManagerActor._
 import cromwell.engine.workflow.workflowstore.{WorkflowHeartbeatConfig, WorkflowStoreActor, WorkflowStoreEngineActor}
 import cromwell.jobstore.JobStoreActor.{JobStoreWriteFailure, JobStoreWriteSuccess, RegisterWorkflowCompleted}
 import cromwell.webservice.EngineStatsActor
+import mouse.boolean._
 import net.ceedubs.ficus.Ficus._
 import org.apache.commons.lang3.exception.ExceptionUtils
 
@@ -290,8 +291,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       logger.info(s"$tag Starting workflow UUID($workflowId)")
     }
 
-    val fileHashCacheActor: Option[ActorRef] =
-      if (fileHashCacheEnabled) Option(context.system.actorOf(RootWorkflowFileHashCacheActor.props(params.ioActor, workflowId))) else None
+    val fileHashCacheActorProps: Option[Props] = fileHashCacheEnabled.option(RootWorkflowFileHashCacheActor.props(params.ioActor, workflowId))
 
     val callCachingBlacklistCache: Option[BlacklistCache] = for {
       config <- config.as[Option[Config]]("call-caching.blacklist-cache")
@@ -317,7 +317,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       serverMode = params.serverMode,
       workflowHeartbeatConfig = params.workflowHeartbeatConfig,
       totalJobsByRootWf = new AtomicInteger(),
-      fileHashCacheActor = fileHashCacheActor,
+      fileHashCacheActorProps = fileHashCacheActorProps,
       blacklistCache = callCachingBlacklistCache)
     val wfActor = context.actorOf(wfProps, name = s"WorkflowActor-$workflowId")
 

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -291,7 +291,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
     }
 
     val fileHashCacheActor: Option[ActorRef] =
-      if (fileHashCacheEnabled) Option(context.system.actorOf(RootWorkflowFileHashCacheActor.props(params.ioActor))) else None
+      if (fileHashCacheEnabled) Option(context.system.actorOf(RootWorkflowFileHashCacheActor.props(params.ioActor, workflowId))) else None
 
     val callCachingBlacklistCache: Option[BlacklistCache] = for {
       config <- config.as[Option[Config]]("call-caching.blacklist-cache")

--- a/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/SimpleWorkflowActorSpec.scala
@@ -77,7 +77,7 @@ class SimpleWorkflowActorSpec extends CromwellTestKitWordSpec with BeforeAndAfte
         workflowStoreActor = system.actorOf(Props.empty),
         workflowHeartbeatConfig = WorkflowHeartbeatConfig(config),
         totalJobsByRootWf = new AtomicInteger(),
-        fileHashCacheActor = None,
+        fileHashCacheActorProps = None,
         blacklistCache = None),
       supervisor = supervisor.ref,
       name = s"workflow-actor-$workflowId"

--- a/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/WorkflowActorSpec.scala
@@ -280,7 +280,7 @@ class WorkflowActorWithTestAddons(val finalizationProbe: TestProbe,
   serverMode = true,
   workflowHeartbeatConfig = workflowHeartbeatConfig,
   totalJobsByRootWf = totalJobsByRootWf,
-  fileHashCacheActor = None,
+  fileHashCacheActorProps = None,
   blacklistCache = None) {
 
   override val pathBuilderFactories: List[PathBuilderFactory] = extraPathBuilderFactory match {


### PR DESCRIPTION
Might not eliminate the "programmer errors" just yet, but does improve logging on (unexpected) restarts and eliminates the weird and unintentional parenting of the RootWorkflowFileHashCacheActor by the WorkflowManagerActor.