### PR TITLE
Add xxh64 and fingerprint call-caching strategies to address shortcomings of current strategies. [BA-6335]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,12 @@
 
 ### New functionality
 
-#### xxHash for faster call-caching using file hashes
+#### new xxh64 and fingerprint strategies for call caching
 
-The `file` strategy uses md5sum hashing which causes a lot of strain on the server, the `path` and `path+modtime` 
-strategies are much lighter, but do not work properly with containers. To alleviate this problem a new file hashing
-strategy called `xxh64` was introduced. This uses the 64-bit implementation of the [xxHash](https://www.xxhash.com)
-algorithm. This algorithm is optimized for file integrity hashing and provides a more than 10x speed improvement over
-md5. The `file` strategy has now been renamed `md5` for clarity. For backwards compatibility reasons, `file` is still
-available (defaults to `md5`) and `md5` is still the default hashing algorithm.
+To alleviate problems with existing call cache strategies, two new strategies have been added: `xxh64` and 
+`fingerprint`. `xxh64` is a lightweight hashing algorithm, `fingerprint` is a strategy designed to be very 
+lightweight. Read more about it in the [call caching documentation](
+https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching).
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ To alleviate problems with existing call cache strategies, two new strategies ha
 lightweight. Read more about it in the [call caching documentation](
 https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching).
 
-### Bugfixes
-
-+ Fixed a bug in Cromwell 49 where the `use_relative_output_paths` option would not preserve intermediate folders.
-
 ## 49 Release Notes
 
 ### Changes and Warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Cromwell Change Log
 
+## 50 Release Notes
+
+### New functionality
+
+#### xxHash for faster call-caching using file hashes
+
+The `file` strategy uses md5sum hashing which causes a lot of strain on the server, the `path` and `path+modtime` 
+strategies are much lighter, but do not work properly with containers. To alleviate this problem a new file hashing
+strategy called `xxh64` was introduced. This uses the 64-bit implementation of the [xxHash](https://www.xxhash.com)
+algorithm. This algorithm is optimized for file integrity hashing and provides a more than 10x speed improvement over
+md5. The `file` strategy has now been renamed `md5` for clarity. For backwards compatibility reasons, `file` is still
+available (defaults to `md5`) and `md5` is still the default hashing algorithm.
+
+### Bugfixes
+
++ Fixed a bug in Cromwell 49 where the `use_relative_output_paths` option would not preserve intermediate folders.
+
 ## 49 Release Notes
 
 ### Changes and Warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### new xxh64 and fingerprint strategies for call caching
 
 Existing call cache strategies `path` and `path+modtime` don't work when using docker on shared filesystems 
-(SFS backend, i.e. not in cloud storage). The `file` (md5) strategy works, but uses a lot of resources.
+(SFS backend, i.e. not in cloud storage). The `file` (md5sum) strategy works, but uses a lot of resources.
 Two faster strategies have been added for this use case: `xxh64` and 
 `fingerprint`. `xxh64` is a lightweight hashing algorithm, `fingerprint` is a strategy designed to be very 
 lightweight. Read more about it in the [call caching documentation](

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 #### new xxh64 and fingerprint strategies for call caching
 
-Existing call cache strategies can be slow on shared filesystems (SFS backend, i.e. not in cloud storage). Two faster strategies have been added for this use case: `xxh64` and 
+Existing call cache strategies `path` and `path+modtime` don't work when using docker on shared filesystems 
+(SFS backend, i.e. not in cloud storage). The `file` (md5) strategy works, but uses a lot of resources.
+Two faster strategies have been added for this use case: `xxh64` and 
 `fingerprint`. `xxh64` is a lightweight hashing algorithm, `fingerprint` is a strategy designed to be very 
 lightweight. Read more about it in the [call caching documentation](
 https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### new xxh64 and fingerprint strategies for call caching
 
-To alleviate problems with existing call cache strategies, two new strategies for files on a shared filesystem (ie not in cloud storage) have been added: `xxh64` and 
+Existing call cache strategies can be slow on shared filesystems (SFS backend, i.e. not in cloud storage). Two faster strategies have been added for this use case: `xxh64` and 
 `fingerprint`. `xxh64` is a lightweight hashing algorithm, `fingerprint` is a strategy designed to be very 
 lightweight. Read more about it in the [call caching documentation](
 https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching).

--- a/build.sbt
+++ b/build.sbt
@@ -223,7 +223,7 @@ lazy val awsBackend = (project in backendRoot / "aws")
   .dependsOn(services % "test->test")
 
 lazy val sfsBackend = (project in backendRoot / "sfs")
-  .withLibrarySettings("cromwell-sfs-backend")
+  .withLibrarySettings("cromwell-sfs-backend", sfsBackendDependencies)
   .dependsOn(backend)
   .dependsOn(gcsFileSystem)
   .dependsOn(httpFileSystem)

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -47,16 +47,22 @@ filesystems {
     ]
 
     caching {
-      # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
+      # When copying a cached result, what type of file duplication should occur.
+      # possible values: "hard-link", "soft-link", "copy", "cached-copy".
+      # For more information check: https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem
+      # Attempted in the order listed below:
+      duplication-strategy: [
+        "hard-link", "soft-link", "copy"
+      ]
       duplication-strategy: [
         "hard-link", "soft-link", "copy"
       ]
 
-      # Possible values: md5, xxh64, path, path+modtime
+      # Possible values: md5, xxh64, fingerprint, path, path+modtime
+      # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
       # "md5" will compute an md5 hash of the file content.
-      # "file" DEPRECATED: same as md5.
-      # "xxh64" will compute an xxh64 hash of the file content. This uses the xxHash algorithm (www.xxhash.com).
-      # xxHash was optimized for file integrity checksums and is more than 10 times faster as md5.
+      # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
+      # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
       # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
       # in order to allow for the original file path to be hashed.
       # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -52,11 +52,16 @@ filesystems {
         "hard-link", "soft-link", "copy"
       ]
 
-      # Possible values: file, path
-      # "file" will compute an md5 hash of the file content.
+      # Possible values: md5, xxh64, path, path+modtime
+      # "md5" will compute an md5 hash of the file content.
+      # "file" DEPRECATED: same as md5.
+      # "xxh64" will compute an xxh64 hash of the file content. This uses the xxHash algorithm (www.xxhash.com).
+      # xxHash was optimized for file integrity checksums and is more than 10 times faster as md5.
       # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
       # in order to allow for the original file path to be hashed.
-      hashing-strategy: "file"
+      # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+      # Default: "md5"
+      hashing-strategy: "md5"
 
       # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
       # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -48,22 +48,13 @@ filesystems {
 
     caching {
       # When copying a cached result, what type of file duplication should occur.
-      # possible values: "hard-link", "soft-link", "copy", "cached-copy".
       # For more information check: https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem
-      # Attempted in the order listed below:
       duplication-strategy: [
         "hard-link", "soft-link", "copy"
       ]
 
-      # Possible values: md5, xxh64, fingerprint, path, path+modtime
-      # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
-      # "md5" will compute an md5 hash of the file content.
-      # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
-      # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
-      # This strategy will only be effective if the duplication-strategy (above) is set to "hard-link", as copying changes the last modified time.
-      # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
-      # in order to allow for the original file path to be hashed.
-      # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
+      # Strategy to determine if a file has been used before.
+      # For extended explanation and alternative strategies check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
       # Default: "md5"
       hashing-strategy: "md5"
 

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -54,9 +54,6 @@ filesystems {
       duplication-strategy: [
         "hard-link", "soft-link", "copy"
       ]
-      duplication-strategy: [
-        "hard-link", "soft-link", "copy"
-      ]
 
       # Possible values: md5, xxh64, fingerprint, path, path+modtime
       # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -55,7 +55,6 @@ filesystems {
 
       # Strategy to determine if a file has been used before.
       # For extended explanation and alternative strategies check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
-      # Default: "md5"
       hashing-strategy: "md5"
 
       # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.

--- a/core/src/main/resources/reference_local_provider_config.inc.conf
+++ b/core/src/main/resources/reference_local_provider_config.inc.conf
@@ -60,6 +60,7 @@ filesystems {
       # "md5" will compute an md5 hash of the file content.
       # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
       # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
+      # This strategy will only be effective if the duplication-strategy (above) is set to "hard-link", as copying changes the last modified time.
       # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
       # in order to allow for the original file path to be hashed.
       # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -105,6 +105,7 @@
               # "md5" will compute an md5 hash of the file content.
               # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
               # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
+              # This strategy will only be effective if the duplication-strategy (above) is set to "hard-link", as copying changes the last modified time.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -92,18 +92,27 @@
 
             # Call caching strategies
             caching {
-              # When copying a cached result, what type of file duplication should occur. Attempted in the order listed below:
+              # When copying a cached result, what type of file duplication should occur.
+              # possible values: "hard-link", "soft-link", "copy", "cached-copy".
+              # For more information check: https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem
+              # Attempted in the order listed below:
+              duplication-strategy: [
+                "hard-link", "soft-link", "copy"
+              ]
               duplication-strategy: [
                 "hard-link", "soft-link", "copy"
               ]
 
-              # Possible values: file, path, path+modtime
-              # "file" will compute an md5 hash of the file content.
+              # Possible values: md5, xxh64, fingerprint, path, path+modtime
+              # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
+              # "md5" will compute an md5 hash of the file content.
+              # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
+              # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
-              # Default: file
-              hashing-strategy: "file"
+              # Default: "md5"
+              hashing-strategy: "fingerprint"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
               # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -99,9 +99,6 @@
               duplication-strategy: [
                 "hard-link", "soft-link", "copy"
               ]
-              duplication-strategy: [
-                "hard-link", "soft-link", "copy"
-              ]
 
               # Possible values: md5, xxh64, fingerprint, path, path+modtime
               # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -93,24 +93,14 @@
             # Call caching strategies
             caching {
               # When copying a cached result, what type of file duplication should occur.
-              # possible values: "hard-link", "soft-link", "copy", "cached-copy".
               # For more information check: https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem
-              # Attempted in the order listed below:
               duplication-strategy: [
                 "hard-link", "soft-link", "copy"
               ]
 
-              # Possible values: md5, xxh64, fingerprint, path, path+modtime
-              # For extended explanation check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
-              # "md5" will compute an md5 hash of the file content.
-              # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
-              # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
-              # This strategy will only be effective if the duplication-strategy (above) is set to "hard-link", as copying changes the last modified time.
-              # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
-              # in order to allow for the original file path to be hashed.
-              # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
-              # Default: "md5"
-              hashing-strategy: "fingerprint"
+              # Strategy to determine if a file has been used before.
+              # For extended explanation and alternative strategies check: https://cromwell.readthedocs.io/en/stable/Configuring/#call-caching
+              hashing-strategy: "md5"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
               # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataDataAccessComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataDataAccessComponent.scala
@@ -23,9 +23,9 @@ class MetadataDataAccessComponent(val driver: JdbcProfile) extends DataAccessCom
   val metadataEntriesToSummarizeQuery = {
     Compiled(
       (limit: ConstColumn[Long]) => (for {
-        (_, metadataEntry) <-
-          summaryQueueEntries join metadataEntries on (_.metadataJournalId === _.metadataEntryId)
-      } yield metadataEntry).sortBy(_.metadataEntryId).take(limit)
+        summaryEntry <- summaryQueueEntries.take(limit)
+        metadataEntry <- metadataEntries if metadataEntry.metadataEntryId === summaryEntry.metadataJournalId
+      } yield metadataEntry).sortBy(_.metadataEntryId)
     )
   }
 }

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -530,6 +530,7 @@ config section:
               # "md5" will compute an md5 hash of the file content.
               # "xxh64" will compute an xxh64 hash of the file content. Much faster than md5
               # "fingerprint" will take last modified time, size and hash the first 10 mb with xxh64 to create a file fingerprint.
+              # This strategy will only be effective if the duplication-strategy (above) is set to "hard-link", as copying changes the last modified time.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -509,19 +509,21 @@ Cromwell also accepts [Workflow Options](wf_options/Overview#call-caching-option
 
 #### Call cache strategy options
 
-* hash based options. These read the entire file. These strategies work with containers.:
+* hash based options. These read the entire file. These strategies work with containers.
     * `xxh64`. This uses the 64-bit implementation of the [xxHash](https://www.xxhash.com)
              algorithm. This algorithm is optimized for file integrity hashing and provides a more than 10x speed improvement over
              md5. 
     * `md5`. The well-known md5sum algorithm
 * Path based options. These are based on filepath. Extremely lightweight, but only work with the `soft-link` file 
-caching strategy. And can therefore never work with containers.
+caching strategy and can therefore never work with containers.
     * `path` creates a md5 hash of the path.
     * `path+modtime` creates a md5 hash of the path and its modification time.
-* Fingerprinting. This strategy also works with containers.
-    * `fingerprint` tries to create a unique hash for each file by taking its last modified time (milliseconds since
+* Fingerprinting. This strategy works with containers.
+    * `fingerprint` tries to create a fingerprint for each file by taking its last modified time (milliseconds since
        epoch in hexadecimal) + size (bytes in hexadecimal) + the xxh64 sum of the first 10 MB of the file. It is much
-       more lightweight than the hash based options while still providing a unique hash.
+       more lightweight than the hash based options while still unique enough that collisions are infeasible. This 
+       strategy works well for workflows that generate multi gigabyte-files and where hashing these files on the 
+       cromwell instance provides CPU or I/O problems. 
 
 ### Local filesystem options
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -535,7 +535,12 @@ config section:
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
               # Default: "md5"
-              hashing-strategy: "fingerprint"
+              hashing-strategy: "md5"
+              
+              # When the 'fingerprint' strategy is used set how much of the beginning of the file is read as fingerprint. 
+              # If the file is smaller than this size the entire file will be read.
+              # Default: 10485760 (10MB). 
+              fingerprint-size: 10485760
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
               # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.
@@ -569,10 +574,7 @@ caching strategy and can therefore never work with containers.
 (*) The `fingerprint` and `xxh64` strategies are features that are community supported by Cromwell's HPC community. There
 is no official support from the core Cromwell team.
 
-(**) 10 MB was chosen because some files have very large headers which might be similar between files, so smaller 
- sizes might be insufficient. On a 100mbit connection, 10MB is transferred within one second, this was deemed an
- acceptable time delay for systems that use a (slow) NFS backend. Taking a larger first file part would increase 
- the transfer time, but is not likely to generate a more unique hash.
+(**) This value is configurable.
  
 ### Workflow log directory
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -522,7 +522,7 @@ caching strategy and can therefore never work with containers.
     * `fingerprint` tries to create a fingerprint for each file by taking its last modified time (milliseconds since
        epoch in hexadecimal) + size (bytes in hexadecimal) + the xxh64 sum of the first 10 MB of the file. It is much
        more lightweight than the hash based options while still unique enough that collisions are infeasible. This 
-       strategy works well for workflows that generate multi gigabyte-files and where hashing these files on the 
+       strategy works well for workflows that generate multi-gigabyte files and where hashing these files on the 
        cromwell instance provides CPU or I/O problems. 
 
 ### Local filesystem options

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -521,12 +521,15 @@ When running a job on the Config (Shared Filesystem) backend, Cromwell provides 
               ]
 
               # Possible values: file, path, path+modtime
-              # "file" will compute an md5 hash of the file content.
+              # "md5" will compute an md5 hash of the file content.
+              # "file" DEPRECATED: same as md5.
+              # "xxh64" will compute an xxh64 hash of the file content. This uses the xxHash algorithm (www.xxhash.com).
+              # xxHash was optimized for file integrity checksums and is more than 10 times faster as md5.
               # "path" will compute an md5 hash of the file path. This strategy will only be effective if the duplication-strategy (above) is set to "soft-link",
               # in order to allow for the original file path to be hashed.
               # "path+modtime" will compute an md5 hash of the file path and the last modified time. The same conditions as for "path" apply here.
-              # Default: file
-              hashing-strategy: "file"
+              # Default: "md5"
+              hashing-strategy: "xxh64"
 
               # When true, will check if a sibling file with the same name and the .md5 extension exists, and if it does, use the content of this file as a hash.
               # If false or the md5 does not exist, will proceed with the above-defined hashing strategy.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -110,7 +110,6 @@ object Dependencies {
   private val workbenchModelV = "0.10-6800f3a"
   private val workbenchUtilV = "0.3-f3ce961"
 
-
   private val slf4jFacadeDependencies = List(
     "org.slf4j" % "slf4j-api" % slf4jV,
     "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,6 +56,7 @@ object Dependencies {
   private val liquibaseSlf4jV = "2.0.0"
   private val liquibaseV = "3.6.3"
   private val logbackV = "1.2.3"
+  private val lz4JavaV = "1.7.1"
   private val mariadbV = "2.4.2"
   private val metrics3ScalaV = "3.5.10" // https://github.com/erikvanoosten/metrics-scala/tree/f733e26#download-4x
   private val metrics3StatsdV = "4.2.0"
@@ -108,7 +109,7 @@ object Dependencies {
   private val workbenchGoogleV = "0.15-2fc79a3"
   private val workbenchModelV = "0.10-6800f3a"
   private val workbenchUtilV = "0.3-f3ce961"
-  private val zeroAllocationHashingV = "0.11"
+
 
   private val slf4jFacadeDependencies = List(
     "org.slf4j" % "slf4j-api" % slf4jV,
@@ -528,7 +529,7 @@ object Dependencies {
   val tesBackendDependencies = akkaHttpDependencies
   val sparkBackendDependencies = akkaHttpDependencies
   val sfsBackendDependencies = List (
-    "net.openhft" % "zero-allocation-hashing" % zeroAllocationHashingV
+    "org.lz4" % "lz4-java" % lz4JavaV
   )
 
   val testDependencies = List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,6 +108,7 @@ object Dependencies {
   private val workbenchGoogleV = "0.15-2fc79a3"
   private val workbenchModelV = "0.10-6800f3a"
   private val workbenchUtilV = "0.3-f3ce961"
+  private val zeroAllocationHashingV = "0.11"
 
   private val slf4jFacadeDependencies = List(
     "org.slf4j" % "slf4j-api" % slf4jV,
@@ -526,6 +527,9 @@ object Dependencies {
   val bcsBackendDependencies = commonDependencies ++ refinedTypeDependenciesList ++ aliyunBatchComputeDependencies
   val tesBackendDependencies = akkaHttpDependencies
   val sparkBackendDependencies = akkaHttpDependencies
+  val sfsBackendDependencies = List (
+    "net.openhft" % "zero-allocation-hashing" % zeroAllocationHashingV
+  )
 
   val testDependencies = List(
     "org.scalatest" %% "scalatest" % scalatestV,
@@ -579,6 +583,7 @@ object Dependencies {
       ossFileSystemDependencies ++
       perfDependencies ++
       serverDependencies ++
+      sfsBackendDependencies ++
       sparkBackendDependencies ++
       spiDependencies ++
       spiUtilDependencies ++

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -107,12 +107,13 @@ final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigH
 }
 
 final case class FingerprintStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
+  private lazy val defaultMaxSize: Long = 10 * 1024 * 1024
   override protected def hash(file: Path): Try[String] = {
     Try {
       file.lastModifiedTime.toEpochMilli.toHexString +
       file.size.toHexString +
       // Only check first 10 MB for performance reasons
-      HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10 * 1024 * 1024)
+      HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = defaultMaxSize)
       }
     }
   override val description = "fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb"
@@ -140,7 +141,7 @@ object HashFileXxH64StrategyMethods {
       while (inputStream.available() > 0 && byteCounter < maxSize) {
         val length: Int = inputStream.read(buffer)
         hasher.update(buffer, 0, length)
-        byteCounter += bufferSize
+        byteCounter += length
       }
     }
     finally inputStream.close()

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -107,13 +107,12 @@ final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigH
 }
 
 final case class FingerprintStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
-  private lazy val defaultMaxSize: Long = 10 * 1024 * 1024
   override protected def hash(file: Path): Try[String] = {
     Try {
       file.lastModifiedTime.toEpochMilli.toHexString +
       file.size.toHexString +
-      // Only check first 10 MB for performance reasons
-      HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = defaultMaxSize)
+      // Only check first 10 MB (10485760 bytes) for performance reasons
+      HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10485760L)
       }
     }
   override val description = "fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb"

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -147,8 +147,6 @@ object HashFileXxH64StrategyMethods {
         byteCounter += length
       }
     }
-    catch {case e: Exception => throw e
-           case t: Throwable => throw t}
     finally inputStream.close()
     // Long.toHexString does not add leading zero's
     f"%%16s".format(hasher.getValue.toHexString).replace(" ", "0")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -28,7 +28,7 @@ object ConfigHashingStrategy {
         case "md5" => HashFileMd5Strategy(checkSiblingMd5)
         case "path+modtime" => HashPathModTimeStrategy(checkSiblingMd5)
         case "xxh64" => HashFileXxH64Strategy(checkSiblingMd5)
-        case "hpc" => HpcStrategy(checkSiblingMd5)
+        case "fingerprint" => FingerprintStrategy(checkSiblingMd5)
         case what =>
           logger.warn(s"Unrecognized hashing strategy $what.")
           HashPathStrategy(checkSiblingMd5)
@@ -106,7 +106,7 @@ final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigH
   override val description = "hash file content with xxh64"
 }
 
-final case class HpcStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
+final case class FingerprintStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
   override protected def hash(file: Path): Try[String] = {
     Try {
       file.lastModifiedTime.toEpochMilli.toHexString +
@@ -115,7 +115,7 @@ final case class HpcStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStra
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10 * 1024 * 1024)
       }
     }
-  override val description = "check size, last modified time and hash first 10 mb of file content with xxh64"
+  override val description = "fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb"
 }
 
 object HashFileXxH64StrategyMethods {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -100,13 +100,13 @@ final case class HashFileMd5Strategy(checkSiblingMd5: Boolean) extends ConfigHas
 
 final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
   override protected def hash(file: Path): Try[String] = {
-    tryWithResource(() => file.newInputStream) {HashFileXxH64Strategy.xxh64sum(_)}
+    tryWithResource(() => file.newInputStream) {HashFileXxH64StrategyMethods.xxh64sum(_)}
   }
   override val description = "hash file content with xxh64"
 
 }
 
-object HashFileXxH64Strategy {
+object HashFileXxH64StrategyMethods {
   // For more information about the choice of buffer size: https://github.com/rhpvorderman/hashtest/
   private lazy val defaultBufferSize: Int = 128 * 1024
   private lazy val xxhashFactory: XXHashFactory = XXHashFactory.fastestInstance()

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -143,6 +143,8 @@ object HashFileXxH64StrategyMethods {
         byteCounter += length
       }
     }
+    catch {case e: Exception => throw e
+           case t: Throwable => throw t}
     finally inputStream.close()
     // Long.toHexString does not add leading zero's
     f"%%16s".format(hasher.getValue.toHexString).replace(" ", "0")

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -109,9 +109,12 @@ final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigH
 final case class FingerprintStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
   override protected def hash(file: Path): Try[String] = {
     Try {
+      // Calculate the xxh64 hash of last modified time and filesize. These are NOT added, as it will lead to loss of
+      // information. Instead their hexstrings are concatenated and then hashed.
       HashFileXxH64StrategyMethods.xxh64sumString(file.lastModifiedTime.toEpochMilli.toHexString +
       file.size.toHexString) +
-      // Only check first 10 MB (10485760 bytes) for performance reasons
+      // Only check first 10 MB (10485760 bytes) for performance reasons. 100 MB will take to much time on network file
+      // systems. 1 MB might not be unique enough.
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10485760L)
       }
     }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -128,6 +128,7 @@ object HashFileXxH64StrategyMethods {
     * Returns the xxh64sum of an input stream. The input stream is read in a buffered way.
     * @param inputStream an input Stream
     * @param bufferSize the size in bytes for the buffer.
+    * @param maxSize, only calculate the hash for the first maxSize bytes. Must be a multiply of bufferSize.
     * @return A hex string of the digest.
     */
   def xxh64sum(inputStream: InputStream,

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -22,10 +22,10 @@ object ConfigHashingStrategy {
   def apply(hashingConfig: Config): ConfigHashingStrategy = {
       val checkSiblingMd5 = hashingConfig.as[Option[Boolean]]("check-sibling-md5").getOrElse(false)
 
-      // Fingerprint strategy by default checks the first 10 MB (10485760 bytes) for performance reasons.
+      // Fingerprint strategy by default checks the first 10 MiB (10485760 bytes) for performance reasons.
       // 100 MB will take to much time on network file systems. 1 MB might not be unique enough.
       // The value is user configurable.
-      lazy val fingerprintSize = hashingConfig.as[Option[Long]]("fingerprint-size").getOrElse(10485760L)
+      lazy val fingerprintSize = hashingConfig.as[Option[Long]]("fingerprint-size").getOrElse(10L * 1024 * 1024)
 
       hashingConfig.as[Option[String]]("hashing-strategy").getOrElse("file") match {
         case "path" => HashPathStrategy(checkSiblingMd5)

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -21,6 +21,10 @@ object ConfigHashingStrategy {
 
   def apply(hashingConfig: Config): ConfigHashingStrategy = {
       val checkSiblingMd5 = hashingConfig.as[Option[Boolean]]("check-sibling-md5").getOrElse(false)
+
+      // Fingerprint strategy by default checks the first 10 MB (10485760 bytes) for performance reasons.
+      // 100 MB will take to much time on network file systems. 1 MB might not be unique enough.
+      // The value is user configurable.
       lazy val fingerprintSize = hashingConfig.as[Option[Long]]("fingerprint-size").getOrElse(10485760L)
 
       hashingConfig.as[Option[String]]("hashing-strategy").getOrElse("file") match {
@@ -114,8 +118,6 @@ final case class FingerprintStrategy(checkSiblingMd5: Boolean, fingerprintSize: 
       // information. Instead their hexstrings are concatenated and then hashed.
       HashFileXxH64StrategyMethods.xxh64sumString(file.lastModifiedTime.toEpochMilli.toHexString +
       file.size.toHexString) +
-      // Only check first 10 MB (10485760 bytes) for performance reasons. 100 MB will take to much time on network file
-      // systems. 1 MB might not be unique enough.
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = fingerprintSize)
       }
     }

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -121,7 +121,7 @@ final case class FingerprintStrategy(checkSiblingMd5: Boolean, fingerprintSize: 
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = fingerprintSize)
       }
     }
-  override val description = "fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb"
+  override val description = "fingerprint the file with last modified time, size and a xxh64 hash of the first part of the file"
 }
 
 object HashFileXxH64StrategyMethods {

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -115,7 +115,6 @@ final case class HpcStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStra
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10 * 1024 * 1024)
       }
     }
-
   override val description = "check size, last modified time and hash first 10 mb of file content with xxh64"
 }
 

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategy.scala
@@ -109,14 +109,14 @@ final case class HashFileXxH64Strategy(checkSiblingMd5: Boolean) extends ConfigH
 final case class HpcStrategy(checkSiblingMd5: Boolean) extends ConfigHashingStrategy {
   override protected def hash(file: Path): Try[String] = {
     Try {
-      file.lastModifiedTime.hashCode().toHexString +
+      file.lastModifiedTime.toEpochMilli.toHexString +
       file.size.toHexString +
       // Only check first 10 MB for performance reasons
       HashFileXxH64StrategyMethods.xxh64sum(file.newInputStream, maxSize = 10 * 1024 * 1024)
       }
     }
 
-  override val description = "Check size, last modified time and hash first 10 mb of file content with xxh64"
+  override val description = "check size, last modified time and hash first 10 mb of file content with xxh64"
 }
 
 object HashFileXxH64StrategyMethods {

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.specs2.mock.Mockito
 import wom.values.WomSingleFile
-
+import net.jpountz.xxhash.XXHashFactory
 import scala.util.Success
 
 class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenPropertyChecks with Mockito with BeforeAndAfterAll {
@@ -21,10 +21,11 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
   behavior of "ConfigHashingStrategy"
 
   val steak = "Steak"
-  val steakHash = DigestUtils.md5Hex(steak)
+  val steakMd5 = DigestUtils.md5Hex(steak)
+  val steakXxh64 = XXHashFactory.fastestInstance().hash64().hash(steak.getBytes, 0, steak.length, 0)
   val file = DefaultPathBuilder.createTempFile()
   val symLinksDir = DefaultPathBuilder.createTempDirectory("sym-dir")
-  val pathHash = DigestUtils.md5Hex(file.pathAsString)
+  val pathMd5 = DigestUtils.md5Hex(file.pathAsString)
   val md5File = file.sibling(s"${file.name}.md5")
   // Not the md5 value of "Steak". This is intentional so we can verify which hash is used depending on the strategy
   val md5FileHash = "103508832bace55730c8ee8d89c1a45f"
@@ -81,9 +82,9 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     val table = Table(
       ("check", "withMd5", "expected"),
       (true, true, md5FileHash),
-      (false, true, pathHash),
-      (true, false, pathHash),
-      (false, false, pathHash)
+      (false, true, pathMd5),
+      (true, false, pathMd5),
+      (false, false, pathMd5)
     )
 
     forAll(table) { (check, withMd5, expected) =>
@@ -167,9 +168,9 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     val table = Table(
       ("check", "withMd5", "expected"),
       (true, true, md5FileHash),
-      (false, true, steakHash),
-      (true, false, steakHash),
-      (false, false, steakHash)
+      (false, true, steakMd5),
+      (true, false, steakMd5),
+      (false, false, steakMd5)
     )
 
     forAll(table) { (check, withMd5, expected) =>

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -245,13 +245,13 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
 
     checkSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     checkSibling.checkSiblingMd5 shouldBe true
-    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb."
+    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found fingerprint the file with last modified time, size and a xxh64 hash of the first part of the file."
 
     val dontCheckSibling = makeStrategy("fingerprint", Option(false))
 
     dontCheckSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
-    dontCheckSibling.toString shouldBe "Call caching hashing strategy: fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb."
+    dontCheckSibling.toString shouldBe "Call caching hashing strategy: fingerprint the file with last modified time, size and a xxh64 hash of the first part of the file."
 
   }
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -22,7 +22,7 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
 
   val steak = "Steak"
   val steakMd5 = DigestUtils.md5Hex(steak)
-  val steakXxh64 = XXHashFactory.fastestInstance().hash64().hash(steak.getBytes, 0, steak.length, 0)
+  val steakXxh64 = XXHashFactory.fastestInstance().hash64().hash(steak.getBytes, 0, steak.length, 0).toHexString
   val file = DefaultPathBuilder.createTempFile()
   val symLinksDir = DefaultPathBuilder.createTempDirectory("sym-dir")
   val pathMd5 = DigestUtils.md5Hex(file.pathAsString)
@@ -146,22 +146,22 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     }
   }
 
-  it should "create a file hashing strategy from config" in {
+  it should "create a md5 hashing strategy from config" in {
     val defaultSibling = makeStrategy("file")
     defaultSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     defaultSibling.checkSiblingMd5 shouldBe false
 
-    val checkSibling = makeStrategy("file", Option(true))
+    val checkSibling = makeStrategy("md5", Option(true))
 
     checkSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     checkSibling.checkSiblingMd5 shouldBe true
-    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found hash file content."
+    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found hash file content with md5."
 
     val dontCheckSibling = makeStrategy("file", Option(false))
 
     dontCheckSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
-    dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content."
+    dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content with md5."
   }
 
   it should "have a file hashing strategy and use md5 sibling file when appropriate" in {
@@ -205,7 +205,7 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content."
   }
 
-  it should "have a file hashing strategy and use md5 sibling file when appropriate" in {
+  it should "have a xxh64 hashing strategy and use md5 sibling file when appropriate" in {
     val table = Table(
       ("check", "withMd5", "expected"),
       (true, true, md5FileHash),

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -228,25 +228,25 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     }
   }
 
-  it should "create a hpc strategy from config" in {
-    val defaultSibling = makeStrategy("hpc")
-    defaultSibling.isInstanceOf[HpcStrategy] shouldBe true
+  it should "create a fingerprint strategy from config" in {
+    val defaultSibling = makeStrategy("fingerprint")
+    defaultSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     defaultSibling.checkSiblingMd5 shouldBe false
 
-    val checkSibling = makeStrategy("hpc", Option(true))
+    val checkSibling = makeStrategy("fingerprint", Option(true))
 
-    checkSibling.isInstanceOf[HpcStrategy] shouldBe true
+    checkSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     checkSibling.checkSiblingMd5 shouldBe true
-    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found check size, last modified time and hash first 10 mb of file content with xxh64."
+    checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb."
 
-    val dontCheckSibling = makeStrategy("hpc", Option(false))
+    val dontCheckSibling = makeStrategy("fingerprint", Option(false))
 
-    dontCheckSibling.isInstanceOf[HpcStrategy] shouldBe true
+    dontCheckSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
-    dontCheckSibling.toString shouldBe "Call caching hashing strategy: check size, last modified time and hash first 10 mb of file content with xxh64."
+    dontCheckSibling.toString shouldBe "Call caching hashing strategy: fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb."
   }
 
-  it should "have a hpc strategy and use md5 sibling file when appropriate" in {
+  it should "have a fingerprint strategy and use md5 sibling file when appropriate" in {
     val hpcHash = file.lastModifiedTime.toEpochMilli.toHexString + file.size.toHexString + steakXxh64
     val table = Table(
       ("check", "withMd5", "expected"),
@@ -258,7 +258,7 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
 
     forAll(table) { (check, withMd5, expected) =>
       md5File.delete(swallowIOExceptions = true)
-      val checkSibling = makeStrategy("hpc", Option(check))
+      val checkSibling = makeStrategy("fingerprint", Option(check))
 
       checkSibling.getHash(mockRequest(withMd5, symlink = false), mock[LoggingAdapter]) shouldBe Success(expected)
 

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -228,9 +228,18 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
   }
 
   it should "create a fingerprint strategy from config" in {
-    val defaultSibling = makeStrategy("fingerprint")
-    defaultSibling.isInstanceOf[FingerprintStrategy] shouldBe true
-    defaultSibling.checkSiblingMd5 shouldBe false
+    val defaultFingerprint:  FingerprintStrategy = makeStrategy("fingerprint").asInstanceOf[FingerprintStrategy]
+    defaultFingerprint.isInstanceOf[FingerprintStrategy] shouldBe true
+    defaultFingerprint.checkSiblingMd5 shouldBe false
+    defaultFingerprint.fingerprintSize shouldBe 10 * 1024 * 1024
+
+    val config = ConfigFactory.parseString(
+      """|hashing-strategy: "fingerprint"
+         |fingerprint-size: 123456789
+         |""".stripMargin)
+    val otherFingerprint: FingerprintStrategy = ConfigHashingStrategy.apply(config).asInstanceOf[FingerprintStrategy]
+    otherFingerprint.fingerprintSize shouldBe 123456789
+    otherFingerprint.isInstanceOf[FingerprintStrategy] shouldBe true
 
     val checkSibling = makeStrategy("fingerprint", Option(true))
 
@@ -243,6 +252,7 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     dontCheckSibling.isInstanceOf[FingerprintStrategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
     dontCheckSibling.toString shouldBe "Call caching hashing strategy: fingerprint the file with last modified time, size and a xxh64 hash of the first 10 mb."
+
   }
 
   it should "have a fingerprint strategy and use md5 sibling file when appropriate" in {

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -147,18 +147,18 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
 
   it should "create a file hashing strategy from config" in {
     val defaultSibling = makeStrategy("file")
-    defaultSibling.isInstanceOf[HashFileStrategy] shouldBe true
+    defaultSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     defaultSibling.checkSiblingMd5 shouldBe false
 
     val checkSibling = makeStrategy("file", Option(true))
 
-    checkSibling.isInstanceOf[HashFileStrategy] shouldBe true
+    checkSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     checkSibling.checkSiblingMd5 shouldBe true
     checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found hash file content."
 
     val dontCheckSibling = makeStrategy("file", Option(false))
 
-    dontCheckSibling.isInstanceOf[HashFileStrategy] shouldBe true
+    dontCheckSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
     dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content."
   }

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/impl/sfs/config/ConfigHashingStrategySpec.scala
@@ -192,17 +192,17 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
     defaultSibling.isInstanceOf[HashFileXxH64Strategy] shouldBe true
     defaultSibling.checkSiblingMd5 shouldBe false
 
-    val checkSibling = makeStrategy("file", Option(true))
+    val checkSibling = makeStrategy("xxh64", Option(true))
 
     checkSibling.isInstanceOf[HashFileXxH64Strategy] shouldBe true
     checkSibling.checkSiblingMd5 shouldBe true
     checkSibling.toString shouldBe "Call caching hashing strategy: Check first for sibling md5 and if not found hash file content with xxh64."
 
-    val dontCheckSibling = makeStrategy("file", Option(false))
+    val dontCheckSibling = makeStrategy("xxh64", Option(false))
 
-    dontCheckSibling.isInstanceOf[HashFileMd5Strategy] shouldBe true
+    dontCheckSibling.isInstanceOf[HashFileXxH64Strategy] shouldBe true
     dontCheckSibling.checkSiblingMd5 shouldBe false
-    dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content."
+    dontCheckSibling.toString shouldBe "Call caching hashing strategy: hash file content with xxh64."
   }
 
   it should "have a xxh64 hashing strategy and use md5 sibling file when appropriate" in {
@@ -216,7 +216,7 @@ class ConfigHashingStrategySpec extends FlatSpec with Matchers with TableDrivenP
 
     forAll(table) { (check, withMd5, expected) =>
       md5File.delete(swallowIOExceptions = true)
-      val checkSibling = makeStrategy("file", Option(check))
+      val checkSibling = makeStrategy("xxh64", Option(check))
 
       checkSibling.getHash(mockRequest(withMd5, symlink = false), mock[LoggingAdapter]) shouldBe Success(expected)
 


### PR DESCRIPTION
## Call-caching problems with path+modtime
I have been doing some call-caching benchmarking on the [BioWDL RNA-seq](https://github.com/biowdl/RNA-seq) pipeline and it turns out any `path` or `path+modtime` strategies do not work with containers. As is reported in these issues: #5405, #5370, #5346 . @cmarkello, @illusional, I am sorry that I insisted that `path+modtime` did work. I was using less complex workflows that did not have this problem at the time.

## Call-caching problems with file strategy
The `file` strategy does work as it uses md5sums in order to calculate the file hash. An unfortunate side effect of this is that md5 uses massive system resources. On HPC systems that are the target for the sfs-backend, this is a big problem. Cromwell will be run from a submit node on the system and greedily grab all processing power on the submit node to calculate all the md5sums. 

## Md5sums
Md5sums are reliable hashes for file integrity, but this was not their intended purpose. Md5sum was intended as a cryptographic hash. A cryptographic hash has the following properties (wikipedia):
1. it is deterministic, meaning that the same message always results in the same hash
2. it is quick to compute the hash value for any given message
3. it is infeasible to generate a message that yields a given hash value
4. it is infeasible to find two different messages with the same hash value
5. a small change to a message should change the hash value so extensively that the new hash value appears uncorrelated with the old hash value (avalanche effect)

I contest point 2, in that many cryptographic explicitly strife for being slow to calculate in order to negate brute force attempts.
Anyway: for call caching we only need points 1. and 4. All the rest is unnecessary ballast. 

## xxHash
Luckily there is a hashing algorithm that is designed explicitly for content hashing only. It was made to generate reliably different hashes for file content as fast as possible. It's called [xxHash](https://www.xxhash.com).

There are Java implementations available and I did [some extensive benchmarking](https://github.com/rhpvorderman/hashtest/) to find out which one was best. The xxh64 (xxhash for 64 bit machines) algorithm was 15 times faster than the java implementation of md5 we currently use in Cromwell.

This PR implements the xxhash algorithm for call-caching in Cromwell:

+ The default strategy will still be using md5 for backwards compatibility.
+ A new `xxh64` strategy is implemented using the 64-bit xxhash algorithm. (I didn't make the xxh32 algorithm available. Is there any Cromwell server still running on 32-bit?) This can be set in the call caching configuration.
+ A new `fingerprint` strategy suggested by @illusional, which takes the modtime, size and a xxh64 hash of the first 10 mb of the file to create a virtually unique fingerprint.
+ The `file` strategy get's a new alias `md5` which is more clear. Although `file` will still work in the config for backwards compatibility. 

I feel we should move to xxh64 as default after it has proven itself in a few releases. The speed-up is an order of magnitude.


