### PR TITLE
add gzipped output to AWS job definition [BA-4216]

### DIFF
--- a/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit.test
+++ b/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit.test
@@ -1,0 +1,23 @@
+name: awsGzContainerOverrideSizeLimit
+testFormat: workflowsuccess
+backends: [AWSBatch]
+tags: ["aws_container_overrides"]
+
+files {
+  workflow: awsGzContainerOverrideSizeLimit/workflow.wdl
+  options: awsGzContainerOverrideSizeLimit/options.json
+}
+
+metadata {
+  status: Succeeded
+}
+
+fileSystemCheck: "aws"
+outputExpectations: {
+    "s3://<<s3-bucket-name-placeholder>>/wf_results/Workflow/<<UUID>>/call-takesSomeFiles/output.txt": 1
+    "s3://<<s3-bucket-name-placeholder>>/wf_logs/workflow.<<UUID>>.log": 1
+    "s3://<<s3-bucket-name-placeholder>>/cl_logs/Workflow/<<UUID>>/call-takesSomeFiles/takesSomeFiles-stderr.log": 1
+    "s3://<<s3-bucket-name-placeholder>>/cl_logs/Workflow/<<UUID>>/call-takesSomeFiles/takesSomeFiles-stdout.log": 1
+    "s3://<<s3-bucket-name-placeholder>>/cl_logs/Workflow/<<UUID>>/call-makeSomeFiles/makeSomeFiles-stderr.log": 1
+    "s3://<<s3-bucket-name-placeholder>>/cl_logs/Workflow/<<UUID>>/call-makeSomeFiles/makeSomeFiles-stdout.log": 1
+}

--- a/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit/options.json
+++ b/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit/options.json
@@ -1,0 +1,6 @@
+{
+  "use_relative_output_paths":false,
+  "final_workflow_outputs_dir":"s3://<<s3-bucket-name-placeholder>>/wf_results",
+  "final_workflow_log_dir":"s3://<<s3-bucket-name-placeholder>>/wf_logs",
+  "final_call_logs_dir":"s3://<<s3-bucket-name-placeholder>>/cl_logs"
+}

--- a/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit/workflow.wdl
+++ b/centaur/src/main/resources/awsGzContainerOverrideTestCases/awsGzContainerOverrideSizeLimit/workflow.wdl
@@ -1,0 +1,71 @@
+workflow Workflow {
+    call makeSomeFiles {}
+    call takesSomeFiles {input: files = makeSomeFiles.createdFiles}
+    output {
+        File outFile = takesSomeFiles.outFile
+    }
+}
+
+task makeSomeFiles {
+    command {
+        for I in $(seq 1 25)
+        do
+          echo $I > some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_$I.txt
+        done
+    }
+
+    output {
+        Array[File] createdFiles = [
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_1.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_2.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_3.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_4.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_5.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_6.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_7.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_8.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_9.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_10.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_11.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_12.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_13.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_14.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_15.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_16.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_17.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_18.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_19.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_20.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_21.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_22.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_23.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_24.txt",
+            "some_filename_that_is_way_longer_than_it_has_to_be_because_that_may_or_may_not_be_relevant_to_triggering_the_behavior_this_test_is_supposed_to_be_testing_25.txt"
+        ]
+    }
+    runtime {
+        docker: "ubuntu"
+        memory: "2G"
+        cpu: 1
+  }
+}
+
+task takesSomeFiles {
+    String outputFileName = "output.txt"
+    Array[File] files
+
+    command {
+        echo 'Hello world' > ${outputFileName}
+    }
+
+    runtime {
+        docker: "ubuntu"
+        memory: "2G"
+        cpu: 1
+    }
+
+    output {
+        File outFile = outputFileName
+    }
+}
+

--- a/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
+++ b/supportedBackends/aws/src/main/resources/ecs-proxy/proxy
@@ -165,6 +165,12 @@ if [ -n "${AWS_CROMWELL_OUTPUTS}" ]; then
   copyfiles "${AWS_CROMWELL_OUTPUTS}" out
 fi
 
+if [ -n "${AWS_CROMWELL_OUTPUTS_GZ}" ]; then
+  echo "Copying output files to S3 (gzipped output)"
+  outputs=$(decompVal "${AWS_CROMWELL_OUTPUTS_GZ}")
+  copyfiles "${outputs}" out
+fi
+
 echo "Removing target container"
 docker rm "${AWS_ECS_PROXY_TARGET_CONTAINER_ID}"
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -96,7 +96,7 @@ trait AwsBatchJobDefinitionBuilder {
           buildKVPair("AWS_CROMWELL_CALL_ROOT",context.jobPaths.callExecutionRoot.toString),
           buildKVPair("AWS_CROMWELL_WORKFLOW_ROOT",context.jobPaths.workflowPaths.workflowRoot.toString),
           gzipKeyValuePair("AWS_CROMWELL_INPUTS", inputinfo),
-          buildKVPair("AWS_CROMWELL_OUTPUTS",outputinfo))
+          gzipKeyValuePair("AWS_CROMWELL_OUTPUTS",outputinfo))
       }.flatten
 
     def getVolPath(d:AwsBatchVolume) : Option[String] =  {


### PR DESCRIPTION
Copy of #5441.

This adds a mechanism of gzipping the list of output files in the AWS backend to avoid the container override size limit. This mechanism was already in place for the inputs, this will simply utilize it for the outputs as well.

I tried testing it, but the new `proxy` file doesn't seem to have been used. I guess the docker image needs to be updated for that. Does anyone have any ideas on how to do that? I couldn't find where this docker image gets used in cromwell.