### PR TITLE
Boot disk size adjustment adjustment [BA-6568]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_dockerhub.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_dockerhub.wdl
@@ -5,7 +5,7 @@ task large_dockerhub_image {
         String docker_image
     }
     command {
-        apt-get install --assume-yes jq > /dev/null
+        which jq > /dev/null || (apt-get update > /dev/null && apt-get install -y jq > /dev/null)
         NAME=`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name`
         ZONE=`basename \`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone\``
         PROJECT=`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id`

--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_dockerhub.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_dockerhub.wdl
@@ -22,7 +22,7 @@ task large_dockerhub_image {
 }
 
 workflow docker_size_dockerhub {
-    call large_dockerhub_image as large_dockerhub_image_with_tag { input: docker_image = "broadinstitute/gatk:4.0.5.1" }
-    # This is 4.0.5.2 - Use a different image to make sure we get the size for both
-    call large_dockerhub_image as large_dockerhub_image_with_hash { input: docker_image = "broadinstitute/gatk@sha256:64c125136d6168250dfab99fd26215f40e6193a3cf1cd166fe70a4b8dd2d621a" }
+    call large_dockerhub_image as large_dockerhub_image_with_tag { input: docker_image = "broadinstitute/gatk:4.1.8.0" }
+    # This is 4.1.8.1 - Use a different image to make sure we get the size for both
+    call large_dockerhub_image as large_dockerhub_image_with_hash { input: docker_image = "broadinstitute/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
 }

--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
@@ -5,7 +5,7 @@ task large_gcr_image {
         String docker_image
     }
     command {
-        apt-get install --assume-yes jq > /dev/null
+        which jq > /dev/null || (apt-get update > /dev/null && apt-get install -y jq > /dev/null)
         NAME=`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name`
         ZONE=`basename \`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone\``
         PROJECT=`curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id`

--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
@@ -22,7 +22,7 @@ task large_gcr_image {
 }
 
 workflow docker_size_gcr {
-   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.0.5.1" }
-   # This is 4.0.5.2 - Use a different image to make sure we get the size for both
-   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:d78b14aa86b42638fe2844def82816d002a134cc19154a21dac7067ecb3c7e06" }
+   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.1.8.0" }
+   # This is 4.1.8.1 - Use a different image to make sure we get the size for both
+   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
 }

--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
@@ -22,7 +22,7 @@ task large_gcr_image {
 }
 
 workflow docker_size_gcr {
-   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.1.8.0" }
+   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "us.gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.1.8.0" }
    # This is 4.1.8.1 - Use a different image to make sure we get the size for both
-   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
+   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "us.gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
 }

--- a/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_size/docker_size_gcr.wdl
@@ -22,7 +22,7 @@ task large_gcr_image {
 }
 
 workflow docker_size_gcr {
-   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "us.gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.1.8.0" }
+   call large_gcr_image as large_gcr_image_with_tag { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk:4.1.8.0" }
    # This is 4.1.8.1 - Use a different image to make sure we get the size for both
-   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "us.gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
+   call large_gcr_image as large_gcr_image_with_hash { input: docker_image = "gcr.io/broad-dsde-cromwell-dev/centaur/gatk@sha256:8051adab0ff725e7e9c2af5997680346f3c3799b2df3785dd51d4abdd3da747b" }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -363,7 +363,7 @@ docker {
     // This factor is used to multiply the compressed size and get an approximation of the size needed on disk so that the 
     // disk can be allocated appropriately.
     // See https://github.com/docker/hub-feedback/issues/331
-    size-compression-factor = 6.0
+    size-compression-factor = 3.0
     
     // Retry configuration for http requests - across all registries
     max-time-between-retries = 1 minute

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
@@ -13,7 +13,7 @@ object ActionUtils {
   val sshPortMappings = Map("22" -> new Integer(22))
 
   /*
-   * At the moment, the cloud-sdk:slim (727MB on 2019-09-26) and possibly stedolan/jq (182MB) decompressed ~= 1 GB
+   * At the moment, cloud-sdk (924MB for 276.0.0-slim) and stedolan/jq (182MB) decompressed ~= 1.1 GB
    */
   val cromwellImagesSizeRoundedUpInGB = 1
 

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -200,16 +200,13 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       val adjustedBootDiskSize = {
         val fromRuntimeAttributes = createPipelineParameters.runtimeAttributes.bootDiskSize
         // Compute the decompressed size based on the information available
-        val actualSizeInBytes = createPipelineParameters.jobDescriptor.dockerSize.map(_.toFullSize(DockerConfiguration.instance.sizeCompressionFactor)).getOrElse(0L)
-        val actualSizeInGB = MemorySize(actualSizeInBytes.toDouble, MemoryUnit.Bytes).to(MemoryUnit.GB).amount
-        val actualSizeRoundedUpInGB = actualSizeInGB.ceil.toInt
+        val userCommandImageSizeInBytes = createPipelineParameters.jobDescriptor.dockerSize.map(_.toFullSize(DockerConfiguration.instance.sizeCompressionFactor)).getOrElse(0L)
+        val userCommandImageSizeInGB = MemorySize(userCommandImageSizeInBytes.toDouble, MemoryUnit.Bytes).to(MemoryUnit.GB).amount
+        val userCommandImageSizeRoundedUpInGB = userCommandImageSizeInGB.ceil.toInt
 
-        // If the size of the image is larger than what is in the runtime attributes, adjust it to uncompressed size
-        if (actualSizeRoundedUpInGB > fromRuntimeAttributes) {
-          jobLogger.info(s"Adjusting boot disk size to $actualSizeRoundedUpInGB GB to account for docker image size")
-        }
-
-        Math.max(fromRuntimeAttributes, actualSizeRoundedUpInGB) + ActionUtils.cromwellImagesSizeRoundedUpInGB
+        val totalSize = fromRuntimeAttributes + userCommandImageSizeRoundedUpInGB + ActionUtils.cromwellImagesSizeRoundedUpInGB
+        jobLogger.info(s"Adjusting boot disk size to $totalSize GB: $fromRuntimeAttributes GB (runtime attributes) + $userCommandImageSizeRoundedUpInGB GB (user command image) + ${ActionUtils.cromwellImagesSizeRoundedUpInGB} GB (Cromwell support images)")
+        totalSize
       }
 
       val virtualMachine = new VirtualMachine()
@@ -266,7 +263,7 @@ object GenomicsFactory {
   val CloudSdkImage: String = if (config.hasPath("cloud-sdk-image-url")) { config.getString("cloud-sdk-image-url").toString } else "gcr.io/google.com/cloudsdktool/cloud-sdk:276.0.0-slim"
 
   /*
-   * At the moment, the cloud-sdk:slim (727MB on 2019-09-26) and possibly stedolan/jq (182MB) decompressed ~= 1 GB
+   * At the moment, cloud-sdk (924MB for 276.0.0-slim) and stedolan/jq (182MB) decompressed ~= 1.1 GB
    */
   val CromwellImagesSizeRoundedUpInGB: Int = if (config.hasPath("cloud-sdk-image-size-gb")) { config.getInt("cloud-sdk-image-size-gb") } else 1
 }

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
@@ -194,16 +194,14 @@ case class LifeSciencesFactory(applicationName: String, authMode: GoogleAuthMode
       val adjustedBootDiskSize = {
         val fromRuntimeAttributes = createPipelineParameters.runtimeAttributes.bootDiskSize
         // Compute the decompressed size based on the information available
-        val actualSizeInBytes = createPipelineParameters.jobDescriptor.dockerSize.map(_.toFullSize(DockerConfiguration.instance.sizeCompressionFactor)).getOrElse(0L)
-        val actualSizeInGB = MemorySize(actualSizeInBytes.toDouble, MemoryUnit.Bytes).to(MemoryUnit.GB).amount
-        val actualSizeRoundedUpInGB = actualSizeInGB.ceil.toInt
+        val userCommandImageSizeInBytes = createPipelineParameters.jobDescriptor.dockerSize.map(_.toFullSize(DockerConfiguration.instance.sizeCompressionFactor)).getOrElse(0L)
+        val userCommandImageSizeInGB = MemorySize(userCommandImageSizeInBytes.toDouble, MemoryUnit.Bytes).to(MemoryUnit.GB).amount
+        val userCommandImageSizeRoundedUpInGB = userCommandImageSizeInGB.ceil.toInt
 
-        // If the size of the image is larger than what is in the runtime attributes, adjust it to uncompressed size
-        if (actualSizeRoundedUpInGB > fromRuntimeAttributes) {
-          jobLogger.info(s"Adjusting boot disk size to $actualSizeRoundedUpInGB GB to account for docker image size")
-        }
+        val totalSize = fromRuntimeAttributes + userCommandImageSizeRoundedUpInGB + ActionUtils.cromwellImagesSizeRoundedUpInGB
+        jobLogger.info(s"Adjusting boot disk size to $totalSize GB: $fromRuntimeAttributes GB (runtime attributes) + $userCommandImageSizeRoundedUpInGB GB (user command image) + ${ActionUtils.cromwellImagesSizeRoundedUpInGB} GB (Cromwell support images)")
 
-        Math.max(fromRuntimeAttributes, actualSizeRoundedUpInGB) + ActionUtils.cromwellImagesSizeRoundedUpInGB
+        totalSize
       }
 
       val virtualMachine = new VirtualMachine()
@@ -260,7 +258,7 @@ object LifeSciencesFactory {
   val CloudSdkImage: String = if (config.hasPath("cloud-sdk-image-url")) { config.getString("cloud-sdk-image-url").toString } else "gcr.io/google.com/cloudsdktool/cloud-sdk:276.0.0-slim"
 
   /*
-   * At the moment, the cloud-sdk:slim (727MB on 2019-09-26) and possibly stedolan/jq (182MB) decompressed ~= 1 GB
+   * At the moment, cloud-sdk (924MB for 276.0.0-slim) and stedolan/jq (182MB) decompressed ~= 1.1 GB
    */
   val CromwellImagesSizeRoundedUpInGB: Int = if (config.hasPath("cloud-sdk-image-size-gb")) { config.getInt("cloud-sdk-image-size-gb") } else 1
 }


### PR DESCRIPTION
Cromwell has a system for adjusting boot disk sizes that is intended to account for large Docker images that would otherwise overflow the boot disk at its default size. However it seems this system is often not preventing boot disks from overflowing: we have received a number of reports recently of users having to explicitly set runtime attributes for boot disk size because this automatic system did not sufficiently increase the boot disk size. Furthermore a review of the "compression factor" used for this boot disk size adjustment system revealed that the default compression factor appears to be much larger than actual compression factors seen in Docker images commonly used in Cromwell (cloud-sdk, gatk, etc). i.e. the current model of boot disk size adjustment does not appear to line up well with actual observed boot disk size behavior.

This PR changes the way boot disk size adjustment is done to use a more realistic compression factor (3.0 vs 6.0), and instead *adds* the estimated uncompressed Docker image sizes to the default boot disk size. This should yield consistently larger and less failure prone boot disk sizes with scaling behavior that should hopefully better align with real world Docker images.