### PR TITLE
Shared IntelliJ config [BW-634]

### DIFF
--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -1,0 +1,26 @@
+<!--
+Start DB:
+  docker run -d -e MYSQL_ROOT_PASSWORD=private -e MYSQL_USER=cromwell -e MYSQL_PASSWORD=test -e MYSQL_DATABASE=cromwell_test -p 3306:3306 -v ${PWD}/src/ci/docker-compose/mysql-conf.d:/etc/mysql/conf.d mysql:5.6
+-->
+
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Cromwell server" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <envs>
+      <env name="CROMWELL_BUILD_CENTAUR_SLICK_PROFILE" value="slick.jdbc.MySQLProfile$" />
+      <env name="CROMWELL_BUILD_CENTAUR_JDBC_DRIVER" value="com.mysql.cj.jdbc.Driver" />
+      <env name="CROMWELL_BUILD_CENTAUR_JDBC_URL" value="jdbc:mysql://localhost:3306/cromwell_test?allowPublicKeyRetrieval=true&amp;useSSL=false&amp;rewriteBatchedStatements=true&amp;serverTimezone=UTC&amp;useInformationSchema=true" />
+      <env name="CROMWELL_BUILD_RESOURCES_DIRECTORY" value="target/ci/resources" />
+      <env name="CROMWELL_BUILD_PAPI_JSON_FILE" value="$HOME/Projects/cromwell/target/ci/resources/cromwell-centaur-service-account.json" />
+      <env name="CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT" value="128000" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="cromwell.CromwellApp" />
+    <module name="cromwell" />
+    <option name="PROGRAM_PARAMETERS" value="server" />
+    <option name="VM_PARAMETERS" value="-Dconfig.file=src/ci/resources/local_application.conf" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -1,5 +1,10 @@
+<!--
+Start DB:
+  docker run -d -e MYSQL_ROOT_PASSWORD=private -e MYSQL_USER=cromwell -e MYSQL_PASSWORD=test -e MYSQL_DATABASE=cromwell_test -p 3306:3306 -v ${PWD}/src/ci/docker-compose/mysql-conf.d:/etc/mysql/conf.d mysql:5.6
+-->
+
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Cromwell server" type="Application" factoryName="Application">
+  <configuration default="false" name="Cromwell server (shared)" type="Application" factoryName="Application">
     <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <envs>

--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -1,8 +1,3 @@
-<!--
-Start DB:
-  docker run -d -e MYSQL_ROOT_PASSWORD=private -e MYSQL_USER=cromwell -e MYSQL_PASSWORD=test -e MYSQL_DATABASE=cromwell_test -p 3306:3306 -v ${PWD}/src/ci/docker-compose/mysql-conf.d:/etc/mysql/conf.d mysql:5.6
--->
-
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Cromwell server" type="Application" factoryName="Application">
     <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
@@ -12,7 +7,7 @@ Start DB:
       <env name="CROMWELL_BUILD_CENTAUR_JDBC_DRIVER" value="com.mysql.cj.jdbc.Driver" />
       <env name="CROMWELL_BUILD_CENTAUR_JDBC_URL" value="jdbc:mysql://localhost:3306/cromwell_test?allowPublicKeyRetrieval=true&amp;useSSL=false&amp;rewriteBatchedStatements=true&amp;serverTimezone=UTC&amp;useInformationSchema=true" />
       <env name="CROMWELL_BUILD_RESOURCES_DIRECTORY" value="target/ci/resources" />
-      <env name="CROMWELL_BUILD_PAPI_JSON_FILE" value="$HOME/Projects/cromwell/target/ci/resources/cromwell-centaur-service-account.json" />
+      <env name="CROMWELL_BUILD_PAPI_JSON_FILE" value="target/ci/resources/cromwell-centaur-service-account.json" />
       <env name="CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT" value="128000" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="cromwell.CromwellApp" />

--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -1,10 +1,5 @@
-<!--
-Start DB:
-  docker run -d -e MYSQL_ROOT_PASSWORD=private -e MYSQL_USER=cromwell -e MYSQL_PASSWORD=test -e MYSQL_DATABASE=cromwell_test -p 3306:3306 -v ${PWD}/src/ci/docker-compose/mysql-conf.d:/etc/mysql/conf.d mysql:5.6
--->
-
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Cromwell server (shared)" type="Application" factoryName="Application">
+  <configuration default="false" name="Repo template: Cromwell server" type="Application" factoryName="Application">
     <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <envs>


### PR DESCRIPTION
IntelliJ automatically locates this file in the repo and shows it as a run configuration.

More convenient to clone that template & modify than to fill in all these fields manually based on prose documentation.

Tested by sending to Bec and it was recognized.