### PR TITLE
Use the dos path plus the optional `fileName` for localization, plus... WA-347

### DIFF
--- a/centaur/src/main/resources/standardTestCases/drs_tests/drs_usa_jdr.wdl
+++ b/centaur/src/main/resources/standardTestCases/drs_tests/drs_usa_jdr.wdl
@@ -4,6 +4,7 @@ workflow drs_usa_jdr {
     call localize_jdr_drs_with_usa
 
     output {
+        String path1 = localize_jdr_drs_with_usa.path1
         String hash1 = localize_jdr_drs_with_usa.hash1
         Float size1 = localize_jdr_drs_with_usa.size1
     }
@@ -15,10 +16,12 @@ task localize_jdr_drs_with_usa {
     }
 
     command <<<
+       echo ~{file1} > path1
        md5sum ~{file1} | cut -c1-32 > hash1
     >>>
 
     output {
+        String path1 = read_string("path1")
         String hash1 = read_string("hash1")
         Float size1 = size(file1)
     }

--- a/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_jdr.test
@@ -15,6 +15,7 @@ metadata {
   workflowName: drs_usa_jdr
   status: Succeeded
 
+  "outputs.drs_usa_jdr.path1" = "/cromwell_root/jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060/hapmap_3.3.hg38.vcf.gz"
   "outputs.drs_usa_jdr.hash1" = "d05ac6b9a247a21ce0030c7494194da9"
   "outputs.drs_usa_jdr.size1" = 62043448
 }

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileProvider.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileProvider.scala
@@ -74,8 +74,12 @@ class DrsCloudNioFileProvider(scheme: String,
     throw new UnsupportedOperationException("DRS currently doesn't support write.")
 
 
-  override def fileAttributes(cloudHost: String, cloudPath: String): Option[CloudNioRegularFileAttributes] =
-    Option(new DrsCloudNioRegularFileAttributes(getDrsPath(cloudHost,cloudPath), drsPathResolver))
+  override def fileAttributes(cloudHost: String, cloudPath: String): Option[CloudNioRegularFileAttributes] = {
+    val drsPath = getDrsPath(cloudHost,cloudPath)
+    val marthaResponseIO = drsPathResolver.resolveDrsThroughMartha(drsPath)
+
+    Option(new DrsCloudNioRegularFileAttributes(getDrsPath(cloudHost,cloudPath), marthaResponseIO))
+  }
 }
 
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
@@ -1,23 +1,41 @@
 package cloud.nio.impl.drs
 
 import java.nio.file.attribute.FileTime
-import java.time.{LocalDateTime, ZoneOffset}
+import java.time.{LocalDateTime, OffsetDateTime, ZoneOffset}
 
 import cats.effect.IO
 import cloud.nio.impl.drs.DrsCloudNioRegularFileAttributes._
 import cloud.nio.spi.CloudNioRegularFileAttributes
 import org.apache.commons.lang3.exception.ExceptionUtils
 
-
 class DrsCloudNioRegularFileAttributes(drsPath: String, drsPathResolver: EngineDrsPathResolver) extends CloudNioRegularFileAttributes{
 
-  private def convertToFileTime(timeInString: String): IO[FileTime] = {
-    //Here timeInString is assumed to be a ISO-8601 DateTime without timezone (possibly invalid assumption when coming from Martha)
-    IO(LocalDateTime.parse(timeInString).toInstant(ZoneOffset.UTC)).map(FileTime.from).handleErrorWith {
-      e => IO.raiseError(new RuntimeException(s"Error while parsing 'updated' value from Martha to FileTime for DRS path $drsPath. Reason: ${ExceptionUtils.getMessage(e)}."))
-    }
+  private def convertToOffsetDateTime(timeInString: String): IO[OffsetDateTime] = {
+    // Here timeInString is assumed to be a ISO-8601 DateTime with timezone
+    IO(OffsetDateTime.parse(timeInString))
+      .handleErrorWith(
+        offsetDateTimeException =>
+          // As a fallback timeInString is assumed to be a ISO-8601 DateTime without timezone
+          IO(LocalDateTime.parse(timeInString).atOffset(ZoneOffset.UTC))
+            .handleErrorWith(_ => IO.raiseError(offsetDateTimeException))
+      )
   }
 
+  private def convertToFileTime(timeInString: String): IO[FileTime] = {
+    convertToOffsetDateTime(timeInString)
+      .map(_.toInstant)
+      .map(FileTime.from)
+      .handleErrorWith(
+        throwable =>
+          IO.raiseError(
+            new RuntimeException(
+              s"Error while parsing 'updated' value from Martha to FileTime for DRS path $drsPath. " +
+                s"Reason: ${ExceptionUtils.getMessage(throwable)}.",
+              throwable,
+          )
+        )
+      )
+  }
 
   override def fileHash: Option[String] = {
     drsPathResolver.resolveDrsThroughMartha(drsPath).map( marthaResponse => {
@@ -65,8 +83,7 @@ object DrsCloudNioRegularFileAttributes {
     Option(preferredHash.getOrElse(hashes.toSeq.minBy(_._1)._2))
   }
 
-  def createMissingKeyException(drsPath: String, missingKey: String) = {
+  def createMissingKeyException(drsPath: String, missingKey: String): RuntimeException = {
     new RuntimeException(s"Failed to resolve DRS path $drsPath. The response from Martha doesn't contain the key '$missingKey'.")
   }
 }
-

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioRegularFileAttributes.scala
@@ -31,7 +31,7 @@ class DrsCloudNioRegularFileAttributes(drsPath: String,
         throwable =>
           IO.raiseError(
             new RuntimeException(
-              s"Error while parsing 'updated' value from Martha to FileTime for DRS path $drsPath. " +
+              s"Error while parsing 'timeUpdated' value from Martha to FileTime for DRS path $drsPath. " +
                 s"Reason: ${ExceptionUtils.getMessage(throwable)}.",
               throwable,
           )
@@ -52,7 +52,8 @@ class DrsCloudNioRegularFileAttributes(drsPath: String,
   override def lastModifiedTime(): FileTime = {
     val lastModifiedIO = for {
       marthaResponse <- marthaResponseIO
-      lastModifiedInString <- IO.fromEither(marthaResponse.timeUpdated.toRight(createMissingKeyException(drsPath, "updated")))
+      lastModifiedInString <-
+        IO.fromEither(marthaResponse.timeUpdated.toRight(createMissingKeyException(drsPath, "timeUpdated")))
       lastModified <- convertToFileTime(lastModifiedInString)
     } yield lastModified
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -79,6 +79,18 @@ final case class SADataObject(data: Json)
 
 final case class MarthaV2Response(dos: DrsObject, googleServiceAccount: Option[SADataObject])
 
+/**
+  * A response from `martha_v3` or converted from `martha_v2`.
+  *
+  * @param size Size of the object stored at gsUri
+  * @param timeUpdated The last update time of the object at gsUri
+  * @param bucket The bucket name port of gsUri, for example "bucket"
+  * @param name The object name part of gsUri, for example "12/345"
+  * @param gsUri Where the object bytes are stored, possibly using a generated path name such as "gs://bucket/12/345"
+  * @param googleServiceAccount The service account to access the gsUri contents
+  * @param fileName A possible different file name for the object at gsUri, ex: "gsutil cp gs://bucket/12/345 my.vcf"
+  * @param hashes Hashes for the contents stored at gsUri
+  */
 final case class MarthaResponse(size: Option[Long],
                                 timeUpdated: Option[String],
                                 bucket: Option[String],

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -70,14 +70,15 @@ final case class DrsConfig(marthaUri: String, marthaRequestJsonTemplate: String)
 
 final case class Url(url: String)
 final case class ChecksumObject(checksum: String, `type`: String)
-final case class DrsDataObject(size: Option[Long],
+final case class DosDataObject(name: Option[String],
+                               size: Option[Long],
                                checksums: Option[Array[ChecksumObject]],
                                updated: Option[String],
                                urls: Array[Url])
-final case class DrsObject(data_object: DrsDataObject)
+final case class DosObject(data_object: DosDataObject)
 final case class SADataObject(data: Json)
 
-final case class MarthaV2Response(dos: DrsObject, googleServiceAccount: Option[SADataObject])
+final case class MarthaV2Response(dos: DosObject, googleServiceAccount: Option[SADataObject])
 
 /**
   * A response from `martha_v3` or converted from `martha_v2`.
@@ -107,9 +108,9 @@ final case class MarthaFailureResponsePayload(text: String)
 object MarthaResponseSupport {
 
   implicit lazy val urlDecoder: Decoder[Url] = deriveDecoder
-  implicit lazy val checksumDecoder: Decoder[ChecksumObject] = deriveDecoder
-  implicit lazy val dataObjectDecoder: Decoder[DrsDataObject] = deriveDecoder
-  implicit lazy val drsObjectDecoder: Decoder[DrsObject] = deriveDecoder
+  implicit lazy val checksumObjectDecoder: Decoder[ChecksumObject] = deriveDecoder
+  implicit lazy val dosDataObjectDecoder: Decoder[DosDataObject] = deriveDecoder
+  implicit lazy val dosObjectDecoder: Decoder[DosObject] = deriveDecoder
   implicit lazy val saDataObjectDecoder: Decoder[SADataObject] = deriveDecoder
   private lazy val marthaV3ResponseDecoder: Decoder[MarthaResponse] = deriveDecoder
   private lazy val marthaV2ResponseDecoder: Decoder[MarthaResponse] =
@@ -137,20 +138,21 @@ object MarthaResponseSupport {
 
   def convertMarthaResponseV2ToV3(response: MarthaV2Response): MarthaResponse = {
     val dataObject = response.dos.data_object
+    val fileName = dataObject.name
     val size = dataObject.size
     val timeUpdated = dataObject.updated
     val hashesMap = dataObject.checksums.map(convertChecksumsToHashesMap)
     val gcsUrl = dataObject.urls.find(_.url.startsWith(GcsScheme)).map(_.url)
-    val (bucketName, fileName) = getGcsBucketAndName(gcsUrl)
+    val (bucketName, objectName) = getGcsBucketAndName(gcsUrl)
 
     MarthaResponse(
       size = size,
       timeUpdated = timeUpdated,
       bucket = bucketName,
-      name = fileName,
+      name = objectName,
       gsUri = gcsUrl,
       googleServiceAccount = response.googleServiceAccount,
-      fileName = None,
+      fileName = fileName,
       hashes = hashesMap
     )
   }

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
@@ -44,6 +44,7 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     name = Option("file-name"),
     gsUri = Option("gs://my-gs-bucket/file-name"),
     googleServiceAccount = Option(mockGSA),
+    fileName = None,
     hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
   )
 
@@ -54,6 +55,7 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     name = Option("file-name"),
     gsUri = Option("gs://my-gs-bucket/file-name"),
     googleServiceAccount = Option(mockGSA),
+    fileName = None,
     hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
   )
 

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
@@ -26,8 +26,9 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
       .asInstanceOf[Lens[MarthaV2Response, Option[String]]]
 
   private val fullMarthaV2Response = MarthaV2Response(
-    dos = DrsObject(
-      data_object = DrsDataObject(
+    dos = DosObject(
+      data_object = DosDataObject(
+        name = Option("actual_file_name"),
         size = Option(34905345),
         checksums = Option(Array(ChecksumObject(checksum = md5HashValue, `type` = "md5"), ChecksumObject(checksum = crcHashValue, `type` = "crc32c"))),
         updated = Option("2020-04-27T15:56:09.696Z"),
@@ -48,7 +49,7 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     name = Option("file-name"),
     gsUri = Option("gs://my-gs-bucket/file-name"),
     googleServiceAccount = Option(mockGSA),
-    fileName = None,
+    fileName = Option("actual_file_name"),
     hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
   )
 

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsPathResolverSpec.scala
@@ -1,18 +1,30 @@
 package cloud.nio.impl.drs
 
-import java.time.{LocalDateTime, OffsetDateTime}
+import java.nio.file.attribute.FileTime
+import java.time.OffsetDateTime
 
+import cats.effect.IO
 import cloud.nio.impl.drs.MarthaResponseSupport.convertMarthaResponseV2ToV3
 import io.circe.{Json, JsonObject}
 import org.apache.http.ProtocolVersion
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import shapeless.{Lens, lens}
 
 class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
   private val mockGSA = SADataObject(data = Json.fromJsonObject(JsonObject("key"-> Json.fromString("value"))))
   private val crcHashValue = "8a366443"
   private val md5HashValue = "336ea55913bc261b72875bd259753046"
   private val shaHashValue = "f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44"
+
+  private val marthaV2UpdatedLens =
+    lens[MarthaV2Response]
+      .dos
+      .data_object
+      .updated
+      // https://stackoverflow.com/questions/23874998/shapeless-lenses-in-idea#23899094
+      .asInstanceOf[Lens[MarthaV2Response, Option[String]]]
+
   private val fullMarthaV2Response = MarthaV2Response(
     dos = DrsObject(
       data_object = DrsDataObject(
@@ -25,19 +37,11 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     googleServiceAccount = Option(mockGSA)
   )
 
-  private val fullMarthaV2ResponseNoTz = MarthaV2Response(
-    dos = DrsObject(
-      data_object = DrsDataObject(
-        size = Option(34905345),
-        checksums = Option(Array(ChecksumObject(checksum = md5HashValue, `type` = "md5"), ChecksumObject(checksum = crcHashValue, `type` = "crc32c"))),
-        updated = Option("2020-01-15T17:46:25.694148"),
-        urls = Array(Url("s3://my-s3-bucket/file-name"), Url("gs://my-gs-bucket/file-name"))
-      )
-    ),
-    googleServiceAccount = Option(mockGSA)
-  )
+  private val fullMarthaV2ResponseNoTz =
+    marthaV2UpdatedLens
+      .set(fullMarthaV2Response)(fullMarthaV2Response.dos.data_object.updated.map(_.stripSuffix("Z")))
 
-  private val fullMarthaResponse =  MarthaResponse(
+  private val fullMarthaResponse = MarthaResponse(
     size = Option(34905345),
     timeUpdated = Option(OffsetDateTime.parse("2020-04-27T15:56:09.696Z").toString),
     bucket = Option("my-gs-bucket"),
@@ -48,16 +52,17 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
   )
 
-  private val fullMarthaResponseNoTz =  MarthaResponse(
-    size = Option(34905345),
-    timeUpdated = Option(LocalDateTime.parse("2020-01-15T17:46:25.694148").toString),
-    bucket = Option("my-gs-bucket"),
-    name = Option("file-name"),
-    gsUri = Option("gs://my-gs-bucket/file-name"),
-    googleServiceAccount = Option(mockGSA),
-    fileName = None,
-    hashes = Option(Map("md5" -> md5HashValue, "crc32c" -> crcHashValue))
-  )
+  private val fullMarthaResponseNoTz =
+    fullMarthaResponse
+      .copy(timeUpdated = fullMarthaResponse.timeUpdated.map(_.stripSuffix("Z")))
+
+  private val fullMarthaResponseNoTime =
+    fullMarthaResponse
+      .copy(timeUpdated = None)
+
+  private val fullMarthaResponseBadTz =
+    fullMarthaResponse
+      .copy(timeUpdated = fullMarthaResponse.timeUpdated.map(_.stripSuffix("Z") + "BADTZ"))
 
   private val alfredHashValue = "xrd"
   private val completeHashesMap = Map(
@@ -185,4 +190,28 @@ class DrsPathResolverSpec extends AnyFlatSpecLike with Matchers {
     }
   }
 
+  it should "resolve an ISO-8601 date with timezone" in {
+    val attributes = new DrsCloudNioRegularFileAttributes("drs://my_awesome_drs", IO.pure(fullMarthaResponse))
+    attributes.lastModifiedTime() should
+      be(FileTime.from(OffsetDateTime.parse("2020-04-27T15:56:09.696Z").toInstant))
+  }
+
+  it should "resolve an ISO-8601 date without timezone" in {
+    val attributes = new DrsCloudNioRegularFileAttributes("drs://my_awesome_drs", IO.pure(fullMarthaResponseNoTz))
+    attributes.lastModifiedTime() should
+      be(FileTime.from(OffsetDateTime.parse("2020-04-27T15:56:09.696Z").toInstant))
+  }
+
+  it should "not resolve an date that does not contain a timeUpdated" in {
+    val attributes = new DrsCloudNioRegularFileAttributes("drs://my_awesome_drs", IO.pure(fullMarthaResponseNoTime))
+    the[RuntimeException] thrownBy attributes.lastModifiedTime() should have message
+      "Failed to resolve DRS path drs://my_awesome_drs. The response from Martha doesn't contain the key 'timeUpdated'."
+  }
+
+  it should "not resolve an date that is not ISO-8601" in {
+    val attributes = new DrsCloudNioRegularFileAttributes("drs://my_awesome_drs", IO.pure(fullMarthaResponseBadTz))
+    the[RuntimeException] thrownBy attributes.lastModifiedTime() should have message
+      "Error while parsing 'timeUpdated' value from Martha to FileTime for DRS path drs://my_awesome_drs. " +
+        "Reason: DateTimeParseException: Text '2020-04-27T15:56:09.696BADTZ' could not be parsed at index 23."
+  }
 }

--- a/cromwell-drs-localizer/src/main/resources/logback.xml
+++ b/cromwell-drs-localizer/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender" target="System.out">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender" target="System.err">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <encoder>
+            <pattern>%red(%msg%n)</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="STDERR" />
+    </root>
+
+</configuration>

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
@@ -153,6 +153,7 @@ class MockGcsLocalizerDrsPathResolver(drsConfig: DrsConfig,
         name= fileName,
         gsUri = gcsUrl,
         googleServiceAccount = None,
+        fileName = None,
         hashes = Option(Map("md5" -> "abc123", "crc32c" -> "34fd67"))
       )
     )

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
@@ -38,9 +38,6 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
 
   private lazy val httpClientBuilder = HttpClientBuilder.create()
 
-  private val GcsScheme = "gs"
-
-
   private def gcsInputStream(gcsFile: GcsFilePath,
                              serviceAccountJson: String,
                              requesterPaysProjectIdOption: Option[String]): IO[ReadableByteChannel] = {
@@ -74,7 +71,6 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
     for {
       serviceAccountJson <- serviceAccountJsonIo
       //Currently, Martha only supports resolving DRS paths to GCS paths
-      _ <- IO.fromEither(marthaResponse.gsUri.toRight(UrlNotFoundException(GcsScheme)))
       bucket <- IO.fromEither(marthaResponse.bucket.toRight(MarthaResponseMissingKeyException("bucket")))
       filePath <- IO.fromEither(marthaResponse.name.toRight(MarthaResponseMissingKeyException("name")))
       readableByteChannel <- gcsInputStream(GcsFilePath(bucket, filePath), serviceAccountJson, requesterPaysProjectIdOption)

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
@@ -1,8 +1,9 @@
 package cromwell.filesystems.drs
 
 import cats.effect.IO
-import cloud.nio.impl.drs.DrsCloudNioFileSystemProvider
+import cloud.nio.impl.drs.{DrsCloudNioFileSystemProvider, MarthaResponse}
 import common.exception._
+import cromwell.core.path.DefaultPathBuilder
 import org.apache.commons.lang3.exception.ExceptionUtils
 import shapeless.syntax.typeable._
 
@@ -10,20 +11,47 @@ import shapeless.syntax.typeable._
 object DrsResolver {
   private val GcsScheme: String = "gs"
 
-  private def urlProtocolLength(scheme: String): Int = scheme.length + 3 //3: length of '://'
+  private val GcsProtocolLength: Int = 5 // length of 'gs://'
 
   def getContainerRelativePath(drsPath: DrsPath): IO[String] = {
     val drsFileSystemProviderOption = drsPath.drsPath.getFileSystem.provider.cast[DrsCloudNioFileSystemProvider]
 
     val noFileSystemForDrsError = s"Unable to cast file system provider to DrsCloudNioFileSystemProvider for DRS path $drsPath."
 
-    for {
+    val pathIo = for {
       drsFileSystemProvider <- toIO(drsFileSystemProviderOption, noFileSystemForDrsError)
       marthaResponse <- drsFileSystemProvider.drsPathResolver.resolveDrsThroughMartha(drsPath.pathAsString)
-      //Currently, Martha only supports resolving DRS paths to GCS paths
-      relativePath <- IO.fromEither(marthaResponse.gsUri.toRight(UrlNotFoundException(GcsScheme)))
-        .map(_.substring(urlProtocolLength(GcsScheme)))
-        .handleErrorWith(e => IO.raiseError(new RuntimeException(s"Error while resolving DRS path: $drsPath. Error: ${ExceptionUtils.getMessage(e)}")))
-    } yield relativePath
+      rootPath = DefaultPathBuilder.get(drsPath.pathWithoutScheme)
+      fileName <- getFileName(marthaResponse)
+      fullPath = rootPath.resolve(fileName)
+      fullPathString = fullPath.pathAsString
+    } yield fullPathString
+
+
+    pathIo
+      .handleErrorWith(
+        exception =>
+          IO.raiseError(
+            new RuntimeException(
+              s"Error while resolving DRS path: $drsPath. Error: ${ExceptionUtils.getMessage(exception)}"
+            )
+          )
+      )
+  }
+
+  /**
+    * Return the file name returned from the martha response or get it from the gsUri
+    */
+  private def getFileName(marthaResponse: MarthaResponse): IO[String] = {
+    marthaResponse.fileName match {
+      case Some(actualFileName) => IO.pure(actualFileName)
+      case None =>
+        //Currently, Martha only supports resolving DRS paths to GCS paths
+        IO
+          .fromEither(marthaResponse.gsUri.toRight(UrlNotFoundException(GcsScheme)))
+          .map(_.substring(GcsProtocolLength))
+          .map(DefaultPathBuilder.get(_))
+          .map(_.name)
+    }
   }
 }

--- a/src/ci/bin/testDbms.sh
+++ b/src/ci/bin/testDbms.sh
@@ -14,11 +14,7 @@ cromwell::build::unit::setup_scale_factor
 
 CROMWELL_SBT_TEST_INCLUDE_TAGS="DbmsTest" \
 CROMWELL_SBT_TEST_SPAN_SCALE_FACTOR="${CROMWELL_BUILD_UNIT_SPAN_SCALE_FACTOR}" \
-sbt \
-    -Dakka.test.timefactor=${CROMWELL_BUILD_UNIT_SPAN_SCALE_FACTOR} \
-    -Dbackend.providers.Local.config.filesystems.local.localization.0=copy \
-    coverage \
-    test
+cromwell:build::run_sbt_test
 
 cromwell::build::generate_code_coverage
 

--- a/src/ci/bin/testSbt.sh
+++ b/src/ci/bin/testSbt.sh
@@ -16,11 +16,7 @@ cromwell::build::unit::setup_exclude_tags
 
 CROMWELL_SBT_TEST_EXCLUDE_TAGS="${CROMWELL_BUILD_UNIT_EXCLUDE_TAGS}" \
 CROMWELL_SBT_TEST_SPAN_SCALE_FACTOR="${CROMWELL_BUILD_UNIT_SPAN_SCALE_FACTOR}" \
-sbt \
-    --warn \
-    -Dakka.test.timefactor=${CROMWELL_BUILD_UNIT_SPAN_SCALE_FACTOR} \
-    -Dbackend.providers.Local.config.filesystems.local.localization.0=copy \
-    coverage test
+cromwell:build::run_sbt_test
 
 cromwell::build::generate_code_coverage
 


### PR DESCRIPTION
- Use the response itself to determine if the GCF was speaking martha_v2 or martha_v3 syntax
- Local testing updates incl. allowing CROMWELL_BUILD_GENERATE_COVERAGE to be pre-est
- Updated the unused DOS/DRS time converter to parse both w/ & w/o TZ