### PR TITLE
Update extra.js

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -141,7 +141,7 @@ var nodemcu = nodemcu || {};
    */
   function replaceRelativeLinksWithStaticGitHubUrl() {
     var relativePath = "../../../..";
-    var gitHubPath = "https://github.com/nodemcu/nodemcu-firmware/tree/" + determineSelectedBranch();
+    var gitHubPath = "https://cromwell.readthedocs.io/en/" + determineSelectedBranch();
     var gitHubLinks = $("a[href^='" + relativePath + "']").each(function (index) {
       var url = $(this).attr('href');
       $(this).attr('href', url.replace(relativePath, gitHubPath));


### PR DESCRIPTION
I think this should fix an issue where if one navigates to any item under the /developers section the links on the menu are pointing to `https://github.com/nodemcu/nodemcu-firmware/tree/stable/` when I think they should be pointing to `https://cromwell.readthedocs.io/en/`.

Also, please note that language support is not considered, forcing it to `.../en/...`