### PR TITLE
Revert "exclude us-central1-c zone with broken e2-medium (#5349)"

### DIFF
--- a/centaur/src/main/resources/integrationTestCases/germline/joint-discovery-gatk/generic.google-papi.options.json
+++ b/centaur/src/main/resources/integrationTestCases/germline/joint-discovery-gatk/generic.google-papi.options.json
@@ -1,7 +1,7 @@
 {
   "read_from_cache":false,
   "default_runtime_attributes": {
-    "zones": "us-central1-a us-central1-b us-central1-f",
+    "zones": "us-central1-a us-central1-b us-central1-c us-central1-f",
     "bootDiskSizeGb": 50
   }
 }


### PR DESCRIPTION
Restore us-central1-c since it should be working correctly now.