### PR TITLE
Alternative workaround for excessive Travis log length problem [BA-6480]

### DIFF
--- a/docs/developers/bitesize/ci/travis_centaur.md
+++ b/docs/developers/bitesize/ci/travis_centaur.md
@@ -51,9 +51,9 @@ or `papi_v2beta_centaur_application.conf`
 
 - Engine Upgrade: Retrieves the [Cromwell Version](https://github.com/broadinstitute/cromwell/blob/47/project/Version.scala#L8) then retrieves the previous jar/docker-image from DockerHub. Centaur starts with the prior version, then restarts with the compiled source code.
 - Horicromtal: Runs a [docker-compose](https://github.com/broadinstitute/cromwell/blob/47/src/ci/docker-compose/docker-compose-horicromtal.yml) with:
-    1. cromwell-database-master: started first
-    2. cromwell-summarizer-plus-backend: runs summarizer
-    3. cromwell-frontend-plus-backend: exposes HTTP
+    1. crom-db-mstr: started first
+    2. crom-sum-back: runs summarizer
+    3. crom-front-back: exposes HTTP
 - Horicromtal Engine Upgrade: Combination of Horicromtal and Engine Upgrade
 - PAPI Upgrade: Tests run with Papi V1 and upon restart use Papi V2
 - PAPI Upgrade New Workflows: Test definition [does not run any tests](https://travis-ci.org/broadinstitute/cromwell/jobs/475378412)

--- a/docs/developers/bitesize/ci/travis_centaur.md
+++ b/docs/developers/bitesize/ci/travis_centaur.md
@@ -51,9 +51,9 @@ or `papi_v2beta_centaur_application.conf`
 
 - Engine Upgrade: Retrieves the [Cromwell Version](https://github.com/broadinstitute/cromwell/blob/47/project/Version.scala#L8) then retrieves the previous jar/docker-image from DockerHub. Centaur starts with the prior version, then restarts with the compiled source code.
 - Horicromtal: Runs a [docker-compose](https://github.com/broadinstitute/cromwell/blob/47/src/ci/docker-compose/docker-compose-horicromtal.yml) with:
-    1. crom-db-mstr: started first
-    2. crom-sum-back: runs summarizer
-    3. crom-front-back: exposes HTTP
+    1. db-mstr: started first
+    2. sum-back: runs summarizer
+    3. front-back: exposes HTTP
 - Horicromtal Engine Upgrade: Combination of Horicromtal and Engine Upgrade
 - PAPI Upgrade: Tests run with Papi V1 and upon restart use Papi V2
 - PAPI Upgrade New Workflows: Test definition [does not run any tests](https://travis-ci.org/broadinstitute/cromwell/jobs/475378412)

--- a/src/ci/docker-compose/docker-compose-horicromtal.yml
+++ b/src/ci/docker-compose/docker-compose-horicromtal.yml
@@ -7,7 +7,7 @@ services:
   # - Running the summarizer
   # - Running the carboniter
   # - Running the archived-metadata-deleter
-  crom-db-mstr:
+  db-mstr:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -41,7 +41,7 @@ services:
   # Is a regular Cromwell workflow-running backend.
   # Makes no changes to the config file we bring in, so always summarizes, and sometimes does carboniting and metadata
   # deletion things, but only if the underlying config file says that we do.
-  crom-sum-back:
+  sum-back:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -63,7 +63,7 @@ services:
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
     depends_on:
-      crom-db-mstr:
+      db-mstr:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8000"]
@@ -76,14 +76,14 @@ services:
   # - Running the summarizer
   # - Running the carboniter
   # - Running the archived-metadata-deleter
-  crom-front-back:
+  front-back:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
     depends_on:
-      crom-db-mstr:
+      db-mstr:
         condition: service_healthy
     command: ["server"]
     environment:

--- a/src/ci/docker-compose/docker-compose-horicromtal.yml
+++ b/src/ci/docker-compose/docker-compose-horicromtal.yml
@@ -76,7 +76,7 @@ services:
   # - Running the summarizer
   # - Running the carboniter
   # - Running the archived-metadata-deleter
-  crm-front-back:
+  crom-front-back:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}

--- a/src/ci/docker-compose/docker-compose-horicromtal.yml
+++ b/src/ci/docker-compose/docker-compose-horicromtal.yml
@@ -7,7 +7,7 @@ services:
   # - Running the summarizer
   # - Running the carboniter
   # - Running the archived-metadata-deleter
-  cromwell-database-master:
+  crom-db-mstr:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -41,7 +41,7 @@ services:
   # Is a regular Cromwell workflow-running backend.
   # Makes no changes to the config file we bring in, so always summarizes, and sometimes does carboniting and metadata
   # deletion things, but only if the underlying config file says that we do.
-  cromwell-summarizer-plus-backend:
+  crom-sum-back:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -63,7 +63,7 @@ services:
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
     depends_on:
-      cromwell-database-master:
+      crom-db-mstr:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8000"]
@@ -76,14 +76,14 @@ services:
   # - Running the summarizer
   # - Running the carboniter
   # - Running the archived-metadata-deleter
-  cromwell-frontend-plus-backend:
+  crm-front-back:
     image: "broadinstitute/cromwell:${CROMWELL_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
     depends_on:
-      cromwell-database-master:
+      crom-db-mstr:
         condition: service_healthy
     command: ["server"]
     environment:


### PR DESCRIPTION
The main thing which differs Horicromtal test logs from others - name of the Docker container in the beginning of each log line. Let's shorten those container names.