### PR TITLE
Raise exception instead of silently retrying in case when Centaur test fails with exception type other than CentaurTestException [BT-145]

### DIFF
--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -190,7 +190,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String], cromw
     runTestIo.redeemWith(
       {
         case centaurTestException: CentaurTestException => maybeRetry(centaurTestException)
-        case _ => runTestIo
+        case nonCentaurException => IO.raiseError(nonCentaurException)
       },
       {
         case workflowResponse: SubmitWorkflowResponse => SuccessReporters.logSuccessfulRun(workflowResponse)

--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -191,9 +191,9 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String], cromw
       {
         case centaurTestException: CentaurTestException =>
           maybeRetry(centaurTestException)
-        case nonCentaurException =>
+        case nonCentaurThrowable: Throwable =>
           val testEnvironment = TestEnvironment(testName, retries = attempt + 1, attempt) // allow one last retry
-          ErrorReporters.logFailure(testEnvironment, nonCentaurException)
+          ErrorReporters.logFailure(testEnvironment, nonCentaurThrowable)
           runTestIo
       },
       {

--- a/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
+++ b/centaur/src/it/scala/centaur/AbstractCentaurTestCaseSpec.scala
@@ -176,7 +176,7 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String], cromw
     def maybeRetry(centaurTestException: CentaurTestException): IO[SubmitResponse] = {
       val testEnvironment = TestEnvironment(testName, retries, attempt)
       for {
-        _ <- ErrorReporters.logCentaurFailure(testEnvironment, centaurTestException)
+        _ <- ErrorReporters.logFailure(testEnvironment, centaurTestException)
         r <- if (attempt < retries) {
           tryTryAgain(testName, runTest, retries, attempt + 1)
         } else {
@@ -189,8 +189,12 @@ abstract class AbstractCentaurTestCaseSpec(cromwellBackends: List[String], cromw
 
     runTestIo.redeemWith(
       {
-        case centaurTestException: CentaurTestException => maybeRetry(centaurTestException)
-        case nonCentaurException => IO.raiseError(nonCentaurException)
+        case centaurTestException: CentaurTestException =>
+          maybeRetry(centaurTestException)
+        case nonCentaurException =>
+          val testEnvironment = TestEnvironment(testName, retries = attempt + 1, attempt) // allow one last retry
+          ErrorReporters.logFailure(testEnvironment, nonCentaurException)
+          runTestIo
       },
       {
         case workflowResponse: SubmitWorkflowResponse => SuccessReporters.logSuccessfulRun(workflowResponse)

--- a/centaur/src/it/scala/centaur/reporting/BigQueryReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/BigQueryReporter.scala
@@ -72,6 +72,10 @@ class BigQueryReporter(override val params: ErrorReporterParams) extends ErrorRe
     }
   }
 
+  /**
+    * In this ErrorReporter implementation this method will send information about exceptions of type
+    * CentaurTestException to BigQuery. Exceptions of other types will be ignored.
+    */
   override def logFailure(testEnvironment: TestEnvironment,
                           ciEnvironment: CiEnvironment,
                           throwable: Throwable)

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporter.scala
@@ -1,7 +1,6 @@
 package centaur.reporting
 
 import cats.effect.IO
-import centaur.test.CentaurTestException
 
 import scala.concurrent.ExecutionContext
 
@@ -15,9 +14,9 @@ trait ErrorReporter {
   /** A description of where the reporter is sending the errors. */
   def destination: String
 
-  /** Send a report of a centaur failure. */
-  def logCentaurFailure(testEnvironment: TestEnvironment,
-                        ciEnvironment: CiEnvironment,
-                        centaurTestException: CentaurTestException)
-                       (implicit executionContext: ExecutionContext): IO[Unit]
+  /** Send a report of a failure. */
+  def logFailure(testEnvironment: TestEnvironment,
+                 ciEnvironment: CiEnvironment,
+                 throwable: Throwable)
+                (implicit executionContext: ExecutionContext): IO[Unit]
 }

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
@@ -41,20 +41,20 @@ class ErrorReporters(rootConfig: Config) {
     *
     * @param testEnvironment      The test information, including the name of the test and the attemp.
     * @param ciEnvironment        The information about the CI environment running the test.
-    * @param centaurTestException The exception that occurred while running the test.
+    * @param throwable            The exception that occurred while running the test.
     * @return An IO effect that will log the failure.
     */
-  def logCentaurFailure(testEnvironment: TestEnvironment,
-                        ciEnvironment: CiEnvironment,
-                        centaurTestException: CentaurTestException)
-                       (implicit executionContext: ExecutionContext): IO[Unit] = {
+  def logFailure(testEnvironment: TestEnvironment,
+                 ciEnvironment: CiEnvironment,
+                 throwable: Throwable)
+                (implicit executionContext: ExecutionContext): IO[Unit] = {
     if (errorReporters.isEmpty) {
       // If the there are no reporters, then just "throw" the exception. Do not retry to run the test.
-      IO.raiseError(centaurTestException)
+      IO.raiseError(throwable)
     } else {
-      val listIo = errorReporters.map(_.logCentaurFailure(testEnvironment, ciEnvironment, centaurTestException))
-      AggregatedIo.aggregateExceptions("Errors while reporting centaur failure", listIo).handleErrorWith(throwable => {
-        throwable.addSuppressed(centaurTestException)
+      val listIo = errorReporters.map(_.logFailure(testEnvironment, ciEnvironment, throwable))
+      AggregatedIo.aggregateExceptions("Errors while reporting a failure", listIo).handleErrorWith(throwable => {
+        throwable.addSuppressed(throwable)
         IO.raiseError(throwable)
       }).void
     }
@@ -86,9 +86,9 @@ object ErrorReporters extends StrictLogging {
   if (retryAttempts > 0)
     logger.info("Error retry count: {}", retryAttempts)
 
-  def logCentaurFailure(testEnvironment: TestEnvironment,
-                        centaurTestException: CentaurTestException)
-                       (implicit executionContext: ExecutionContext): IO[Unit] = {
-    errorReporters.logCentaurFailure(testEnvironment, ciEnvironment, centaurTestException)
+  def logFailure(testEnvironment: TestEnvironment,
+                 throwable: Throwable)
+                (implicit executionContext: ExecutionContext): IO[Unit] = {
+    errorReporters.logFailure(testEnvironment, ciEnvironment, throwable)
   }
 }

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
@@ -52,9 +52,9 @@ class ErrorReporters(rootConfig: Config) {
       IO.raiseError(throwable)
     } else {
       val listIo = errorReporters.map(_.logFailure(testEnvironment, ciEnvironment, throwable))
-      AggregatedIo.aggregateExceptions("Errors while reporting a failure", listIo).handleErrorWith(throwable => {
-        throwable.addSuppressed(throwable)
-        IO.raiseError(throwable)
+      AggregatedIo.aggregateExceptions("Errors while reporting a failure", listIo).handleErrorWith(err => {
+        err.addSuppressed(throwable)
+        IO.raiseError(err)
       }).void
     }
   }

--- a/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
+++ b/centaur/src/it/scala/centaur/reporting/ErrorReporters.scala
@@ -1,7 +1,6 @@
 package centaur.reporting
 
 import cats.effect.IO
-import centaur.test.CentaurTestException
 import centaur.{CentaurConfig, CromwellDatabase}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging

--- a/centaur/src/it/scala/centaur/reporting/GcsReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/GcsReporter.scala
@@ -17,7 +17,10 @@ class GcsReporter(override val params: ErrorReporterParams) extends ErrorReporte
   /** A description of where the reporter is sending the errors. */
   override def destination = "GCS bucket"
 
-  /** Send a report of a centaur failure. */
+  /**
+    * In this ErrorReporter implementation this method will save information about exceptions of type
+    * CentaurTestException to GCS. Exceptions of other types will be ignored.
+    */
   override def logFailure(testEnvironment: TestEnvironment,
                           ciEnvironment: CiEnvironment,
                           throwable: Throwable)

--- a/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
@@ -17,22 +17,30 @@ class Slf4jReporter(override val params: ErrorReporterParams)
 
   override lazy val destination: String = "error"
 
-  override def logCentaurFailure(testEnvironment: TestEnvironment,
-                                 ciEnvironment: CiEnvironment,
-                                 centaurTestException: CentaurTestException)
-                                (implicit executionContext: ExecutionContext): IO[Unit] = {
+  override def logFailure(testEnvironment: TestEnvironment,
+                          ciEnvironment: CiEnvironment,
+                          throwable: Throwable)
+                         (implicit executionContext: ExecutionContext): IO[Unit] = {
     IO {
+
+      val errorMessage = throwable match {
+        case centaurTestException: CentaurTestException =>
+          centaurTestException.workflowIdOption.map("with workflow id '" + _ + "' ").getOrElse("")
+        case nonCentaurException =>
+          s"with unexpected non-Centaur exception $nonCentaurException"
+      }
+
       val message =
         s"Test '${testEnvironment.name}' " +
           s"failed on attempt ${testEnvironment.attempt + 1} " +
           s"of ${testEnvironment.retries + 1} " +
-          centaurTestException.workflowIdOption.map("with workflow id '" + _ + "' ").getOrElse("")
+          errorMessage
 
       // Only log fully on the final attempt. Otherwise log a shortened version
       if (testEnvironment.attempt >= testEnvironment.retries) {
-        logger.error(message, centaurTestException)
+        logger.error(message, throwable)
       } else {
-        val messageWithShortExceptionContext = message + " (" + centaurTestException.message.replace("\n", " ").take(150) + "[...])"
+        val messageWithShortExceptionContext = message + " (" + Option(throwable.getMessage).getOrElse("").replace("\n", " ").take(150) + "[...])"
         logger.warn(messageWithShortExceptionContext)
       }
     }

--- a/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
+++ b/centaur/src/it/scala/centaur/reporting/Slf4jReporter.scala
@@ -3,6 +3,7 @@ package centaur.reporting
 import cats.effect.IO
 import centaur.test.CentaurTestException
 import com.typesafe.scalalogging.StrictLogging
+import org.testcontainers.shaded.org.apache.commons.lang.exception.ExceptionUtils
 
 import scala.concurrent.ExecutionContext
 
@@ -40,7 +41,7 @@ class Slf4jReporter(override val params: ErrorReporterParams)
       if (testEnvironment.attempt >= testEnvironment.retries) {
         logger.error(message, throwable)
       } else {
-        val messageWithShortExceptionContext = message + " (" + Option(throwable.getMessage).getOrElse("").replace("\n", " ").take(150) + "[...])"
+        val messageWithShortExceptionContext = message + " (" + ExceptionUtils.getMessage(throwable).replace("\n", " ").take(150) + "[...])"
         logger.warn(messageWithShortExceptionContext)
       }
     }


### PR DESCRIPTION
Some background about this fix:
1. Centaur submits a workflow to Cromwell
2. Workflow succeeds
3. Some non-CentaurTestException exception occurs
4. Centaur swallows it silently and resubmits the workflow.
5. The resubmitted workflow succeeds using call cached results
6. Centaur test fails because tasks of the workflow are not expected to be call cached

This fix alters #4 from the above list and makes Centaur to report the exception before resubmitting the workflow. It doesn't solve the flakiness problem itself, but at least we'll see what happened the during the failed attempt

Regarding the non-CentaurTestException which caused flakiness in the first place I suspect the TimeoutExceptions happening in CentaurCromwellClient, but not 100% sure