### PR TITLE
Fix metadata count safety limit when not expanding subwfs [BA-6576]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -128,7 +128,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
                                     expandSubWorkflows: Boolean,
                                     timeout: Duration)
                                    (implicit ec: ExecutionContext): Future[Int] = {
-    val action = dataAccess.countMetadataEntriesForWorkflowExecutionUuid(workflowExecutionUuid, expandSubWorkflows).result
+    val action = dataAccess.countMetadataEntriesForWorkflowExecutionUuid((workflowExecutionUuid, expandSubWorkflows)).result
     runTransaction(action, timeout = timeout)
   }
 

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -125,9 +125,10 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   }
 
   override def countMetadataEntries(workflowExecutionUuid: String,
+                                    expandSubWorkflows: Boolean,
                                     timeout: Duration)
                                    (implicit ec: ExecutionContext): Future[Int] = {
-    val action = dataAccess.countMetadataEntriesForWorkflowExecutionUuid(workflowExecutionUuid).result
+    val action = dataAccess.countMetadataEntriesForWorkflowExecutionUuid(workflowExecutionUuid, expandSubWorkflows).result
     runTransaction(action, timeout = timeout)
   }
 
@@ -142,10 +143,11 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
 
   override def countMetadataEntries(workflowExecutionUuid: String,
                                     metadataKey: String,
+                                    expandSubWorkflows: Boolean,
                                     timeout: Duration)
                                    (implicit ec: ExecutionContext): Future[Int] = {
     val action =
-      dataAccess.countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey((workflowExecutionUuid, metadataKey)).result
+      dataAccess.countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey((workflowExecutionUuid, metadataKey, expandSubWorkflows)).result
     runTransaction(action, timeout = timeout)
   }
 
@@ -164,10 +166,11 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
                                     callFullyQualifiedName: String,
                                     jobIndex: Option[Int],
                                     jobAttempt: Option[Int],
+                                    expandSubWorkflows: Boolean,
                                     timeout: Duration)
                                    (implicit ec: ExecutionContext): Future[Int] = {
     val action = dataAccess.
-      countMetadataEntriesForJobKey((workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt)).result
+      countMetadataEntriesForJobKey((workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt, expandSubWorkflows)).result
     runTransaction(action, timeout = timeout)
   }
 
@@ -188,10 +191,11 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
                                     callFullyQualifiedName: String,
                                     jobIndex: Option[Int],
                                     jobAttempt: Option[Int],
+                                    expandSubWorkflows: Boolean,
                                     timeout: Duration)
                                    (implicit ec: ExecutionContext): Future[Int] = {
     val action = dataAccess.countMetadataEntriesForJobKeyAndMetadataKey((
-      workflowUuid, metadataKey, callFullyQualifiedName, jobIndex, jobAttempt)).result
+      workflowUuid, metadataKey, callFullyQualifiedName, jobIndex, jobAttempt, expandSubWorkflows)).result
     runTransaction(action, timeout = timeout)
   }
 
@@ -216,15 +220,16 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
                                                     metadataKeysToFilterFor: List[String],
                                                     metadataKeysToFilterOut: List[String],
                                                     metadataJobQueryValue: MetadataJobQueryValue,
+                                                    expandSubWorkflows: Boolean,
                                                     timeout: Duration)
                                                    (implicit ec: ExecutionContext): Future[Int] = {
     val action = metadataJobQueryValue match {
       case CallQuery(callFqn, jobIndex, jobAttempt) =>
-        dataAccess.countMetadataEntriesForJobWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, callFqn, jobIndex, jobAttempt).result
+        dataAccess.countMetadataEntriesForJobWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, callFqn, jobIndex, jobAttempt, expandSubWorkflows).result
       case WorkflowQuery =>
-        dataAccess.countMetadataEntriesWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, requireEmptyJobKey = true).result
+        dataAccess.countMetadataEntriesWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, requireEmptyJobKey = true, expandSubWorkflows = expandSubWorkflows).result
       case CallOrWorkflowQuery =>
-        dataAccess.countMetadataEntriesWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, requireEmptyJobKey = false).result
+        dataAccess.countMetadataEntriesWithKeyConstraints(workflowExecutionUuid, metadataKeysToFilterFor, metadataKeysToFilterOut, requireEmptyJobKey = false, expandSubWorkflows = expandSubWorkflows).result
     }
     runTransaction(action, timeout = timeout)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -67,7 +67,7 @@ trait MetadataEntryComponent {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+        if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -124,7 +124,7 @@ trait MetadataEntryComponent {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+        if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -155,7 +155,7 @@ trait MetadataEntryComponent {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+        if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -186,7 +186,7 @@ trait MetadataEntryComponent {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+        if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -241,7 +241,7 @@ trait MetadataEntryComponent {
     val targetWorkflowIds = for {
       summary <- workflowMetadataSummaryEntries
       // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+      if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
     } yield summary.workflowExecutionUuid
 
     (for {
@@ -290,7 +290,7 @@ trait MetadataEntryComponent {
     val targetWorkflowIds = for {
       summary <- workflowMetadataSummaryEntries
       // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
+      if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
     } yield summary.workflowExecutionUuid
 
     (for {

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -63,11 +63,11 @@ trait MetadataEntryComponent {
   )
 
   val countMetadataEntriesForWorkflowExecutionUuid = Compiled(
-    (rootWorkflowId: Rep[String]) => {
+    (rootWorkflowId: Rep[String], expandSubWorkflows: Rep[Boolean]) => {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -120,11 +120,11 @@ trait MetadataEntryComponent {
   )
 
   val countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey = Compiled(
-    (rootWorkflowId: Rep[String], metadataKey: Rep[String]) => {
+    (rootWorkflowId: Rep[String], metadataKey: Rep[String], expandSubWorkflows: Rep[Boolean]) => {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -151,11 +151,11 @@ trait MetadataEntryComponent {
 
   val countMetadataEntriesForJobKey = Compiled(
     (rootWorkflowId: Rep[String], callFullyQualifiedName: Rep[String], jobIndex: Rep[Option[Int]],
-     jobAttempt: Rep[Option[Int]]) => {
+     jobAttempt: Rep[Option[Int]], expandSubWorkflows: Rep[Boolean]) => {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -182,11 +182,11 @@ trait MetadataEntryComponent {
 
   val countMetadataEntriesForJobKeyAndMetadataKey = Compiled(
     (rootWorkflowId: Rep[String], metadataKey: Rep[String], callFullyQualifiedName: Rep[String],
-     jobIndex: Rep[Option[Int]], jobAttempt: Rep[Option[Int]]) => {
+     jobIndex: Rep[Option[Int]], jobAttempt: Rep[Option[Int]], expandSubWorkflows: Rep[Boolean]) => {
       val targetWorkflowIds = for {
         summary <- workflowMetadataSummaryEntries
         // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-        if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+        if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
       } yield summary.workflowExecutionUuid
 
       for {
@@ -235,12 +235,13 @@ trait MetadataEntryComponent {
   def countMetadataEntriesWithKeyConstraints(rootWorkflowId: String,
                                              metadataKeysToFilterFor: List[String],
                                              metadataKeysToFilterOut: List[String],
-                                             requireEmptyJobKey: Boolean) = {
+                                             requireEmptyJobKey: Boolean,
+                                             expandSubWorkflows: Boolean) = {
 
     val targetWorkflowIds = for {
       summary <- workflowMetadataSummaryEntries
       // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
     } yield summary.workflowExecutionUuid
 
     (for {
@@ -283,12 +284,13 @@ trait MetadataEntryComponent {
                                                    metadataKeysToFilterOut: List[String],
                                                    callFqn: String,
                                                    jobIndex: Option[Int],
-                                                   jobAttempt: Option[Int]) = {
+                                                   jobAttempt: Option[Int],
+                                                   expandSubWorkflows: Boolean) = {
 
     val targetWorkflowIds = for {
       summary <- workflowMetadataSummaryEntries
       // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.rootWorkflowExecutionUuid === rootWorkflowId || summary.workflowExecutionUuid === rootWorkflowId
+      if summary.workflowExecutionUuid === rootWorkflowId || (expandSubWorkflows && summary.rootWorkflowExecutionUuid === rootWorkflowId)
     } yield summary.workflowExecutionUuid
 
     (for {

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -44,6 +44,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
   def countMetadataEntries(workflowExecutionUuid: String,
+                           expandSubWorkflows: Boolean,
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Int]
 
@@ -54,6 +55,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def countMetadataEntries(workflowExecutionUuid: String,
                            metadataKey: String,
+                           expandSubWorkflows: Boolean,
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Int]
 
@@ -68,6 +70,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            callFullyQualifiedName: String,
                            jobIndex: Option[Int],
                            jobAttempt: Option[Int],
+                           expandSubWorkflows: Boolean,
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Int]
 
@@ -84,6 +87,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            callFullyQualifiedName: String,
                            jobIndex: Option[Int],
                            jobAttempt: Option[Int],
+                           expandSubWorkflows: Boolean,
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Int]
 
@@ -98,6 +102,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                                            metadataKeysToFilterFor: List[String],
                                            metadataKeysToFilterAgainst: List[String],
                                            metadataJobQueryValue: MetadataJobQueryValue,
+                                           expandSubWorkflows: Boolean,
                                            timeout: Duration)
                                           (implicit ec: ExecutionContext): Future[Int]
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -136,21 +136,21 @@ trait MetadataDatabaseAccess {
     val uuid = query.workflowId.id.toString
 
     query match {
-      case MetadataQuery(_, None, None, None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, timeout)
-      case MetadataQuery(_, None, Some(key), None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, key, timeout)
-      case MetadataQuery(_, Some(jobKey), None, None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, jobKey.callFqn, jobKey.index, jobKey.attempt, timeout)
-      case MetadataQuery(_, Some(jobKey), Some(key), None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, key, jobKey.callFqn, jobKey.index, jobKey.attempt, timeout)
-      case MetadataQuery(_, None, None, includeKeys, excludeKeys, _) =>
+      case q @ MetadataQuery(_, None, None, None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, q.expandSubWorkflows, timeout)
+      case q @ MetadataQuery(_, None, Some(key), None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, key, q.expandSubWorkflows, timeout)
+      case q @ MetadataQuery(_, Some(jobKey), None, None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, jobKey.callFqn, jobKey.index, jobKey.attempt, q.expandSubWorkflows, timeout)
+      case q @ MetadataQuery(_, Some(jobKey), Some(key), None, None, _) =>
+        metadataDatabaseInterface.countMetadataEntries(uuid, key, jobKey.callFqn, jobKey.index, jobKey.attempt, q.expandSubWorkflows, timeout)
+      case q @ MetadataQuery(_, None, None, includeKeys, excludeKeys, _) =>
         val excludeKeyRequirements = listKeyRequirements(excludeKeys)
         val queryType = if (excludeKeyRequirements.contains("calls%")) WorkflowQuery else CallOrWorkflowQuery
 
-        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), excludeKeyRequirements, queryType, timeout)
-      case MetadataQuery(_, Some(MetadataQueryJobKey(callFqn, index, attempt)), None, includeKeys, excludeKeys, _) =>
-        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), listKeyRequirements(excludeKeys), CallQuery(callFqn, index, attempt), timeout)
+        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), excludeKeyRequirements, queryType, q.expandSubWorkflows, timeout)
+      case q @ MetadataQuery(_, Some(MetadataQueryJobKey(callFqn, index, attempt)), None, includeKeys, excludeKeys, _) =>
+        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid, listKeyRequirements(includeKeys), listKeyRequirements(excludeKeys), CallQuery(callFqn, index, attempt), q.expandSubWorkflows, timeout)
       case _ => Future.failed(new IllegalArgumentException(s"Invalid MetadataQuery: $query"))
     }
   }

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -41,6 +41,10 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
 
     val rootCountableId = "root workflow id: countable stuff"
 
+    val subWorkflowCountableId = "subworkflow id: countable stuff"
+
+    val subSubWorkflowCountableId = "subsubworkflow id: countable stuff"
+
     it should "set up the test data" taggedAs DbmsTest in {
       database.runTestTransaction(
         database.dataAccess.metadataEntries ++= Seq(
@@ -70,6 +74,30 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
           //   Excludable call attempt
           MetadataEntry(rootCountableId, Option("includableCall"), Option(0), Option(2), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
           MetadataEntry(rootCountableId, Option("excludableCall"), Option(0), Option(1), "whateverKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+
+          // Subworkflow level
+          MetadataEntry(subWorkflowCountableId, None, None, None, "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subWorkflowCountableId, None, None, None, "excludableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          // Call level
+          MetadataEntry(subWorkflowCountableId, Option("includableCall"), Option(0), Option(1), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subWorkflowCountableId, Option("includableCall"), Option(0), Option(1), "excludableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          //   Excludable call index
+          MetadataEntry(subWorkflowCountableId, Option("includableCall"), Option(1), Option(1), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          //   Excludable call attempt
+          MetadataEntry(subWorkflowCountableId, Option("includableCall"), Option(0), Option(2), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subWorkflowCountableId, Option("excludableCall"), Option(0), Option(1), "whateverKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+
+          // Subsubworkflow level
+          MetadataEntry(subSubWorkflowCountableId, None, None, None, "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subSubWorkflowCountableId, None, None, None, "excludableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          // Call level
+          MetadataEntry(subSubWorkflowCountableId, Option("includableCall"), Option(0), Option(1), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subSubWorkflowCountableId, Option("includableCall"), Option(0), Option(1), "excludableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          //   Excludable call index
+          MetadataEntry(subSubWorkflowCountableId, Option("includableCall"), Option(1), Option(1), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          //   Excludable call attempt
+          MetadataEntry(subSubWorkflowCountableId, Option("includableCall"), Option(0), Option(2), "includableKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
+          MetadataEntry(subSubWorkflowCountableId, Option("excludableCall"), Option(0), Option(1), "whateverKey", None, None, OffsetDateTime.now().toSystemTimestamp, None),
         )
       ).futureValue(Timeout(10.seconds))
 
@@ -85,7 +113,9 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
           WorkflowMetadataSummaryEntry("nested subworkflows: second nesting", Option("workflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), Option("nested subworkflows: first nesting"), Option("nested subworkflows: root"), None, None),
           WorkflowMetadataSummaryEntry("nested subworkflows: third nesting", Option("workflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), Option("nested subworkflows: second nesting"), Option("nested subworkflows: root"), None, None),
 
-          WorkflowMetadataSummaryEntry(rootCountableId, Option("workflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), None, None, None, None)
+          WorkflowMetadataSummaryEntry(rootCountableId, Option("workflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), None, None, None, None),
+          WorkflowMetadataSummaryEntry(subWorkflowCountableId, Option("subworkflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), Option(rootCountableId), Option(rootCountableId), None, None),
+          WorkflowMetadataSummaryEntry(subSubWorkflowCountableId, Option("subsubworkflow name"), Option("Succeeded"), Option(now), Option(now), Option(now), Option(subWorkflowCountableId), Option(rootCountableId), None, None)
         )
       ).futureValue(Timeout(10.seconds))
     }
@@ -106,61 +136,64 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
     }
 
     it should "count up rows" taggedAs DbmsTest in {
-      // Everything
-      {
-        val count = database.countMetadataEntries(rootCountableId, expandSubWorkflows = false, 10 seconds)
-        count.futureValue(Timeout(10.seconds)) should be(7)
-      }
+      List(true, false) foreach { expandSubWorkflows =>
+        val expansionFactor = if (expandSubWorkflows) 3 else 1;
+        // Everything
+        {
+          val count = database.countMetadataEntries(rootCountableId, expandSubWorkflows = expandSubWorkflows, 10 seconds)
+          count.futureValue(Timeout(10.seconds)) should be(7 * expansionFactor)
+        }
 
-      // Only includable keys - this looks for workflow level data only
-      {
-        val count = database.countMetadataEntries(rootCountableId, "includableKey", expandSubWorkflows = false, 10 seconds)
-        count.futureValue(Timeout(10.seconds)) should be(1)
-      }
+        // Only includable keys - this looks for workflow level data only
+        {
+          val count = database.countMetadataEntries(rootCountableId, "includableKey", expandSubWorkflows = expandSubWorkflows, 10 seconds)
+          count.futureValue(Timeout(10.seconds)) should be(1 * expansionFactor)
+        }
 
-      {
-        val count = database.countMetadataEntries(rootCountableId, "includableCall", Option(0), Option(1), expandSubWorkflows = false, 10 seconds)
-        count.futureValue(Timeout(10 seconds)) should be(2)
-      }
+        {
+          val count = database.countMetadataEntries(rootCountableId, "includableCall", Option(0), Option(1), expandSubWorkflows = expandSubWorkflows, 10 seconds)
+          count.futureValue(Timeout(10 seconds)) should be(2 * expansionFactor)
+        }
 
-      {
-        val count = database.countMetadataEntries(rootCountableId, "includableKey", "includableCall", Option(0), Option(1), expandSubWorkflows = false, 10 seconds)
-        count.futureValue(Timeout(10 seconds)) should be(1)
-      }
+        {
+          val count = database.countMetadataEntries(rootCountableId, "includableKey", "includableCall", Option(0), Option(1), expandSubWorkflows = expandSubWorkflows, 10 seconds)
+          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
+        }
 
-      {
-        val count = database.countMetadataEntryWithKeyConstraints(
-          workflowExecutionUuid = rootCountableId,
-          metadataKeysToFilterFor = List("includable%"),
-          metadataKeysToFilterOut = List("excludable%"),
-          CallQuery("includableCall", Option(0), Option(1)),
-          expandSubWorkflows = false,
-          10 seconds)
-        count.futureValue(Timeout(10 seconds)) should be(1)
-      }
+        {
+          val count = database.countMetadataEntryWithKeyConstraints(
+            workflowExecutionUuid = rootCountableId,
+            metadataKeysToFilterFor = List("includable%"),
+            metadataKeysToFilterOut = List("excludable%"),
+            CallQuery("includableCall", Option(0), Option(1)),
+            expandSubWorkflows = expandSubWorkflows,
+            10 seconds)
+          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
+        }
 
-      {
-        val count = database.countMetadataEntryWithKeyConstraints(
-          workflowExecutionUuid = rootCountableId,
-          metadataKeysToFilterFor = List("includable%"),
-          metadataKeysToFilterOut = List("excludable%"),
-          CallOrWorkflowQuery,
-          expandSubWorkflows = false,
-          10 seconds
-        )
-        count.futureValue(Timeout(10 seconds)) should be(4)
-      }
+        {
+          val count = database.countMetadataEntryWithKeyConstraints(
+            workflowExecutionUuid = rootCountableId,
+            metadataKeysToFilterFor = List("includable%"),
+            metadataKeysToFilterOut = List("excludable%"),
+            CallOrWorkflowQuery,
+            expandSubWorkflows = expandSubWorkflows,
+            10 seconds
+          )
+          count.futureValue(Timeout(10 seconds)) should be(4 * expansionFactor)
+        }
 
-      {
-        val count = database.countMetadataEntryWithKeyConstraints(
-          workflowExecutionUuid = rootCountableId,
-          metadataKeysToFilterFor = List("includable%"),
-          metadataKeysToFilterOut = List("excludable%"),
-          WorkflowQuery,
-          expandSubWorkflows = false,
-          10 seconds
-        )
-        count.futureValue(Timeout(10 seconds)) should be(1)
+        {
+          val count = database.countMetadataEntryWithKeyConstraints(
+            workflowExecutionUuid = rootCountableId,
+            metadataKeysToFilterFor = List("includable%"),
+            metadataKeysToFilterOut = List("excludable%"),
+            WorkflowQuery,
+            expandSubWorkflows = expandSubWorkflows,
+            10 seconds
+          )
+          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
+        }
       }
     }
 

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -108,23 +108,23 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
     it should "count up rows" taggedAs DbmsTest in {
       // Everything
       {
-        val count = database.countMetadataEntries(rootCountableId, 10 seconds)
+        val count = database.countMetadataEntries(rootCountableId, expandSubWorkflows = false, 10 seconds)
         count.futureValue(Timeout(10.seconds)) should be(7)
       }
 
       // Only includable keys - this looks for workflow level data only
       {
-        val count = database.countMetadataEntries(rootCountableId, "includableKey", 10 seconds)
+        val count = database.countMetadataEntries(rootCountableId, "includableKey", expandSubWorkflows = false, 10 seconds)
         count.futureValue(Timeout(10.seconds)) should be(1)
       }
 
       {
-        val count = database.countMetadataEntries(rootCountableId, "includableCall", Option(0), Option(1), 10 seconds)
+        val count = database.countMetadataEntries(rootCountableId, "includableCall", Option(0), Option(1), expandSubWorkflows = false, 10 seconds)
         count.futureValue(Timeout(10 seconds)) should be(2)
       }
 
       {
-        val count = database.countMetadataEntries(rootCountableId, "includableKey", "includableCall", Option(0), Option(1), 10 seconds)
+        val count = database.countMetadataEntries(rootCountableId, "includableKey", "includableCall", Option(0), Option(1), expandSubWorkflows = false, 10 seconds)
         count.futureValue(Timeout(10 seconds)) should be(1)
       }
 
@@ -134,6 +134,7 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
           metadataKeysToFilterFor = List("includable%"),
           metadataKeysToFilterOut = List("excludable%"),
           CallQuery("includableCall", Option(0), Option(1)),
+          expandSubWorkflows = false,
           10 seconds)
         count.futureValue(Timeout(10 seconds)) should be(1)
       }
@@ -144,6 +145,7 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
           metadataKeysToFilterFor = List("includable%"),
           metadataKeysToFilterOut = List("excludable%"),
           CallOrWorkflowQuery,
+          expandSubWorkflows = false,
           10 seconds
         )
         count.futureValue(Timeout(10 seconds)) should be(4)
@@ -155,6 +157,7 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with Matchers with ScalaFutu
           metadataKeysToFilterFor = List("includable%"),
           metadataKeysToFilterOut = List("excludable%"),
           WorkflowQuery,
+          expandSubWorkflows = false,
           10 seconds
         )
         count.futureValue(Timeout(10 seconds)) should be(1)

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -285,23 +285,23 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
       notImplemented()
     }
 
-    override def countMetadataEntries(workflowExecutionUuid: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntries(workflowExecutionUuid: String, expandSubWorkflows: Boolean, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
 
-    override def countMetadataEntries(workflowExecutionUuid: String, metadataKey: String, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntries(workflowExecutionUuid: String, metadataKey: String, expandSubWorkflows: Boolean, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
 
-    override def countMetadataEntries(workflowExecutionUuid: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntries(workflowExecutionUuid: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], expandSubWorkflows: Boolean, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
 
-    override def countMetadataEntries(workflowUuid: String, metadataKey: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntries(workflowUuid: String, metadataKey: String, callFullyQualifiedName: String, jobIndex: Option[Int], jobAttempt: Option[Int], expandSubWorkflows: Boolean, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
 
-    override def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String, metadataKeysToFilterFor: List[String], metadataKeysToFilterAgainst: List[String], metadataJobQueryValue: MetadataJobQueryValue, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
+    override def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String, metadataKeysToFilterFor: List[String], metadataKeysToFilterAgainst: List[String], metadataJobQueryValue: MetadataJobQueryValue, expandSubWorkflows: Boolean, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }
   }


### PR DESCRIPTION
Bug fix: subworkflow rows should not be included in the metadata safety limit count when subworkflows are not being expanded.