### PR TITLE
Update insecure Netty/Codec version [BA-6371]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   private val mockserverNettyV = "5.5.1"
   private val mouseV = "0.23"
   private val mysqlV = "8.0.15"
-  private val nettyV = "4.1.33.Final"
+  private val nettyV = "4.1.46.Final"
   private val owlApiV = "5.1.9"
   private val paradiseV = "2.1.1"
   private val pegdownV = "1.6.0"


### PR DESCRIPTION
Dump the dependency tree before and after upgrade: 
```
sbt coursierDependencyTree > coursier_dependency_tree_$(date +%s).txt
```

look for all the `:netty-codec:`s, with a dash of `sed` and `sort -u` to squash duplicates:

before:
```
$ grep ':netty-codec:' coursier_dependency_tree_1586897217.txt | sed -E 's/.*:(.*)/\1/' | sort -u
4.1.30.Final -> 4.1.33.Final
4.1.32.Final -> 4.1.33.Final
4.1.33.Final
$
```

after:
```
$ grep ':netty-codec:' coursier_dependency_tree_1586898071.txt | sed -E 's/.*:(.*)/\1/' | sort -u
4.1.32.Final -> 4.1.46.Final
4.1.46.Final
$
```


