### PR TITLE
Give akka logger a little more time to start [CROM-6738]

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -21,6 +21,11 @@ akka {
 
     #parallelism-factor = 3.0
     #parallelism-max = 64
+
+    # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
+    # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini
+    # This gives the logger a little more than 5 seconds to startup. 5s was *almost* always enough, so a safe 30s should be *plenty* of time:
+    logger-startup-timeout: 30s
   }
 
   priority-mailbox {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -21,11 +21,6 @@ akka {
 
     #parallelism-factor = 3.0
     #parallelism-max = 64
-
-    # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
-    # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini
-    # This gives the logger a little more than 5 seconds to startup. 5s was *almost* always enough, so a safe 30s should be *plenty* of time:
-    logger-startup-timeout: 30s
   }
 
   priority-mailbox {

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -11,6 +11,11 @@ akka {
     }
 
     client.connecting-timeout = 40s
+
+    # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
+    # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini
+    # This gives the logger a little more than 5 seconds to startup. 5s was *almost* always enough, so a safe 30s should be *plenty* of time:
+    logger-startup-timeout: 30s
   }
 
   coordinated-shutdown.phases {


### PR DESCRIPTION
Resolves flaky tests, and covers real-users too in case they ever run into a similar situation.