### PR TITLE
Re-allow coercion to array[X?] in WDL 1.0 for select_all, select_first [NOJIRA]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/coerce_to_array_of_optionals.test
+++ b/centaur/src/main/resources/standardTestCases/coerce_to_array_of_optionals.test
@@ -1,0 +1,15 @@
+name: coerce_to_array_of_optionals
+testFormat: workflowsuccess
+
+files {
+  workflow: coerce_to_array_of_optionals/coerce_to_array_of_optionals.wdl
+}
+
+metadata {
+  workflowName: coerce_to_array_of_optionals
+  status: Succeeded
+  "outputs.coerce_to_array_of_optionals.first_out": "hello"
+  "outputs.coerce_to_array_of_optionals.all_out.0": "hello"
+  "outputs.coerce_to_array_of_optionals.all_out.1": "world"
+
+}

--- a/centaur/src/main/resources/standardTestCases/coerce_to_array_of_optionals/coerce_to_array_of_optionals.wdl
+++ b/centaur/src/main/resources/standardTestCases/coerce_to_array_of_optionals/coerce_to_array_of_optionals.wdl
@@ -1,0 +1,13 @@
+version 1.0
+
+workflow coerce_to_array_of_optionals {
+    # Technically, select_first and select_all take Array[String?] and we're providing Array[String], but we should be able to
+    # coerce between those types:
+    String first = select_first(["hello", "world"])
+    Array[String] all = select_all(["hello", "world"])
+
+    output {
+        String first_out = first
+        Array[String] all_out = all
+    }
+}

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/types/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/types/EngineFunctionEvaluators.scala
@@ -182,6 +182,7 @@ object EngineFunctionEvaluators {
                              (implicit expressionTypeEvaluator: TypeEvaluator[ExpressionElement]): ErrorOr[WomType] = {
       a.param.evaluateType(linkedValues).flatMap {
         case WomArrayType(WomOptionalType(inner)) => inner.validNel
+        case WomArrayType(alreadyNonOptional) => alreadyNonOptional.validNel
         case foundType => s"Invalid parameter '${a.param}'. Expected an array of optional values (eg 'Array[X?]') but got '${foundType.stableName}'".invalidNel
       }
     }
@@ -192,6 +193,7 @@ object EngineFunctionEvaluators {
                              (implicit expressionTypeEvaluator: TypeEvaluator[ExpressionElement]): ErrorOr[WomType] = {
       a.param.evaluateType(linkedValues).flatMap {
         case WomArrayType(WomOptionalType(inner)) => WomArrayType(inner).validNel
+        case alreadyNonOptional: WomArrayType => alreadyNonOptional.validNel
         case foundType => s"Invalid parameter '${a.param}'. Expected an array of optional values (eg 'Array[X?]') but got '${foundType.stableName}'".invalidNel
       }
     }


### PR DESCRIPTION
Small but annoying bug in WDL 1.0 support identified on the openWDL slack channel.

The evaluation logic was all present and correct, only the type evaluators were not set up to determine the types of the expressions correctly, and returning errors inappropriately.