### PR TITLE
Cromwell Martha integration handles timezoneless dates [QA-1244]

### DIFF
--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
@@ -12,7 +12,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 class DrsCloudNioRegularFileAttributes(drsPath: String, drsPathResolver: EngineDrsPathResolver) extends CloudNioRegularFileAttributes{
 
   private def convertToFileTime(timeInString: String): IO[FileTime] = {
-    //Here timeInString is assumed to be a ISO-8601 DateTime without timezone
+    //Here timeInString is assumed to be a ISO-8601 DateTime without timezone (possibly invalid assumption when coming from Martha)
     IO(LocalDateTime.parse(timeInString).toInstant(ZoneOffset.UTC)).map(FileTime.from).handleErrorWith {
       e => IO.raiseError(new RuntimeException(s"Error while parsing 'updated' value from Martha to FileTime for DRS path $drsPath. Reason: ${ExceptionUtils.getMessage(e)}."))
     }

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -1,7 +1,5 @@
 package cloud.nio.impl.drs
 
-import java.time.{LocalDateTime, OffsetDateTime}
-
 import cats.effect.{IO, Resource}
 import cats.instances.option._
 import cats.instances.string._
@@ -120,15 +118,7 @@ object MarthaResponseSupport {
   def convertMarthaResponseV2ToV3(response: MarthaV2Response): MarthaResponse = {
     val dataObject = response.dos.data_object
     val size = dataObject.size
-
-    val timeUpdated: Option[String] = dataObject.updated map { time: String =>
-      if (time.endsWith("Z")) {
-        OffsetDateTime.parse(time).toString
-      } else {
-        LocalDateTime.parse(time).toString
-      }
-    }
-
+    val timeUpdated = dataObject.updated
     val hashesMap = dataObject.checksums.map(convertChecksumsToHashesMap)
     val gcsUrl = dataObject.urls.find(_.url.startsWith(GcsScheme)).map(_.url)
     val (bucketName, fileName) = getGcsBucketAndName(gcsUrl)

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -1,6 +1,6 @@
 package cloud.nio.impl.drs
 
-import java.time.OffsetDateTime
+import java.time.{LocalDateTime, OffsetDateTime}
 
 import cats.effect.{IO, Resource}
 import cats.instances.option._
@@ -120,7 +120,15 @@ object MarthaResponseSupport {
   def convertMarthaResponseV2ToV3(response: MarthaV2Response): MarthaResponse = {
     val dataObject = response.dos.data_object
     val size = dataObject.size
-    val timeUpdated = dataObject.updated.map(OffsetDateTime.parse(_).toString)
+
+    val timeUpdated: Option[String] = dataObject.updated map { time: String =>
+      if (time.endsWith("Z")) {
+        OffsetDateTime.parse(time).toString
+      } else {
+        LocalDateTime.parse(time).toString
+      }
+    }
+
     val hashesMap = dataObject.checksums.map(convertChecksumsToHashesMap)
     val gcsUrl = dataObject.urls.find(_.url.startsWith(GcsScheme)).map(_.url)
     val (bucketName, fileName) = getGcsBucketAndName(gcsUrl)

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
@@ -1,6 +1,6 @@
 package cloud.nio.impl.drs
 
-import java.time.OffsetDateTime
+import java.time.{LocalDateTime, OffsetDateTime}
 
 import cloud.nio.impl.drs.MarthaResponseSupport.convertMarthaResponseV2ToV3
 import io.circe.{Json, JsonObject}
@@ -24,9 +24,31 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     googleServiceAccount = Option(mockGSA)
   )
 
+  private val fullMarthaV2ResponseNoTz = MarthaV2Response(
+    dos = DrsObject(
+      data_object = DrsDataObject(
+        size = Option(34905345),
+        checksums = Option(Array(ChecksumObject(checksum = md5HashValue, `type` = "md5"), ChecksumObject(checksum = crcHashValue, `type` = "crc32c"))),
+        updated = Option("2020-01-15T17:46:25.694148"),
+        urls = Array(Url("s3://my-s3-bucket/file-name"), Url("gs://my-gs-bucket/file-name"))
+      )
+    ),
+    googleServiceAccount = Option(mockGSA)
+  )
+
   private val fullMarthaResponse =  MarthaResponse(
     size = Option(34905345),
     timeUpdated = Option(OffsetDateTime.parse("2020-04-27T15:56:09.696Z").toString),
+    bucket = Option("my-gs-bucket"),
+    name = Option("file-name"),
+    gsUri = Option("gs://my-gs-bucket/file-name"),
+    googleServiceAccount = Option(mockGSA),
+    hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
+  )
+
+  private val fullMarthaResponseNoTz =  MarthaResponse(
+    size = Option(34905345),
+    timeUpdated = Option(LocalDateTime.parse("2020-01-15T17:46:25.694148").toString),
     bucket = Option("my-gs-bucket"),
     name = Option("file-name"),
     gsUri = Option("gs://my-gs-bucket/file-name"),
@@ -87,5 +109,9 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
 
   it should "convert a full martha_v2 response to a the standard Martha response" in {
     convertMarthaResponseV2ToV3(fullMarthaV2Response) shouldBe fullMarthaResponse
+  }
+
+  it should "convert a full martha_v2 response to a the standard Martha response even if there is no timezone in `updated` field" in {
+    convertMarthaResponseV2ToV3(fullMarthaV2ResponseNoTz) shouldBe fullMarthaResponseNoTz
   }
 }


### PR DESCRIPTION
Gary [reports](https://broadworkbench.atlassian.net/browse/QA-1244) that the updates to Cromwell <> Martha glue code have regressed in that they fail to accept date formats found in the wild:

![Screenshot_2020-08-31 Job Manager](https://user-images.githubusercontent.com/1087943/91759930-7a74ef80-eba0-11ea-97e0-4c512d291ae0.png)

Made this [fix suggested by Khalid](https://broadinstitute.slack.com/archives/CNZREM6TZ/p1598900079041200).