### PR TITLE
Preemptible recovery from a checkpointing file [BW-460]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,21 @@ More information on JSON Type to WDL Type conversion can be found [here](https:/
 
 * Now retries HTTP 408 responses as well as HTTP 429 responses during DOS/DRS resolution requests.
 
-### Reference disk support on PAPI v2
+### New Features
+
+#### Reference disk support on PAPI v2
 
 Cromwell now offers support for the use of reference disks on the PAPI v2 backend as an alternative to localizing
 reference inputs. More details [here](https://cromwell.readthedocs.io/en/develop/backends/Google#reference-disk-support).
 
-### Docker image cache support on PAPI v2 lifesciences beta
+#### Docker image cache support on PAPI v2 lifesciences beta
 
 Cromwell now offers support for the use of Docker image caches on the PAPI v2 lifesciences beta backend. More details [here](https://cromwell.readthedocs.io/en/develop/backends/Google#docker-image-cache-support).
+
+#### Preemptible Recovery via Checkpointing
+
+* Cromwell can now help tasks recover from preemption by allowing them to specify a 'checkpoint' file which will be restored
+to the worker VM on the next attempt if the task is interrupted. More details [here](https://cromwell.readthedocs.io/en/develop/optimizations/CheckpointFiles)
 
 ## 54 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/checkpointing.test
+++ b/centaur/src/main/resources/standardTestCases/checkpointing.test
@@ -1,7 +1,6 @@
 name: checkpointing
 testFormat: workflowsuccess
 backends: [Papiv2]
-tags: [localdockertest]
 
 files {
   workflow: checkpointing/checkpointing.wdl

--- a/centaur/src/main/resources/standardTestCases/checkpointing.test
+++ b/centaur/src/main/resources/standardTestCases/checkpointing.test
@@ -1,0 +1,14 @@
+name: checkpointing
+testFormat: workflowsuccess
+backends: [Papiv2]
+tags: [localdockertest]
+
+files {
+  workflow: checkpointing/checkpointing.wdl
+}
+
+metadata {
+  workflowName: checkpointing
+  status: Succeeded
+  "outputs.checkpointing.preempted": "GOTPREEMPTED"
+}

--- a/centaur/src/main/resources/standardTestCases/checkpointing/checkpointing.wdl
+++ b/centaur/src/main/resources/standardTestCases/checkpointing/checkpointing.wdl
@@ -1,0 +1,69 @@
+version 1.0
+
+workflow checkpointing {
+  call count { input: count_to = 100 }
+  output {
+    String preempted = count.preempted
+  }
+}
+
+task count {
+  input {
+    Int count_to
+  }
+
+  meta {
+    volatile: true
+  }
+
+  command <<<
+    # Read from the my_checkpoint file if there's content there:
+    FROM_CKPT=$(cat my_checkpoint | tail -n1 | awk '{ print $1 }')
+    FROM_CKPT=${FROM_CKPT:-1}
+
+    # We don't want any single VM run the entire count, so work out the max counter value for this attempt:
+    MAX="$(($FROM_CKPT + 66))"
+
+    INSTANCE_NAME=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google")
+    echo "Discovered instance: $INSTANCE_NAME"
+
+    # Run the counter:
+    echo '--' >> my_checkpoint
+    for i in $(seq $FROM_CKPT ~{count_to})
+    do
+      echo $i
+      echo $i ${INSTANCE_NAME} $(date) >> my_checkpoint
+
+      # If we're over our max, simulate "preempting" the VM by killing it:
+      if [ "${i}" -gt "${MAX}" ]
+      then
+        fully_qualified_zone=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone)
+        zone=$(basename "$fully_qualified_zone")
+        gcloud compute instances delete ${INSTANCE_NAME} --zone=$zone -q
+      fi
+
+      sleep 1
+    done
+
+    # Prove that we got preempted at least once:
+    FIRST_INSTANCE=$(cat my_checkpoint | head -n1 | awk '{ print $2 }')
+    LAST_INSTANCE=$(cat my_checkpoint | tail -n1 | awk '{ print $2 }')
+    if [ "${FIRST_INSTANCE}" != "LAST_INSTANCE" ]
+    then
+      echo "GOTPREEMPTED" > preempted.txt
+    else
+      echo "NEVERPREEMPTED" > preempted.txt
+    fi
+  >>>
+
+  runtime {
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+    preemptible: 3
+    checkpointFile: "my_checkpoint"
+  }
+
+  output {
+    File checkpoint_log = "my_checkpoint"
+    String preempted = read_string("preempted.txt")
+  }
+}

--- a/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
+++ b/centaur/src/main/resources/standardTestCases/drs_usa_hca.test
@@ -1,3 +1,4 @@
+ignore: true # See https://broadworkbench.atlassian.net/browse/BW-467
 name: drs_usa_hca
 testFormat: WorkflowSuccess
 backends: ["papi-v2-usa"]

--- a/docs/optimizations/CheckpointFiles.md
+++ b/docs/optimizations/CheckpointFiles.md
@@ -1,0 +1,70 @@
+# The 'Checkpoint File' Optimization
+
+## Overview
+
+Available in Cromwell version 55 and higher.
+
+### Description
+
+Specifying a `checkpointFile` value in a task's `runtime` section designates a checkpoint file which will occasionally be
+copied out to cloud storage. This file will then be restored automatically on subsequent attempts if the job is interrupted.
+
+*Note:* Additional charges may accrue storing the checkpoint file, and by transferring it to and from the cloud. This
+should be balanced against the performance and cost benefits of being able to restore from the checkpoint when preemptible VMs are interrupted.   
+
+### Effect on Call Caching
+
+The presence or absence of the `checkpointingFile` attribute is not considered when determining whether to call cache.  
+
+### Example
+
+The following WDL demonstrates the use of the `checkpointFile` optimization. It has a command which is checkpoint-aware:
+
+* It starts by attempting to restore state from the `my_checkpoint` file (or starts at `1` if the checkpoint is empty)
+* Then it counts up to 100, printing out the current counter value and a date timestamp at each value.
+
+To make the checkpointing work, the `runtime` section specifies `checkpointFile: "my_checkpoint"`.
+
+```wdl
+version 1.0
+
+workflow count_wf {
+  call count { input: count_to = 100 }
+}
+
+task count {
+  input {
+    Int count_to
+  }
+
+  command <<<
+    # Read from the my_checkpoint file if there's content there:
+    FROM_CKPT=$(cat my_checkpoint | tail -n1 | awk '{ print $1 }')
+    FROM_CKPT=${FROM_CKPT:-1}
+
+    echo '--' >> my_checkpoint
+    for i in $(seq $FROM_CKPT ~{count_to})
+    do
+      echo $i $(date) >> my_checkpoint
+      sleep 4
+    done
+  >>>
+
+  runtime {
+    docker: "ubuntu:latest"
+    preemptible: 3
+    checkpointFile: "my_checkpoint"
+  }
+
+  output {
+    Array[String] out = read_lines("my_checkpoint")
+  }
+}
+```
+
+## Backend Support
+
+The `checkpointFile` attribute is currently understood by and implemented for:
+
+* The Google PAPIv2 (alpha1) backend
+* The Google Life Sciences (beta) backend

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Optimizations: optimizations/optimizations.md
   - "Task inputs: localization_optional": optimizations/FileLocalization.md
   - "Volatile Tasks: volatile": optimizations/VolatileTasks.md
+  - "CheckpointFiles": optimizations/CheckpointFiles.md
 - Configuration: Configuring.md
 - Scaling / Horizontal Cromwell: Scaling.md
 - Ecosystem: Ecosystem.md

--- a/src/ci/resources/papi_v1_v2alpha1_provider_config.inc.conf
+++ b/src/ci/resources/papi_v1_v2alpha1_provider_config.inc.conf
@@ -18,3 +18,5 @@ filesystems {
 slow-job-warning-time: 20 minutes
 
 allow-noAddress-attribute: false
+
+checkpointing-interval: "10 seconds"

--- a/src/ci/resources/papi_v2beta_provider_config.inc.conf
+++ b/src/ci/resources/papi_v2beta_provider_config.inc.conf
@@ -19,3 +19,5 @@ filesystems {
 slow-job-warning-time: 20 minutes
 
 allow-noAddress-attribute: false
+
+checkpointing-interval: "10 seconds"

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -24,7 +24,7 @@ import cromwell.backend.google.pipelines.common.api.clients.{PipelinesApiAbortCl
 import cromwell.backend.google.pipelines.common.authentication.PipelinesApiDockerCredentials
 import cromwell.backend.google.pipelines.common.errors.FailedToDelocalizeFailure
 import cromwell.backend.google.pipelines.common.io._
-import cromwell.backend.google.pipelines.common.monitoring.MonitoringImage
+import cromwell.backend.google.pipelines.common.monitoring.{CheckpointingConfiguration, MonitoringImage}
 import cromwell.backend.io.DirectoryFunctions
 import cromwell.backend.standard.{StandardAdHocValue, StandardAsyncExecutionActor, StandardAsyncExecutionActorParams, StandardAsyncJob}
 import cromwell.core._
@@ -471,6 +471,14 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
             localMonitoringImageScriptPath = localMonitoringImageScriptPath,
           )
 
+        val checkpointingConfiguration =
+          new CheckpointingConfiguration(
+            jobDescriptor = jobDescriptor,
+            workflowPaths = workflowPaths,
+            commandDirectory = commandDirectory,
+            pipelinesConfiguration.papiAttributes.checkpointingInterval
+          )
+
         val enableSshAccess = workflowOptions.getBoolean(WorkflowOptionKeys.EnableSSHAccess).toOption.contains(true)
 
         CreatePipelineParameters(
@@ -497,6 +505,7 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
           allowNoAddress = pipelinesConfiguration.papiAttributes.allowNoAddress,
           referenceDisksForLocalizationOpt = referenceDisksToMount,
           monitoringImage = monitoringImage,
+          checkpointingConfiguration,
           enableSshAccess = enableSshAccess,
           vpcNetworkAndSubnetworkProjectLabels = data.vpcNetworkAndSubnetworkProjectLabels,
           useDockerImageCache = runtimeAttributes.useDockerImageCache.getOrElse(useDockerImageCache(jobDescriptor.workflowDescriptor)),

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -49,7 +49,9 @@ case class PipelinesApiConfigurationAttributes(project: String,
                                                memoryRetryConfiguration: Option[MemoryRetryConfiguration],
                                                allowNoAddress: Boolean,
                                                referenceFileToDiskImageMappingOpt: Option[Map[String, PipelinesApiReferenceFilesDisk]],
-                                               dockerImageToCacheDiskImageMappingOpt: Option[Map[String, String]])
+                                               dockerImageToCacheDiskImageMappingOpt: Option[Map[String, String]],
+                                               checkpointingInterval: FiniteDuration
+                                              )
 
 object PipelinesApiConfigurationAttributes
   extends PipelinesApiDockerCacheMappingOperations
@@ -221,6 +223,8 @@ object PipelinesApiConfigurationAttributes
 
     val dockerImageCacheManifestFile: ErrorOr[Option[ValidFullGcsPath]] = validateGcsPathToDockerImageCacheManifestFile(backendConfig)
 
+    val checkpointingInterval: FiniteDuration = backendConfig.getOrElse("checkpointing-interval", 10.minutes)
+
     def authGoogleConfigForPapiConfigurationAttributes(project: String,
                                                        bucket: String,
                                                        endpointUrl: URL,
@@ -268,7 +272,8 @@ object PipelinesApiConfigurationAttributes
             memoryRetryConfiguration = memoryRetryConfig,
             allowNoAddress,
             referenceFileToDiskImageMappingOpt = generatedReferenceFilesMappingOpt,
-            dockerImageToCacheDiskImageMappingOpt = dockerImageToCacheDiskImageMappingOpt
+            dockerImageToCacheDiskImageMappingOpt = dockerImageToCacheDiskImageMappingOpt,
+            checkpointingInterval = checkpointingInterval
           )
     }
 

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -75,6 +75,7 @@ object PipelinesApiConfigurationAttributes
   lazy val DefaultMemoryRetryFactor: GreaterEqualRefined = refineMV[GreaterEqualOne](2.0)
 
   val allowNoAddressAttributeKey = "allow-noAddress-attribute"
+  val checkpointingIntervalKey = "checkpointing-interval"
 
   private val papiKeys = CommonBackendConfigurationAttributes.commonValidConfigurationAttributeKeys ++ Set(
     "project",
@@ -112,7 +113,8 @@ object PipelinesApiConfigurationAttributes
     "memory-retry.multiplier",
     allowNoAddressAttributeKey,
     "reference-disk-localization-manifest-files",
-    "docker-image-cache-manifest-file"
+    "docker-image-cache-manifest-file",
+    checkpointingIntervalKey
   )
 
   private val deprecatedJesKeys: Map[String, String] = Map(
@@ -223,7 +225,7 @@ object PipelinesApiConfigurationAttributes
 
     val dockerImageCacheManifestFile: ErrorOr[Option[ValidFullGcsPath]] = validateGcsPathToDockerImageCacheManifestFile(backendConfig)
 
-    val checkpointingInterval: FiniteDuration = backendConfig.getOrElse("checkpointing-interval", 10.minutes)
+    val checkpointingInterval: FiniteDuration = backendConfig.getOrElse(checkpointingIntervalKey, 10.minutes)
 
     def authGoogleConfigForPapiConfigurationAttributes(project: String,
                                                        bucket: String,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
@@ -50,7 +50,8 @@ final case class PipelinesApiRuntimeAttributes(cpu: Int Refined Positive,
                                                continueOnReturnCode: ContinueOnReturnCode,
                                                noAddress: Boolean,
                                                googleLegacyMachineSelection: Boolean,
-                                               useDockerImageCache: Option[Boolean])
+                                               useDockerImageCache: Option[Boolean],
+                                               checkpointFilename: Option[String])
 
 object PipelinesApiRuntimeAttributes {
 
@@ -77,6 +78,9 @@ object PipelinesApiRuntimeAttributes {
 
   val UseDockerImageCacheKey = "useDockerImageCache"
   private val useDockerImageCacheValidationInstance = new BooleanRuntimeAttributesValidation(UseDockerImageCacheKey).optional
+
+  val CheckpointFileKey = "checkpointFile"
+  private val checkpointFileValidationInstance = new StringRuntimeAttributesValidation(CheckpointFileKey).optional
 
   private val MemoryDefaultValue = "2048 MB"
 
@@ -164,6 +168,7 @@ object PipelinesApiRuntimeAttributes {
       noAddressValidation(runtimeConfig),
       cpuPlatformValidation(runtimeConfig),
       useDockerImageCacheValidation(runtimeConfig),
+      checkpointFileValidationInstance,
       dockerValidation,
       outDirMinValidation,
       tmpDirMinValidation,
@@ -174,6 +179,8 @@ object PipelinesApiRuntimeAttributes {
   def apply(validatedRuntimeAttributes: ValidatedRuntimeAttributes, runtimeAttrsConfig: Option[Config], googleLegacyMachineSelection: Boolean = false): PipelinesApiRuntimeAttributes = {
     val cpu: Int Refined Positive = RuntimeAttributesValidation.extract(cpuValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
     val cpuPlatform: Option[String] = RuntimeAttributesValidation.extractOption(cpuPlatformValidation(runtimeAttrsConfig).key, validatedRuntimeAttributes)
+
+    val checkpointFileName: Option[String] = RuntimeAttributesValidation.extractOption(checkpointFileValidationInstance.key, validatedRuntimeAttributes)
 
     // GPU
     lazy val gpuType: Option[GpuType] = RuntimeAttributesValidation.extractOption(gpuTypeValidation(runtimeAttrsConfig).key, validatedRuntimeAttributes)
@@ -220,7 +227,8 @@ object PipelinesApiRuntimeAttributes {
       continueOnReturnCode,
       noAddress,
       googleLegacyMachineSelection,
-      useDockerImageCache
+      useDockerImageCache,
+      checkpointFileName
     )
   }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
@@ -37,9 +37,10 @@ object ActionUtils {
   val aggregatedLog = s"$logsRoot/output"
 
   /**
-    * Define a shared PID namespace for the monitoring container and its termination controller
+    * Define a shared PID namespace for background action containers and their termination controller.
+    * The value is "monitoring" for historical (first usage) reasons.
     */
-  val monitoringPidNamespace = "monitoring"
+  val backgroundActionPidNamespace = "monitoring"
 
   /**
     * monitoringTerminationAction is needed to gracefully terminate monitoring action,
@@ -47,9 +48,9 @@ object ActionUtils {
     *
     * A fixed timeout is used to avoid hunting for monitoring PID.
     */
-  private val monitoringTerminationGraceTime = 10
+  private val backgroundActionTerminationGraceTime = 10
 
-  val monitoringTerminationCommand: String = s"kill -TERM -1 && sleep $monitoringTerminationGraceTime || true"
+  val terminateAllBackgroundActionsCommand: String = s"kill -TERM -1 && sleep $backgroundActionTerminationGraceTime || true"
 
   /** Start background actions first, leave the rest as is */
   def sortActions[Action](containerSetup: List[Action],
@@ -59,6 +60,8 @@ object ActionUtils {
                           deLocalization: List[Action],
                           monitoringSetup: List[Action],
                           monitoringShutdown: List[Action],
+                          checkpointingStart: List[Action],
+                          checkpointingShutdown: List[Action],
                           sshAccess: List[Action],
                           isBackground: Action => Boolean,
                          ): List[Action] = {
@@ -67,6 +70,6 @@ object ActionUtils {
       case (action, _) => isBackground(action)
     })
 
-    sshAccess ++ containerSetup ++ monitoringSetup ++ sortedActions ++ monitoringShutdown
+    sshAccess ++ containerSetup ++ monitoringSetup ++ checkpointingStart ++ sortedActions ++ checkpointingShutdown ++ monitoringShutdown
   }
 }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -6,7 +6,7 @@ import cromwell.backend.google.pipelines.common.PipelinesApiConfigurationAttribu
 import cromwell.backend.google.pipelines.common._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
 import cromwell.backend.google.pipelines.common.io.PipelinesApiAttachedDisk
-import cromwell.backend.google.pipelines.common.monitoring.MonitoringImage
+import cromwell.backend.google.pipelines.common.monitoring.{CheckpointingConfiguration, MonitoringImage}
 import cromwell.backend.standard.StandardAsyncJob
 import cromwell.core.logging.JobLogger
 import cromwell.core.path.Path
@@ -89,6 +89,7 @@ object PipelinesApiRequestFactory {
                                       allowNoAddress: Boolean,
                                       referenceDisksForLocalizationOpt: Option[List[PipelinesApiAttachedDisk]],
                                       monitoringImage: MonitoringImage,
+                                      checkpointingConfiguration: CheckpointingConfiguration,
                                       enableSshAccess: Boolean,
                                       vpcNetworkAndSubnetworkProjectLabels: Option[VpcAndSubnetworkProjectLabelValues],
                                       useDockerImageCache: Boolean,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/monitoring/CheckpointingConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/monitoring/CheckpointingConfiguration.scala
@@ -12,7 +12,8 @@ final class CheckpointingConfiguration(jobDescriptor: BackendJobDescriptor,
                                        checkpointInterval: FiniteDuration
                                       ) {
   def checkpointFileCloud(checkpointFileName: String): String = {
-    // Fix the attempt at 1 because we always use the base directory to store the checkpoint file.
+    // The checkpoint file for ANY attempt always goes in the "attempt 1" directory. That way we guarantee that
+    // every attempt is able to recover from the single source of checkpointing truth.
     workflowPaths.toJobPaths(jobDescriptor.key.copy(attempt = 1), jobDescriptor.workflowDescriptor)
       .callExecutionRoot.resolve("__checkpointing").resolve(checkpointFileName).toAbsolutePath.pathAsString
   }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/monitoring/CheckpointingConfiguration.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/monitoring/CheckpointingConfiguration.scala
@@ -1,0 +1,74 @@
+package cromwell.backend.google.pipelines.common.monitoring
+
+import cromwell.backend.BackendJobDescriptor
+import cromwell.backend.io.WorkflowPaths
+import cromwell.core.path.Path
+
+import scala.concurrent.duration.FiniteDuration
+
+final class CheckpointingConfiguration(jobDescriptor: BackendJobDescriptor,
+                                       workflowPaths: WorkflowPaths,
+                                       commandDirectory: Path,
+                                       checkpointInterval: FiniteDuration
+                                      ) {
+  def checkpointFileCloud(checkpointFileName: String): String = {
+    // Fix the attempt at 1 because we always use the base directory to store the checkpoint file.
+    workflowPaths.toJobPaths(jobDescriptor.key.copy(attempt = 1), jobDescriptor.workflowDescriptor)
+      .callExecutionRoot.resolve("__checkpointing").resolve(checkpointFileName).toAbsolutePath.pathAsString
+  }
+  def tmpCheckpointFileCloud(checkpointFileName: String): String = checkpointFileCloud(checkpointFileName) + "-tmp"
+
+  def checkpointFileLocal(checkpointFileName: String): String = {
+    commandDirectory.resolve(checkpointFileName).toAbsolutePath.pathAsString
+  }
+  def tmpCheckpointFileLocal(checkpointFileName: String): String = checkpointFileLocal(checkpointFileName) + "-tmp"
+
+  def localizePreviousCheckpointCommand(checkpointFileName: String): String = {
+    val local = checkpointFileLocal(checkpointFileName)
+    val cloud = checkpointFileCloud(checkpointFileName)
+
+    s"gsutil cp $cloud $local || touch $local"
+  }
+
+  def checkpointingCommand(checkpointFilename: String, multilineActionSquasher: String => String): List[String] = {
+    val local = checkpointFileLocal(checkpointFilename)
+    val localTmp = tmpCheckpointFileLocal(checkpointFilename)
+    val cloud = checkpointFileCloud(checkpointFilename)
+    val cloudTmp = tmpCheckpointFileCloud(checkpointFilename)
+
+    val checkpointUploadScript =
+      s"""touch $local
+         |while true
+         |do
+         |  # Attempt to make a local copy of the checkpoint file
+         |  echo "CHECKPOINTING: Making local copy of $local"
+         |  COPY_SUCCESS="false"
+         |  while [ "$$COPY_SUCCESS" != "true" ]
+         |  do
+         |    PRE_COPY_TIMESTAMP="$$(stat -c'%Z' $local)"
+         |    cp $local $localTmp
+         |    if [ "$$PRE_COPY_TIMESTAMP" == "$$(stat -c'%Z' $local)" ]
+         |    then
+         |      COPY_SUCCESS="true"
+         |    else
+         |      echo "CHECKPOINTING: $local was modified while trying to make a local copy. Will retry in 10s..."
+         |      sleep 10
+         |    fi
+         |  done
+         |
+         |  # Perform the upload:
+         |  echo "CHECKPOINTING: Uploading new checkpoint content"
+         |  gsutil -m mv $localTmp $cloudTmp
+         |  echo "CHECKPOINTING: Replacing cloud checkpoint file with new content"
+         |  gsutil -m mv $cloudTmp $cloud
+         |  echo "CHECKPOINTING: Sleeping for ${checkpointInterval.toString} before next checkpoint"
+         |  sleep ${checkpointInterval.toSeconds}
+         |done""".stripMargin
+
+    List(
+      "/bin/bash",
+      "-c",
+      multilineActionSquasher(checkpointUploadScript)
+    )
+  }
+}

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributesSpec.scala
@@ -263,7 +263,7 @@ trait PipelinesApiRuntimeAttributesSpecsMixin { this: TestSuite =>
 
   val expectedDefaults = new PipelinesApiRuntimeAttributes(refineMV(1), None, None, Vector("us-central1-b", "us-central1-a"), 0, 10,
     MemorySize(2, MemoryUnit.GB), Vector(PipelinesApiWorkingDisk(DiskType.SSD, 10)), "ubuntu:latest", false,
-    ContinueOnReturnCodeSet(Set(0)), false, false, None)
+    ContinueOnReturnCodeSet(Set(0)), false, false, None, None)
 
   def assertPapiRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WomValue],
                                                     expectedRuntimeAttributes: PipelinesApiRuntimeAttributes,

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
@@ -424,7 +424,8 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite
       memoryRetryConfiguration = None,
       allowNoAddress = true,
       referenceFileToDiskImageMappingOpt = None,
-      dockerImageToCacheDiskImageMappingOpt = None
+      dockerImageToCacheDiskImageMappingOpt = None,
+      checkpointingInterval = 10.minutes
     )
 
     val papiConfiguration = mock[PipelinesApiConfiguration]

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -30,6 +30,7 @@ import scala.collection.JavaConverters._
 case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, endpointUrl: URL)(implicit gcsTransferConfiguration: GcsTransferConfiguration) extends PipelinesApiFactoryInterface
   with ContainerSetup
   with MonitoringAction
+  with CheckpointingAction
   with Localization
   with UserAction
   with Delocalization
@@ -87,6 +88,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
       val deLocalization: List[Action] = deLocalizeActions(createPipelineParameters, mounts)
       val monitoringSetup: List[Action] = monitoringSetupActions(createPipelineParameters, mounts)
       val monitoringShutdown: List[Action] = monitoringShutdownActions(createPipelineParameters)
+      val checkpointingStart: List[Action] = checkpointingSetupActions(createPipelineParameters, mounts)
+      val checkpointingShutdown: List[Action] = checkpointingShutdownActions(createPipelineParameters)
       val sshAccess: List[Action] = sshAccessActions(createPipelineParameters, mounts)
 
       // adding memory as environment variables makes it easy for a user to retrieve the new value of memory
@@ -103,6 +106,8 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
           deLocalization = deLocalization,
           monitoringSetup = monitoringSetup,
           monitoringShutdown = monitoringShutdown,
+          checkpointingStart = checkpointingStart,
+          checkpointingShutdown = checkpointingShutdown,
           sshAccess = sshAccess,
           isBackground =
             action =>

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionBuilder.scala
@@ -77,7 +77,7 @@ object ActionBuilder {
     ActionBuilder.cloudSdkShellAction(command)(mounts = mounts, labels = labels)
   }
 
-  def monitoringAction(image: String,
+  def backgroundAction(image: String,
                        command: List[String],
                        environment: Map[String, String],
                        mounts: List[Mount],
@@ -89,14 +89,20 @@ object ActionBuilder {
       .withMounts(mounts)
       .setEnvironment(environment.asJava)
       .withLabels(Map(Key.Tag -> Value.Monitoring))
-      .setPidNamespace(monitoringPidNamespace)
+      .setPidNamespace(backgroundActionPidNamespace)
   }
 
-  def monitoringTerminationAction(): Action =
-    cloudSdkShellAction(monitoringTerminationCommand)(
+  def terminateBackgroundActionsAction(): Action =
+    cloudSdkShellAction(terminateAllBackgroundActionsCommand)(
       flags = List(ActionFlag.AlwaysRun),
       labels = Map(Key.Tag -> Value.Monitoring)
-    ).setPidNamespace(monitoringPidNamespace)
+    ).setPidNamespace(backgroundActionPidNamespace)
+
+  def gcsFileDeletionAction(cloudPath: String): Action =
+    cloudSdkShellAction(s"gsutil rm $cloudPath")(
+      flags = List(ActionFlag.IgnoreExitStatus),
+      labels = Map(Key.Tag -> Value.Monitoring)
+    )
 
   def userAction(docker: String,
                  scriptContainerPath: String,

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/ActionCommands.scala
@@ -146,14 +146,17 @@ object ActionCommands {
     s"grep -E -q '$lookupKeysAsString' /cromwell_root/stderr ; echo $$? > /cromwell_root/memory_retry_rc"
   }
 
-  def multiLineCommand(commandString: String) = {
+  def multiLineCommandTransformer(shell: String)(commandString: String): String = {
     val randomUuid = UUID.randomUUID().toString
     val withBashShebang = s"#!/bin/bash\n\n$commandString"
     val base64EncodedScript = Base64.encodeBase64String(withBashShebang.getBytes)
     val scriptPath = s"/tmp/$randomUuid.sh"
 
-      s"""python -c 'import base64; print(base64.b64decode("$base64EncodedScript"));' > $scriptPath && """ +
+    s"""python -c 'import base64; print(base64.b64decode("$base64EncodedScript"));' > $scriptPath && """ +
       s"chmod u+x $scriptPath && " +
-      s"sh $scriptPath"
+      s"$shell $scriptPath"
   }
+
+  def multiLineCommand(commandString: String): String = multiLineCommandTransformer("sh")(commandString)
+  def multiLineBinBashCommand(commandString: String): String = multiLineCommandTransformer("/bin/bash")(commandString)
 }

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/CheckpointingAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/CheckpointingAction.scala
@@ -1,0 +1,44 @@
+package cromwell.backend.google.pipelines.v2alpha1.api
+
+import com.google.api.services.genomics.v2alpha1.model.{Action, Mount}
+import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
+import cromwell.backend.google.pipelines.v2alpha1.GenomicsFactory
+
+trait CheckpointingAction {
+  def checkpointingSetupActions(createPipelineParameters: CreatePipelineParameters,
+                                mounts: List[Mount]
+                            ): List[Action] =
+    createPipelineParameters.runtimeAttributes.checkpointFilename map { checkpointFilename =>
+      val checkpointingImage = GenomicsFactory.CloudSdkImage
+      val checkpointingCommand = createPipelineParameters.checkpointingConfiguration.checkpointingCommand(checkpointFilename, ActionCommands.multiLineBinBashCommand)
+      val checkpointingEnvironment = Map.empty[String, String]
+
+      // Initial sync from cloud:
+      val initialCheckpointSyncAction = ActionBuilder.cloudSdkShellAction(
+        createPipelineParameters.checkpointingConfiguration.localizePreviousCheckpointCommand(checkpointFilename)
+      )(mounts = mounts)
+      val describeInitialCheckpointingSyncAction = ActionBuilder.describeDocker("initial checkpointing sync", initialCheckpointSyncAction)
+
+      // Background upload action:
+      val backgroundCheckpointingAction = ActionBuilder.backgroundAction(
+        image = checkpointingImage,
+        command = checkpointingCommand,
+        environment = checkpointingEnvironment,
+        mounts = mounts
+      )
+      val describeBackgroundCheckpointingAction = ActionBuilder.describeDocker("begin checkpointing background action", backgroundCheckpointingAction)
+
+      List(describeInitialCheckpointingSyncAction, initialCheckpointSyncAction, describeBackgroundCheckpointingAction, backgroundCheckpointingAction)
+    } getOrElse(Nil)
+
+  def checkpointingShutdownActions(createPipelineParameters: CreatePipelineParameters): List[Action] =
+    createPipelineParameters.runtimeAttributes.checkpointFilename map { checkpointFilename =>
+      val terminationAction = ActionBuilder.terminateBackgroundActionsAction()
+      val describeTerminationAction = ActionBuilder.describeDocker("terminate checkpointing action", terminationAction)
+
+      val deleteCheckpointAction = ActionBuilder.gcsFileDeletionAction(createPipelineParameters.checkpointingConfiguration.checkpointFileCloud(checkpointFilename))
+      val deleteTmpCheckpointAction = ActionBuilder.gcsFileDeletionAction(createPipelineParameters.checkpointingConfiguration.tmpCheckpointFileCloud(checkpointFilename))
+
+      List(describeTerminationAction, terminationAction, deleteCheckpointAction, deleteTmpCheckpointAction)
+    } getOrElse(Nil)
+}

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/MonitoringAction.scala
@@ -35,7 +35,7 @@ trait MonitoringAction {
           val monitoringImageCommand = createPipelineParameters.monitoringImage.monitoringImageCommand
           val monitoringImageEnvironment = createPipelineParameters.monitoringImage.monitoringImageEnvironment
 
-          val monitoringAction = ActionBuilder.monitoringAction(
+          val monitoringAction = ActionBuilder.backgroundAction(
             monitoringImage,
             monitoringImageCommand,
             monitoringImageEnvironment(mounts.map(_.getPath)),
@@ -55,7 +55,7 @@ trait MonitoringAction {
   def monitoringShutdownActions(createPipelineParameters: CreatePipelineParameters): List[Action] = {
     createPipelineParameters.monitoringImage.monitoringImageOption match {
       case Some(_) =>
-        val terminationAction = ActionBuilder.monitoringTerminationAction()
+        val terminationAction = ActionBuilder.terminateBackgroundActionsAction()
 
         val describeTerminationAction = ActionBuilder.describeDocker("terminate monitoring action", terminationAction)
 

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
@@ -30,6 +30,7 @@ import scala.collection.JavaConverters._
 case class LifeSciencesFactory(applicationName: String, authMode: GoogleAuthMode, endpointUrl: URL, location: String)(implicit gcsTransferConfiguration: GcsTransferConfiguration) extends PipelinesApiFactoryInterface
   with ContainerSetup
   with MonitoringAction
+  with CheckpointingAction
   with Localization
   with UserAction
   with Delocalization
@@ -87,6 +88,8 @@ case class LifeSciencesFactory(applicationName: String, authMode: GoogleAuthMode
       val deLocalization: List[Action] = deLocalizeActions(createPipelineParameters, mounts)
       val monitoringSetup: List[Action] = monitoringSetupActions(createPipelineParameters, mounts)
       val monitoringShutdown: List[Action] = monitoringShutdownActions(createPipelineParameters)
+      val checkpointingStart: List[Action] = checkpointingSetupActions(createPipelineParameters, mounts)
+      val checkpointingShutdown: List[Action] = checkpointingShutdownActions(createPipelineParameters)
       val sshAccess: List[Action] = sshAccessActions(createPipelineParameters, mounts)
 
       // adding memory as environment variables makes it easy for a user to retrieve the new value of memory
@@ -103,6 +106,8 @@ case class LifeSciencesFactory(applicationName: String, authMode: GoogleAuthMode
           deLocalization = deLocalization,
           monitoringSetup = monitoringSetup,
           monitoringShutdown = monitoringShutdown,
+          checkpointingStart = checkpointingStart,
+          checkpointingShutdown = checkpointingShutdown,
           sshAccess = sshAccess,
           isBackground = _.getRunInBackground,
         )

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionBuilder.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionBuilder.scala
@@ -78,7 +78,7 @@ object ActionBuilder {
     ActionBuilder.cloudSdkShellAction(command)(mounts = mounts, labels = labels)
   }
 
-  def monitoringAction(image: String,
+  def backgroundAction(image: String,
                        command: List[String],
                        environment: Map[String, String],
                        mounts: List[Mount],
@@ -91,13 +91,19 @@ object ActionBuilder {
       .withMounts(mounts)
       .setEnvironment(environment.asJava)
       .withLabels(Map(Key.Tag -> Value.Monitoring))
-      .setPidNamespace(monitoringPidNamespace)
+      .setPidNamespace(backgroundActionPidNamespace)
   }
 
-  def monitoringTerminationAction(): Action =
-    cloudSdkShellAction(monitoringTerminationCommand)(labels = Map(Key.Tag -> Value.Monitoring))
+  def terminateBackgroundActionsAction(): Action =
+    cloudSdkShellAction(terminateAllBackgroundActionsCommand)(labels = Map(Key.Tag -> Value.Monitoring))
       .withAlwaysRun(true)
-      .setPidNamespace(monitoringPidNamespace)
+      .setPidNamespace(backgroundActionPidNamespace)
+
+  def gcsFileDeletionAction(cloudPath: String): Action =
+    cloudSdkShellAction(
+      s"""gsutil rm '$cloudPath'"""
+    )(labels = Map(Key.Tag -> Value.Monitoring))
+      .withIgnoreExitStatus(true)
 
   def userAction(docker: String,
                  scriptContainerPath: String,

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionCommands.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/ActionCommands.scala
@@ -146,7 +146,7 @@ object ActionCommands {
     s"grep -E -q '$lookupKeysAsString' /cromwell_root/stderr ; echo $$? > /cromwell_root/memory_retry_rc"
   }
 
-  def multiLineCommand(commandString: String) = {
+  def multiLineCommandTransformer(shell: String)(commandString: String): String = {
     val randomUuid = UUID.randomUUID().toString
     val withBashShebang = s"#!/bin/bash\n\n$commandString"
     val base64EncodedScript = Base64.encodeBase64String(withBashShebang.getBytes)
@@ -154,6 +154,9 @@ object ActionCommands {
 
       s"""python -c 'import base64; print(base64.b64decode("$base64EncodedScript"));' > $scriptPath && """ +
       s"chmod u+x $scriptPath && " +
-      s"sh $scriptPath"
+      s"$shell $scriptPath"
   }
+
+  def multiLineCommand(commandString: String): String = multiLineCommandTransformer("sh")(commandString)
+  def multiLineBinBashCommand(commandString: String): String = multiLineCommandTransformer("/bin/bash")(commandString)
 }

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/CheckpointingAction.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/CheckpointingAction.scala
@@ -1,0 +1,45 @@
+package cromwell.backend.google.pipelines.v2beta.api
+
+import com.google.api.services.lifesciences.v2beta.model.{Action, Mount}
+import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory.CreatePipelineParameters
+import cromwell.backend.google.pipelines.v2beta.LifeSciencesFactory
+
+trait CheckpointingAction {
+  def checkpointingSetupActions(createPipelineParameters: CreatePipelineParameters,
+                                mounts: List[Mount]
+                            ): List[Action] =
+    createPipelineParameters.runtimeAttributes.checkpointFilename map { checkpointFilename =>
+      val checkpointingImage = LifeSciencesFactory.CloudSdkImage
+      val checkpointingCommand = createPipelineParameters.checkpointingConfiguration.checkpointingCommand(checkpointFilename, ActionCommands.multiLineBinBashCommand)
+      val checkpointingEnvironment = Map.empty[String, String]
+
+      // Initial sync from cloud:
+      val initialCheckpointSyncAction = ActionBuilder.cloudSdkShellAction(
+        createPipelineParameters.checkpointingConfiguration.localizePreviousCheckpointCommand(checkpointFilename)
+      )(mounts = mounts)
+      val describeInitialCheckpointingSyncAction = ActionBuilder.describeDocker("initial checkpointing sync", initialCheckpointSyncAction)
+
+      // Background upload action:
+      val backgroundCheckpointingAction = ActionBuilder.backgroundAction(
+        image = checkpointingImage,
+        command = checkpointingCommand,
+        environment = checkpointingEnvironment,
+        mounts = mounts
+      )
+      val describeBackgroundCheckpointingAction = ActionBuilder.describeDocker("begin checkpointing background action", backgroundCheckpointingAction)
+
+      List(describeInitialCheckpointingSyncAction, initialCheckpointSyncAction, describeBackgroundCheckpointingAction, backgroundCheckpointingAction)
+    } getOrElse(Nil)
+
+  def checkpointingShutdownActions(createPipelineParameters: CreatePipelineParameters): List[Action] = {
+    createPipelineParameters.runtimeAttributes.checkpointFilename map { checkpointFilename =>
+      val terminationAction = ActionBuilder.terminateBackgroundActionsAction()
+      val describeTerminationAction = ActionBuilder.describeDocker("terminate checkpointing action", terminationAction)
+
+      val deleteCheckpointAction = ActionBuilder.gcsFileDeletionAction(createPipelineParameters.checkpointingConfiguration.checkpointFileCloud(checkpointFilename))
+      val deleteTmpCheckpointAction = ActionBuilder.gcsFileDeletionAction(createPipelineParameters.checkpointingConfiguration.tmpCheckpointFileCloud(checkpointFilename))
+
+      List(describeTerminationAction, terminationAction, deleteCheckpointAction, deleteTmpCheckpointAction)
+    } getOrElse(Nil)
+  }
+}

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/MonitoringAction.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/MonitoringAction.scala
@@ -35,7 +35,7 @@ trait MonitoringAction {
           val monitoringImageCommand = createPipelineParameters.monitoringImage.monitoringImageCommand
           val monitoringImageEnvironment = createPipelineParameters.monitoringImage.monitoringImageEnvironment
 
-          val monitoringAction = ActionBuilder.monitoringAction(
+          val monitoringAction = ActionBuilder.backgroundAction(
             monitoringImage,
             monitoringImageCommand,
             monitoringImageEnvironment(mounts.map(_.getPath)),
@@ -55,7 +55,7 @@ trait MonitoringAction {
   def monitoringShutdownActions(createPipelineParameters: CreatePipelineParameters): List[Action] = {
     createPipelineParameters.monitoringImage.monitoringImageOption match {
       case Some(_) =>
-        val terminationAction = ActionBuilder.monitoringTerminationAction()
+        val terminationAction = ActionBuilder.terminateBackgroundActionsAction()
 
         val describeTerminationAction = ActionBuilder.describeDocker("terminate monitoring action", terminationAction)
 


### PR DESCRIPTION
Allows PAPI/GLS jobs to run a background action to upload a checkpoint file to GCS at regular intervals

Notes from demo:

- [x] Remove checkpoint file when task completes
- [x] Change upload interval to 10m