### PR TITLE
De-emphasize run mode [BW-563]

### DIFF
--- a/docs/CommandLine.md
+++ b/docs/CommandLine.md
@@ -34,11 +34,11 @@ The Cromwell jar file can be built as described in [Building](Building).
 
 ## `server`
 
-`server` mode accepts no arguments and runs Cromwell as a web server that accepts REST requests. See the documentation for [Cromwell's REST endpoints](/api/RESTAPI) for how to interact with Cromwell in `server` mode.
+`server` mode accepts no arguments and runs Cromwell as a web server that accepts REST requests. The default mode for most applications of Cromwell, suitable for production use. See the documentation for [Cromwell's REST endpoints](/api/RESTAPI) for how to interact with Cromwell in `server` mode.
 
 ## `run`
 
-`run` mode executes a single workflow in Cromwell and then exits.
+`run` mode executes a single workflow in Cromwell and then exits. It is designed for local prototyping or demos and has limited features compared to `server`.
 
 * **`workflow-source`**  
 The single required argument. It can be either a local path or a remote URL pointing to the workflow source file.

--- a/docs/Modes.md
+++ b/docs/Modes.md
@@ -1,19 +1,14 @@
+## Server
+
+The default mode for most applications of Cromwell, suitable for production use. Server mode starts Cromwell as a web server that exposes REST endpoints. All features and APIs are available.
+
+By default the server will be accessible at `http://localhost:8000`. See the [Server Section](Configuring#server) of the configuration for more information on how to configure it. A description of the endpoints can be found in the [API Section](api/RESTAPI).
+
+Follow the [Server Tutorial](tutorials/ServerMode) to get your Cromwell server up and running in a few steps.
+
 ## Run
 
-Run mode will run a single workflow from the command line, and exit when the workflow completes (successfully or not).
-The exit code of the run command will be `0` if the workflow succeeds or is aborted, `1` if it fails.
+A good way to get started with Cromwell and experiment quickly. Run mode launches a single workflow from the command line and exits `0` or `1` to indicate the result. Appropriate for prototyping or demo use on a user's local machine. Features are limited and the web API is not supported.
 
 Sending a `SIGINT` signal (via `CTRL-C` for example) will by default abort all running jobs and then exit.
 This behavior can be configured, and is explained in more details in the [Abort](Configuring#abort) section of the configuration.
-
-Run mode is a good way to get started with Cromwell and experiment quickly.
-For more advanced use cases involving large workflows or multi-tenancy for example, Server mode is recommended. It also offers a larger set of features through its endpoints that are not available in run mode.
-
-## Server
-
-Server mode will start Cromwell as a web server that exposes REST endpoints.
-By default the server will be accessible at `http://localhost:8000`. See the [Server Section](Configuring#server) of the configuration for more information on how to configure it.
-
-A description of those endpoints can be found in the [API Section](api/RESTAPI).
-
-Follow the [Server Tutorial](tutorials/ServerMode) to get your Cromwell server up and running in a few steps !


### PR DESCRIPTION
Users often file issues suggesting they are using run mode for production or production-like use cases and running into its known limitations.

Let's do a better job explaining its intended purpose.

h/t @geoffjentry for the clues on its origin.