### PR TITLE
Refactored IO command creation to return errors instead of throw BT-8

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -128,11 +128,11 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   override lazy val configurationDescriptor: BackendConfigurationDescriptor = standardParams.configurationDescriptor
   protected val commandBuilder: IoCommandBuilder = DefaultIoCommandBuilder
 
-  lazy val cacheCopyJobPaths = jobPaths.forCallCacheCopyAttempts
+  lazy val cacheCopyJobPaths: JobPaths = jobPaths.forCallCacheCopyAttempts
   lazy val destinationCallRootPath: Path = cacheCopyJobPaths.callRoot
   def destinationJobDetritusPaths: Map[String, Path] = cacheCopyJobPaths.detritusPaths
 
-  lazy val ioActor = standardParams.ioActor
+  lazy val ioActor: ActorRef = standardParams.ioActor
 
   startWith(Idle, None)
 
@@ -174,10 +174,29 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
                       detritusAndOutputsIoCommands foreach sendIoCommand
 
                       // Add potential additional commands to the list
-                      val additionalCommands = additionalIoCommands(sourceCallRootPath, simpletons, destinationCallOutputs, jobDetritus, destinationDetritus)
-                      val allCommands = List(detritusAndOutputsIoCommands) ++ additionalCommands
-
-                      goto(WaitingForIoResponses) using Option(StandardCacheHitCopyingActorData(allCommands, destinationCallOutputs, destinationDetritus, cacheHit, returnCode))
+                      val additionalCommandsTry =
+                        additionalIoCommands(
+                          sourceCallRootPath = sourceCallRootPath,
+                          originalSimpletons = simpletons,
+                          newOutputs = destinationCallOutputs,
+                          originalDetritus = jobDetritus,
+                          newDetritus = destinationDetritus,
+                        )
+                      additionalCommandsTry match {
+                        case Success(additionalCommands) =>
+                          val allCommands = List(detritusAndOutputsIoCommands) ++ additionalCommands
+                          goto(WaitingForIoResponses) using
+                            Option(StandardCacheHitCopyingActorData(
+                              commandsToWaitFor = allCommands,
+                              newJobOutputs = destinationCallOutputs,
+                              newDetritus = destinationDetritus,
+                              cacheHit = cacheHit,
+                              returnCode = returnCode,
+                            ))
+                        // Something went wrong in generating duplication commands.
+                        // We consider this loggable error because we don't expect this to happen:
+                        case Failure(failure) => failAndStop(CopyAttemptError(failure))
+                      }
                     case _ => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)
                   }
 
@@ -270,7 +289,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
     andThen
   }
 
-  def succeedAndStop(returnCode: Option[Int], copiedJobOutputs: CallOutputs, detritusMap: DetritusMap) = {
+  def succeedAndStop(returnCode: Option[Int], copiedJobOutputs: CallOutputs, detritusMap: DetritusMap): State = {
     import cromwell.services.metadata.MetadataService.implicits.MetadataAutoPutter
     serviceRegistryActor.putMetadata(jobDescriptor.workflowDescriptor.id, Option(jobDescriptor.key), startMetadataKeyValues)
     context.parent ! JobSucceededResponse(jobDescriptor.key, returnCode, copiedJobOutputs, Option(detritusMap), Seq.empty, None, resultGenerationMode = CallCached)
@@ -300,7 +319,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
     }
   }
 
-  def abort() = {
+  def abort(): State = {
     log.warning("{}: Abort not supported during cache hit copying", jobTag)
     context.parent ! JobAbortedResponse(jobDescriptor.key)
     context stop self
@@ -329,7 +348,8 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val destinationSimpleton = WomValueSimpleton(key, WomSingleFile(destinationPath.pathAsString))
 
-        List(destinationSimpleton) -> Set(commandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
+        // PROD-444: Keep It Short and Simple: Throw on the first error and let the outer Try catch-and-re-wrap
+        List(destinationSimpleton) -> Set(commandBuilder.copyCommand(sourcePath, destinationPath).get)
       case nonFileSimpleton => (List(nonFileSimpleton), Set.empty[IoCommand[_]])
     })
 
@@ -339,7 +359,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   /**
     * Returns the file (and ONLY the file detritus) intersection between the cache hit and this call.
     */
-  protected final def detritusFileKeys(sourceJobDetritusFiles: Map[String, String]) = {
+  protected final def detritusFileKeys(sourceJobDetritusFiles: Map[String, String]): Set[String] = {
     val sourceKeys = sourceJobDetritusFiles.keySet
     val destinationKeys = destinationJobDetritusPaths.keySet
     sourceKeys.intersect(destinationKeys).filterNot(_ == JobPaths.CallRootPathKey)
@@ -360,7 +380,8 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
         val newDetrituses = detrituses + (detritus -> destinationPath)
 
-        (newDetrituses, commands + commandBuilder.copyCommand(sourcePath, destinationPath, overwrite = true))
+      // PROD-444: Keep It Short and Simple: Throw on the first error and let the outer Try catch-and-re-wrap
+      (newDetrituses, commands + commandBuilder.copyCommand(sourcePath, destinationPath).get)
     })
 
     (destinationDetritus + (JobPaths.CallRootPathKey -> destinationCallRootPath), ioCommands)
@@ -374,7 +395,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
                                      originalSimpletons: Seq[WomValueSimpleton],
                                      newOutputs: CallOutputs,
                                      originalDetritus:  Map[String, String],
-                                     newDetritus: Map[String, Path]): List[Set[IoCommand[_]]] = List.empty
+                                     newDetritus: Map[String, Path]): Try[List[Set[IoCommand[_]]]] = Success(Nil)
 
   override protected def onTimeout(message: Any, to: ActorRef): Unit = {
     val exceptionMessage = message match {

--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -194,7 +194,7 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
                               returnCode = returnCode,
                             ))
                         // Something went wrong in generating duplication commands.
-                        // We consider this loggable error because we don't expect this to happen:
+                        // We consider this a loggable error because we don't expect this to happen:
                         case Failure(failure) => failAndStop(CopyAttemptError(failure))
                       }
                     case _ => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)

--- a/backend/src/test/scala/cromwell/backend/standard/callcaching/StandardFileHashingActorSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/standard/callcaching/StandardFileHashingActorSpec.scala
@@ -6,26 +6,29 @@ import cromwell.backend.standard.callcaching.StandardFileHashingActor.SingleFile
 import cromwell.backend.{BackendConfigurationDescriptor, BackendInitializationData, BackendJobDescriptor}
 import cromwell.core.TestKitSuite
 import cromwell.core.callcaching.HashingFailedMessage
-import cromwell.core.io.{IoCommandBuilder, IoHashCommand, PartialIoCommandBuilder}
+import cromwell.core.io.{IoCommand, IoCommandBuilder, IoHashCommand, IoSuccess, PartialIoCommandBuilder}
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import org.specs2.mock.Mockito
 import wom.values.WomSingleFile
 
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
-import scala.util.Try
+import scala.util.control.NoStackTrace
+import scala.util.{Failure, Try}
 
 class StandardFileHashingActorSpec extends TestKitSuite("StandardFileHashingActorSpec") with ImplicitSender
-  with AnyFlatSpecLike with Matchers {
+  with AnyFlatSpecLike with Matchers with Mockito {
 
   behavior of "StandardFileHashingActor"
 
-  it should "return a failure to the parent when getPath throws an exception" in {
+  it should "return a failure to the parent when getPath returns an exception" in {
     val parentProbe = TestProbe()
     val params = StandardFileHashingActorSpec.defaultParams()
     val props = Props(new StandardFileHashingActor(params) {
-      override def getPath(str: String): Try[Path] = throw new RuntimeException("I am expected during tests")
+      override def getPath(str: String): Try[Path] =
+        Failure(new RuntimeException("I am expected during tests") with NoStackTrace)
     })
     val standardFileHashingActorRef = TestActorRef(props, parentProbe.ref)
     val request = SingleFileHashRequest(null, null, WomSingleFile("/expected/failure/path"), None)
@@ -44,7 +47,7 @@ class StandardFileHashingActorSpec extends TestKitSuite("StandardFileHashingActo
     val parentProbe = TestProbe()
     val params = StandardFileHashingActorSpec.defaultParams()
     val props = Props(new StandardFileHashingActor(params) {
-      override val ioCommandBuilder = IoCommandBuilder(
+      override val ioCommandBuilder: IoCommandBuilder = IoCommandBuilder(
         new PartialIoCommandBuilder {
           override def hashCommand = throw new RuntimeException("I am expected during tests")
         }
@@ -69,7 +72,7 @@ class StandardFileHashingActorSpec extends TestKitSuite("StandardFileHashingActo
     val ioActorProbe = TestProbe()
     val params = StandardFileHashingActorSpec.ioActorParams(ioActorProbe.ref)
     val props = Props(new StandardFileHashingActor(params) {
-      override lazy val defaultIoTimeout = 1.second.dilated
+      override lazy val defaultIoTimeout: FiniteDuration = 1.second.dilated
 
       override def getPath(str: String): Try[Path] = Try(DefaultPathBuilder.get(str))
     })
@@ -87,6 +90,32 @@ class StandardFileHashingActorSpec extends TestKitSuite("StandardFileHashingActo
       case failed: HashingFailedMessage if failed.file == "/expected/failure/path" =>
         failed.reason should be(a[TimeoutException])
         failed.reason.getMessage should be("Hashing request timed out for: /expected/failure/path")
+      case unexpected => fail(s"received unexpected message $unexpected")
+    }
+  }
+
+  it should "handle string hash responses" in {
+    val parentProbe = TestProbe("testParentHashString")
+    val params = StandardFileHashingActorSpec.ioActorParams(ActorRef.noSender)
+    val props = Props(new StandardFileHashingActor(params) {
+      override lazy val defaultIoTimeout: FiniteDuration = 1.second.dilated
+
+      override def getPath(str: String): Try[Path] = Try(DefaultPathBuilder.get(str))
+    })
+    val standardFileHashingActorRef = parentProbe.childActorOf(props, "testStandardFileHashingActorHashString")
+
+    val fileHashContext = mock[FileHashContext].smart
+    fileHashContext.file returns "/expected/failure/path"
+    val command = mock[IoCommand[Int]].smart
+    val message: (FileHashContext, IoSuccess[Int]) = (fileHashContext, IoSuccess(command, 1357))
+
+    standardFileHashingActorRef ! message
+
+    parentProbe.expectMsgPF(10.seconds.dilated) {
+      case failed: HashingFailedMessage =>
+        failed.reason should be(a[Exception])
+        failed.reason.getMessage should
+          be("Hash function supposedly succeeded but responded with '1357' instead of a string hash")
       case unexpected => fail(s"received unexpected message $unexpected")
     }
   }
@@ -113,15 +142,15 @@ object StandardFileHashingActorSpec {
                     withBackendInitializationDataOption: => Option[BackendInitializationData]
                    ): StandardFileHashingActorParams = new StandardFileHashingActorParams {
 
-    override def jobDescriptor = withJobDescriptor
+    override def jobDescriptor: BackendJobDescriptor = withJobDescriptor
 
-    override def configurationDescriptor = withConfigurationDescriptor
+    override def configurationDescriptor: BackendConfigurationDescriptor = withConfigurationDescriptor
 
-    override def ioActor = withIoActor
+    override def ioActor: ActorRef = withIoActor
 
-    override def serviceRegistryActor = withServiceRegistryActor
+    override def serviceRegistryActor: ActorRef = withServiceRegistryActor
 
-    override def backendInitializationDataOption = withBackendInitializationDataOption
+    override def backendInitializationDataOption: Option[BackendInitializationData] = withBackendInitializationDataOption
 
     override def fileHashCachingActor: Option[ActorRef] = None
   }

--- a/centaur/src/main/resources/standardTestCases/attempt_to_call_size_function_on_bucket.test
+++ b/centaur/src/main/resources/standardTestCases/attempt_to_call_size_function_on_bucket.test
@@ -7,5 +7,6 @@ files {
 }
 
 metadata {
-  "failures.0.causedBy.0.causedBy.0.message": "Failed to evaluate input 'in_file_size' (reason 1 of 1): [Attempted 1 time(s)] - AggregatedMessageException: Unexpected result in successful Google API call:\n'gs://hsd_salmon_index/' in project 'broad-dsde-cromwell-dev' returned null size"
+  "failures.0.causedBy.0.causedBy.0.message":
+    "Failed to evaluate input 'in_file_size' (reason 1 of 1): GcsPath 'gs://hsd_salmon_index/' is bucket only and does not specify an object blob."
 }

--- a/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
+++ b/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
@@ -5,11 +5,11 @@ backends: [Papiv2]
 files {
   workflow: attempt_to_localize_bucket_as_file/attempt_to_localize_bucket_as_file.wdl
   inputs: attempt_to_localize_bucket_as_file/bucket_name_with_no_trailing_slash.json
+}
 
   metadata {
     "calls.localizer_workflow.localizer_task.callCaching.allowResultReuse": false
     "calls.localizer_workflow.localizer_task.callCaching.effectiveCallCachingMode": "CallCachingOff"
-    "calls.localizer_workflow.localizer_task.callCaching.hashFailures.0.message": "Hash function supposedly succeeded but responded with 'null' instead of a string hash"
+    "calls.localizer_workflow.localizer_task.callCaching.hashFailures.0.message": "GcsPath 'gs://gcp-public-data-landsat/' is bucket only and does not specify an object blob."
     "calls.localizer_workflow.localizer_task.callCaching.hit": false
   }
-}

--- a/centaur/src/main/resources/standardTestCases/bucket_name_with_trailing_slash.test
+++ b/centaur/src/main/resources/standardTestCases/bucket_name_with_trailing_slash.test
@@ -10,6 +10,6 @@ files {
   metadata {
     "calls.localizer_workflow.localizer_task.callCaching.allowResultReuse": false
     "calls.localizer_workflow.localizer_task.callCaching.effectiveCallCachingMode": "CallCachingOff"
-    "calls.localizer_workflow.localizer_task.callCaching.hashFailures.0.message": "[Attempted 1 time(s)] - AggregatedMessageException: Unexpected result in successful Google API call:\n'gs://gcp-public-data-landsat/' in project 'broad-dsde-cromwell-dev' returned null CRC32C checksum"
+    "calls.localizer_workflow.localizer_task.callCaching.hashFailures.0.message": "GcsPath 'gs://gcp-public-data-landsat/' is bucket only and does not specify an object blob."
     "calls.localizer_workflow.localizer_task.callCaching.hit": false
   }

--- a/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
@@ -7,8 +7,8 @@ import cromwell.core.path.Path
 object DefaultIoCommand {
   case class DefaultIoCopyCommand(override val source: Path,
                                   override val destination: Path,
-                                  override val overwrite: Boolean) extends IoCopyCommand(source, destination, overwrite) {
-    override def commandDescription: String = s"DefaultIoCopyCommand source '$source' destination '$destination' overwrite '$overwrite'"
+                                 ) extends IoCopyCommand(source, destination) {
+    override def commandDescription: String = s"DefaultIoCopyCommand source '$source' destination '$destination'"
   }
 
   case class DefaultIoContentAsStringCommand(override val file: Path, override val options: IoReadOptions) extends IoContentAsStringCommand(file, options) {

--- a/core/src/main/scala/cromwell/core/io/IoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommand.scala
@@ -5,20 +5,21 @@ import java.util.UUID
 
 import better.files.File.OpenOptions
 import com.google.api.client.util.ExponentialBackOff
+import common.util.Backoff
 import common.util.StringUtil.EnhancedToStringable
 import cromwell.core.io.IoContentAsStringCommand.IoReadOptions
 import cromwell.core.path.Path
 import cromwell.core.retry.SimpleExponentialBackoff
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.duration._
 import scala.language.postfixOps
 
 object IoCommand {
   private val logger = LoggerFactory.getLogger(IoCommand.getClass)
   val IOCommandWarnLimit: FiniteDuration = 5 minutes
 
-  def defaultGoogleBackoff = new ExponentialBackOff.Builder()
+  def defaultGoogleBackoff: ExponentialBackOff = new ExponentialBackOff.Builder()
     .setInitialIntervalMillis((1 second).toMillis.toInt)
     .setMaxIntervalMillis((5 minutes).toMillis.toInt)
     .setMultiplier(3L)
@@ -26,7 +27,7 @@ object IoCommand {
     .setMaxElapsedTimeMillis((10 minutes).toMillis.toInt)
     .build()
   
-  def defaultBackoff = SimpleExponentialBackoff(defaultGoogleBackoff)
+  def defaultBackoff: Backoff = SimpleExponentialBackoff(defaultGoogleBackoff)
   
   type RetryCommand[T] = (FiniteDuration, IoCommand[T])
 }
@@ -93,8 +94,8 @@ trait SingleFileIoCommand[T] extends IoCommand[T] {
   * Copy source -> destination
   * Will create the destination directory if it doesn't exist.
   */
-abstract class IoCopyCommand(val source: Path, val destination: Path, val overwrite: Boolean) extends IoCommand[Unit] {
-  override def toString = s"copy ${source.pathAsString} to ${destination.pathAsString} with overwrite = $overwrite"
+abstract class IoCopyCommand(val source: Path, val destination: Path) extends IoCommand[Unit] {
+  override def toString = s"copy ${source.pathAsString} to ${destination.pathAsString}"
   override lazy val name = "copy"
 }
   

--- a/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
@@ -5,20 +5,24 @@ import cromwell.core.io.IoContentAsStringCommand.IoReadOptions
 import cromwell.core.path.BetterFileMethods.OpenOptions
 import cromwell.core.path.Path
 
+import scala.util.Try
+
 /**
   * Can be used to customize IoCommands for the desired I/O operations
   */
+//noinspection MutatorLikeMethodIsParameterless
 abstract class PartialIoCommandBuilder {
-  def contentAsStringCommand: PartialFunction[(Path, Option[Int], Boolean), IoContentAsStringCommand] = PartialFunction.empty
-  def writeCommand: PartialFunction[(Path, String, OpenOptions, Boolean), IoWriteCommand] = PartialFunction.empty
-  def sizeCommand: PartialFunction[Path, IoSizeCommand] = PartialFunction.empty
-  def deleteCommand: PartialFunction[(Path, Boolean), IoDeleteCommand] = PartialFunction.empty
-  def copyCommand: PartialFunction[(Path, Path, Boolean), IoCopyCommand] = PartialFunction.empty
-  def hashCommand: PartialFunction[Path, IoHashCommand] = PartialFunction.empty
-  def touchCommand: PartialFunction[Path, IoTouchCommand] = PartialFunction.empty
-  def existsCommand: PartialFunction[Path, IoExistsCommand] = PartialFunction.empty
-  def isDirectoryCommand: PartialFunction[Path, IoIsDirectoryCommand] = PartialFunction.empty
-  def readLinesCommand: PartialFunction[Path, IoReadLinesCommand] = PartialFunction.empty
+  def contentAsStringCommand: PartialFunction[(Path, Option[Int], Boolean), Try[IoContentAsStringCommand]] =
+    PartialFunction.empty
+  def writeCommand: PartialFunction[(Path, String, OpenOptions, Boolean), Try[IoWriteCommand]] = PartialFunction.empty
+  def sizeCommand: PartialFunction[Path, Try[IoSizeCommand]] = PartialFunction.empty
+  def deleteCommand: PartialFunction[(Path, Boolean), Try[IoDeleteCommand]] = PartialFunction.empty
+  def copyCommand: PartialFunction[(Path, Path), Try[IoCopyCommand]] = PartialFunction.empty
+  def hashCommand: PartialFunction[Path, Try[IoHashCommand]] = PartialFunction.empty
+  def touchCommand: PartialFunction[Path, Try[IoTouchCommand]] = PartialFunction.empty
+  def existsCommand: PartialFunction[Path, Try[IoExistsCommand]] = PartialFunction.empty
+  def isDirectoryCommand: PartialFunction[Path, Try[IoIsDirectoryCommand]] = PartialFunction.empty
+  def readLinesCommand: PartialFunction[Path, Try[IoReadLinesCommand]] = PartialFunction.empty
 }
 
 object IoCommandBuilder {
@@ -43,51 +47,56 @@ object IoCommandBuilder {
   */
 class IoCommandBuilder(partialBuilders: List[PartialIoCommandBuilder] = List.empty) {
   // Find the first partialBuilder for which the partial function is defined, or use the default
-  private def buildOrDefault[A, B](builder: PartialIoCommandBuilder => PartialFunction[A, B],
+  private def buildOrDefault[A, B](builder: PartialIoCommandBuilder => PartialFunction[A, Try[B]],
                                    params: A,
-                                   default: => B) = {
+                                   default: => B): Try[B] = {
     partialBuilders.toStream.map(builder(_).lift(params)).collectFirst({
       case Some(command) => command
-    }).getOrElse(default)
+    }).getOrElse(Try(default))
   }
   
-  def contentAsStringCommand(path: Path, maxBytes: Option[Int], failOnOverflow: Boolean): IoContentAsStringCommand = {
+  def contentAsStringCommand(path: Path,
+                             maxBytes: Option[Int],
+                             failOnOverflow: Boolean): Try[IoContentAsStringCommand] = {
     buildOrDefault(_.contentAsStringCommand, (path, maxBytes, failOnOverflow), DefaultIoContentAsStringCommand(path, IoReadOptions(maxBytes, failOnOverflow)))
   }
   
-  def writeCommand(path: Path, content: String, options: OpenOptions, compressPayload: Boolean = false): IoWriteCommand = {
+  def writeCommand(path: Path,
+                   content: String,
+                   options: OpenOptions,
+                   compressPayload: Boolean = false): Try[IoWriteCommand] = {
     buildOrDefault(_.writeCommand, (path, content, options, compressPayload), DefaultIoWriteCommand(path, content, options, compressPayload))
   }
   
-  def sizeCommand(path: Path): IoSizeCommand = {
+  def sizeCommand(path: Path): Try[IoSizeCommand] = {
     buildOrDefault(_.sizeCommand, path, DefaultIoSizeCommand(path))
   } 
   
-  def deleteCommand(path: Path, swallowIoExceptions: Boolean = true): IoDeleteCommand = {
+  def deleteCommand(path: Path, swallowIoExceptions: Boolean = true): Try[IoDeleteCommand] = {
     buildOrDefault(_.deleteCommand, (path, swallowIoExceptions), DefaultIoDeleteCommand(path, swallowIoExceptions))
   }
   
-  def copyCommand(src: Path, dest: Path, overwrite: Boolean): IoCopyCommand = {
-    buildOrDefault(_.copyCommand, (src, dest, overwrite), DefaultIoCopyCommand(src, dest, overwrite))
+  def copyCommand(src: Path, dest: Path): Try[IoCopyCommand] = {
+    buildOrDefault(_.copyCommand, (src, dest), DefaultIoCopyCommand(src, dest))
   }
   
-  def hashCommand(file: Path): IoHashCommand = {
+  def hashCommand(file: Path): Try[IoHashCommand] = {
     buildOrDefault(_.hashCommand, file, DefaultIoHashCommand(file))
   }
   
-  def touchCommand(file: Path): IoTouchCommand = {
+  def touchCommand(file: Path): Try[IoTouchCommand] = {
     buildOrDefault(_.touchCommand, file, DefaultIoTouchCommand(file))
   }
 
-  def existsCommand(file: Path): IoExistsCommand = {
+  def existsCommand(file: Path): Try[IoExistsCommand] = {
     buildOrDefault(_.existsCommand, file, DefaultIoExistsCommand(file))
   }
 
-  def isDirectoryCommand(file: Path): IoIsDirectoryCommand = {
+  def isDirectoryCommand(file: Path): Try[IoIsDirectoryCommand] = {
     buildOrDefault(_.isDirectoryCommand, file, DefaultIoIsDirectoryCommand(file))
   }
 
-  def readLines(file: Path): IoReadLinesCommand = {
+  def readLines(file: Path): Try[IoReadLinesCommand] = {
     buildOrDefault(_.readLinesCommand, file, DefaultIoReadLinesCommand(file))
   }
 }

--- a/core/src/test/scala/cromwell/core/SimpleIoActor.scala
+++ b/core/src/test/scala/cromwell/core/SimpleIoActor.scala
@@ -10,15 +10,15 @@ import scala.concurrent.Promise
 import scala.util.{Failure, Success, Try}
 
 object SimpleIoActor {
-  def props = Props(new SimpleIoActor)
+  def props: Props = Props(new SimpleIoActor)
 }
 
 class SimpleIoActor extends Actor {
   
-  override def receive = {
+  override def receive: Receive = {
     case command: IoCopyCommand =>
       
-      Try(command.source.copyTo(command.destination, command.overwrite)) match {
+      Try(command.source.copyTo(command.destination)) match {
         case Success(_) => sender() ! IoSuccess(command, ())
         case Failure(failure) => sender() ! IoFailure(command, failure)
       }
@@ -66,7 +66,7 @@ class SimpleIoActor extends Actor {
     // With context
     case (requestContext: Any, command: IoCopyCommand) =>
       
-      Try(command.source.copyTo(command.destination, command.overwrite)) match {
+      Try(command.source.copyTo(command.destination, overwrite = true)) match {
         case Success(_) => sender() ! (requestContext -> IoSuccess(command, ()))
         case Failure(failure) => sender() ! (requestContext -> IoFailure(command, failure))
       }

--- a/core/src/test/scala/cromwell/core/io/IoAckSpec.scala
+++ b/core/src/test/scala/cromwell/core/io/IoAckSpec.scala
@@ -12,7 +12,7 @@ class IoAckSpec extends AnyFlatSpecLike with CromwellTimeoutSpec with Matchers {
 
   "IoFailAck pattern matching" should "work for both IoFailure and IoReadForbiddenFailure" in {
     import DefaultPathBuilder._
-    val command = DefaultIoCopyCommand(build(Paths.get("foo")), build(Paths.get("bar")), overwrite = false)
+    val command = DefaultIoCopyCommand(build(Paths.get("foo")), build(Paths.get("bar")))
 
     val ioFailure = IoFailure(command, new RuntimeException("blah"))
     val ioReadForbiddenFailure = IoFailure(command, new RuntimeException("blah"))

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -8,7 +8,7 @@ import akka.NotUsed
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Timers}
 import akka.dispatch.ControlMessage
 import akka.stream._
-import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink, Source}
+import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink, Source, SourceQueueWithComplete}
 import com.google.cloud.storage.StorageException
 import com.typesafe.config.ConfigFactory
 import cromwell.core.Dispatcher.IoDispatcher
@@ -24,6 +24,8 @@ import cromwell.engine.io.nio.NioFlow
 import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
 import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
 import javax.net.ssl.SSLException
+
+import scala.concurrent.ExecutionContext
 
 /**
   * Actor that performs IO operations asynchronously using akka streams
@@ -41,7 +43,7 @@ final class IoActor(queueSize: Int,
                     override val serviceRegistryActor: ActorRef,
                     applicationName: String)(implicit val materializer: ActorMaterializer)
   extends Actor with ActorLogging with StreamActorHelper[IoCommandContext[_]] with IoInstrumentation with Timers {
-  implicit val ec = context.dispatcher
+  implicit val ec: ExecutionContext = context.dispatcher
 
   /**
     * Method for instrumentation to be executed when a IoCommand failed and is being retried.
@@ -51,18 +53,21 @@ final class IoActor(queueSize: Int,
     incrementIoRetry(commandContext.request, throwable)
   }
   
-  override def preStart() = {
+  override def preStart(): Unit = {
     // On start up, let the controller know that the load is normal
     serviceRegistryActor ! LoadMetric("IO", NormalLoad)
     super.preStart()
   }
   
-  private [io] lazy val defaultFlow = new NioFlow(parallelism = nioParallelism, context.system.scheduler, onRetry).flow.withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
+  private [io] lazy val defaultFlow =
+    new NioFlow(parallelism = nioParallelism, onRetry)
+      .flow
+      .withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
   private [io] lazy val gcsBatchFlow = new ParallelGcsBatchFlow(parallelism = gcsParallelism, batchSize = 100, context.system.scheduler, onRetry, applicationName).flow.withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
   
-  protected val source = Source.queue[IoCommandContext[_]](queueSize, OverflowStrategy.dropNew)
+  private val source = Source.queue[IoCommandContext[_]](queueSize, OverflowStrategy.dropNew)
 
-  protected val flow = GraphDSL.create() { implicit builder =>
+  private val flow = GraphDSL.create() { implicit builder =>
     import GraphDSL.Implicits._
     
     val input = builder.add(Flow[IoCommandContext[_]])
@@ -95,7 +100,7 @@ final class IoActor(queueSize: Int,
     FlowShape[IoCommandContext[_], IoResult](input.in, merger.out)
   }
 
-  protected val throttledFlow = throttle map { t => 
+  private val throttledFlow = throttle map { t =>
     Flow[IoCommandContext[_]]
       .throttle(t.elements, t.per, t.maximumBurst, ThrottleMode.Shaping)
       .via(flow)
@@ -103,12 +108,15 @@ final class IoActor(queueSize: Int,
   
   private val instrumentationSink = Sink.foreach[IoResult](instrumentIoResult)
   
-  override protected lazy val streamSource = source
+  override protected lazy val streamSource: Source[
+    (Any, IoCommandContext[_]),
+    SourceQueueWithComplete[IoCommandContext[_]]
+  ] = source
     .via(throttledFlow)
     .alsoTo(instrumentationSink)  
     .withAttributes(ActorAttributes.dispatcher(Dispatcher.IoDispatcher))
 
-  override def onBackpressure() = {
+  override def onBackpressure(): Unit = {
     incrementBackpressure()
     serviceRegistryActor ! LoadMetric("IO", HighLoad)
     // Because this method will be called every time we backpressure, the timer will be overridden every
@@ -165,7 +173,7 @@ object IoActor {
   private val ioConfig = ConfigFactory.load().getConfig("system.io")
   
   /** Maximum number of times a command will be attempted: First attempt + 5 retries */
-  val MaxAttemptsNumber = ioConfig.getOrElse[Int]("number-of-attempts", 5)
+  val MaxAttemptsNumber: Int = ioConfig.getOrElse("number-of-attempts", 5)
 
   case class DefaultCommandContext[T](request: IoCommand[T], replyTo: ActorRef, override val clientContext: Option[Any] = None) extends IoCommandContext[T]
   
@@ -197,7 +205,7 @@ object IoActor {
     Option(failure.getMessage).exists(_.matches(serverErrorPattern))
   }
 
-  val AdditionalRetryableHttpCodes = List(
+  private val AdditionalRetryableHttpCodes = List(
     // HTTP 410: Gone
     // From Google doc (https://cloud.google.com/storage/docs/json_api/v1/status-codes):
     // "You have attempted to use a resumable upload session that is no longer available.
@@ -211,7 +219,7 @@ object IoActor {
   )
 
   // Error messages not included in the list of built-in GCS retryable errors (com.google.cloud.storage.StorageException) but that we still want to retry
-  val AdditionalRetryableErrorMessages = List(
+  private val AdditionalRetryableErrorMessages = List(
     "Connection closed prematurely"
   ).map(_.toLowerCase)
 
@@ -233,9 +241,16 @@ object IoActor {
     case other => isTransient(other)
   }
 
-  def isFatal(failure: Throwable) = !isRetryable(failure)
+  def isFatal(failure: Throwable): Boolean = !isRetryable(failure)
   
-  def props(queueSize: Int, nioParallelism: Int, gcsParallelism: Int, throttle: Option[Throttle], serviceRegistryActor: ActorRef, applicationName: String)(implicit materializer: ActorMaterializer) = {
+  def props(queueSize: Int,
+            nioParallelism: Int,
+            gcsParallelism: Int,
+            throttle: Option[Throttle],
+            serviceRegistryActor: ActorRef,
+            applicationName: String,
+           )
+           (implicit materializer: ActorMaterializer): Props = {
     Props(new IoActor(queueSize, nioParallelism, gcsParallelism, throttle, serviceRegistryActor, applicationName)).withDispatcher(IoDispatcher)
   }
 }

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -3,9 +3,8 @@ package cromwell.engine.io.nio
 import java.io._
 import java.nio.charset.StandardCharsets
 
-import akka.actor.Scheduler
 import akka.stream.scaladsl.Flow
-import cats.effect.IO
+import cats.effect.{IO, Timer}
 import cloud.nio.impl.drs.DrsCloudNioFileSystemProvider
 import common.util.IORetry
 import cromwell.core.io._
@@ -20,18 +19,17 @@ import cromwell.util.TryWithResource._
 
 import scala.concurrent.ExecutionContext
 object NioFlow {
-  def NoopOnRetry(context: IoCommandContext[_])(failure: Throwable) = ()
+  val NoopOnRetry: IoCommandContext[_] => Throwable => Unit = _ => _ => ()
 }
 
 /**
   * Flow that executes IO operations by calling java.nio.Path methods
   */
 class NioFlow(parallelism: Int,
-              scheduler: Scheduler,
               onRetryCallback: IoCommandContext[_] => Throwable => Unit = NioFlow.NoopOnRetry,
               nbAttempts: Int = MaxAttemptsNumber)(implicit ec: ExecutionContext) {
   
-  implicit private val timer = IO.timer(ec)
+  implicit private val timer: Timer[IO] = IO.timer(ec)
   
   private val processCommand: DefaultCommandContext[_] => IO[IoResult] = commandContext => {
 
@@ -76,11 +74,12 @@ class NioFlow(parallelism: Int,
     }
   }
 
-  val flow = Flow[DefaultCommandContext[_]].mapAsyncUnordered[IoResult](parallelism)(processCommand.andThen(_.unsafeToFuture()))
+  private[io] val flow =
+    Flow[DefaultCommandContext[_]].mapAsyncUnordered[IoResult](parallelism)(processCommand.andThen(_.unsafeToFuture()))
 
   private def copy(copy: IoCopyCommand) = IO {
     createDirectories(copy.destination)
-    copy.source.copyTo(copy.destination, copy.overwrite)
+    copy.source.copyTo(copy.destination, overwrite = true)
     ()
   }
 
@@ -109,7 +108,7 @@ class NioFlow(parallelism: Int,
 
   private def hash(hash: IoHashCommand): IO[String] = {
     hash.file match {
-      case gcsPath: GcsPath => IO { gcsPath.cloudStorage.get(gcsPath.blob).getCrc32c }
+      case gcsPath: GcsPath => IO.fromTry { gcsPath.objectBlobId.map(gcsPath.cloudStorage.get(_).getCrc32c) }
       case drsPath: DrsPath => getFileHashForDrsPath(drsPath)
       case s3Path: S3Path => IO { s3Path.eTag }
       case ossPath: OssPath => IO { ossPath.eTag}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
@@ -30,6 +30,22 @@ object CopyWorkflowLogsActor {
             ioActor: ActorRef,
             workflowLogConfigurationOption: Option[WorkflowLogConfiguration] =
             WorkflowLogger.workflowLogConfiguration,
+            /*
+            The theory is that the `GcsBatchCommandBuilder` copies the temporary workflow logs from the local disk to
+            GCS. Then later, the separate `DefaultIOCommandBuilder` deletes files from the local disk.
+
+            But...
+
+            I believe the `GcsBatchCommandBuilder` _always_ fails to create a copy command as it only copies from GCS to
+            GCS. Since a GCS to GCS copy command isn't created the `IoCommandBuilder.copyCommand` returns its
+            `DefaultIoCopyCommand`.
+
+            Then `cromwell.engine.io.nio.NioFlow.copy` does the copy.
+
+            So in theory one could just use the `DefaultIoCommandBuilder` for both command builders. However
+            attempting-to-use the `GcsBatchCommandBuilder` to create copy commands is the way this was previously
+            implemented, It Works (TM), and I'm not changing it for now.
+             */
             copyCommandBuilder: IoCommandBuilder = GcsBatchCommandBuilder,
             deleteCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder,
            ): Props = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActor.scala
@@ -8,48 +8,76 @@ import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core._
 import cromwell.core.io._
 import cromwell.core.logging.WorkflowLogger
+import cromwell.core.logging.WorkflowLogger.WorkflowLogConfiguration
 import cromwell.core.path.Path
 import cromwell.engine.workflow.WorkflowMetadataHelper
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.metadata.MetadataService.PutMetadataAction
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success, Try}
+
 object CopyWorkflowLogsActor {
   // Commands
   case class Copy(workflowId: WorkflowId, destinationDirPath: Path)
 
-  val strategy = OneForOneStrategy(maxNrOfRetries = 3) {
+  val strategy: OneForOneStrategy = OneForOneStrategy(maxNrOfRetries = 3) {
     case _: IOException => Restart
   }
 
-  def props(serviceRegistryActor: ActorRef, ioActor: ActorRef) = Props(new CopyWorkflowLogsActor(serviceRegistryActor, ioActor)).withDispatcher(IoDispatcher)
+  def props(serviceRegistryActor: ActorRef,
+            ioActor: ActorRef,
+            workflowLogConfigurationOption: Option[WorkflowLogConfiguration] =
+            WorkflowLogger.workflowLogConfiguration,
+            copyCommandBuilder: IoCommandBuilder = GcsBatchCommandBuilder,
+            deleteCommandBuilder: IoCommandBuilder = DefaultIoCommandBuilder,
+           ): Props = {
+    Props(new CopyWorkflowLogsActor(
+      serviceRegistryActor = serviceRegistryActor,
+      ioActor = ioActor,
+      workflowLogConfigurationOption = workflowLogConfigurationOption,
+      copyCommandBuilder = copyCommandBuilder,
+      deleteCommandBuilder = deleteCommandBuilder,
+    )).withDispatcher(IoDispatcher)
+  }
 }
 
 // This could potentially be turned into a more generic "Copy/Move something from A to B"
 // Which could be used for other copying work (outputs, call logs..)
-class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, override val ioActor: ActorRef) extends Actor 
+class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef,
+                            override val ioActor: ActorRef,
+                            workflowLogConfigurationOption: Option[WorkflowLogConfiguration],
+                            copyCommandBuilder: IoCommandBuilder,
+                            deleteCommandBuilder: IoCommandBuilder,
+                           ) extends Actor
   with ActorLogging with IoClientHelper with WorkflowMetadataHelper with MonitoringCompanionHelper {
 
-  implicit val ec = context.dispatcher
-  
-  def copyLog(src: Path, dest: Path, workflowId: WorkflowId) = {
-    // Send the workflowId as context along with the copy so we can update metadata when the response comes back
-    sendIoCommandWithContext(GcsBatchCommandBuilder.copyCommand(src, dest, overwrite = true), workflowId)
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  private def tryCopyLog(src: Path, dest: Path, workflowId: WorkflowId): Try[Unit] = {
     // In order to keep "copy and then delete" operations atomic as far as monitoring is concerned, removeWork will only be called
     // when the delete is complete (successfully or not), or when the copy completes if WorkflowLogger.isTemporary is false
     addWork()
+    // Send the workflowId as context along with the copy so we can update metadata when the response comes back
+    copyCommandBuilder.copyCommand(src, dest).map(sendIoCommandWithContext(_, workflowId))
   }
 
-  def deleteLog(src: Path) = if (WorkflowLogger.isTemporary) {
-    sendIoCommand(DefaultIoCommandBuilder.deleteCommand(src))
+  private def deleteLog(src: Path): Unit = if (workflowLogConfigurationOption.exists(_.temporary)) {
+    deleteCommandBuilder.deleteCommand(src) match {
+      case Success(command) => sendIoCommand(command)
+      case Failure(failure) =>
+        log.error(s"Failed to delete workflow logs from ${src.pathAsString}: ${failure.getMessage}")
+        removeWork()
+    }
   } else removeWork()
   
-  def updateLogsPathInMetadata(workflowId: WorkflowId, path: Path) = {
+  private def updateLogsPathInMetadata(workflowId: WorkflowId, path: Path): Unit = {
     val metadataEventMsg = MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.WorkflowLog), MetadataValue(path.pathAsString))
     serviceRegistryActor ! PutMetadataAction(metadataEventMsg)
   }
 
-  def copyLogsReceive: Receive = {
+  private def copyLogsReceive: Receive = {
     case CopyWorkflowLogsActor.Copy(workflowId, destinationDir) =>
       val workflowLogger = new WorkflowLogger(
         loggerName = self.path.name,
@@ -59,12 +87,23 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
       )
 
       workflowLogger.workflowLogPath foreach { src =>
-        if (src.exists) {
+        if (Try(src.exists).getOrElse(false)) {
           val destPath = destinationDir.resolve(src.name)
           workflowLogger.info(s"Copying workflow logs from $src to $destPath")
 
-          copyLog(src, destPath, workflowId)
-          // Deliberately not deleting the file here, that will be done in batch in `deleteLog` after the copy is terminal.
+          tryCopyLog(src, destPath, workflowId) match {
+            case Failure(failure) =>
+              log.error(
+                cause = failure,
+                message =
+                  s"Failed to copy workflow logs from ${src.pathAsString} to ${destPath.pathAsString}: " +
+                    s"${failure.getMessage}",
+              )
+              deleteLog(src)
+            case Success(_) =>
+              // Deliberately not deleting the file here, that will be done in batch in `deleteLog`
+              // after the copy is terminal.
+          }
           workflowLogger.close()
         }
       }
@@ -86,10 +125,14 @@ class CopyWorkflowLogsActor(override val serviceRegistryActor: ActorRef, overrid
 
     case other => log.warning(s"CopyWorkflowLogsActor received an unexpected message: $other")
   }
-  
-  override def receive = monitoringReceive orElse ioReceive orElse copyLogsReceive
 
-  override def preRestart(t: Throwable, message: Option[Any]) = {
+  /*_*/
+  // shh intellij is ok...
+  // https://stackoverflow.com/questions/36679973/controlling-false-intellij-code-editor-error-in-scala-plugin
+  override def receive: Receive = monitoringReceive orElse ioReceive orElse copyLogsReceive
+  /*_*/
+
+  override def preRestart(t: Throwable, message: Option[Any]): Unit = {
     message foreach self.forward
   }
 

--- a/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorProxyGcsBatchSpec.scala
@@ -2,6 +2,7 @@ package cromwell.engine.io
 
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
@@ -21,13 +22,13 @@ import scala.language.postfixOps
 class IoActorProxyGcsBatchSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with ImplicitSender with Eventually {
   behavior of "IoActor [GCS Batch]"
 
-  implicit val actorSystem = system
+  implicit val actorSystem: ActorSystem = system
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  val instanceConfig = ConfigFactory.parseString("auth = \"application-default\"")
+  private val instanceConfig = ConfigFactory.parseString("auth = \"application-default\"")
 
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     materializer.shutdown()
     src.delete(swallowIOExceptions = true)
     srcRequesterPays.delete(swallowIOExceptions = true)
@@ -38,23 +39,29 @@ class IoActorProxyGcsBatchSpec extends TestKitSuite with AnyFlatSpecLike with Ma
     super.afterAll()
   }
 
-  lazy val gcsPathBuilder = GcsPathBuilderFactory(ConfigFactory.load(), instanceConfig)
-  lazy val pathBuilder: GcsPathBuilder = Await.result(gcsPathBuilder.withOptions(WorkflowOptions.empty), 1 second)
+  private lazy val gcsPathBuilder = GcsPathBuilderFactory(ConfigFactory.load(), instanceConfig)
+  private lazy val pathBuilder: GcsPathBuilder =
+    Await.result(gcsPathBuilder.withOptions(WorkflowOptions.empty), 1 second)
 
-  lazy val randomUUID = UUID.randomUUID().toString
+  private lazy val randomUUID = UUID.randomUUID().toString
 
-  lazy val directory = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test").get
-  lazy val src = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFile.txt").get
-  lazy val dst = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFile-copy.txt").get
+  private lazy val directory = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test").get
+  private lazy val src = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFile.txt").get
+  private lazy val dst = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFile-copy.txt").get
 
-  lazy val directoryRequesterPays = pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test").get
-  lazy val srcRequesterPays = pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test/$randomUUID/testFile.txt").get
-  lazy val dstRequesterPays = pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test/$randomUUID/testFile-copy.txt").get
+  private lazy val directoryRequesterPays =
+    pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test").get
+  private lazy val srcRequesterPays =
+    pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test/$randomUUID/testFile.txt").get
+  private lazy val dstRequesterPays =
+    pathBuilder.build(s"gs://cromwell_bucket_with_requester_pays/unit-test/$randomUUID/testFile-copy.txt").get
 
-  lazy val srcRegional = pathBuilder.build(s"gs://cloud-cromwell-dev-regional/unit-test/$randomUUID/testRegional.txt").get
-  lazy val dstMultiRegional = pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFileRegional-copy.txt").get
+  private lazy val srcRegional =
+    pathBuilder.build(s"gs://cloud-cromwell-dev-regional/unit-test/$randomUUID/testRegional.txt").get
+  private lazy val dstMultiRegional =
+    pathBuilder.build(s"gs://cloud-cromwell-dev/unit-test/$randomUUID/testFileRegional-copy.txt").get
 
-  override def beforeAll() = {
+  override def beforeAll(): Unit = {
     // Write commands can't be batched, so for the sake of this test, just create a file in GCS synchronously here
     src.write("hello")
     srcRequesterPays.write("hello")
@@ -62,19 +69,19 @@ class IoActorProxyGcsBatchSpec extends TestKitSuite with AnyFlatSpecLike with Ma
     super.beforeAll()
   }
 
-  def testWith(src: GcsPath, dst: GcsPath, directory: GcsPath) = {
+  private def testWith(src: GcsPath, dst: GcsPath, directory: GcsPath) = {
     val testActor = TestActorRef(new IoActor(10, 10, 10, None, TestProbe().ref, "cromwell test"))
 
-    val copyCommand = GcsBatchCopyCommand(src, dst, overwrite = false)
-    val sizeCommand = GcsBatchSizeCommand(src)
-    val hashCommand = GcsBatchCrc32Command(src)
+    val copyCommand = GcsBatchCopyCommand.forPaths(src, dst).get
+    val sizeCommand = GcsBatchSizeCommand.forPath(src).get
+    val hashCommand = GcsBatchCrc32Command.forPath(src).get
     // Should return true
-    val isDirectoryCommand = GcsBatchIsDirectoryCommand(directory)
+    val isDirectoryCommand = GcsBatchIsDirectoryCommand.forPath(directory).get
     // Should return false
-    val isDirectoryCommand2 = GcsBatchIsDirectoryCommand(src)
+    val isDirectoryCommand2 = GcsBatchIsDirectoryCommand.forPath(src).get
 
-    val deleteSrcCommand = GcsBatchDeleteCommand(src, swallowIOExceptions = false)
-    val deleteDstCommand = GcsBatchDeleteCommand(dst, swallowIOExceptions = false)
+    val deleteSrcCommand = GcsBatchDeleteCommand.forPath(src, swallowIOExceptions = false).get
+    val deleteDstCommand = GcsBatchDeleteCommand.forPath(dst, swallowIOExceptions = false).get
 
     testActor ! copyCommand
     testActor ! sizeCommand
@@ -126,7 +133,7 @@ class IoActorProxyGcsBatchSpec extends TestKitSuite with AnyFlatSpecLike with Ma
   it should "copy files across GCS storage classes" taggedAs IntegrationTest in {
     val testActor = TestActorRef(new IoActor(10, 10, 10, None, TestProbe().ref, "cromwell test"))
 
-    val copyCommand = GcsBatchCopyCommand(srcRegional, dstMultiRegional, overwrite = false)
+    val copyCommand = GcsBatchCopyCommand.forPaths(srcRegional, dstMultiRegional).get
 
     testActor ! copyCommand
 

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -3,6 +3,7 @@ package cromwell.engine.io
 import java.io.IOException
 import java.net.{SocketException, SocketTimeoutException}
 
+import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import better.files.File.OpenOptions
@@ -23,11 +24,11 @@ import scala.language.postfixOps
 class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with ImplicitSender {
   behavior of "IoActor"
   
-  implicit val actorSystem = system
+  implicit val actorSystem: ActorSystem = system
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
   
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     materializer.shutdown()
     super.afterAll()
   }
@@ -38,7 +39,7 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
     val src = DefaultPathBuilder.createTempFile()
     val dst: Path = src.parent.resolve(src.name + "-dst")
     
-    val copyCommand = DefaultIoCopyCommand(src, dst, overwrite = true)
+    val copyCommand = DefaultIoCopyCommand(src, dst)
     
     testActor ! copyCommand
     expectMsgPF(5 seconds) {

--- a/engine/src/test/scala/cromwell/engine/io/gcs/GcsBatchFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/gcs/GcsBatchFlowSpec.scala
@@ -52,8 +52,13 @@ class GcsBatchFlowSpec extends TestKitSuite with AnyFlatSpecLike with CromwellTi
     implicit val ec: ExecutionContextExecutor = system.dispatcher
     val gcsBatchFlow = new GcsBatchFlow(1, system.scheduler, null, "testAppName")
 
-    val mockGcsPath = GcsPath(CloudStorageFileSystem.forBucket("bucket").getPath("test"), any[com.google.api.services.storage.Storage], any[com.google.cloud.storage.Storage], anyString)
-    val gcsBatchCommandContext = GcsBatchCommandContext(GcsBatchCrc32Command(mockGcsPath), TestProbe().ref)
+    val mockGcsPath = GcsPath(
+      nioPath = CloudStorageFileSystem.forBucket("bucket").getPath("test"),
+      apiStorage = anyObject[com.google.api.services.storage.Storage],
+      cloudStorage = anyObject[com.google.cloud.storage.Storage],
+      projectId = anyString,
+    )
+    val gcsBatchCommandContext = GcsBatchCommandContext(GcsBatchCrc32Command.forPath(mockGcsPath).get, TestProbe().ref)
     val recoverCommandPrivateMethod = PrivateMethod[PartialFunction[Throwable, Future[GcsBatchResponse[_]]]]('recoverCommand)
     val partialFuncAcceptingThrowable = gcsBatchFlow invokePrivate recoverCommandPrivateMethod(gcsBatchCommandContext)
 

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.engine.io.nio
 
-import java.nio.file.{FileAlreadyExistsException, NoSuchFileException}
+import java.nio.file.NoSuchFileException
 import java.util.UUID
 
 import akka.actor.ActorRef
@@ -13,29 +13,35 @@ import cromwell.core.io._
 import cromwell.core.path.DefaultPathBuilder
 import cromwell.core.{CromwellFatalExceptionMarker, TestKitSuite}
 import cromwell.engine.io.IoActor.DefaultCommandContext
+import cromwell.engine.io.IoAttempts.EnhancedCromwellIoException
 import cromwell.engine.io.IoCommandContext
+import cromwell.filesystems.gcs.GcsPath
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
+import org.specs2.mock.Mockito._
+
+import scala.util.Failure
+import scala.util.control.NoStackTrace
 
 class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with MockitoSugar {
 
   behavior of "NioFlowSpec"
 
-  val flow = new NioFlow(1, system.scheduler)(system.dispatcher).flow
+  private val flow = new NioFlow(1)(system.dispatcher).flow
   
-  implicit val materializer = ActorMaterializer()
-  val replyTo = mock[ActorRef]
-  val readSink = Sink.head[(IoAck[_], IoCommandContext[_])]
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  private val replyTo = mock[ActorRef]
+  private val readSink = Sink.head[(IoAck[_], IoCommandContext[_])]
 
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     materializer.shutdown()
     super.afterAll()
   }
 
   it should "write to a Nio Path" in {
     val testPath = DefaultPathBuilder.createTempFile()
-    val context = DefaultCommandContext(writeCommand(testPath, "hello", Seq.empty), replyTo)
+    val context = DefaultCommandContext(writeCommand(testPath, "hello", Seq.empty).get, replyTo)
     val testSource = Source.single(context)
 
     val stream = testSource.via(flow).toMat(readSink)(Keep.right)
@@ -49,7 +55,7 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
     
-    val context = DefaultCommandContext(contentAsStringCommand(testPath, None, failOnOverflow = false), replyTo)
+    val context = DefaultCommandContext(contentAsStringCommand(testPath, None, failOnOverflow = false).get, replyTo)
     val testSource = Source.single(context)
 
     val stream = testSource.via(flow).toMat(readSink)(Keep.right)
@@ -64,7 +70,7 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
 
-    val context = DefaultCommandContext(sizeCommand(testPath), replyTo)
+    val context = DefaultCommandContext(sizeCommand(testPath).get, replyTo)
     val testSource = Source.single(context)
 
     val stream = testSource.via(flow).toMat(readSink)(Keep.right)
@@ -79,7 +85,7 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("hello")
 
-    val context = DefaultCommandContext(hashCommand(testPath), replyTo)
+    val context = DefaultCommandContext(hashCommand(testPath).get, replyTo)
     val testSource = Source.single(context)
 
     val stream = testSource.via(flow).toMat(readSink)(Keep.right)
@@ -90,11 +96,28 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     }
   }
 
+  it should "get hash from a GcsPath" in {
+    val exception = new Exception("everything's fine, I am an expected blob failure") with NoStackTrace
+    val testPath = mock[GcsPath].smart
+    testPath.objectBlobId returns Failure(exception)
+
+    val context = DefaultCommandContext(hashCommand(testPath).get, replyTo)
+    val testSource = Source.single(context)
+
+    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
+
+    stream.run() map {
+      case (IoFailure(_, EnhancedCromwellIoException(_, receivedException)), _) =>
+        receivedException should be(receivedException)
+      case unexpected => fail(s"hash returned an unexpected message: $unexpected")
+    }
+  }
+
   it should "copy Nio paths" in {
     val testPath = DefaultPathBuilder.createTempFile()
     val testCopyPath = testPath.sibling(UUID.randomUUID().toString)
 
-    val context = DefaultCommandContext(copyCommand(testPath, testCopyPath, overwrite = false), replyTo)
+    val context = DefaultCommandContext(copyCommand(testPath, testCopyPath).get, replyTo)
 
     val testSource = Source.single(context)
 
@@ -106,14 +129,14 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     }
   }
 
-  it should "copy Nio paths with overwrite true" in {
+  it should "copy Nio paths with" in {
     val testPath = DefaultPathBuilder.createTempFile()
     testPath.write("goodbye")
     
     val testCopyPath = DefaultPathBuilder.createTempFile()
     testCopyPath.write("hello")
     
-    val context = DefaultCommandContext(copyCommand(testPath, testCopyPath, overwrite = true), replyTo)
+    val context = DefaultCommandContext(copyCommand(testPath, testCopyPath).get, replyTo)
 
     val testSource = Source.single(context)
 
@@ -127,27 +150,9 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     }
   }
 
-  it should "copy Nio paths with overwrite false" in {
-    val testPath = DefaultPathBuilder.createTempFile()
-    val testCopyPath = DefaultPathBuilder.createTempFile()
-
-    val context = DefaultCommandContext(copyCommand(testPath, testCopyPath, overwrite = false), replyTo)
-
-    val testSource = Source.single(context)
-
-    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
-
-   stream.run() map {
-      case (failure: IoFailure[_], _) =>
-        assert(failure.failure.isInstanceOf[CromwellFatalExceptionMarker])
-        assert(failure.failure.getCause.isInstanceOf[FileAlreadyExistsException])
-      case _ => fail("copy returned an unexpected message")
-    }
-  }
-
   it should "delete a Nio path" in {
     val testPath = DefaultPathBuilder.createTempFile()
-    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = false), replyTo)
+    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = false).get, replyTo)
     val testSource = Source.single(context)
 
     val stream = testSource.via(flow).toMat(readSink)(Keep.right)
@@ -161,7 +166,8 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
   it should "delete a Nio path with swallowIoExceptions true" in {
     val testPath = DefaultPathBuilder.build("/this/does/not/exist").get
 
-    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = true), replyTo)
+    //noinspection RedundantDefaultArgument
+    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = true).get, replyTo)
 
     val testSource = Source.single(context)
 
@@ -176,7 +182,7 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
   it should "delete a Nio path with swallowIoExceptions false" in {
     val testPath = DefaultPathBuilder.build("/this/does/not/exist").get
 
-    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = false), replyTo)
+    val context = DefaultCommandContext(deleteCommand(testPath, swallowIoExceptions = false).get, replyTo)
 
     val testSource = Source.single(context)
 
@@ -187,20 +193,20 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
         assert(failure.failure.isInstanceOf[CromwellFatalExceptionMarker])
         assert(failure.failure.getMessage == "[Attempted 1 time(s)] - NoSuchFileException: /this/does/not/exist")
         assert(failure.failure.getCause.isInstanceOf[NoSuchFileException])
-      case other @ _ => fail(s"delete returned an unexpected message")
+      case _ => fail(s"delete returned an unexpected message")
     }
   }
 
   it should "retry on retryable exceptions" in {
     val testPath = DefaultPathBuilder.build("does/not/matter").get
 
-    val context = DefaultCommandContext(contentAsStringCommand(testPath, None, failOnOverflow = false), replyTo)
+    val context = DefaultCommandContext(contentAsStringCommand(testPath, None, failOnOverflow = false).get, replyTo)
 
     val testSource = Source.single(context)
 
-    val customFlow = new NioFlow(1, system.scheduler, NioFlow.NoopOnRetry, 3)(system.dispatcher) {
+    val customFlow = new NioFlow(1, NioFlow.NoopOnRetry, 3)(system.dispatcher) {
       private var tries = 0
-      override def handleSingleCommand(ioSingleCommand: IoCommand[_]) = {
+      override def handleSingleCommand(ioSingleCommand: IoCommand[_]): IO[IoSuccess[_]] = {
         IO {
           tries += 1
           if (tries < 3) throw new StorageException(500, "message")

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActorSpec.scala
@@ -7,13 +7,13 @@ import akka.testkit.{TestFSMRef, TestProbe}
 import common.util.Backoff
 import cromwell.core._
 import cromwell.core.actor.StreamIntegration.BackPressure
-import cromwell.core.io.{IoDeleteCommand, IoFailure, IoSuccess}
+import cromwell.core.io.{IoCommandBuilder, IoDeleteCommand, IoFailure, IoSuccess, PartialIoCommandBuilder}
 import cromwell.core.path.Path
 import cromwell.core.path.PathFactory.PathBuilders
 import cromwell.core.retry.SimpleExponentialBackoff
 import cromwell.engine.io.IoAttempts.EnhancedCromwellIoException
 import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor.{StartWorkflowFilesDeletion, WaitingForIoResponses}
-import cromwell.filesystems.gcs.batch.GcsBatchDeleteCommand
+import cromwell.filesystems.gcs.batch.{GcsBatchCommandBuilder, GcsBatchDeleteCommand}
 import cromwell.filesystems.gcs.{GcsPath, GcsPathBuilder, MockGcsPathBuilder}
 import cromwell.services.metadata.MetadataService.PutMetadataAction
 import cromwell.services.metadata.impl.FileDeletionStatus
@@ -28,6 +28,8 @@ import wom.types.{WomMaybeEmptyArrayType, WomSingleFileType, WomStringType}
 import wom.values.{WomArray, WomSingleFile, WomString}
 
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+import scala.util.{Failure, Try}
 
 class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActorSpec")
   with AnyFlatSpecLike
@@ -36,8 +38,8 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
 
   val mockPathBuilder: GcsPathBuilder = MockGcsPathBuilder.instance
   val mockPathBuilders = List(mockPathBuilder)
-  val serviceRegistryActor = TestProbe()
-  val ioActor = TestProbe()
+  private val serviceRegistryActor = TestProbe()
+  private val ioActor = TestProbe()
 
   val emptyWorkflowIdSet = Set.empty[WorkflowId]
 
@@ -98,7 +100,8 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
       testDeleteWorkflowFilesActor.stateName shouldBe WaitingForIoResponses
     }
 
-    testDeleteWorkflowFilesActor ! IoSuccess(GcsBatchDeleteCommand(gcsFilePath, swallowIOExceptions = false), ())
+    testDeleteWorkflowFilesActor !
+      IoSuccess(GcsBatchDeleteCommand.forPath(gcsFilePath, swallowIOExceptions = false).get, ())
 
     serviceRegistryActor.expectMsgPF(10.seconds) {
       case m: PutMetadataAction =>
@@ -125,7 +128,7 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
         event.value.get.value shouldBe FileDeletionStatus.toDatabaseValue(InProgress)
     }
 
-    val expectedDeleteCommand = GcsBatchDeleteCommand(gcsFilePath, swallowIOExceptions = false)
+    val expectedDeleteCommand = GcsBatchDeleteCommand.forPath(gcsFilePath, swallowIOExceptions = false).get
 
     ioActor.expectMsgPF(10.seconds) {
       case `expectedDeleteCommand` => // woohoo!
@@ -136,7 +139,7 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
     }
 
     // Simulate a few backpressure events before we get the success:
-    (0.until(10)) foreach { _ =>
+    0 until 10 foreach { _ =>
       ioActor.send(testDeleteWorkflowFilesActor, BackPressure(expectedDeleteCommand))
       ioActor.expectMsgPF(10.seconds) {
         case cmd: IoDeleteCommand => cmd.file shouldBe gcsFilePath
@@ -179,7 +182,11 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
       testDeleteWorkflowFilesActor.stateName shouldBe WaitingForIoResponses
     }
 
-    testDeleteWorkflowFilesActor ! IoFailure(GcsBatchDeleteCommand(gcsFilePath, swallowIOExceptions = false), new Exception(s"Something is fishy!"))
+    testDeleteWorkflowFilesActor !
+      IoFailure(
+        command = GcsBatchDeleteCommand.forPath(gcsFilePath, swallowIOExceptions = false).get,
+        failure = new Exception(s"Something is fishy!"),
+      )
 
     serviceRegistryActor.expectMsgPF(10.seconds) {
       case m: PutMetadataAction =>
@@ -216,7 +223,11 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
     }
 
     val fileNotFoundException = EnhancedCromwellIoException(s"File not found", new FileNotFoundException(gcsFilePath.pathAsString))
-    testDeleteWorkflowFilesActor ! IoFailure(GcsBatchDeleteCommand(gcsFilePath, swallowIOExceptions = false), fileNotFoundException)
+    testDeleteWorkflowFilesActor !
+      IoFailure(
+        command = GcsBatchDeleteCommand.forPath(gcsFilePath, swallowIOExceptions = false).get,
+        failure = fileNotFoundException,
+      )
 
     serviceRegistryActor.expectMsgPF(10.seconds) {
       case m: PutMetadataAction =>
@@ -262,6 +273,41 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
     actualIntermediateFiles shouldBe expectedIntermediateFiles
   }
 
+  it should "send failure when delete command creation is unsuccessful for a file" in {
+
+    val partialIoCommandBuilder = new PartialIoCommandBuilder {
+      override def deleteCommand: PartialFunction[(Path, Boolean), Try[IoDeleteCommand]] = {
+        case _ => Failure(new Exception("everything's fine, I am an expected delete fail") with NoStackTrace)
+      }
+    }
+    val ioCommandBuilder = new IoCommandBuilder(List(partialIoCommandBuilder))
+
+    testDeleteWorkflowFilesActor =
+      TestFSMRef(new MockDeleteWorkflowFilesActor(rootWorkflowId,
+        rootAndSubworkflowIds = emptyWorkflowIdSet,
+        workflowFinalOutputs = finalOutputs,
+        workflowAllOutputs = allOutputs,
+        pathBuilders = mockPathBuilders,
+        serviceRegistryActor = serviceRegistryActor.ref,
+        ioActor = ioActor.ref,
+        gcsCommandBuilder = ioCommandBuilder,
+      ))
+    testProbe.watch(testDeleteWorkflowFilesActor)
+
+    testDeleteWorkflowFilesActor ! StartWorkflowFilesDeletion
+
+    serviceRegistryActor.expectMsgPF(10.seconds) {
+      case m: PutMetadataAction =>
+        val event = m.events.head
+        m.events.size shouldBe 1
+        event.key.workflowId shouldBe rootWorkflowId
+        event.key.key shouldBe WorkflowMetadataKeys.FileDeletionStatus
+        event.value.get.value shouldBe FileDeletionStatus.toDatabaseValue(InProgress)
+    }
+
+    testProbe.expectTerminated(testDeleteWorkflowFilesActor, 10.seconds)
+    testProbe.unwatch(testDeleteWorkflowFilesActor)
+  }
 
   it should "terminate if root workflow has no intermediate outputs to delete" in {
 
@@ -338,8 +384,12 @@ class DeleteWorkflowFilesActorSpec extends TestKitSuite("DeleteWorkflowFilesActo
 class MockDeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
                                    rootAndSubworkflowIds: Set[WorkflowId],
                                    workflowFinalOutputs: CallOutputs,
-                                   workflowAllOutputs: CallOutputs, pathBuilders: PathBuilders,
-                                   serviceRegistryActor: ActorRef, ioActor: ActorRef) extends
+                                   workflowAllOutputs: CallOutputs,
+                                   pathBuilders: PathBuilders,
+                                   serviceRegistryActor: ActorRef,
+                                   ioActor: ActorRef,
+                                   gcsCommandBuilder: IoCommandBuilder = GcsBatchCommandBuilder,
+                                  ) extends
   DeleteWorkflowFilesActor(
     rootWorkflowId,
     rootAndSubworkflowIds,
@@ -347,7 +397,8 @@ class MockDeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
     workflowAllOutputs.outputs.values.toSet,
     pathBuilders,
     serviceRegistryActor,
-    ioActor
+    ioActor,
+    gcsCommandBuilder,
   ) {
   // Override the IO actor backoff for the benefit of the backpressure tests:
   override def initialBackoff(): Backoff = SimpleExponentialBackoff(100.millis, 1.second, 1.2D)

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowLogsActorSpec.scala
@@ -1,0 +1,192 @@
+package cromwell.engine.workflow.lifecycle.finalization
+
+import akka.testkit._
+import cromwell.core.io.DefaultIoCommand.{DefaultIoCopyCommand, DefaultIoDeleteCommand}
+import cromwell.core.io._
+import cromwell.core.logging.WorkflowLogger
+import cromwell.core.path.{DefaultPathBuilder, Path}
+import cromwell.core.{TestKitSuite, WorkflowId}
+import cromwell.util.GracefulShutdownHelper
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+import scala.util.{Failure, Try}
+
+class CopyWorkflowLogsActorSpec
+  extends TestKitSuite("CopyWorkflowLogsActorSpec") with AnyFlatSpecLike with Matchers {
+
+  behavior of "CopyWorkflowLogsActor"
+
+  private val msgWait = 10.second.dilated
+  private val serviceRegistryActor = TestProbe("testServiceRegistryActor")
+  private val ioActor = TestProbe("testIoActor")
+  private val deathWatch = TestProbe("deathWatch")
+  private val tempDir = DefaultPathBuilder.createTempDirectory("tempDir.")
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    tempDir.delete(true)
+  }
+
+  it should "send a command to delete" in {
+    val workflowId = WorkflowId.randomId()
+    val destinationDir = tempDir.resolve("deleteAFile")
+    val props =
+      CopyWorkflowLogsActor.props(
+        serviceRegistryActor = serviceRegistryActor.ref,
+        ioActor = ioActor.ref,
+        workflowLogConfigurationOption = WorkflowLogger.workflowLogConfiguration,
+        copyCommandBuilder = DefaultIoCommandBuilder,
+        deleteCommandBuilder = DefaultIoCommandBuilder,
+      )
+    val copyWorkflowLogsActor = system.actorOf(props, "testCopyWorkflowLogsActor")
+
+    // The delete command uses singletons so we expect that directory to be used
+    lazy val workflowLogPath = WorkflowLogger.workflowLogConfiguration.get.dir.resolve(s"workflow.$workflowId.log")
+    copyWorkflowLogsActor ! CopyWorkflowLogsActor.Copy(workflowId, destinationDir)
+
+    // We expect a copy command to be created and sent to the ioActor as a Tuple2
+    val copyCommand =
+      DefaultIoCopyCommand(workflowLogPath, destinationDir.resolve(workflowLogPath.name))
+    ioActor.expectMsg(msgWait, (workflowId, copyCommand))
+
+    // Tell the copyWorkflowLogsActor the copy failed as a Tuple2
+    copyWorkflowLogsActor !
+      ((
+        workflowId,
+        IoFailure(copyCommand, new Exception("everything's fine, I am an expected copy fail") with NoStackTrace),
+      ))
+
+    // There should now be a delete command sent to the ioActor
+    val deleteCommand = DefaultIoDeleteCommand(workflowLogPath, swallowIOExceptions = true)
+    ioActor.expectMsg(msgWait, deleteCommand)
+
+    // Tell the copyWorkflowLogsActor the delete failed
+    copyWorkflowLogsActor !
+      IoFailure(deleteCommand, new Exception("everything's fine, I am an expected delete fail") with NoStackTrace)
+
+    // Send a shutdown after the delete
+    deathWatch.watch(copyWorkflowLogsActor)
+    copyWorkflowLogsActor ! GracefulShutdownHelper.ShutdownCommand
+
+    // Then the actor should shutdown
+    deathWatch.expectTerminated(copyWorkflowLogsActor, msgWait)
+  }
+
+  it should "skip copy and still delete if unable to create a copy command" in {
+    val workflowId = WorkflowId.randomId()
+    val destinationPath = DefaultPathBuilder.createTempFile(s"test_file_$workflowId.", ".file", Option(tempDir))
+    val partialIoCommandBuilder = new PartialIoCommandBuilder {
+      override def copyCommand: PartialFunction[(Path, Path), Try[IoCopyCommand]] = {
+        case _ => Failure(new Exception("everything's fine, I am an expected copy fail") with NoStackTrace)
+      }
+    }
+    val ioCommandBuilder = new IoCommandBuilder(List(partialIoCommandBuilder))
+    val props =
+      CopyWorkflowLogsActor.props(
+        serviceRegistryActor = serviceRegistryActor.ref,
+        ioActor = ioActor.ref,
+        workflowLogConfigurationOption = WorkflowLogger.workflowLogConfiguration,
+        copyCommandBuilder = ioCommandBuilder,
+      )
+    val copyWorkflowLogsActor = system.actorOf(props, "testCopyWorkflowLogsActorFailCopy")
+
+    // The delete command uses singletons so we expect that directory to be used
+    lazy val workflowLogPath = WorkflowLogger.workflowLogConfiguration.get.dir.resolve(s"workflow.$workflowId.log")
+    copyWorkflowLogsActor ! CopyWorkflowLogsActor.Copy(workflowId, destinationPath)
+
+    // Because the copy failed we expect a delete command to be sent immediately to the ioActor
+    val deleteCommand = DefaultIoDeleteCommand(workflowLogPath, swallowIOExceptions = true)
+    ioActor.expectMsg(msgWait, deleteCommand)
+
+    copyWorkflowLogsActor ! IoFailure(deleteCommand, new Exception("everything's fine, I am an expected delete fail") with NoStackTrace)
+
+    // Send a shutdown after the delete
+    deathWatch.watch(copyWorkflowLogsActor)
+    copyWorkflowLogsActor ! GracefulShutdownHelper.ShutdownCommand
+
+    // Then the actor should shutdown
+    deathWatch.expectTerminated(copyWorkflowLogsActor, msgWait)
+  }
+
+  it should "skip copy and still delete if unable to create a copy command while shutting down" in {
+    val workflowId = WorkflowId.randomId()
+    val destinationPath = DefaultPathBuilder.createTempFile(s"test_file_$workflowId.", ".file", Option(tempDir))
+    val partialIoCommandBuilder = new PartialIoCommandBuilder {
+      override def copyCommand: PartialFunction[(Path, Path), Try[IoCopyCommand]] = {
+        case _ => Failure(new Exception("everything's fine, I am an expected copy fail") with NoStackTrace)
+      }
+    }
+    val ioCommandBuilder = new IoCommandBuilder(List(partialIoCommandBuilder))
+    val props = CopyWorkflowLogsActor.props(
+      serviceRegistryActor = serviceRegistryActor.ref,
+      ioActor = ioActor.ref,
+      workflowLogConfigurationOption = WorkflowLogger.workflowLogConfiguration,
+      copyCommandBuilder = ioCommandBuilder,
+    )
+    val copyWorkflowLogsActor = system.actorOf(props, "testCopyWorkflowLogsActorFailCopyShutdown")
+
+    // The delete command uses singletons so we expect that directory to be used
+    lazy val workflowLogPath = WorkflowLogger.workflowLogConfiguration.get.dir.resolve(s"workflow.$workflowId.log")
+    copyWorkflowLogsActor ! CopyWorkflowLogsActor.Copy(workflowId, destinationPath)
+
+    // Send a shutdown before the delete
+    deathWatch.watch(copyWorkflowLogsActor)
+    copyWorkflowLogsActor ! GracefulShutdownHelper.ShutdownCommand
+
+    // Because the copy failed we instead expect a delete command to be sent to the ioActor
+    val deleteCommand = DefaultIoDeleteCommand(workflowLogPath, swallowIOExceptions = true)
+    ioActor.expectMsg(msgWait, deleteCommand)
+
+    // Test that the actor is still alive and receiving messages even after a shutdown was requested
+    EventFilter.error(pattern = "Failed to delete workflow logs", occurrences = 1).intercept {
+      copyWorkflowLogsActor ! IoFailure(deleteCommand, new Exception("everything's fine, I am an expected delete fail") with NoStackTrace)
+    }
+
+    // Then the actor should shutdown
+    deathWatch.expectTerminated(copyWorkflowLogsActor, msgWait)
+  }
+
+  it should "exit if creating a delete commands fails after failing to create a copy command" in {
+    val workflowId = WorkflowId.randomId()
+    val destinationPath = DefaultPathBuilder.createTempFile(s"test_file_$workflowId.", ".file", Option(tempDir))
+    val partialIoCommandBuilder = new PartialIoCommandBuilder {
+      override def copyCommand: PartialFunction[(Path, Path), Try[IoCopyCommand]] = {
+        case _ => Failure(new Exception("everything's fine, I am an expected copy fail") with NoStackTrace)
+      }
+
+      override def deleteCommand: PartialFunction[(Path, Boolean), Try[IoDeleteCommand]] = {
+        case _ => Failure(new Exception("everything's fine, I am an expected delete fail") with NoStackTrace)
+      }
+    }
+    val ioCommandBuilder = new IoCommandBuilder(List(partialIoCommandBuilder))
+    val props =
+      CopyWorkflowLogsActor.props(
+        serviceRegistryActor = serviceRegistryActor.ref,
+        ioActor = ioActor.ref,
+        workflowLogConfigurationOption = WorkflowLogger.workflowLogConfiguration,
+        copyCommandBuilder = ioCommandBuilder,
+        deleteCommandBuilder = ioCommandBuilder,
+      )
+    val copyWorkflowLogsActor = system.actorOf(props, "testCopyWorkflowLogsActorFailDelete")
+
+    EventFilter.error(pattern = "Failed to delete workflow logs", occurrences = 1).intercept {
+      EventFilter.error(pattern = "Failed to copy workflow logs", occurrences = 1).intercept {
+        copyWorkflowLogsActor ! CopyWorkflowLogsActor.Copy(workflowId, destinationPath)
+      }
+    }
+
+    // Send a shutdown
+    deathWatch.watch(copyWorkflowLogsActor)
+    copyWorkflowLogsActor ! GracefulShutdownHelper.ShutdownCommand
+
+    // Then the actor should shutdown
+    deathWatch.expectTerminated(copyWorkflowLogsActor, msgWait)
+  }
+}

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
@@ -1,35 +1,38 @@
 package cromwell.filesystems.gcs.batch
 
 import cromwell.core.io._
+import cromwell.core.path.Path
 import cromwell.filesystems.gcs.GcsPath
 
+import scala.util.Try
+
 private case object PartialGcsBatchCommandBuilder extends PartialIoCommandBuilder {
-  override def sizeCommand = {
-    case gcsPath: GcsPath => GcsBatchSizeCommand(gcsPath)
+  override def sizeCommand: PartialFunction[Path, Try[GcsBatchSizeCommand]] = {
+    case gcsPath: GcsPath => GcsBatchSizeCommand.forPath(gcsPath)
   }
   
-  override def deleteCommand = {
-    case (gcsPath: GcsPath, swallowIoExceptions) => GcsBatchDeleteCommand(gcsPath, swallowIoExceptions)
+  override def deleteCommand: PartialFunction[(Path, Boolean), Try[GcsBatchDeleteCommand]] = {
+    case (gcsPath: GcsPath, swallowIoExceptions) => GcsBatchDeleteCommand.forPath(gcsPath, swallowIoExceptions)
   }
   
-  override def copyCommand = {
-    case (gcsSrc: GcsPath, gcsDest: GcsPath, overwrite) => GcsBatchCopyCommand(gcsSrc, gcsDest, overwrite)
+  override def copyCommand: PartialFunction[(Path, Path), Try[GcsBatchCopyCommand]] = {
+    case (gcsSrc: GcsPath, gcsDest: GcsPath) => GcsBatchCopyCommand.forPaths(gcsSrc, gcsDest)
   }
   
-  override def hashCommand = {
-    case gcsPath: GcsPath => GcsBatchCrc32Command(gcsPath)
+  override def hashCommand: PartialFunction[Path, Try[GcsBatchCrc32Command]] = {
+    case gcsPath: GcsPath => GcsBatchCrc32Command.forPath(gcsPath)
   }
 
-  override def touchCommand = {
-    case gcsPath: GcsPath => GcsBatchTouchCommand(gcsPath)
+  override def touchCommand: PartialFunction[Path, Try[GcsBatchTouchCommand]] = {
+    case gcsPath: GcsPath => GcsBatchTouchCommand.forPath(gcsPath)
   }
 
-  override def existsCommand = {
-    case gcsPath: GcsPath => GcsBatchExistsCommand(gcsPath)
+  override def existsCommand: PartialFunction[Path, Try[GcsBatchExistsCommand]] = {
+    case gcsPath: GcsPath => GcsBatchExistsCommand.forPath(gcsPath)
   }
 
-  override def isDirectoryCommand = {
-    case gcsPath: GcsPath => GcsBatchIsDirectoryCommand(gcsPath)
+  override def isDirectoryCommand: PartialFunction[Path, Try[GcsBatchIsDirectoryCommand]] = {
+    case gcsPath: GcsPath => GcsBatchIsDirectoryCommand.forPath(gcsPath)
   }
 }
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
@@ -5,6 +5,7 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.google.api.services.storage.StorageRequest
 import com.google.api.services.storage.model.{Objects, RewriteResponse, StorageObject}
+import com.google.cloud.storage.BlobId
 import common.util.StringUtil._
 import common.validation.ErrorOr.ErrorOr
 import cromwell.core.io._
@@ -12,6 +13,7 @@ import cromwell.filesystems.gcs._
 import mouse.all._
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 /**
   * NOTE: the setUserProject commented out code disables uses of requester pays bucket
@@ -21,7 +23,7 @@ import scala.collection.JavaConverters._
   * @tparam T Return type of the IoCommand
   * @tparam U Return type of the Google response
   */
-trait GcsBatchIoCommand[T, U] extends IoCommand[T] {
+sealed trait GcsBatchIoCommand[T, U] extends IoCommand[T] {
   /**
     * StorageRequest operation to be executed by this command
     */
@@ -34,7 +36,7 @@ trait GcsBatchIoCommand[T, U] extends IoCommand[T] {
 
   /**
     * Method called in the success callback of a batched request to decide what to do next.
-    * Returns an ErrorOr[Either[T, GcsBatchIoCommand[T, U]]]
+    * Returns an `ErrorOr[Either[T, GcsBatchIoCommand[T, U]]]`
     * Within the Either:
     *   Left(value) means the command is complete, and the result can be sent back to the sender.
     *   Right(newCommand) means the command is not complete and needs another request to be executed.
@@ -58,22 +60,22 @@ trait GcsBatchIoCommand[T, U] extends IoCommand[T] {
 
 sealed trait SingleFileGcsBatchIoCommand[T, U] extends GcsBatchIoCommand[T, U] with SingleFileIoCommand[T] {
   override def file: GcsPath
+  //noinspection MutatorLikeMethodIsParameterless
   def setUserProject: Boolean
-  def userProject = setUserProject.option(file.projectId).orNull
+  def userProject: String = setUserProject.option(file.projectId).orNull
 }
 
 case class GcsBatchCopyCommand(
                                 override val source: GcsPath,
+                                sourceBlob: BlobId,
                                 override val destination: GcsPath,
-                                override val overwrite: Boolean,
+                                destinationBlob: BlobId,
                                 rewriteToken: Option[String] = None,
                                 setUserProject: Boolean = false
-                              ) extends IoCopyCommand(source, destination, overwrite) with GcsBatchIoCommand[Unit, RewriteResponse] {
-  val sourceBlob = source.blob
-  val destinationBlob = destination.blob
-
+                              )
+  extends IoCopyCommand(source, destination) with GcsBatchIoCommand[Unit, RewriteResponse] {
   override def commandDescription: String = s"GcsBatchCopyCommand source '$source' destination '$destination' " +
-    s"overwrite '$overwrite' setUserProject '$setUserProject'"
+    s"setUserProject '$setUserProject'"
 
   override def operation: StorageRequest[RewriteResponse] = {
     val rewriteOperation = source.apiStorage.objects()
@@ -88,36 +90,57 @@ case class GcsBatchCopyCommand(
   /**
     * Clone this command with the give rewrite token
     */
-  def withRewriteToken(rewriteToken: String) = copy(rewriteToken = Option(rewriteToken))
+  def withRewriteToken(rewriteToken: String): GcsBatchCopyCommand = copy(rewriteToken = Option(rewriteToken))
 
-  override def onSuccess(response: RewriteResponse, httpHeaders: HttpHeaders) = {
-    if (response.getDone) super.onSuccess(response, httpHeaders)
-    else {
+  override def onSuccess(response: RewriteResponse, httpHeaders: HttpHeaders): ErrorOr[Either[Unit, GcsBatchCopyCommand]] = {
+    if (response.getDone) {
+      mapGoogleResponse(response) map Left.apply
+    } else {
       Right(withRewriteToken(response.getRewriteToken)).validNel
     }
   }
 
   override def mapGoogleResponse(response: RewriteResponse): ErrorOr[Unit] = ().validNel
-  override def withUserProject = this.copy(setUserProject = true)
+
+  override def withUserProject: GcsBatchCopyCommand = this.copy(setUserProject = true)
+}
+
+object GcsBatchCopyCommand {
+  def forPaths(source: GcsPath, destination: GcsPath): Try[GcsBatchCopyCommand] = {
+    for {
+      sourceBlob <- source.objectBlobId
+      destinationBlob <- destination.objectBlobId
+    } yield GcsBatchCopyCommand(source, sourceBlob, destination, destinationBlob)
+  }
 }
 
 case class GcsBatchDeleteCommand(
                                   override val file: GcsPath,
+                                  blob: BlobId,
                                   override val swallowIOExceptions: Boolean,
                                   setUserProject: Boolean = false
                                 ) extends IoDeleteCommand(file, swallowIOExceptions) with SingleFileGcsBatchIoCommand[Unit, Void] {
-  private val blob = file.blob
   override def operation: StorageRequest[Void] = {
     file.apiStorage.objects().delete(blob.getBucket, blob.getName).setUserProject(userProject)
   }
-  override protected def mapGoogleResponse(response: Void): ErrorOr[Unit] = ().validNel
-  override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders) = {
+
+  override def mapGoogleResponse(response: Void): ErrorOr[Unit] = ().validNel
+
+  override def onFailure(googleJsonError: GoogleJsonError,
+                         httpHeaders: HttpHeaders,
+                        ): Option[Either[Unit, GcsBatchDeleteCommand]] = {
     if (swallowIOExceptions) Option(Left(())) else None
   }
-  override def withUserProject = this.copy(setUserProject = true)
+  override def withUserProject: GcsBatchDeleteCommand = this.copy(setUserProject = true)
 
   override def commandDescription: String = s"GcsBatchDeleteCommand file '$file' swallowIOExceptions " +
     s"'$swallowIOExceptions' setUserProject '$setUserProject'"
+}
+
+object GcsBatchDeleteCommand {
+  def forPath(file: GcsPath, swallowIOExceptions: Boolean): Try[GcsBatchDeleteCommand] = {
+    file.objectBlobId.map(GcsBatchDeleteCommand(file, _, swallowIOExceptions))
+  }
 }
 
 /**
@@ -125,38 +148,71 @@ case class GcsBatchDeleteCommand(
   */
 sealed trait GcsBatchGetCommand[T] extends SingleFileGcsBatchIoCommand[T, StorageObject] {
   def file: GcsPath
-  private val blob = file.blob
+  def blob: BlobId
   override def operation: StorageRequest[StorageObject] = {
     file.apiStorage.objects().get(blob.getBucket, blob.getName).setUserProject(userProject)
   }
 }
 
-case class GcsBatchSizeCommand(override val file: GcsPath, setUserProject: Boolean = false) extends IoSizeCommand(file) with GcsBatchGetCommand[Long] {
+case class GcsBatchSizeCommand(override val file: GcsPath,
+                               override val blob: BlobId,
+                               setUserProject: Boolean = false,
+                              ) extends IoSizeCommand(file) with GcsBatchGetCommand[Long] {
   override def mapGoogleResponse(response: StorageObject): ErrorOr[Long] = {
     Option(response.getSize) match {
       case None => s"'${file.pathAsString}' in project '${file.projectId}' returned null size".invalidNel
       case Some(size) => size.longValue().validNel
     }
   }
-  override def withUserProject = this.copy(setUserProject = true)
+
+  override def withUserProject: GcsBatchSizeCommand = this.copy(setUserProject = true)
+
   override def commandDescription: String = s"GcsBatchSizeCommand file '$file' setUserProject '$setUserProject'"
 }
 
-case class GcsBatchCrc32Command(override val file: GcsPath, setUserProject: Boolean = false) extends IoHashCommand(file) with GcsBatchGetCommand[String] {
+object GcsBatchSizeCommand {
+  def forPath(file: GcsPath): Try[GcsBatchSizeCommand] = {
+    file.objectBlobId.map(GcsBatchSizeCommand(file, _))
+  }
+}
+
+case class GcsBatchCrc32Command(override val file: GcsPath,
+                                override val blob: BlobId,
+                                setUserProject: Boolean = false,
+                               ) extends IoHashCommand(file) with GcsBatchGetCommand[String] {
   override def mapGoogleResponse(response: StorageObject): ErrorOr[String] = {
     Option(response.getCrc32c) match {
       case None => s"'${file.pathAsString}' in project '${file.projectId}' returned null CRC32C checksum".invalidNel
       case Some(crc32c) => crc32c.validNel
     }
   }
-  override def withUserProject = this.copy(setUserProject = true)
+
+  override def withUserProject: GcsBatchCrc32Command = this.copy(setUserProject = true)
+
   override def commandDescription: String = s"GcsBatchCrc32Command file '$file' setUserProject '$setUserProject'"
 }
 
-case class GcsBatchTouchCommand(override val file: GcsPath, setUserProject: Boolean = false) extends IoTouchCommand(file) with GcsBatchGetCommand[Unit] {
+object GcsBatchCrc32Command {
+  def forPath(file: GcsPath): Try[GcsBatchCrc32Command] = {
+    file.objectBlobId.map(GcsBatchCrc32Command(file, _))
+  }
+}
+
+case class GcsBatchTouchCommand(override val file: GcsPath,
+                                override val blob: BlobId,
+                                setUserProject: Boolean = false,
+                               ) extends IoTouchCommand(file) with GcsBatchGetCommand[Unit] {
   override def mapGoogleResponse(response: StorageObject): ErrorOr[Unit] = ().validNel
-  override def withUserProject = this.copy(setUserProject = true)
+
+  override def withUserProject: GcsBatchTouchCommand = this.copy(setUserProject = true)
+
   override def commandDescription: String = s"GcsBatchTouchCommand file '$file' setUserProject '$setUserProject'"
+}
+
+object GcsBatchTouchCommand {
+  def forPath(file: GcsPath): Try[GcsBatchTouchCommand] = {
+    file.objectBlobId.map(GcsBatchTouchCommand(file, _))
+  }
 }
 
 /*
@@ -164,26 +220,77 @@ case class GcsBatchTouchCommand(override val file: GcsPath, setUserProject: Bool
  * Specifically, list objects that have this path as a prefix. Since we don't really care about what's inside here,
  * set max results to 1 to avoid unnecessary payload.
  */
-case class GcsBatchIsDirectoryCommand(override val file: GcsPath, setUserProject: Boolean = false) extends IoIsDirectoryCommand(file) with SingleFileGcsBatchIoCommand[Boolean, Objects] {
-  private val blob = file.blob
+case class GcsBatchIsDirectoryCommand(override val file: GcsPath,
+                                      blob: BlobId,
+                                      setUserProject: Boolean = false,
+                                     )
+  extends IoIsDirectoryCommand(file) with SingleFileGcsBatchIoCommand[Boolean, Objects] {
   override def operation: StorageRequest[Objects] = {
     file.apiStorage.objects().list(blob.getBucket).setPrefix(blob.getName.ensureSlashed).setMaxResults(1L).setUserProject(userProject)
   }
+
   override def mapGoogleResponse(response: Objects): ErrorOr[Boolean] = {
     // Wrap in an Option because getItems can (always ?) return null if there are no objects
     Option(response.getItems).map(_.asScala).exists(_.nonEmpty).validNel
   }
-  override def withUserProject = this.copy(setUserProject = true)
+  override def withUserProject: GcsBatchIsDirectoryCommand = this.copy(setUserProject = true)
   override def commandDescription: String = s"GcsBatchIsDirectoryCommand file '$file' setUserProject '$setUserProject'"
 }
 
-case class GcsBatchExistsCommand(override val file: GcsPath, setUserProject: Boolean = false) extends IoExistsCommand(file) with GcsBatchGetCommand[Boolean] {
+object GcsBatchIsDirectoryCommand {
+  def forPath(file: GcsPath): Try[GcsBatchIsDirectoryCommand] = {
+    file.bucketOrObjectBlobId.map(GcsBatchIsDirectoryCommand(file, _))
+  }
+}
+
+case class GcsBatchExistsCommand(override val file: GcsPath,
+                                 override val blob: BlobId,
+                                 setUserProject: Boolean = false,
+                                ) extends IoExistsCommand(file) with GcsBatchGetCommand[Boolean] {
   override def mapGoogleResponse(response: StorageObject): ErrorOr[Boolean] = true.validNel
 
-  override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders) = {
+  override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders): Option[Either[Boolean, GcsBatchIoCommand[Boolean, StorageObject]]] = {
     // If the object can't be found, don't fail the request but just return false as we were testing for existence
     if (googleJsonError.getCode == 404) Option(Left(false)) else None
   }
-  override def withUserProject = this.copy(setUserProject = true)
+  override def withUserProject: GcsBatchExistsCommand = this.copy(setUserProject = true)
   override def commandDescription: String = s"GcsBatchExistsCommand file '$file' setUserProject '$setUserProject'"
+}
+
+object GcsBatchExistsCommand {
+  def forPath(file: GcsPath): Try[GcsBatchExistsCommand] = {
+    file.objectBlobId.map(GcsBatchExistsCommand(file, _))
+  }
+}
+
+/** A GcsBatchIoCommand for use in tests. */
+case object ExceptionSpewingGcsBatchIoCommand extends GcsBatchIoCommand[Unit, Void] {
+  override lazy val name: String = "exception"
+
+  override def operation: Nothing = throw new UnsupportedOperationException("operation is not supported")
+
+  override def withUserProject: Nothing = throw new UnsupportedOperationException("withUserProject is not supported")
+
+  override def mapGoogleResponse(response: Void): Nothing =
+    sys.error("Ill behaved code that throws in mapGoogleResponse")
+
+  override def onFailure(googleJsonError: GoogleJsonError, httpHeaders: HttpHeaders): Nothing =
+    sys.error("Ill behaved code that throws in onFailure")
+
+  override def commandDescription: String = s"ExceptionSpewingGcsBatchIoCommand (mock class for tests)"
+}
+
+/** A GcsBatchIoCommand for use in tests. */
+case class ErrorReturningGcsBatchIoCommand() extends GcsBatchIoCommand[Unit, Unit] {
+  override def operation: Nothing = throw new UnsupportedOperationException("operation is not supported")
+
+  override def mapGoogleResponse(response: Unit): ErrorOr[Unit] =
+    "Well behaved code that returns an error in mapGoogleResponse".invalidNel
+
+  override def withUserProject: Nothing = throw new UnsupportedOperationException("withUserProject is not supported")
+
+  /* Better to return a java.lang.Exception than try to shutdown the JVM with a java.lang.Error like this was before. */
+  override def name: Nothing = throw new UnsupportedOperationException("a ErrorReturningGcsBatchIoCommand has no name")
+
+  override def commandDescription: String = s"ErrorReturningGcsBatchIoCommand (mock class for tests)"
 }

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommandSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommandSpec.scala
@@ -1,0 +1,213 @@
+package cromwell.filesystems.gcs.batch
+
+import cats.data.NonEmptyList
+import cats.data.Validated.{Invalid, Valid}
+import com.google.api.client.googleapis.json.GoogleJsonError
+import com.google.api.client.http.HttpHeaders
+import com.google.api.services.storage.model.{Objects, RewriteResponse, StorageObject}
+import cromwell.filesystems.gcs.{GcsPathBuilder, MockGcsPathBuilder}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class GcsBatchIoCommandSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  behavior of "GcsBatchIoCommand"
+
+  private lazy val gcsPathBuilder: GcsPathBuilder = MockGcsPathBuilder.instance
+
+  private lazy val gcsPath = gcsPathBuilder.build("gs://hello/world").get
+
+  it should "test GcsBatchDeleteCommand" in {
+    val command = PartialGcsBatchCommandBuilder.deleteCommand((gcsPath, false)).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Delete
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getObject should be("world")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    command.mapGoogleResponse(null)
+
+    command.onSuccess(null, new HttpHeaders()).toEither.right.get.left.get
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchSizeCommand" in {
+    val command = PartialGcsBatchCommandBuilder.sizeCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Get
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getObject should be("world")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new StorageObject()
+    command.mapGoogleResponse(response) should
+      be(Invalid(NonEmptyList.one("'gs://hello/world' in project 'cromwell-test' returned null size")))
+
+    response.setSize(BigInt(139).bigInteger)
+    command.mapGoogleResponse(response) should be(Valid(139L))
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be(139L)
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchCrc32Command" in {
+    val command = PartialGcsBatchCommandBuilder.hashCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Get
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getObject should be("world")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new StorageObject()
+    response.setCrc32c("aeiouy")
+
+    command.mapGoogleResponse(response) should be(Valid("aeiouy"))
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be("aeiouy")
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchTouchCommand" in {
+    val command = PartialGcsBatchCommandBuilder.touchCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Get
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getObject should be("world")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new StorageObject()
+    command.mapGoogleResponse(response)
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchExistsCommand" in {
+    val command = PartialGcsBatchCommandBuilder.existsCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Get
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getObject should be("world")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new StorageObject()
+    command.mapGoogleResponse(response) should be(Valid(true))
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be(true)
+
+    val error = new GoogleJsonError()
+    command.onFailure(error, new HttpHeaders()) should be(None)
+
+    error.setCode(404)
+    command.onFailure(error, new HttpHeaders()) should be(Option(Left(false)))
+  }
+
+  it should "test GcsBatchIsDirectoryCommand" in {
+    val command = PartialGcsBatchCommandBuilder.isDirectoryCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#List
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getBucket should be("hello")
+    operation.getPrefix should be("world/")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new Objects()
+    command.mapGoogleResponse(response) should be(Valid(false))
+
+    response.setItems(List(new StorageObject()).asJava)
+    command.mapGoogleResponse(response) should be(Valid(true))
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be(true)
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchCopyCommand" in {
+    val gcsDestination = gcsPathBuilder.build("gs://howdy/universe").get
+
+    val command = PartialGcsBatchCommandBuilder.copyCommand((gcsPath, gcsDestination)).get
+
+    type commandType = com.google.api.services.storage.Storage#Objects#Rewrite
+    command.operation should be(a[commandType])
+
+    val operation = command.operation.asInstanceOf[commandType]
+    operation.getSourceBucket should be("hello")
+    operation.getSourceObject should be("world")
+    operation.getDestinationBucket should be("howdy")
+    operation.getDestinationObject should be("universe")
+
+    command.setUserProject should be(false)
+    command.withUserProject.setUserProject should be(true)
+
+    val response = new RewriteResponse()
+    command.mapGoogleResponse(response) should be(Valid(()))
+
+    response.setDone(true)
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be(())
+
+    response.setDone(false)
+    response.setRewriteToken("token")
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.right.get.rewriteToken should be(Option("token"))
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test ExceptionSpewingGcsBatchIoCommand" in {
+    val command = ExceptionSpewingGcsBatchIoCommand
+
+    the[UnsupportedOperationException] thrownBy {
+      command.operation
+    } should have message "operation is not supported"
+
+    the[UnsupportedOperationException] thrownBy {
+      command.withUserProject
+    } should have message "withUserProject is not supported"
+
+    the[RuntimeException] thrownBy {
+      command.mapGoogleResponse(null)
+    } should have message "Ill behaved code that throws in mapGoogleResponse"
+
+    the[RuntimeException] thrownBy {
+      command.onSuccess(null, new HttpHeaders())
+    } should have message "Ill behaved code that throws in mapGoogleResponse"
+
+    the[RuntimeException] thrownBy {
+      command.onFailure(new GoogleJsonError(), new HttpHeaders())
+    } should have message "Ill behaved code that throws in onFailure"
+  }
+}

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/batch/OssBatchCommandBuilder.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/batch/OssBatchCommandBuilder.scala
@@ -1,31 +1,34 @@
 package cromwell.filesystems.oss.batch
 
 import cromwell.core.io._
+import cromwell.core.path.Path
 import cromwell.filesystems.oss.OssPath
 
+import scala.util.Try
+
 private case object PartialOssBatchCommandBuilder extends PartialIoCommandBuilder {
-  override def sizeCommand = {
-    case ossPath: OssPath => OssBatchSizeCommand(ossPath)
+  override def sizeCommand: PartialFunction[Path, Try[IoSizeCommand]] = {
+    case ossPath: OssPath => Try(OssBatchSizeCommand(ossPath))
   }
   
-  override def deleteCommand = {
-    case (ossPath: OssPath, swallowIoExceptions) => OssBatchDeleteCommand(ossPath, swallowIoExceptions)
+  override def deleteCommand: PartialFunction[(Path, Boolean), Try[IoDeleteCommand]] = {
+    case (ossPath: OssPath, swallowIoExceptions) => Try(OssBatchDeleteCommand(ossPath, swallowIoExceptions))
   }
   
-  override def copyCommand = {
-    case (ossSrc: OssPath, ossDest: OssPath, overwrite) => OssBatchCopyCommand(ossSrc, ossDest, overwrite)
+  override def copyCommand: PartialFunction[(Path, Path), Try[IoCopyCommand]] = {
+    case (ossSrc: OssPath, ossDest: OssPath) => Try(OssBatchCopyCommand(ossSrc, ossDest))
   }
   
-  override def hashCommand = {
-    case ossPath: OssPath => OssBatchEtagCommand(ossPath)
+  override def hashCommand: PartialFunction[Path, Try[IoHashCommand]] = {
+    case ossPath: OssPath => Try(OssBatchEtagCommand(ossPath))
   }
 
-  override def touchCommand = {
-    case ossPath: OssPath => OssBatchTouchCommand(ossPath)
+  override def touchCommand: PartialFunction[Path, Try[IoTouchCommand]] = {
+    case ossPath: OssPath => Try(OssBatchTouchCommand(ossPath))
   }
 
-  override def existsCommand = {
-    case ossPath: OssPath => OssBatchExistsCommand(ossPath)
+  override def existsCommand: PartialFunction[Path, Try[IoExistsCommand]] = {
+    case ossPath: OssPath => Try(OssBatchExistsCommand(ossPath))
   }
 }
 

--- a/filesystems/oss/src/main/scala/cromwell/filesystems/oss/batch/OssBatchIoCommand.scala
+++ b/filesystems/oss/src/main/scala/cromwell/filesystems/oss/batch/OssBatchIoCommand.scala
@@ -2,9 +2,7 @@ package cromwell.filesystems.oss.batch
 
 import com.aliyun.oss.OSSException
 import com.aliyun.oss.model._
-
 import com.google.api.client.http.HttpHeaders
-
 import cromwell.core.io._
 import cromwell.filesystems.oss._
 
@@ -26,7 +24,7 @@ sealed trait OssBatchIoCommand[T, U] extends IoCommand[T] {
 
   /**
     * Method called in the success callback of a batched request to decide what to do next.
-    * Returns an Either[T, OssBatchIoCommand[T, U]]
+    * Returns an `Either[T, OssBatchIoCommand[T, U]]`
     *   Left(value) means the command is complete, and the result can be sent back to the sender.
     *   Right(newCommand) means the command is not complete and needs another request to be executed.
     * Most commands will reply with Left(value).
@@ -44,22 +42,22 @@ sealed trait OssBatchIoCommand[T, U] extends IoCommand[T] {
 case class OssBatchCopyCommand(
                                 override val source: OssPath,
                                 override val destination: OssPath,
-                                override val overwrite: Boolean
-                              ) extends IoCopyCommand(source, destination, overwrite) with OssBatchIoCommand[Unit, CopyObjectResult] {
+                              )
+  extends IoCopyCommand(source, destination) with OssBatchIoCommand[Unit, CopyObjectResult] {
   override def operation: GenericResult = {
     val getObjectRequest = new CopyObjectRequest(source.bucket, source.key, destination.bucket, destination.key)
     // TODO: Copy other attributes (encryption, metadata, etc.)
     source.ossClient.copyObject(getObjectRequest)
   }
   override def mapOssResponse(response: CopyObjectResult): Unit = ()
-  override def commandDescription: String = s"OssBatchCopyCommand source '$source' destination '$destination' overwrite '$overwrite'"
+  override def commandDescription: String = s"OssBatchCopyCommand source '$source' destination '$destination'"
 }
 
 case class OssBatchDeleteCommand(
                                  override val file: OssPath,
                                  override val swallowIOExceptions: Boolean
                                ) extends IoDeleteCommand(file, swallowIOExceptions) with OssBatchIoCommand[Unit, Void] {
-  def operation = file.ossClient.deleteObject(file.bucket, file.key)
+  def operation: Unit = file.ossClient.deleteObject(file.bucket, file.key)
   override protected def mapOssResponse(response: Void): Unit = ()
   override def commandDescription: String = s"OssBatchDeleteCommand file '$file' swallowIOExceptions '$swallowIOExceptions'"
 }

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
@@ -34,32 +34,34 @@ import cromwell.core.io.{IoCommandBuilder, PartialIoCommandBuilder}
 import cromwell.core.path.Path
 import cromwell.filesystems.s3.S3Path
 
+import scala.util.Try
+
 /**
   * Generates commands for IO operations on S3
   */
 private case object PartialS3BatchCommandBuilder extends PartialIoCommandBuilder {
-  override def sizeCommand: PartialFunction[Path, S3BatchSizeCommand] = {
-    case path: S3Path => S3BatchSizeCommand(path)
+  override def sizeCommand: PartialFunction[Path, Try[S3BatchSizeCommand]] = {
+    case path: S3Path => Try(S3BatchSizeCommand(path))
   }
 
-  override def deleteCommand: PartialFunction[(Path, Boolean), S3BatchDeleteCommand] = {
-    case (path: S3Path, swallowIoExceptions) => S3BatchDeleteCommand(path, swallowIoExceptions)
+  override def deleteCommand: PartialFunction[(Path, Boolean), Try[S3BatchDeleteCommand]] = {
+    case (path: S3Path, swallowIoExceptions) => Try(S3BatchDeleteCommand(path, swallowIoExceptions))
   }
 
-  override def copyCommand: PartialFunction[(Path, Path, Boolean), S3BatchCopyCommand] = {
-    case (src: S3Path, dest: S3Path, overwrite) => S3BatchCopyCommand(src, dest, overwrite)
+  override def copyCommand: PartialFunction[(Path, Path), Try[S3BatchCopyCommand]] = {
+    case (src: S3Path, dest: S3Path) => Try(S3BatchCopyCommand(src, dest))
   }
 
-  override def hashCommand: PartialFunction[Path, S3BatchEtagCommand] = {
-    case path: S3Path => S3BatchEtagCommand(path)
+  override def hashCommand: PartialFunction[Path, Try[S3BatchEtagCommand]] = {
+    case path: S3Path => Try(S3BatchEtagCommand(path))
   }
 
-  override def touchCommand: PartialFunction[Path, S3BatchTouchCommand] = {
-    case path: S3Path => S3BatchTouchCommand(path)
+  override def touchCommand: PartialFunction[Path, Try[S3BatchTouchCommand]] = {
+    case path: S3Path => Try(S3BatchTouchCommand(path))
   }
 
-  override def existsCommand: PartialFunction[Path, S3BatchExistsCommand] = {
-    case path: S3Path => S3BatchExistsCommand(path)
+  override def existsCommand: PartialFunction[Path, Try[S3BatchExistsCommand]] = {
+    case path: S3Path => Try(S3BatchExistsCommand(path))
   }
 }
 

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
@@ -74,10 +74,9 @@ sealed trait S3BatchIoCommand[T, U] extends IoCommand[T] {
 case class S3BatchCopyCommand(
                            override val source: S3Path,
                            override val destination: S3Path,
-                           override val overwrite: Boolean,
-                         ) extends IoCopyCommand(source, destination, overwrite) with S3BatchIoCommand[Unit, CopyObjectResponse] {
+                         ) extends IoCopyCommand(source, destination) with S3BatchIoCommand[Unit, CopyObjectResponse] {
   override def mapResponse(response: CopyObjectResponse): Unit = ()
-  override def commandDescription: String = s"S3BatchCopyCommand source '$source' destination '$destination' overwrite '$overwrite'"
+  override def commandDescription: String = s"S3BatchCopyCommand source '$source' destination '$destination'"
 }
 
 case class S3BatchDeleteCommand(

--- a/src/ci/bin/testCentaurPapiV2alpha1.sh
+++ b/src/ci/bin/testCentaurPapiV2alpha1.sh
@@ -18,10 +18,8 @@ cromwell::build::assemble_jars
 
 cromwell::build::run_centaur \
     -p 100 \
-    -e localdockertest \
-    -e relative_output_paths \
-    -e relative_output_paths_colliding \
-    -e standard_output_paths_colliding_prevented \
-    -e papi_v2beta_gcsa \
+    -i attempt_to_call_size_function_on_bucket \
+    -i bucket_name_with_no_trailing_slash \
+    -i bucket_name_with_trailing_slash \
 
 cromwell::build::generate_code_coverage


### PR DESCRIPTION
- Some IoCommands cannot be created so return a `Failure` when that happens
- FYI: in some cases throwing-and-re-catching the first `Failure`
- No longer passing `overwrite = true` since it was always true
- Resealed `GcsBatchIoCommand` by moving the test instance into main