### PR TITLE
Reference conda and docker as installation methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 49 Release Notes
 
+### Installation methods
+
+Links to the conda package and docker container are now available in 
+[the install documentation](https://cromwell.readthedocs.io/en/stable/Getting/).
+
 ### Job store database refactoring
 
 The primary keys of Cromwell's job store tables have been refactored to use a `BIGINT` datatype in place of the previous

--- a/docs/Getting.md
+++ b/docs/Getting.md
@@ -3,7 +3,7 @@
 Cromwell releases are available at the [GitHub Releases](https://github.com/broadinstitute/cromwell/releases/latest) page. 
 You are strongly encouraged to use the latest release of Cromwell whenever possible.
 
-Cromwell is distributed is a conda package on [conda-forge](https://conda-forge.org/).
+Cromwell is distributed as a conda package on [conda-forge](https://conda-forge.org/).
 These instructions need to be followed for [installing the miniconda distribution](https://docs.conda.io/en/latest/miniconda.html) and 
 [activating the conda-forge channel](https://conda-forge.org/#about). After this Cromwell can be installed in the 
 base environment with `conda install cromwell` or a separate environment for Cromwell can be created with 

--- a/docs/Getting.md
+++ b/docs/Getting.md
@@ -7,10 +7,10 @@ Cromwell is distributed as a conda package on [conda-forge](https://conda-forge.
 These instructions need to be followed for [installing the miniconda distribution](https://docs.conda.io/en/latest/miniconda.html) and 
 [activating the conda-forge channel](https://conda-forge.org/#about). After this Cromwell can be installed in the 
 base environment with `conda install cromwell` or a separate environment for Cromwell can be created with 
-`conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows it is recommended you take 
+`conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows, you might like to take
 a look at [bioconda](http://bioconda.github.io)  as well. 
-The conda installation of Cromwell comes with a wrapper that eliminates the need for using 
-a `java -jar /path/to/jar` type of command. Conda also installs the required Java dependency 
+The conda installation of Cromwell comes with a wrapper that locates the jar for you and allows for running Cromwell or Womtool with a 
+`cromwell run`, `womtool validate` or other command. Conda also installs the required Java dependency 
 in the environment automatically.
 
 Mac users with Homebrew can also get Cromwell with the command `brew install cromwell`.

--- a/docs/Getting.md
+++ b/docs/Getting.md
@@ -6,7 +6,12 @@ You are strongly encouraged to use the latest release of Cromwell whenever possi
 Cromwell is distributed is a conda package on [conda-forge](https://conda-forge.org/).
 These instructions need to be followed for [installing the miniconda distribution](https://docs.conda.io/en/latest/miniconda.html) and 
 [activating the conda-forge channel](https://conda-forge.org/#about). After this Cromwell can be installed in the 
-base environt with `conda install cromwell` or a separate environment for Cromwell can be created with `conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows it is recommended you take a look at [bioconda](http://bioconda.github.io)  as well. The conda installation of Cromwell comes with a wrapper that eliminates the need for using a `java -jar /path/to/jar` type of command. Conda also installs the required Java dependency fot you.
+base environment with `conda install cromwell` or a separate environment for Cromwell can be created with 
+`conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows it is recommended you take 
+a look at [bioconda](http://bioconda.github.io)  as well. 
+The conda installation of Cromwell comes with a wrapper that eliminates the need for using 
+a `java -jar /path/to/jar` type of command. Conda also installs the required Java dependency 
+in the environment automatically.
 
 Mac users with Homebrew can also get Cromwell with the command `brew install cromwell`.
 

--- a/docs/Getting.md
+++ b/docs/Getting.md
@@ -1,7 +1,12 @@
 **Cromwell Releases**
 
-The preferred way of getting Cromwell releases is at the [GitHub Releases](https://github.com/broadinstitute/cromwell/releases/latest) page. 
+Cromwell releases are available at the [GitHub Releases](https://github.com/broadinstitute/cromwell/releases/latest) page. 
 You are strongly encouraged to use the latest release of Cromwell whenever possible.
+
+Cromwell is distributed is a conda package on [conda-forge](https://conda-forge.org/).
+These instructions need to be followed for [installing the miniconda distribution](https://docs.conda.io/en/latest/miniconda.html) and 
+[activating the conda-forge channel](https://conda-forge.org/#about). After this Cromwell can be installed in the 
+base environt with `conda install cromwell` or a separate environment for Cromwell can be created with `conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows it is recommended you take a look at [bioconda](http://bioconda.github.io)  as well. The conda installation of Cromwell comes with a wrapper that eliminates the need for using a `java -jar /path/to/jar` type of command. Conda also installs the required Java dependency fot you.
 
 Mac users with Homebrew can also get Cromwell with the command `brew install cromwell`.
 
@@ -9,3 +14,5 @@ This documentation frequently refers to a "Cromwell jar" with a name like `cromw
 This is the main artifact in Cromwell releases that contains all executable Cromwell code and default configuration.   
 
 [Java 8](http://www.oracle.com/technetwork/java/javase/overview/java8-2100321.html) is required to run Cromwell.
+
+For users running a cromwell server [a docker image](https://hub.docker.com/r/broadinstitute/cromwell) has been made available.


### PR DESCRIPTION
Both conda and docker are great for certain use cases. So it is of benefit that these are mentioned in the docs.

I removed "the preferred way is getting the jar" text because both the conda package and the docker container also contain the original jar. These are both way easier to use than a jar, so I would not recommend getting the jar over those two methods.