### PR TITLE
Allow use of predefined PAPI v1 style VMs from v2 [BA-6264]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -171,6 +171,9 @@ google {
 
   #application-name = "cromwell"
 
+  # Should Cromwell request PAPI v1 predefined machine types? Default: false
+  #use-v1-machine-types = false
+
   # Default: just application default
   #auths = [
 

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -171,8 +171,8 @@ google {
 
   #application-name = "cromwell"
 
-  # Should Cromwell request PAPI v1 predefined machine types? Default: false
-  #use-v1-machine-types = false
+  # Should Cromwell request PAPI v1-style predefined machine types when using PAPI v2? Default: false
+  #papiv2-use-v1-style-machine-types = false
 
   # Default: just application default
   #auths = [

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineConstraints.scala
@@ -23,7 +23,7 @@ object MachineConstraints {
   private val maxMemoryPerCpu = MemorySize(6.5, MemoryUnit.GB)
   private val memoryFactor = MemorySize(256, MemoryUnit.MB)
 
-  private lazy val usePredefinedMachineTypes: Boolean = ConfigFactory.load().getOrElse("google.use-v1-machine-types", false)
+  private lazy val usePredefinedMachineTypes: Boolean = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
 
   private def validateCpu(cpu: Int Refined Positive) = cpu.value match {
     // One CPU is cool

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/MachineConstraints.scala
@@ -7,7 +7,7 @@ import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
 import mouse.all._
 import net.ceedubs.ficus.Ficus._
-import org.slf4j.Logger
+import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
@@ -23,7 +23,12 @@ object MachineConstraints {
   private val maxMemoryPerCpu = MemorySize(6.5, MemoryUnit.GB)
   private val memoryFactor = MemorySize(256, MemoryUnit.MB)
 
-  private lazy val usePredefinedMachineTypes: Boolean = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
+  private lazy val log = LoggerFactory.getLogger("MachineConstraints")
+  private lazy val usePredefinedMachineTypes: Boolean = {
+    val predefinedMachineTypes = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
+    log.info("PAPI v2 alpha 1 using PAPI v1-style predefined machine types? " + predefinedMachineTypes)
+    predefinedMachineTypes
+  }
 
   private def validateCpu(cpu: Int Refined Positive) = cpu.value match {
     // One CPU is cool

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/MachineConstraints.scala
@@ -1,10 +1,12 @@
 package cromwell.backend.google.pipelines.v2beta
 
+import com.typesafe.config.ConfigFactory
 import common.util.IntUtil._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
 import mouse.all._
+import net.ceedubs.ficus.Ficus._
 import org.slf4j.Logger
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
@@ -20,6 +22,8 @@ object MachineConstraints {
   private val minMemoryPerCpu = MemorySize(0.9, MemoryUnit.GB)
   private val maxMemoryPerCpu = MemorySize(6.5, MemoryUnit.GB)
   private val memoryFactor = MemorySize(256, MemoryUnit.MB)
+
+  private lazy val usePredefinedMachineTypes: Boolean = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
 
   private def validateCpu(cpu: Int Refined Positive) = cpu.value match {
     // One CPU is cool
@@ -70,8 +74,12 @@ object MachineConstraints {
   }
 
   def machineType(memory: MemorySize, cpu: Int Refined Positive, jobLogger: Logger) = {
-    val (validCpu, validMemory) = balanceMemoryAndCpu(memory |> validateMemory, cpu |> validateCpu)
-    logAdjustment(cpu.value, validCpu, memory, validMemory, jobLogger)
-    s"custom-$validCpu-${validMemory.to(MemoryUnit.MB).amount.intValue()}"
+    if (usePredefinedMachineTypes) {
+      s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.toInt}"
+    } else {
+      val (validCpu, validMemory) = balanceMemoryAndCpu(memory |> validateMemory, cpu |> validateCpu)
+      logAdjustment(cpu.value, validCpu, memory, validMemory, jobLogger)
+      s"custom-$validCpu-${validMemory.to(MemoryUnit.MB).amount.intValue()}"
+    }
   }
 }

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/MachineConstraints.scala
@@ -7,7 +7,7 @@ import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
 import mouse.all._
 import net.ceedubs.ficus.Ficus._
-import org.slf4j.Logger
+import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
@@ -23,7 +23,12 @@ object MachineConstraints {
   private val maxMemoryPerCpu = MemorySize(6.5, MemoryUnit.GB)
   private val memoryFactor = MemorySize(256, MemoryUnit.MB)
 
-  private lazy val usePredefinedMachineTypes: Boolean = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
+  private lazy val log = LoggerFactory.getLogger("MachineConstraints")
+  private lazy val usePredefinedMachineTypes: Boolean = {
+    val predefinedMachineTypes = ConfigFactory.load().getOrElse("google.papiv2-use-v1-style-machine-types", false)
+    log.info("PAPI v2 beta using PAPI v1-style predefined machine types? " + predefinedMachineTypes)
+    predefinedMachineTypes
+  }
 
   private def validateCpu(cpu: Int Refined Positive) = cpu.value match {
     // One CPU is cool


### PR DESCRIPTION
Config only and no automated tests. Confirmed working in v2alpha1, code is in place for v2beta but may not be working there yet if the changes have not yet been promoted to beta.