### PR TITLE
Update Dockerfile to newer OpenJDK to sidestep expired cert [BA-6466]

### DIFF
--- a/scripts/docker-develop/Dockerfile
+++ b/scripts/docker-develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u171
+FROM openjdk:8u252
 
 # docker build -t vanessa/cromwell-dev .
 

--- a/scripts/docker-develop/Dockerfile
+++ b/scripts/docker-develop/Dockerfile
@@ -13,9 +13,6 @@ FROM openjdk:8u252
 ENV SCALA_VERSION 2.12.9
 ENV SBT_VERSION 1.2.8
 
-# Scala expects this file
-RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
-
 #
 ## Scala
 #


### PR DESCRIPTION
Thanks to @kshakir for the correct diagnosis of the cert problem. 🙂 