### PR TITLE
Remove obsolete config setting [BT-216]

### DIFF
--- a/src/ci/resources/papi_v2_shared_application.inc.conf
+++ b/src/ci/resources/papi_v2_shared_application.inc.conf
@@ -177,9 +177,7 @@ backend {
 
         genomics.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
         filesystems.http {}
-        # Old Cromwell 55 and 56 level-of-indirection-to-GCS reference disk manifest specification
-        # Currently required for engine upgrade test cases but should be deleted after Cromwell 57 is published.
-        reference-disk-localization-manifest-files = ["gs://gcp-public-data--broad-references/refdisk_manifest.json"]
+
         # Cromwell 57+ reference disk manifest specification included here.
         include "papi_v2_reference_image_manifest.conf"
 


### PR DESCRIPTION
Removes an alarming but harmless warning in CI.