### PR TITLE
Remove dead metadata code [BW-654]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -469,12 +469,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     }
   }
 
-  override def isRootWorkflow(rootWorkflowId: String)(implicit ec: ExecutionContext): Future[Option[Boolean]] = {
-    runTransaction(
-      dataAccess.isRootWorkflow(rootWorkflowId).result.headOption
-    )
-  }
-
   override def getRootWorkflowId(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
     runAction(
       dataAccess.rootWorkflowId(workflowId).result.headOption

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -487,12 +487,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     )
   }
 
-  override def countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp)(implicit ec: ExecutionContext): Future[Int] = {
-    runAction(
-      dataAccess.countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp((archiveStatus, thresholdTimestamp)).result
-    )
-  }
-
   override def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] =
     runAction(
       countSummaryQueueEntries()

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
@@ -100,15 +100,6 @@ trait WorkflowMetadataSummaryEntryComponent {
     } yield workflowMetadataSummaryEntry.workflowStatus
   )
 
-  val isRootWorkflow = Compiled(
-    (workflowId: Rep[String]) => for {
-      summary <- workflowMetadataSummaryEntries
-      if summary.workflowExecutionUuid === workflowId
-    } yield {
-      summary.rootWorkflowExecutionUuid.isEmpty && summary.parentWorkflowExecutionUuid.isEmpty
-    }
-  )
-
   val rootWorkflowId = Compiled(
     (workflowId: Rep[String]) => for {
       summary <- workflowMetadataSummaryEntries

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
@@ -80,16 +80,6 @@ trait WorkflowMetadataSummaryEntryComponent {
       } yield summary.workflowExecutionUuid).take(batchSize)
     })
 
-  val countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp = Compiled(
-    (metadataArchiveStatus: Rep[Option[String]], workflowEndTimestampThreshold: Rep[Timestamp]) => {
-      (for {
-        summary <- workflowMetadataSummaryEntries
-        if summary.rootWorkflowExecutionUuid.isEmpty && summary.parentWorkflowExecutionUuid.isEmpty // is root workflow entry
-        if summary.metadataArchiveStatus === metadataArchiveStatus
-        if summary.endTimestamp <= workflowEndTimestampThreshold
-      } yield summary.workflowExecutionUuid).length
-    })
-
   val workflowMetadataSummaryEntriesForWorkflowExecutionUuid = Compiled(
     (workflowExecutionUuid: Rep[String]) => for {
       workflowMetadataSummaryEntry <- workflowMetadataSummaryEntries

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -185,8 +185,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def queryWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp, batchSizeOpt: Long)(implicit ec: ExecutionContext): Future[Seq[String]]
 
-  def countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp)(implicit ec: ExecutionContext): Future[Int]
-
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int]
 
   def getMetadataArchiveStatus(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]]

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -179,8 +179,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def deleteAllMetadataForWorkflowAndUpdateArchiveStatus(rootWorkflowId: String, newArchiveStatus: Option[String])(implicit ec: ExecutionContext): Future[Int]
 
-  def isRootWorkflow(rootWorkflowId: String)(implicit ec: ExecutionContext): Future[Option[Boolean]]
-
   def getRootWorkflowId(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]]
 
   def queryWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp, batchSizeOpt: Long)(implicit ec: ExecutionContext): Future[Seq[String]]

--- a/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
@@ -20,6 +20,8 @@ case class EngineWorkflowDescriptor(topLevelCallable: Callable,
     case None => this
   }
 
+  def isRootWorkflow: Boolean = rootWorkflow.parentWorkflow.isEmpty
+
   lazy val id = backendDescriptor.id
   lazy val possiblyNotRootWorkflowId = id.toPossiblyNotRoot
   lazy val rootWorkflowId = rootWorkflow.id.toRoot

--- a/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
+++ b/engine/src/main/scala/cromwell/engine/EngineWorkflowDescriptor.scala
@@ -20,8 +20,6 @@ case class EngineWorkflowDescriptor(topLevelCallable: Callable,
     case None => this
   }
 
-  def isRootWorkflow: Boolean = rootWorkflow.parentWorkflow.isEmpty
-
   lazy val id = backendDescriptor.id
   lazy val possiblyNotRootWorkflowId = id.toPossiblyNotRoot
   lazy val rootWorkflowId = rootWorkflow.id.toRoot

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -359,9 +359,6 @@ trait MetadataDatabaseAccess {
   def queryWorkflowIdsByArchiveStatusAndOlderThanTimestamp(archiveStatus: Option[String], thresholdTimestamp: OffsetDateTime, batchSize: Long)(implicit ec: ExecutionContext): Future[Seq[String]] =
     metadataDatabaseInterface.queryWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus, thresholdTimestamp.toSystemTimestamp, batchSize)
 
-  def countRootWorkflowSummaryEntriesByArchiveStatusAndOlderThanTimestamp(archiveStatus: Option[String], thresholdTimestamp: OffsetDateTime)(implicit ec: ExecutionContext): Future[Int] =
-    metadataDatabaseInterface.countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus, thresholdTimestamp.toSystemTimestamp)
-
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] =
     metadataDatabaseInterface.getSummaryQueueSize()
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/archiver/ArchiveMetadataSchedulerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/archiver/ArchiveMetadataSchedulerActor.scala
@@ -99,8 +99,8 @@ class ArchiveMetadataSchedulerActor(archiveMetadataConfig: ArchiveMetadataConfig
       maybeWorkflowQueryResult <- lookupNextWorkflowToArchive()
       result <- maybeWorkflowQueryResult match {
         case Some(workflow) => for {
+          path <- Future.fromTry(getGcsPathForMetadata(workflow))
           dbStream <- fetchStreamFromDatabase(WorkflowId(UUID.fromString(workflow.id)))
-          path: Path <- Future.fromTry(getGcsPathForMetadata(workflow))
           _ = log.info(s"Archiving metadata for ${workflow.id} to ${path.pathAsString}")
           _ <- streamMetadataToGcs(path, dbStream)
           _ <- updateMetadataArchiveStatus(WorkflowId(UUID.fromString(workflow.id)), Archived)

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -266,10 +266,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
       notImplemented()
     }
 
-    override def isRootWorkflow(rootWorkflowId: String)(implicit ec: ExecutionContext): Future[Option[Boolean]] = {
-      notImplemented()
-    }
-
     override def getRootWorkflowId(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
       notImplemented()
     }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -278,10 +278,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
       notImplemented()
     }
 
-    override def countRootWorkflowIdsByArchiveStatusAndEndedOnOrBeforeThresholdTimestamp(archiveStatus: Option[String], thresholdTimestamp: Timestamp)(implicit ec: ExecutionContext): Future[Int] = {
-      notImplemented()
-    }
-
     override def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] = {
       notImplemented()
     }


### PR DESCRIPTION
These methods date to a previous version of archiving based on root workflow IDs. When I see them floating around I second-guess whether we're still using roots or not.