### PR TITLE
Remove redundant WaitingForQueueSpace execution status [BA-6487 prereq]

### DIFF
--- a/core/src/main/scala/cromwell/core/ExecutionStatus.scala
+++ b/core/src/main/scala/cromwell/core/ExecutionStatus.scala
@@ -2,16 +2,15 @@ package cromwell.core
 
 object ExecutionStatus extends Enumeration {
   type ExecutionStatus = Value
-  val NotStarted, WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
+  val NotStarted, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
   val TerminalStatuses = Set(Failed, Done, Aborted, Bypassed, Unstartable)
   val TerminalOrRetryableStatuses = TerminalStatuses + RetryableFailure
   val NonTerminalStatuses = values.diff(TerminalOrRetryableStatuses)
-  val ActiveStatuses = Set(WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting)
+  val ActiveStatuses = Set(QueuedInCromwell, Starting, Running, Aborting)
 
   implicit val ExecutionStatusOrdering = Ordering.by { status: ExecutionStatus =>
     status match {
       case NotStarted => 0
-      case WaitingForQueueSpace => 1
       case QueuedInCromwell => 2
       case Starting => 3
       case Running => 4

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -65,11 +65,6 @@ trait CallMetadataHelper {
 
     serviceRegistryActor ! PutMetadataAction(events)
   }
-  
-  def pushWaitingForQueueSpaceCallMetadata(jobKey: JobKey) = {
-    val event = MetadataEvent(metadataKeyForCall(jobKey, CallMetadataKeys.ExecutionStatus), MetadataValue(WaitingForQueueSpace))
-    serviceRegistryActor ! PutMetadataAction(event)
-  }
 
   def pushSuccessfulCallMetadata(jobKey: JobKey, returnCode: Option[Int], outputs: CallOutputs) = {
     val completionEvents = completedCallMetadataEvents(jobKey, ExecutionStatus.Done, returnCode)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -511,7 +511,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       else updatedData.mergeExecutionDiffs(diffs)
     }
 
-    val DataStoreUpdate(runnableKeys, statusChanges, updatedData) = data.executionStoreUpdate
+    val DataStoreUpdate(runnableKeys, _, updatedData) = data.executionStoreUpdate
     val runnableCalls = runnableKeys.view
       .collect({ case k: BackendJobDescriptorKey => k })
       .groupBy(_.node)
@@ -524,10 +524,6 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       })
     val mode = if (restarting) "Restarting" else "Starting"
     if (runnableCalls.nonEmpty) workflowLogger.info(s"$mode " + runnableCalls.mkString(", "))
-
-    statusChanges.collect({
-      case (jobKey, WaitingForQueueSpace) => pushWaitingForQueueSpaceCallMetadata(jobKey)
-    })
 
     val diffValidation = runnableKeys.traverse[ErrorOr, WorkflowExecutionDiff]({
       case key: BackendJobDescriptorKey => processRunnableJob(key, data)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -9,7 +9,7 @@ import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.BackendJobDescriptorKey
 import cromwell.core.ExecutionIndex.ExecutionIndex
 import cromwell.core.ExecutionStatus._
-import cromwell.core.{CallKey, ExecutionIndex, ExecutionStatus, JobKey}
+import cromwell.core.{ExecutionIndex, ExecutionStatus, JobKey}
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor.{apply => _}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStore._
@@ -154,7 +154,6 @@ final case class SealedExecutionStore private[stores](private val statusStore: M
 sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, ExecutionStatus], val needsUpdate: Boolean) {
   // View of the statusStore more suited for lookup based on status
   lazy val store: Map[ExecutionStatus, List[JobKey]] = statusStore.groupBy(_._2).safeMapValues(_.keys.toList)
-  lazy val queuedJobsAboveThreshold = queuedJobs > MaxJobsToStartPerTick
 
   def backendJobDescriptorKeyForNode(node: GraphNode): Option[BackendJobDescriptorKey] = {
     statusStore.keys collectFirst { case k: BackendJobDescriptorKey if k.node eq node => k }
@@ -174,6 +173,9 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     * Update key statuses
     */
   def updateKeys(values: Map[JobKey, ExecutionStatus]): ExecutionStore = {
+    // The store might newly need updating now if keys have changed and either:
+    // - A job has completed -> downstream jobs might now be runnable
+    // - The store had jobs waiting for queue space -> more queue space might have been freed up
     updateKeys(values, needsUpdate || values.values.exists(_.isTerminalOrRetryable))
   }
 
@@ -196,7 +198,7 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
     * Create 2 Tables, one for keys in done status and one for keys in terminal status.
     * A Table is nothing more than a Map[R, Map[C, V]], see Table trait for more details
     * In this case, rows are GraphNodes, columns are ExecutionIndexes, and values are JobKeys
-    * This allows for quick lookup of all shards for a node, as well as accessing a specific key with a 
+    * This allows for quick lookup of all shards for a node, as well as accessing a specific key with a
     * (node, index) pair
    */
   lazy val (doneStatus, terminalStatus) = {
@@ -270,22 +272,15 @@ sealed abstract class ExecutionStore private[stores](statusStore: Map[JobKey, Ex
         internalUpdates = internalUpdates ++ key.nonStartableOutputKeys.map(_ -> Unstartable) + (key -> Unstartable)
       }
 
-      key match {
-        // Even if the key is runnable, if it's a call key and there's already too many queued jobs,
-        // don't start it and mark it as WaitingForQueueSpace
-        // TODO maybe also limit the number of expression keys to run somehow ?
-        case callKey: CallKey if runnable && queuedJobsAboveThreshold =>
-          internalUpdates = internalUpdates + (callKey -> WaitingForQueueSpace)
-          false
-        case _ => runnable
-      }
+      runnable
     }
 
-    // If the queued jobs are not above the threshold, use the nodes that are already waiting for queue space
-    val runnableWaitingForQueueSpace = if (!queuedJobsAboveThreshold) keysWithStatus(WaitingForQueueSpace).toStream else Stream.empty[JobKey]
-    
+//    // If the queued jobs are not above the threshold, use the nodes that are already waiting for queue space
+//    val runnableWaitingForQueueSpace = if (startableJobLimit > 0) keysWithStatus(WaitingForQueueSpace).toStream else Stream.empty[JobKey]
+
     // Start with keys that are waiting for queue space as we know they're runnable already. Then filter the not started ones
-    val readyToStart = runnableWaitingForQueueSpace ++ keysWithStatus(NotStarted).toStream.filter(filterFunction)
+//    val readyToStart = runnableWaitingForQueueSpace ++ keysWithStatus(NotStarted).toStream.filter(filterFunction)
+    val readyToStart = keysWithStatus(NotStarted).toStream.filter(filterFunction)
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
     val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -1,0 +1,60 @@
+package cromwell.engine.workflow.lifecycle.execution.stores
+
+import cromwell.backend.BackendJobDescriptorKey
+import cromwell.core.ExecutionStatus.{ExecutionStatus, _}
+import cromwell.core.JobKey
+import cromwell.engine.workflow.lifecycle.execution.stores.ExecutionStoreSpec._
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import wom.graph._
+
+import scala.util.Random
+
+class ExecutionStoreSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  var store: ExecutionStore = _
+
+  before {
+    def jobKeys: Map[JobKey, ExecutionStatus] = (0.until(10000).toList map {
+      i => BackendJobDescriptorKey(noConnectionsGraphNode, Option(i), 1) -> NotStarted })
+      .toMap
+
+    store = ActiveExecutionStore(jobKeys, needsUpdate = true)
+  }
+
+  def updateStoreToEnqueueNewlyRunnableJobs(): Unit = {
+    while (store.needsUpdate) {
+      val update = store.update
+      store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
+    }
+  }
+
+  it should "keep allowing updates while 10000 call keys are enqueued and then started in small batches" in {
+
+    updateStoreToEnqueueNewlyRunnableJobs()
+
+    store.store.getOrElse(QueuedInCromwell, List.empty).size should be(10000)
+    store.store.getOrElse(Running, List.empty).size should be(0)
+
+    while(store.store.getOrElse(Running, List.empty).size < 10000) {
+      val newlyRunning = Random.nextInt(1000)
+      store = store.updateKeys(store.store(QueuedInCromwell).take(newlyRunning).map(j => j -> Running).toMap)
+      updateStoreToEnqueueNewlyRunnableJobs()
+    }
+
+    store.store.getOrElse(QueuedInCromwell, List.empty).size should be(0)
+    store.store.getOrElse(Running, List.empty).size should be(10000)
+  }
+}
+
+object ExecutionStoreSpec {
+
+  val noConnectionsGraphNode: CommandCallNode = CommandCallNode(
+    identifier = WomIdentifier("mock_task", "mock_wf.mock_task"),
+    callable = null,
+    inputPorts =  Set.empty[GraphNodePort.InputPort],
+    inputDefinitionMappings = List.empty,
+    nonInputBasedPrerequisites = Set.empty[GraphNode],
+    outputIdentifierCompoundingFunction = (wi, _) => wi,
+    sourceLocation = None
+  )
+}


### PR DESCRIPTION
Alternative to #5588 which completely removes this redundant queuing mechanism which doesn't seem to be doing what it thinks it was doing, and is worse in any case than the existing token distribution safety mechanisms.