### PR TITLE
 Remove group from call caching metrics coordinates due to spamminess [BA-6588]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/job/EngineJobExecutionActor.scala
@@ -741,11 +741,11 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     val copyErrorsPerHitPath: NonEmptyList[String] =
       NonEmptyList.of(
         "job",
-        "callcaching", "read", "error", "invalidhits", data.jobDescriptor.workflowDescriptor.hogGroup.value, "copyerrors")
+        "callcaching", "read", "error", "invalidhits", "copyerrors")
     val copyBlacklistsPerHitPath: NonEmptyList[String] =
       NonEmptyList.of(
         "job",
-        "callcaching", "read", "error", "invalidhits", data.jobDescriptor.workflowDescriptor.hogGroup.value, "blacklisted")
+        "callcaching", "read", "error", "invalidhits", "blacklisted")
 
     sendGauge(copyErrorsPerHitPath, data.failedCopyAttempts.longValue)
     sendGauge(copyBlacklistsPerHitPath, data.cacheHitFailureCount - data.failedCopyAttempts.longValue)
@@ -755,7 +755,7 @@ class EngineJobExecutionActor(replyTo: ActorRef,
     val cacheCopyAttemptAbandonedPath: NonEmptyList[String] =
       NonEmptyList.of(
         "job",
-        "callcaching", "read", "error", "invalidhits",  data.jobDescriptor.workflowDescriptor.hogGroup.value, "abandonments")
+        "callcaching", "read", "error", "invalidhits", "abandonments")
     increment(cacheCopyAttemptAbandonedPath)
 
     // Also publish the attempt failure metrics

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
@@ -107,11 +107,11 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
         _.bucket.path.toList.contains("hit")
       }
 
-      hitBegin.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, UntestedCacheResult)
-      bucketBegin.bucket.path.toList shouldBe expectedMetric(Bucket, Read, grouping = GoogleProject, UntestedCacheResult)
+      hitBegin.bucket.path.toList shouldBe expectedMetric(Hit, Read, UntestedCacheResult)
+      bucketBegin.bucket.path.toList shouldBe expectedMetric(Bucket, Read, UntestedCacheResult)
 
-      hitEnd.bucket.path.toList shouldBe expectedMetric(Hit, Write, grouping = GoogleProject, GoodCacheResult)
-      bucketEnd.bucket.path.toList shouldBe expectedMetric(Bucket, Write, grouping = GoogleProject, GoodCacheResult)
+      hitEnd.bucket.path.toList shouldBe expectedMetric(Hit, Write, GoodCacheResult)
+      bucketEnd.bucket.path.toList shouldBe expectedMetric(Bucket, Write, GoodCacheResult)
 
       blacklistCache.bucketCache.size() shouldBe 1
       blacklistCache.bucketCache.get(WideOpenBucket) shouldBe GoodCacheResult
@@ -160,11 +160,11 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
           _.bucket.path.toList.contains("hit")
         }
 
-        hitBegin.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, UntestedCacheResult)
-        bucketBegin.bucket.path.toList shouldBe expectedMetric(Bucket, Read, grouping = GoogleProject, UntestedCacheResult)
+        hitBegin.bucket.path.toList shouldBe expectedMetric(Hit, Read, UntestedCacheResult)
+        bucketBegin.bucket.path.toList shouldBe expectedMetric(Bucket, Read, UntestedCacheResult)
 
-        hitEnd.bucket.path.toList shouldBe expectedMetric(Hit, Write, grouping = GoogleProject, BadCacheResult)
-        bucketEnd.bucket.path.toList shouldBe expectedMetric(Bucket, Write, grouping = GoogleProject, BadCacheResult)
+        hitEnd.bucket.path.toList shouldBe expectedMetric(Hit, Write, BadCacheResult)
+        bucketEnd.bucket.path.toList shouldBe expectedMetric(Bucket, Write, BadCacheResult)
       }
 
       // Assert blacklist entries were made for bucket and hit.
@@ -207,8 +207,8 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
       val List(hitMessage, bucketMessage) = instrumentationCounts(n = 2, serviceRegistryActor = serviceRegistryActor)
 
       // Hit status is unknown but bucket status is known bad.
-      hitMessage.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, UntestedCacheResult)
-      bucketMessage.bucket.path.toList shouldBe expectedMetric(Bucket, Read, grouping = GoogleProject, BadCacheResult)
+      hitMessage.bucket.path.toList shouldBe expectedMetric(Hit, Read, UntestedCacheResult)
+      bucketMessage.bucket.path.toList shouldBe expectedMetric(Bucket, Read, BadCacheResult)
 
       blacklistCache.bucketCache.size() shouldBe 2
       blacklistCache.bucketCache.get(WideOpenBucket) shouldBe GoodCacheResult
@@ -250,9 +250,9 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
 
       val List(readHit, readBucket, writeHit) = instrumentationCounts(n = 3, serviceRegistryActor = serviceRegistryActor)
 
-      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, UntestedCacheResult)
-      readBucket.bucket.path.toList shouldBe expectedMetric(Bucket, Read, grouping = GoogleProject, GoodCacheResult)
-      writeHit.bucket.path.toList shouldBe expectedMetric(Hit, Write, grouping = GoogleProject, BadCacheResult)
+      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, UntestedCacheResult)
+      readBucket.bucket.path.toList shouldBe expectedMetric(Bucket, Read, GoodCacheResult)
+      writeHit.bucket.path.toList shouldBe expectedMetric(Hit, Write, BadCacheResult)
 
       // Assert blacklist entries were made for bucket and hit.
       blacklistCache.bucketCache.size() shouldBe 2
@@ -300,7 +300,7 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
 
       val List(readHit) = instrumentationCounts(n = 1, serviceRegistryActor = serviceRegistryActor)
 
-      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, BadCacheResult)
+      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, BadCacheResult)
 
       // Assert blacklist entries were made for bucket and hit.
       blacklistCache.bucketCache.size() shouldBe 2
@@ -342,8 +342,8 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
 
       val List(readHit, readBucket) = instrumentationCounts(n = 2, serviceRegistryActor = serviceRegistryActor)
 
-      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, grouping = GoogleProject, UntestedCacheResult)
-      readBucket.bucket.path.toList shouldBe expectedMetric(Bucket, Read, grouping = GoogleProject, BadCacheResult)
+      readHit.bucket.path.toList shouldBe expectedMetric(Hit, Read, UntestedCacheResult)
+      readBucket.bucket.path.toList shouldBe expectedMetric(Bucket, Read, BadCacheResult)
 
       // Assert blacklist entries were made for bucket and hit.
       blacklistCache.bucketCache.size() shouldBe 2
@@ -536,11 +536,10 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite("Pipeline
   case object Read extends CacheAccessType
   case object Write extends CacheAccessType
 
-  private def expectedMetric(hitOrBucket: BlacklistingType, accessType: CacheAccessType, grouping: String, status: BlacklistStatus) = {
+  private def expectedMetric(hitOrBucket: BlacklistingType, accessType: CacheAccessType, status: BlacklistStatus): List[String] = {
     List("job", "callcaching", "blacklist",
       accessType.metricFormat,
       hitOrBucket.metricFormat,
-      grouping,
       status.getClass.getSimpleName.dropRight(1))
   }
 }


### PR DESCRIPTION
We are already about 3x over our allowance for metrics with only partial k8s deployment, and this is in the pre-group-per-workspace world...