### PR TITLE
Emit "time since workflow ended" time metric when accessing metadata [BW-710]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -486,9 +486,9 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
       countSummaryQueueEntries()
     )
 
-  override def getMetadataArchiveStatus(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]] = {
-    val action = dataAccess.metadataArchiveStatusByWorkflowId(workflowId).result.headOption
-    runTransaction(action).map(_.flatten)
+  override def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit ec: ExecutionContext):  Future[(Option[String], Option[Timestamp])] = {
+    val action = dataAccess.metadataArchiveStatusAndEndTimeByWorkflowId(workflowId).result.headOption
+    runTransaction(action).map(_.getOrElse((None, None)))
   }
 
   override def queryWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String],

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowMetadataSummaryEntryComponent.scala
@@ -115,6 +115,12 @@ trait WorkflowMetadataSummaryEntryComponent {
       if workflowMetadataSummaryEntry.workflowExecutionUuid === workflowExecutionUuid
     } yield workflowMetadataSummaryEntry.metadataArchiveStatus)
 
+  val metadataArchiveStatusAndEndTimeByWorkflowId = Compiled(
+    (workflowExecutionUuid: Rep[String]) => for {
+      workflowMetadataSummaryEntry <- workflowMetadataSummaryEntries
+      if workflowMetadataSummaryEntry.workflowExecutionUuid === workflowExecutionUuid
+    } yield (workflowMetadataSummaryEntry.metadataArchiveStatus, workflowMetadataSummaryEntry.endTimestamp))
+
   private def fetchAllWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String],
                                                                               workflowEndTimestampThreshold: Timestamp): Query[WorkflowMetadataSummaryEntries, WorkflowMetadataSummaryEntry, Seq] = {
     for {

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -185,7 +185,7 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int]
 
-  def getMetadataArchiveStatus(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]]
+  def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit ec: ExecutionContext): Future[(Option[String], Option[Timestamp])]
 
   def queryWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String],
                                                                    workflowEndTimestampThreshold: Timestamp,

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -20,7 +20,7 @@ import cromwell.core.{WorkflowId, WorkflowMetadataKeys, path => _}
 import cromwell.engine.instrumentation.HttpInstrumentation
 import cromwell.server.CromwellShutdown
 import cromwell.services._
-import cromwell.services.instrumentation.{CromwellBucket, CromwellCount, CromwellIncrement, CromwellTiming}
+import cromwell.services.instrumentation.{CromwellBucket, CromwellIncrement, CromwellTiming}
 import cromwell.services.instrumentation.InstrumentationService.InstrumentationServiceMessage
 import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService._
@@ -177,7 +177,7 @@ object MetadataRouteSupport {
       serviceRegistryActor ! lagMessage
 
       val interestingDayMarks = (5.to(55, step = 5) :+ 1).map(d => (d.days, s"${d}_day_old_lookups"))
-      val interestingMonthMarks = 2.to(11).map(m => (30.days * m, s"${m}_month_old_lookups"))
+      val interestingMonthMarks = 2.to(11).map(m => (30.days * m.longValue(), s"${m}_month_old_lookups"))
 
       (interestingDayMarks ++ interestingMonthMarks) foreach {
         case (timeSpan, metricName) if timeSinceEndTime > timeSpan =>

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -135,7 +135,7 @@ object MetadataRouteSupport {
     val timeSinceMessage = endTime map { timestamp =>
       val duration = FiniteDuration(JDuration.between(timestamp, OffsetDateTime.now()).toMillis, TimeUnit.MILLISECONDS)
       s" The workflow completed at $timestamp, which was ${duration} ago."
-    }
+    } getOrElse("")
     val additionalDetails = if (archiveStatus == MetadataArchiveStatus.ArchivedAndDeleted)
       " It is available in the archive bucket, or via a support request in the case of a managed instance."
     else ""

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -176,12 +176,12 @@ object MetadataRouteSupport {
       val lagMessage = InstrumentationServiceMessage(CromwellTiming(CromwellBucket(ServicesPrefix.toList, lagInstrumentationPath), timeSinceEndTime))
       serviceRegistryActor ! lagMessage
 
-      val interestingDayMarks = (5.to(55, step = 5) :+ 1).map(d => (d.days, s"${d}_day_old_lookups"))
-      val interestingMonthMarks = 2.to(11).map(m => (30.days * m.longValue(), s"${m}_month_old_lookups"))
+      val interestingDayMarks = (5.to(55, step = 5) ++ 0.to(4)).map(d => (d.days, s"${d}_day_old"))
+      val interestingMonthMarks = 2.to(11).map(m => (30.days * m.longValue(), s"${m}_month_old"))
 
       (interestingDayMarks ++ interestingMonthMarks) foreach {
-        case (timeSpan, metricName) if timeSinceEndTime > timeSpan =>
-          val oldMetadataCounterPath = MetadataServiceActor.MetadataInstrumentationPrefix :+ "archiver" :+ "historical_metadata_lookup" :+ s"${metricName}_lookup"
+        case (timeSpan, metricName) if timeSinceEndTime >= timeSpan =>
+          val oldMetadataCounterPath = MetadataServiceActor.MetadataInstrumentationPrefix :+ "archiver" :+ "historical_metadata_lookup" :+ "lookup_age_counts" :+ metricName
           val oldMetadataCounterMessage = InstrumentationServiceMessage(CromwellIncrement(CromwellBucket(ServicesPrefix.toList, oldMetadataCounterPath)))
           serviceRegistryActor ! oldMetadataCounterMessage
         case _ => // Do nothing

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -1,5 +1,7 @@
 package cromwell.webservice.routes
 
+import java.time.OffsetDateTime
+
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.ContentTypes._
@@ -605,11 +607,11 @@ object CromwellApiServiceSpec {
       case ValidateWorkflowIdInMetadataSummaries(id) =>
         if (SummarizedWorkflowIds.contains(id)) sender ! MetadataService.RecognizedWorkflowId
         else sender ! MetadataService.UnrecognizedWorkflowId
-      case FetchWorkflowMetadataArchiveStatus(id) =>
+      case FetchWorkflowMetadataArchiveStatusAndEndTime(id) =>
         id match {
-          case ArchivedAndDeletedWorkflowId => sender ! WorkflowMetadataArchivedStatus(ArchivedAndDeleted)
-          case ArchivedWorkflowId => sender ! WorkflowMetadataArchivedStatus(Archived)
-          case _ => sender ! WorkflowMetadataArchivedStatus(Unarchived)
+          case ArchivedAndDeletedWorkflowId => sender ! WorkflowMetadataArchivedStatusAndEndTime(ArchivedAndDeleted, Option(OffsetDateTime.now))
+          case ArchivedWorkflowId => sender ! WorkflowMetadataArchivedStatusAndEndTime(Archived, Option(OffsetDateTime.now))
+          case _ => sender ! WorkflowMetadataArchivedStatusAndEndTime(Unarchived, Option(OffsetDateTime.now))
         }
       case GetCurrentStatus =>
         sender ! StatusCheckResponse(
@@ -689,7 +691,7 @@ object CromwellApiServiceSpec {
       case GetWorkflowStoreStats => sender ! Map(WorkflowRunning -> 5, WorkflowSubmitted -> 3, WorkflowAborting -> 2)
     }
   }
-  
+
   class MockWorkflowManagerActor extends Actor with ActorLogging {
     override def receive: Receive = {
       case WorkflowManagerActor.EngineStatsCommand =>

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -125,7 +125,7 @@ object MetadataService {
 
   final case class ValidateWorkflowIdInMetadata(possibleWorkflowId: WorkflowId) extends MetadataServiceAction
   final case class ValidateWorkflowIdInMetadataSummaries(possibleWorkflowId: WorkflowId) extends MetadataServiceAction
-  final case class FetchWorkflowMetadataArchiveStatus(workflowId: WorkflowId) extends MetadataServiceAction
+  final case class FetchWorkflowMetadataArchiveStatusAndEndTime(workflowId: WorkflowId) extends MetadataServiceAction
 
   /**
     * Responses
@@ -166,9 +166,9 @@ object MetadataService {
   case object UnrecognizedWorkflowId extends WorkflowValidationResponse
   final case class FailedToCheckWorkflowId(cause: Throwable) extends WorkflowValidationResponse
 
-  sealed abstract class FetchWorkflowArchiveStatusResponse extends MetadataServiceResponse
-  final case class WorkflowMetadataArchivedStatus(archiveStatus: MetadataArchiveStatus) extends FetchWorkflowArchiveStatusResponse
-  final case class FailedToGetArchiveStatus(reason: Throwable) extends FetchWorkflowArchiveStatusResponse
+  sealed abstract class FetchWorkflowArchiveStatusAndEndTimeResponse extends MetadataServiceResponse
+  final case class WorkflowMetadataArchivedStatusAndEndTime(archiveStatus: MetadataArchiveStatus, endTime: Option[OffsetDateTime]) extends FetchWorkflowArchiveStatusAndEndTimeResponse
+  final case class FailedToGetArchiveStatusAndEndTime(reason: Throwable) extends FetchWorkflowArchiveStatusAndEndTimeResponse
 
   sealed abstract class MetadataQueryResponse extends MetadataServiceResponse
   final case class WorkflowQuerySuccess(response: WorkflowQueryResponse, meta: Option[QueryMetadata]) extends MetadataQueryResponse
@@ -183,12 +183,12 @@ object MetadataService {
         .flatMap { case (value, index) => womValueToMetadataEvents(metadataKey.copy(key = s"${metadataKey.key}[$index]"), value) }
     }
   }
-  
+
   private def toPrimitiveEvent(metadataKey: MetadataKey, valueName: String)(value: Option[Any]) = value match {
     case Some(v) => MetadataEvent(metadataKey.copy(key = s"${metadataKey.key}:$valueName"), MetadataValue(v))
     case None => MetadataEvent(metadataKey.copy(key = s"${metadataKey.key}:$valueName"), MetadataValue("", MetadataNull))
   }
-  
+
   def womValueToMetadataEvents(metadataKey: MetadataKey, womValue: WomValue): Iterable[MetadataEvent] = womValue match {
     case WomArray(_, valueSeq) => valueSeq.toEvents(metadataKey)
     case WomMap(_, valueMap) =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -16,7 +16,7 @@ import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataService.{QueryMetadata, WorkflowQueryResponse}
 import cromwell.services.metadata._
-import cromwell.services.metadata.impl.MetadataDatabaseAccess.SummaryResult
+import cromwell.services.metadata.impl.MetadataDatabaseAccess._
 import mouse.boolean._
 import slick.basic.DatabasePublisher
 
@@ -84,7 +84,8 @@ object MetadataDatabaseAccess {
     }
   }
 
-  case class SummaryResult(rowsProcessedIncreasing: Long, rowsProcessedDecreasing: Long, decreasingGap: Long)
+  final case class SummaryResult(rowsProcessedIncreasing: Long, rowsProcessedDecreasing: Long, decreasingGap: Long)
+  final case class WorkflowArchiveStatusAndEndTimestamp(archiveStatus: Option[String], endTimestamp: Option[OffsetDateTime])
 }
 
 trait MetadataDatabaseAccess {
@@ -362,9 +363,9 @@ trait MetadataDatabaseAccess {
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] =
     metadataDatabaseInterface.getSummaryQueueSize()
 
-  def getMetadataArchiveStatusAndEndTime(id: WorkflowId)(implicit ec: ExecutionContext): Future[(Option[String], Option[OffsetDateTime])] = {
+  def getMetadataArchiveStatusAndEndTime(id: WorkflowId)(implicit ec: ExecutionContext): Future[WorkflowArchiveStatusAndEndTimestamp] = {
     metadataDatabaseInterface.getMetadataArchiveStatusAndEndTime(id.toString).map {
-      case (statusOption, timestampOption) => (statusOption, timestampOption.map(_.toSystemOffsetDateTime))
+      case (statusOption, timestampOption) => WorkflowArchiveStatusAndEndTimestamp(statusOption, timestampOption.map(_.toSystemOffsetDateTime))
     }
   }
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -362,8 +362,10 @@ trait MetadataDatabaseAccess {
   def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] =
     metadataDatabaseInterface.getSummaryQueueSize()
 
-  def getMetadataArchiveStatus(id: WorkflowId)(implicit ec: ExecutionContext): Future[Option[String]] = {
-    metadataDatabaseInterface.getMetadataArchiveStatus(id.toString)
+  def getMetadataArchiveStatusAndEndTime(id: WorkflowId)(implicit ec: ExecutionContext): Future[(Option[String], Option[OffsetDateTime])] = {
+    metadataDatabaseInterface.getMetadataArchiveStatusAndEndTime(id.toString).map {
+      case (statusOption, timestampOption) => (statusOption, timestampOption.map(_.toSystemOffsetDateTime))
+    }
   }
 
   def queryWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String],

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -12,6 +12,7 @@ import cromwell.core.{LoadConfig, WorkflowId}
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService._
+import cromwell.services.metadata.impl.MetadataDatabaseAccess.WorkflowArchiveStatusAndEndTimestamp
 import cromwell.services.metadata.impl.MetadataSummaryRefreshActor.{MetadataSummaryFailure, MetadataSummarySuccess, SummarizeMetadata}
 import cromwell.services.metadata.impl.archiver.{ArchiveMetadataConfig, ArchiveMetadataSchedulerActor}
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
@@ -151,7 +152,7 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
 
   private def fetchWorkflowMetadataArchiveStatusAndEndTime(workflowId: WorkflowId, sender: ActorRef): Unit = {
     getMetadataArchiveStatusAndEndTime(workflowId) onComplete {
-      case Success((status, endTime)) =>
+      case Success(WorkflowArchiveStatusAndEndTimestamp(status, endTime)) =>
         MetadataArchiveStatus.fromDatabaseValue(status).toTry match {
           case Success(archiveStatus) => sender ! WorkflowMetadataArchivedStatusAndEndTime(archiveStatus, endTime)
           case Failure(e) => sender ! FailedToGetArchiveStatusAndEndTime(new RuntimeException(s"Failed to get metadata archive status for workflow ID $workflowId", e))

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -149,14 +149,14 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
     }
   }
 
-  private def fetchWorkflowMetadataArchiveStatus(workflowId: WorkflowId, sender: ActorRef): Unit = {
-    getMetadataArchiveStatus(workflowId) onComplete {
-      case Success(status) =>
+  private def fetchWorkflowMetadataArchiveStatusAndEndTime(workflowId: WorkflowId, sender: ActorRef): Unit = {
+    getMetadataArchiveStatusAndEndTime(workflowId) onComplete {
+      case Success((status, endTime)) =>
         MetadataArchiveStatus.fromDatabaseValue(status).toTry match {
-          case Success(archiveStatus) => sender ! WorkflowMetadataArchivedStatus(archiveStatus)
-          case Failure(e) => sender ! FailedToGetArchiveStatus(new RuntimeException(s"Failed to get metadata archive status for workflow ID $workflowId", e))
+          case Success(archiveStatus) => sender ! WorkflowMetadataArchivedStatusAndEndTime(archiveStatus, endTime)
+          case Failure(e) => sender ! FailedToGetArchiveStatusAndEndTime(new RuntimeException(s"Failed to get metadata archive status for workflow ID $workflowId", e))
         }
-      case Failure(e) => sender ! FailedToGetArchiveStatus(new RuntimeException(s"Failed to get metadata archive status for workflow ID $workflowId", e))
+      case Failure(e) => sender ! FailedToGetArchiveStatusAndEndTime(new RuntimeException(s"Failed to get metadata archive status for workflow ID $workflowId", e))
     }
   }
 
@@ -176,7 +176,7 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
     case listen: Listen => writeActor forward listen
     case v: ValidateWorkflowIdInMetadata => validateWorkflowIdInMetadata(v.possibleWorkflowId, sender())
     case v: ValidateWorkflowIdInMetadataSummaries => validateWorkflowIdInMetadataSummaries(v.possibleWorkflowId, sender())
-    case g: FetchWorkflowMetadataArchiveStatus => fetchWorkflowMetadataArchiveStatus(g.workflowId, sender())
+    case g: FetchWorkflowMetadataArchiveStatusAndEndTime => fetchWorkflowMetadataArchiveStatusAndEndTime(g.workflowId, sender())
     case action: BuildMetadataJsonAction => readActor forward action
     case streamAction: GetMetadataStreamAction => readActor forward streamAction
   }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -298,7 +298,7 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
       notImplemented()
     }
 
-    override def getMetadataArchiveStatus(workflowId: String)(implicit ec: ExecutionContext): Future[Option[String]] = notImplemented()
+    override def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit ec: ExecutionContext):  Future[(Option[String], Option[Timestamp])] = notImplemented()
 
     override def queryWorkflowsToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String], workflowEndTimestampThreshold: Timestamp, batchSize: Long)(implicit ec: ExecutionContext): Future[Seq[WorkflowMetadataSummaryEntry]] = notImplemented()
 


### PR DESCRIPTION
For graphs like:
![image](https://user-images.githubusercontent.com/13006282/121751274-cfed0e00-cadb-11eb-9210-a13b539a6c1b.png)
