### PR TITLE
Work on SQLite support

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -82,6 +82,7 @@
     <include file="changesets/mariadb_engine_schema.xml" relativeToChangelogFile="true" />
     <include file="changesets/resync_engine_schema.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_job_store_ids.xml" relativeToChangelogFile="true" />
+    <include file="changesets/sqlite_engine_schema.xml" relativeToChangelogFile="true" />
     <!-- REMINDER!
       Before appending here, did you remember to include the 'objectQuotingStrategy="QUOTE_ALL_OBJECTS"' line in your changeset/xyz.xml...?
     -->

--- a/database/migration/src/main/resources/changesets/sqlite_engine_schema.xml
+++ b/database/migration/src/main/resources/changesets/sqlite_engine_schema.xml
@@ -1,0 +1,236 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="rhpvorderman" id="sqlite-engine-init" dbms="sqlite">
+        <createTable tableName="CALL_CACHING_AGGREGATION_ENTRY">
+            <column autoIncrement="true" name="CALL_CACHING_AGGREGATION_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_AGGREGATION_ENTRY"/>
+            </column>
+            <column name="CALL_CACHING_ENTRY_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="BASE_AGGREGATION" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="INPUT_FILES_AGGREGATION" type="TEXT"/>
+        </createTable>
+
+        <createTable tableName="CALL_CACHING_DETRITUS_ENTRY">
+            <column autoIncrement="true" name="CALL_CACHING_DETRITUS_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_DETRITUS_ENTRY"/>
+            </column>
+            <column name="DETRITUS_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="DETRITUS_VALUE" type="TEXT"/>
+            <column name="CALL_CACHING_ENTRY_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="CALL_CACHING_ENTRY">
+            <column autoIncrement="true" name="CALL_CACHING_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_FULLY_QUALIFIED_NAME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_INDEX" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="RETURN_CODE" type="INTEGER"/>
+            <column defaultValueBoolean="true" name="ALLOW_RESULT_REUSE" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueComputed="NULL" name="JOB_ATTEMPT" type="INTEGER"/>
+        </createTable>
+
+        <createTable tableName="CALL_CACHING_HASH_ENTRY">
+            <column autoIncrement="true" name="CALL_CACHING_HASH_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_HASH_ENTRY"/>
+            </column>
+            <column name="HASH_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="HASH_VALUE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_CACHING_ENTRY_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="CALL_CACHING_SIMPLETON_ENTRY">
+            <column autoIncrement="true" name="CALL_CACHING_SIMPLETON_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CALL_CACHING_SIMPLETON_ENTRY"/>
+            </column>
+            <column name="SIMPLETON_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SIMPLETON_VALUE" type="TEXT"/>
+            <column name="WDL_TYPE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_CACHING_ENTRY_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="DOCKER_HASH_STORE_ENTRY">
+            <column autoIncrement="true" name="DOCKER_HASH_STORE_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_DOCKER_HASH_STORE_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="DOCKER_TAG" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="DOCKER_HASH" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueComputed="NULL" name="DOCKER_SIZE" type="INTEGER"/>
+        </createTable>
+
+        <createTable tableName="JOB_KEY_VALUE_ENTRY">
+            <column autoIncrement="true" name="JOB_KEY_VALUE_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_JOB_KEY_VALUE_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_FULLY_QUALIFIED_NAME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_INDEX" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_ATTEMPT" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="STORE_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="STORE_VALUE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="JOB_STORE_ENTRY">
+            <column autoIncrement="true" name="JOB_STORE_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_JOB_STORE_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_FULLY_QUALIFIED_NAME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_INDEX" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_ATTEMPT" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_SUCCESSFUL" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="RETURN_CODE" type="INTEGER"/>
+            <column name="EXCEPTION_MESSAGE" type="TEXT"/>
+            <column name="RETRYABLE_FAILURE" type="INTEGER"/>
+        </createTable>
+
+        <createTable tableName="JOB_STORE_SIMPLETON_ENTRY">
+            <column autoIncrement="true" name="JOB_STORE_SIMPLETON_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_JOB_STORE_SIMPLETON_ENTRY"/>
+            </column>
+            <column name="SIMPLETON_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SIMPLETON_VALUE" type="TEXT"/>
+            <column name="WDL_TYPE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="JOB_STORE_ENTRY_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="SUB_WORKFLOW_STORE_ENTRY">
+            <column autoIncrement="true" name="SUB_WORKFLOW_STORE_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_SUB_WORKFLOW_STORE_ENTRY"/>
+            </column>
+            <column name="ROOT_WORKFLOW_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="PARENT_WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_FULLY_QUALIFIED_NAME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_INDEX" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_ATTEMPT" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SUB_WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <createTable tableName="WORKFLOW_STORE_ENTRY">
+            <column autoIncrement="true" name="WORKFLOW_STORE_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_WORKFLOW_STORE_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="WORKFLOW_DEFINITION" type="TEXT"/>
+            <column name="WORKFLOW_INPUTS" type="TEXT"/>
+            <column name="WORKFLOW_OPTIONS" type="TEXT"/>
+            <column name="WORKFLOW_STATE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SUBMISSION_TIME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="IMPORTS_ZIP" type="BLOB"/>
+            <column name="CUSTOM_LABELS" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="WORKFLOW_TYPE" type="TEXT"/>
+            <column name="WORKFLOW_TYPE_VERSION" type="TEXT"/>
+            <column name="WORKFLOW_ROOT" type="TEXT"/>
+            <column name="CROMWELL_ID" type="TEXT"/>
+            <column name="HEARTBEAT_TIMESTAMP" type="TEXT"/>
+            <column name="WORKFLOW_URL" type="TEXT"/>
+            <column name="HOG_GROUP" type="TEXT"/>
+        </createTable>
+
+        <createIndex indexName="IX_CALL_CACHING_AGGREGATION_ENTRY_BA_IFA" tableName="CALL_CACHING_AGGREGATION_ENTRY">
+            <column name="BASE_AGGREGATION"/>
+            <column name="INPUT_FILES_AGGREGATION"/>
+        </createIndex>
+
+        <createIndex indexName="IX_JOB_STORE_ENTRY_WEU" tableName="JOB_STORE_ENTRY">
+            <column name="WORKFLOW_EXECUTION_UUID"/>
+        </createIndex>
+
+        <createIndex indexName="IX_SUB_WORKFLOW_STORE_ENTRY_PWEU" tableName="SUB_WORKFLOW_STORE_ENTRY">
+            <column name="PARENT_WORKFLOW_EXECUTION_UUID"/>
+        </createIndex>
+
+        <createIndex indexName="IX_WORKFLOW_STORE_ENTRY_WS" tableName="WORKFLOW_STORE_ENTRY">
+            <column name="WORKFLOW_STATE"/>
+        </createIndex>
+
+    </changeSet>
+</databaseChangeLog>

--- a/database/migration/src/main/resources/metadata_changesets/sqlite_metadata_schema.xml
+++ b/database/migration/src/main/resources/metadata_changesets/sqlite_metadata_schema.xml
@@ -1,0 +1,131 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-1" dbms="sqlite">
+        <createTable tableName="CUSTOM_LABEL_ENTRY">
+            <column autoIncrement="true" name="CUSTOM_LABEL_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_CUSTOM_LABEL_ENTRY"/>
+            </column>
+            <column name="CUSTOM_LABEL_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CUSTOM_LABEL_VALUE" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-2" dbms="sqlite">
+        <createTable tableName="METADATA_ENTRY">
+            <column autoIncrement="true" name="METADATA_JOURNAL_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_METADATA_JOURNAL"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="METADATA_KEY" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CALL_FQN" type="TEXT"/>
+            <column name="JOB_SCATTER_INDEX" type="INTEGER"/>
+            <column name="JOB_RETRY_ATTEMPT" type="INTEGER"/>
+            <column name="METADATA_VALUE" type="TEXT"/>
+            <column name="METADATA_TIMESTAMP" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="METADATA_VALUE_TYPE" type="TEXT"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-3" dbms="sqlite">
+        <createTable tableName="SUMMARY_STATUS_ENTRY">
+            <column autoIncrement="true" name="SUMMARY_STATUS_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_SUMMARY_STATUS_ENTRY"/>
+            </column>
+            <column name="SUMMARY_NAME" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="SUMMARY_POSITION" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-4" dbms="sqlite">
+        <createTable tableName="WORKFLOW_METADATA_SUMMARY_ENTRY">
+            <column autoIncrement="true" name="WORKFLOW_METADATA_SUMMARY_ENTRY_ID" type="INTEGER">
+                <constraints primaryKey="true" primaryKeyName="PK_WORKFLOW_METADATA_SUMMARY_ENTRY"/>
+            </column>
+            <column name="WORKFLOW_EXECUTION_UUID" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="WORKFLOW_NAME" type="TEXT"/>
+            <column name="WORKFLOW_STATUS" type="TEXT"/>
+            <column name="START_TIMESTAMP" type="TEXT"/>
+            <column name="END_TIMESTAMP" type="TEXT"/>
+            <column name="SUBMISSION_TIMESTAMP" type="TEXT"/>
+            <column name="PARENT_WORKFLOW_EXECUTION_UUID" type="TEXT"/>
+            <column name="ROOT_WORKFLOW_EXECUTION_UUID" type="TEXT"/>
+            <column name="METADATA_ARCHIVE_STATUS" type="TEXT">
+                <constraints nullable="true" />
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="summary_queue_table" author="rhpvorderman" dbms="sqlite">
+        <createTable tableName="SUMMARY_QUEUE_ENTRY">
+            <column name="METADATA_JOURNAL_ID" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+    </createTable>
+    </changeSet>
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-5" dbms="sqlite">
+        <createIndex indexName="IX_CUSTOM_LABEL_ENTRY_CLK_CLV" tableName="CUSTOM_LABEL_ENTRY">
+            <column name="CUSTOM_LABEL_KEY"/>
+            <column name="CUSTOM_LABEL_VALUE"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-6" dbms="sqlite">
+        <createIndex indexName="IX_WORKFLOW_METADATA_SUMMARY_ENTRY_PWEU" tableName="WORKFLOW_METADATA_SUMMARY_ENTRY">
+            <column name="PARENT_WORKFLOW_EXECUTION_UUID"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-7" dbms="sqlite">
+        <createIndex indexName="IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU" tableName="WORKFLOW_METADATA_SUMMARY_ENTRY">
+            <column name="ROOT_WORKFLOW_EXECUTION_UUID"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-8" dbms="sqlite">
+        <createIndex indexName="IX_WORKFLOW_METADATA_SUMMARY_ENTRY_WN" tableName="WORKFLOW_METADATA_SUMMARY_ENTRY">
+            <column name="WORKFLOW_NAME"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-9" dbms="sqlite">
+        <createIndex indexName="IX_WORKFLOW_METADATA_SUMMARY_ENTRY_WS" tableName="WORKFLOW_METADATA_SUMMARY_ENTRY">
+            <column name="WORKFLOW_STATUS"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="rhpvorderman" id="sqlite-metadata-init-10" dbms="sqlite">
+        <createIndex indexName="METADATA_WORKFLOW_IDX" tableName="METADATA_ENTRY">
+            <column name="WORKFLOW_EXECUTION_UUID"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="metadata_archive_status_index" author="cjllanwarne" dbms="sqlite">
+        <createIndex indexName="IX_WORKFLOW_METADATA_SUMMARY_ENTRY_MAS"
+                     tableName="WORKFLOW_METADATA_SUMMARY_ENTRY" unique="false">
+            <column name="METADATA_ARCHIVE_STATUS"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/database/migration/src/main/resources/metadata_changesets/summarization_queue_table.xml
+++ b/database/migration/src/main/resources/metadata_changesets/summarization_queue_table.xml
@@ -37,7 +37,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="summary_queue_initialization_postgresql" author="gsterin" dbms="postgresql">
+    <changeSet id="summary_queue_initialization_postgresql" author="gsterin" dbms="postgresql,sqlite">
         <preConditions onFail="MARK_RAN">
             <!-- if METADATA_ENTRY table not exists yet, then skip this changeset -->
             <tableExists tableName="METADATA_ENTRY"/>

--- a/database/migration/src/main/resources/sql_metadata_changelog.xml
+++ b/database/migration/src/main/resources/sql_metadata_changelog.xml
@@ -14,6 +14,7 @@
     <include file="metadata_changesets/postgresql_metadata_schema.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/mariadb_metadata_schema.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/add_metadata_archive_status.xml" relativeToChangelogFile="true" />
+    <include file="metadata_changesets/sqlite_metadata_schema.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table_add_primary_key.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/SlickDatabase.scala
@@ -167,6 +167,7 @@ abstract class SlickDatabase(override val originalDatabaseConfig: Config) extend
                                         isolationLevel: TransactionIsolation = TransactionIsolation.RepeatableRead,
                                         timeout: Duration = Duration.Inf): Future[R] = {
     dataAccess.driver match {
+      // SQLite supports only TRANSACTION_SERIALIZABLE and TRANSACTION_READ_UNCOMMITTED
       case SQLiteProfile => runActionInternal(action.transactionally, timeout = timeout)
       case _ => runActionInternal(action.transactionally.withTransactionIsolation(isolationLevel), timeout = timeout)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,6 +86,7 @@ object Dependencies {
   private val simulacrumV = "0.15.0"
   private val slf4jV = "1.7.25"
   private val slickCatsV = "0.9.0"
+  private val sqliteV = "3.30.1"
   private val testContainersScalaV = "0.35.2"
 
   /* If you're about to update our Slick version:
@@ -354,7 +355,8 @@ object Dependencies {
     "org.hsqldb" % "hsqldb" % hsqldbV,
     "org.mariadb.jdbc" % "mariadb-java-client" % mariadbV,
     "mysql" % "mysql-connector-java" % mysqlV,
-    "org.postgresql" % "postgresql" % postgresV
+    "org.postgresql" % "postgresql" % postgresV,
+    "org.xerial" % "sqlite-jdbc" % sqliteV,
   )
 
   private val refinedTypeDependenciesList = List(

--- a/services/src/test/scala/cromwell/services/database/DatabasePlatform.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabasePlatform.scala
@@ -24,3 +24,7 @@ case object MysqlDatabasePlatform extends DatabasePlatform {
 case object PostgresqlDatabasePlatform extends DatabasePlatform {
   override val name: String = "PostgreSQL"
 }
+
+case object SQLiteDatabasePlatform extends DatabasePlatform {
+  override val name: String = "SQLite"
+}

--- a/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
@@ -20,6 +20,7 @@ object DatabaseSystem {
     MysqlLatestDatabaseSystem,
     PostgresqlEarliestDatabaseSystem,
     PostgresqlLatestDatabaseSystem,
+    SqliteDatabaseSystem,
   )
 }
 

--- a/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
@@ -20,7 +20,7 @@ object DatabaseSystem {
     MysqlLatestDatabaseSystem,
     PostgresqlEarliestDatabaseSystem,
     PostgresqlLatestDatabaseSystem,
-    SqliteDatabaseSystem,
+    SQLiteDatabaseSystem,
   )
 }
 
@@ -29,7 +29,7 @@ case object HsqldbDatabaseSystem extends DatabaseSystem {
   override val platform: HsqldbDatabasePlatform.type = HsqldbDatabasePlatform
 }
 
-case object SqliteDatabaseSystem extends DatabaseSystem {
+case object SQLiteDatabaseSystem extends DatabaseSystem {
   override val name: String = "SQLite"
   override val platform: SQLiteDatabasePlatform.type = SQLiteDatabasePlatform
 }

--- a/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
@@ -28,6 +28,11 @@ case object HsqldbDatabaseSystem extends DatabaseSystem {
   override val platform: HsqldbDatabasePlatform.type = HsqldbDatabasePlatform
 }
 
+case object SqliteDatabaseSystem extends DatabaseSystem {
+  override val name: String = "SQLite"
+  override val platform: SQLiteDatabasePlatform.type = SQLiteDatabasePlatform
+}
+
 sealed trait NetworkDatabaseSystem extends DatabaseSystem {
   val dockerImageVersion: String
 }

--- a/services/src/test/scala/cromwell/services/database/DatabaseTestKit.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabaseTestKit.scala
@@ -110,6 +110,7 @@ object DatabaseTestKit extends StrictLogging {
   def getDatabaseTestContainer(databaseSystem: DatabaseSystem): Option[Container] = {
     databaseSystem match {
       case HsqldbDatabaseSystem => None
+      case SqliteDatabaseSystem => None
       case networkDbSystem: NetworkDatabaseSystem =>
         networkDbSystem.platform match {
           case MariadbDatabasePlatform =>
@@ -157,6 +158,7 @@ object DatabaseTestKit extends StrictLogging {
           case MariadbDatabasePlatform => ("slick.jdbc.MySQLProfile$", "org.mariadb.jdbc.Driver")
           case MysqlDatabasePlatform => ("slick.jdbc.MySQLProfile$", "com.mysql.cj.jdbc.Driver")
           case PostgresqlDatabasePlatform => ("slick.jdbc.PostgresProfile$", "org.postgresql.Driver")
+          case SQLiteDatabasePlatform => ("slick.jdbc.SQLiteProfile$", "org.sqlite.JDBC")
         }
         ConfigFactory.parseString(
           s"""|profile = "$slickProfile"

--- a/services/src/test/scala/cromwell/services/database/LiquibaseComparisonSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/LiquibaseComparisonSpec.scala
@@ -348,6 +348,18 @@ object LiquibaseComparisonSpec {
       ),
     )
 
+  private val SQLiteColumnMapping =
+    ColumnMapping(
+      typeMapping = Map(
+        HsqldbTypeBigInt -> ColumnType("INT8", None),
+        HsqldbTypeBlob -> ColumnType("BLOB", None),
+        HsqldbTypeBoolean -> ColumnType("INTEGER", None),
+        HsqldbTypeClob -> ColumnType("TEXT", None),
+        HsqldbTypeInteger -> ColumnType("INTEGER", None),
+        HsqldbTypeTimestamp -> ColumnType("TEXT", None)
+      )
+    )
+
   /**
     * Returns the column mapping for the DBMS.
     */
@@ -357,6 +369,7 @@ object LiquibaseComparisonSpec {
       case MariadbDatabasePlatform => MariadbColumnMapping
       case MysqlDatabasePlatform => MysqldbColumnMapping
       case PostgresqlDatabasePlatform => PostgresqlColumnMapping
+      case SQLiteDatabasePlatform => SQLiteColumnMapping
     }
   }
 

--- a/services/src/test/scala/cromwell/services/database/QueryTimeoutSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/QueryTimeoutSpec.scala
@@ -56,6 +56,7 @@ class QueryTimeoutSpec extends FlatSpec with Matchers with ScalaFutures {
         // HSQL does not document a SLEEP() function, which is essential for this test
         // The functionality being tested is not relevant to an HSQL user, so the omission is probably acceptable
         None
+      case SQLiteDatabasePlatform => None  // SQLite also does not document a sleep function.
       case MariadbDatabasePlatform =>
         Option((
           "select sleep(10);",

--- a/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/keyvalue/impl/KeyValueDatabaseSpec.scala
@@ -126,6 +126,7 @@ object KeyValueDatabaseSpec {
       case MariadbDatabasePlatform => """\(conn=\d+\) Column 'STORE_VALUE' cannot be null"""
       case MysqlDatabasePlatform => "Column 'STORE_VALUE' cannot be null"
       case PostgresqlDatabasePlatform => """ERROR: null value in column "STORE_VALUE" violates not-null constraint"""
+      case SQLiteDatabasePlatform => """alksdaljkjncoqwe""" // TODO: Get correct error
     }
   }
 
@@ -135,6 +136,7 @@ object KeyValueDatabaseSpec {
       case MariadbDatabasePlatform => classOf[BatchUpdateException]
       case MysqlDatabasePlatform => classOf[BatchUpdateException]
       case PostgresqlDatabasePlatform => classOf[PSQLException]
+      case SQLiteDatabasePlatform => classOf[SQLIntegrityConstraintViolationException]
     }
   }
 }


### PR DESCRIPTION
Dear Cromwell developers,

I am working on SQLite support at the moment. I have been successful in instantiating the database with all the correct tables. In other words the Liquibase migration seems to function fine.

Unfortunately, the LiquibaseComparisonSpec keeps failing with a rather non-descript error:
```
java.lang.NullPointerException was thrown.
java.lang.NullPointerException
	at liquibase.structure.core.Index.setColumns(Index.java:118)
	at liquibase.snapshot.jvm.PrimaryKeySnapshotGenerator.snapshotObject(PrimaryKeySnapshotGenerator.java:80)
	at liquibase.snapshot.jvm.JdbcSnapshotGenerator.snapshot(JdbcSnapshotGenerator.java:66)
...
```
If I write the database to a file, all the correct tables seem to be present (I might have missed one, but the database is certainly populated with a schema).

Now I have been doing some digging and this is the database object that is created:
```
database = {SQLiteDatabase@5510} "null @ jdbc:sqlite::memory:"
 systemTables = {HashSet@5517}  size = 2
 reservedWords = {HashSet@5518}  size = 43
 defaultCatalogName = null
 defaultSchemaName = null
 currentDateTimeFunction = "CURRENT_TIMESTAMP"
 sequenceNextValueFunction = null
 sequenceCurrentValueFunction = null
 dateFunctions = {ArrayList@5520}  size = 1
 unmodifiableDataTypes = {ArrayList@5521}  size = 0
 defaultAutoIncrementStartWith = {BigInteger@5522} "1"
 defaultAutoIncrementBy = {BigInteger@5522} "1"
 unquotedObjectsAreUppercased = null
 quotingStrategy = {ObjectQuotingStrategy@5523} "QUOTE_ALL_OBJECTS"
 caseSensitive = {Boolean@5524} true
 databaseChangeLogTableName = null
 databaseChangeLogLockTableName = null
 liquibaseTablespaceName = null
 liquibaseSchemaName = null
 liquibaseCatalogName = null
 previousAutoCommit = {Boolean@5524} true
 canCacheLiquibaseTableInfo = false
 connection = {JdbcConnection@5525} 
 outputDefaultSchema = true
 outputDefaultCatalog = true
 defaultCatalogSet = false
 attributes = {HashMap@5526}  size = 0
```

`defaultCatalogName` and `defaultSchemaName` are all defined for the HSQLDB database so maybe it is something there?

Anyway it also does not run properly outside of the test configuration. Running cromwell (compiled from this branch) with the following configuration:
```
database {
  profile = "slick.jdbc.SQLiteProfile$"
  db {
    driver = "org.sqlite.JDBC"
    url = "jdbc:sqlite::memory:"
  }
```

Gives the following error:
```
org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (near "for": syntax error)
        at org.sqlite.core.DB.newSQLException(DB.java:941)
        at org.sqlite.core.DB.newSQLException(DB.java:953)
        at org.sqlite.core.DB.throwex(DB.java:918)
```
Which is rather non-descript. 

I have been digging for the entire afternoon, but I can not find the root cause. The other database types seem to work fine without lots of additional configuration, so I did not get much inspiration from that. Could somebody help me out?  I will then do all the rest of the work, write the documentation etc. 

Thanks!

Best regards,
Ruben
