### PR TITLE
Fix confusing metadata-summary-refresh-interval example [BW-733]

### DIFF
--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -485,7 +485,7 @@ services {
     # config {
     #   # For the standard MetadataService implementation, cromwell.services.metadata.impl.MetadataServiceActor:
     #   #   Set this value to "Inf" to turn off metadata summary refresh.  The default value is currently "1 second".
-    #   metadata-summary-refresh-interval = "Inf"
+    #   metadata-summary-refresh-interval = "1 second"
     #
     #   #   Set this value to the maximum number of metadata rows to be considered per summarization cycle.
     #   metadata-summary-refresh-limit = 5000


### PR DESCRIPTION
A user who copy-pasted from this config inadvertently disabled summarization on his unicromtal instance.