### PR TITLE
Metadata Integrity: await write confirmation on final workflow status metadatum [CROM-6443]

### DIFF
--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -40,6 +40,7 @@ case object WorkflowRunning extends WorkflowState {
   override val ordinal = 2
 }
 
+// Cromwell performs internal housekeeping such as flushing metadata to the DB before marking complete
 case object WorkflowFinalizing extends WorkflowState {
   override val toString: String = "Finalizing"
   override val isTerminal = false

--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -10,7 +10,7 @@ sealed trait WorkflowState {
 }
 
 object WorkflowState {
-  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
+  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFinalizing, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
 
   def withName(str: String): WorkflowState = WorkflowStateValues.find(_.toString.equalsIgnoreCase(str)).getOrElse(
     throw new NoSuchElementException(s"No such WorkflowState: $str"))
@@ -40,26 +40,32 @@ case object WorkflowRunning extends WorkflowState {
   override val ordinal = 2
 }
 
+case object WorkflowFinalizing extends WorkflowState {
+  override val toString: String = "Finalizing"
+  override val isTerminal = false
+  override val ordinal = 3
+}
+
 case object WorkflowAborting extends WorkflowState {
   override val toString: String = "Aborting"
   override val isTerminal = false
-  override val ordinal = 3
+  override val ordinal = 4
 }
 
 case object WorkflowAborted extends WorkflowState {
   override val toString: String = "Aborted"
   override val isTerminal = true
-  override val ordinal = 4
+  override val ordinal = 5
 }
 
 case object WorkflowSucceeded extends WorkflowState {
   override val toString: String = "Succeeded"
   override val isTerminal = true
-  override val ordinal = 5
+  override val ordinal = 6
 }
 
 case object WorkflowFailed extends WorkflowState {
   override val toString: String = "Failed"
   override val isTerminal = true
-  override val ordinal = 6
+  override val ordinal = 7
 }

--- a/core/src/main/scala/cromwell/core/WorkflowState.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowState.scala
@@ -10,7 +10,7 @@ sealed trait WorkflowState {
 }
 
 object WorkflowState {
-  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFinalizing, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
+  lazy val WorkflowStateValues = Seq(WorkflowOnHold, WorkflowSubmitted, WorkflowRunning, WorkflowFailed, WorkflowSucceeded, WorkflowAborting, WorkflowAborted)
 
   def withName(str: String): WorkflowState = WorkflowStateValues.find(_.toString.equalsIgnoreCase(str)).getOrElse(
     throw new NoSuchElementException(s"No such WorkflowState: $str"))
@@ -40,33 +40,26 @@ case object WorkflowRunning extends WorkflowState {
   override val ordinal = 2
 }
 
-// Cromwell performs internal housekeeping such as flushing metadata to the DB before marking complete
-case object WorkflowFinalizing extends WorkflowState {
-  override val toString: String = "Finalizing"
-  override val isTerminal = false
-  override val ordinal = 3
-}
-
 case object WorkflowAborting extends WorkflowState {
   override val toString: String = "Aborting"
   override val isTerminal = false
-  override val ordinal = 4
+  override val ordinal = 3
 }
 
 case object WorkflowAborted extends WorkflowState {
   override val toString: String = "Aborted"
   override val isTerminal = true
-  override val ordinal = 5
+  override val ordinal = 4
 }
 
 case object WorkflowSucceeded extends WorkflowState {
   override val toString: String = "Succeeded"
   override val isTerminal = true
-  override val ordinal = 6
+  override val ordinal = 5
 }
 
 case object WorkflowFailed extends WorkflowState {
   override val toString: String = "Failed"
   override val isTerminal = true
-  override val ordinal = 7
+  override val ordinal = 6
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -17,6 +17,7 @@ import cromwell.engine._
 import cromwell.engine.backend.BackendSingletonCollection
 import cromwell.engine.instrumentation.WorkflowInstrumentation
 import cromwell.engine.workflow.WorkflowActor._
+import cromwell.engine.workflow.WorkflowManagerActor.WorkflowActorWorkComplete
 import cromwell.engine.workflow.lifecycle._
 import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor
 import cromwell.engine.workflow.lifecycle.deletion.DeleteWorkflowFilesActor.{DeleteWorkflowFilesFailedResponse, DeleteWorkflowFilesSucceededResponse, StartWorkflowFilesDeletion}
@@ -30,6 +31,7 @@ import cromwell.engine.workflow.lifecycle.materialization.MaterializeWorkflowDes
 import cromwell.engine.workflow.lifecycle.materialization.MaterializeWorkflowDescriptorActor.{MaterializeWorkflowDescriptorCommand, MaterializeWorkflowDescriptorFailureResponse, MaterializeWorkflowDescriptorSuccessResponse}
 import cromwell.engine.workflow.workflowstore.WorkflowStoreActor.WorkflowStoreWriteHeartbeatCommand
 import cromwell.engine.workflow.workflowstore.{RestartableAborting, StartableState, WorkflowHeartbeatConfig, WorkflowToStart}
+import cromwell.services.metadata.MetadataService.{MetadataWriteFailure, MetadataWriteSuccess, PutMetadataActionAndRespond}
 import cromwell.subworkflowstore.SubWorkflowStoreActor.WorkflowComplete
 import cromwell.webservice.EngineStatsActor
 import org.apache.commons.lang3.exception.ExceptionUtils
@@ -49,6 +51,7 @@ object WorkflowActor {
   case object AbortWorkflowCommand extends WorkflowActorCommand
   final case class AbortWorkflowWithExceptionCommand(exception: Throwable) extends WorkflowActorCommand
   case object SendWorkflowHeartbeatCommand extends WorkflowActorCommand
+  case object AwaitMetadataIntegrity
 
   case class WorkflowFailedResponse(workflowId: WorkflowId, inState: WorkflowActorState, reasons: Seq[Throwable])
 
@@ -56,12 +59,13 @@ object WorkflowActor {
     * States for the WorkflowActor FSM
     */
   sealed trait WorkflowActorState {
-    def terminal = false
     // Each state in the FSM maps to a state in the `WorkflowState` which is used for Metadata reporting purposes
     def workflowState: WorkflowState
   }
-  sealed trait WorkflowActorTerminalState extends WorkflowActorState { override val terminal = true }
+
+  sealed trait WorkflowActorTerminalState extends WorkflowActorState
   sealed trait WorkflowActorRunningState extends WorkflowActorState { override val workflowState = WorkflowRunning }
+  sealed trait WorkflowActorFinalizingState extends WorkflowActorState { override val workflowState = WorkflowFinalizing }
 
   /**
     * Waiting for a Start or Restart command.
@@ -88,13 +92,18 @@ object WorkflowActor {
   /**
     * The WorkflowActor has completed. So we're now finalizing whatever needs to be finalized on the backends
     */
-  case object FinalizingWorkflowState extends WorkflowActorRunningState
+  case object FinalizingWorkflowState extends WorkflowActorFinalizingState
 
   /**
     * The workflow and finalization has succeeded and wants to delete intermediate files. So we are now in deleting
     * those files state.
     */
-  case object DeletingFilesState extends WorkflowActorRunningState
+  case object DeletingFilesState extends WorkflowActorFinalizingState
+
+  case object MetadataIntegrityValidationState extends WorkflowActorState {
+    override def toString = "MetadataIntegrityValidationState"
+    override def workflowState: WorkflowState = WorkflowFinalizing
+  }
 
   /**
     * The WorkflowActor is aborting. We're just waiting for everything to finish up then we'll respond back to the
@@ -402,7 +411,21 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
       goto(WorkflowFailedState) using data.copy(lastStateReached = StateCheckpoint(FinalizingWorkflowState, Option(failures)))
     case Event(AbortWorkflowCommand, _) => stay()
   }
-  
+
+  when(MetadataIntegrityValidationState) {
+    case Event(_: MetadataWriteSuccess, _) =>
+      context.parent ! WorkflowActorWorkComplete(workflowId, self, stateData.lastStateReached.state.workflowState)
+      context stop self
+      stay()
+    case Event(MetadataWriteFailure(reason, msgs), _) =>
+      // If we shut down now the WMA will erase this workflow from the workflow store, so try again and hope for
+      // better luck. If we continue to be unable to write the completion message to the DB it's better to leave the
+      // workflow in its current state in the DB than to let the WMA delete it
+      workflowLogger.error(reason, "Unable to complete workflow due to inability to write concluding metadata status. Retrying...")
+      PutMetadataActionAndRespond(msgs, self)
+      stay()
+  }
+
   def handleAbortCommand(data: WorkflowActorData, workflowDescriptor: EngineWorkflowDescriptor, exceptionCausedAbortOpt: Option[Throwable] = None) = {
     data.currentLifecycleStateActor match {
       case Some(currentActor) =>
@@ -449,6 +472,8 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
         case None => sender ! EngineStatsActor.NoJobs // This should be impossible, but if somehow here it's technically correct
       }
       stay()
+    case Event(AwaitMetadataIntegrity, data) =>
+      goto(MetadataIntegrityValidationState) using data.copy(lastStateReached = data.lastStateReached.copy(state = stateName))
   }
 
   onTransition {
@@ -464,7 +489,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
           val failures = nextStateData.lastStateReached.failures.getOrElse(List.empty)
           pushWorkflowFailures(workflowId, failures)
           context.parent ! WorkflowFailedResponse(workflowId, nextStateData.lastStateReached.state, failures)
-        case _ => // The WMA is watching state transitions and needs no further info
+        case _ => // The WMA is waiting for the WorkflowActorWorkComplete message. No extra information needed here.
       }
 
       // Copy/Delete workflow logs
@@ -498,16 +523,19 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
           }
         }
       }
-      context stop self
-  }
 
-  onTransition {
+      // We can't transition from within another transition function, but we can instruct ourselves to with a message:
+      self ! AwaitMetadataIntegrity
+
+      // Push the final status and ask for an acknowledgement (which we will now be waiting for):
+      pushCurrentStateToMetadataService(workflowId, terminalState.workflowState, confirmTo = Option(self))
+
     case fromState -> toState =>
       workflowLogger.debug(s"transitioning from {} to {}", arg1 = fromState, arg2 = toState)
       // This updates the workflow status
       // Only publish "External" state to metadata service
       // workflowState maps a state to an "external" state (e.g all states extending WorkflowActorRunningState map to WorkflowRunning)
-      if (fromState.workflowState != toState.workflowState) {
+      if (fromState.workflowState != toState.workflowState && toState != MetadataIntegrityValidationState) {
         pushCurrentStateToMetadataService(workflowId, toState.workflowState)
       }
   }

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -65,7 +65,6 @@ object WorkflowActor {
 
   sealed trait WorkflowActorTerminalState extends WorkflowActorState
   sealed trait WorkflowActorRunningState extends WorkflowActorState { override val workflowState = WorkflowRunning }
-  sealed trait WorkflowActorFinalizingState extends WorkflowActorState { override val workflowState = WorkflowFinalizing }
 
   /**
     * Waiting for a Start or Restart command.
@@ -92,17 +91,17 @@ object WorkflowActor {
   /**
     * The WorkflowActor has completed. So we're now finalizing whatever needs to be finalized on the backends
     */
-  case object FinalizingWorkflowState extends WorkflowActorFinalizingState
+  case object FinalizingWorkflowState extends WorkflowActorRunningState
 
   /**
     * The workflow and finalization has succeeded and wants to delete intermediate files. So we are now in deleting
     * those files state.
     */
-  case object DeletingFilesState extends WorkflowActorFinalizingState
+  case object DeletingFilesState extends WorkflowActorRunningState
 
   case object MetadataIntegrityValidationState extends WorkflowActorState {
     override def toString = "MetadataIntegrityValidationState"
-    override def workflowState: WorkflowState = WorkflowFinalizing
+    override def workflowState: WorkflowState = WorkflowRunning
   }
 
   /**

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -420,6 +420,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
       // If we shut down now the WMA will erase this workflow from the workflow store, so try again and hope for
       // better luck. If we continue to be unable to write the completion message to the DB it's better to leave the
       // workflow in its current state in the DB than to let the WMA delete it
+      // Note: this is an infinite retry right now, but it doesn't consume much in terms of resources and could help us successfully weather maintenance downtime on the DB
       workflowLogger.error(reason, "Unable to complete workflow due to inability to write concluding metadata status. Retrying...")
       PutMetadataActionAndRespond(msgs, self)
       stay()

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowMetadataHelper.scala
@@ -32,10 +32,13 @@ trait WorkflowMetadataHelper {
     serviceRegistryActor ! PutMetadataAction(failureEvents)
   }
   
-  def pushCurrentStateToMetadataService(workflowId: WorkflowId, workflowState: WorkflowState): Unit = {
-    val metadataEventMsg = MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.Status),
-      MetadataValue(workflowState))
-    serviceRegistryActor ! PutMetadataAction(metadataEventMsg)
+  def pushCurrentStateToMetadataService(workflowId: WorkflowId, workflowState: WorkflowState, confirmTo: Option[ActorRef] = None): Unit = {
+    val metadataEventMsg = MetadataEvent(MetadataKey(workflowId, None, WorkflowMetadataKeys.Status), MetadataValue(workflowState))
+
+    confirmTo match {
+      case None => serviceRegistryActor ! PutMetadataAction(metadataEventMsg)
+      case Some(actorRef) => serviceRegistryActor ! PutMetadataActionAndRespond(List(metadataEventMsg), actorRef)
+    }
   }
   
 }

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o nounset -o pipefail +x
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
@@ -18,7 +18,7 @@ java \
 | tee console_output.txt
 
 # grep exits 1 if no matches
-grep "terminal state: WorkflowSucceededState" console_output.txt
+grep "completed with status 'Succeeded'" console_output.txt
 grep "\"wf_hello.hello.salutation\": \"Hello m'Lord!\"" console_output.txt
 
 cat > expected.json <<FIN


### PR DESCRIPTION
Inspired by https://github.com/broadinstitute/cromwell/compare/rsa_ss_crom_6443, this should stop workflows from being deleted from the workflow store before their final metadata has been written to the database.

* Workflows now request confirmation on the push of their final status to metadata.
* Workflows are not removed from the WorkflowStore until that confirmation happens

Bonus:

* Workflow actor states that follow on from completion (like log copying, output copying, metadata integrity checking, ...) are now recorded as "Finalizing" in metadata.