### PR TITLE
docs: add Ecosystem page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 Cromwell is a Workflow Management System geared towards scientific workflows. Cromwell is open sourced under the [BSD 3-Clause license](LICENSE.txt).
 
-The Cromwell documentation has a new home, [click here to check it out](http://cromwell.readthedocs.io/en/develop)!
+The Cromwell documentation has a new home, [click here to check it out](https://cromwell.readthedocs.io/en/stable)!
 
-First time to Cromwell? Get started with [Tutorials](http://cromwell.readthedocs.io/en/develop/tutorials/FiveMinuteIntro/)!
+First time to Cromwell? Get started with [Tutorials](https://cromwell.readthedocs.io/en/stable/tutorials/FiveMinuteIntro/)!
 
 Thinking about contributing to Cromwell? Get started by reading our [Contributor Guide](CONTRIBUTING.md).
 
-Cromwell has a growing ecosystem of community-backed projects to make your experience even better! Check out our [Ecosystem](https://cromwell.readthedocs.io/en/develop/Ecosystem/) page to learn more.
+Cromwell has a growing ecosystem of community-backed projects to make your experience even better! Check out our [Ecosystem](https://cromwell.readthedocs.io/en/stable/Ecosystem/) page to learn more.
 
 ### Issue tracking is now on JIRA
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ First time to Cromwell? Get started with [Tutorials](http://cromwell.readthedocs
 
 Thinking about contributing to Cromwell? Get started by reading our [Contributor Guide](CONTRIBUTING.md).
 
+Cromwell has a growing ecosystem of community-backed projects to make your experience even better! Check out our [Ecosystem](https://cromwell.readthedocs.io/en/develop/Ecosystem/) page to learn more.
+
 ### Issue tracking is now on JIRA
 
 Need to file an issue? Head over to [our JIRA](https://broadworkbench.atlassian.net/projects/BA/issues). You can sign in with any Google account. 

--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -1,0 +1,6 @@
+# Ecosystem
+
+Many community projects have been created to support the use of the core Cromwell engine. Check them out to make your Cromwell experience even better!
+
+* [Cromshell](https://github.com/broadinstitute/cromshell): Shell script for interacting with cromwell servers created at the [Broad Institute](https://github.com/broadinstitute).
+* [Oliver](https://github.com/stjudecloud/oliver): An opinionated Cromwell orchestration manager created by the [St. Jude Cloud team](https://github.com/stjudecloud).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Optimizations: optimizations/optimizations.md
   - "Task inputs: localization_optional": optimizations/FileLocalization.md
 - Configuration: Configuring.md
+- Ecosystem: Ecosystem.md
 - WOMtool: WOMtool.md
 - Imports: Imports.md
 - Sub-Workflows: SubWorkflows.md


### PR DESCRIPTION
I considered filing an issue, but it seems like the best avenue to get the maintainers thoughts. How do you all feel about creating a page where community-backed projects can be highlighted? The idea occurred to me as I was thinking about our impending release of `oliver` (not quite there yet).

The only other project I was aware of was `cromshell`, not sure if there are any others you would want to add 🤷‍♂ .