### PR TITLE
Output JSON in Cromwell Run mode [BA-6278]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -209,8 +209,8 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
           log.info(s"$Tag writing output to $p")
           p.createIfNotExists(createParents = true).write(outputs.prettyPrint)
         }
-    }
       case _ => println(outputs.prettyPrint)
+    }
   }
 
   private def outputMetadata(metadata: JsObject): Try[Unit] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/SingleWorkflowRunnerActor.scala
@@ -201,13 +201,16 @@ class SingleWorkflowRunnerActor(source: WorkflowSourceFilesCollection,
     * Outputs the outputs to stdout or a file, based on whether an output json path was specified
     */
   private def outputOutputs(outputs: JsObject): Unit = {
+
     workflowOutputPath match {
-      case Some(p: Path) =>
+      case Some(p) =>
         if (p.isDirectory) {
           log.error("Specified metadata path is a directory, should be a file: " + p)
         } else {
+          //The extract outputs stanza entirely
+          val purelyOutputs = outputs.fields("outputs")
+          p.createIfNotExists(createParents = true).write(purelyOutputs.prettyPrint)
           log.info(s"$Tag writing output to $p")
-          p.createIfNotExists(createParents = true).write(outputs.prettyPrint)
         }
       case _ => println(outputs.prettyPrint)
     }

--- a/server/src/main/scala/cromwell/CommandLineArguments.scala
+++ b/server/src/main/scala/cromwell/CommandLineArguments.scala
@@ -44,6 +44,7 @@ case class CommandLineArguments(command: Option[Command] = None,
                                 workflowLabels: Option[Path] = None,
                                 imports: Option[Path] = None,
                                 metadataOutput: Option[Path] = None,
+                                workflowOutput: Option[Path] = None,
                                 host: URL = CommandLineArguments.DefaultCromwellHost
                                ) {
   private lazy val cwlPreProcessor = new CwlPreProcessor()

--- a/server/src/main/scala/cromwell/CommandLineParser.scala
+++ b/server/src/main/scala/cromwell/CommandLineParser.scala
@@ -31,6 +31,8 @@ object CommandLineParser {
 //  -p, --imports <value>    A directory or zipfile to search for workflow imports.
 //  -m, --metadata-output <value>
 //                           An optional JSON file path to output metadata.
+//  -w, --workflow-output <value>
+//                           An optional JSON file path to declared workflow outputs.
 //  -h, --host               Cromwell server URL
 class CommandLineParser extends scopt.OptionParser[CommandLineArguments]("java -jar /path/to/cromwell.jar") {
   
@@ -79,7 +81,11 @@ class CommandLineParser extends scopt.OptionParser[CommandLineArguments]("java -
         opt[String]('m', "metadata-output").text(
           "An optional JSON file path to output metadata.").
           action((s, c) =>
-            c.copy(metadataOutput = Option(DefaultPathBuilder.get(s))))
+            c.copy(metadataOutput = Option(DefaultPathBuilder.get(s)))),
+        opt[String]('w', "workflow-output").text(
+          "An optional JSON file path to declared workflow outputs.").
+          action((s, c) =>
+            c.copy(workflowOutput = Option(DefaultPathBuilder.get(s))))
       ): _*
     )
 

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -68,6 +68,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
     val runnerProps = SingleWorkflowRunnerActor.props(
       source = sources,
       metadataOutputFile = args.metadataOutput,
+      workflowOutputFile = args.workflowOutput,
       terminator = cromwellSystem,
       gracefulShutdown = gracefulShutdown,
       abortJobsOnTerminate = abortJobsOnTerminate.getOrElse(true),


### PR DESCRIPTION
For Cromwell run mode, add the option to add outputs explicitly to an output json file.

The thinking is that for a WDL testing framework, being able to diff expected outputs with generated outputs (both from Cromwell and miniWDL) if they are in a json format, it becomes easy to use them. The alternatives are digging through the metadata json or cromwell logs -- so this option is meant to just increase convenience of outputs for a test framework. 

It could also be used as documentation for the expected output format for example WDLs in the WDL spec.