### PR TITLE
Partition summarizable from not [BA-6425]

### DIFF
--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -5,6 +5,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb,mariadb,mysql,postgresql">
+        <comment>
+            Delete rows from the summary queue that correspond to metadata that will not be summarized.
+        </comment>
         <sql>
             DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
             INNER JOIN METADATA_ENTRY ON
@@ -19,9 +22,6 @@
                     )
                 )
         </sql>
-        <modifySql dbms="mysql">
-            <append value=" ENGINE=INNODB"/>
-        </modifySql>
     </changeSet>
 
 </databaseChangeLog>

--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -4,7 +4,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb">
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb,postgresql">
         <comment>
             Delete rows from the summary queue that correspond to metadata that will not be summarized.
         </comment>
@@ -24,11 +24,11 @@
         </sql>
     </changeSet>
 
-    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="mariadb,mysql,postgresql">
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="mariadb,mysql">
         <sql>
             DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
                 INNER JOIN METADATA_ENTRY ON
-                SUMMARY_QUEUE_ENTRY.METADATA_JOURNAL_ID = METADATA_ENTRY.METADATA_JOURNAL_ID WHERE NOT(
+                SUMMARY_QUEUE_ENTRY.METADATA_JOURNAL_ID = METADATA_ENTRY.METADATA_JOURNAL_ID WHERE NOT (
                     METADATA_ENTRY.CALL_FQN IS NULL AND
                     METADATA_ENTRY.JOB_SCATTER_INDEX IS NULL AND
                     METADATA_ENTRY.JOB_RETRY_ATTEMPT IS NULL AND (

--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -4,9 +4,9 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb,postgresql">
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb">
         <comment>
-            Delete rows from the summary queue that correspond to metadata that will not be summarized.
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
         </comment>
         <sql>
             DELETE FROM SUMMARY_QUEUE_ENTRY queue WHERE queue.METADATA_JOURNAL_ID NOT IN (
@@ -24,7 +24,30 @@
         </sql>
     </changeSet>
 
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="postgresql">
+        <comment>
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
+        </comment>
+        <sql>
+            DELETE FROM "SUMMARY_QUEUE_ENTRY" queue WHERE queue."METADATA_JOURNAL_ID" NOT IN (
+                SELECT metadata."METADATA_JOURNAL_ID" FROM "METADATA_ENTRY" metadata WHERE
+                    metadata."METADATA_JOURNAL_ID" = queue."METADATA_JOURNAL_ID" AND
+                    metadata."CALL_FQN" IS NULL AND
+                    metadata."JOB_SCATTER_INDEX" IS NULL AND
+                    metadata."JOB_RETRY_ATTEMPT" IS NULL AND (
+                        metadata."METADATA_KEY" in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        metadata."METADATA_KEY" LIKE 'labels%'
+                    )
+            )
+        </sql>
+    </changeSet>
+
     <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="mariadb,mysql">
+        <comment>
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
+        </comment>
         <sql>
             DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
                 INNER JOIN METADATA_ENTRY ON

--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb,mariadb,mysql,postgresql">
+        <sql>
+            DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
+            INNER JOIN METADATA_ENTRY ON
+                SUMMARY_QUEUE_ENTRY.METADATA_JOURNAL_ID = METADATA_ENTRY.METADATA_JOURNAL_ID WHERE NOT(
+                    METADATA_ENTRY.CALL_FQN IS NULL AND
+                    METADATA_ENTRY.JOB_SCATTER_INDEX IS NULL AND
+                    METADATA_ENTRY.JOB_RETRY_ATTEMPT IS NULL AND (
+                        METADATA_ENTRY.METADATA_KEY in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        METADATA_ENTRY.METADATA_KEY LIKE 'labels%'
+                    )
+                )
+        </sql>
+        <modifySql dbms="mysql">
+            <append value=" ENGINE=INNODB"/>
+        </modifySql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -4,13 +4,30 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb,mariadb,mysql,postgresql">
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb">
         <comment>
             Delete rows from the summary queue that correspond to metadata that will not be summarized.
         </comment>
         <sql>
+            DELETE FROM SUMMARY_QUEUE_ENTRY queue WHERE queue.METADATA_JOURNAL_ID NOT IN (
+                SELECT metadata.METADATA_JOURNAL_ID FROM METADATA_ENTRY metadata WHERE
+                    metadata.METADATA_JOURNAL_ID = queue.METADATA_JOURNAL_ID AND
+                    metadata.CALL_FQN IS NULL AND
+                    metadata.JOB_SCATTER_INDEX IS NULL AND
+                    metadata.JOB_RETRY_ATTEMPT IS NULL AND (
+                        metadata.METADATA_KEY in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        metadata.METADATA_KEY LIKE 'labels%'
+                    )
+                )
+        </sql>
+    </changeSet>
+
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="mariadb,mysql,postgresql">
+        <sql>
             DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
-            INNER JOIN METADATA_ENTRY ON
+                INNER JOIN METADATA_ENTRY ON
                 SUMMARY_QUEUE_ENTRY.METADATA_JOURNAL_ID = METADATA_ENTRY.METADATA_JOURNAL_ID WHERE NOT(
                     METADATA_ENTRY.CALL_FQN IS NULL AND
                     METADATA_ENTRY.JOB_SCATTER_INDEX IS NULL AND

--- a/database/migration/src/main/resources/sql_metadata_changelog.xml
+++ b/database/migration/src/main/resources/sql_metadata_changelog.xml
@@ -16,5 +16,6 @@
     <include file="metadata_changesets/add_metadata_archive_status.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table_add_primary_key.xml" relativeToChangelogFile="true"/>
+    <include file="metadata_changesets/remove_non_summarizable_metadata_from_queue.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>
 <!-- See Dos and Don'ts in changelog.xml -->

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -25,7 +25,15 @@ trait MetadataSqlDatabase extends SqlDatabase {
   /**
     * Add metadata events to the database transactionally.
     */
-  def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])(implicit ec: ExecutionContext): Future[Unit]
+  def addMetadataEntries(metadataEntries: Iterable[MetadataEntry],
+                         startMetadataKey: String,
+                         endMetadataKey: String,
+                         nameMetadataKey: String,
+                         statusMetadataKey: String,
+                         submissionMetadataKey: String,
+                         parentWorkflowIdKey: String,
+                         rootWorkflowIdKey: String,
+                         labelMetadataKey: String)(implicit ec: ExecutionContext): Future[Unit]
 
   def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean]
 

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -76,14 +76,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
     * @param buildUpdatedSummary Takes in the optional existing summary and the metadata, returns the new summary.
     * @return A `Future` with the number of rows summarized by the invocation, and the number of rows still to summarize.
     */
-  def summarizeIncreasing(startMetadataKey: String,
-                          endMetadataKey: String,
-                          nameMetadataKey: String,
-                          statusMetadataKey: String,
-                          submissionMetadataKey: String,
-                          parentWorkflowIdKey: String,
-                          rootWorkflowIdKey: String,
-                          labelMetadataKey: String,
+  def summarizeIncreasing(labelMetadataKey: String,
                           limit: Int,
                           buildUpdatedSummary:
                           (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
@@ -98,13 +91,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
     */
   def summarizeDecreasing(summaryNameDecreasing: String,
                           summaryNameIncreasing: String,
-                          startMetadataKey: String,
-                          endMetadataKey: String,
-                          nameMetadataKey: String,
-                          statusMetadataKey: String,
-                          submissionMetadataKey: String,
-                          parentWorkflowIdKey: String,
-                          rootWorkflowIdKey: String,
                           labelMetadataKey: String,
                           limit: Int,
                           buildUpdatedSummary:

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -179,26 +179,12 @@ trait MetadataDatabaseAccess {
   def refreshWorkflowMetadataSummaries(limit: Int)(implicit ec: ExecutionContext): Future[SummaryResult] = {
     for {
       increasingProcessed <- metadataDatabaseInterface.summarizeIncreasing(
-        startMetadataKey = WorkflowMetadataKeys.StartTime,
-        endMetadataKey = WorkflowMetadataKeys.EndTime,
-        nameMetadataKey = WorkflowMetadataKeys.Name,
-        statusMetadataKey = WorkflowMetadataKeys.Status,
-        submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
-        parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
-        rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
         labelMetadataKey = WorkflowMetadataKeys.Labels,
         limit = limit,
         buildUpdatedSummary = MetadataDatabaseAccess.buildUpdatedSummary)
       (decreasingProcessed, decreasingGap) <- metadataDatabaseInterface.summarizeDecreasing(
         summaryNameDecreasing = WorkflowMetadataKeys.SummaryNameDecreasing,
         summaryNameIncreasing = WorkflowMetadataKeys.SummaryNameIncreasing,
-        startMetadataKey = WorkflowMetadataKeys.StartTime,
-        endMetadataKey = WorkflowMetadataKeys.EndTime,
-        nameMetadataKey = WorkflowMetadataKeys.Name,
-        statusMetadataKey = WorkflowMetadataKeys.Status,
-        submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
-        parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
-        rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
         labelMetadataKey = WorkflowMetadataKeys.Labels,
         limit = limit,
         buildUpdatedSummary = MetadataDatabaseAccess.buildUpdatedSummary)

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -100,7 +100,16 @@ trait MetadataDatabaseAccess {
       MetadataEntry(workflowUuid, jobKey.map(_._1), jobKey.flatMap(_._2), jobKey.map(_._3),
         key.key, value.toClobOption, valueType, timestamp)
     }
-    metadataDatabaseInterface.addMetadataEntries(metadata)
+    metadataDatabaseInterface.addMetadataEntries(
+      metadataEntries = metadata,
+      startMetadataKey = WorkflowMetadataKeys.StartTime,
+      endMetadataKey = WorkflowMetadataKeys.EndTime,
+      nameMetadataKey = WorkflowMetadataKeys.Name,
+      statusMetadataKey = WorkflowMetadataKeys.Status,
+      submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
+      parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
+      rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
+      labelMetadataKey = WorkflowMetadataKeys.Labels)
   }
 
   private def metadataToMetadataEvents(workflowId: WorkflowId)(metadata: Seq[MetadataEntry]): Seq[MetadataEvent] = {

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -9,6 +9,7 @@ import cromwell.database.migration.metadata.table.symbol.MetadataStatement._
 import cromwell.database.slick.MetadataSlickDatabase
 import cromwell.database.slick.MetadataSlickDatabase.SummarizationPartitionedMetadata
 import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
+import cromwell.services.metadata.CallMetadataKeys
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FlatSpec, Matchers}
@@ -149,6 +150,25 @@ class MetadataSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures
         callEntry("rubbish")
       )
 
+      val thingsThatLookKindOfLikeTheRightWorkflowKeysButActuallyAreNotAndAreCallScopedAnyway = List(
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.StartTime),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.EndTime),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Name),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Status),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.SubmissionTime),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.ParentWorkflowId),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.RootWorkflowId),
+        callEntry(CallMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Labels + ":arbitrary-label"),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.StartTime),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.EndTime),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Name),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Status),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.SubmissionTime),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.ParentWorkflowId),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.RootWorkflowId),
+        callEntry(CallMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Labels + ":arbitrary-label")
+      )
+
       val rightKeysWorkflowLevel = List(
         workflowEntry(WorkflowMetadataKeys.StartTime),
         workflowEntry(WorkflowMetadataKeys.EndTime),
@@ -165,8 +185,31 @@ class MetadataSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures
         workflowEntry("garbage")
       )
 
-      val partitioned = partition(rightKeysCallLevel ++ rightKeysWorkflowLevel ++ wrongKeysCallLevel ++ wrongKeysWorkflowLevel)
-      partitioned.nonSummarizableMetadata.toSet shouldBe (rightKeysCallLevel ++ wrongKeysCallLevel ++ wrongKeysWorkflowLevel).toSet
+      val thingsThatLookKindOfLikeTheRightWorkflowKeysButActuallyAreNot = List(
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.StartTime),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.EndTime),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Name),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Status),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.SubmissionTime),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.ParentWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.RootWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.Inputs + ":" + WorkflowMetadataKeys.Labels + ":arbitrary-label"),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.StartTime),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.EndTime),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Name),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Status),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.SubmissionTime),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.ParentWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.RootWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.Outputs + ":" + WorkflowMetadataKeys.Labels + ":arbitrary-label")
+      )
+
+      val allTheWrongThings = rightKeysCallLevel ++ wrongKeysCallLevel ++ wrongKeysWorkflowLevel ++
+        thingsThatLookKindOfLikeTheRightWorkflowKeysButActuallyAreNot ++
+        thingsThatLookKindOfLikeTheRightWorkflowKeysButActuallyAreNotAndAreCallScopedAnyway
+
+      val partitioned = partition(rightKeysWorkflowLevel ++ allTheWrongThings)
+      partitioned.nonSummarizableMetadata.toSet shouldBe (allTheWrongThings).toSet
       partitioned.summarizableMetadata shouldBe rightKeysWorkflowLevel
     }
   }

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -135,7 +135,13 @@ class MetadataSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures
 
       val rightKeysCallLevel = List(
         callEntry(WorkflowMetadataKeys.StartTime),
-        callEntry(WorkflowMetadataKeys.EndTime)
+        callEntry(WorkflowMetadataKeys.EndTime),
+        callEntry(WorkflowMetadataKeys.Name),
+        callEntry(WorkflowMetadataKeys.Status),
+        callEntry(WorkflowMetadataKeys.SubmissionTime),
+        callEntry(WorkflowMetadataKeys.ParentWorkflowId),
+        callEntry(WorkflowMetadataKeys.RootWorkflowId),
+        callEntry(WorkflowMetadataKeys.Labels + ":arbitrary-label")
       )
 
       val wrongKeysCallLevel = List(
@@ -145,7 +151,13 @@ class MetadataSlickDatabaseSpec extends FlatSpec with Matchers with ScalaFutures
 
       val rightKeysWorkflowLevel = List(
         workflowEntry(WorkflowMetadataKeys.StartTime),
-        workflowEntry(WorkflowMetadataKeys.EndTime)
+        workflowEntry(WorkflowMetadataKeys.EndTime),
+        workflowEntry(WorkflowMetadataKeys.Name),
+        workflowEntry(WorkflowMetadataKeys.Status),
+        workflowEntry(WorkflowMetadataKeys.SubmissionTime),
+        workflowEntry(WorkflowMetadataKeys.ParentWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.RootWorkflowId),
+        workflowEntry(WorkflowMetadataKeys.Labels + ":arbitrary-label")
       )
 
       val wrongKeysWorkflowLevel = List(

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -183,14 +183,7 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
                                              timeout: Duration)
                                             (implicit ec: ExecutionContext): Nothing = notImplemented()
 
-    override def summarizeIncreasing(startMetadataKey: String,
-                                     endMetadataKey: String,
-                                     nameMetadataKey: String,
-                                     statusMetadataKey: String,
-                                     submissionMetadataKey: String,
-                                     parentWorkflowIdKey: String,
-                                     rootWorkflowIdKey: String,
-                                     labelMetadataKey: String,
+    override def summarizeIncreasing(labelMetadataKey: String,
                                      limit: Int,
                                      buildUpdatedSummary:
                                      (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
@@ -205,13 +198,6 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
       */
     override def summarizeDecreasing(summaryNameDecreasing: String,
                                      summaryNameIncreasing: String,
-                                     startMetadataKey: String,
-                                     endMetadataKey: String,
-                                     nameMetadataKey: String,
-                                     statusMetadataKey: String,
-                                     submissionMetadataKey: String,
-                                     parentWorkflowIdKey: String,
-                                     rootWorkflowIdKey: String,
                                      labelMetadataKey: String,
                                      limit: Int,
                                      buildUpdatedSummary:

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -130,7 +130,15 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
 
     var requestsSinceLastSuccess = 0
     // Return successful
-    override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
+    override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry],
+                                    startMetadataKey: String,
+                                    endMetadataKey: String,
+                                    nameMetadataKey: String,
+                                    statusMetadataKey: String,
+                                    submissionMetadataKey: String,
+                                    parentWorkflowIdKey: String,
+                                    rootWorkflowIdKey: String,
+                                    labelMetadataKey: String)
                                    (implicit ec: ExecutionContext): Future[Unit] = {
       if (requestsSinceLastSuccess == failuresBetweenEachSuccess) {
         requestsSinceLastSuccess = 0


### PR DESCRIPTION
Non-summarizable metadata (>>> 99% of real world metadata) uses the fast insertion path. Currently includes some spamming code for testing that definitely should not be merged.