### PR TITLE
Emit 'rows deleted' metric on success as well as failure [BW-707]

### DIFF
--- a/services/src/main/scala/cromwell/services/metadata/impl/deleter/DeleteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/deleter/DeleteMetadataActor.scala
@@ -104,6 +104,7 @@ class DeleteMetadataActor(deleteMetadataConfig: DeleteMetadataConfig,
         log.info(s"Workflow $id identified for metadata deletion")
         for {
           rowsDeleted <- deleteAllMetadataEntriesForWorkflowAndUpdateArchiveStatus(id, MetadataArchiveStatus.toDatabaseValue(ArchivedAndDeleted))
+          _ = count(rowsDeletedMetricPath, rowsDeleted.longValue(), ServicesPrefix)
           _ = log.info(s"Deleted $rowsDeleted metadata rows for $id")
         } yield true
       case None => Future.successful(false)


### PR DESCRIPTION
Confirmed working with an ad-hoc alpha deployment test:

![image](https://user-images.githubusercontent.com/13006282/119009188-debf2580-b960-11eb-90c5-03c397abe1c4.png)
