### PR TITLE
Call cache blacklist grouping support [BA-6427]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -157,15 +157,21 @@ call-caching {
   #   # The call caching blacklist cache is off by default. This cache is used to blacklist cache hit paths based on the
   #   # prefixes of cache hit paths that Cromwell has previously failed to copy for permissions reasons.
   #   enabled: true
-  #   # A blacklist grouping can be specified in workflow options which will inform the blacklister which workflows
-  #   # should share a blacklist cache.
-  #   grouping-workflow-option: call-cache-blackist-group
   #   # Guava cache concurrency.
   #   concurrency: 10000
   #   # How long entries in the cache should live from the time of their last access.
   #   ttl: 20 minutes
   #   # Maximum number of entries in the cache.
   #   size: 1000
+  #
+  #   # A blacklist grouping can be specified in workflow options which will inform the blacklister which workflows
+  #   # should share a blacklist cache.
+  #   groupings {
+  #     workflow-option: call-cache-blackist-group
+  #     concurrency: 10000
+  #     ttl: 2 hours
+  #     size: 1000
+  #   }
   # }
 }
 

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -157,6 +157,9 @@ call-caching {
   #   # The call caching blacklist cache is off by default. This cache is used to blacklist cache hit paths based on the
   #   # prefixes of cache hit paths that Cromwell has previously failed to copy for permissions reasons.
   #   enabled: true
+  #   # A blacklist grouping can be specified in workflow options which will inform the blacklister which workflows
+  #   # should share a blacklist cache.
+  #   grouping-workflow-option: call-cache-blackist-group
   #   # Guava cache concurrency.
   #   concurrency: 10000
   #   # How long entries in the cache should live from the time of their last access.

--- a/engine/src/main/scala/cromwell/engine/workflow/CallCachingBlacklistManager.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/CallCachingBlacklistManager.scala
@@ -1,0 +1,64 @@
+package cromwell.engine.workflow
+
+import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
+import com.typesafe.config.Config
+import cromwell.backend.standard.callcaching.BlacklistCache
+import cromwell.core.CacheConfig
+import net.ceedubs.ficus.Ficus._
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class CallCachingBlacklistManager(config: Config) {
+  private val blacklistCacheConfig: Option[Config] = config.as[Option[Config]]("call-caching.blacklist-cache")
+
+  private val blacklistGroupCacheConfig: Option[Config] = blacklistCacheConfig.flatMap(_.as[Option[Config]]("groupings"))
+
+  private val blacklistGroupWorkflowOptionKey: Option[String] = blacklistGroupCacheConfig.flatMap(_.as[Option[String]]("workflow-option"))
+
+  // If configuration allows, build a cache of blacklist groupings to BlacklistCaches.
+  private val blacklistGroupingsCache: Option[LoadingCache[String, BlacklistCache]] = {
+    def buildBlacklistGroupingsCache(cacheConfig: CacheConfig): LoadingCache[String, BlacklistCache] = {
+      val emptyBlacklistCacheLoader = new CacheLoader[String, BlacklistCache]() {
+        override def load(key: String): BlacklistCache = BlacklistCache(cacheConfig)
+      }
+
+      CacheBuilder.
+        newBuilder().
+        concurrencyLevel(cacheConfig.concurrency).
+        maximumSize(cacheConfig.size).
+        expireAfterWrite(cacheConfig.ttl.length, cacheConfig.ttl.unit).
+        build[String, BlacklistCache](emptyBlacklistCacheLoader)
+    }
+
+    for {
+      conf <- blacklistGroupCacheConfig
+      _ <- blacklistGroupWorkflowOptionKey // Only build groupings if a workflow option key is specified in config.
+      groupingsConfig <- CacheConfig.optionalConfig(conf, defaultConcurrency = 10000, defaultSize = 1000, defaultTtl = 2 hours)
+    } yield buildBlacklistGroupingsCache(groupingsConfig)
+  }
+
+  /**
+    * If configured return a group blacklist cache, otherwise if configured return a root workflow cache,
+    * otherwise return nothing.
+    */
+  def blacklistCacheFor(workflow: workflowstore.WorkflowToStart): Option[BlacklistCache] = {
+    // If configuration is set up for blacklist groups and a blacklist group is specified in workflow options,
+    // get the BlacklistCache for the group.
+    val groupBlacklistCache: Option[BlacklistCache] = for {
+      groupings <- blacklistGroupingsCache
+      groupKey <- blacklistGroupWorkflowOptionKey
+      groupFromWorkflowOptions <- workflow.sources.workflowOptions.get(groupKey).toOption
+    } yield groupings.get(groupFromWorkflowOptions)
+
+    // Build a blacklist cache for a single, ungrouped root workflow.
+    def rootWorkflowBlacklistCache: Option[BlacklistCache] = {
+      for {
+        config <- blacklistCacheConfig
+        cacheConfig <- CacheConfig.optionalConfig(config, defaultConcurrency = 1000, defaultSize = 1000, defaultTtl = 1 hour)
+      } yield BlacklistCache(cacheConfig)
+    }
+
+    // Return the group blacklist cache if available, otherwise a blacklist cache for the root workflow.
+    groupBlacklistCache orElse rootWorkflowBlacklistCache
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -6,13 +6,12 @@ import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor._
 import akka.event.Logging
 import cats.data.NonEmptyList
-import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.typesafe.config.Config
 import common.exception.ThrowableAggregation
 import cromwell.backend.async.KnownJobFailureException
-import cromwell.backend.standard.callcaching.{BlacklistCache, RootWorkflowFileHashCacheActor}
+import cromwell.backend.standard.callcaching.RootWorkflowFileHashCacheActor
 import cromwell.core.Dispatcher.EngineDispatcher
-import cromwell.core.{CacheConfig, WorkflowId}
+import cromwell.core.WorkflowId
 import cromwell.engine.SubWorkflowStart
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.workflow.WorkflowActor._
@@ -26,7 +25,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.Try
 
 object WorkflowManagerActor {
@@ -279,54 +277,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       logger.debug(s"$tag transitioning from $fromState to $toState")
   }
 
-  private val blacklistCacheConfig: Option[Config] = config.as[Option[Config]]("call-caching.blacklist-cache")
-
-  private val blacklistGroupKey: Option[String] = blacklistCacheConfig.flatMap(_.as[Option[String]]("grouping-workflow-option"))
-
-  // If configuration allows, build a cache of blacklist groupings to BlacklistCaches.
-  private val blacklistGroupings: Option[LoadingCache[String, BlacklistCache]] = {
-    def buildBlacklistGroupings(cacheConfig: CacheConfig): LoadingCache[String, BlacklistCache] = {
-      val emptyBlacklistCacheLoader = new CacheLoader[String, BlacklistCache]() {
-        override def load(key: String): BlacklistCache = BlacklistCache(cacheConfig)
-      }
-
-      CacheBuilder.
-        newBuilder().
-        concurrencyLevel(cacheConfig.concurrency).
-        maximumSize(cacheConfig.size).
-        expireAfterWrite(cacheConfig.ttl.length, cacheConfig.ttl.unit).
-        build[String, BlacklistCache](emptyBlacklistCacheLoader)
-    }
-
-    for {
-      conf <- blacklistCacheConfig
-      _ <- blacklistGroupKey // Only build groupings if a group key is specified in config.
-      cacheConfig <- CacheConfig.optionalConfig(conf, defaultConcurrency = 1000, defaultSize = 1000, defaultTtl = 1 hour)
-    } yield buildBlacklistGroupings(cacheConfig)
-  }
-
-  // If configured return a group blacklist cache, otherwise if configured return a root workflow cache,
-  // otherwise return nothing.
-  private def blacklistCache(workflow: workflowstore.WorkflowToStart): Option[BlacklistCache] = {
-    // If configuration is set up for blacklist groups and a blacklist group is specified in workflow options,
-    // get the BlacklistCache for the group.
-    val groupBlacklistCache: Option[BlacklistCache] = for {
-      groupings <- blacklistGroupings
-      groupKey <- blacklistGroupKey
-      groupFromWorkflowOptions <- workflow.sources.workflowOptions.get(groupKey).toOption
-    } yield groupings.get(groupFromWorkflowOptions)
-
-    // Build a blacklist cache for a single, ungrouped root workflow.
-    def rootWorkflowBlacklistCache: Option[BlacklistCache] = {
-       for {
-        config <- blacklistCacheConfig
-        cacheConfig <- CacheConfig.optionalConfig(config, defaultConcurrency = 1000, defaultSize = 1000, defaultTtl = 1 hour)
-      } yield BlacklistCache(cacheConfig)
-    }
-
-    // Return the group blacklist cache if available, otherwise a blacklist cache for the root workflow.
-    groupBlacklistCache orElse rootWorkflowBlacklistCache
-  }
+  private val callCachingBlacklistManager = new CallCachingBlacklistManager(config)
 
   /**
     * Submit the workflow and return an updated copy of the state data reflecting the addition of a
@@ -363,7 +314,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       workflowHeartbeatConfig = params.workflowHeartbeatConfig,
       totalJobsByRootWf = new AtomicInteger(),
       fileHashCacheActorProps = fileHashCacheActorProps,
-      blacklistCache = blacklistCache(workflow))
+      blacklistCache = callCachingBlacklistManager.blacklistCacheFor(workflow))
     val wfActor = context.actorOf(wfProps, name = s"WorkflowActor-$workflowId")
 
     wfActor ! SubscribeTransitionCallBack(self)


### PR DESCRIPTION
Inspired by hog groups and recent production conflagrations, allow for workflows to share a blacklist call cache as specified by a workflow option.