### PR TITLE
Add WebHookMetadataServiceActor to send metadata to webhook

### DIFF
--- a/services/src/main/scala/cromwell/services/metadata/impl/webhook/WebHookMetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/webhook/WebHookMetadataServiceActor.scala
@@ -1,0 +1,95 @@
+package cromwell.services.metadata.impl.webhook
+
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import com.typesafe.config.Config
+import cromwell.core.Dispatcher._
+import cromwell.services.metadata.MetadataService.{MetadataWriteFailure, MetadataWriteSuccess, PutMetadataAction, PutMetadataActionAndRespond}
+import cromwell.services.metadata._
+import cromwell.services.metadata.impl.MetadataServiceActor
+import net.ceedubs.ficus.Ficus._
+import spray.json._
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Failure, Success}
+
+
+class WebHookHybridMetadataServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+
+  val standardMetadataActor: ActorRef = context.actorOf(MetadataServiceActor.props(serviceConfig, globalConfig, serviceRegistryActor))
+  val webHookActor: ActorRef = context.actorOf(WebHookMetadataServiceActor.props(serviceConfig, globalConfig, serviceRegistryActor))
+
+  override def receive = {
+    case action: PutMetadataAction =>
+      standardMetadataActor forward action
+      webHookActor forward action
+    case action: PutMetadataActionAndRespond =>
+      standardMetadataActor forward action
+      webHookActor forward PutMetadataAction(action.events)
+    case anythingElse => standardMetadataActor forward anythingElse
+  }
+}
+
+/**
+  * A *write-only* metadata service implementation which pushes all events to an HTTP webhook.
+  * The expectation is that metadata reads are being handled outside of this Cromwell instance.
+  */
+class WebHookMetadataServiceActor(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) extends Actor with ActorLogging {
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
+  implicit val system: ActorSystem = context.system
+//  implicit val materializer = ActorMaterializer(system)
+
+  val httphook: String = serviceConfig.getOrElse("url", "localhost:8080")
+
+  override def receive = {
+    case action: PutMetadataAction =>
+      publishMessages(action.events).failed foreach { e =>
+        log.error(e, "Failed to post metadata: " + action.events)
+      }
+    case action: PutMetadataActionAndRespond =>
+      publishMessages(action.events) onComplete {
+        case Success(_) => action.replyTo ! MetadataWriteSuccess(action.events)
+        case Failure(e) => action.replyTo ! MetadataWriteFailure(e, action.events)
+      }
+  }
+
+
+  private def publishMessages(events: Iterable[MetadataEvent]): Future[Unit] = {
+
+    import WebHookMetadataServiceActor.EnhancedMetadataEvents
+
+    val eventsJson = events.toJson
+    log.debug("Publishing metadata event to " + httphook)
+
+    val httpRequest = HttpRequest(
+      method = HttpMethods.POST,
+      uri = httphook,
+      headers = List[HttpHeader](),
+      entity=HttpEntity(ContentTypes.`application/json`, eventsJson.mkString(","))
+    )
+
+
+    val responseFuture = Http().singleRequest(httpRequest)
+
+    Future {
+      responseFuture
+          .onComplete {
+            case Failure(exception) => log.error("Failed to persist metadata: " + exception.toString)
+          }
+    }
+  }
+}
+
+object WebHookMetadataServiceActor {
+  def props(serviceConfig: Config, globalConfig: Config, serviceRegistryActor: ActorRef) = {
+    Props(new WebHookMetadataServiceActor(serviceConfig, globalConfig, serviceRegistryActor)).withDispatcher(ServiceDispatcher)
+  }
+
+  implicit class EnhancedMetadataEvents(val e: Iterable[MetadataEvent]) extends AnyVal {
+    import MetadataJsonSupport._
+
+    def toJson: Seq[String] = e.map(_.toJson.toString()).toSeq
+  }
+}
+


### PR DESCRIPTION
Very much a DRAFT. But following a discussion in the Cromwell Slack (tagging @patmagee), I wanted to test how easy it would be to create a webhook metadata actor that could post metadata to some user-specified URL. 

It's pretty basic, in your config, you specify class `...WebHookMetadataServiceActor` (or `WebHookHybridMetadataServiceActor`) with a config.url, eg:

```hocon
services {
  MetadataService {
    class = "cromwell.services.metadata.impl.webhook.WebHookMetadataServiceActor"
    config {
      url = "http://localhost:8080"
    }
  }
}
```

With a stupidly simple python server listening on 8080, I received metadata responses.

Todo:
- Fix the content to be a proper JSON object (rather than comma separated JSON objects), Request library is complaining about this.

Long goal:
- Filter metadata events by type, but unless there's serious request for this, it's outside the scope (as I don't know what types of metadata events there are).



