### PR TITLE
Metadata entry count safety limit should apply to matched rows only [52-hotfix]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -62,6 +62,21 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataTimestamp)
   )
 
+  val countMetadataEntriesForWorkflowExecutionUuid = Compiled(
+    (rootWorkflowId: Rep[String]) => {
+      val targetWorkflowIds = for {
+        summary <- workflowMetadataSummaryEntries
+        // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      } yield summary.workflowExecutionUuid
+
+      for {
+        metadata <- metadataEntries
+        if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `METADATA_WORKFLOW_IDX`
+      } yield metadata
+    }.size
+  )
+
   val metadataEntriesWithoutLabelsForRootWorkflowId = Compiled(
     (rootWorkflowId: Rep[String]) => {
       val targetWorkflowIds = for {
@@ -76,21 +91,6 @@ trait MetadataEntryComponent {
         if !(metadata.metadataKey like "labels:%")
       } yield metadata
     }
-  )
-
-  val metadataTotalSizeRowsForRootWorkflowId = Compiled(
-    (rootWorkflowId: Rep[String]) => {
-      val targetWorkflowIds = for {
-        summary <- workflowMetadataSummaryEntries
-        // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
-      } yield summary.workflowExecutionUuid
-
-      for {
-        metadata <- metadataEntries
-        if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `METADATA_WORKFLOW_IDX`
-      } yield metadata
-    }.size
   )
 
   val metadataEntryExistsForWorkflowExecutionUuid = Compiled(
@@ -119,6 +119,25 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataTimestamp)
   )
 
+  val countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey = Compiled(
+    (rootWorkflowId: Rep[String], metadataKey: Rep[String]) => {
+      val targetWorkflowIds = for {
+        summary <- workflowMetadataSummaryEntries
+        // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      } yield summary.workflowExecutionUuid
+
+      for {
+        metadata <- metadataEntries
+        if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `METADATA_WORKFLOW_IDX`
+        if metadata.metadataKey === metadataKey
+        if metadata.callFullyQualifiedName.isEmpty
+        if metadata.jobIndex.isEmpty
+        if metadata.jobAttempt.isEmpty
+      } yield metadata
+    }.size
+  )
+
   val metadataEntriesForJobKey = Compiled(
     (workflowExecutionUuid: Rep[String], callFullyQualifiedName: Rep[String], jobIndex: Rep[Option[Int]],
      jobAttempt: Rep[Option[Int]]) => (for {
@@ -128,6 +147,25 @@ trait MetadataEntryComponent {
       if hasSameIndex(metadataEntry, jobIndex)
       if hasSameAttempt(metadataEntry, jobAttempt)
     } yield metadataEntry).sortBy(_.metadataTimestamp)
+  )
+
+  val countMetadataEntriesForJobKey = Compiled(
+    (rootWorkflowId: Rep[String], callFullyQualifiedName: Rep[String], jobIndex: Rep[Option[Int]],
+     jobAttempt: Rep[Option[Int]]) => {
+      val targetWorkflowIds = for {
+        summary <- workflowMetadataSummaryEntries
+        // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      } yield summary.workflowExecutionUuid
+
+      for {
+        metadata <- metadataEntries
+        if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `METADATA_WORKFLOW_IDX`
+        if metadata.callFullyQualifiedName === callFullyQualifiedName
+        if hasSameIndex(metadata, jobIndex)
+        if hasSameAttempt(metadata, jobAttempt)
+      } yield metadata
+    }.size
   )
 
   val metadataEntriesForJobKeyAndMetadataKey = Compiled(
@@ -140,6 +178,26 @@ trait MetadataEntryComponent {
       if hasSameIndex(metadataEntry, jobIndex)
       if hasSameAttempt(metadataEntry, jobAttempt)
     } yield metadataEntry).sortBy(_.metadataTimestamp)
+  )
+
+  val countMetadataEntriesForJobKeyAndMetadataKey = Compiled(
+    (rootWorkflowId: Rep[String], metadataKey: Rep[String], callFullyQualifiedName: Rep[String],
+     jobIndex: Rep[Option[Int]], jobAttempt: Rep[Option[Int]]) => {
+      val targetWorkflowIds = for {
+        summary <- workflowMetadataSummaryEntries
+        // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      } yield summary.workflowExecutionUuid
+
+      for {
+        metadata <- metadataEntries
+        if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `METADATA_WORKFLOW_IDX`
+        if metadata.metadataKey === metadataKey
+        if metadata.callFullyQualifiedName === callFullyQualifiedName
+        if hasSameIndex(metadata, jobIndex)
+        if hasSameAttempt(metadata, jobAttempt)
+      } yield metadata
+    }.size
   )
 
   val metadataEntriesForIdRange = Compiled(
@@ -170,6 +228,30 @@ trait MetadataEntryComponent {
   }
 
   /**
+    * Counts metadata entries that are "like" metadataKeys for the specified workflow.
+    * If requireEmptyJobKey is true, only workflow level keys are counted, otherwise both workflow and call level
+    * keys are counted.
+    */
+  def countMetadataEntriesWithKeyConstraints(rootWorkflowId: String,
+                                             metadataKeysToFilterFor: List[String],
+                                             metadataKeysToFilterOut: List[String],
+                                             requireEmptyJobKey: Boolean) = {
+
+    val targetWorkflowIds = for {
+      summary <- workflowMetadataSummaryEntries
+      // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+      if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+    } yield summary.workflowExecutionUuid
+
+    (for {
+      metadataEntry <- metadataEntries
+      if metadataEntry.workflowExecutionUuid in targetWorkflowIds
+      if metadataEntryHasMetadataKeysLike(metadataEntry, metadataKeysToFilterFor, metadataKeysToFilterOut)
+      if metadataEntryHasEmptyJobKey(metadataEntry, requireEmptyJobKey)
+    } yield metadataEntry).size
+  }
+
+  /**
     * Returns metadata entries that are "like" metadataKeys for the specified call.
     * If jobAttempt has no value, all metadata keys for all attempts are returned.
     */
@@ -190,6 +272,36 @@ trait MetadataEntryComponent {
       // regardless of the attempt
       if (metadataEntry.jobAttempt === jobAttempt) || jobAttempt.isEmpty
     } yield metadataEntry).sortBy(_.metadataTimestamp)
+  }
+
+  /**
+    * Counts metadata entries that are "like" metadataKeys for the specified call.
+    * If jobAttempt has no value, all metadata keys for all attempts are counted.
+    */
+  def countMetadataEntriesForJobWithKeyConstraints(rootWorkflowId: String,
+                                                   metadataKeysToFilterFor: List[String],
+                                                   metadataKeysToFilterOut: List[String],
+                                                   callFqn: String,
+                                                   jobIndex: Option[Int],
+                                                   jobAttempt: Option[Int]) = {
+
+    val targetWorkflowIds = for {
+      summary <- workflowMetadataSummaryEntries
+      // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
+      if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+    } yield summary.workflowExecutionUuid
+
+    (for {
+      metadataEntry <- metadataEntries
+      if metadataEntry.workflowExecutionUuid in targetWorkflowIds
+      if metadataEntryHasMetadataKeysLike(metadataEntry, metadataKeysToFilterFor, metadataKeysToFilterOut)
+      if metadataEntry.callFullyQualifiedName === callFqn
+      if hasSameIndex(metadataEntry, jobIndex)
+      // Assume that every metadata entry for a call should have a non null attempt value
+      // Because of that, if the jobAttempt parameter is Some(_), make sure it matches, otherwise take all entries
+      // regardless of the attempt
+      if (metadataEntry.jobAttempt === jobAttempt) || jobAttempt.isEmpty
+    } yield metadataEntry).size
   }
 
   private[this] def metadataEntryHasMetadataKeysLike(metadataEntry: MetadataEntries,

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -43,10 +43,19 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
+  def countMetadataEntries(workflowExecutionUuid: String,
+                           timeout: Duration)
+                          (implicit ec: ExecutionContext): Future[Int]
+
   def queryMetadataEntries(workflowExecutionUuid: String,
                            metadataKey: String,
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
+
+  def countMetadataEntries(workflowExecutionUuid: String,
+                           metadataKey: String,
+                           timeout: Duration)
+                          (implicit ec: ExecutionContext): Future[Int]
 
   def queryMetadataEntries(workflowExecutionUuid: String,
                            callFullyQualifiedName: String,
@@ -54,6 +63,13 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            jobAttempt: Option[Int],
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
+
+  def countMetadataEntries(workflowExecutionUuid: String,
+                           callFullyQualifiedName: String,
+                           jobIndex: Option[Int],
+                           jobAttempt: Option[Int],
+                           timeout: Duration)
+                          (implicit ec: ExecutionContext): Future[Int]
 
   def queryMetadataEntries(workflowUuid: String,
                            metadataKey: String,
@@ -63,12 +79,27 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
+  def countMetadataEntries(workflowUuid: String,
+                           metadataKey: String,
+                           callFullyQualifiedName: String,
+                           jobIndex: Option[Int],
+                           jobAttempt: Option[Int],
+                           timeout: Duration)
+                          (implicit ec: ExecutionContext): Future[Int]
+
   def queryMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
                                            metadataKeysToFilterFor: List[String],
                                            metadataKeysToFilterAgainst: List[String],
                                            metadataJobQueryValue: MetadataJobQueryValue,
                                            timeout: Duration)
                                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
+
+  def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
+                                           metadataKeysToFilterFor: List[String],
+                                           metadataKeysToFilterAgainst: List[String],
+                                           metadataJobQueryValue: MetadataJobQueryValue,
+                                           timeout: Duration)
+                                          (implicit ec: ExecutionContext): Future[Int]
 
   /**
     * Retrieves next summarizable block of metadata satisfying the specified criteria.
@@ -150,6 +181,4 @@ trait MetadataSqlDatabase extends SqlDatabase {
   def countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp)(implicit ec: ExecutionContext): Future[Int]
 
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int]
-
-  def getMetadataTotalRowNumberByRootWorkflowId(rootWorkflowId: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int]
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -129,8 +129,30 @@ trait MetadataDatabaseAccess {
     }
   }
 
-  def queryMetadataEventsTotalRowNumber(workflowId: WorkflowId, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
-    metadataDatabaseInterface.getMetadataTotalRowNumberByRootWorkflowId(workflowId.toString, timeout)
+  def getMetadataReadRowCount(query: MetadataQuery, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+
+    def listKeyRequirements(keyRequirementsInput: Option[NonEmptyList[String]]): List[String] = keyRequirementsInput.map(_.toList).toList.flatten.map(_ + "%")
+
+    val uuid = query.workflowId.id.toString
+
+    query match {
+      case MetadataQuery(_, None, None, None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, timeout)
+      case MetadataQuery(_, None, Some(key), None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, key, timeout)
+      case MetadataQuery(_, Some(jobKey), None, None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, jobKey.callFqn, jobKey.index, jobKey.attempt, timeout)
+      case MetadataQuery(_, Some(jobKey), Some(key), None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, key, jobKey.callFqn, jobKey.index, jobKey.attempt, timeout)
+      case MetadataQuery(_, None, None, includeKeys, excludeKeys, _) =>
+        val excludeKeyRequirements = listKeyRequirements(excludeKeys)
+        val queryType = if (excludeKeyRequirements.contains("calls%")) WorkflowQuery else CallOrWorkflowQuery
+
+        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), excludeKeyRequirements, queryType, timeout)
+      case MetadataQuery(_, Some(MetadataQueryJobKey(callFqn, index, attempt)), None, includeKeys, excludeKeys, _) =>
+        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), listKeyRequirements(excludeKeys), CallQuery(callFqn, index, attempt), timeout)
+      case _ => Future.failed(new IllegalArgumentException(s"Invalid MetadataQuery: $query"))
+    }
   }
 
   def queryMetadataEvents(query: MetadataQuery, timeout: Duration)(implicit ec: ExecutionContext): Future[Seq[MetadataEvent]] = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -51,9 +51,9 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataRea
 
   private def getMetadata(query: MetadataQuery, checkResultSizeBeforeQuerying: Boolean): Future[MetadataServiceResponse] = {
     if (checkResultSizeBeforeQuerying) {
-      queryMetadataEventsTotalRowNumber(query.workflowId, metadataReadTimeout) flatMap { size =>
-        if (size > metadataReadRowNumberSafetyThreshold) {
-          Future.successful(MetadataLookupFailedTooLargeResponse(query, size))
+      getMetadataReadRowCount(query, metadataReadTimeout) flatMap { count =>
+        if (count > metadataReadRowNumberSafetyThreshold) {
+          Future.successful(MetadataLookupFailedTooLargeResponse(query, count))
         } else {
           queryMetadata(query)
         }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -284,7 +284,23 @@ class WriteMetadataActorSpec extends TestKitSuite with FlatSpecLike with Matcher
       notImplemented()
     }
 
-    override def getMetadataTotalRowNumberByRootWorkflowId(rootWorkflowId: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntries(workflowExecutionUuid: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+      notImplemented()
+    }
+
+    override def countMetadataEntries(workflowExecutionUuid: String, metadataKey: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+      notImplemented()
+    }
+
+    override def countMetadataEntries(workflowExecutionUuid: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+      notImplemented()
+    }
+
+    override def countMetadataEntries(workflowUuid: String, metadataKey: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+      notImplemented()
+    }
+
+    override def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String, metadataKeysToFilterFor: List[String], metadataKeysToFilterAgainst: List[String], metadataJobQueryValue: MetadataJobQueryValue, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
   }


### PR DESCRIPTION
Metadata entry count safety limit should apply to matched rows only [BA-6484]

[BA-6484]: https://broadworkbench.atlassian.net/browse/BA-6484