### PR TITLE
Improved ExecutionStore and ValueStore toString methods [BW-435]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -119,6 +119,17 @@ object ExecutionStore {
   * Execution store in its nominal state
   */
 final case class ActiveExecutionStore private[stores](private val statusStore: Map[JobKey, ExecutionStatus], override val needsUpdate: Boolean) extends ExecutionStore(statusStore, needsUpdate) {
+
+  override def toString: String = {
+    import io.circe.syntax._
+    import io.circe.Printer
+
+    statusStore.map {
+      case (k, v) if k.isShard => s"${k.node.fullyQualifiedName}:${k.index.get}" -> v.toString
+      case (k, v) => k.node.fullyQualifiedName -> v.toString
+    }.asJson.printWith(Printer.spaces2.copy(dropNullValues = true, colonLeft = ""))
+  }
+
   override def updateKeys(values: Map[JobKey, ExecutionStatus], needsUpdate: Boolean): ActiveExecutionStore = {
     this.copy(statusStore = statusStore ++ values, needsUpdate = needsUpdate)
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
@@ -27,15 +27,15 @@ object ValueStore {
 case class ValueStore(store: Table[OutputPort, ExecutionIndex, WomValue]) {
 
   override def toString: String = {
-    val values = store.valuesTriplet.map {
-      case (node, index, value) => s"$node:${index.fromIndex} -> $value"
-    }
+    import io.circe.syntax._
+    import io.circe.Printer
 
-    s"""
-      |ValueStore {
-      |  ${values.mkString("," + System.lineSeparator + "  ")}
-      |}
-    """.stripMargin
+    val values = store.valuesTriplet.map {
+      case (node, None, value) => node.name -> value.valueString
+      case (node, index, value) => s"${node.name}:${index.fromIndex}" -> value.valueString
+    }.toMap
+
+    values.asJson.printWith(Printer.spaces2.copy(dropNullValues = true, colonLeft = ""))
   }
 
   final def add(values: Map[ValueKey, WomValue]): ValueStore = {


### PR DESCRIPTION
Improved `toString` methods. Useful when poking at these stores and debugging their state, but unused in production code today.