### PR TITLE
Fix broken links referencing backend conf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1157,7 +1157,7 @@ data. When switching connection information for an existing database containing 
 should be manually replicated from one database instance to another using the tools appropriate for your specific
 database types. Cromwell will not move any existing data automatically. This feature should be considered experimental
 and likely to change in the future. See the [Database Documentation](https://cromwell.readthedocs.io/en/develop/Configuring/#database) or the `database` section in
-[cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf) for more
+[cromwell.examples.conf](https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf) for more
 information.
 
 * **StatsD**  

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -476,7 +476,7 @@ ontology {
 }
 
 
-# Other backend examples are in cromwell.examples.conf
+# Other backend examples are in cromwell.example.backends
 backend {
   default = "Local"
   providers {

--- a/cromwell.example.backends/AWS.conf
+++ b/cromwell.example.backends/AWS.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the Amazon Web Services Backend
 # provider. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/BCS.conf
+++ b/cromwell.example.backends/BCS.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the Alibaba Cloud Batch Compute (BCS)
 # backend provider. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/Docker.conf
+++ b/cromwell.example.backends/Docker.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use Docker only workflows as a Cromwell
 # backend provider. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/HtCondor.conf
+++ b/cromwell.example.backends/HtCondor.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the the HtCondor backend with Cromwell.
 # *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/LSF.conf
+++ b/cromwell.example.backends/LSF.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the LSF platform backend
 # with Cromwell. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the LocalExample backend to define
 # a new backend provider. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/PAPIv2.conf
+++ b/cromwell.example.backends/PAPIv2.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the Google Pipelines API backend
 # provider. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://broadworkbench.atlassian.net/projects/BA/issues
 

--- a/cromwell.example.backends/SGE.conf
+++ b/cromwell.example.backends/SGE.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the the Sungrid Engine backend
 # for Cromwell. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/TES.conf
+++ b/cromwell.example.backends/TES.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the TES backend provider. 
 # *This is not a complete configuration file!* The
 # content here should be copy pasted to the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/TESK.conf
+++ b/cromwell.example.backends/TESK.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use the TES (with kubernetes) 
 # backend provider, *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/singularity.conf
+++ b/cromwell.example.backends/singularity.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use Singularity containers with Cromwell
 # *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/singularity.slurm.conf
+++ b/cromwell.example.backends/singularity.slurm.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use Singularity containers with Cromwell
 # *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/slurm.conf
+++ b/cromwell.example.backends/slurm.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use Cromwell to interact with SLURM
 # workload manager. *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/udocker.conf
+++ b/cromwell.example.backends/udocker.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use udocker with Cromwell
 # *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/udocker.slurm.conf
+++ b/cromwell.example.backends/udocker.slurm.conf
@@ -1,8 +1,8 @@
 # This is an example of how you can use udocker containers with slurm
 # *This is not a complete configuration file!* The
 # content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 

--- a/cromwell.example.backends/volcano.conf
+++ b/cromwell.example.backends/volcano.conf
@@ -3,8 +3,8 @@
 # This is an example of how you can use Cromwell to interact with Volcano
 # batch system on kubernetes. *This is not a complete configuration file!*
 # The content here should be copy pasted into the backend -> providers section
-# of the cromwell.examples.conf in the root of the repository. You should
-# uncomment lines that you want to define, and read carefully to customize
+# of cromwell.example.backends/cromwell.examples.conf in the root of the repository.
+# You should uncomment lines that you want to define, and read carefully to customize
 # the file. If you have any questions, please feel free to open an issue at
 # https://www.github.com/broadinstitute/cromwell/issues
 # or

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -559,7 +559,7 @@ per-backend basis with `<config-key-for-backend>.job-shell`. For example:
 For the Config backend the value of the job shell will be available in the `${job_shell}` variable. See Cromwell's `reference.conf` for an example
 of how this is used for the default configuration of the `Local` backend.
 
-[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf
 [cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends
 
 ### Workflow Heartbeats

--- a/docs/cromwell_features/HogFactors.md
+++ b/docs/cromwell_features/HogFactors.md
@@ -207,4 +207,4 @@ assign all workflows to the same hog-group in their workflow options.
     + To set this as the default, you can add a value to the default workflow options. 
     + For an example see the `workflow-options` / `default` stanza of [cromwell.examples.conf][cromwell-examples-conf].
 
-[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf

--- a/docs/tutorials/ConfigurationFiles.md
+++ b/docs/tutorials/ConfigurationFiles.md
@@ -64,7 +64,7 @@ In addition to the common configuration properties listed on the [configuration]
 backend provider examples in [cromwell.example.backends][cromwell-examples-folder].
 
 
-[cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf).
+[cromwell.examples.conf](https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf).
 
 ### Next Steps
 
@@ -73,5 +73,5 @@ After completing this tutorial you might find the following pages interesting:
 * [Configuring the Local Backend](LocalBackendIntro)
 * [Server Mode](ServerMode.md)
 
-[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf
 [cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends

--- a/docs/tutorials/Containers.md
+++ b/docs/tutorials/Containers.md
@@ -512,5 +512,5 @@ Congratulations for improving the reproducibility of your workflows! You might f
 - [Getting started on Alibaba Cloud](BCSIntro/)
 
 
-[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
+[cromwell-examples-conf]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends/cromwell.examples.conf
 [cromwell-examples-folder]: https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.example.backends


### PR DESCRIPTION
Going through the docs, I hit two broken links:
 - https://www.github.com/broadinstitute/cromwell/tree/develop/cromwell.examples.conf
 - https://www.github.com/broadinstitute/cromwell/blob/develop/cromwell.examples.conf

This fixes those links and corrects them to:
- https://github.com/broadinstitute/cromwell/blob/develop/cromwell.example.backends/cromwell.examples.conf
