### PR TITLE
change from hardlink to symlink

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -245,7 +245,7 @@ trait StandardAsyncExecutionActor
     val absoluteGlobValue = commandDirectory.resolve(globFile.value).pathAsString
     val globLinkCommand: String = configurationDescriptor.backendConfig.getAs[String]("glob-link-command")
       .map("( " + _ + " )")
-      .getOrElse("( ln -L GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null ) || ( ln GLOB_PATTERN GLOB_DIRECTORY )")
+      .getOrElse("( ln -sL GLOB_PATTERN GLOB_DIRECTORY 2> /dev/null ) || ( ln -s GLOB_PATTERN GLOB_DIRECTORY )")
       .replaceAll("GLOB_PATTERN", absoluteGlobValue)
       .replaceAll("GLOB_DIRECTORY", globDirectory.pathAsString)
 


### PR DESCRIPTION
This hard coded hard link breaks workflows on file systems that do no support cross-directory hard links (e.g. beegfs) .

Just like https://github.com/ENCODE-DCC/chip-seq-pipeline2/issues/91 this patch fixed the issue for us and we run a patched version of cromwell for the last month without any problems. Hopefully we can fix this upstream as all pacbio sequencers are affected as well.

******* EDIT****
Just saw the PR #5250 proposes the same change ..... please feel free to discard mine 