### PR TITLE
Discontinue sort by summary ID [BW-692]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
@@ -139,7 +139,7 @@ trait WorkflowMetadataSummaryEntryComponent {
     fetchAllWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(
       workflowStatuses,
       workflowEndTimestampThreshold
-    ).sortBy(_.workflowMetadataSummaryEntryId).take(batchSize)
+    ).take(batchSize)
   }
 
   def countWorkflowsLeftToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String],


### PR DESCRIPTION
@salonishah11 I think you introduced the `sortBy` in https://github.com/broadinstitute/cromwell/pull/6325 so I wanted to make sure I'm not missing something essential by removing it.

See [ticket](https://broadworkbench.atlassian.net/browse/BW-692) for my reasoning, tl;dr significant performance gain.