### PR TITLE
Archiving scale fixes: Pin fetchSize for DB stream, better metric reporting [BW-610]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -127,14 +127,13 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     runTransaction(action, timeout = timeout)
   }
 
-  override def streamMetadataEntries(workflowExecutionUuid: String,
-                                     fetchSize: Int): DatabasePublisher[MetadataEntry] = {
+  override def streamMetadataEntries(workflowExecutionUuid: String): DatabasePublisher[MetadataEntry] = {
     val action = dataAccess.metadataEntriesForWorkflowExecutionUuid(workflowExecutionUuid)
       .result
       .withStatementParameters(
         rsType = ResultSetType.ForwardOnly,
         rsConcurrency = ResultSetConcurrency.ReadOnly,
-        fetchSize = fetchSize)
+        fetchSize = Integer.MIN_VALUE)
     database.stream(action)
   }
 

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -133,6 +133,8 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
       .withStatementParameters(
         rsType = ResultSetType.ForwardOnly,
         rsConcurrency = ResultSetConcurrency.ReadOnly,
+        // Magic number alert: fetchSize is set to MIN_VALUE for MySQL to stream rather than cache in memory first.
+        // Inspired by: https://github.com/slick/slick/issues/1218
         fetchSize = Integer.MIN_VALUE)
     database.stream(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -44,8 +44,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            timeout: Duration)
                           (implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
-  def streamMetadataEntries(workflowExecutionUuid: String,
-                            fetchSize: Int): DatabasePublisher[MetadataEntry]
+  def streamMetadataEntries(workflowExecutionUuid: String): DatabasePublisher[MetadataEntry]
 
   def countMetadataEntries(workflowExecutionUuid: String,
                            expandSubWorkflows: Boolean,

--- a/services/src/main/scala/cromwell/services/instrumentation/AsynchronousThrottlingGaugeMetricActor.scala
+++ b/services/src/main/scala/cromwell/services/instrumentation/AsynchronousThrottlingGaugeMetricActor.scala
@@ -38,7 +38,7 @@ class AsynchronousThrottlingGaugeMetricActor(metricPath: NonEmptyList[String],
       sendGauge(metricPath, value, instrumentationPrefix)
       goto(WaitingForMetricCalculationRequestOrMetricValue)
     case Event(Status.Failure(ex), _) =>
-      log.error(s"Cannot send gauge metric value: error occurred while evaluating Future value.", ex)
+      log.error(ex, s"Cannot send gauge metric value: error occurred while evaluating Future value.")
       goto(WaitingForMetricCalculationRequestOrMetricValue)
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -107,7 +107,7 @@ object MetadataService {
     override def workflowId: WorkflowId = key.workflowId
   }
 
-  final case class GetMetadataStreamAction(workflowId: WorkflowId, fetchSize: Int) extends MetadataServiceAction
+  final case class GetMetadataStreamAction(workflowId: WorkflowId) extends MetadataServiceAction
 
   final case class GetStatus(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction
   final case class GetLabels(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -156,8 +156,8 @@ trait MetadataDatabaseAccess {
     }
   }
 
-  def metadataEventsStream(workflowId: WorkflowId, fetchSize: Int): Try[DatabasePublisher[MetadataEntry]] = {
-    Try(metadataDatabaseInterface.streamMetadataEntries(workflowId.id.toString, fetchSize))
+  def metadataEventsStream(workflowId: WorkflowId): Try[DatabasePublisher[MetadataEntry]] = {
+    Try(metadataDatabaseInterface.streamMetadataEntries(workflowId.id.toString))
   }
 
   def queryMetadataEvents(query: MetadataQuery, timeout: Duration)(implicit ec: ExecutionContext): Future[Seq[MetadataEvent]] = {

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -29,8 +29,8 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataRea
   def receive = {
     case GetMetadataAction(query: MetadataQuery, checkTotalMetadataRowNumberBeforeQuerying: Boolean) =>
       evaluateRespondAndStop(sender(), getMetadata(query, checkTotalMetadataRowNumberBeforeQuerying))
-    case GetMetadataStreamAction(workflowId, fetchSize) =>
-      evaluateRespondAndStop(sender(), Future.fromTry(getMetadataStream(workflowId, fetchSize)))
+    case GetMetadataStreamAction(workflowId) =>
+      evaluateRespondAndStop(sender(), Future.fromTry(getMetadataStream(workflowId)))
     case GetStatus(workflowId) => evaluateRespondAndStop(sender(), getStatus(workflowId))
     case GetLabels(workflowId) => evaluateRespondAndStop(sender(), queryLabelsAndRespond(workflowId))
     case GetRootAndSubworkflowLabels(rootWorkflowId: WorkflowId) => evaluateRespondAndStop(sender(), queryRootAndSubworkflowLabelsAndRespond(rootWorkflowId))
@@ -68,8 +68,8 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataRea
     }
   }
 
-  private def getMetadataStream(workflowId: WorkflowId, fetchSize: Int): Try[MetadataServiceResponse] = {
-    metadataEventsStream(workflowId, fetchSize) map {
+  private def getMetadataStream(workflowId: WorkflowId): Try[MetadataServiceResponse] = {
+    metadataEventsStream(workflowId) map {
       s => MetadataLookupStreamSuccess(workflowId, s)
     } recover {
       case t => MetadataLookupStreamFailed(workflowId, t)

--- a/services/src/main/scala/cromwell/services/metadata/impl/archiver/ArchiveMetadataConfig.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/archiver/ArchiveMetadataConfig.scala
@@ -18,7 +18,6 @@ import scala.util.Try
 final case class ArchiveMetadataConfig(pathBuilders: PathBuilders,
                                        bucket: String,
                                        backoffInterval: FiniteDuration,
-                                       databaseStreamFetchSize: Int,
                                        archiveDelay: FiniteDuration,
                                        debugLogging: Boolean) {
 }
@@ -36,9 +35,8 @@ object ArchiveMetadataConfig {
         .toCheckedWithContext("construct archiver path builders from factories")
       bucket <- Try(archiveMetadataConfig.getString("bucket")).toCheckedWithContext("parse Carboniter 'bucket' field from config")
       backoffInterval <- Try(archiveMetadataConfig.getOrElse[FiniteDuration]("backoff-interval", defaultMaxInterval)).toChecked
-      databaseStreamFetchSize <- Try(archiveMetadataConfig.getOrElse[Int]("database-stream-fetch-size", 100)).toChecked
       archiveDelay <- Try(archiveMetadataConfig.getOrElse("archive-delay", defaultArchiveDelay)).toChecked
       debugLogging <- Try(archiveMetadataConfig.getOrElse("debug-logging", defaultDebugLogging)).toChecked
-    } yield ArchiveMetadataConfig(pathBuilders, bucket, backoffInterval, databaseStreamFetchSize, archiveDelay, debugLogging)
+    } yield ArchiveMetadataConfig(pathBuilders, bucket, backoffInterval, archiveDelay, debugLogging)
   }
 }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -160,8 +160,7 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
                                       timeout: Duration)
                                      (implicit ec: ExecutionContext): Nothing = notImplemented()
 
-    override def streamMetadataEntries(workflowExecutionUuid: String,
-                                       fetchSize: Int): Nothing = notImplemented()
+    override def streamMetadataEntries(workflowExecutionUuid: String): Nothing = notImplemented()
 
     override def queryMetadataEntries(workflowExecutionUuid: String,
                                       metadataKey: String,

--- a/src/ci/resources/enable_metadata_archiving.inc.conf
+++ b/src/ci/resources/enable_metadata_archiving.inc.conf
@@ -21,8 +21,8 @@ services.MetadataService {
       # How long to require after workflow completion before going ahead with archiving:
       archive-delay = 10 minutes
 
-      # How many rows to fetch from the DB at a time while streaming:
-      database-stream-fetch-size = 1000
+      # Turn on debug logging from the archiver classes:
+      debug-logging = true
     }
   }
 }


### PR DESCRIPTION
- Removes the `fetchSize` configuration because it turns out we need to pin it at `Integer.MIN_VALUE`
- Pins the `fetchSize` at `Integer.MIN_VALUE`, for the same reason
- Adds more frequent metrics outputs during large workflow uploads, AND when there is nothing being uploaded