### PR TITLE
ExecutionStore should cycle through queued elements [BA-6487 prerequisite]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -281,7 +281,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
         // Even if the key is runnable, if it's a call key and there's already too many queued jobs,
         // don't start it and mark it as WaitingForQueueSpace
         // TODO maybe also limit the number of expression keys to run somehow ?
-        case callKey: CallKey if runnable && startableJobLimit > 0 =>
+        case callKey: CallKey if runnable && startableJobLimit <= 0 =>
           internalUpdates = internalUpdates + (callKey -> WaitingForQueueSpace)
           false
         case _ => runnable

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -22,7 +22,7 @@ class ExecutionStoreSpec extends FlatSpec with Matchers {
     while (store.needsUpdate) {
       val update = store.update
       update.runnableKeys.size should be(1000)
-      print("Started 1000 jobs...")
+      println("Started 1000 jobs...")
       store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -1,0 +1,50 @@
+package cromwell.engine.workflow.lifecycle.execution.stores
+
+import cromwell.backend.BackendJobDescriptorKey
+import cromwell.core.ExecutionStatus.{ExecutionStatus, _}
+import cromwell.core.{CallKey, JobKey}
+import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStoreSpec._
+import org.scalatest.{FlatSpec, Matchers}
+import wom.graph._
+
+class ExecutionStoreSpec extends FlatSpec with Matchers {
+
+
+
+  it should "keep requiring an update until all 10000 call keys are started" in {
+
+    def jobKeys: Map[JobKey, ExecutionStatus] = (0.until(10000).toList map {
+      i => BackendJobDescriptorKey(noConnectionsGraphNode, Option(i), 1) -> NotStarted })
+      .toMap
+
+    var store: ExecutionStore = ActiveExecutionStore(jobKeys, needsUpdate = true)
+
+    while (store.needsUpdate) {
+      print("cycle")
+      val update = store.update
+      update.runnableKeys.size should be(1000)
+      store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
+    }
+
+    store.store(QueuedInCromwell).size should be(10000)
+  }
+}
+
+object ExecutionStoreSpec {
+  final case class MockJobKey(i: Int) extends CallKey {
+    override def node: CallNode = noConnectionsGraphNode
+    override def index: Option[Int] = Option(0)
+    override def attempt: Int = 0
+    override def tag: String = s"test_job_0"
+  }
+
+  val noConnectionsGraphNode: CommandCallNode = CommandCallNode(
+    identifier = WomIdentifier("mock_task", "mock_wf.mock_task"),
+    callable = null,
+    inputPorts =  Set.empty[GraphNodePort.InputPort],
+    inputDefinitionMappings = List.empty,
+    nonInputBasedPrerequisites = Set.empty[GraphNode],
+    outputIdentifierCompoundingFunction = (wi, _) => wi,
+    sourceLocation = None
+  )
+}

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -20,9 +20,9 @@ class ExecutionStoreSpec extends FlatSpec with Matchers {
     var store: ExecutionStore = ActiveExecutionStore(jobKeys, needsUpdate = true)
 
     while (store.needsUpdate) {
-      print("cycle")
       val update = store.update
       update.runnableKeys.size should be(1000)
+      print("Started 1000 jobs...")
       store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
     }
 
@@ -31,12 +31,6 @@ class ExecutionStoreSpec extends FlatSpec with Matchers {
 }
 
 object ExecutionStoreSpec {
-  final case class MockJobKey(i: Int) extends CallKey {
-    override def node: CallNode = noConnectionsGraphNode
-    override def index: Option[Int] = Option(0)
-    override def attempt: Int = 0
-    override def tag: String = s"test_job_0"
-  }
 
   val noConnectionsGraphNode: CommandCallNode = CommandCallNode(
     identifier = WomIdentifier("mock_task", "mock_wf.mock_task"),

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -2,7 +2,7 @@ package cromwell.engine.workflow.lifecycle.execution.stores
 
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionStatus.{ExecutionStatus, _}
-import cromwell.core.{CallKey, JobKey}
+import cromwell.core.JobKey
 import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStoreSpec._
 import org.scalatest.{FlatSpec, Matchers}
 import wom.graph._

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -4,36 +4,58 @@ import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionStatus.{ExecutionStatus, _}
 import cromwell.core.JobKey
 import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStoreSpec._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import wom.graph._
 
-class ExecutionStoreSpec extends FlatSpec with Matchers {
+import scala.util.Random
 
+class ExecutionStoreSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
+  var store: ExecutionStore = _
 
-  it should "keep requiring an update until all 10000 call keys are started" in {
-
+  before {
     def jobKeys: Map[JobKey, ExecutionStatus] = (0.until(10000).toList map {
       i => BackendJobDescriptorKey(noConnectionsGraphNode, Option(i), 1) -> NotStarted })
       .toMap
 
-    var store: ExecutionStore = ActiveExecutionStore(jobKeys, needsUpdate = true)
+    store = ActiveExecutionStore(jobKeys, needsUpdate = true)
+  }
 
-    def updateStoreToEnqueueNewlyRunnableJobs(): Unit = {
-      while (store.needsUpdate) {
-        val update = store.update
-        store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
-      }
+  def updateStoreToEnqueueNewlyRunnableJobs(): Unit = {
+    while (store.needsUpdate) {
+      val update = store.update
+      store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
     }
+  }
+
+  it should "keep allowing updates while 10000 call keys are enqueued and then started" in {
 
     updateStoreToEnqueueNewlyRunnableJobs()
 
     store.store(QueuedInCromwell).size should be(1000)
     store.store(WaitingForQueueSpace).size should be(9000)
+    store.store.contains(Running) should be(false)
 
     while(store.store.getOrElse(Running, List.empty).size < 10000) {
       store = store.updateKeys(store.store(QueuedInCromwell).map(j => j -> Running).toMap)
       updateStoreToEnqueueNewlyRunnableJobs()
+    }
+  }
+
+  it should "never enqueue more than the total allowed queue space" in {
+
+    updateStoreToEnqueueNewlyRunnableJobs()
+
+    while(store.store.getOrElse(Running, List.empty).size < 10000) {
+      val newlyRunning = Random.nextInt(1000)
+      store = store.updateKeys(store.store(QueuedInCromwell).take(newlyRunning).map(j => j -> Running).toMap)
+      updateStoreToEnqueueNewlyRunnableJobs()
+
+      // In all situations, the queue should never go above the queue limit:
+      (store.store.getOrElse(QueuedInCromwell, List.empty).size <= 1000) should be(true)
+
+      // Additionally, as long as elements are waiting for queue space, the queue should be exactly 1000 long
+      if (store.store.contains(WaitingForQueueSpace)) { store.store(QueuedInCromwell).size should be(1000) }
     }
   }
 }


### PR DESCRIPTION
Updating keys in the ExecutionStore might leave room for previously "waiting for queue space" jobs to start.

TOL: I'm not 100% sure what this concept of "waiting for queue space" is, it seems to be distinct from the EJEA QueuedInCromwell task status since it's quite possible to have over 100,000 jobs in _that_ status just fine... 🤔 