### PR TITLE
[AWS] Exit job with same exit code as rc file

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -212,6 +212,8 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
          |echo '*** DELOCALIZING OUTPUTS ***'
          |$outputCopyCommand
          |echo '*** COMPLETED DELOCALIZATION ***'
+         |echo '*** EXITING WITH RC CODE ***'
+         |exit $$(head -n 1 $workDir/${jobPaths.returnCodeFilename})
          |}
          |""".stripMargin
   }


### PR DESCRIPTION
On the current implementation of AWS backend, if there are no files to delocalize, AWS Batch will see the task as succeeded, even if it something fails on the command script. So, in the worst case, it can happen that for cromwell the task failed and for AWS Batch it succeeded. 

With this change that I propose, after the delocalization process, we will exit the script with the same exit code as the one written on rc file. 