### PR TITLE
Dependency bot fixup [BW-615]

### DIFF
--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -5,6 +5,7 @@ name: combine-scalasteward-prs
   # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       prLimit:
@@ -25,9 +26,11 @@ jobs:
           git config user.name "broadbot"
 
           echo "Bringing in PRs:"
-          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
+          #gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
+          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n10
 
-          PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
+          #PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
+          PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n10)
           BRANCH="consolidated-scala-steward-prs-$(date +'%Y-%m-%d_%H-%M')"
 
           SUCCESSFUL_PRS=()

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -43,7 +43,7 @@ jobs:
             git fetch origin pull/${pr}/head:pr_${pr}
 
             git checkout $BRANCH
-            git merge -m "merging PR #${pr}" pr_${pr} && EXIT_CODE=$? || EXIT_CODE=$?
+            git merge -m "merging PR #${pr}" pr_${pr} --allow-unrelated-histories && EXIT_CODE=$? || EXIT_CODE=$?
 
             if [ "${EXIT_CODE}" == "0" ]
             then

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -5,7 +5,6 @@ name: combine-scalasteward-prs
   # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       prLimit:
@@ -26,11 +25,9 @@ jobs:
           git config user.name "broadbot"
 
           echo "Bringing in PRs:"
-          #gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
-          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n10
+          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          #PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
-          PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n10)
+          PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
           BRANCH="consolidated-scala-steward-prs-$(date +'%Y-%m-%d_%H-%M')"
 
           SUCCESSFUL_PRS=()


### PR DESCRIPTION
Follows on from https://github.com/broadinstitute/cromwell/pull/6284. Allowing unrelated histories turns out to be important when the scala-steward branches are behind the head of develop (eg because someone just merged some more content in)

Note, as with #6284, skipping CI and code-cov because this is updating a github action, not a code change.