### PR TITLE
Additionally blacklist hits (not buckets) that fail copying for any reason [BA-6428]

### DIFF
--- a/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
+++ b/backend/src/main/scala/cromwell/backend/BackendLifecycleActorFactory.scala
@@ -8,6 +8,7 @@ import cromwell.core.CallOutputs
 import cromwell.core.JobExecutionToken.JobExecutionTokenType
 import cromwell.core.path.Path
 import cromwell.core.path.PathFactory.PathBuilders
+import cromwell.services.CallCaching.CallCachingEntryId
 import net.ceedubs.ficus.Ficus._
 import wom.expression.{IoFunctionSet, NoIoFunctionSet}
 import wom.graph.CommandCallNode
@@ -88,7 +89,7 @@ trait BackendLifecycleActorFactory {
     *
     * Simples!
     */
-  def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int, Option[BlacklistCache]) => Props] = None
+  def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int, CallCachingEntryId, Option[BlacklistCache]) => Props] = None
 
   /* ****************************** */
   /*              Misc.             */

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/BlacklistCache.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/BlacklistCache.scala
@@ -33,11 +33,9 @@ case class BlacklistCache(config: CacheConfig) {
       build[CallCachingEntryId, java.lang.Boolean](falseLoader)
   }
 
-  def isBlacklisted(bucket: String): Boolean = bucketCache.get(bucket)
+  def isBlacklisted(hit: CallCachingEntryId, bucket: String): Boolean = hitCache.get(hit) || bucketCache.get(bucket)
 
-  def isBlacklisted(hit: CallCachingEntryId): Boolean = hitCache.get(hit)
+  def blacklistBucket(bucket: String): Unit = bucketCache.put(bucket, true)
 
-  def blacklist(bucket: String): Unit = bucketCache.put(bucket, true)
-
-  def blacklist(hit: CallCachingEntryId): Unit = hitCache.put(hit, true)
+  def blacklistHit(hit: CallCachingEntryId): Unit = hitCache.put(hit, true)
 }

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/BlacklistCache.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/BlacklistCache.scala
@@ -2,10 +2,11 @@ package cromwell.backend.standard.callcaching
 
 import com.google.common.cache.{CacheBuilder, CacheLoader}
 import cromwell.core.CacheConfig
+import cromwell.services.CallCaching.CallCachingEntryId
 
 case class BlacklistCache(config: CacheConfig) {
-  val cache = {
-    // Queries to the blacklist cache return false by default (i.e. not blacklisted).
+  val bucketCache = {
+    // Queries to the bucket blacklist cache return false by default (i.e. not blacklisted).
     val falseLoader = new CacheLoader[String, java.lang.Boolean]() {
       override def load(key: String): java.lang.Boolean = false
     }
@@ -18,7 +19,25 @@ case class BlacklistCache(config: CacheConfig) {
       build[String, java.lang.Boolean](falseLoader)
   }
 
-  def isBlacklisted(bucket: String): Boolean = cache.get(bucket)
+  val hitCache = {
+    // Queries to the hit blacklist cache return false by default (i.e. not blacklisted).
+    val falseLoader = new CacheLoader[CallCachingEntryId, java.lang.Boolean]() {
+      override def load(key: CallCachingEntryId): java.lang.Boolean = false
+    }
 
-  def blacklist(bucket: String): Unit = cache.put(bucket, true)
+    CacheBuilder.
+      newBuilder().
+      concurrencyLevel(config.concurrency).
+      maximumSize(config.size).
+      expireAfterWrite(config.ttl.length, config.ttl.unit).
+      build[CallCachingEntryId, java.lang.Boolean](falseLoader)
+  }
+
+  def isBlacklisted(bucket: String): Boolean = bucketCache.get(bucket)
+
+  def isBlacklisted(hit: CallCachingEntryId): Boolean = hitCache.get(hit)
+
+  def blacklist(bucket: String): Unit = bucketCache.put(bucket, true)
+
+  def blacklist(hit: CallCachingEntryId): Unit = hitCache.put(hit, true)
 }

--- a/backend/src/test/scala/cromwell/backend/standard/callcaching/BlacklistCacheSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/standard/callcaching/BlacklistCacheSpec.scala
@@ -1,22 +1,24 @@
 package cromwell.backend.standard.callcaching
 
 import cromwell.core.CacheConfig
+import cromwell.services.CallCaching.CallCachingEntryId
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class BlacklistCacheSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
+  val hit = CallCachingEntryId(3)
   "The blacklist cache" should "default, blacklist and expire" in {
     val bucket = "foo"
     val cacheConfig = CacheConfig(concurrency = 1, size = Integer.MAX_VALUE, ttl = 1 second)
     val cache = BlacklistCache(cacheConfig)
-    cache.isBlacklisted(bucket) shouldBe false
-    cache.blacklist(bucket)
-    cache.isBlacklisted(bucket) shouldBe true
+    cache.isBlacklisted(hit, bucket) shouldBe false
+    cache.blacklistBucket(bucket)
+    cache.isBlacklisted(hit, bucket) shouldBe true
 
     // Test ttl
     Thread.sleep(5000L)
-    cache.isBlacklisted(bucket) shouldBe false
+    cache.isBlacklisted(hit, bucket) shouldBe false
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
@@ -10,6 +10,7 @@ import cromwell.engine.io.IoAttempts.EnhancedCromwellIoException
 import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching._
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.services.EngineServicesStore
 import cromwell.services.metadata.MetadataService.PutMetadataAction
 import cromwell.services.metadata.impl.FileDeletionStatus

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCache.scala
@@ -16,11 +16,11 @@ import cromwell.database.sql.tables._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor.AggregatedCallHashes
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.CallCacheHashes
+import cromwell.services.CallCaching.CallCachingEntryId
 import wom.core._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-final case class CallCachingEntryId(id: Int)
 /**
   * Given a database-layer CallCacheStore, this accessor can access the database with engine-friendly data types.
   */

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheInvalidateActor.scala
@@ -3,6 +3,7 @@ package cromwell.engine.workflow.lifecycle.execution.callcaching
 import akka.actor.{Actor, ActorLogging, Props}
 import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.database.sql.tables.CallCachingEntry
+import cromwell.services.CallCaching.CallCachingEntryId
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadActor.scala
@@ -13,6 +13,7 @@ import cromwell.services.EnhancedThrottlerActor
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 import CallCache._
+import cromwell.services.CallCaching.CallCachingEntryId
 
 /**
   * Queues up work sent to it because its receive is non-blocking.

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/EngineJobHashingActor.scala
@@ -11,6 +11,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCache.CallCa
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheHashingJobActor.{CompleteFileHashingResult, FinalFileHashingResult, InitialHashingResult, NoFileHashesResult}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.NextHit
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor._
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.services.metadata.CallMetadataKeys
 
 /**

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/FetchCachedResultsActor.scala
@@ -6,6 +6,7 @@ import cromwell.core.Dispatcher.EngineDispatcher
 import cromwell.core.simpleton.WomValueSimpleton
 import cromwell.database.sql.SqlConverters._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
+import cromwell.services.CallCaching.CallCachingEntryId
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -37,6 +37,7 @@ import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, Tim
 import cromwell.engine.workflow.tokens.JobExecutionTokenDispenserActor.{JobExecutionTokenDispensed, JobExecutionTokenRequest, JobExecutionTokenReturn}
 import cromwell.jobstore.JobStoreActor._
 import cromwell.jobstore._
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.services.EngineServicesStore
 import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.metadata.CallMetadataKeys.CallCachingKeys
@@ -623,7 +624,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
                                       cacheCopyAttempt: Int) = {
     backendLifecycleActorFactory.cacheHitCopyingActorProps match {
       case Some(propsMaker) =>
-        val backendCacheHitCopyingActorProps = propsMaker(data.jobDescriptor, initializationData, serviceRegistryActor, ioActor, cacheCopyAttempt, blacklistCache)
+        val backendCacheHitCopyingActorProps = propsMaker(data.jobDescriptor, initializationData, serviceRegistryActor, ioActor, cacheCopyAttempt, cacheResultId, blacklistCache)
         val cacheHitCopyActor = context.actorOf(backendCacheHitCopyingActorProps, buildCacheHitCopyingActorName(data.jobDescriptor, cacheResultId))
         cacheHitCopyActor ! CopyOutputsCommand(womValueSimpletons, jobDetritusFiles, returnCode)
         replyTo ! JobRunning(data.jobDescriptor.key, data.jobDescriptor.evaluatedTaskInputs)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheReadingJobActorSpec.scala
@@ -7,6 +7,7 @@ import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheHashing
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.{CCRJAWithData, WaitingForCacheHitOrMiss, _}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, HashError}
+import cromwell.services.CallCaching.CallCachingEntryId
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{FlatSpecLike, Matchers}
 

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaBackendIsCopyingCachedOutputsSpec.scala
@@ -4,10 +4,10 @@ import cats.data.NonEmptyList
 import cromwell.core.callcaching._
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.NextHit
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CallCacheHashes, EJHAResponse, HashError}
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.services.instrumentation.{CromwellBucket, CromwellIncrement}
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
 

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaCheckingCallCacheSpec.scala
@@ -2,9 +2,9 @@ package cromwell.engine.workflow.lifecycle.execution.ejea
 
 import cromwell.core.callcaching.{CallCachingActivity, CallCachingOff, ReadCache}
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor.{CheckingCallCache, FetchingCachedOutputsFromDatabase, ResponsePendingData, RunningJob}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, CacheMiss, HashError}
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec.EnhancedTestEJEA
+import cromwell.services.CallCaching.CallCachingEntryId
 import org.scalatest.concurrent.Eventually
 
 import scala.util.control.NoStackTrace

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaFetchingCachedOutputsFromDatabaseSpec.scala
@@ -7,12 +7,11 @@ import cromwell.core.simpleton.WomValueSimpleton
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CacheHit, HashError}
 import cromwell.engine.workflow.lifecycle.execution.callcaching.FetchCachedResultsActor.{CachedOutputLookupFailed, CachedOutputLookupSucceeded}
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.ejea.HasJobSuccessResponse.SuccessfulCallCacheHashes
 import wom.values.WomString
-
 import common.assertion.CaseClassAssertions._
+import cromwell.services.CallCaching.CallCachingEntryId
 
 import scala.util.{Failure, Success}
 

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaInvalidatingCacheEntrySpec.scala
@@ -4,8 +4,9 @@ import akka.actor.ActorRef
 import cromwell.core.callcaching.{CallCachingActivity, ReadCache}
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCacheReadingJobActor.NextHit
-import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheInvalidatedFailure, CallCacheInvalidatedSuccess, CallCachingEntryId}
+import cromwell.engine.workflow.lifecycle.execution.callcaching.{CallCacheInvalidatedFailure, CallCacheInvalidatedSuccess}
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
+import cromwell.services.CallCaching.CallCachingEntryId
 
 class EjeaInvalidatingCacheEntrySpec extends EngineJobExecutionActorSpec {
 

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EngineJobExecutionActorSpecUtil.scala
@@ -4,11 +4,11 @@ import cromwell.backend.BackendCacheHitCopyingActor.{CopyingOutputsFailedRespons
 import cromwell.backend.{BackendJobDescriptor, MetricableCacheCopyErrorCategory}
 import cromwell.backend.BackendJobExecutionActor._
 import cromwell.core.callcaching._
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.callcaching.EngineJobHashingActor.{CallCacheHashes, FileHashes}
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor.{EJEAData, SucceededResponseData, UpdatingCallCache, UpdatingJobStore}
 import cromwell.jobstore.JobStoreActor.RegisterJobCompleted
 import cromwell.jobstore.{JobResultFailure, JobResultSuccess, JobStoreKey}
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.util.WomMocks
 import org.scalatest.concurrent.Eventually
 import wom.values.{WomInteger, WomString}

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/PerTestHelper.scala
@@ -8,11 +8,11 @@ import cromwell.backend.standard.callcaching._
 import cromwell.core.callcaching._
 import cromwell.core.{CallOutputs, HogGroup, WorkflowId, WorkflowOptions}
 import cromwell.engine.EngineWorkflowDescriptor
-import cromwell.engine.workflow.lifecycle.execution.callcaching.CallCachingEntryId
 import cromwell.engine.workflow.lifecycle.execution.ejea.EngineJobExecutionActorSpec._
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor.{EJEAData, EngineJobExecutionActorState, ResponsePendingData}
 import cromwell.engine.workflow.mocks.{DeclarationMock, TaskMock, WdlWomExpressionMock}
+import cromwell.services.CallCaching.CallCachingEntryId
 import cromwell.util.AkkaTestUtil._
 import cromwell.util.WomMocks
 import org.specs2.mock.Mockito
@@ -84,7 +84,7 @@ private[ejea] class PerTestHelper(implicit val system: ActorSystem) extends Mock
                                         ioActor: ActorRef,
                                         backendSingletonActor: Option[ActorRef]): Props = bjeaProps
 
-    override def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int, Option[BlacklistCache]) => Props] = Option((_, _, _, _, _, _) => callCacheHitCopyingProbe.props)
+    override def cacheHitCopyingActorProps: Option[(BackendJobDescriptor, Option[BackendInitializationData], ActorRef, ActorRef, Int, CallCachingEntryId, Option[BlacklistCache]) => Props] = Option((_, _, _, _, _, _, _) => callCacheHitCopyingProbe.props)
 
     override def expressionLanguageFunctions(workflowDescriptor: BackendWorkflowDescriptor,
                                              jobKey: BackendJobDescriptorKey,

--- a/services/src/main/scala/cromwell/services/CallCaching.scala
+++ b/services/src/main/scala/cromwell/services/CallCaching.scala
@@ -1,0 +1,5 @@
+package cromwell.services
+
+object CallCaching {
+  final case class CallCachingEntryId(id: Int)
+}


### PR DESCRIPTION
Blacklists individual cache hits that fail copying for whatever reason. This is in addition to the existing bucket-based 403 blacklisting, not instead of it. Needs tests and docs.

Apologies for the diff noise of `CallCachingEntryId` changing subprojects. I would also like to rename this type at some point but I'm holding off for now since that would create even more noise. 