### PR TITLE
Quiet v2 alpha warning [BA-6487 prereq]

### DIFF
--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -72,6 +72,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
           val httpCredentialsAdapter = new HttpCredentialsAdapter(credentials)
           val cloudResourceManagerBuilder = new CloudResourceManager
           .Builder(GoogleAuthMode.httpTransport, GoogleAuthMode.jsonFactory, httpCredentialsAdapter)
+            .setApplicationName(applicationName)
             .build()
 
           val project = cloudResourceManagerBuilder.projects().get(createPipelineParameters.projectId)


### PR DESCRIPTION
10K copies of the same error message per Cloud NAT run gets old fast.