### PR TITLE
AWS-EFS postmapping and return code fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ ftp_centaur_cwl_runner.conf
 tesk_application.conf
 **/__pycache__/
 **/venv/
+exome_germline_single_sample_v1.3/

--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -394,7 +394,8 @@ trait StandardAsyncExecutionActor
         |ENVIRONMENT_VARIABLES
         |INSTANTIATED_COMMAND
         |) $stdinRedirection > "$$$out" 2> "$$$err"
-        |echo $$? > $rcTmpPath
+        |rc=$$?
+        |echo $$rc > $rcTmpPath
         |$emptyDirectoryFillCommand
         |(
         |cd ${cwd.pathAsString}
@@ -403,6 +404,7 @@ trait StandardAsyncExecutionActor
         |${directoryScripts(directoryOutputs)}
         |)
         |mv $rcTmpPath $rcPath
+        |exit $$rc
         |""".stripMargin
       .replace("SCRIPT_PREAMBLE", scriptPreamble)
       .replace("ENVIRONMENT_VARIABLES", environmentVariables)

--- a/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
+++ b/database/migration/src/main/resources/metadata_changesets/remove_non_summarizable_metadata_from_queue.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="hsqldb">
+        <comment>
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
+        </comment>
+        <sql>
+            DELETE FROM SUMMARY_QUEUE_ENTRY queue WHERE queue.METADATA_JOURNAL_ID NOT IN (
+                SELECT metadata.METADATA_JOURNAL_ID FROM METADATA_ENTRY metadata WHERE
+                    metadata.METADATA_JOURNAL_ID = queue.METADATA_JOURNAL_ID AND
+                    metadata.CALL_FQN IS NULL AND
+                    metadata.JOB_SCATTER_INDEX IS NULL AND
+                    metadata.JOB_RETRY_ATTEMPT IS NULL AND (
+                        metadata.METADATA_KEY in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        metadata.METADATA_KEY LIKE 'labels%'
+                    )
+                )
+        </sql>
+    </changeSet>
+
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="postgresql">
+        <comment>
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
+        </comment>
+        <sql>
+            DELETE FROM "SUMMARY_QUEUE_ENTRY" queue WHERE queue."METADATA_JOURNAL_ID" NOT IN (
+                SELECT metadata."METADATA_JOURNAL_ID" FROM "METADATA_ENTRY" metadata WHERE
+                    metadata."METADATA_JOURNAL_ID" = queue."METADATA_JOURNAL_ID" AND
+                    metadata."CALL_FQN" IS NULL AND
+                    metadata."JOB_SCATTER_INDEX" IS NULL AND
+                    metadata."JOB_RETRY_ATTEMPT" IS NULL AND (
+                        metadata."METADATA_KEY" in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        metadata."METADATA_KEY" LIKE 'labels%'
+                    )
+            )
+        </sql>
+    </changeSet>
+
+    <changeSet id="delete_non_summarizable_metadata_from_queue" author="mcovarr" dbms="mariadb,mysql">
+        <comment>
+            Delete rows from the summary queue corresponding to metadata that will not be summarized.
+        </comment>
+        <sql>
+            DELETE SUMMARY_QUEUE_ENTRY FROM SUMMARY_QUEUE_ENTRY
+                INNER JOIN METADATA_ENTRY ON
+                SUMMARY_QUEUE_ENTRY.METADATA_JOURNAL_ID = METADATA_ENTRY.METADATA_JOURNAL_ID WHERE NOT (
+                    METADATA_ENTRY.CALL_FQN IS NULL AND
+                    METADATA_ENTRY.JOB_SCATTER_INDEX IS NULL AND
+                    METADATA_ENTRY.JOB_RETRY_ATTEMPT IS NULL AND (
+                        METADATA_ENTRY.METADATA_KEY in
+                            ('start', 'end', 'workflowName', 'status', 'submission', 'parentWorkflowId', 'rootWorkflowId')
+                        OR
+                        METADATA_ENTRY.METADATA_KEY LIKE 'labels%'
+                    )
+                )
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/sql_metadata_changelog.xml
+++ b/database/migration/src/main/resources/sql_metadata_changelog.xml
@@ -16,5 +16,6 @@
     <include file="metadata_changesets/add_metadata_archive_status.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table.xml" relativeToChangelogFile="true" />
     <include file="metadata_changesets/summarization_queue_table_add_primary_key.xml" relativeToChangelogFile="true"/>
+    <include file="metadata_changesets/remove_non_summarizable_metadata_from_queue.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>
 <!-- See Dos and Don'ts in changelog.xml -->

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -18,6 +18,33 @@ object MetadataSlickDatabase {
     val databaseConfig = SlickDatabase.getDatabaseConfig("metadata", parentConfig)
     new MetadataSlickDatabase(databaseConfig)
   }
+
+  case class SummarizationPartitionedMetadata(nonSummarizableMetadata: Seq[MetadataEntry],
+                                              summarizableMetadata: Seq[MetadataEntry])
+
+  def partitionSummarizationMetadata(rawMetadataEntries: Seq[MetadataEntry],
+                                     startMetadataKey: String,
+                                     endMetadataKey: String,
+                                     nameMetadataKey: String,
+                                     statusMetadataKey: String,
+                                     submissionMetadataKey: String,
+                                     parentWorkflowIdKey: String,
+                                     rootWorkflowIdKey: String,
+                                     labelMetadataKey: String): SummarizationPartitionedMetadata = {
+
+    val exactMatchMetadataKeys = Set(startMetadataKey, endMetadataKey, nameMetadataKey, statusMetadataKey, submissionMetadataKey, parentWorkflowIdKey, rootWorkflowIdKey)
+    val startsWithMetadataKeys = Set(labelMetadataKey)
+
+    val (summarizable, nonSummarizable) = rawMetadataEntries partition { entry =>
+      entry.callFullyQualifiedName.isEmpty && entry.jobIndex.isEmpty && entry.jobAttempt.isEmpty &&
+        (exactMatchMetadataKeys.contains(entry.metadataKey) || startsWithMetadataKeys.exists(entry.metadataKey.startsWith))
+    }
+
+    SummarizationPartitionedMetadata(
+      summarizableMetadata = summarizable,
+      nonSummarizableMetadata = nonSummarizable
+    )
+  }
 }
 
 class MetadataSlickDatabase(originalDatabaseConfig: Config)
@@ -28,24 +55,56 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   override lazy val dataAccess = new MetadataDataAccessComponent(slickConfig.profile)
 
   import dataAccess.driver.api._
+  import MetadataSlickDatabase._
 
   override def existsMetadataEntries()(implicit ec: ExecutionContext): Future[Boolean] = {
     val action = dataAccess.metadataEntriesExists.result
     runTransaction(action)
   }
 
-  override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
+  override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry],
+                                  startMetadataKey: String,
+                                  endMetadataKey: String,
+                                  nameMetadataKey: String,
+                                  statusMetadataKey: String,
+                                  submissionMetadataKey: String,
+                                  parentWorkflowIdKey: String,
+                                  rootWorkflowIdKey: String,
+                                  labelMetadataKey: String)
                                  (implicit ec: ExecutionContext): Future[Unit] = {
 
-    if (metadataEntries.isEmpty) Future.successful(()) else {
+    val partitioned = partitionSummarizationMetadata(
+        rawMetadataEntries = metadataEntries.toSeq,
+        startMetadataKey,
+        endMetadataKey,
+        nameMetadataKey,
+        statusMetadataKey,
+        submissionMetadataKey,
+        parentWorkflowIdKey,
+        rootWorkflowIdKey,
+        labelMetadataKey)
 
-      val batchesToWrite = metadataEntries.grouped(insertBatchSize).toList
+    // These entries also require a write to the summary queue.
+    def writeSummarizable(): Future[Unit] = if (partitioned.summarizableMetadata.isEmpty) Future.successful(()) else {
+      val batchesToWrite = partitioned.summarizableMetadata.grouped(insertBatchSize).toList
       val insertActions = batchesToWrite.map { batch =>
         val insertMetadata = dataAccess.metadataEntryIdsAutoInc ++= batch
         insertMetadata.flatMap(ids => writeSummaryQueueEntries(ids))
       }
       runTransaction(DBIO.sequence(insertActions)).void
     }
+
+    // Non-summarizable metadata that only needs to go to the metadata table can be written much more efficiently
+    // than summarizable metadata.
+    def writeNonSummarizable(): Future[Unit] = if (partitioned.nonSummarizableMetadata.isEmpty) Future.successful(()) else {
+      val action = DBIO.sequence(partitioned.nonSummarizableMetadata.grouped(insertBatchSize).map(dataAccess.metadataEntries ++= _))
+      runLobAction(action).void
+    }
+
+    for {
+      _ <- writeSummarizable()
+      _ <- writeNonSummarizable()
+    } yield ()
   }
 
   override def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean] = {
@@ -177,14 +236,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     }
   }
 
-  override def summarizeIncreasing(startMetadataKey: String,
-                                   endMetadataKey: String,
-                                   nameMetadataKey: String,
-                                   statusMetadataKey: String,
-                                   submissionMetadataKey: String,
-                                   parentWorkflowIdKey: String,
-                                   rootWorkflowIdKey: String,
-                                   labelMetadataKey: String,
+  override def summarizeIncreasing(labelMetadataKey: String,
                                    limit: Int,
                                    buildUpdatedSummary:
                                    (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
@@ -195,13 +247,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
       _ <-
         buildMetadataSummaryFromRawMetadataAndWriteToDb(
           rawMetadataEntries = rawMetadataEntries,
-          startMetadataKey = startMetadataKey,
-          endMetadataKey = endMetadataKey,
-          nameMetadataKey = nameMetadataKey,
-          statusMetadataKey = statusMetadataKey,
-          submissionMetadataKey = submissionMetadataKey,
-          parentWorkflowIdKey = parentWorkflowIdKey,
-          rootWorkflowIdKey = rootWorkflowIdKey,
           labelMetadataKey = labelMetadataKey,
           buildUpdatedSummary = buildUpdatedSummary
         )
@@ -214,13 +259,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
 
   override def summarizeDecreasing(summaryNameDecreasing: String,
                                    summaryNameIncreasing: String,
-                                   startMetadataKey: String,
-                                   endMetadataKey: String,
-                                   nameMetadataKey: String,
-                                   statusMetadataKey: String,
-                                   submissionMetadataKey: String,
-                                   parentWorkflowIdKey: String,
-                                   rootWorkflowIdKey: String,
                                    labelMetadataKey: String,
                                    limit: Int,
                                    buildUpdatedSummary:
@@ -242,13 +280,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
             _ <-
               buildMetadataSummaryFromRawMetadataAndWriteToDb(
                 rawMetadataEntries = rawMetadataEntries,
-                startMetadataKey = startMetadataKey,
-                endMetadataKey = endMetadataKey,
-                nameMetadataKey = nameMetadataKey,
-                statusMetadataKey = statusMetadataKey,
-                submissionMetadataKey = submissionMetadataKey,
-                parentWorkflowIdKey = parentWorkflowIdKey,
-                rootWorkflowIdKey = rootWorkflowIdKey,
                 labelMetadataKey = labelMetadataKey,
                 buildUpdatedSummary = buildUpdatedSummary
               )
@@ -262,33 +293,17 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   }
 
   private def buildMetadataSummaryFromRawMetadataAndWriteToDb(rawMetadataEntries: Seq[MetadataEntry],
-                                                              startMetadataKey: String,
-                                                              endMetadataKey: String,
-                                                              nameMetadataKey: String,
-                                                              statusMetadataKey: String,
-                                                              submissionMetadataKey: String,
-                                                              parentWorkflowIdKey: String,
-                                                              rootWorkflowIdKey: String,
                                                               labelMetadataKey: String,
                                                               buildUpdatedSummary:
                                                               (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry]) => WorkflowMetadataSummaryEntry
                                                              )(implicit ec: ExecutionContext): DBIO[Unit] = {
 
-    val exactMatchMetadataKeys = Set(startMetadataKey, endMetadataKey, nameMetadataKey, statusMetadataKey, submissionMetadataKey, parentWorkflowIdKey, rootWorkflowIdKey)
-    val startsWithMetadataKeys = Set(labelMetadataKey)
-
-    val metadataEntries = rawMetadataEntries filter { entry =>
-      entry.callFullyQualifiedName.isEmpty && entry.jobIndex.isEmpty && entry.jobAttempt.isEmpty &&
-        (exactMatchMetadataKeys.contains(entry.metadataKey) || startsWithMetadataKeys.exists(entry.metadataKey.startsWith))
-    }
-    val metadataWithoutLabels = metadataEntries
-      .filterNot(_.metadataKey.contains(labelMetadataKey)) // Why are these "contains" while the filtering is "starts with"?
-      .groupBy(_.workflowExecutionUuid)
-    val customLabelEntries = metadataEntries.filter(_.metadataKey.contains(labelMetadataKey))
+    val (summarizableLabelsMetadata, summarizableRegularMetadata) = rawMetadataEntries.partition(_.metadataKey.contains(labelMetadataKey))
+    val groupedSummarizableRegularMetadata = summarizableRegularMetadata.groupBy(_.workflowExecutionUuid)
 
     for {
-      _ <- DBIO.sequence(metadataWithoutLabels map updateWorkflowMetadataSummaryEntry(buildUpdatedSummary))
-      _ <- DBIO.sequence(customLabelEntries map toCustomLabelEntry map upsertCustomLabelEntry)
+      _ <- DBIO.sequence(groupedSummarizableRegularMetadata map updateWorkflowMetadataSummaryEntry(buildUpdatedSummary))
+      _ <- DBIO.sequence(summarizableLabelsMetadata map toCustomLabelEntry map upsertCustomLabelEntry)
     } yield ()
   }
 

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -25,7 +25,15 @@ trait MetadataSqlDatabase extends SqlDatabase {
   /**
     * Add metadata events to the database transactionally.
     */
-  def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])(implicit ec: ExecutionContext): Future[Unit]
+  def addMetadataEntries(metadataEntries: Iterable[MetadataEntry],
+                         startMetadataKey: String,
+                         endMetadataKey: String,
+                         nameMetadataKey: String,
+                         statusMetadataKey: String,
+                         submissionMetadataKey: String,
+                         parentWorkflowIdKey: String,
+                         rootWorkflowIdKey: String,
+                         labelMetadataKey: String)(implicit ec: ExecutionContext): Future[Unit]
 
   def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean]
 
@@ -68,14 +76,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
     * @param buildUpdatedSummary Takes in the optional existing summary and the metadata, returns the new summary.
     * @return A `Future` with the number of rows summarized by the invocation, and the number of rows still to summarize.
     */
-  def summarizeIncreasing(startMetadataKey: String,
-                          endMetadataKey: String,
-                          nameMetadataKey: String,
-                          statusMetadataKey: String,
-                          submissionMetadataKey: String,
-                          parentWorkflowIdKey: String,
-                          rootWorkflowIdKey: String,
-                          labelMetadataKey: String,
+  def summarizeIncreasing(labelMetadataKey: String,
                           limit: Int,
                           buildUpdatedSummary:
                           (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
@@ -90,13 +91,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
     */
   def summarizeDecreasing(summaryNameDecreasing: String,
                           summaryNameIncreasing: String,
-                          startMetadataKey: String,
-                          endMetadataKey: String,
-                          nameMetadataKey: String,
-                          statusMetadataKey: String,
-                          submissionMetadataKey: String,
-                          parentWorkflowIdKey: String,
-                          rootWorkflowIdKey: String,
                           labelMetadataKey: String,
                           limit: Int,
                           buildUpdatedSummary:

--- a/scripts/metadata_comparison/metadata_comparison/digester.py
+++ b/scripts/metadata_comparison/metadata_comparison/digester.py
@@ -1,0 +1,107 @@
+import argparse
+import json
+from metadata_comparison.lib import logging, operation_ids
+from metadata_comparison.lib.operation_ids import CallNameSequence, JsonObject, OperationId
+from metadata_comparison.lib.comparison_paths import ComparisonPath
+
+import dateutil.parser
+from typing import AnyStr, Dict
+
+Version = "0.0.1"
+
+
+def main(args: argparse.Namespace) -> None:
+    for path in args.paths:
+        parent_path = ComparisonPath.create(path)
+
+        workflow_path = parent_path / 'workflow.json'
+        operations_dir_path = parent_path / 'operations'
+
+        digest_parent = parent_path / 'digests' / Version
+        digest_path = digest_parent / 'digest.json'
+
+        if not digest_path.exists() or args.force:
+            digest_parent.mkdir_p()
+            digest_json = digest(workflow_path, operations_dir_path)
+            digest_string = json.dumps(digest_json, sort_keys=True, indent=4)
+            digest_path.write_text(digest_string)
+        else:
+            raise ValueError(f'digest file already exists at {digest_path} and --force not specified')
+
+
+def parse_args() -> argparse.Namespace:
+    def validate_path(p: AnyStr) -> AnyStr:
+        if ComparisonPath.is_valid_path_string(p):
+            return p
+        raise ValueError(f'{p} is not a valid path whatsoever')
+
+    parser = argparse.ArgumentParser(
+        description='Digest workflow metadata and job operation details, reading from and reuploading to GCS.')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='whether to log verbosely (default False)')
+    parser.add_argument('-f', '--force', action='store_true',
+                        help='whether to overwrite existing digests (default False)')
+    parser.add_argument('paths', metavar="PATH", nargs='+', type=validate_path,
+                        help="Location at which to find metadata (local or GCS)")
+
+    return parser.parse_args()
+
+
+CallName = AnyStr
+
+
+def digest(workflow_path: ComparisonPath, operations_path: ComparisonPath) -> JsonObject:
+    def call_fn(succeeded_operations: Dict[CallName, JsonObject],
+                operation_id: OperationId,
+                path: CallNameSequence,
+                attempt: JsonObject) -> None:
+        backend_status = attempt.get('backendStatus', 'Unknown')
+        # This script should only ever be pointed at successful workflow metadata. All jobs that have a backend status
+        # other than `Success` must have later been re-run successfully, so any un`Success`ful attempts are ignored.
+        # It's possible that a future version of the digester might actually want to look at these jobs since they
+        # may have completed some lifecycle events which could be useful in accumulating more performance data.
+        if backend_status == 'Success':
+            string_path = '.'.join(path)
+            cromwell_start = attempt.get('start')
+            cromwell_end = attempt.get('end')
+
+            cromwell_total_time_seconds = (dateutil.parser.parse(cromwell_end) -
+                                           dateutil.parser.parse(cromwell_start)).total_seconds()
+
+            bare_operation_id = operation_id.split('/')[-1]
+            operations_file_path = operations_path / f'{bare_operation_id}.json'
+            operations_data = operations_file_path.read_text()
+            operations_metadata = json.loads(operations_data).get('metadata')
+            papi_start = operations_metadata.get('createTime')
+            papi_end = operations_metadata.get('endTime')
+            papi_total_time_seconds = (dateutil.parser.parse(papi_end) -
+                                       dateutil.parser.parse(papi_start)).total_seconds()
+            cromwell_additional_total_time_seconds = \
+                float("%.3f" % (cromwell_total_time_seconds - papi_total_time_seconds))
+
+            succeeded_operations[string_path] = {
+                "attempt": attempt.get('attempt'),
+                "shardIndex": attempt.get('shardIndex'),
+                "operationId": operation_id,
+                "cromwellStart": cromwell_start,
+                "cromwellEnd": cromwell_end,
+                "cromwellTotalTimeSeconds": cromwell_total_time_seconds,
+                "papiStart": papi_start,
+                "papiEnd": papi_end,
+                "papiTotalTimeSeconds": papi_total_time_seconds,
+                "cromwellAdditionalTotalTimeSeconds": cromwell_additional_total_time_seconds
+            }
+
+    data = workflow_path.read_text()
+    metadata = json.loads(data)
+
+    shards = operation_ids.visit_papi_operations(metadata, call_fn, initial_accumulator={})
+    return {'version': Version, 'calls': shards, 'workflowId': metadata['id']}
+
+
+if __name__ == "__main__":
+    logging.quieten_chatty_imports()
+    _args = parse_args()
+    logging.set_log_verbosity(_args.verbose)
+
+    main(_args)

--- a/scripts/metadata_comparison/metadata_comparison/lib/argument_regex.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/argument_regex.py
@@ -3,6 +3,7 @@
 import argparse
 import re
 
+
 def workflow_regex_validator(value: str) -> str:
     """Makes sure that a value is a valid Cromwell workflow ID then returns the workflow ID"""
     workflow_regex=re.compile('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
@@ -41,10 +42,12 @@ def gcs_path_regex_validator(value: str) -> (str, str):
         or
         'gs://bucket/path/to/file.ext' -> ('bucket', 'path/to/file.ext')
     """
-    gcs_regex = re.compile('^gs://([a-zA-Z0-9-]+)/(([a-zA-Z0-9-]+/)*[\.a-zA-Z0-9-]+)/?$')
+    bucket_class = 'a-zA-Z0-9-'
+    object_class = '_\\.' + bucket_class
+    gcs_regex = re.compile(f'^gs://(?P<bucket>[{bucket_class}]+)/(?P<object>([{object_class}]+/)*[{object_class}]+)/?$')
     m = gcs_regex.match(value)
     if m:
-        return m.group(1), m.group(2)
+        return m.group('bucket'), m.group('object')
     else:
         msg = f'Invalid GCS path {value}. Expected {gcs_regex.pattern}'
         raise argparse.ArgumentTypeError(msg)
@@ -54,7 +57,7 @@ def digester_version_regex_validator(value: str) -> str:
     """
     Validates that digester version looks like 0.0.1
     """
-    digester_version_regex = re.compile('^\d+\.\d+\.\d+$')
+    digester_version_regex = re.compile('^\\d+\\.\\d+\\.\\d+$')
     m = digester_version_regex.match(value)
     if m:
         return m.group(0)

--- a/scripts/metadata_comparison/metadata_comparison/lib/comparison_paths.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/comparison_paths.py
@@ -1,0 +1,127 @@
+from google.cloud import storage
+import google.auth
+import logging
+from metadata_comparison.lib import argument_regex
+
+from pathlib import Path, PosixPath
+from typing import AnyStr, Union
+from abc import ABC, abstractmethod
+
+
+class ComparisonPath(ABC):
+    """
+    Abstract Base Class for Local and GCS paths sharing an interface for the purpose of PAPI metadata comparison.
+    There's nothing particularly "Comparison" about these paths, I just couldn't think of a better name.
+    """
+    @staticmethod
+    def create(path: Union[AnyStr, Path]):
+        if isinstance(path, PosixPath):
+            return LocalPath(path)
+        elif path.startswith('gs://'):
+            bucket, obj = argument_regex.gcs_path_regex_validator(path)
+            return GcsPath(bucket, obj)
+        return LocalPath(path)
+
+    @staticmethod
+    def is_valid_path_string(path: AnyStr) -> bool:
+        # ick
+        return GcsPath.is_valid_path_string(path) or LocalPath.is_valid_path_string(path)
+
+    @abstractmethod
+    def read_text(self, encoding: AnyStr = 'utf_8') -> AnyStr: pass
+
+    # `/` operator, used to implement pathlib.Path style `<existing path> / <new path element>` syntax.
+    @abstractmethod
+    def __truediv__(self, other): pass
+
+    @abstractmethod
+    def exists(self) -> bool: pass
+
+    @abstractmethod
+    def mkdir_p(self) -> None: pass
+
+    @abstractmethod
+    def write_text(self, content: AnyStr, encoding: AnyStr = 'utf_8') -> None: pass
+
+    @abstractmethod
+    def description(self) -> AnyStr: pass
+
+
+class GcsPath(ComparisonPath):
+    def __init__(self, bucket: AnyStr, obj: AnyStr, storage_bucket: storage.Bucket = None):
+        self._bucket = bucket
+        self._object = obj
+        self._storage_blob = None
+        if storage_bucket is None:
+            credentials, project_id = google.auth.default()
+            logging.info(f'Creating storage client for bucket {bucket}')
+            client = storage.Client(credentials=credentials)
+            self._storage_bucket = client.bucket(bucket)
+        else:
+            self._storage_bucket = storage_bucket
+
+    def __storage_blob(self) -> storage.Blob:
+        if self._storage_blob is None:
+            logging.info(f'Creating storage blob for {self}')
+            self._storage_blob = self._storage_bucket.blob(self._object)
+        return self._storage_blob
+
+    def read_text(self, encoding: AnyStr = 'utf_8') -> AnyStr:
+        return self.__storage_blob().download_as_string()
+
+    def __truediv__(self, other) -> ComparisonPath:
+        return GcsPath(bucket=self._bucket,
+                       obj=f'{self._object}/{other}',
+                       storage_bucket=self._storage_bucket)
+
+    def exists(self) -> bool:
+        return self.__storage_blob().exists()
+
+    def mkdir_p(self) -> None:
+        # Nothing to do here, "directory structure" is implicitly "mkdir -p"'d in GCS.
+        pass
+
+    def write_text(self, content: AnyStr, encoding: AnyStr = 'utf_8') -> None:
+        self.__storage_blob().upload_from_string(content)
+
+    @staticmethod
+    def is_valid_path_string(path: AnyStr) -> bool:
+        if path.startswith('gs://'):
+            return argument_regex.gcs_path_regex_validator(path)
+        return False
+
+    def __str__(self) -> AnyStr:
+        return f'gs://{self._bucket}/{self._object}'
+
+    def description(self) -> AnyStr:
+        return 'GCS'
+
+
+class LocalPath(ComparisonPath):
+    def __init__(self, local_spec: Union[AnyStr, Path]):
+        self.path = Path(local_spec)
+
+    def read_text(self, encoding: AnyStr = 'utf_8') -> AnyStr:
+        return self.path.read_text(encoding)
+
+    def __truediv__(self, other) -> ComparisonPath:
+        return LocalPath(self.path / other)
+
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    def mkdir_p(self) -> None:
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    def write_text(self, content: AnyStr, encoding: AnyStr = 'utf_8') -> None:
+        self.path.write_text(content, encoding)
+
+    @staticmethod
+    def is_valid_path_string(path: AnyStr) -> bool:
+        return True
+
+    def __str__(self) -> AnyStr:
+        return str(self.path)
+
+    def description(self) -> AnyStr:
+        return 'Local filesystem'

--- a/scripts/metadata_comparison/metadata_comparison/lib/logging.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/logging.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
 import logging
+import warnings
+
 
 def set_log_verbosity(verbose: bool) -> None:
-    if verbose:
-        logging.basicConfig(format='[%(asctime)s] [%(name)s] %(message)s', level=logging.INFO)
-    else:
-        logging.basicConfig(format='[%(asctime)s] [%(name)s] %(message)s', level=logging.WARNING)
+    level = logging.INFO if verbose else logging.WARNING
+    logging.basicConfig(format='[%(asctime)s] [%(name)s] %(message)s', level=level)
 
 
 def quieten_chatty_imports() -> None:
     logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
     logging.getLogger('googleapiclient.discovery').setLevel(logging.WARNING)
+    # Controversial and doesn't seem to work for the tests anyway, YMMV.
+    # warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")

--- a/scripts/metadata_comparison/metadata_comparison/lib/operation_ids.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/operation_ids.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import re
-from typing import Sequence, Mapping, Any
+from typing import Any, AnyStr, Callable, Dict, List, Sequence, TypeVar, Union
 
 PAPI_V1_OPERATION_REGEX = re.compile('^operations/[^/]*')
 PAPI_V2ALPHA1_OPERATION_REGEX = re.compile('^projects/[^/]*/operations/[0-9]*')
@@ -33,30 +33,67 @@ def operation_id_to_api_version(value: str) -> str:
         raise Exception(f'Cannot deduce PAPI api version from unexpected operation ID format \'{value}\'')
 
 
-def find_operation_ids_in_metadata(json_metadata: Mapping[str, Any]) -> Sequence[str]:
-    """Finds all instances of PAPI operations IDs in a workflow"""
-    # Eg given:
-    # {
-    #   "calls": {
-    #     "workflow_name.task_name": [
-    #       {
-    #         "jobId": "projects/broad-dsde-cromwell-dev/operations/01234567891011121314",
-    # ...
-    #
-    # We want to extract "projects/broad-dsde-cromwell-dev/operations/01234567891011121314"
-    papi_operations = []
+# What a JSON Object works out to be.
+JsonObject = Dict[str, Union[Union[None, AnyStr, float], Any]]
+Accumulator = TypeVar('Accumulator')
+OperationId = AnyStr
+CallNameSequence = Sequence[AnyStr]
 
-    def find_operation_ids_in_calls(calls):
-        for callname in calls:
-            attempts = calls[callname]
+OperationMappingCallFunction = Callable[[Accumulator, OperationId, CallNameSequence, JsonObject], None]
+
+
+def visit_papi_operations(json_metadata: JsonObject,
+                          call_fn: OperationMappingCallFunction,
+                          initial_accumulator: Accumulator) -> Accumulator:
+    """
+    Visits all PAPI operations represented in the Cromwell metadata of `json_metadata`.
+    There will be more operations than calls if any of the operations were preempted or were failed and retried.
+    For every PAPI operation, the function `call_fn` is invoked with the parameters:
+
+    - Accumulator: an object of the type specified by the caller of this function per `initial_accumulator`.
+    - OperationId: The PAPI operation ID of the job as a string.
+    - CallNameSequence: The "breadcrumbs" leading to this call (e.g. [grandparent_wf, parent_wf, wf, call])
+    - JsonObject: The JSON object representing the individual job being examined.
+
+    The final Accumulator is returned as the result of this function.
+    """
+
+    accumulator = initial_accumulator
+
+    def examine_calls(calls: JsonObject, path_so_far: List[AnyStr]) -> None:
+        for call_name in calls:
+            attempts = calls[call_name]
             for attempt in attempts:
                 operation_id = attempt.get('jobId')
-                subWorkflowMetadata = attempt.get('subWorkflowMetadata')
+                sub_workflow_metadata = attempt.get('subWorkflowMetadata')
+                path = build_call_path(call_name, path_so_far, attempt)
                 if operation_id:
-                    papi_operations.append(operation_id)
-                if subWorkflowMetadata:
-                    find_operation_ids_in_calls(subWorkflowMetadata.get('calls', {}))
+                    call_fn(accumulator, operation_id, path, attempt)
+                if sub_workflow_metadata:
+                    examine_calls(sub_workflow_metadata.get('calls', {}), path)
 
-    find_operation_ids_in_calls(json_metadata.get('calls', {}))
+    def build_call_path(call_name: str, path_so_far: List[AnyStr], attempt: dict) -> List[AnyStr]:
+        call_path = path_so_far.copy()
 
-    return papi_operations
+        # Remove confusing duplication in subworkflow call names.
+        # A parent workflow would name a subworkflow call "parent_wf.sub_wf".
+        # The subworkflow would name its calls "sub_wf.sub_call".
+        # If those call components were simply joined the result would be
+        # "parent_wf.sub_wf.sub_wf.sub_call". This logic removes the duplication of "sub_wf",
+        # resulting in "parent_wf.sub_wf.sub_call".
+        deduplicated_call_name = call_name
+        if len(path_so_far) > 0:
+            this_call_components = call_name.split('.')
+            if len(this_call_components) > 1 and path_so_far[-1].endswith('.' + this_call_components[0]):
+                deduplicated_call_name = '.'.join(this_call_components[1:])
+
+        call_path.append(deduplicated_call_name)
+        shard_index = attempt.get('shardIndex', -1)
+        if shard_index != -1:
+            call_path.append(f"shard_{shard_index:04d}")
+
+        return call_path
+
+    examine_calls(calls=json_metadata.get('calls', {}), path_so_far=[])
+
+    return accumulator

--- a/scripts/metadata_comparison/metadata_comparison/lib/storage.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/storage.py
@@ -2,10 +2,11 @@
 
 from google.cloud import storage
 import logging
+from typing import AnyStr
 
 
 def upload_blob(bucket_name: str,
-                source_file_contents: str,
+                source_file_contents: AnyStr,
                 destination_blob_name: str,
                 gcs_storage_client: storage.Client,
                 logger: logging.Logger) -> None:

--- a/scripts/metadata_comparison/test/test_digester.py
+++ b/scripts/metadata_comparison/test/test_digester.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+from typing import AnyStr, Callable
+from metadata_comparison.lib.comparison_paths import ComparisonPath
+from pathlib import Path
+import logging
+from metadata_comparison.digester import digest
+from metadata_comparison.lib.logging import quieten_chatty_imports, set_log_verbosity
+import google.auth
+from google.cloud import storage
+
+
+def read_resource(filename: AnyStr) -> AnyStr:
+    path = Path('test/resources') / filename
+    with open(path, 'r') as file:
+        data = file.read()
+    return data
+
+
+class DigesterTestMethods(unittest.TestCase):
+    set_log_verbosity(verbose=True)
+    quieten_chatty_imports()
+
+    def test_digestion(self) -> None:
+        """
+        This uses "real" metadata from the PAPI v2 performance spike to drive digester testing. The metadata is stored
+        in GCS and copied down to the local machine if not already present from an earlier run. The digester can run
+        against either local or GCS paths using `ComparisonPath`s. Local is nicer to iterate on than GCS since it
+        runs so much more quickly. GCS testing can be turned off by setting the DIGESTER_TEST_LOCAL_ONLY environment
+        variable.
+        """
+        bucket_name = 'papi-performance-analysis'
+        subdir = 'exome_germline_single_sample_v1.3/PAPIv2_alpha1/v1_style_machine_types'
+
+        local_parent = ComparisonPath.create(subdir)
+        gcs_parent = ComparisonPath.create(f'gs://{bucket_name}/{subdir}')
+
+        credentials, project_id = google.auth.default()
+        storage_client = storage.Client(credentials=credentials)
+        bucket = storage_client.get_bucket(bucket_name)
+
+        def download_metadata_from_gcs(_local_sample_path: ComparisonPath) -> None:
+            _local_sample_path.mkdir_p()
+            (_local_sample_path / "operations").mkdir_p()
+
+            prefix = str(_local_sample_path)
+            blobs = bucket.list_blobs(prefix=prefix)
+            for blob in blobs:
+                if not blob.name.endswith('/digest.json'):
+                    logging.info(f'Downloading blob: {blob.name}')
+                    blob.download_to_filename(blob.name)
+
+        samples = {
+            'dev_C1963.CHMI_CHMI3_Nex1': {
+                'total_jobs': 133,
+                'more_than_1_attempts': 12,
+                'more_than_2_attempts': 1,
+                'more_than_3_attempts': 0,
+                'cromwell_time_more_than_3_minutes_longer_total': 21,
+                'cromwell_time_more_than_4_minutes_longer_total': 7,
+                'cromwell_time_more_than_5_minutes_longer_total': 4,
+                'cromwell_time_more_than_6_minutes_longer_total': 2,
+                'cromwell_time_more_than_7_minutes_longer_total': 1,
+                'cromwell_time_more_than_8_minutes_longer_total': 0,
+                # insert more intelligent assertions here
+            }
+            # more samples if needed
+            # 'dev_C862.NA19238',
+            # 'dev_D5327.NA12878',
+            # 'dev_D5327.NA12891',
+            # 'dev_D5327.NA12892',
+            # 'dev_RP-1535.NA17-308'
+        }
+
+        for sample_name in samples.keys():
+            # Copy down workflow and PAPI operations metadata from GCS if needed to test Local
+            local_sample_path = local_parent / sample_name
+            if not local_sample_path.exists():
+                logging.info(f"Local sample directory '{local_sample_path}' does not exist, downloading from GCS.")
+                download_metadata_from_gcs(local_sample_path)
+
+            parents_to_test = [local_parent, gcs_parent]
+
+            for parent in parents_to_test:
+                description = parent.description()
+                logging.info(f"Running digester test on {description} for sample '{sample_name}'")
+                sample_path = parent / sample_name
+                workflow_path = sample_path / 'workflow.json'
+                operations_path = sample_path / 'operations'
+                actual = digest(workflow_path, operations_path)
+
+                expected = samples[sample_name]
+                calls = actual.get('calls')
+
+                actual_total = len(calls)
+                self.assertEqual(actual_total, expected['total_jobs'])
+
+                def more_than_x_attempts(attempts: int) -> Callable[[AnyStr], bool]:
+                    def inner(call_name: AnyStr) -> bool:
+                        return calls.get(call_name).get('attempt') > attempts
+                    return inner
+
+                for num_attempts in [1, 2, 3]:
+                    actual = len(list(filter(more_than_x_attempts(num_attempts), calls)))
+                    self.assertEqual(actual, expected[f'more_than_{num_attempts}_attempts'])
+
+                def more_than_x_minutes_longer(minutes: int) -> Callable[[AnyStr], bool]:
+                    def inner(call_name: AnyStr) -> bool:
+                        return calls.get(call_name).get('cromwellAdditionalTotalTimeSeconds') > minutes * 60
+                    return inner
+
+                for minutes_longer in range(3, 9):
+                    actual = len(list(filter(more_than_x_minutes_longer(minutes_longer), calls)))
+                    self.assertEqual(actual, expected[f'cromwell_time_more_than_{minutes_longer}_minutes_longer_total'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -100,7 +100,16 @@ trait MetadataDatabaseAccess {
       MetadataEntry(workflowUuid, jobKey.map(_._1), jobKey.flatMap(_._2), jobKey.map(_._3),
         key.key, value.toClobOption, valueType, timestamp)
     }
-    metadataDatabaseInterface.addMetadataEntries(metadata)
+    metadataDatabaseInterface.addMetadataEntries(
+      metadataEntries = metadata,
+      startMetadataKey = WorkflowMetadataKeys.StartTime,
+      endMetadataKey = WorkflowMetadataKeys.EndTime,
+      nameMetadataKey = WorkflowMetadataKeys.Name,
+      statusMetadataKey = WorkflowMetadataKeys.Status,
+      submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
+      parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
+      rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
+      labelMetadataKey = WorkflowMetadataKeys.Labels)
   }
 
   private def metadataToMetadataEvents(workflowId: WorkflowId)(metadata: Seq[MetadataEntry]): Seq[MetadataEvent] = {
@@ -170,26 +179,12 @@ trait MetadataDatabaseAccess {
   def refreshWorkflowMetadataSummaries(limit: Int)(implicit ec: ExecutionContext): Future[SummaryResult] = {
     for {
       increasingProcessed <- metadataDatabaseInterface.summarizeIncreasing(
-        startMetadataKey = WorkflowMetadataKeys.StartTime,
-        endMetadataKey = WorkflowMetadataKeys.EndTime,
-        nameMetadataKey = WorkflowMetadataKeys.Name,
-        statusMetadataKey = WorkflowMetadataKeys.Status,
-        submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
-        parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
-        rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
         labelMetadataKey = WorkflowMetadataKeys.Labels,
         limit = limit,
         buildUpdatedSummary = MetadataDatabaseAccess.buildUpdatedSummary)
       (decreasingProcessed, decreasingGap) <- metadataDatabaseInterface.summarizeDecreasing(
         summaryNameDecreasing = WorkflowMetadataKeys.SummaryNameDecreasing,
         summaryNameIncreasing = WorkflowMetadataKeys.SummaryNameIncreasing,
-        startMetadataKey = WorkflowMetadataKeys.StartTime,
-        endMetadataKey = WorkflowMetadataKeys.EndTime,
-        nameMetadataKey = WorkflowMetadataKeys.Name,
-        statusMetadataKey = WorkflowMetadataKeys.Status,
-        submissionMetadataKey = WorkflowMetadataKeys.SubmissionTime,
-        parentWorkflowIdKey = WorkflowMetadataKeys.ParentWorkflowId,
-        rootWorkflowIdKey = WorkflowMetadataKeys.RootWorkflowId,
         labelMetadataKey = WorkflowMetadataKeys.Labels,
         limit = limit,
         buildUpdatedSummary = MetadataDatabaseAccess.buildUpdatedSummary)

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -130,7 +130,15 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
 
     var requestsSinceLastSuccess = 0
     // Return successful
-    override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry])
+    override def addMetadataEntries(metadataEntries: Iterable[MetadataEntry],
+                                    startMetadataKey: String,
+                                    endMetadataKey: String,
+                                    nameMetadataKey: String,
+                                    statusMetadataKey: String,
+                                    submissionMetadataKey: String,
+                                    parentWorkflowIdKey: String,
+                                    rootWorkflowIdKey: String,
+                                    labelMetadataKey: String)
                                    (implicit ec: ExecutionContext): Future[Unit] = {
       if (requestsSinceLastSuccess == failuresBetweenEachSuccess) {
         requestsSinceLastSuccess = 0
@@ -175,14 +183,7 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
                                              timeout: Duration)
                                             (implicit ec: ExecutionContext): Nothing = notImplemented()
 
-    override def summarizeIncreasing(startMetadataKey: String,
-                                     endMetadataKey: String,
-                                     nameMetadataKey: String,
-                                     statusMetadataKey: String,
-                                     submissionMetadataKey: String,
-                                     parentWorkflowIdKey: String,
-                                     rootWorkflowIdKey: String,
-                                     labelMetadataKey: String,
+    override def summarizeIncreasing(labelMetadataKey: String,
                                      limit: Int,
                                      buildUpdatedSummary:
                                      (Option[WorkflowMetadataSummaryEntry], Seq[MetadataEntry])
@@ -197,13 +198,6 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
       */
     override def summarizeDecreasing(summaryNameDecreasing: String,
                                      summaryNameIncreasing: String,
-                                     startMetadataKey: String,
-                                     endMetadataKey: String,
-                                     nameMetadataKey: String,
-                                     statusMetadataKey: String,
-                                     submissionMetadataKey: String,
-                                     parentWorkflowIdKey: String,
-                                     rootWorkflowIdKey: String,
                                      labelMetadataKey: String,
                                      limit: Int,
                                      buildUpdatedSummary:

--- a/src/ci/bin/testMetadataComparisonPython.sh
+++ b/src/ci/bin/testMetadataComparisonPython.sh
@@ -2,6 +2,8 @@
 
 set -o errexit -o nounset -o pipefail
 
+export CROMWELL_BUILD_REQUIRES_SECURE=true
+
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
@@ -11,7 +13,15 @@ cromwell::build::setup_common_environment
 # Our Python scripts can only be run by Python version >= 3.6, because we use string interpolation which was introduced
 # in Python 3.6. But Travis environment is Ubuntu 16.04 Xenial LTS, which officially supports only Python <= 3.5.
 # Thus we have to run Python tests in Docker container.
-docker run -it --rm -v "${CROMWELL_BUILD_ROOT_DIRECTORY}/scripts/metadata_comparison:/metadata_comparison" python:3 /bin/bash -c "
+GOOGLE_CENTAUR_SERVICE_ACCOUNT_JSON="cromwell-centaur-service-account.json"
+export GOOGLE_APPLICATION_CREDENTIALS="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${GOOGLE_CENTAUR_SERVICE_ACCOUNT_JSON}"
+
+docker run -it --rm \
+           -e GOOGLE_APPLICATION_CREDENTIALS \
+           -v "${CROMWELL_BUILD_RESOURCES_DIRECTORY}:${CROMWELL_BUILD_RESOURCES_DIRECTORY}" \
+           -v "${CROMWELL_BUILD_ROOT_DIRECTORY}/scripts/metadata_comparison:/metadata_comparison" \
+           python:3 /bin/bash -c "
+
 pip install --upgrade requests
 pip install --upgrade google-api-python-client
 pip install --upgrade google-cloud

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchExpressionFunctions.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchExpressionFunctions.scala
@@ -36,6 +36,7 @@ import cromwell.core.io.IoCommandBuilder
 import cromwell.filesystems.s3.S3PathBuilder
 import cromwell.filesystems.s3.S3PathBuilder.{InvalidS3Path, PossiblyValidRelativeS3Path, ValidFullS3Path}
 import cromwell.filesystems.s3.batch.S3BatchCommandBuilder
+import cromwell.core.path.{DefaultPath, Path}
 
 class AwsBatchExpressionFunctions(standardParams: StandardExpressionFunctionsParams)
   extends StandardExpressionFunctions(standardParams) {
@@ -52,5 +53,10 @@ class AwsBatchExpressionFunctions(standardParams: StandardExpressionFunctionsPar
 
 class AwsBatchExpressionFunctionsForFS(standardParams: StandardExpressionFunctionsParams)
   extends StandardExpressionFunctions(standardParams) {
-
+  override def postMapping(path: Path) = {
+    path match {
+      case _: DefaultPath if !path.isAbsolute => callContext.root.resolve(path)
+      case _ => path
+    }
+  }
 }


### PR DESCRIPTION
1. When the AWS backend job actually failed with memory error, instead of returning that error code the commandScript returned zero.  Fixed it to return the  error code so that it a failed job in batch.
2. Added AWS-EFS expression post mapping function so the output expressions with files with relative paths get mapped to the correct path.