### PR TITLE
Use genomics auth rather than GCS auth for ref disk validation [BT-303]

### DIFF
--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiConfigurationAttributes.scala
@@ -217,10 +217,10 @@ object PipelinesApiConfigurationAttributes
       (googleConfig.auth(genomicsName), googleConfig.auth(gcsName)) mapN {
         (genomicsAuth, gcsAuth) =>
           val generatedReferenceFilesMappingOpt = referenceDiskLocalizationManifestFilesOpt map {
-            generateReferenceFilesMapping(gcsAuth, _)
+            generateReferenceFilesMapping(genomicsAuth, _)
           }
           val dockerImageToCacheDiskImageMappingOpt = dockerImageCacheManifestFileOpt map {
-            generateDockerImageToDiskImageMapping(gcsAuth, _)
+            generateDockerImageToDiskImageMapping(genomicsAuth, _)
           }
           PipelinesApiConfigurationAttributes(
             project = project,


### PR DESCRIPTION
Use genomics auth rather than GCS auth for reference and Docker image cache validation. GCS auth can be user service account which will not work for this purpose, see BT-303 for more details.