### PR TITLE
Workaround for "The job exceeded the maximum log length, and has been terminated" Travis error [BA-6480]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ after_failure:
   # show 10 lines before and after each occurrence of `*** FAILED ***` pattern (Centaur error) in case of build failure.
   # If grep returns no matches, it means that error is not Centaur-related and we try to print the whole log to stdout.
   # In case of successful build we won't print out the Centaur log at all.
-  - cat logfile.txt | grep -B 10 -A 10 "\*\*\* FAILED \*\*\*" || cat logfile.txt
+  - grep -C 10 "\*\*\* FAILED \*\*\*" logfile.txt || cat logfile.txt
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,9 @@ env:
     - >-
       BUILD_TYPE=metadataComparisonPython
 script:
+  # print result of `uptime` command to stdout every 5 minutes in order to avoid Travis log silence timeout (10 minutes)
+  - while sleep 300; do uptime; done &
+  # execute test suite
   - src/ci/bin/test.sh > logfile.txt
 after_failure:
   # Travis fails the job when log size grows over 4 Mb. Here we try to overcome this by using `grep` in order to only

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,13 @@ env:
     - >-
       BUILD_TYPE=metadataComparisonPython
 script:
-  - src/ci/bin/test.sh
+  - src/ci/bin/test.sh > logfile.txt
+after_failure:
+  # Travis fails the job when log size grows over 4 Mb. Here we try to overcome this by using `grep` in order to only
+  # show 10 lines before and after each occurrence of `*** FAILED ***` pattern (Centaur error) in case of build failure.
+  # If grep returns no matches, it means that error is not Centaur-related and we try to print the whole log to stdout.
+  # In case of successful build we won't print out the Centaur log at all.
+  - cat logfile.txt | grep -B 10 -A 10 "\*\*\* FAILED \*\*\*" || cat logfile.txt
 notifications:
   slack:
     rooms:

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -7,8 +7,6 @@ source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
 
 cromwell::build::setup_common_environment
 
-cromwell::build::start_build_heartbeat
-
 cromwell::build::assemble_jars
 
 # Test 1: basic hello world


### PR DESCRIPTION
One downside of `grep` approach - result of `grep` is collapsed by default, so one would need to expand it to see actual errors. I think this is tolerable.
![image](https://user-images.githubusercontent.com/4853242/85418371-b5263000-b53e-11ea-95f3-7bff39b08cff.png)
