### PR TITLE
Be resilient if the db has WaitingForQueueSpace statuses [BW-387 fixup]

### DIFF
--- a/core/src/main/scala/cromwell/core/ExecutionStatus.scala
+++ b/core/src/main/scala/cromwell/core/ExecutionStatus.scala
@@ -2,25 +2,26 @@ package cromwell.core
 
 object ExecutionStatus extends Enumeration {
   type ExecutionStatus = Value
-  val NotStarted, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
+  val NotStarted, WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting, Failed, RetryableFailure, Done, Bypassed, Aborted, Unstartable = Value
   val TerminalStatuses = Set(Failed, Done, Aborted, Bypassed, Unstartable)
   val TerminalOrRetryableStatuses = TerminalStatuses + RetryableFailure
   val NonTerminalStatuses = values.diff(TerminalOrRetryableStatuses)
-  val ActiveStatuses = Set(QueuedInCromwell, Starting, Running, Aborting)
+  val ActiveStatuses = Set(WaitingForQueueSpace, QueuedInCromwell, Starting, Running, Aborting)
 
   implicit val ExecutionStatusOrdering = Ordering.by { status: ExecutionStatus =>
     status match {
       case NotStarted => 0
-      case QueuedInCromwell => 1
-      case Starting => 2
-      case Running => 3
-      case Aborting => 4
-      case Unstartable => 5
-      case Aborted => 6
-      case Bypassed => 7
-      case RetryableFailure => 8
-      case Failed => 9
-      case Done => 10
+      case WaitingForQueueSpace => 1
+      case QueuedInCromwell => 2
+      case Starting => 3
+      case Running => 4
+      case Aborting => 5
+      case Unstartable => 6
+      case Aborted => 7
+      case Bypassed => 8
+      case RetryableFailure => 9
+      case Failed => 10
+      case Done => 11
     }
   }
   

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -46,6 +46,7 @@ class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with 
     val mockReadMetadataWorkerActor = TestProbe("mockReadMetadataWorkerActor")
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
+
     val mba = system.actorOf(
       props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
       name = s"mba-${mbaCounter.getAndIncrement()}",
@@ -819,10 +820,6 @@ object MetadataBuilderActorSpec {
 
   case object Description extends Attr {
     override val name = "description"
-  }
-
-  case object ExecutionStatusAttr extends Attr {
-    override val name = "executionStatus"
   }
 
   sealed trait Call {

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -727,7 +727,7 @@ class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with 
       setupStatusesPlusConclusion("Baz", "Failed") ++
       setupStatusesPlusConclusion("Qux", "RetryableFailure") ++
       setupStatusesPlusConclusion("Quux", "Bypassed") ++
-      setupStatusesPlusConclusion("Quuux", "Unstartable").reverse
+      setupStatusesPlusConclusion("Quuux", "Unstartable")
 
     val expectedRes =
       s"""{

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -715,6 +715,11 @@ class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with 
       statusEvent(callName, "Running")
     ) ++ conclusionStatuses.map(statusEvent(callName, _))
 
+    /** WARNING!
+      * Think twice before removing any of these entries! Even if a status is no longer used, the database can
+      * (and probably will!) still contain entries specifying that status.
+      */
+
     val events =
       setupStatusesPlusConclusion("Foo", "Done") ++
       setupStatusesPlusConclusion("Bar", "Aborting", "Aborted") ++

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -24,6 +24,7 @@ import spray.json._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.Random
 
 class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with Mockito
   with TableDrivenPropertyChecks with ImplicitSender {
@@ -44,7 +45,6 @@ class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with 
                              expectedRes: String): Future[Assertion] = {
     val mockReadMetadataWorkerActor = TestProbe("mockReadMetadataWorkerActor")
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
-
 
     val mba = system.actorOf(
       props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
@@ -699,6 +699,53 @@ class MetadataBuilderActorSpec extends TestKitSuite with AsyncFlatSpecLike with 
     matchesExpectations.reduceLeft(_ && _) shouldBe true
   }
 
+  it should "correctly order statuses (even unused ones)" in {
+    val workflowId = WorkflowId.randomId()
+
+    def statusEvent(callName: String, status: String) = {
+      MetadataEvent(MetadataKey(workflowId, Option(MetadataJobKey(callName, None, 1)), "executionStatus"), MetadataValue(status))
+    }
+
+    // Combines standard "setup" statuses plus the conclusion status(es).
+    def setupStatusesPlusConclusion(callName: String, conclusionStatuses: String*): Vector[MetadataEvent] = Vector(
+      statusEvent(callName, "NotStarted"),
+      statusEvent(callName, "WaitingForQueueSpace"),
+      statusEvent(callName, "QueuedInCromwell"),
+      statusEvent(callName, "Starting"),
+      statusEvent(callName, "Running")
+    ) ++ conclusionStatuses.map(statusEvent(callName, _))
+
+    val events =
+      setupStatusesPlusConclusion("Foo", "Done") ++
+      setupStatusesPlusConclusion("Bar", "Aborting", "Aborted") ++
+      setupStatusesPlusConclusion("Baz", "Failed") ++
+      setupStatusesPlusConclusion("Qux", "RetryableFailure") ++
+      setupStatusesPlusConclusion("Quux", "Bypassed") ++
+      setupStatusesPlusConclusion("Quuux", "Unstartable").reverse
+
+    val expectedRes =
+      s"""{
+         |  "calls": {
+         |    "Foo": [{ "attempt": 1, "executionStatus": "Done", "shardIndex": -1 }],
+         |    "Bar": [{ "attempt": 1, "executionStatus": "Aborted", "shardIndex": -1 }],
+         |    "Baz": [{ "attempt": 1, "executionStatus": "Failed", "shardIndex": -1 }],
+         |    "Qux": [{ "attempt": 1, "executionStatus": "RetryableFailure", "shardIndex": -1 }],
+         |    "Quux": [{ "attempt": 1, "executionStatus": "Bypassed", "shardIndex": -1 }],
+         |    "Quuux": [{ "attempt": 1, "executionStatus": "Unstartable", "shardIndex": -1 }]
+         |  },
+         |  "id": "$workflowId",
+         |  "metadataSource": "Unarchived"
+         |}""".stripMargin
+
+    val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
+    val queryAction = GetMetadataAction(mdQuery)
+
+    // The result should always be the same regardless of what order the list arrives in (forward, reverse, random):
+    assertMetadataResponse(queryAction, mdQuery, events, expectedRes)
+    assertMetadataResponse(queryAction, mdQuery, events.reverse, expectedRes)
+    assertMetadataResponse(queryAction, mdQuery, Random.shuffle(events), expectedRes)
+  }
+
   it should "politely refuse building metadata JSON if metadata number of rows is too large" in {
     val workflowId = WorkflowId.randomId()
 
@@ -767,6 +814,10 @@ object MetadataBuilderActorSpec {
 
   case object Description extends Attr {
     override val name = "description"
+  }
+
+  case object ExecutionStatusAttr extends Attr {
+    override val name = "executionStatus"
   }
 
   sealed trait Call {


### PR DESCRIPTION
Spoiler alert: The DB *does* have `WaitingForQueueSpace` statuses.

Notes for reviewers:

* The metadata builder was throwing errors on old workflows which had previously generated `WaitingForQueueSpace` execution statuses (ie almost all of them).
* This PR fixes that by re-specifying that value as a valid status, even though nothing in the code _generates_ this status any more.
  * The only "live code" changes are undoing the status deletion from https://github.com/broadinstitute/cromwell/pull/6047
* The test case is deliberately over-comprehensive (it makes sure the metadata builder can handle *ALL* current statuses). I'm trying to prevent future situations where statuses are removed from the list without realizing that that might break metadata builder logic.