### PR TITLE
Scala Steward shepherding: PRs between 5770 and 5791 (except 5775) [BA-6578]

### DIFF
--- a/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
+++ b/centaur/src/main/scala/centaur/test/workflow/WorkflowData.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.Executors
 
 import better.files.File
 import cats.data.Validated._
-import cats.effect.{ContextShift, IO}
+import cats.effect.{Blocker, ContextShift, IO}
 import com.google.cloud.storage.{BlobId, StorageOptions}
 import com.typesafe.config.Config
 import common.validation.ErrorOr.ErrorOr
@@ -39,7 +39,7 @@ case class WorkflowData(workflowContent: Option[String],
 object WorkflowData {
   val blockingEC = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(5))
   implicit val cs: ContextShift[IO] = IO.contextShift(blockingEC)
-  val httpClient: Client[IO] = JavaNetClientBuilder[IO](blockingEC).create
+  val httpClient: Client[IO] = JavaNetClientBuilder[IO](Blocker.liftExecutionContext(blockingEC)).create
   val gcsStorage = StorageOptions.getDefaultInstance.getService
 
   def fromConfig(filesConfig: Config, fullConfig: Config, basePath: File): ErrorOr[WorkflowData] = {

--- a/dockerHashing/src/main/scala/cromwell/docker/registryv2/DockerRegistryV2Abstract.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/registryv2/DockerRegistryV2Abstract.scala
@@ -99,7 +99,7 @@ abstract class DockerRegistryV2Abstract(override val config: DockerRegistryConfi
 
   // Execute a request. No retries because they're expected to already be handled by the client
   private def executeRequest[A](request: IO[Request[IO]], handler: Response[IO] => IO[A])(implicit client: Client[IO]): IO[A] = {
-    client.fetch[A](request)(handler)
+    request.flatMap(client.run(_).use[IO, A](handler))
   }
 
   /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,13 +5,13 @@ object Dependencies {
   private val akkaHttpV = "10.1.12"
   val akkaV = "2.6.8" // When updating: Do we still need the merge "fix" from https://github.com/broadinstitute/cromwell/pull/5776 (not private because used in Merging.scala)
   private val aliyunBcsV = "6.2.4"
-  private val aliyunCoreV = "4.5.6"
+  private val aliyunCoreV = "4.5.7"
   private val aliyunCrV = "4.1.1"
   private val aliyunOssV = "3.10.2"
-  private val ammoniteOpsV = "1.9.9"
+  private val ammoniteOpsV = "2.2.0"
   private val apacheCommonNetV = "3.7"
   private val apacheHttpClientV = "4.5.12"
-  private val awsSdkV = "2.10.91"
+  private val awsSdkV = "2.14.3"
   private val betterFilesV = "3.9.1"
   private val catsEffectV = "2.1.4"
   private val catsV = "2.1.1"
@@ -26,15 +26,19 @@ object Dependencies {
   private val commonsTextV = "1.9"
   private val configsV = "0.4.4"
   private val delightRhinoSandboxV = "0.0.11"
-  private val ficusV = "1.4.7"
+  private val ficusV = "1.5.0"
   // The "com.vladsch.flexmark" % "flexmark-profile-pegdown" % flexmarkV dependency is an implicit, version-specific
   // runtime dependency of ScalaTest. At the time of this writing this is the newest version known to work.
   private val flexmarkV = "0.36.8" // scala-steward:off
   private val fs2V = "2.0.1"
-  private val fs2VStatsDProxy = "1.0.5"
+  // Scala Steward opened PR #5775 titled "Update fs2-io from 2.0.1 to 2.4.3" to upgrade the following dependency.
+  // However that PR was actually attempting an upgrade from 1.0.5 to 2.4.3 which is a much more significant
+  // undertaking, resulting in some thoroughly broken code statsd proxy code. As this is probably not the most important
+  // corner of the Cromwell repo, going to punt on this for now.
+  private val fs2VStatsDProxy = "1.0.5" // scala-steward:off
   private val googleApiClientV = "1.30.10"
   private val googleCloudBigQueryV = "1.116.9"
-  private val googleCloudKmsV = "v1-rev20200803-1.30.10"
+  private val googleCloudKmsV = "v1-rev20200814-1.30.10"
   private val googleCloudMonitoringV = "2.0.1"
   private val googleCloudNioV = "0.61.0-alpha" // scala-steward:off
   private val googleCloudStorageV = "1.111.2"
@@ -43,7 +47,7 @@ object Dependencies {
   private val googleGenomicsServicesV2Alpha1ApiV = "v2alpha1-rev20200330-1.30.9"
   private val googleHttpClientApacheV = "2.1.2"
   private val googleHttpClientV = "1.36.0"
-  private val googleLifeSciencesServicesV2BetaApiV = "v2beta-rev20200603-1.30.10"
+  private val googleLifeSciencesServicesV2BetaApiV = "v2beta-rev20200806-1.30.10"
   private val googleOauth2V = "0.21.1"
   private val googleOauthClientV = "1.31.0"
   private val googleCloudResourceManagerV = "0.87.0-alpha"
@@ -51,7 +55,7 @@ object Dependencies {
   private val guavaV = "29.0-jre"
   private val heterodonV = "1.0.0-beta3"
   private val hsqldbV = "2.5.1"
-  private val http4sVersion = "0.20.23"
+  private val http4sVersion = "0.21.7"
   private val jacksonV = "2.11.2"
   private val jacksonJqV = "1.0.0-preview.20191208"
   private val janinoV = "3.0.16"
@@ -99,10 +103,10 @@ object Dependencies {
   private val scalacheckV = "1.14.3"
   private val scalacticV = "3.2.2"
   private val scalameterV = "0.19"
-  private val scalamockV = "4.4.0"
+  private val scalamockV = "5.0.0"
   private val scalatestV = "3.2.2"
   private val scalatestPlusMockitoV = "1.0.0-M2"
-  private val scalazV = "7.2.30"
+  private val scalazV = "7.3.2"
   private val scoptV = "3.7.1"
   private val sentryLogbackV = "1.7.30"
   private val shapelessV = "2.3.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,8 +33,8 @@ object Dependencies {
   private val fs2V = "2.0.1"
   // Scala Steward opened PR #5775 titled "Update fs2-io from 2.0.1 to 2.4.3" to upgrade the following dependency.
   // However that PR was actually attempting an upgrade from 1.0.5 to 2.4.3 which is a much more significant
-  // undertaking, resulting in some thoroughly broken code statsd proxy code. As this is probably not the most important
-  // corner of the Cromwell repo, going to punt on this for now.
+  // undertaking, resulting in some thoroughly broken statsd proxy code. As this component lacks tests and is
+  // probably not the most important corner of the Cromwell repo, going to punt on this for now.
   private val fs2VStatsDProxy = "1.0.5" // scala-steward:off
   private val googleApiClientV = "1.30.10"
   private val googleCloudBigQueryV = "1.116.9"


### PR DESCRIPTION
Excluding 5775 since it was much larger than advertised, required manual changes to statsd proxy code which we don't care about that much.