### PR TITLE
Increase the number of characters shown in case of error [NOJIRA]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -335,7 +335,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       case reason: ThrowableAggregation => expandFailureReasons(reason.throwables.toSeq)
       case reason: KnownJobFailureException =>
         val stderrMessage = reason.stderrPath map { path => 
-          val content = Try(path.annotatedContentAsStringWithLimit(300)).recover({
+          val content = Try(path.annotatedContentAsStringWithLimit(3000)).recover({
             case e => s"Could not retrieve content: ${e.getMessage}"
           }).get
           s"\nCheck the content of stderr for potential additional information: ${path.pathAsString}.\n $content" 


### PR DESCRIPTION
The limit of 300 is unsufficient for most tools, which log some startup messages before starting the actual work. This exceeds 300 characters easily. It results in not being able to see the actual error that crashed the job. This is quite annoying. Especially when the job fails on a CI job and you can't look into the logs on the remote CI server.

3000 is just another arbitrary limit, but hopefully better.

EDIT: Example: https://github.com/biowdl/germline-DNA/pull/78/checks?check_run_id=1549055042