### PR TITLE
Add localization doc for Configuring#local-filesystem-options

### DIFF
--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -523,6 +523,13 @@ config section:
       config {
         filesystems {
           local {
+            # When localizing a file, what type of file duplication should occur. 
+            # possible values: "hard-link", "soft-link", "copy", "cached-copy".
+            # For more information check: https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem
+            localization: [
+              "hard-link", "soft-link", "copy"
+            ]
+
             caching {
               # When copying a cached result, what type of file duplication should occur. 
               # possible values: "hard-link", "soft-link", "copy", "cached-copy".


### PR DESCRIPTION
Add `localization` field on the [Configuring#local-filesystem-options](https://cromwell.readthedocs.io/en/stable/Configuring/#local-filesystem-options) documentation page. I got confused about what options were present, and I realise the problems that I'd actually had (https://github.com/broadinstitute/cromwell/issues/5533).

I think this little change (backed up by a [HPC#shared-filesystem](https://cromwell.readthedocs.io/en/stable/backends/HPC/#shared-filesystem) makes it clearer about what's expected when configuring localization options for a local filesystem.

