### PR TITLE
Fix relative output dirs

### DIFF
--- a/centaur/src/main/resources/standardTestCases/relative_output_paths.test
+++ b/centaur/src/main/resources/standardTestCases/relative_output_paths.test
@@ -12,5 +12,5 @@ metadata {
 fileSystemCheck: "local"
 outputExpectations: {
     "/tmp/outputs/relative_output_paths/typeset.txt": 1
-    "/tmp/outputs/relative_output_paths/greatpress.txt": 1
+    "/tmp/outputs/relative_output_paths/greatpress/typeset.txt": 1
 }

--- a/centaur/src/main/resources/standardTestCases/relative_output_paths/workflow_output_paths.wdl
+++ b/centaur/src/main/resources/standardTestCases/relative_output_paths/workflow_output_paths.wdl
@@ -26,7 +26,7 @@ workflow Gutenberg {
     call text_to_file as great_press {
         input:
             text="This press is working great!",
-            filepath="greatpress.txt"
+            filepath="greatpress/typeset.txt"
     }
     output {
         File typeset = set_type.text_file

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -98,7 +98,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
     // Truncate regex is declared here. If it were declared in the if statement the regex would have to be
     // compiled for every single file.
     // "execution" should be optional, because its not created on AWS.
-    lazy val truncateRegex = ".*\\/call-.*\\/(execution\\/)?".r
+    lazy val truncateRegex = ".*/call-[^/]*/(execution/)?".r
     val outputFileDestinations = rootAndFiles flatMap {
       case (workflowRoot, outputs) =>
         outputs map { output => 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -98,7 +98,8 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
     // Truncate regex is declared here. If it were declared in the if statement the regex would have to be
     // compiled for every single file.
     // "execution" should be optional, because its not created on AWS.
-    lazy val truncateRegex = ".*/call-[^/]*/(execution/)?".r
+    // Also cacheCopy or attempt-<int> folders are optional.
+    lazy val truncateRegex = ".*/call-[^/]*/(cacheCopy/)?(attempt-[1-9]+/)?(execution/)?".r
     val outputFileDestinations = rootAndFiles flatMap {
       case (workflowRoot, outputs) =>
         outputs map { output => 


### PR DESCRIPTION
Due to some updates that got in cromwell version 49 the regex that creates the relative outputs was evaluated differently (correctly, to be precise). This made it so that any directory structure created by the user is lost. This broke all the testing on biowdl.
I have updated the test cases to notice such a regression in the future. I also fixed the regex to behave like it is described in the documentation.


