### PR TITLE
Allow nested inputs when corresponding meta setting is set to true

### DIFF
--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/CallElementToGraphNode.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/CallElementToGraphNode.scala
@@ -54,7 +54,7 @@ object CallElementToGraphNode {
 
     def supplyableInput(definition: Callable.InputDefinition): Boolean = {
         !definition.isInstanceOf[FixedInputDefinitionWithDefault] &&
-        !definition.name.contains(".") // NB: Remove this check when sub-workflows allow pass-through task inputs
+          (!definition.name.contains(".") || a.allowNestedInputs)
     }
 
     def validInput(name: String, definition: Callable.InputDefinition): Boolean = {
@@ -224,4 +224,5 @@ case class CallNodeMakerInputs(node: CallElement,
                                availableTypeAliases: Map[String, WomType],
                                workflowName: String,
                                insideAnotherScatter: Boolean,
+                               allowNestedInputs: Boolean,
                                callables: Map[String, Callable])

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/IfElementToGraphNode.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/IfElementToGraphNode.scala
@@ -76,6 +76,7 @@ object IfElementToGraphNode {
       val graphLikeConvertInputs = GraphLikeConvertInputs(graphElements.toSet, ogins, foundOuterGenerators.completionPorts, a.availableTypeAliases, a.workflowName,
                                                           insideAScatter = a.insideAnotherScatter,
                                                           convertNestedScatterToSubworkflow = a.convertNestedScatterToSubworkflow,
+                                                          allowNestedInputs = a.allowNestedInputs,
                                                           a.callables)
       val innerGraph: ErrorOr[Graph] = WorkflowDefinitionElementToWomWorkflowDefinition.convertGraphElements(graphLikeConvertInputs)
 
@@ -96,4 +97,5 @@ final case class ConditionalNodeMakerInputs(node: IfElement,
                                             workflowName: String,
                                             insideAnotherScatter: Boolean,
                                             convertNestedScatterToSubworkflow : Boolean,
+                                            allowNestedInputs: Boolean,
                                             callables: Map[String, Callable])

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/ScatterElementToGraphNode.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/ScatterElementToGraphNode.scala
@@ -103,6 +103,7 @@ object ScatterElementToGraphNode {
       val graphLikeConvertInputs = GraphLikeConvertInputs(graphElements.toSet, ogins ++ Set(womInnerGraphScatterVariableInput), foundOuterGenerators.completionPorts, a.availableTypeAliases, a.workflowName,
                                                           insideAScatter = true,
                                                           convertNestedScatterToSubworkflow = a.convertNestedScatterToSubworkflow,
+                                                          allowNestedInputs = a.allowNestedInputs,
                                                           a.callables)
       val innerGraph: ErrorOr[Graph] = WorkflowDefinitionElementToWomWorkflowDefinition.convertGraphElements(graphLikeConvertInputs)
 
@@ -131,6 +132,7 @@ object ScatterElementToGraphNode {
       val graphLikeConvertInputs = GraphLikeConvertInputs(Set(a.node), subWorkflowInputs, Map.empty, a.availableTypeAliases, a.workflowName,
                                                           insideAScatter = false,
                                                           convertNestedScatterToSubworkflow = a.convertNestedScatterToSubworkflow,
+                                                          allowNestedInputs = a.allowNestedInputs,
                                                           a.callables)
       val subWorkflowGraph = WorkflowDefinitionElementToWomWorkflowDefinition.convertGraphElements(graphLikeConvertInputs)
       subWorkflowGraph map { WomGraphMakerTools.addDefaultOutputs(_) }
@@ -188,4 +190,5 @@ final case class ScatterNodeMakerInputs(node: ScatterElement,
                                         workflowName: String,
                                         insideAnotherScatter: Boolean,
                                         convertNestedScatterToSubworkflow: Boolean,
+                                        allowNestedInputs: Boolean,
                                         callables: Map[String, Callable])

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/WorkflowGraphElementToGraphNode.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/wdlom2wom/graph/WorkflowGraphElementToGraphNode.scala
@@ -50,15 +50,15 @@ object WorkflowGraphElementToGraphNode {
       result.contextualizeErrors(s"process declaration '${typeElement.toWdlV1} $name = ${expr.toWdlV1}'")
 
     case se: ScatterElement =>
-      val scatterMakerInputs = ScatterNodeMakerInputs(se, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.convertNestedScatterToSubworkflow, a.callables)
+      val scatterMakerInputs = ScatterNodeMakerInputs(se, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.convertNestedScatterToSubworkflow, a.allowNestedInputs, a.callables)
       ScatterElementToGraphNode.convert(scatterMakerInputs)
 
     case ie: IfElement =>
-      val ifMakerInputs = ConditionalNodeMakerInputs(ie, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.convertNestedScatterToSubworkflow, a.callables)
+      val ifMakerInputs = ConditionalNodeMakerInputs(ie, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.convertNestedScatterToSubworkflow, a.allowNestedInputs, a.callables)
       IfElementToGraphNode.convert(ifMakerInputs)
 
     case ce: CallElement =>
-      val callNodeMakerInputs = CallNodeMakerInputs(ce, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.callables)
+      val callNodeMakerInputs = CallNodeMakerInputs(ce, a.upstreamCalls, a.linkableValues, a.linkablePorts, a.availableTypeAliases, a.workflowName, a.insideAScatter, a.allowNestedInputs, a.callables)
       CallElementToGraphNode.convert(callNodeMakerInputs)
   }
 
@@ -81,4 +81,5 @@ final case class GraphNodeMakerInputs(node: WorkflowGraphElement,
                                       workflowName: String,
                                       insideAScatter: Boolean,
                                       convertNestedScatterToSubworkflow : Boolean,
+                                      allowNestedInputs: Boolean,
                                       callables: Map[String, Callable])

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/import_me.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/import_me.wdl
@@ -1,0 +1,28 @@
+version 1.0
+
+workflow sub_wf {
+  input {
+    Int y
+  }
+  # Calls foo but doesn't provide an 'x'. That's fine because the input was optional, but now the outer WF cannot override it.
+  call foo { input: y = y }
+
+  # No outputs, but we don't want that to be the error:
+  output { }
+  meta {allowNestedInputs: true}
+}
+
+task foo {
+  input {
+    Int? x
+    Int y
+  }
+  command {
+  }
+  output {
+    Int z = y
+  }
+  runtime {
+    docker: "ubuntu:latest"
+  }
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/supplied_optional_subwf_sub_inputs_meta_enabled.inputs.json
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/supplied_optional_subwf_sub_inputs_meta_enabled.inputs.json
@@ -1,0 +1,4 @@
+{
+  "supplied_optional_subwf_sub_inputs.y": 5,
+  "supplied_optional_subwf_sub_inputs.sub_wf.foo.x": 5
+}

--- a/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/supplied_optional_subwf_sub_inputs_meta_enabled.wdl
+++ b/womtool/src/test/resources/validate/wdl_draft3/valid/supplied_optional_subwf_sub_inputs_meta_enabled/supplied_optional_subwf_sub_inputs_meta_enabled.wdl
@@ -1,0 +1,14 @@
+version 1.0
+
+import "import_me.wdl"
+
+workflow supplied_optional_subwf_sub_inputs {
+  input {
+    Int y
+  }
+  # Shouldn't (strictly) be able to call this sub-workflow because the inputs are not passed through
+  call import_me.sub_wf {input: y=y}
+  meta {
+    allowNestedInputs: true
+  }
+}


### PR DESCRIPTION
This implements part of the spec change that handles inputs https://github.com/openwdl/wdl/pull/359

A rewrite from https://github.com/broadinstitute/cromwell/pull/5523 .

This foregoes the restriction that the specs requires that all required inputs should be set at the top-level workflow.

It does enable using bubbled up inputs when the meta flag is set.

The restrictions should be enabled on biscayne. But I have no idea how to implement that in this code base. Some help is needed. For now implementing this in the new base at least implements part of the spec.