### PR TITLE
Wire through environment and other default values in CI [BA-6546]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ dockerhub_provider_config_v1.inc.conf
 dockerhub_provider_config_v2.inc.conf
 github_private_deploy_key
 papi_application.inc.conf
-papi_refresh_token.txt
+papi_refresh_token.options.json
 papi_v2_gcsa.options.json
 private_docker_papi_v2_usa.options
 tesk_application_ftp.conf

--- a/centaur/src/main/resources/reference.conf
+++ b/centaur/src/main/resources/reference.conf
@@ -47,19 +47,18 @@ centaur {
   # case will be in a subdirectory named FOO with workflow, inputs, and options files.
   standardTestCasePath: "centaur/src/main/resources/standardTestCases"
   # optionalTestPath: "/some/path/to/tests"
-  optionalTokenPath: ${?GOOGLE_REFRESH_TOKEN_PATH}
 
   # A mixture of syntaxes used by
   # - cromwell.cloudsupport.gcp.GoogleConfiguration
   # - centaur.test.Operations
   google {
     application-name = "centaur"
-    genomics.endpoint-url = "https://lifesciences.googleapis.com/"
-    genomics.endpoint-url = ${?PAPI_ENDPOINT_URL}
+    genomics.endpoint-url = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_ENDPOINT_URL must be set/export pointing to a valid endpoint such as 'https://lifesciences.googleapis.com/'"
+    genomics.endpoint-url = ${?CROMWELL_BUILD_PAPI_ENDPOINT_URL}
     genomics.location = "us-central1"
-    auth = "application-default"
-    auth = ${?GOOGLE_AUTH_MODE}
-    json-dir = "target/ci/resources"
+    auth = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_AUTH_MODE must be set/export pointing to a valid auth such as 'application-default'"
+    auth = ${?CROMWELL_BUILD_PAPI_AUTH_MODE}
+    json-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as 'target/ci/resources'"
     json-dir = ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
     auths = [
       {

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
@@ -6,7 +6,7 @@ files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl
   # Updated the options to read_from_cache: false for
   # https://github.com/broadinstitute/cromwell/issues/3998
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/private_docker_papi_v2_usa.options
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
@@ -6,7 +6,7 @@ files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl
   # Updated the options to read_from_cache: false for
   # https://github.com/broadinstitute/cromwell/issues/3998
-  options-dir: ../../../../../target/ci/resources/
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/private_docker_papi_v2_usa.options
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
@@ -6,7 +6,7 @@ files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl
   # Updated the options to read_from_cache: false for
   # https://github.com/broadinstitute/cromwell/issues/3998
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/private_docker_papi_v2_usa.options
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
@@ -6,7 +6,7 @@ files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl
   # Updated the options to read_from_cache: false for
   # https://github.com/broadinstitute/cromwell/issues/3998
-  options-dir: ../../../../../target/ci/resources/
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/private_docker_papi_v2_usa.options
 }

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
@@ -5,7 +5,7 @@ skipDescribeEndpointValidation: true
 
 files {
   workflow: drs_tests/drs_usa_hca.wdl
-  options-dir: ../../../../../target/ci/resources/
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_usa_martha_v2.options.json
   inputs: drs_tests/drs_usa_hca.inputs

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
@@ -5,7 +5,7 @@ skipDescribeEndpointValidation: true
 
 files {
   workflow: drs_tests/drs_usa_hca.wdl
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_usa_martha_v2.options.json
   inputs: drs_tests/drs_usa_hca.inputs

--- a/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
@@ -5,7 +5,7 @@ skipDescribeEndpointValidation: true
 
 files {
   workflow: drs_tests/drs_usa_jdr.wdl
-  options-dir: ../../../../../target/ci/resources/
+  options-dir: = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_usa.options.json
   inputs: drs_tests/drs_usa_jdr.inputs

--- a/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
@@ -5,7 +5,7 @@ skipDescribeEndpointValidation: true
 
 files {
   workflow: drs_tests/drs_usa_jdr.wdl
-  options-dir: = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_usa.options.json
   inputs: drs_tests/drs_usa_jdr.inputs

--- a/centaur/src/main/resources/standardTestCases/papi_v2alpha1_gcsa.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2alpha1_gcsa.test
@@ -4,7 +4,7 @@ backends: [papi-v2-gcsa]
 
 files {
   workflow: papi_v2_gcsa/papi_v2_gcsa.wdl
-  options-dir: ../../../../../target/ci/resources/
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_gcsa.options.json
 }

--- a/centaur/src/main/resources/standardTestCases/papi_v2alpha1_gcsa.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2alpha1_gcsa.test
@@ -4,7 +4,7 @@ backends: [papi-v2-gcsa]
 
 files {
   workflow: papi_v2_gcsa/papi_v2_gcsa.wdl
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_gcsa.options.json
 }

--- a/centaur/src/main/resources/standardTestCases/papi_v2beta_gcsa.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2beta_gcsa.test
@@ -4,7 +4,7 @@ backends: [papi-v2-gcsa]
 
 files {
   workflow: papi_v2_gcsa/papi_v2_gcsa.wdl
-  options-dir: ../../../../../target/ci/resources/
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_gcsa.options.json
 }

--- a/centaur/src/main/resources/standardTestCases/papi_v2beta_gcsa.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2beta_gcsa.test
@@ -4,7 +4,7 @@ backends: [papi-v2-gcsa]
 
 files {
   workflow: papi_v2_gcsa/papi_v2_gcsa.wdl
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_v2_gcsa.options.json
 }

--- a/centaur/src/main/resources/standardTestCases/refresh_token.test
+++ b/centaur/src/main/resources/standardTestCases/refresh_token.test
@@ -7,7 +7,7 @@ backends: [Papi-Refresh]
 files {
   workflow: refresh_token/refresh_token.wdl
   inputs: refresh_token/refresh_token.inputs
-  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   options: ${files.options-dir}/papi_refresh_token.options.json
 }

--- a/centaur/src/main/resources/standardTestCases/refresh_token.test
+++ b/centaur/src/main/resources/standardTestCases/refresh_token.test
@@ -7,7 +7,9 @@ backends: [Papi-Refresh]
 files {
   workflow: refresh_token/refresh_token.wdl
   inputs: refresh_token/refresh_token.inputs
-  options: refresh_token/refresh_token.options
+  options-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
+  options: ${files.options-dir}/papi_refresh_token.options.json
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/refresh_token/refresh_token.options
+++ b/centaur/src/main/resources/standardTestCases/refresh_token/refresh_token.options
@@ -1,5 +1,0 @@
-{
-    "backend": "Papi-Refresh",
-    "refresh_token": "",
-    "auth_bucket": "gs://centaur-auth"
-}

--- a/centaur/src/main/scala/centaur/CentaurConfig.scala
+++ b/centaur/src/main/scala/centaur/CentaurConfig.scala
@@ -4,14 +4,13 @@ import java.net.URL
 import java.nio.file.{Path, Paths}
 import java.util.concurrent.TimeUnit
 
-import better.files._
 import com.typesafe.config.{Config, ConfigFactory}
 import configs.syntax._
 
 import scala.concurrent.duration.FiniteDuration
 
 object CentaurRunMode {
-  def apply(config: Config) = {
+  def apply(config: Config): CentaurRunMode = {
     val cromwellConfig = config.getConfig("cromwell")
     cromwellConfig.get[String]("mode").value match {
       case "url" =>
@@ -48,26 +47,23 @@ case class ManagedCromwellServer(preRestart: CromwellConfiguration, postRestart:
 }
 
 object CentaurConfig {
-  lazy val conf = ConfigFactory.load().getConfig("centaur")
+  lazy val conf: Config = ConfigFactory.load().getConfig("centaur")
   
-  lazy val runMode = CentaurRunMode(conf)
-  lazy val expectCarbonite = if (conf.hasPath("expectCarbonite")) conf.getBoolean("expectCarbonite") else false
+  lazy val runMode: CentaurRunMode = CentaurRunMode(conf)
+  lazy val expectCarbonite: Boolean = conf.getOrElse("expectCarbonite", false).value
   
-  lazy val cromwellUrl = runMode.cromwellUrl
-  lazy val sendReceiveTimeout = conf.getDuration("sendReceiveTimeout").toScala
-  lazy val maxWorkflowLength = conf.getDuration("maxWorkflowLength").toScala
-  lazy val metadataConsistencyTimeout = conf.getDuration("metadataConsistencyTimeout").toScala
+  lazy val cromwellUrl: URL = runMode.cromwellUrl
+  lazy val sendReceiveTimeout: FiniteDuration = conf.getDuration("sendReceiveTimeout").toScala
+  lazy val maxWorkflowLength: FiniteDuration = conf.getDuration("maxWorkflowLength").toScala
+  lazy val metadataConsistencyTimeout: FiniteDuration = conf.getDuration("metadataConsistencyTimeout").toScala
 
-  lazy val metadataDeletionMinimumWait = conf.getDuration("metadataDeletionMinimumWait").toScala
-  lazy val metadataDeletionMaximumWait = conf.getDuration("metadataDeletionMaximumWait").toScala
+  lazy val metadataDeletionMinimumWait: FiniteDuration = conf.getDuration("metadataDeletionMinimumWait").toScala
+  lazy val metadataDeletionMaximumWait: FiniteDuration = conf.getDuration("metadataDeletionMaximumWait").toScala
 
-  lazy val standardTestCasePath = Paths.get(conf.getString("standardTestCasePath"))
+  lazy val standardTestCasePath: Path = Paths.get(conf.getString("standardTestCasePath"))
 
   // If provided, any tests will be appended to the tests in standardTestCasePath
-  lazy val optionalTestPath: Option[Path] = conf.get[Option[Path]]("optionalTestPath") valueOrElse None
-  // If provided, the token will become the default value for the workflow option "refresh_token"
-  lazy val optionalTokenPath: Option[Path] = conf.get[Option[Path]]("optionalTokenPath") valueOrElse None
-  lazy val optionalToken: Option[String] = optionalTokenPath.map(File(_).contentAsString.trim)
+  lazy val optionalTestPath: Option[Path] = conf.get[Option[Path]]("optionalTestPath").value
 
   implicit class EnhancedJavaDuration(val javaDuration: java.time.Duration) extends AnyVal {
     def toScala: FiniteDuration = FiniteDuration(javaDuration.toMillis, TimeUnit.MILLISECONDS)

--- a/centaur/src/main/scala/centaur/CromwellConfiguration.scala
+++ b/centaur/src/main/scala/centaur/CromwellConfiguration.scala
@@ -4,6 +4,7 @@ import java.lang.ProcessBuilder.Redirect
 
 import better.files.File
 import com.typesafe.scalalogging.StrictLogging
+import scala.collection.JavaConverters._
 
 trait CromwellProcess extends StrictLogging {
   def logFile: String
@@ -12,12 +13,13 @@ trait CromwellProcess extends StrictLogging {
   def isAlive: Boolean
   def cromwellConfiguration: CromwellConfiguration
 
-  protected def runProcess(command: Array[String]): Process = {
+  protected def runProcess(command: Array[String], additionalEnv: Map[String, String]): Process = {
     logger.info(s"Running: ${command.mkString(" ")}")
     val processBuilder = new java.lang.ProcessBuilder()
       .command(command: _*)
       .redirectOutput(Redirect.appendTo(File(logFile).toJava))
       .redirectErrorStream(true)
+    processBuilder.environment().putAll(additionalEnv.asJava)
     processBuilder.start()
   }
 

--- a/centaur/src/main/scala/centaur/JarCromwellConfiguration.scala
+++ b/centaur/src/main/scala/centaur/JarCromwellConfiguration.scala
@@ -27,7 +27,7 @@ case class JarCromwellConfiguration(jar: String, conf: String, logFile: String) 
       private var process: Option[Process] = None
 
       override def start(): Unit = {
-        process = Option(runProcess(command))
+        process = Option(runProcess(command, Map.empty))
       }
 
       override def stop(): Unit = {

--- a/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
+++ b/centaur/src/main/scala/centaur/api/CentaurCromwellClient.scala
@@ -45,7 +45,7 @@ object CentaurCromwellClient extends StrictLogging {
 
   def submit(workflow: Workflow): IO[SubmittedWorkflow] = {
     sendReceiveFutureCompletion(() => {
-      val submitted = cromwellClient.submit(workflow.toWorkflowSubmission(refreshToken = CentaurConfig.optionalToken))
+      val submitted = cromwellClient.submit(workflow.toWorkflowSubmission)
       submitted.biSemiflatMap(
         httpResponse =>
           for {

--- a/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/Workflow.scala
@@ -12,7 +12,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import common.validation.ErrorOr.ErrorOr
 import configs.Result
 import configs.syntax._
-import cromwell.api.CromwellClient
 import cromwell.api.model.{WorkflowDescribeRequest, WorkflowSingleSubmission}
 
 import scala.util.{Failure, Success, Try}
@@ -26,18 +25,18 @@ final case class Workflow private(testName: String,
                                   retryTestFailures: Boolean,
                                   allowOtherOutputs: Boolean,
                                   skipDescribeEndpointValidation: Boolean) {
-  def toWorkflowSubmission(refreshToken: Option[String]) = WorkflowSingleSubmission(
+  def toWorkflowSubmission: WorkflowSingleSubmission = WorkflowSingleSubmission(
     workflowSource = data.workflowContent,
     workflowUrl = data.workflowUrl,
     workflowRoot = data.workflowRoot,
     workflowType = data.workflowType,
     workflowTypeVersion = data.workflowTypeVersion,
     inputsJson = data.inputs.map(_.unsafeRunSync()),
-    options = CromwellClient.replaceJson(data.options.map(_.unsafeRunSync()), "refresh_token", refreshToken),
+    options = data.options.map(_.unsafeRunSync()),
     labels = Option(data.labels),
     zippedImports = data.zippedImports)
 
-  def toWorkflowDescribeRequest = WorkflowDescribeRequest(
+  def toWorkflowDescribeRequest: WorkflowDescribeRequest = WorkflowDescribeRequest(
     workflowSource = data.workflowContent,
     workflowUrl = data.workflowUrl,
     workflowType = data.workflowType,

--- a/centaurCwlRunner/src/main/resources/reference.conf
+++ b/centaurCwlRunner/src/main/resources/reference.conf
@@ -1,37 +1,29 @@
 centaur {
   cwl-runner {
-    mode=local
-    mode=${?CROMWELL_BUILD_CWL_RUNNER_MODE}
+    mode = local
 
-    papi {
-      default-input-gcs-prefix = "gs://centaur-cwl-conformance-1f501e3/cwl-inputs/"
-    }
-    tesk {
-      default-input-ftp-prefix = "ftp://ftp.hexdump.org/centaur-cwl-conformance/cwl-inputs/"
-    }
-    
+    # End of actual references and begin BA-6546 exceptions...
+    # Not sure if this reference conf is used by testers outside of DSP/broad?
+    # If you know for sure then do some combination of:
+    # - update this comment with the location of those tests
+    # - update the external tests to explicitly pass in their own config
+    # - if the external tests are 100% confirmed not to exist state how you know that
+    # Not really reference, but leaving just in case someone is relying on these values.
+    papi.default-input-gcs-prefix = "gs://centaur-cwl-conformance-1f501e3/cwl-inputs/"
+    tesk.default-input-ftp-prefix = "ftp://ftp.hexdump.org/centaur-cwl-conformance/cwl-inputs/"
     google {
       application-name = "centaur-cwl-runner"
       genomics.endpoint-url = "https://lifesciences.googleapis.com/"
-      genomics.endpoint-url = ${?PAPI_ENDPOINT_URL}
       genomics.location = "us-central1"
       max-attempts = 3
       auth = "application-default"
-      auth = ${?GOOGLE_AUTH_MODE}
-      json-dir = "target/ci/resources"
-      json-dir = ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
-
       auths = [
         {
           name = "application-default"
           scheme = "application_default"
         }
-        {
-          name = "service-account"
-          scheme = "service_account"
-          json-file = ${centaur.cwl-runner.google.json-dir}/cromwell-centaur-service-account.json
-        }
       ]
     }
+    # End BA-6546 exceptions
   }
 }

--- a/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
+++ b/cromwellApiClient/src/main/scala/cromwell/api/CromwellClient.scala
@@ -221,49 +221,6 @@ object CromwellClient {
 
   final case class UnsuccessfulRequestException(message: String, httpResponse: HttpResponse) extends Exception(message)
 
-  /**
-    * Optionally replace a json value. Returns the original json if:
-    * - The jsonOption is None
-    * - The key is not found in the json
-    * - The valueOption is None
-    *
-    * @param jsonOption The optional json
-    * @param key The key
-    * @param valueOption The optional value
-    * @return The json with the modified value, or the original json
-    */
-  def replaceJson(jsonOption: Option[String], key: String, valueOption: Option[String]): Option[String] = {
-    val newJsonOption = for {
-      value <- valueOption
-      json <- jsonOption
-      newJson = replaceJson(json, key, value)
-    } yield newJson
-
-    newJsonOption orElse jsonOption
-  }
-
-  /**
-    * Replace a json value. Returns the original json if the key is not found in the json.
-    *
-    * @param json The json
-    * @param key The key
-    * @param value The value
-    * @return The json with the modified value, or the original json
-    */
-  def replaceJson(json: String, key: String, value: String): String = {
-    import DefaultJsonProtocol._
-    val newJsonOption = for {
-      _ <- Option(json)
-      if json.contains(key)
-      map = json.parseJson.asJsObject.convertTo[Map[String, JsValue]]
-      if map.contains(key)
-      newMap = map.updated(key, JsString(value))
-      newJson = newMap.toJson.toString
-    } yield newJson
-
-    newJsonOption getOrElse json
-  }
-
   private[api] def requestEntityForSubmit(workflowSubmission: WorkflowSubmission): MessageEntity = {
     import cromwell.api.model.LabelsJsonFormatter._
 

--- a/cromwellApiClient/src/test/scala/cromwell/api/CromwellClientSpec.scala
+++ b/cromwellApiClient/src/test/scala/cromwell/api/CromwellClientSpec.scala
@@ -8,13 +8,12 @@ import better.files.File
 import cromwell.api.model.{Label, WorkflowBatchSubmission, WorkflowId, WorkflowSingleSubmission}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfterAll, Matchers}
-import spray.json.JsonParser.ParsingException
 
 class CromwellClientSpec extends AsyncFlatSpec with BeforeAndAfterAll with Matchers with TableDrivenPropertyChecks {
   behavior of "CromwellClient"
 
-  implicit val system = ActorSystem("CromwellClientSpec")
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem("CromwellClientSpec")
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
   private val tempFile: File = File.newTemporaryFile("cromwell_client_spec.", ".tmp").write("hello")
 
@@ -36,39 +35,7 @@ class CromwellClientSpec extends AsyncFlatSpec with BeforeAndAfterAll with Match
       s"http://submit/$id/endpoint?key1=%25v11%25&key1=v12&key2=v2"
   }
 
-  val okRefreshTokenTests = Table(
-    ("description", "optionsOption", "refreshTokenOption", "expected"),
-    ("ignore bad json when refresh token not provided", Option("{"), None, Option("{")),
-    ("ignore bad json when refresh token provided but not used", Option("{"), Option("myToken"), Option("{")),
-    ("not format json when refresh token key not found", Option("{   }"), Option("myToken"), Option("{   }")),
-    ("replace token when found", Option("""{"refresh_token" : "replace_me"}"""), Option("myToken"),
-      Option("""{"refresh_token":"myToken"}"""))
-  )
-
-  forAll(okRefreshTokenTests) { (description, optionsOption, refreshTokenOption, expected) =>
-    it should description in {
-      val actual = CromwellClient.replaceJson(optionsOption, "refresh_token", refreshTokenOption)
-      actual should be(expected)
-      succeed
-    }
-  }
-
-  it should "throw an exception when inserting a refresh token into bad json using the token" in {
-    val optionsOption = Option("""{"refresh_token" : "replace_me"""")
-    val refreshTokenOption = Option("myToken")
-    val actual = intercept[ParsingException] {
-      CromwellClient.replaceJson(optionsOption, "refresh_token", refreshTokenOption)
-    }
-    actual.summary should be("""Unexpected end-of-input at input index 31 (line 1, position 32), expected '}'""")
-    actual.detail should be(
-      """|
-         |{"refresh_token" : "replace_me"
-         |                               ^
-         |""".stripMargin)
-    succeed
-  }
-
-  val okRequestEntityTests = Table(
+  private val okRequestEntityTests = Table(
     ("description", "workflowSubmission", "expectedJsons", "expectedFiles"),
 
     ("submit a wdl",

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -52,10 +52,38 @@ object Publishing {
         add(artifact, artifactTargetPath)
         runRaw(s"ln -s $artifactTargetPath /app/$projectName.jar")
 
-        // If you use the 'exec' form for an entry point, shell processing is not performed and
-        // environment variable substitution does not occur.  Thus we have to /bin/bash here
-        // and pass along any subsequent command line arguments
-        // See https://docs.docker.com/engine/reference/builder/#/entrypoint
+        /*
+        If you use the 'exec' form for an entry point, shell processing is not performed and
+        environment variable substitution does not occur.  Thus we have to /bin/bash here
+        and pass along any subsequent command line arguments
+        See https://docs.docker.com/engine/reference/builder/#/entrypoint
+
+        Notes and warnings on JAVA_OPTS in docker-compose YAML files:
+
+        Setting JAVA_OPTS in a docker-compose YAML requires a combination of passing and parsing values through:
+        1. docker-compose
+        2. environment key/values
+        3. bash parameter expansion without full bash command parsing
+
+        Examples:
+        - docker-compose splits the env key/value on the first `=`:
+          - If in the docker-compose YAML:              my_key=my_val1=my_al2
+          - Then in the environment key "my_key" value: my_val1=my_val2
+        - For legibility the YAMLs use chomped-block-scalar for JAVA_OPTS: https://yaml-multiline.info/
+          - Newlines are removed, and the yaml value is compressed into a space separated string.
+          - Again, only the first `=` sign is used by docker-compose to separate the env key/value pair.
+          - The newlines-that-are-now-spaces get included into the env values.
+        - Do not quote args! The quotes will be passed into the env-value by docker-compose. Bash will not remove them.
+          - If in the docker-compose YAML: -Dmy_key="my_val"
+          - Then in the running program:   conf.getString("my_key") == "\"my_val\"")
+        - Spaces are ok in YAML values, but NOT env values! The JAVA_OPTS in the `entrypoint` below does not "quote".
+          - If the env key "ENV_PATH" has value: /path/dir with spaces/file.conf
+          - If in the docker-compose YAML:       JAVA_OPTS=-Dconfig.file=${ENV_PATH} -Dfoo=bar
+          - Then `entryPoint` bash runs command: "java" "-Dconf.file=/path/dir" "with" "spaces/file.conf" "-Dfoo=bar"
+        - If needed use $$ to escape dollar signs: https://docs.docker.com/compose/compose-file/#variable-substitution
+          - Don't have a current example where this is required
+          - Often one can just allow docker-compose to pass or perform environment variable substitution
+         */
         entryPoint(
           "/bin/bash",
           "-c",

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -22,6 +22,11 @@ set -o errexit -o nounset -o pipefail
 #
 #   - crmcit
 #     Simulate a centaur integration test build. Example: `crmcit=y src/ci/bin/testCentaurPapiV2beta.sh`
+#
+#   - crmddm
+#     Use "Docker Desktop for Mac" DNS names instead of `localhost`.
+#     Example: `crmddm=y src/ci/bin/testCentaurHoricromtalPapiV2alpha1.sh`
+#     More info: https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
 
 cromwell::private::check_debug() {
     # shellcheck disable=SC2154
@@ -33,6 +38,11 @@ cromwell::private::check_debug() {
     if [[ -n "${crmcit:+set}" ]]; then
         CROMWELL_BUILD_CENTAUR_TYPE="integration"
     fi
+
+    # shellcheck disable=SC2154
+    if [[ -n "${crmddm:+set}" ]]; then
+        CROMWELL_BUILD_DOCKER_LOCALHOST="host.docker.internal"
+    fi
 }
 
 cromwell::private::set_variable_if_only_some_files_changed() {
@@ -41,7 +51,7 @@ cromwell::private::set_variable_if_only_some_files_changed() {
 
     if [[ "${TRAVIS_EVENT_TYPE:-unset}" != "pull_request" ]]; then
         export "${variable_to_set}=false"
-    elif git diff --name-only "origin/${TRAVIS_BRANCH}" 2>&1 | egrep -q --invert-match "${files_changed_regex}"; then
+    elif git diff --name-only "origin/${TRAVIS_BRANCH}" 2>&1 | grep -E -q --invert-match "${files_changed_regex}"; then
         export "${variable_to_set}=false"
     else
         export "${variable_to_set}=true"
@@ -109,25 +119,7 @@ cromwell::private::create_build_variables() {
     if [[ "${CROMWELL_BUILD_IS_HOTFIX}" == "true" ]]; then
         CROMWELL_BUILD_PRIOR_VERSION_NUMBER=${CROMWELL_BUILD_CURRENT_VERSION_NUMBER}
     else
-        CROMWELL_BUILD_PRIOR_VERSION_NUMBER=$((${CROMWELL_BUILD_CURRENT_VERSION_NUMBER} - 1))
-    fi
-
-    local git_commit_message
-    # The commit message to analyze should be the last one in the commit range.
-    # This works for both pull_request and push builds, unlike using 'git log HEAD' which gives a merge commit message
-    # on pull requests:
-    git_commit_message="$(git log --reverse ${TRAVIS_COMMIT_RANGE} | tail -n1 2>/dev/null || true)"
-    echo "Building for git commit message: ${git_commit_message}"
-
-    if [[ "${git_commit_message}" == *"[force ci]"* ]]; then
-        CROMWELL_BUILD_FORCE_TESTS=true
-        CROMWELL_BUILD_MINIMAL_TESTS=false
-    elif [[ "${git_commit_message}" == *"[minimal ci]"* ]]; then
-        CROMWELL_BUILD_FORCE_TESTS=false
-        CROMWELL_BUILD_MINIMAL_TESTS=true
-    else
-      CROMWELL_BUILD_FORCE_TESTS=false
-      CROMWELL_BUILD_MINIMAL_TESTS=false
+        CROMWELL_BUILD_PRIOR_VERSION_NUMBER=$((CROMWELL_BUILD_CURRENT_VERSION_NUMBER - 1))
     fi
 
     local git_revision
@@ -160,14 +152,41 @@ cromwell::private::create_build_variables() {
             CROMWELL_BUILD_HEARTBEAT_PATTERN="…"
             CROMWELL_BUILD_GENERATE_COVERAGE=true
 
+            local travis_commit_message
+            local travis_force_tests
+            local travis_minimal_tests
+            if [[ -n "${TRAVIS_COMMIT_RANGE:+set}" ]]; then
+                # The commit message to analyze should be the last one in the commit range.
+                # This works for both pull_request and push builds, unlike using 'git log HEAD' which
+                # gives a merge commit message on pull requests.
+                travis_commit_message="$(git log --reverse "${TRAVIS_COMMIT_RANGE}" | tail -n1 2>/dev/null || true)"
+            fi
+
+            if [[ -z "${travis_commit_message:+set}" ]]; then
+                travis_commit_message="$(git log --format=%B --max-count=1 HEAD 2>/dev/null || true)"
+            fi
+
+            if [[ "${travis_commit_message}" == *"[force ci]"* ]]; then
+                travis_force_tests=true
+                travis_minimal_tests=false
+            elif [[ "${travis_commit_message}" == *"[minimal ci]"* ]]; then
+                travis_force_tests=false
+                travis_minimal_tests=true
+            else
+                travis_force_tests=false
+                travis_minimal_tests=false
+            fi
+
+            echo "Building for commit message='${travis_commit_message}' with force=${travis_force_tests} and minimal=${travis_minimal_tests}"
+
             # For solely documentation updates run only checkPublish. Otherwise always run sbt, even for 'push'.
             # This allows quick sanity checks before starting PRs *and* publishing after merges into develop.
-            if [[ "${CROMWELL_BUILD_FORCE_TESTS}" == "true" ]]; then
+            if [[ "${travis_force_tests}" == "true" ]]; then
                 CROMWELL_BUILD_RUN_TESTS=true
             elif [[ "${CROMWELL_BUILD_ONLY_DOCS_CHANGED}" == "true" ]] && \
                 [[ "${BUILD_TYPE}" != "checkPublish" ]]; then
                 CROMWELL_BUILD_RUN_TESTS=false
-            elif [[ "${CROMWELL_BUILD_MINIMAL_TESTS}" == "true" ]] && \
+            elif [[ "${travis_minimal_tests}" == "true" ]] && \
                 [[ "${TRAVIS_EVENT_TYPE}" != "push" ]]; then
                 CROMWELL_BUILD_RUN_TESTS=false
             elif [[ "${CROMWELL_BUILD_ONLY_SCRIPTS_CHANGED}" == "true" ]] && \
@@ -270,12 +289,21 @@ cromwell::private::create_build_variables() {
             ;;
     esac
 
+    if [[ "${CROMWELL_BUILD_IS_CI}" == "true" ]]; then
+        CROMWELL_BUILD_DOCKER_TAG="${CROMWELL_BUILD_PROVIDER}-${CROMWELL_BUILD_NUMBER}"
+    else
+        CROMWELL_BUILD_DOCKER_TAG="${CROMWELL_BUILD_PROVIDER}-${CROMWELL_BUILD_TYPE}-${CROMWELL_BUILD_GIT_HASH_SUFFIX}"
+    fi
+
+    # Trim and replace invalid characters in the docker tag
+    # https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+    CROMWELL_BUILD_DOCKER_TAG="${CROMWELL_BUILD_DOCKER_TAG:0:128}"
+    CROMWELL_BUILD_DOCKER_TAG="${CROMWELL_BUILD_DOCKER_TAG//[^a-zA-Z0-9.-]/_}"
+
     CROMWELL_BUILD_OPTIONAL_SECURE="${CROMWELL_BUILD_OPTIONAL_SECURE-false}"
     CROMWELL_BUILD_REQUIRES_SECURE="${CROMWELL_BUILD_REQUIRES_SECURE-false}"
     CROMWELL_BUILD_REQUIRES_PRIOR_VERSION="${CROMWELL_BUILD_REQUIRES_PRIOR_VERSION-false}"
     CROMWELL_BUILD_SBT_ASSEMBLY_COMMAND="${CROMWELL_BUILD_SBT_ASSEMBLY_COMMAND-assembly}"
-    CROMWELL_BUILD_CROMWELL_DOCKER_TAG="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG-just-testing-horicromtal}"
-    CROMWELL_BUILD_CROMWELL_DOCKER_COMPOSE="${CROMWELL_BUILD_DOCKER_DIRECTORY}/docker-compose-horicromtal.yml"
     VAULT_TOKEN="${VAULT_TOKEN-vault token is not set as an environment variable}"
 
     local hours_to_minutes
@@ -289,9 +317,9 @@ cromwell::private::create_build_variables() {
     export CROMWELL_BUILD_CROMWELL_LOG
     export CROMWELL_BUILD_CURRENT_VERSION_NUMBER
     export CROMWELL_BUILD_DOCKER_DIRECTORY
+    export CROMWELL_BUILD_DOCKER_TAG
     export CROMWELL_BUILD_EVENT
     export CROMWELL_BUILD_EXIT_FUNCTIONS
-    export CROMWELL_BUILD_FORCE_TESTS
     export CROMWELL_BUILD_GENERATE_COVERAGE
     export CROMWELL_BUILD_GIT_HASH_SUFFIX
     export CROMWELL_BUILD_GIT_SECRETS_COMMIT
@@ -325,8 +353,6 @@ cromwell::private::create_build_variables() {
     export CROMWELL_BUILD_SBT_ASSEMBLY_COMMAND
     export CROMWELL_BUILD_SCRIPTS_DIRECTORY
     export CROMWELL_BUILD_TAG
-    export CROMWELL_BUILD_CROMWELL_DOCKER_COMPOSE
-    export CROMWELL_BUILD_CROMWELL_DOCKER_TAG
     export CROMWELL_BUILD_TYPE
     export CROMWELL_BUILD_URL
     export CROMWELL_BUILD_WAIT_FOR_IT_BRANCH
@@ -404,22 +430,26 @@ cromwell::private::create_database_variables() {
             CROMWELL_BUILD_POSTGRESQL_LATEST_TAG=""
             ;;
         *)
-            CROMWELL_BUILD_MARIADB_HOSTNAME="${CROMWELL_BUILD_MARIADB_HOSTNAME-localhost}"
+            if [[ -z "${CROMWELL_BUILD_DOCKER_LOCALHOST-}" ]]; then
+                CROMWELL_BUILD_DOCKER_LOCALHOST="localhost"
+            fi
+
+            CROMWELL_BUILD_MARIADB_HOSTNAME="${CROMWELL_BUILD_MARIADB_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_MARIADB_PORT="${CROMWELL_BUILD_MARIADB_PORT-13306}"
             CROMWELL_BUILD_MARIADB_DOCKER_TAG=""
-            CROMWELL_BUILD_MARIADB_LATEST_HOSTNAME="${CROMWELL_BUILD_MARIADB_LATEST_HOSTNAME-localhost}"
+            CROMWELL_BUILD_MARIADB_LATEST_HOSTNAME="${CROMWELL_BUILD_MARIADB_LATEST_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_MARIADB_LATEST_PORT="${CROMWELL_BUILD_MARIADB_LATEST_PORT-13306}"
             CROMWELL_BUILD_MARIADB_LATEST_TAG=""
-            CROMWELL_BUILD_MYSQL_HOSTNAME="${CROMWELL_BUILD_MYSQL_HOSTNAME-localhost}"
+            CROMWELL_BUILD_MYSQL_HOSTNAME="${CROMWELL_BUILD_MYSQL_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_MYSQL_PORT="${CROMWELL_BUILD_MYSQL_PORT-3306}"
             CROMWELL_BUILD_MYSQL_DOCKER_TAG=""
-            CROMWELL_BUILD_MYSQL_LATEST_HOSTNAME="${CROMWELL_BUILD_MYSQL_LATEST_HOSTNAME-localhost}"
+            CROMWELL_BUILD_MYSQL_LATEST_HOSTNAME="${CROMWELL_BUILD_MYSQL_LATEST_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_MYSQL_LATEST_PORT="${CROMWELL_BUILD_MYSQL_LATEST_PORT-13306}"
             CROMWELL_BUILD_MYSQL_LATEST_TAG=""
-            CROMWELL_BUILD_POSTGRESQL_HOSTNAME="${CROMWELL_BUILD_POSTGRESQL_HOSTNAME-localhost}"
+            CROMWELL_BUILD_POSTGRESQL_HOSTNAME="${CROMWELL_BUILD_POSTGRESQL_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_POSTGRESQL_PORT="${CROMWELL_BUILD_POSTGRESQL_PORT-5432}"
             CROMWELL_BUILD_POSTGRESQL_DOCKER_TAG=""
-            CROMWELL_BUILD_POSTGRESQL_LATEST_HOSTNAME="${CROMWELL_BUILD_POSTGRESQL_LATEST_HOSTNAME-localhost}"
+            CROMWELL_BUILD_POSTGRESQL_LATEST_HOSTNAME="${CROMWELL_BUILD_POSTGRESQL_LATEST_HOSTNAME-${CROMWELL_BUILD_DOCKER_LOCALHOST}}"
             CROMWELL_BUILD_POSTGRESQL_LATEST_PORT="${CROMWELL_BUILD_POSTGRESQL_LATEST_PORT-13306}"
             CROMWELL_BUILD_POSTGRESQL_LATEST_TAG=""
             ;;
@@ -564,17 +594,6 @@ cromwell::private::create_centaur_variables() {
             ;;
     esac
 
-    if [[ "${CROMWELL_BUILD_IS_CI}" == "true" ]]; then
-        CROMWELL_BUILD_CENTAUR_DOCKER_TAG="${CROMWELL_BUILD_PROVIDER}-${CROMWELL_BUILD_NUMBER}"
-    else
-        CROMWELL_BUILD_CENTAUR_DOCKER_TAG="${CROMWELL_BUILD_PROVIDER}-${CROMWELL_BUILD_TYPE}-${CROMWELL_BUILD_GIT_HASH_SUFFIX}"
-    fi
-
-    # Trim and replace invalid characters in the docker tag
-    # https://docs.docker.com/engine/reference/commandline/tag/#extended-description
-    CROMWELL_BUILD_CENTAUR_DOCKER_TAG="${CROMWELL_BUILD_CENTAUR_DOCKER_TAG:0:128}"
-    CROMWELL_BUILD_CENTAUR_DOCKER_TAG="${CROMWELL_BUILD_CENTAUR_DOCKER_TAG//[^a-zA-Z0-9.-]/_}"
-
     case "${CROMWELL_BUILD_CENTAUR_TYPE}" in
         "${CROMWELL_BUILD_CENTAUR_TYPE_INTEGRATION}")
             CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT=512000
@@ -602,11 +621,9 @@ cromwell::private::create_centaur_variables() {
 
     export CROMWELL_BUILD_CENTAUR_256_BITS_KEY
     export CROMWELL_BUILD_CENTAUR_CONFIG
-    export CROMWELL_BUILD_CENTAUR_DOCKER_TAG
+    export CROMWELL_BUILD_DOCKER_TAG
     export CROMWELL_BUILD_CENTAUR_JDBC_DRIVER
-    export CROMWELL_BUILD_CENTAUR_JDBC_PASSWORD
     export CROMWELL_BUILD_CENTAUR_JDBC_URL
-    export CROMWELL_BUILD_CENTAUR_JDBC_USERNAME
     export CROMWELL_BUILD_CENTAUR_LOG
     export CROMWELL_BUILD_CENTAUR_TEST_ADDITIONAL_PARAMETERS
     export CROMWELL_BUILD_CENTAUR_TEST_DIRECTORY
@@ -619,8 +636,6 @@ cromwell::private::create_centaur_variables() {
     export CROMWELL_BUILD_CENTAUR_TYPE_ENGINE_UPGRADE
     export CROMWELL_BUILD_CENTAUR_PRIOR_SLICK_PROFILE
     export CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_DRIVER
-    export CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_USERNAME
-    export CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
     export CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
 }
 
@@ -635,8 +650,21 @@ cromwell::private::create_conformance_variables() {
     CROMWELL_BUILD_CWL_TEST_WDL="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.wdl"
     CROMWELL_BUILD_CWL_TEST_INPUTS="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cwl_conformance_test.inputs.json"
     CROMWELL_BUILD_CWL_TEST_OUTPUT="${CROMWELL_BUILD_LOG_DIRECTORY}/cwl_conformance_test.out.txt"
-    CROMWELL_BUILD_CWL_TEST_PARALLELISM=10 # Set too high will cause false negatives due to cromwell server timeouts.
 
+    # Setting CROMWELL_BUILD_CWL_TEST_PARALLELISM too high will cause false negatives due to cromwell server timeouts.
+    case "${CROMWELL_BUILD_TYPE}" in
+        conformanceTesk)
+            # BA-6547: TESK is not currently tested in GOTC-Jenkins, FC-Jenkins, nor Travis
+            CROMWELL_BUILD_CWL_RUNNER_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/ftp_centaur_cwl_runner.conf"
+            CROMWELL_BUILD_CWL_TEST_PARALLELISM=8
+            ;;
+        *)
+            CROMWELL_BUILD_CWL_RUNNER_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/centaur_cwl_runner_application.conf"
+            CROMWELL_BUILD_CWL_TEST_PARALLELISM=10
+            ;;
+    esac
+
+    export CROMWELL_BUILD_CWL_RUNNER_CONFIG
     export CROMWELL_BUILD_CWL_RUNNER_MODE
     export CROMWELL_BUILD_CWL_TOOL_VERSION
     export CROMWELL_BUILD_CWL_TEST_VERSION
@@ -849,7 +877,8 @@ cromwell::private::pull_common_docker_images() {
     # All tests use ubuntu:latest - make sure it's there before starting the tests
     # because pulling the image during some of the tests would cause them to fail
     # (specifically output_redirection which expects a specific value in stderr)
-    docker pull ubuntu
+    # Use cat to quiet docker: https://github.com/moby/moby/issues/36655#issuecomment-375136087
+    docker pull ubuntu | cat
 }
 
 cromwell::private::install_cwltest() {
@@ -1002,39 +1031,31 @@ cromwell::private::setup_prior_version_resources() {
         prior_jar="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell_${CROMWELL_BUILD_PRIOR_VERSION_NUMBER}.jar"
 
         if [[ -f "${prior_config}" ]]; then
-            CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG="${prior_config}"
+            CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG="${prior_config}"
         else
-            CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG="${CROMWELL_BUILD_CROMWELL_CONFIG}"
+            CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG="${CROMWELL_BUILD_CROMWELL_CONFIG}"
         fi
 
-        CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_DOCKER_TAG="${CROMWELL_BUILD_PRIOR_VERSION_NUMBER}"
-        CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_JAR="${prior_jar}"
+        CROMWELL_BUILD_PRE_RESTART_DOCKER_TAG="${CROMWELL_BUILD_PRIOR_VERSION_NUMBER}"
+        CROMWELL_BUILD_PRE_RESTART_CROMWELL_JAR="${prior_jar}"
 
         # Copy the prior versions jar out of the previously published docker image
         docker run \
             --rm \
             --entrypoint= \
             --volume "${CROMWELL_BUILD_RESOURCES_DIRECTORY}:${CROMWELL_BUILD_RESOURCES_DIRECTORY}" \
-            broadinstitute/cromwell:"${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_DOCKER_TAG}" \
-            cp /app/cromwell.jar "${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_JAR}"
+            broadinstitute/cromwell:"${CROMWELL_BUILD_PRE_RESTART_DOCKER_TAG}" \
+            cp /app/cromwell.jar "${CROMWELL_BUILD_PRE_RESTART_CROMWELL_JAR}"
     else
         # In tests that are looking for a prior version, actually just use the current version
-        CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG="${CROMWELL_BUILD_CROMWELL_CONFIG}"
-        CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_DOCKER_TAG="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}"
-        CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_JAR="${CROMWELL_BUILD_CROMWELL_JAR}"
+        CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG="${CROMWELL_BUILD_CROMWELL_CONFIG}"
+        CROMWELL_BUILD_PRE_RESTART_DOCKER_TAG="${CROMWELL_BUILD_DOCKER_TAG}"
+        CROMWELL_BUILD_PRE_RESTART_CROMWELL_JAR="${CROMWELL_BUILD_CROMWELL_JAR}"
     fi
 
-    export CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG
-    export CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_DOCKER_TAG
-    export CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_JAR
-}
-
-cromwell::private::exists_cromwell_docker() {
-    docker image ls --quiet broadinstitute/cromwell:"${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}" | grep .
-}
-
-cromwell::private::build_cromwell_docker() {
-    CROMWELL_SBT_DOCKER_TAGS="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}" sbt server/docker -error
+    export CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG
+    export CROMWELL_BUILD_PRE_RESTART_DOCKER_TAG
+    export CROMWELL_BUILD_PRE_RESTART_CROMWELL_JAR
 }
 
 cromwell::private::generate_code_coverage() {
@@ -1214,7 +1235,8 @@ cromwell::private::kill_conformance_cromwell() {
 cromwell::private::run_conformance_wdl() {
     pushd "${CROMWELL_BUILD_CWL_TEST_RESOURCES}" > /dev/null
 
-    java \
+    CENTAUR_CWL_JAVA_ARGS="-Dconfig.file=${CROMWELL_BUILD_CWL_RUNNER_CONFIG}" \
+        java \
         -Xmx6g \
         -Dbackend.providers.Local.config.concurrent-job-limit="${CROMWELL_BUILD_CWL_TEST_PARALLELISM}" \
         -jar "${CROMWELL_BUILD_CROMWELL_JAR}" \
@@ -1321,11 +1343,26 @@ cromwell::build::assemble_jars() {
     cromwell::private::setup_prior_version_resources
 }
 
-cromwell::build::build_cromwell_docker() {
-    if [[ "${CROMWELL_BUILD_IS_CI}" == "true" ]] || ! cromwell::private::exists_cromwell_docker; then
-        echo "Please wait, building cromwell docker…"
-        cromwell::private::build_cromwell_docker
+cromwell::build::build_docker_image() {
+    local executable_name
+    local docker_image
+    executable_name="${1:?build_docker_image called without a executable_name}"
+    docker_image="${2:?build_docker_image called without a docker_image}"
+    shift
+    shift
+
+    if [[ "${CROMWELL_BUILD_IS_CI}" == "true" ]] || ! docker image ls --quiet "${docker_image}" | grep .; then
+        echo "Please wait, building ${executable_name} into ${docker_image}…"
+
+        sbt \
+            --error \
+            "set \`${executable_name}\`/docker/imageNames := List(ImageName(\"${docker_image}\"))" \
+            "${executable_name}/docker"
     fi
+}
+
+cromwell::build::build_cromwell_docker() {
+    cromwell::build::build_docker_image server broadinstitute/cromwell:"${CROMWELL_BUILD_DOCKER_TAG}"
 }
 
 cromwell::build::run_centaur() {

--- a/src/ci/bin/testCentaurPapiUpgradePapiV1.sh
+++ b/src/ci/bin/testCentaurPapiUpgradePapiV1.sh
@@ -13,6 +13,8 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
+cromwell::build::papi::setup_papi_centaur_environment
+
 cromwell::build::assemble_jars
 
 cromwell::build::run_centaur \

--- a/src/ci/bin/testCentaurPapiUpgradePapiV2alpha1.sh
+++ b/src/ci/bin/testCentaurPapiUpgradePapiV2alpha1.sh
@@ -13,6 +13,8 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
+cromwell::build::papi::setup_papi_centaur_environment
+
 cromwell::build::assemble_jars
 
 cromwell::build::run_centaur \

--- a/src/ci/bin/testConformanceTesk.sh
+++ b/src/ci/bin/testConformanceTesk.sh
@@ -1,28 +1,4 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o pipefail
-export CROMWELL_BUILD_REQUIRES_SECURE=true
-# import in shellcheck / CI / IntelliJ compatible ways
-# shellcheck source=/dev/null
-source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
-
-if [[ "${CROMWELL_BUILD_EVENT}" != "cron" ]]; then
-    echo "TESK integration tests run only as a CRON JOB"
-    exit 0
-fi
-
-cromwell::build::setup_common_environment
-
-cromwell::build::setup_conformance_environment
-
-cromwell::build::assemble_jars
-
-CENTAUR_CWL_JAVA_ARGS="-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/ftp_centaur_cwl_runner.conf"
-CROMWELL_BUILD_CWL_TEST_PARALLELISM=8
-
-export CENTAUR_CWL_JAVA_ARGS
-export CROMWELL_BUILD_CWL_TEST_PARALLELISM
-
-cromwell::build::run_conformance
-
-cromwell::build::generate_code_coverage
+echo "$(tput setab 1)$(tput blink)BA-6547: TESK is not currently tested in GOTC-Jenkins, FC-Jenkins, nor Travis... so this 'test' was quick!$(tput sgr 0)"
+exit 0

--- a/src/ci/bin/testHoricromtalDeadlock.sh
+++ b/src/ci/bin/testHoricromtalDeadlock.sh
@@ -16,7 +16,6 @@ cromwell::build::build_cromwell_docker
 
 # Turn off exit-on-error temporarily, as we expect an error
 set +o errexit
-CROMWELL_TAG="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}" \
 docker-compose \
     --file "${CROMWELL_BUILD_DOCKER_DIRECTORY}/docker-compose-deadlock.yml" \
     up \
@@ -44,12 +43,10 @@ then
 fi
 
 # Tear everything down, but dump out the logs first
-CROMWELL_TAG="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}" \
 docker-compose \
     --file "${CROMWELL_BUILD_DOCKER_DIRECTORY}/docker-compose-deadlock.yml" \
     logs --no-color > "${CROMWELL_BUILD_LOG_DIRECTORY}/deadlock.logs"
 
-CROMWELL_TAG="${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}" \
 docker-compose \
     --file "${CROMWELL_BUILD_DOCKER_DIRECTORY}/docker-compose-deadlock.yml" \
     down \

--- a/src/ci/bin/test_papi.inc.sh
+++ b/src/ci/bin/test_papi.inc.sh
@@ -68,12 +68,10 @@ cromwell::private::papi::gcr_image_push() {
     shift
     shift
 
+    cromwell::build::build_docker_image "${executable_name}" "${docker_image}"
     echo "${docker_image}" >> "${CROMWELL_BUILD_PAPI_GCR_IMAGES}"
-
-    sbt \
-        --error \
-        "set \`${executable_name}\`/docker/imageNames := List(ImageName(\"${docker_image}\"))" \
-        "${executable_name}/dockerBuildAndPush"
+    # Use cat to quiet docker: https://github.com/moby/moby/issues/36655#issuecomment-375136087
+    docker push "${docker_image}" | cat
 }
 
 cromwell::private::papi::gcr_image_delete() {
@@ -87,55 +85,46 @@ cromwell::private::papi::setup_papi_gcr() {
     if command -v docker; then
         # Upload images built from this commit
         gcloud auth configure-docker --quiet
-        CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS="gcr.io/${CROMWELL_BUILD_PAPI_PROJECT_ID}/cromwell-drs-localizer:${CROMWELL_BUILD_CENTAUR_DOCKER_TAG}"
+        CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS="gcr.io/${CROMWELL_BUILD_PAPI_PROJECT_ID}/cromwell-drs-localizer:${CROMWELL_BUILD_DOCKER_TAG}"
         cromwell::private::papi::gcr_image_push cromwell-drs-localizer "${CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS}"
-    else
-        # Just use the default images
-        # Due to a bug, Travis is not able to build and use the cromwell-drs-localizer image built through the commit.
-        # We built a SNAPSHOT image of the current localizer script in develop, pushed it and are setting it as a default here.
-        # Bug ticket: https://broadworkbench.atlassian.net/browse/BA-6546
-        # TODO: Once a stable image of cromwell-drs-localizer is pushed to Dockerhub, replace the default image with that
-        CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS="broadinstitute/cromwell-drs-localizer:53-0341123-SNAP"
+        export CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS
+    elif [[ -z "${CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS:+set}" ]]; then
+        echo "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS must be set/export pointing to a valid docker image" >&2
+        exit 1
     fi
-
-    export CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS
 }
 
 cromwell::private::papi::setup_papi_service_account() {
-    GOOGLE_AUTH_MODE="service-account"
+    CROMWELL_BUILD_PAPI_AUTH_MODE="service-account"
 
-    # See papi_application.inc.conf.ctmpl for more info.
-    # Delete GOOGLE_SERVICE_ACCOUNT_JSON from there if you delete this block!
+    # Delete all usages of CROMWELL_BUILD_PAPI_JSON_FILE from there if you delete this block!
     if [[ "${CROMWELL_BUILD_TYPE}" == "centaurPapiV1" ]]; then
-        GOOGLE_SERVICE_ACCOUNT_JSON="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell-service-account.json"
+        # Downgrade to an older service account on Papi V1 until refresh_token_no_auth_bucket.test is
+        # migrated/fixed/added for the Papi V2 credential below
+        CROMWELL_BUILD_PAPI_JSON_FILE="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell-service-account.json"
     else
-        GOOGLE_SERVICE_ACCOUNT_JSON="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell-centaur-service-account.json"
+        # This service account does not have billing permission, and therefore cannot be used for requester pays
+        CROMWELL_BUILD_PAPI_JSON_FILE="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell-centaur-service-account.json"
     fi
 
-    export GOOGLE_AUTH_MODE
-    export GOOGLE_SERVICE_ACCOUNT_JSON
-}
-
-cromwell::private::papi::setup_papi_refresh_token() {
-    GOOGLE_REFRESH_TOKEN_PATH="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/papi_refresh_token.txt"
-    export GOOGLE_REFRESH_TOKEN_PATH
+    export CROMWELL_BUILD_PAPI_AUTH_MODE
+    export CROMWELL_BUILD_PAPI_JSON_FILE
 }
 
 cromwell::private::papi::setup_papi_endpoint_url() {
     if [[ "${CROMWELL_BUILD_TYPE}" == "centaurPapiV2" ]]; then
-        PAPI_ENDPOINT_URL="https://lifesciences.googleapis.com/"
+        CROMWELL_BUILD_PAPI_ENDPOINT_URL="https://lifesciences.googleapis.com/"
     else
-        PAPI_ENDPOINT_URL="https://genomics.googleapis.com/"
+        CROMWELL_BUILD_PAPI_ENDPOINT_URL="https://genomics.googleapis.com/"
     fi
 
-    export PAPI_ENDPOINT_URL
+    export CROMWELL_BUILD_PAPI_ENDPOINT_URL
 }
 
 cromwell::build::papi::setup_papi_centaur_environment() {
     cromwell::private::papi::setup_papi_gcloud
     cromwell::private::papi::setup_papi_gcr
     cromwell::private::papi::setup_papi_service_account
-    cromwell::private::papi::setup_papi_refresh_token
     cromwell::private::papi::setup_papi_endpoint_url
 }
 

--- a/src/ci/docker-compose/docker-compose-deadlock.yml
+++ b/src/ci/docker-compose/docker-compose-deadlock.yml
@@ -32,7 +32,7 @@ services:
       timeout: 30s
       retries: 15
   cromwell-master:
-    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    image: "broadinstitute/cromwell:${CROMWELL_BUILD_DOCKER_TAG}"
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -41,6 +41,7 @@ services:
         condition: service_healthy
     command: ["server"]
     environment:
+      # See notes and warnings on JAVA_OPTS in Publishing.scala
       - >-
         JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/local_application_deadlock.conf
     healthcheck:
@@ -49,7 +50,7 @@ services:
       timeout: 30s
       retries: 60
   cromwell-norefresh:
-    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    image: "broadinstitute/cromwell:${CROMWELL_BUILD_DOCKER_TAG}"
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
@@ -60,6 +61,7 @@ services:
         condition: service_healthy
     command: ["server"]
     environment:
+      # See notes and warnings on JAVA_OPTS in Publishing.scala
       - >-
         JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_RESOURCES_DIRECTORY}/local_application_deadlock.conf
         -Dservices.MetadataService.config.metadata-summary-refresh-interval=Inf

--- a/src/ci/docker-compose/docker-compose-horicromtal.yml
+++ b/src/ci/docker-compose/docker-compose-horicromtal.yml
@@ -8,15 +8,16 @@ services:
   # - Running the carboniter
   # - Running the archived-metadata-deleter
   db-mstr:
-    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    image: "broadinstitute/cromwell:${CROMWELL_BUILD_CENTAUR_MANAGED_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
     command: ["server"]
     environment:
+      # See notes and warnings on JAVA_OPTS in Publishing.scala
       - >-
-        JAVA_OPTS=-Dconfig.file=${CROMWELL_CONFIG}
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_CENTAUR_MANAGED_CONFIG}
         -Dwebservice.port=8080
         -Dsystem.cromwell_id=master
         -Dsystem.max-workflow-launch-count=0
@@ -30,9 +31,14 @@ services:
       - CROMWELL_BUILD_CENTAUR_JDBC_URL
       - CROMWELL_BUILD_CENTAUR_PRIOR_SLICK_PROFILE
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_DRIVER
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_USERNAME
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
+      - CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT
+      - CROMWELL_BUILD_CENTAUR_256_BITS_KEY
+      - CROMWELL_BUILD_BCS_CLUSTER_ID
+      - CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS
+      - CROMWELL_BUILD_PAPI_AUTH_MODE
+      - CROMWELL_BUILD_PAPI_JSON_FILE
+      - CROMWELL_BUILD_PAPI_ENDPOINT_URL
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost:8080"]
       interval: 2s
@@ -42,15 +48,16 @@ services:
   # Makes no changes to the config file we bring in, so always summarizes, and sometimes does carboniting and metadata
   # deletion things, but only if the underlying config file says that we do.
   sum-back:
-    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    image: "broadinstitute/cromwell:${CROMWELL_BUILD_CENTAUR_MANAGED_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
       - ${CROMWELL_BUILD_ROOT_DIRECTORY}:${CROMWELL_BUILD_ROOT_DIRECTORY}
     command: ["server"]
     environment:
+      # See notes and warnings on JAVA_OPTS in Publishing.scala
       - >-
-        JAVA_OPTS=-Dconfig.file=${CROMWELL_CONFIG}
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_CENTAUR_MANAGED_CONFIG}
         -Dwebservice.port=8000
         -Dsystem.cromwell_id=summarizer
       - CROMWELL_BUILD_RESOURCES_DIRECTORY
@@ -59,9 +66,14 @@ services:
       - CROMWELL_BUILD_CENTAUR_JDBC_URL
       - CROMWELL_BUILD_CENTAUR_PRIOR_SLICK_PROFILE
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_DRIVER
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_USERNAME
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
+      - CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT
+      - CROMWELL_BUILD_CENTAUR_256_BITS_KEY
+      - CROMWELL_BUILD_BCS_CLUSTER_ID
+      - CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS
+      - CROMWELL_BUILD_PAPI_AUTH_MODE
+      - CROMWELL_BUILD_PAPI_JSON_FILE
+      - CROMWELL_BUILD_PAPI_ENDPOINT_URL
     depends_on:
       db-mstr:
         condition: service_healthy
@@ -77,7 +89,7 @@ services:
   # - Running the carboniter
   # - Running the archived-metadata-deleter
   front-back:
-    image: "broadinstitute/cromwell:${CROMWELL_TAG}"
+    image: "broadinstitute/cromwell:${CROMWELL_BUILD_CENTAUR_MANAGED_TAG}"
     network_mode: host
     working_dir: ${CROMWELL_BUILD_ROOT_DIRECTORY}
     volumes:
@@ -87,9 +99,10 @@ services:
         condition: service_healthy
     command: ["server"]
     environment:
+      # See notes and warnings on JAVA_OPTS in Publishing.scala
       - >-
-        JAVA_OPTS=-Dconfig.file=${CROMWELL_CONFIG}
-        -Dwebservice.port=${MANAGED_CROMWELL_PORT-8008}
+        JAVA_OPTS=-Dconfig.file=${CROMWELL_BUILD_CENTAUR_MANAGED_CONFIG}
+        -Dwebservice.port=${CROMWELL_BUILD_CENTAUR_MANAGED_PORT}
         -Dsystem.cromwell_id=frontend
         -Dservices.MetadataService.config.metadata-summary-refresh-interval=Inf
         -Dservices.MetadataService.config.carbonite-metadata-service.metadata-freezing.initial-interval=Inf
@@ -100,12 +113,16 @@ services:
       - CROMWELL_BUILD_CENTAUR_JDBC_URL
       - CROMWELL_BUILD_CENTAUR_PRIOR_SLICK_PROFILE
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_DRIVER
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_USERNAME
-      - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_PASSWORD
       - CROMWELL_BUILD_CENTAUR_PRIOR_JDBC_URL
-      - MANAGED_CROMWELL_PORT
+      - CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT
+      - CROMWELL_BUILD_CENTAUR_256_BITS_KEY
+      - CROMWELL_BUILD_BCS_CLUSTER_ID
+      - CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS
+      - CROMWELL_BUILD_PAPI_AUTH_MODE
+      - CROMWELL_BUILD_PAPI_JSON_FILE
+      - CROMWELL_BUILD_PAPI_ENDPOINT_URL
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:${MANAGED_CROMWELL_PORT-8008}"]
+      test: ["CMD", "curl", "--fail", "http://localhost:${CROMWELL_BUILD_CENTAUR_MANAGED_PORT}"]
       interval: 2s
       timeout: 120s
       retries: 60

--- a/src/ci/resources/bcs_application.conf.ctmpl
+++ b/src/ci/resources/bcs_application.conf.ctmpl
@@ -35,7 +35,7 @@ backend {
           #cluster: "OnDemand ecs.sn1.medium img-ubuntu"
           # Alternatively leave a fixed cluster spun up via:
           # bcs cc cromwell_test_cluster -i img-ubuntu -t ecs.sn1.medium -n 1 -d 'cromwell test cluster'
-          cluster: "OnDemand ecs.sn1.medium img-ubuntu"
+          cluster: "Error: BA-6546 The environment variable CROMWELL_BUILD_BCS_CLUSTER_ID must be set/export pointing to a valid cluster id"
           cluster: ${?CROMWELL_BUILD_BCS_CLUSTER_ID}
 
           # TODO: We should continue to allow users and our CI tests to cache images in their own OSS bucket

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -1,7 +1,7 @@
 akka.http.host-connection-pool.max-open-requests = 1024
 
 workflow-options {
-  base64-encryption-key = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  base64-encryption-key = "Error: BA-6546 The environment variable CROMWELL_BUILD_CENTAUR_256_BITS_KEY must be set/export pointing to a valid 256-bit base-64 value such as 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='"
   base64-encryption-key = ${?CROMWELL_BUILD_CENTAUR_256_BITS_KEY}
   encrypted-fields = [
     "docker_credentials_key_name",
@@ -26,9 +26,7 @@ system {
 
   input-read-limits {
 
-    # These two lines taken together are saying "set 'lines' at 128000, but then immediately replace
-    # it with a value - if one exists - from "CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT".
-    lines = 128000
+    lines = "Error: BA-6546 The environment variable CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT must be set/export pointing to a valid value such as '128000'"
     lines = ${?CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT}
 
     bool = 7

--- a/src/ci/resources/centaur_application.conf
+++ b/src/ci/resources/centaur_application.conf
@@ -26,8 +26,8 @@ centaur {
     mode: jar
     jar {
       withRestart: true
-      path: ${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_JAR}
-      conf: ${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG}
+      path: ${CROMWELL_BUILD_PRE_RESTART_CROMWELL_JAR}
+      conf: ${CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG}
       log: ${CROMWELL_BUILD_CROMWELL_LOG}
     }
     post-restart-jar {

--- a/src/ci/resources/centaur_application_horicromtal.conf
+++ b/src/ci/resources/centaur_application_horicromtal.conf
@@ -8,14 +8,14 @@ centaur {
     # Note only the tag and conf are currently prior-versionable.
     docker-compose {
       withRestart: true
-      docker-compose-file: ${CROMWELL_BUILD_CROMWELL_DOCKER_COMPOSE}
-      docker-tag: ${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_DOCKER_TAG}
-      conf: ${CROMWELL_BUILD_CROMWELL_PRIOR_VERSION_CONFIG}
+      docker-compose-file: ${CROMWELL_BUILD_DOCKER_DIRECTORY}"/docker-compose-horicromtal.yml"
+      docker-tag: ${CROMWELL_BUILD_PRE_RESTART_DOCKER_TAG}
+      conf: ${CROMWELL_BUILD_PRE_RESTART_CROMWELL_CONFIG}
       log: ${CROMWELL_BUILD_CROMWELL_LOG}
     }
     post-restart-docker-compose {
-      docker-compose-file: ${CROMWELL_BUILD_CROMWELL_DOCKER_COMPOSE}
-      docker-tag: ${CROMWELL_BUILD_CROMWELL_DOCKER_TAG}
+      docker-compose-file: ${CROMWELL_BUILD_DOCKER_DIRECTORY}"/docker-compose-horicromtal.yml"
+      docker-tag: ${CROMWELL_BUILD_DOCKER_TAG}
       conf: ${CROMWELL_BUILD_CROMWELL_CONFIG}
       log: ${CROMWELL_BUILD_CROMWELL_LOG}
     }

--- a/src/ci/resources/centaur_cwl_runner_application.conf
+++ b/src/ci/resources/centaur_cwl_runner_application.conf
@@ -1,0 +1,44 @@
+include required(classpath("application.conf"))
+
+centaur {
+  cwl-runner {
+    mode = "Error: BA-6546 The environment variable CROMWELL_BUILD_CWL_RUNNER_MODE must be set/export pointing to a valid mode such as 'local'"
+    mode = ${?CROMWELL_BUILD_CWL_RUNNER_MODE}
+
+    papi {
+      default-input-gcs-prefix = "gs://centaur-cwl-conformance-1f501e3/cwl-inputs/"
+    }
+    tesk {
+      default-input-ftp-prefix = "ftp://ftp.hexdump.org/centaur-cwl-conformance/cwl-inputs/"
+    }
+
+    google {
+      application-name = "centaur-cwl-runner"
+      genomics.location = "us-central1"
+      max-attempts = 3
+
+      auth = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_AUTH_MODE must be set/export pointing to a valid mode such as 'application-default'"
+      auth = ${?CROMWELL_BUILD_PAPI_AUTH_MODE}
+      json-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid mode such as 'target/ci/resources'"
+      json-dir = ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
+
+      genomics {
+        endpoint-url = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_ENDPOINT_URL must be set/export pointing to a valid mode such as 'https://lifesciences.googleapis.com/'"
+        endpoint-url = ${?CROMWELL_BUILD_PAPI_ENDPOINT_URL}
+      }
+
+      auths = [
+        {
+          name = "application-default"
+          scheme = "application_default"
+        }
+        {
+          name = "service-account"
+          scheme = "service_account"
+          json-file = ${centaur.cwl-runner.google.json-dir}/cromwell-centaur-service-account.json
+        }
+      ]
+
+    }
+  }
+}

--- a/src/ci/resources/cromwell_database.inc.conf
+++ b/src/ci/resources/cromwell_database.inc.conf
@@ -1,10 +1,10 @@
 database {
-  profile = "slick.jdbc.MySQLProfile$"
+  profile = "Error: BA-6546 The environment variable CROMWELL_BUILD_CENTAUR_SLICK_PROFILE must be set/export pointing to a valid profile such as 'slick.jdbc.MySQLProfile$'"
   profile = ${?CROMWELL_BUILD_CENTAUR_SLICK_PROFILE}
   db {
-    driver = "com.mysql.cj.jdbc.Driver"
+    driver = "Error: BA-6546 The environment variable CROMWELL_BUILD_CENTAUR_JDBC_DRIVER must be set/export pointing to a valid driver such as 'com.mysql.cj.jdbc.Driver'"
     driver = ${?CROMWELL_BUILD_CENTAUR_JDBC_DRIVER}
-    url = "jdbc:mysql://localhost:3306/cromwell_test?allowPublicKeyRetrieval=true&useSSL=false&rewriteBatchedStatements=true&serverTimezone=UTC&useInformationSchema=true"
+    url = "Error: BA-6546 The environment variable CROMWELL_BUILD_CENTAUR_JDBC_URL must be set/export pointing to a valid jdbc url"
     url = ${?CROMWELL_BUILD_CENTAUR_JDBC_URL}
     user = "cromwell"
     password = "test"

--- a/src/ci/resources/ftp_centaur_cwl_runner.conf.ctmpl
+++ b/src/ci/resources/ftp_centaur_cwl_runner.conf.ctmpl
@@ -1,4 +1,5 @@
 include required(classpath("application.conf"))
+include "centaur_cwl_runner_application.conf"
 
 {{with $cromwellFtp := vault (printf "secret/dsde/cromwell/common/cromwell-ftp")}}
 centaur {

--- a/src/ci/resources/papi_application.inc.conf.ctmpl
+++ b/src/ci/resources/papi_application.inc.conf.ctmpl
@@ -19,17 +19,15 @@ engine {
 {{with $cromwellRefreshToken := vault (printf "secret/dsde/cromwell/common/cromwell-refresh-token")}}
 google {
   application-name = "cromwell"
-  json-dir = "target/ci/resources"
+  json-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
   json-dir = ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
   auths = [
     {
       name = "service_account"
       scheme = "service_account"
-      # This service account does not have billing permission, and therefore cannot be used for requester pays
-      json-file = ${google.json-dir}/cromwell-centaur-service-account.json
-      # Allow downgrading to an older service account on Papi V1 until refresh_token_no_auth_bucket.test is
-      # migrated/fixed/added for the Papi V2 credential above.
-      json-file = ${?GOOGLE_SERVICE_ACCOUNT_JSON}
+      # See cromwell::private::papi::setup_papi_service_account() for more info
+      json-dir = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_JSON_FILE must be set/export pointing to a valid json path for your specific Papi backend"
+      json-file = ${?CROMWELL_BUILD_PAPI_JSON_FILE}
     }
     {
       name = "requester_pays_service_account"
@@ -79,11 +77,7 @@ filesystems.drs.global.config.martha.url = "https://us-central1-broad-dsde-dev.c
 
 drs {
   localization {
-    # Due to a bug, Travis is not able to build and use the cromwell-drs-localizer image built through the commit.
-    # We built a SNAPSHOT image of the current localizer script in develop, pushed it and are setting it as a default here.
-    # Bug ticket: https://broadworkbench.atlassian.net/browse/BA-6546
-    # TODO: Once a stable image of cromwell-drs-localizer is pushed to Dockerhub, replace the default image with that
-    docker-image = "broadinstitute/cromwell-drs-localizer:53-0341123-SNAP"
+    docker-image = "Error: BA-6546 The environment variable CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS must be set/export pointing to a valid docker image"
     docker-image = ${?CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS}
   }
 }

--- a/src/ci/resources/papi_refresh_token.options.json.ctmpl
+++ b/src/ci/resources/papi_refresh_token.options.json.ctmpl
@@ -1,0 +1,7 @@
+{{with $cromwellRefreshToken := vault (printf "secret/dsde/cromwell/common/cromwell-refresh-token")}}
+{
+    "backend": "Papi-Refresh",
+    "refresh_token": "{{$cromwellRefreshToken.Data.token}}",
+    "auth_bucket": "gs://centaur-auth"
+}
+{{end}}

--- a/src/ci/resources/papi_refresh_token.txt.ctmpl
+++ b/src/ci/resources/papi_refresh_token.txt.ctmpl
@@ -1,3 +1,0 @@
-{{with $cromwellRefreshToken := vault (printf "secret/dsde/cromwell/common/cromwell-refresh-token")}}
-{{$cromwellRefreshToken.Data.token}}
-{{end}}


### PR DESCRIPTION
---

> All hoped-for things will come to you
> Who have the strength to watch and wait,
> Our longings spur the steeds of Fate,
> This has been said by one who knew.

---

- Don't set defaults for CI build variables 
- Removed many unused CI build variables 
- Renamed CI build variables based on generation and/or usage
- Ensure only passed values for CI build variables are used 
- Fixed tests that were using defaults and not passing in variables 
- Render centaur refresh tokens instead of rewriting json in memory 
- Don't use a bash wrapper-process for launching docker-compose from centaur 
- Pass centaur CI variables to docker-compose using env directly 
- Print docker-compose logs when centaur is unable to run `docker-compose up` 
- Better local docker-compose CI debugging with `crmdmm=y testFoo.sh` 
- Fix local CI debugging that was looking for `[force ci]` on prior commit 
- Allow force pushes to GitHub to use `[force ci]` syntax 
- Left `conformanceTesk` references while stubbing unused test 
- Consolidate tag generation for various docker images 
- Consolidate sbt invocation to build various docker images 
- On local tests, cache docker images just like assembly jars 
- Consistent level of verbosity on CI docker pushes and pulls 
- Moved conformance CI env-based-customization out of the reference.conf