### PR TITLE
remove the $HOME/.config/gcloud/gce file before each gsutil invocation [BA-6161]

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/resources/gcs_transfer.sh
@@ -158,8 +158,8 @@ localize_files() {
   fi
 
   # We need to determine requester pays status of the first file attempting at most `max_attempts` times.
-  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' cp '$first_cloud_file' '$container_parent'"
-  REQUESTER_PAYS_COMMAND="gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' -u $project cp '$first_cloud_file' '$container_parent'"
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && rm -f "$HOME/.config/gcloud/gce" && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' cp '$first_cloud_file' '$container_parent'"
+  REQUESTER_PAYS_COMMAND="rm -f "$HOME/.config/gcloud/gce" && gsutil -o 'GSUtil:parallel_thread_count=1' -o 'GSUtil:sliced_object_download_max_components=${num_cpus}' -u $project cp '$first_cloud_file' '$container_parent'"
 
   basefile=$(basename "$first_cloud_file")
   private::localize_message "$first_cloud_file" "${container_parent}${basefile}"
@@ -189,6 +189,7 @@ localize_files() {
     attempt=1
     while [[ ${attempt} -le ${max_attempts} ]]; do
       # parallel transfer the remaining files
+      rm -f "$HOME/.config/gcloud/gce"
       if cat files_to_localize.txt | gsutil -o "GSUtil:parallel_thread_count=1" -o "GSUtil:sliced_object_download_max_components=${num_cpus}" -m ${rpflag} cp -I "$container_parent"; then
         break
       else
@@ -367,8 +368,8 @@ localize_singleton_file() {
   local container_parent=$(dirname "$container")
 
   private::localize_message "$cloud" "$container"
-  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && gsutil cp '$cloud' '$container'"
-  REQUESTER_PAYS_COMMAND="gsutil -u $project cp '$cloud' '$container'"
+  NO_REQUESTER_PAYS_COMMAND="mkdir -p '$container_parent' && rm -f "$HOME/.config/gcloud/gce" && gsutil cp '$cloud' '$container'"
+  REQUESTER_PAYS_COMMAND="rm -f "$HOME/.config/gcloud/gce" && gsutil -u $project cp '$cloud' '$container'"
   # As a side effect of determining requester pays this one file will be localized.
   private::determine_requester_pays ${max_attempts}
 }


### PR DESCRIPTION
I believe the deletion of $HOME/.config/gcloud/gce file before each gsutil invocation was intended to be a workaround for a gsutil issue. The issue was believed to be fixed in gcloud 275 but since the hanging issues appear to persist I added back in the deletion of this file everywhere I could find.