### PR TITLE
[53_hotfix] Call-by-name to avoid instantiating default commands if unused [BW-416]

### DIFF
--- a/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
@@ -45,7 +45,7 @@ class IoCommandBuilder(partialBuilders: List[PartialIoCommandBuilder] = List.emp
   // Find the first partialBuilder for which the partial function is defined, or use the default
   private def buildOrDefault[A, B](builder: PartialIoCommandBuilder => PartialFunction[A, B],
                                    params: A,
-                                   default: B) = {
+                                   default: => B) = {
     partialBuilders.toStream.map(builder(_).lift(params)).collectFirst({
       case Some(command) => command
     }).getOrElse(default)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -102,7 +102,14 @@ object Settings {
     organization := "org.broadinstitute",
     scalaVersion := ScalaVersion,
     resolvers ++= commonResolvers,
-    parallelExecution := false,
+    // Don't run tasks in parallel, especially helps in low CPU environments like Travis
+    parallelExecution in Global := false,
+    concurrentRestrictions in Global ++= List(
+      // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
+      Tags.exclusive(Tags.Test),
+      // Only run tests on one sub-project at a time, especially helps in low CPU environments like Travis
+      Tags.limit(Tags.Test, 1)
+    ),
     dependencyOverrides ++= cromwellDependencyOverrides,
     scalacOptions ++= baseSettings ++ warningSettings ++ consoleHostileSettings,
     // http://stackoverflow.com/questions/31488335/scaladoc-2-11-6-fails-on-throws-tag-with-unable-to-find-any-member-to-link#31497874

--- a/src/ci/resources/aws_application.conf
+++ b/src/ci/resources/aws_application.conf
@@ -42,7 +42,7 @@ backend {
         concurrent-job-limit = 24
 
         default-runtime-attributes {
-          queueArn: "arn:aws:batch:us-east-1:952500931424:job-queue/highpriority-737f0580-c602-11ea-82b4-12cf2806950f"
+          queueArn: "arn:aws:batch:us-east-1:952500931424:job-queue/priority-cromwell-ci-stack-newest"
           scriptBucketName: "cromwell-centaur-execution-new"
         }
 


### PR DESCRIPTION
GcsCommandBuilder overrides the default commands of IoCommandBuilder. The previous call-by-value syntax was creating default commands that were almost immediately thrown away, but not before they confused and distracted this developer.