### PR TITLE
Fix GAX RPC dependency scope [BA-6509]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
   private val googleOauth2V = "0.21.0"
   private val googleOauthClientV = "1.31.0"
   private val googleCloudResourceManagerV = "0.87.0-alpha"
-  private val grpcV = "1.28.1"
+  private val grpcV = "1.30.1"
   private val guavaV = "27.0.1-jre"
   private val heterodonV = "1.0.0-beta3"
   private val hsqldbV = "2.4.1"
@@ -510,7 +510,7 @@ object Dependencies {
   )
 
   val servicesDependencies = List(
-    "com.google.api" % "gax-grpc" % googleGaxGrpcV % Test
+    "com.google.api" % "gax-grpc" % googleGaxGrpcV
   )
 
   val serverDependencies = slf4jBindingDependencies


### PR DESCRIPTION
The GRPC version bump was motivated by merge conflicts at assembly time.