### PR TITLE
make a lot of metadata [BA-6417]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/square_lots_of_metadata/square_lots.inputs
+++ b/centaur/src/main/resources/standardTestCases/square_lots_of_metadata/square_lots.inputs
@@ -1,0 +1,4 @@
+{
+   "megadata.base": 200,
+   "megadata.string": "Jamie"
+}

--- a/centaur/src/main/resources/standardTestCases/square_lots_of_metadata/square_lots.wdl
+++ b/centaur/src/main/resources/standardTestCases/square_lots_of_metadata/square_lots.wdl
@@ -1,0 +1,36 @@
+version 1.0
+
+task square_lots {
+    input {
+        Int base
+        String string
+    }
+    command {
+        python <<FIN
+        for row in range(~{base}):
+            print('\t'.join(['~{string}'] * ~{base}))
+        FIN
+    }
+    runtime {
+        docker: "python:latest"
+    }
+    output {
+        Array[Array[String]] outputs = read_tsv(stdout())
+    }
+}
+
+workflow megadata {
+    input {
+        Int base
+        String string
+    }
+    call square_lots { input:
+        base = base,
+        string = string
+    }
+    output {
+        Array[Array[String]] outputs = square_lots.outputs
+    }
+}
+
+


### PR DESCRIPTION
Makes ~ 2 * &lt;base&gt;^2 rows of metadata (~80000 as currently configured) in one burst. I Intentionally did not write a .test for this as I doubt Travis would survive. Not sure where this should live.