### PR TITLE
Add optional output support for WDL draft 2 on PAPI v2 [BA-6618]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2.test
@@ -1,0 +1,12 @@
+name: wdl_optional_outputs_draft2
+testFormat: workflowsuccess
+backends: [Papiv2]
+
+files {
+  workflow: wdl_optional_outputs_draft2/wdl_optional_outputs_draft2.wdl
+}
+
+metadata {
+  workflowName: wdl_optional_outputs
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2/wdl_optional_outputs_draft2.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2/wdl_optional_outputs_draft2.wdl
@@ -1,0 +1,40 @@
+
+task maybe_create_file {
+    Boolean do_it
+    command {
+        if [ "${do_it}" = true ]; then
+          touch maybe
+        else
+          echo "No file is being generated here..."
+        fi
+    }
+    output {
+        File? maybe = "maybe"
+    }
+    runtime {
+       docker: "ubuntu:latest"
+    }
+}
+
+task more_complicated_maybe_file_tests {
+    command {
+        touch yes
+        echo not touching no
+    }
+    output {
+        Array[File?] array_of_maybe_files = ["yes", "no"]
+        Map[String, File?] map_with_maybe_file_values = { "yes": "yes", "no": "no" }
+    }
+    runtime {
+        docker: "ubuntu:latest"
+    }
+}
+
+
+workflow wdl_optional_outputs {
+    call maybe_create_file as no_create_file { input: do_it = false }
+    call maybe_create_file as yes_create_file { input: do_it = true }
+
+    call more_complicated_maybe_file_tests
+
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2/wdl_optional_outputs_unsupported_draft2.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2/wdl_optional_outputs_unsupported_draft2.wdl
@@ -1,0 +1,19 @@
+task unsupported_pairs {
+    command {
+        touch yes
+        # no no touching
+        # touch no
+    }
+    output {
+        # Even though the nonexistent file is being assigned to the optional File? in the Pair,
+        # Cromwell can't currently work out optionality in Pairs with both optional and non-optional files.
+        Pair[File?, File] one_optional = ("no", "yes")
+    }
+    runtime {
+        docker: "ubuntu:latest"
+    }
+}
+
+workflow wdl_optional_outputs_unsupported {
+    call unsupported_pairs
+}

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported_draft2.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported_draft2.test
@@ -1,0 +1,13 @@
+name: wdl_optional_outputs_unsupported_draft2
+testFormat: workflowfailure
+backends: [Papiv2]
+
+files {
+  workflow: wdl_optional_outputs_draft2/wdl_optional_outputs_unsupported_draft2.wdl
+}
+
+metadata {
+  workflowName: wdl_optional_outputs_unsupported
+  status: Failed
+  "calls.wdl_optional_outputs_unsupported.unsupported_pairs.executionStatus" = "Failed"
+}

--- a/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlExpression.scala
+++ b/wdl/model/draft2/src/main/scala/wdl/draft2/model/WdlExpression.scala
@@ -246,7 +246,9 @@ final case class WdlWomExpression(wdlExpression: WdlExpression, from: Scope) ext
 
       override protected val fileSizeLimitationConfig: FileSizeLimitationConfig = FileSizeLimitationConfig.fileSizeLimitationConfig
     }
-    wdlExpression.evaluateFiles(inputTypes.apply, wdlFunctions, coerceTo).toErrorOr.map(_.toSet[WomFile] map FileEvaluation.requiredFile)
+    wdlExpression.evaluateFiles(inputTypes.apply, wdlFunctions, coerceTo).toErrorOr.map(_.toSet[WomFile] map { file =>
+      FileEvaluation(file, optional = areAllFileTypesInWomTypeOptional(coerceTo), secondary = false)
+    })
   }
 }
 


### PR DESCRIPTION
I hadn't realized there were separate `WomExpession` implementations for WDL draft 2 and 1.0 so until now only 1.0 was supporting optional File outputs 😬 