### PR TITLE
Pin flexmark-profile-pegdown [BA-6573]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,9 @@ object Dependencies {
   private val configsV = "0.4.4"
   private val delightRhinoSandboxV = "0.0.11"
   private val ficusV = "1.4.7"
-  private val flexmarkV = "0.36.8"
+  // The "com.vladsch.flexmark" % "flexmark-profile-pegdown" % flexmarkV dependency is an implicit, version-specific
+  // runtime dependency of ScalaTest. At the time of this writing this is the newest version known to work.
+  private val flexmarkV = "0.36.8" // scala-steward:off
   private val fs2V = "2.0.1"
   private val fs2VStatsDProxy = "1.0.5"
   private val googleApiClientV = "1.30.10"


### PR DESCRIPTION
This keeps Scala Steward from opening PRs to upgrade flexmark-profile-pegdown that we can't currently merge because ScalaTest is only binary compatible with specific versions of flexmark-profile-pegdown.