### PR TITLE
Metadata table size metrics [BW-722]

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -504,8 +504,6 @@ services {
     config {
       # See cromwell.examples.conf for details on settings one can use here as they depend on the implementation
       # being used.
-      # TODO: Remove this after testing
-      metadata-table-metrics-interval = 15 minutes
     }
   }
   Instrumentation {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -504,6 +504,8 @@ services {
     config {
       # See cromwell.examples.conf for details on settings one can use here as they depend on the implementation
       # being used.
+      # TODO: Remove this after testing
+      metadata-table-metrics-interval = 15 minutes
     }
   }
   Instrumentation {

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -9,7 +9,7 @@ import cromwell.database.slick.tables.MetadataDataAccessComponent
 import cromwell.database.sql.MetadataSqlDatabase
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.joins.{CallOrWorkflowQuery, CallQuery, MetadataJobQueryValue, WorkflowQuery}
-import cromwell.database.sql.tables.{CustomLabelEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
+import cromwell.database.sql.tables.{CustomLabelEntry, InformationSchemaEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 import slick.basic.DatabasePublisher
 import slick.jdbc.{ResultSetConcurrency, ResultSetType}
 
@@ -510,5 +510,9 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     runAction(
       dataAccess.countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold).result
     )
+  }
+
+  override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = {
+    runAction(dataAccess.metadataTableSizeInformation())
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -512,7 +512,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     )
   }
 
-  override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = {
+  override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[Option[InformationSchemaEntry]] = {
     runAction(dataAccess.metadataTableSizeInformation())
   }
 }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -1,9 +1,10 @@
 package cromwell.database.slick.tables
 
 import java.sql.Timestamp
-import javax.sql.rowset.serial.SerialClob
 
-import cromwell.database.sql.tables.MetadataEntry
+import javax.sql.rowset.serial.SerialClob
+import cromwell.database.sql.tables.{InformationSchemaEntry, MetadataEntry}
+import slick.jdbc.GetResult
 
 trait MetadataEntryComponent {
 
@@ -295,6 +296,18 @@ trait MetadataEntryComponent {
       // regardless of the attempt
       if (metadataEntry.jobAttempt === jobAttempt) || jobAttempt.isEmpty
     } yield metadataEntry).size
+  }
+
+  def metadataTableSizeInformation() = {
+    val query =
+      sql"""
+          |SELECT DATA_LENGTH, INDEX_LENGTH, DATA_FREE
+          |FROM information_schema.tables
+          |WHERE TABLE_NAME = 'METADATA_ENTRY'
+         """.stripMargin
+    query.as[InformationSchemaEntry](rconv = GetResult { r =>
+      InformationSchemaEntry(r.<<, r.<<, r.<<)
+    }).head
   }
 
   private[this] def metadataEntryHasMetadataKeysLike(metadataEntry: MetadataEntries,

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -307,7 +307,7 @@ trait MetadataEntryComponent {
          """.stripMargin
     query.as[InformationSchemaEntry](rconv = GetResult { r =>
       InformationSchemaEntry(r.<<, r.<<, r.<<)
-    }).head
+    }).headOption
   }
 
   private[this] def metadataEntryHasMetadataKeysLike(metadataEntry: MetadataEntries,

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -196,5 +196,5 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int]
 
-  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry]
+  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[Option[InformationSchemaEntry]]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -3,7 +3,7 @@ package cromwell.database.sql
 import java.sql.Timestamp
 
 import cromwell.database.sql.joins.MetadataJobQueryValue
-import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
+import cromwell.database.sql.tables.{InformationSchemaEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 import slick.basic.DatabasePublisher
 
 import scala.concurrent.duration.Duration
@@ -195,4 +195,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
                                                                        workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int]
 
   def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int]
+
+  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/InformationSchemaEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/InformationSchemaEntry.scala
@@ -1,0 +1,8 @@
+package cromwell.database.sql.tables
+
+case class InformationSchemaEntry
+(
+  dataLength: Long,
+  indexLength: Long,
+  dataFree: Long
+)

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/InformationSchemaEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/InformationSchemaEntry.scala
@@ -1,6 +1,6 @@
 package cromwell.database.sql.tables
 
-case class InformationSchemaEntry
+final case class InformationSchemaEntry
 (
   dataLength: Long,
   indexLength: Long,

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -116,6 +116,7 @@ object MetadataService {
   final case class WorkflowOutputs(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonWithOverridableSourceAction
   final case class GetLogs(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonWithOverridableSourceAction
   case object RefreshSummary extends MetadataServiceAction
+  case object SendMetadataTableSizeMetrics extends MetadataServiceAction
   trait ValidationCallback {
     def onMalformed(possibleWorkflowId: String): Unit
     def onRecognized(workflowId: WorkflowId): Unit

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -12,7 +12,7 @@ import common.validation.Validation._
 import cromwell.core._
 import cromwell.database.sql.SqlConverters._
 import cromwell.database.sql.joins.{CallOrWorkflowQuery, CallQuery, WorkflowQuery}
-import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
+import cromwell.database.sql.tables.{InformationSchemaEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 import cromwell.services.MetadataServicesStore
 import cromwell.services.metadata.MetadataService.{QueryMetadata, WorkflowQueryResponse}
 import cromwell.services.metadata._
@@ -380,4 +380,6 @@ trait MetadataDatabaseAccess {
 
   def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: OffsetDateTime)(implicit ec: ExecutionContext): Future[Int] =
     metadataDatabaseInterface.countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold.toSystemTimestamp)
+
+  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = metadataDatabaseInterface.getMetadataTableSizeInformation()
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -381,5 +381,5 @@ trait MetadataDatabaseAccess {
   def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: OffsetDateTime)(implicit ec: ExecutionContext): Future[Int] =
     metadataDatabaseInterface.countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold.toSystemTimestamp)
 
-  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = metadataDatabaseInterface.getMetadataTableSizeInformation()
+  def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[Option[InformationSchemaEntry]] = metadataDatabaseInterface.getMetadataTableSizeInformation()
 }

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -99,10 +99,7 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
   private val deleteMetadataActor: Option[ActorRef] = buildDeleteMetadataActor
 
   // if `metadata-table-size-metrics-interval` is specified, schedule sending size metrics at that interval
-  metadataTableMetricsInterval.map { x =>
-    println(s"****** FIND ME: Metadata table size metric interval: ${x.toSeconds}")
-    context.system.scheduler.schedule(1.minute, x, self, SendMetadataTableSizeMetrics)(context.dispatcher, self)
-  }
+  metadataTableMetricsInterval.map(context.system.scheduler.schedule(1.minute, _, self, SendMetadataTableSizeMetrics)(context.dispatcher, self))
 
   private def scheduleSummary(): Unit = {
     metadataSummaryRefreshInterval foreach { interval =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -99,7 +99,10 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
   private val deleteMetadataActor: Option[ActorRef] = buildDeleteMetadataActor
 
   // if `metadata-table-size-metrics-interval` is specified, schedule sending size metrics at that interval
-  metadataTableMetricsInterval.map(context.system.scheduler.schedule(1.minute, _, self, SendMetadataTableSizeMetrics)(context.dispatcher, self))
+  metadataTableMetricsInterval.map { x =>
+    println(s"****** FIND ME: Metadata table size metric interval: ${x.toSeconds}")
+    context.system.scheduler.schedule(1.minute, x, self, SendMetadataTableSizeMetrics)(context.dispatcher, self)
+  }
 
   private def scheduleSummary(): Unit = {
     metadataSummaryRefreshInterval foreach { interval =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -68,9 +68,9 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
   private val metadataTableMetricsInterval = serviceConfig.getOrElse[FiniteDuration]("table-size-metrics-interval", 1.hour)
 
   private val metadataTableMetricsPath: NonEmptyList[String] = MetadataServiceActor.MetadataInstrumentationPrefix :+ "table"
-  private val dataFreeMetricsPath: NonEmptyList[String] = metadataTableMetricsPath :+ "data_free_in_gb"
-  private val dataLengthMetricsPath: NonEmptyList[String] = metadataTableMetricsPath :+ "data_length_in_gb"
-  private val indexLengthMetricsPath:  NonEmptyList[String] = metadataTableMetricsPath :+ "index_length_in_gb"
+  private val dataFreeMetricsPath: NonEmptyList[String] = metadataTableMetricsPath :+ "data_free_in_gib"
+  private val dataLengthMetricsPath: NonEmptyList[String] = metadataTableMetricsPath :+ "data_length_in_gib"
+  private val indexLengthMetricsPath:  NonEmptyList[String] = metadataTableMetricsPath :+ "index_length_in_gib"
 
   def readMetadataWorkerActorProps(): Props =
     ReadDatabaseMetadataWorkerActor

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -306,7 +306,7 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
 
     override def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int] = notImplemented()
 
-    override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = notImplemented()
+    override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[Option[InformationSchemaEntry]] = notImplemented()
   }
 }
 

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -8,7 +8,7 @@ import cats.data.NonEmptyVector
 import com.typesafe.config.ConfigFactory
 import cromwell.core.{TestKitSuite, WorkflowId}
 import cromwell.database.sql.joins.MetadataJobQueryValue
-import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
+import cromwell.database.sql.tables.{InformationSchemaEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 import cromwell.database.sql.{MetadataSqlDatabase, SqlDatabase}
 import cromwell.services.metadata.MetadataService.{MetadataWriteAction, MetadataWriteFailure, MetadataWriteSuccess, PutMetadataAction, PutMetadataActionAndRespond}
 import cromwell.services.metadata.impl.WriteMetadataActorSpec.BatchSizeCountingWriteMetadataActor
@@ -305,6 +305,8 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
     override def countWorkflowsLeftToArchiveThatEndedOnOrBeforeThresholdTimestamp(workflowStatuses: List[String], workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int] = notImplemented()
 
     override def countWorkflowsLeftToDeleteThatEndedOnOrBeforeThresholdTimestamp(workflowEndTimestampThreshold: Timestamp)(implicit ec: ExecutionContext): Future[Int] = notImplemented()
+
+    override def getMetadataTableSizeInformation()(implicit ec: ExecutionContext): Future[InformationSchemaEntry] = notImplemented()
   }
 }
 


### PR DESCRIPTION
This PR adds 3 metrics related to metadata table size:

- cromwell.metadata.table.data_free_in_gib
- cromwell.metadata.table.data_length_in_gib
- cromwell.metadata.table.index_length_in_gib

Below is a graph from hosting Grafana locally. Since my local database is small, the numbers seen in graph are actually MiB even though it says GiB (I had tweaked the code to convert values into MiB) with metrics interval at 30 seconds:

![Screen Shot 2021-06-28 at 2 27 56 PM](https://user-images.githubusercontent.com/16748522/123685780-0be2db80-d81d-11eb-97af-1c54fbb9431a.png)

TODO: After this PR is reviewed, create a fc-develop PR to set the `metadata-table-size-metrics-interval` config for summarizer

Closes https://broadworkbench.atlassian.net/browse/BW-722