### PR TITLE
Redirect extra logging generated during DRS file localization [WA-307]

### DIFF
--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
@@ -53,15 +53,16 @@ class DrsLocalizerMainSpec extends FlatSpec with Matchers {
         |# Run gsutil copy without using project flag
         |gsutil  cp ${MockDrsPaths.fakeDrsUrl} $fakeDownloadLocation > gsutil_output.txt 2>&1
         |RC_GSUTIL=$$?
-        |if [ "$$RC_GSUTIL" != "0" ]; then
-        |    echo "Failed to download the file. Error: $$(cat gsutil_output.txt)" >&2
-        |  exit "$$RC_GSUTIL"
         |
+        |
+        |
+        |if [ "$$RC_GSUTIL" != "0" ]; then
+        |  echo "Failed to download the file. Error: $$(cat gsutil_output.txt)" >&2
+        |  exit "$$RC_GSUTIL"
         |else
         |  echo "Download complete!"
         |  exit 0
-        |fi
-        |""".stripMargin
+        |fi""".stripMargin
 
     mockDrsLocalizer.downloadScript(MockDrsPaths.fakeDrsUrl, fakeDownloadLocation, None, None) shouldBe expectedDownloadScript
   }
@@ -90,21 +91,23 @@ class DrsLocalizerMainSpec extends FlatSpec with Matchers {
         |# Run gsutil copy without using project flag
         |gsutil  cp ${MockDrsPaths.fakeDrsUrl} $fakeDownloadLocation > gsutil_output.txt 2>&1
         |RC_GSUTIL=$$?
+        |
         |if [ "$$RC_GSUTIL" != "0" ]; then
         |  # Check if error is requester pays. If yes, retry gsutil copy using project flag
-        |if grep -q 'Bucket is requester pays bucket but no user project provided.' gsutil_output.txt; then
-        |  echo "Received 'Bucket is requester pays' error. Attempting again using Requester Pays billing project"
-        |  gsutil -u fake-billing-project cp ${MockDrsPaths.fakeDrsUrl} $fakeDownloadLocation
-        |else
-        |  echo "Failed to download the file. Error: $$(cat gsutil_output.txt)" >&2
-        |  exit "$$RC_GSUTIL"
+        |  if grep -q 'Bucket is requester pays bucket but no user project provided.' gsutil_output.txt; then
+        |    echo "Received 'Bucket is requester pays' error. Attempting again using Requester Pays billing project"
+        |    gsutil -u fake-billing-project cp ${MockDrsPaths.fakeDrsUrl} $fakeDownloadLocation >> gsutil_output.txt 2>&1
+        |    RC_GSUTIL=$$?
+        |  fi
         |fi
         |
+        |if [ "$$RC_GSUTIL" != "0" ]; then
+        |  echo "Failed to download the file. Error: $$(cat gsutil_output.txt)" >&2
+        |  exit "$$RC_GSUTIL"
         |else
         |  echo "Download complete!"
         |  exit 0
-        |fi
-        |""".stripMargin
+        |fi""".stripMargin
 
     mockDrsLocalizer.downloadScript(MockDrsPaths.fakeDrsUrl, fakeDownloadLocation, Option(fakeSAJsonPath), Option(fakeRequesterPaysId)) shouldBe expectedDownloadScript
   }

--- a/src/ci/bin/test_papi.inc.sh
+++ b/src/ci/bin/test_papi.inc.sh
@@ -95,7 +95,7 @@ cromwell::private::papi::setup_papi_gcr() {
         # We built a SNAPSHOT image of the current localizer script in develop, pushed it and are setting it as a default here.
         # Bug ticket: https://broadworkbench.atlassian.net/browse/BA-6546
         # TODO: Once a stable image of cromwell-drs-localizer is pushed to Dockerhub, replace the default image with that
-        CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS="broadinstitute/cromwell-drs-localizer:53-ea36a7b-SNAP"
+        CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS="broadinstitute/cromwell-drs-localizer:53-0341123-SNAP"
     fi
 
     export CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS

--- a/src/ci/resources/papi_application.inc.conf.ctmpl
+++ b/src/ci/resources/papi_application.inc.conf.ctmpl
@@ -83,7 +83,7 @@ drs {
     # We built a SNAPSHOT image of the current localizer script in develop, pushed it and are setting it as a default here.
     # Bug ticket: https://broadworkbench.atlassian.net/browse/BA-6546
     # TODO: Once a stable image of cromwell-drs-localizer is pushed to Dockerhub, replace the default image with that
-    docker-image = "broadinstitute/cromwell-drs-localizer:53-ea36a7b-SNAP"
+    docker-image = "broadinstitute/cromwell-drs-localizer:53-0341123-SNAP"
     docker-image = ${?CROMWELL_BUILD_PAPI_DOCKER_IMAGE_DRS}
   }
 }


### PR DESCRIPTION
~This PR is set to merge to `rsa_ss_jdr_integration_with_test` as it contains the JDR integration test. This way the localizer changes are tested against 2 drs centaur tests.~
~Once [PR-5719](https://github.com/broadinstitute/cromwell/pull/5719) is merged to develop, the base of this PR will change to develop.~

~Do not merge this PR before PR-5719 is merged to develop.~

Update: [PR-5719](https://github.com/broadinstitute/cromwell/pull/5719) has been merged. The base of this PR has now been updated to `develop`.