### PR TITLE
Additional null safety for GCS IO [CROM-6670]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -1,7 +1,5 @@
 package cromwell.engine.io
 
-import java.io.IOException
-import java.net.{SocketException, SocketTimeoutException}
 import java.time.OffsetDateTime
 
 import akka.NotUsed
@@ -9,7 +7,6 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props, Timers}
 import akka.dispatch.ControlMessage
 import akka.stream._
 import akka.stream.scaladsl.{Flow, GraphDSL, Merge, Partition, Sink, Source, SourceQueueWithComplete}
-import com.google.cloud.storage.StorageException
 import com.typesafe.config.ConfigFactory
 import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core.actor.StreamActorHelper
@@ -18,12 +15,10 @@ import cromwell.core.io.{IoAck, IoCommand, Throttle}
 import cromwell.core.{Dispatcher, LoadConfig}
 import cromwell.engine.instrumentation.IoInstrumentation
 import cromwell.engine.io.IoActor._
-import cromwell.engine.io.gcs.GcsBatchFlow.BatchFailedException
 import cromwell.engine.io.gcs.{GcsBatchCommandContext, ParallelGcsBatchFlow}
 import cromwell.engine.io.nio.NioFlow
 import cromwell.filesystems.gcs.batch.GcsBatchIoCommand
 import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
-import javax.net.ssl.SSLException
 
 import scala.concurrent.ExecutionContext
 
@@ -180,69 +175,6 @@ object IoActor {
   case object BackPressureTimerResetKey
   case object BackPressureTimerResetAction extends ControlMessage
 
-  /**
-    * ATTENTION: Transient failures are retried *forever* 
-    * Be careful when adding error codes to this method.
-    * Currently only 429 (= quota exceeded are considered truly transient)
-    */
-  def isTransient(failure: Throwable): Boolean = failure match {
-    case gcs: StorageException => gcs.getCode == 429
-    case _ => false
-  }
-
-  def isGcs500(failure: Throwable): Boolean = {
-    val serverErrorPattern = ".*Could not read from gs.+500 Internal Server Error.*"
-    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
-  }
-
-  def isGcs503(failure: Throwable): Boolean = {
-    val serverErrorPattern = ".*Could not read from gs.+503 Service Unavailable.*"
-    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
-  }
-
-  def isGcs504(failure: Throwable): Boolean = {
-    val serverErrorPattern = ".*Could not read from gs.+504 Gateway Timeout.*"
-    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
-  }
-
-  private val AdditionalRetryableHttpCodes = List(
-    // HTTP 410: Gone
-    // From Google doc (https://cloud.google.com/storage/docs/json_api/v1/status-codes):
-    // "You have attempted to use a resumable upload session that is no longer available.
-    // If the reported status code was not successful and you still wish to upload the file, you must start a new session."
-    410,
-    // Some 503 errors seem to yield "false" on the "isRetryable" method because they are not retried.
-    // The CloudStorage exception mechanism is not flawless yet (https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1545)
-    // so that could be the cause.
-    // For now explicitly lists 503 as a retryable code here to work around that.
-    503
-  )
-
-  // Error messages not included in the list of built-in GCS retryable errors (com.google.cloud.storage.StorageException) but that we still want to retry
-  private val AdditionalRetryableErrorMessages = List(
-    "Connection closed prematurely"
-  ).map(_.toLowerCase)
-
-  /**
-    * Failures that are considered retryable.
-    * Retrying them should increase the "retry counter"
-    */
-  def isRetryable(failure: Throwable): Boolean = failure match {
-    case gcs: StorageException => gcs.isRetryable ||
-      isRetryable(gcs.getCause) ||
-      AdditionalRetryableHttpCodes.contains(gcs.getCode) ||
-      AdditionalRetryableErrorMessages.exists(gcs.getMessage.toLowerCase.contains)
-    case _: SSLException => true
-    case _: BatchFailedException => true
-    case _: SocketException => true
-    case _: SocketTimeoutException => true
-    case ioE: IOException if Option(ioE.getMessage).exists(_.contains("Error getting access token for service account")) => true
-    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE) || isGcs504(ioE)
-    case other => isTransient(other)
-  }
-
-  def isFatal(failure: Throwable): Boolean = !isRetryable(failure)
-  
   def props(queueSize: Int,
             nioParallelism: Int,
             gcsParallelism: Int,

--- a/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
+++ b/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
@@ -19,7 +19,8 @@ trait RetryableRequestSupport {
     case gcs: StorageException => gcs.isRetryable ||
       isRetryable(gcs.getCause) ||
       AdditionalRetryableHttpCodes.contains(gcs.getCode) ||
-      AdditionalRetryableErrorMessages.exists(gcs.getMessage.toLowerCase.contains)
+      Option(gcs.getMessage).exists(msg =>
+        AdditionalRetryableErrorMessages.contains(msg.toLowerCase))
     case _: SSLException => true
     case _: BatchFailedException => true
     case _: SocketException => true

--- a/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
+++ b/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
@@ -1,0 +1,74 @@
+package cromwell.engine.io
+
+import java.io.IOException
+import java.net.{SocketException, SocketTimeoutException}
+
+import com.google.cloud.storage.StorageException
+import cromwell.engine.io.gcs.GcsBatchFlow.BatchFailedException
+import javax.net.ssl.SSLException
+
+trait RetryableRequestSupport {
+
+  def isFatal(failure: Throwable): Boolean = !isRetryable(failure)
+
+  /**
+    * Failures that are considered retryable.
+    * Retrying them should increase the "retry counter"
+    */
+  def isRetryable(failure: Throwable): Boolean = failure match {
+    case gcs: StorageException => gcs.isRetryable ||
+      isRetryable(gcs.getCause) ||
+      AdditionalRetryableHttpCodes.contains(gcs.getCode) ||
+      AdditionalRetryableErrorMessages.exists(gcs.getMessage.toLowerCase.contains)
+    case _: SSLException => true
+    case _: BatchFailedException => true
+    case _: SocketException => true
+    case _: SocketTimeoutException => true
+    case ioE: IOException if Option(ioE.getMessage).exists(_.contains("Error getting access token for service account")) => true
+    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE) || isGcs504(ioE)
+    case other => isTransient(other)
+  }
+
+  private val AdditionalRetryableHttpCodes = List(
+    // HTTP 410: Gone
+    // From Google doc (https://cloud.google.com/storage/docs/json_api/v1/status-codes):
+    // "You have attempted to use a resumable upload session that is no longer available.
+    // If the reported status code was not successful and you still wish to upload the file, you must start a new session."
+    410,
+    // Some 503 errors seem to yield "false" on the "isRetryable" method because they are not retried.
+    // The CloudStorage exception mechanism is not flawless yet (https://github.com/GoogleCloudPlatform/google-cloud-java/issues/1545)
+    // so that could be the cause.
+    // For now explicitly lists 503 as a retryable code here to work around that.
+    503
+  )
+
+  // Error messages not included in the list of built-in GCS retryable errors (com.google.cloud.storage.StorageException) but that we still want to retry
+  private val AdditionalRetryableErrorMessages = List(
+    "Connection closed prematurely"
+  ).map(_.toLowerCase)
+
+  /**
+    * ATTENTION: Transient failures are retried *forever*
+    * Be careful when adding error codes to this method.
+    * Currently only 429 (= quota exceeded are considered truly transient)
+    */
+  def isTransient(failure: Throwable): Boolean = failure match {
+    case gcs: StorageException => gcs.getCode == 429
+    case _ => false
+  }
+
+  def isGcs500(failure: Throwable): Boolean = {
+    val serverErrorPattern = ".*Could not read from gs.+500 Internal Server Error.*"
+    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
+  }
+
+  def isGcs503(failure: Throwable): Boolean = {
+    val serverErrorPattern = ".*Could not read from gs.+503 Service Unavailable.*"
+    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
+  }
+
+  def isGcs504(failure: Throwable): Boolean = {
+    val serverErrorPattern = ".*Could not read from gs.+504 Gateway Timeout.*"
+    Option(failure.getMessage).exists(_.matches(serverErrorPattern))
+  }
+}

--- a/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
+++ b/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
@@ -7,7 +7,7 @@ import com.google.cloud.storage.StorageException
 import cromwell.engine.io.gcs.GcsBatchFlow.BatchFailedException
 import javax.net.ssl.SSLException
 
-trait RetryableRequestSupport {
+object RetryableRequestSupport {
 
   def isFatal(failure: Throwable): Boolean = !isRetryable(failure)
 

--- a/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/gcs/GcsBatchFlow.scala
@@ -15,8 +15,9 @@ import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.cloudsupport.gcp.gcs.GcsStorage
 import cromwell.engine.io.IoActor._
 import cromwell.engine.io.IoAttempts.EnhancedCromwellIoException
+import cromwell.engine.io.RetryableRequestSupport.{isRetryable, isTransient}
 import cromwell.engine.io.gcs.GcsBatchFlow.{BatchFailedException, _}
-import cromwell.engine.io.{IoAttempts, IoCommandContext, RetryableRequestSupport}
+import cromwell.engine.io.{IoAttempts, IoCommandContext}
 import mouse.boolean._
 
 import scala.concurrent.duration._
@@ -42,7 +43,7 @@ object GcsBatchFlow {
 }
 
 class GcsBatchFlow(batchSize: Int, scheduler: Scheduler, onRetry: IoCommandContext[_] => Throwable => Unit, applicationName: String)
-                  (implicit ec: ExecutionContext) extends StrictLogging with RetryableRequestSupport {
+                  (implicit ec: ExecutionContext) extends StrictLogging {
 
   // Does not carry any authentication, assumes all underlying requests are properly authenticated
   private val httpRequestInitializer = new HttpRequestInitializer {

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -10,7 +10,8 @@ import common.util.IORetry
 import cromwell.core.io._
 import cromwell.core.path.Path
 import cromwell.engine.io.IoActor._
-import cromwell.engine.io.{IoAttempts, IoCommandContext, RetryableRequestSupport}
+import cromwell.engine.io.RetryableRequestSupport.{isFatal, isTransient}
+import cromwell.engine.io.{IoAttempts, IoCommandContext}
 import cromwell.filesystems.drs.DrsPath
 import cromwell.filesystems.gcs.GcsPath
 import cromwell.filesystems.oss.OssPath
@@ -27,7 +28,7 @@ object NioFlow {
   */
 class NioFlow(parallelism: Int,
               onRetryCallback: IoCommandContext[_] => Throwable => Unit = NioFlow.NoopOnRetry,
-              nbAttempts: Int = MaxAttemptsNumber)(implicit ec: ExecutionContext) extends RetryableRequestSupport {
+              nbAttempts: Int = MaxAttemptsNumber)(implicit ec: ExecutionContext) {
   
   implicit private val timer: Timer[IO] = IO.timer(ec)
   

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -10,7 +10,7 @@ import common.util.IORetry
 import cromwell.core.io._
 import cromwell.core.path.Path
 import cromwell.engine.io.IoActor._
-import cromwell.engine.io.{IoAttempts, IoCommandContext}
+import cromwell.engine.io.{IoAttempts, IoCommandContext, RetryableRequestSupport}
 import cromwell.filesystems.drs.DrsPath
 import cromwell.filesystems.gcs.GcsPath
 import cromwell.filesystems.oss.OssPath
@@ -27,7 +27,7 @@ object NioFlow {
   */
 class NioFlow(parallelism: Int,
               onRetryCallback: IoCommandContext[_] => Throwable => Unit = NioFlow.NoopOnRetry,
-              nbAttempts: Int = MaxAttemptsNumber)(implicit ec: ExecutionContext) {
+              nbAttempts: Int = MaxAttemptsNumber)(implicit ec: ExecutionContext) extends RetryableRequestSupport {
   
   implicit private val timer: Timer[IO] = IO.timer(ec)
   

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -279,4 +279,15 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
     nonRetryables foreach { new ConcreteRetry().isRetryable(_) shouldBe false }
     nonRetryables foreach { new ConcreteRetry().isFatal(_) shouldBe true }
   }
+
+  it should "not crash when certain exception members are `null`" in {
+
+    // Javadoc for `com.google.cloud.storage.StorageException` says `message`, `cause` may be `null`
+    val nullCause = new StorageException(3, "blah", "no reason", null)
+    val nullMessage = new StorageException(4, null)
+
+    new ConcreteRetry().isRetryable(nullCause) shouldBe false
+    new ConcreteRetry().isRetryable(nullMessage) shouldBe false
+
+  }
 }

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -20,6 +20,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
+class ConcreteRetry extends RetryableRequestSupport
+
 class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with ImplicitSender {
   behavior of "IoActor"
   
@@ -260,8 +262,8 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       new IOException("Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 504 Gateway Timeout"),
     )
 
-    retryables foreach { IoActor.isRetryable(_) shouldBe true }
-    retryables foreach { IoActor.isFatal(_) shouldBe false }
+    retryables foreach { new ConcreteRetry().isRetryable(_) shouldBe true }
+    retryables foreach { new ConcreteRetry().isFatal(_) shouldBe false }
   }
 
   it should "have correct non-retryable exceptions" in {
@@ -274,7 +276,7 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-500/rc: 404 File Not Found")
     )
 
-    nonRetryables foreach {IoActor.isRetryable(_) shouldBe false}
-    nonRetryables foreach {IoActor.isFatal(_) shouldBe true}
+    nonRetryables foreach { new ConcreteRetry().isRetryable(_) shouldBe false }
+    nonRetryables foreach { new ConcreteRetry().isFatal(_) shouldBe true }
   }
 }

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -20,8 +20,6 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
 
-class ConcreteRetry extends RetryableRequestSupport
-
 class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with ImplicitSender {
   behavior of "IoActor"
   
@@ -262,8 +260,8 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       new IOException("Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 504 Gateway Timeout"),
     )
 
-    retryables foreach { new ConcreteRetry().isRetryable(_) shouldBe true }
-    retryables foreach { new ConcreteRetry().isFatal(_) shouldBe false }
+    retryables foreach { RetryableRequestSupport.isRetryable(_) shouldBe true }
+    retryables foreach { RetryableRequestSupport.isFatal(_) shouldBe false }
   }
 
   it should "have correct non-retryable exceptions" in {
@@ -276,8 +274,8 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       new IOException("Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-500/rc: 404 File Not Found")
     )
 
-    nonRetryables foreach { new ConcreteRetry().isRetryable(_) shouldBe false }
-    nonRetryables foreach { new ConcreteRetry().isFatal(_) shouldBe true }
+    nonRetryables foreach { RetryableRequestSupport.isRetryable(_) shouldBe false }
+    nonRetryables foreach { RetryableRequestSupport.isFatal(_) shouldBe true }
   }
 
   it should "not crash when certain exception members are `null`" in {
@@ -286,8 +284,8 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
     val nullCause = new StorageException(3, "blah", "no reason", null)
     val nullMessage = new StorageException(4, null)
 
-    new ConcreteRetry().isRetryable(nullCause) shouldBe false
-    new ConcreteRetry().isRetryable(nullMessage) shouldBe false
+    RetryableRequestSupport.isRetryable(nullCause) shouldBe false
+    RetryableRequestSupport.isRetryable(nullMessage) shouldBe false
 
   }
 }


### PR DESCRIPTION
The Methods Cromwell recently experienced an outage nearly identical to the Terra one, where requests to GCS and the database timed out. Like on Terra, a server restart fixed it.

Their server is running version `54-97597a4` that [definitely has](https://github.com/broadinstitute/cromwell/commits/54_hotfix) the [PR](https://github.com/broadinstitute/cromwell/pull/5994) we did to handle null messages.

In this PR I fixed another possible source of NPEs in `cromwell.engine.io.gcs.GcsBatchFlow#recoverCommand`.
