### PR TITLE
[BW-677] Windowed scala steward combiner

### DIFF
--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -36,7 +36,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${PR_LIMIT}
 
-          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${PR_LIMIT} | tac | tr '\n' ' '))
+          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | head -n${PR_LIMIT} | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST[@]}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -8,9 +8,13 @@ on:
   workflow_dispatch:
     inputs:
       prLimit:
-        description: 'How many scala-steward PRs to consolidate'
+        description: 'How many scala-steward PRs to consolidate in total'
         required: true
         default: 1000
+      prGroupSize:
+        description: 'How many scala-steward PRs to consolidate in each PR'
+        required: true
+        default: 10
 
 jobs:
   build:
@@ -22,46 +26,60 @@ jobs:
         id: msp
         run: |
           export GITHUB_TOKEN=${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          PR_LIMIT=${{ github.event.inputs.prLimit }}
+          PR_GROUP_SIZE=${{ github.event.inputs.prGroupSize }}
           git config user.name "broadbot"
 
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
           PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
-          BRANCH="consolidated-scala-steward-prs-$(date +'%Y-%m-%d_%H-%M')"
+          PR_LIST_LENGTH=${#PR_LIST[@]}
 
-          SUCCESSFUL_PRS=()
-          UNSUCCESSFUL_PRS=()
-
-          git fetch
-          git checkout develop
-          git checkout -B $BRANCH
-
-          while IFS= read -r pr
+          NEXT_INDEX=0
+          NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
+          while [[ "${#NEXT_SLICE[@]}" -gt "0" ]]
           do
-            echo "Bringing in: $pr"
-            git fetch origin pull/${pr}/head:pr_${pr}
+            FIRST_PR="${NEXT_SLICE[0]}"
+            LAST_PR="${NEXT_SLICE[0]}"
+            REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
 
-            git checkout $BRANCH
-            git merge -m "merging PR #${pr}" pr_${pr} --allow-unrelated-histories && EXIT_CODE=$? || EXIT_CODE=$?
+            NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
+            git checkout develop
+            git pull
+            git checkout -B ${NEW_BRANCH}
 
-            if [ "${EXIT_CODE}" == "0" ]
-            then
-              SUCCESSFUL_PRS+=( "
-          * #$pr" )
-            else
-              echo "Unexpected exit code: ${EXIT_CODE}"
-              git reset --hard HEAD
-              UNSUCCESSFUL_PRS+=( "
-          * #$pr" )
-            fi
-          done <<< "$PR_LIST"
-          git checkout $BRANCH
-          git push origin $BRANCH
-          gh pr create \
-            --title '[!! NEEDS Jira ID !!] Scala-steward shepherding consolidation' \
-            --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
+            SUCCESSFUL_PRS=()
+            UNSUCCESSFUL_PRS=()
 
-          Consolidates scala-steward PRs ${SUCCESSFUL_PRS[*]}.
+            while IFS= read -r pr
+            do
+              echo "Bringing in: $pr"
+#              git fetch origin pull/${pr}/head:pr_${pr}
+#
+#              git rebase "pr_${pr}" "${NEW_BRANCH}"
+#
+#              if [ "${EXIT_CODE}" == "0" ]
+#              then
+#                SUCCESSFUL_PRS+=( "
+#            * #$pr" )
+#              else
+#                echo "Unexpected exit code: ${EXIT_CODE}"
+#                git reset --hard HEAD
+#                UNSUCCESSFUL_PRS+=( "
+#            * #$pr" )
+              fi
+            done <<< "$REVERSED_SLICE"
 
-          Note that the following PRs were not able to be consolidated: ${UNSUCCESSFUL_PRS[*]}"
+#            git push origin "${NEW_BRANCH}"
+#            gh pr create \
+#              --title '[!! NEEDS Jira ID !!] Scala-steward shepherding consolidation' \
+#              --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
+#
+#            Consolidates scala-steward PRs ${SUCCESSFUL_PRS[*]}.
+#
+#            Note that the following PRs were not able to be consolidated: ${UNSUCCESSFUL_PRS[*]}"
+#
+#            NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
+#            NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"
+          done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -12,9 +12,9 @@ on:
         required: true
         default: 1000
       prGroupSize:
-        description: 'How many scala-steward PRs to consolidate in each PR'
+        description: 'How many scala-steward PRs to consolidate in each "consolidated" PR'
         required: true
-        default: 10
+        default: 5
 
 jobs:
   build:
@@ -65,8 +65,7 @@ jobs:
               echo "Bringing in: $pr"
 
               git fetch origin pull/${pr}/head:pr_${pr}_temp
-              git rebase "${NEW_BRANCH}" "pr_${pr}_temp"
-              EXIT_CODE=$?
+              git rebase "${NEW_BRANCH}" "pr_${pr}_temp" && EXIT_CODE=$? || EXIT_CODE=$?
 
               if [ "${EXIT_CODE}" == "0" ]
               then

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
+          PR_LIST="$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr -d '\n')"
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -29,6 +29,7 @@ jobs:
           PR_LIMIT=${{ github.event.inputs.prLimit }}
           PR_GROUP_SIZE=${{ github.event.inputs.prGroupSize }}
           git config user.name "broadbot"
+          git fetch
 
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
@@ -45,7 +46,7 @@ jobs:
             REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
-            git checkout origin/develop
+            git checkout develop
             git pull
             git checkout -B ${NEW_BRANCH}
 

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -61,6 +61,20 @@ jobs:
 
             for pr in ${NEXT_SLICE[@]}
             do
+              git fetch origin pull/${pr}/head:pr_${pr}
+
+              git rebase "pr_${pr}" "${NEW_BRANCH}"
+
+              if [ "${EXIT_CODE}" == "0" ]
+              then
+                SUCCESSFUL_PRS+=( "
+              * #$pr" )
+              else
+                echo "Unexpected exit code: ${EXIT_CODE}"
+                git reset --hard HEAD
+                UNSUCCESSFUL_PRS+=( "
+              * #$pr" )
+              fi
               echo "Bringing in: $pr"
             done <<< ${NEXT_SLICE[@]}
 

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -57,4 +57,7 @@ jobs:
             do
               echo "Bringing in: $pr"
             done <<< "$REVERSED_SLICE"
+
+            NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
+            NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"
           done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -59,7 +59,7 @@ jobs:
             while IFS= read -r pr
             do
               echo "Bringing in: $pr"
-            done <<< "${NEXT_SLICE[@]}"
+            done <<< ${NEXT_SLICE[@]}
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -56,7 +56,7 @@ jobs:
             SUCCESSFUL_PRS=()
             UNSUCCESSFUL_PRS=()
 
-            while IFS= read -r pr
+            for pr in ${NEXT_SLICE[@]}
             do
               echo "Bringing in: $pr"
             done <<< ${NEXT_SLICE[@]}

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          PR_LIST="$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr -d '\n')"
+          PR_LIST=("$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr -d '\n')")
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -51,8 +51,6 @@ jobs:
           do
             FIRST_PR="${NEXT_SLICE[0]}"
             LAST_PR="${NEXT_SLICE[-1]}"
-            #echo "NEXT_SLICE=${NEXT_SLICE[@]}"
-            #echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
             echo "NEW_BRANCH=${NEW_BRANCH}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -68,7 +68,7 @@ jobs:
 #                git reset --hard HEAD
 #                UNSUCCESSFUL_PRS+=( "
 #            * #$pr" )
-              fi
+#              fi
             done <<< "$REVERSED_SLICE"
 
 #            git push origin "${NEW_BRANCH}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          PR_LIST=("$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr -d '\n')")
+          PR_LIST=("$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr '\n' ' ')")
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -31,7 +31,8 @@ jobs:
           echo "BASH_VERSION=${BASH_VERSION}"
 
           git config user.name "broadbot"
-          git fetch
+          echo "Fetching repo state..."
+          git fetch 1>/dev/null
 
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${PR_LIMIT}
@@ -64,8 +65,7 @@ jobs:
               echo "Bringing in: $pr"
 
               git fetch origin pull/${pr}/head:pr_${pr}
-              git checkout "pr_${pr}_temp"
-              git rebase "${NEW_BRANCH}" "pr_${pr}_temp"
+              git rebase "${NEW_BRANCH}" "pr_${pr}"
               EXIT_CODE=$?
 
               if [ "${EXIT_CODE}" == "0" ]

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -36,7 +36,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${PR_LIMIT}
 
-          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | head -n${PR_LIMIT} | tr '\n' ' '))
+          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${PR_LIMIT} | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST[@]}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -37,18 +37,18 @@ jobs:
           PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
-          echo "PR_LIST=${PR_LIST}"
+          echo "PR_LIST=${PR_LIST[@]}"
           echo "PR_LIST_COUNT=${#PR_LIST[@]}"
           NEXT_INDEX=0
           NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           while [[ "${#NEXT_SLICE[@]}" -gt "0" ]]
           do
             FIRST_PR="${NEXT_SLICE[0]}"
-            LAST_PR="${NEXT_SLICE[0]}"
+            LAST_PR="${NEXT_SLICE[-1]}"
             REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
-            echo "NEXT_SLICE=${NEXT_SLICE}"
+            echo "NEXT_SLICE=${NEXT_SLICE[@]}"
             echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
-            echo "REVERSED_SLICE=${#REVERSED_SLICE[@]}"
+            echo "REVERSED_SLICE=${REVERSED_SLICE[@]}"
             echo "REVERSED_SLICE_COUNT=${#REVERSED_SLICE_COUNT[@]}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -32,7 +32,7 @@ jobs:
 
           git config user.name "broadbot"
           echo "Fetching repo state..."
-          git fetch 1>/dev/null
+          git fetch --quiet
 
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${PR_LIMIT}

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -95,9 +95,9 @@ jobs:
                 --title "[${{ github.event.inputs.jiraTicketId }}] Scala-steward shepherding consolidation (${FIRST_PR} to ${LAST_PR})" \
                 --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
 
-              Consolidates scala-steward PRs: ${SUCCESSFUL_PRS[*]}
+          Consolidates scala-steward PRs: ${SUCCESSFUL_PRS[*]}
 
-              Merge conflicts during consolidation (might be empty): ${UNSUCCESSFUL_PRS[*]}"
+          Merge conflicts during consolidation (might be empty): ${UNSUCCESSFUL_PRS[*]}"
             fi
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -55,31 +55,5 @@ jobs:
             while IFS= read -r pr
             do
               echo "Bringing in: $pr"
-#              git fetch origin pull/${pr}/head:pr_${pr}
-#
-#              git rebase "pr_${pr}" "${NEW_BRANCH}"
-#
-#              if [ "${EXIT_CODE}" == "0" ]
-#              then
-#                SUCCESSFUL_PRS+=( "
-#            * #$pr" )
-#              else
-#                echo "Unexpected exit code: ${EXIT_CODE}"
-#                git reset --hard HEAD
-#                UNSUCCESSFUL_PRS+=( "
-#            * #$pr" )
-#              fi
             done <<< "$REVERSED_SLICE"
-
-#            git push origin "${NEW_BRANCH}"
-#            gh pr create \
-#              --title '[!! NEEDS Jira ID !!] Scala-steward shepherding consolidation' \
-#              --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
-#
-#            Consolidates scala-steward PRs ${SUCCESSFUL_PRS[*]}.
-#
-#            Note that the following PRs were not able to be consolidated: ${UNSUCCESSFUL_PRS[*]}"
-#
-#            NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
-#            NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"
           done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -75,15 +75,15 @@ jobs:
               * #$pr" )
               else
                 echo "Unexpected exit code: ${EXIT_CODE}"
-                git reset --hard
+                git rebase --abort
                 git checkout ${NEW_BRANCH}
                 UNSUCCESSFUL_PRS+=( "
               * #$pr" )
               fi
             done <<< ${NEXT_SLICE[@]}
 
-            echo "SUCCESSFUL_PRS=${SUCCESSFUL_PRS}"
-            echo "UNSUCCESSFUL_PRS=${UNSUCCESSFUL_PRS}"
+            echo "SUCCESSFUL_PRS=${SUCCESSFUL_PRS[@]}"
+            echo "UNSUCCESSFUL_PRS=${UNSUCCESSFUL_PRS[@]}"
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -44,6 +44,8 @@ jobs:
             FIRST_PR="${NEXT_SLICE[0]}"
             LAST_PR="${NEXT_SLICE[0]}"
             REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
+            echo "NEXT_SLICE=${NEXT_SLICE}"
+            echo "REVERSED_SLICE=${REVERSED_SLICE}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
             git checkout develop

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -45,7 +45,7 @@ jobs:
           do
             FIRST_PR="${NEXT_SLICE[0]}"
             LAST_PR="${NEXT_SLICE[-1]}"
-            REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
+            REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}" | tac | tr '\n' ' ')")
             echo "NEXT_SLICE=${NEXT_SLICE[@]}"
             echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
             echo "REVERSED_SLICE=${REVERSED_SLICE[@]}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -38,6 +38,7 @@ jobs:
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST}"
+          echo "PR_LIST_COUNT=${#PR_LIST[@]}"
           NEXT_INDEX=0
           NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           while [[ "${#NEXT_SLICE[@]}" -gt "0" ]]
@@ -46,7 +47,9 @@ jobs:
             LAST_PR="${NEXT_SLICE[0]}"
             REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
             echo "NEXT_SLICE=${NEXT_SLICE}"
-            echo "REVERSED_SLICE=${REVERSED_SLICE}"
+            echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
+            echo "REVERSED_SLICE=${#REVERSED_SLICE[@]}"
+            echo "REVERSED_SLICE_COUNT=${#REVERSED_SLICE_COUNT[@]}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
             git checkout develop

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -61,21 +61,26 @@ jobs:
 
             for pr in ${NEXT_SLICE[@]}
             do
-              git fetch origin pull/${pr}/head:pr_${pr}
+              echo "Bringing in: $pr"
 
-              git rebase "pr_${pr}" "${NEW_BRANCH}"
+              git fetch origin pull/${pr}/head:pr_${pr}
+              git checkout "pr_${pr}_temp"
+              git rebase "${NEW_BRANCH}" "pr_${pr}_temp"
+              EXIT_CODE=$?
 
               if [ "${EXIT_CODE}" == "0" ]
               then
+                git checkout ${NEW_BRANCH}
+                git reset --hard "pr_${pr}_temp"
                 SUCCESSFUL_PRS+=( "
               * #$pr" )
               else
                 echo "Unexpected exit code: ${EXIT_CODE}"
-                git reset --hard HEAD
+                git reset --hard
+                git checkout ${NEW_BRANCH}
                 UNSUCCESSFUL_PRS+=( "
               * #$pr" )
               fi
-              echo "Bringing in: $pr"
             done <<< ${NEXT_SLICE[@]}
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -37,6 +37,7 @@ jobs:
           PR_LIST=$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }})
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
+          echo "PR_LIST=${PR_LIST}"
           NEXT_INDEX=0
           NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           while [[ "${#NEXT_SLICE[@]}" -gt "0" ]]

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -82,6 +82,9 @@ jobs:
               fi
             done <<< ${NEXT_SLICE[@]}
 
+            echo "SUCCESSFUL_PRS=${SUCCESSFUL_PRS}"
+            echo "UNSUCCESSFUL_PRS=${UNSUCCESSFUL_PRS}"
+
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -64,8 +64,8 @@ jobs:
             do
               echo "Bringing in: $pr"
 
-              git fetch origin pull/${pr}/head:pr_${pr}
-              git rebase "${NEW_BRANCH}" "pr_${pr}"
+              git fetch origin pull/${pr}/head:pr_${pr}_temp
+              git rebase "${NEW_BRANCH}" "pr_${pr}_temp"
               EXIT_CODE=$?
 
               if [ "${EXIT_CODE}" == "0" ]

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -92,7 +92,7 @@ jobs:
             then
               git push origin "${NEW_BRANCH}"
               gh pr create \
-                --title '[${{ github.event.inputs.jiraTicketId }}] Scala-steward shepherding consolidation (${FIRST_PR} to ${LAST_PR})' \
+                --title "[${{ github.event.inputs.jiraTicketId }}] Scala-steward shepherding consolidation (${FIRST_PR} to ${LAST_PR})" \
                 --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
 
               Consolidates scala-steward PRs: ${SUCCESSFUL_PRS[*]}

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          PR_LIST=("$(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr '\n' ' ')")
+          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -45,7 +45,7 @@ jobs:
             REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}"|tac)")
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
-            git checkout develop
+            git checkout origin/develop
             git pull
             git checkout -B ${NEW_BRANCH}
 

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -85,6 +85,18 @@ jobs:
             echo "SUCCESSFUL_PRS=${SUCCESSFUL_PRS[@]}"
             echo "UNSUCCESSFUL_PRS=${UNSUCCESSFUL_PRS[@]}"
 
+            if [[ "${#SUCCESSFUL_PRS[@]}" -gt "0" ]]
+            then
+              git push origin "${NEW_BRANCH}"
+              gh pr create \
+                --title '[${{ github.event.inputs.jiraTicketId }}] Scala-steward shepherding consolidation (${FIRST_PR} to ${LAST_PR})' \
+                --body "This PR was generated automatically by the github action: https://github.com/broadinstitute/cromwell/actions/workflows/combine_scalasteward_prs.yml
+
+              Consolidates scala-steward PRs: ${SUCCESSFUL_PRS[*]}
+
+              Merge conflicts during consolidation (might be empty): ${UNSUCCESSFUL_PRS[*]}"
+            fi
+
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -34,7 +34,7 @@ jobs:
           echo "Bringing in PRs:"
           gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
 
-          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tr '\n' ' '))
+          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tac | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST[@]}"
@@ -45,11 +45,8 @@ jobs:
           do
             FIRST_PR="${NEXT_SLICE[0]}"
             LAST_PR="${NEXT_SLICE[-1]}"
-            REVERSED_SLICE=("$(printf '%s\n' "${NEXT_SLICE[@]}" | tac | tr '\n' ' ')")
             echo "NEXT_SLICE=${NEXT_SLICE[@]}"
             echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
-            echo "REVERSED_SLICE=${REVERSED_SLICE[@]}"
-            echo "REVERSED_SLICE_COUNT=${#REVERSED_SLICE_COUNT[@]}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
             git checkout develop
@@ -62,7 +59,7 @@ jobs:
             while IFS= read -r pr
             do
               echo "Bringing in: $pr"
-            done <<< "$REVERSED_SLICE"
+            done <<< "$NEXT_SLICE"
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -47,10 +47,11 @@ jobs:
           do
             FIRST_PR="${NEXT_SLICE[0]}"
             LAST_PR="${NEXT_SLICE[-1]}"
-            echo "NEXT_SLICE=${NEXT_SLICE[@]}"
-            echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
+            #echo "NEXT_SLICE=${NEXT_SLICE[@]}"
+            #echo "NEXT_SLICE_COUNT=${#NEXT_SLICE[@]}"
 
             NEW_BRANCH="consolidated-scala-steward-prs-${FIRST_PR}-${LAST_PR}-$(date +'%Y-%m-%d_%H-%M')"
+            echo "NEW_BRANCH=${NEW_BRANCH}"
             git checkout develop
             git pull
             git checkout -B ${NEW_BRANCH}

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -15,6 +15,9 @@ on:
         description: 'How many scala-steward PRs to consolidate in each "consolidated" PR'
         required: true
         default: 5
+      jiraTicketId:
+        description: 'A Jira ticket ID to associate the new PRs with'
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -28,13 +28,15 @@ jobs:
           export GITHUB_TOKEN=${{ secrets.BROADBOT_GITHUB_TOKEN }}
           PR_LIMIT=${{ github.event.inputs.prLimit }}
           PR_GROUP_SIZE=${{ github.event.inputs.prGroupSize }}
+          echo "BASH_VERSION=${BASH_VERSION}"
+
           git config user.name "broadbot"
           git fetch
 
           echo "Bringing in PRs:"
-          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${{ github.event.inputs.prLimit }}
+          gh pr list --limit 1000 | grep 'scala-steward:' | tac | head -n${PR_LIMIT}
 
-          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${{ github.event.inputs.prLimit }} | tac | tr '\n' ' '))
+          PR_LIST=($(gh pr list --limit 1000 | grep 'scala-steward:' | cut -d$'\t'  -f 1 | tac | head -n${PR_LIMIT} | tac | tr '\n' ' '))
           PR_LIST_LENGTH=${#PR_LIST[@]}
 
           echo "PR_LIST=${PR_LIST[@]}"
@@ -62,5 +64,5 @@ jobs:
             done <<< ${NEXT_SLICE[@]}
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
-            NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"
+            NEXT_SLICE=("${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}")
           done

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -59,7 +59,7 @@ jobs:
             while IFS= read -r pr
             do
               echo "Bringing in: $pr"
-            done <<< "$NEXT_SLICE"
+            done <<< "${NEXT_SLICE[@]}"
 
             NEXT_INDEX=$(( NEXT_INDEX + PR_GROUP_SIZE ))
             NEXT_SLICE="${PR_LIST[@]:$NEXT_INDEX:$PR_GROUP_SIZE}"


### PR DESCRIPTION
Replaces the "merge" strategy which I didn't understand and didn't seem to work (perhaps related) with a rebase strategy which makes sense to me (and seems to work).

Also allows windowed sets of PRs to be created so that we can group into many "manageable chunks" in one action, without having to wait the first chunk to merge before we can consider subsequent chunks