### PR TITLE
Stabilize docker image for cache tests [CROM-6704]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_false.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_false.wdl
@@ -11,7 +11,7 @@ task check_if_docker_image_cache_disk_mounted {
     fi
   }
   runtime {
-    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     backend: "Papiv2-Docker-Image-Cache"
     useDockerImageCache: false
   }

--- a/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_true.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_true.wdl
@@ -2,14 +2,14 @@ version 1.0
 
 task check_if_docker_image_cache_disk_mounted {
   String google_docker_cache_disk_name = "google-docker-cache"
-  command <<<
+  command {
     instance_metadata_disks=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/disks/?recursive=true" -H "Metadata-Flavor: Google")
     if [[ "$instance_metadata_disks" == *~{google_docker_cache_disk_name}* ]]; then
       echo "true"
     else
       echo "false"
     fi
-  >>>
+  }
   runtime {
     docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     backend: "Papiv2-Docker-Image-Cache"

--- a/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_true.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_true.wdl
@@ -2,16 +2,16 @@ version 1.0
 
 task check_if_docker_image_cache_disk_mounted {
   String google_docker_cache_disk_name = "google-docker-cache"
-  command {
+  command <<<
     instance_metadata_disks=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/disks/?recursive=true" -H "Metadata-Flavor: Google")
     if [[ "$instance_metadata_disks" == *~{google_docker_cache_disk_name}* ]]; then
       echo "true"
     else
       echo "false"
     fi
-  }
+  >>>
   runtime {
-    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     backend: "Papiv2-Docker-Image-Cache"
     useDockerImageCache: true
   }

--- a/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_unspecified.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_image_cache/docker_image_cache_unspecified.wdl
@@ -11,7 +11,7 @@ task check_if_docker_image_cache_disk_mounted {
     fi
   }
   runtime {
-    docker: "gcr.io/gcp-runtimes/ubuntu_16_0_4:latest"
+    docker: "us.gcr.io/broad-gatk/gatk:4.1.3.0"
     backend: "Papiv2-Docker-Image-Cache"
   }
   meta {


### PR DESCRIPTION
Switches the cache tests to use the GATK image, on the assumption that its specifically versioned tag is much less likely to move than `ubuntu:latest`