### PR TITLE
Ensure stdout and stderr always exist for delocalization [BW-620]

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -444,6 +444,7 @@ trait StandardAsyncExecutionActor
         |$out="$${tmpDir}/out.$$$$" $err="$${tmpDir}/err.$$$$"
         |mkfifo "$$$out" "$$$err"
         |trap 'rm "$$$out" "$$$err"' EXIT
+        |touch $stdoutRedirection $stderrRedirection
         |tee $stdoutRedirection < "$$$out" &
         |tee $stderrRedirection < "$$$err" >&2 &
         |(


### PR DESCRIPTION
Outcome of a "I wonder whether...." investigation into missing stdout files in approximately 0.01% of cases if no content is written to `stdout`. Probably a relatively low priority for "real" users - but useful from a marketing perspective to be able to get to 100% success in such workflows.