### PR TITLE
Minor fixes to Cromwell server repo config [BT-243]

### DIFF
--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Repo template: Cromwell server" type="Application" factoryName="Application">
     <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <envs>
       <env name="CROMWELL_BUILD_CENTAUR_SLICK_PROFILE" value="slick.jdbc.MySQLProfile$" />
       <env name="CROMWELL_BUILD_CENTAUR_JDBC_DRIVER" value="com.mysql.cj.jdbc.Driver" />
@@ -13,9 +12,10 @@
     <option name="MAIN_CLASS_NAME" value="cromwell.CromwellApp" />
     <module name="cromwell" />
     <option name="PROGRAM_PARAMETERS" value="server" />
-    <option name="VM_PARAMETERS" value="-Dconfig.file=src/ci/resources/local_application.conf" />
+    <option name="VM_PARAMETERS" value="-Dconfig.file=target/ci/resources/local_application.conf" />
     <method v="2">
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="renderCiResources" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>
 </component>

--- a/runConfigurations/renderCiResources.run.xml
+++ b/runConfigurations/renderCiResources.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="renderCiResources" type="SbtRunConfiguration" factoryName="sbt Task" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="projectPathOnTarget" />
+    <option name="selectedOptions">
+      <list />
+    </option>
+    <option name="tasks" value="renderCiResources" />
+    <option name="useSbtShell" value="false" />
+    <option name="vmparams" value="-Xms512M -Xmx1024M -Xss1M -XX:+CMSClassUnloadingEnabled" />
+    <option name="workingDir" value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
tyvm for the super useful repo config! I found a couple of minor issues while working on BT-226 as documented in BT-243.

Before: 
<img width="649" alt="Screen Shot 2021-04-25 at 11 11 12 AM" src="https://user-images.githubusercontent.com/10790523/115998865-5cd51a00-a5b7-11eb-9165-8a4abb8a340c.png">

After:
<img width="649" alt="Screen Shot 2021-04-25 at 11 15 01 AM" src="https://user-images.githubusercontent.com/10790523/115998922-a9b8f080-a5b7-11eb-834e-db6dfbef292b.png">

