### PR TITLE
CROM-6718: FR: Call Caching - Add flag for minimizing chance of GCP cross-region network egress charges being incurred

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/callcaching/StandardCacheHitCopyingActor.scala
@@ -63,9 +63,9 @@ object StandardCacheHitCopyingActor {
 
   sealed trait StandardCacheHitCopyingActorState
   case object Idle extends StandardCacheHitCopyingActorState
-  case object WaitingForIoResponses extends StandardCacheHitCopyingActorState
+  case object CheckingCacheHitLocation extends StandardCacheHitCopyingActorState
+  case object WaitingForCopyIoResponses extends StandardCacheHitCopyingActorState
   case object FailedState extends StandardCacheHitCopyingActorState
-  case object WaitingForOnSuccessResponse extends StandardCacheHitCopyingActorState
 
   // TODO: this mechanism here is very close to the one in CallCacheHashingJobActorData
   // Abstracting it might be valuable
@@ -76,32 +76,49 @@ object StandardCacheHitCopyingActor {
     * If at any point a response comes back as a failure. Other responses for the current set will be awaited for
     * but subsequent sets will not be sent and the actor will send back a failure message.
     */
-  case class StandardCacheHitCopyingActorData(commandsToWaitFor: List[Set[IoCommand[_]]],
-                                              newJobOutputs: CallOutputs,
-                                              newDetritus: DetritusMap,
-                                              cacheHit: CallCachingEntryId,
-                                              returnCode: Option[Int]
-                                             ) {
+  sealed trait StandardCacheHitCopyingActorData {
+    def cacheHit: CallCachingEntryId
+    def commandComplete(command: IoCommand[_]): (this.type, CommandSetState)
+  }
 
+  case class SourceLocationCheckData(copyCommand: CopyOutputsCommand) extends StandardCacheHitCopyingActorData {
+    override def cacheHit: CallCachingEntryId = copyCommand.cacheHit
+    // This method is called to determine the remaining IO commands. Location checking only issues one IO command so
+    // there are no more commands, return `AllCommandsDone`.
+    override def commandComplete(command: IoCommand[_]): (this.type, CommandSetState) = (this.asInstanceOf[this.type], AllCommandsDone)
+  }
+
+  case class DestinationLocationCheckData(sourceLocation: String, copyCommand: CopyOutputsCommand) extends StandardCacheHitCopyingActorData {
+    override def cacheHit: CallCachingEntryId = copyCommand.cacheHit
+    // This method is called to determine the remaining IO commands. Location checking only issues one IO command so
+    // there are no more commands, return `AllCommandsDone`.
+    override def commandComplete(command: IoCommand[_]): (this.type, CommandSetState) = (this.asInstanceOf[this.type], AllCommandsDone)
+  }
+
+  case class CacheHitCopyingData(commandsToWaitFor: List[Set[IoCommand[_]]],
+                                 newJobOutputs: CallOutputs,
+                                 newDetritus: DetritusMap,
+                                 override val cacheHit: CallCachingEntryId,
+                                 returnCode: Option[Int]) extends StandardCacheHitCopyingActorData {
     /**
       * Removes the command from commandsToWaitFor
       * returns a pair of the new state data and CommandSetState giving information about what to do next
       */
-    def commandComplete(command: IoCommand[_]): (StandardCacheHitCopyingActorData, CommandSetState) = commandsToWaitFor match {
+    override def commandComplete(command: IoCommand[_]): (this.type, CommandSetState) = commandsToWaitFor match {
       // If everything was already done send back current data and AllCommandsDone
-      case Nil => (this, AllCommandsDone)
+      case Nil => (this.asInstanceOf[this.type], AllCommandsDone)
       case lastSubset :: Nil =>
         val updatedSubset = lastSubset - command
         // If the last subset is now empty, we're done
-        if (updatedSubset.isEmpty) (this.copy(commandsToWaitFor = List.empty), AllCommandsDone)
+        if (updatedSubset.isEmpty) (this.copy(commandsToWaitFor = List.empty).asInstanceOf[this.type], AllCommandsDone)
         // otherwise update commandsToWaitFor and keep waiting
-        else (this.copy(commandsToWaitFor = List(updatedSubset)), StillWaiting)
+        else (this.copy(commandsToWaitFor = List(updatedSubset)).asInstanceOf[this.type], StillWaiting)
       case currentSubset :: otherSubsets =>
         val updatedSubset = currentSubset - command
         // This subset is done but there are other ones, remove it from commandsToWaitFor and return the next round of commands
-        if (updatedSubset.isEmpty) (this.copy(commandsToWaitFor = otherSubsets), NextSubSet(otherSubsets.head))
+        if (updatedSubset.isEmpty) (this.copy(commandsToWaitFor = otherSubsets).asInstanceOf[this.type], NextSubSet(otherSubsets.head))
         // otherwise update the head subset and keep waiting
-        else (this.copy(commandsToWaitFor = List(updatedSubset) ++ otherSubsets), StillWaiting)
+        else (this.copy(commandsToWaitFor = List(updatedSubset) ++ otherSubsets).asInstanceOf[this.type], StillWaiting)
     }
   }
 
@@ -142,82 +159,72 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   /** Override this method if you want to provide an alternative way to duplicate files than copying them. */
   protected def duplicate(copyPairs: Set[PathPair]): Option[Try[Unit]] = None
 
+  // Override to check the location of a cache hit before attempting to copy.
+  protected def locationCheckRequired: Boolean = false
+
+  // Override to disallow copying from some locations.
+  protected def copyAllowedFromLocation(sourceLocation: String, destinationLocation: String): Boolean = true
+
+  // Override if location checking is configured to be non-strict.
+  protected def locationCheckStrictMode: Boolean = true
+
   when(Idle) {
-    case Event(command @ CopyOutputsCommand(simpletons, jobDetritus, cacheHit, returnCode), None) =>
+    case Event(copyCommand @ CopyOutputsCommand(_, _, cacheHit, _), None) =>
       val (nextState, cacheReadType) =
         if (isSourceBlacklisted(cacheHit)) {
           // We don't want to log this because blacklisting is a common and expected occurrence.
           (failAndStop(BlacklistSkip(MetricableCacheCopyErrorCategory.HitBlacklisted)), ReadHitOnly)
-        } else if (isSourceBlacklisted(command)) {
+        } else if (isSourceBlacklisted(copyCommand)) {
           // We don't want to log this because blacklisting is a common and expected occurrence.
           (failAndStop(BlacklistSkip(MetricableCacheCopyErrorCategory.BucketBlacklisted)), ReadHitAndBucket)
+        } else if (locationCheckRequired) {
+          val next = issueSourceLocationCommand(copyCommand)
+          (next, ReadHitAndBucket)
         } else {
-          // Try to make a Path of the callRootPath from the detritus
-          val next = lookupSourceCallRootPath(jobDetritus) match {
-            case Success(sourceCallRootPath) =>
-
-              // process simpletons and detritus to get updated paths and corresponding IoCommands
-              val processed = for {
-                (destinationCallOutputs, simpletonIoCommands) <- processSimpletons(simpletons, sourceCallRootPath)
-                (destinationDetritus, detritusIoCommands) <- processDetritus(jobDetritus)
-              } yield (destinationCallOutputs, destinationDetritus, simpletonIoCommands ++ detritusIoCommands)
-
-              processed match {
-                case Success((destinationCallOutputs, destinationDetritus, detritusAndOutputsIoCommands)) =>
-                  duplicate(ioCommandsToCopyPairs(detritusAndOutputsIoCommands)) match {
-                    // Use the duplicate override if exists
-                    case Some(Success(_)) => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)
-                    case Some(Failure(failure)) =>
-                      // Something went wrong in the custom duplication code. We consider this loggable because it's most likely a user-permission error:
-                      failAndStop(CopyAttemptError(failure))
-                    // Otherwise send the first round of IoCommands (file outputs and detritus) if any
-                    case None if detritusAndOutputsIoCommands.nonEmpty =>
-                      detritusAndOutputsIoCommands foreach sendIoCommand
-
-                      // Add potential additional commands to the list
-                      val additionalCommandsTry =
-                        additionalIoCommands(
-                          sourceCallRootPath = sourceCallRootPath,
-                          originalSimpletons = simpletons,
-                          newOutputs = destinationCallOutputs,
-                          originalDetritus = jobDetritus,
-                          newDetritus = destinationDetritus,
-                        )
-                      additionalCommandsTry match {
-                        case Success(additionalCommands) =>
-                          val allCommands = List(detritusAndOutputsIoCommands) ++ additionalCommands
-                          goto(WaitingForIoResponses) using
-                            Option(StandardCacheHitCopyingActorData(
-                              commandsToWaitFor = allCommands,
-                              newJobOutputs = destinationCallOutputs,
-                              newDetritus = destinationDetritus,
-                              cacheHit = cacheHit,
-                              returnCode = returnCode,
-                            ))
-                        // Something went wrong in generating duplication commands.
-                        // We consider this a loggable error because we don't expect this to happen:
-                        case Failure(failure) => failAndStop(CopyAttemptError(failure))
-                      }
-                    case _ => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)
-                  }
-
-                // Something went wrong in generating duplication commands. We consider this loggable error because we don't expect this to happen:
-                case Failure(failure) => failAndStop(CopyAttemptError(failure))
-              }
-
-            // Something went wrong in looking up the call root... loggable because we don't expect this to happen:
-            case Failure(failure) => failAndStop(CopyAttemptError(failure))
-          }
+          val next = issueCopyCommands(copyCommand)
           (next, ReadHitAndBucket)
         }
 
-      publishBlacklistReadMetrics(command, cacheHit, cacheReadType)
+      publishBlacklistReadMetrics(copyCommand, cacheHit, cacheReadType)
 
       nextState
   }
 
-  when(WaitingForIoResponses) {
-    case Event(IoSuccess(command: IoCommand[_], _), Some(data)) =>
+  when(CheckingCacheHitLocation) {
+    case Event(IoSuccess(_: IoCommand[_], sourceLocation: String), Some(SourceLocationCheckData(copyCommand))) =>
+      issueDestinationLocationCommand(sourceLocation, copyCommand)
+    case Event(IoSuccess(_: IoCommand[_], destinationLocation: String), Some(DestinationLocationCheckData(sourceLocation, copyCommand))) =>
+      if (copyAllowedFromLocation(sourceLocation, destinationLocation)) {
+        issueCopyCommands(copyCommand)
+      } else {
+        failAndStop(CopyAttemptError(new Throwable(s"disallowed copy location from $sourceLocation to $destinationLocation")))
+      }
+    case Event(f: IoReadForbiddenFailure[_], Some(data)) =>
+      // Read forbidden failures during location checking are handled the same as with copy attempts.
+      // Update the blacklist cache and fail.
+      handleBlacklistingForForbidden(
+        path = f.forbiddenPath,
+        // Loggable because this is an attempt-specific problem:
+        andThen = failAndAwaitPendingResponses(CopyAttemptError(f.failure), f.command, data)
+      )
+    case Event(IoFailAck(command: IoCommand[_], failure), Some(data @ SourceLocationCheckData(copyCommand))) =>
+      // For location checking the correct next step likely depends on strict mode.
+      if (locationCheckStrictMode) {
+        // Do the same things as for copy failure
+        handleBlacklistingForGenericFailure()
+        // Loggable because this is an attempt-specific problem:
+        failAndAwaitPendingResponses(CopyAttemptError(failure), command, data)
+      } else {
+        // YOLO
+        issueCopyCommands(copyCommand)
+      }
+
+    // Should not be possible
+    case Event(IoFailAck(_: IoCommand[_], failure), None) => failAndStop(CopyAttemptError(failure))
+  }
+
+  when(WaitingForCopyIoResponses) {
+    case Event(IoSuccess(command: IoCommand[_], _), Some(data: CacheHitCopyingData)) =>
       val (newData, commandState) = data.commandComplete(command)
 
       commandState match {
@@ -236,13 +243,13 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
           commands foreach sendIoCommand
           stay() using Option(newData)
       }
-    case Event(f: IoReadForbiddenFailure[_], Some(data)) =>
+    case Event(f: IoReadForbiddenFailure[_], Some(data: CacheHitCopyingData)) =>
       handleBlacklistingForForbidden(
         path = f.forbiddenPath,
         // Loggable because this is an attempt-specific problem:
         andThen = failAndAwaitPendingResponses(CopyAttemptError(f.failure), f.command, data)
       )
-    case Event(IoFailAck(command: IoCommand[_], failure), Some(data)) =>
+    case Event(IoFailAck(command: IoCommand[_], failure), Some(data: CacheHitCopyingData)) =>
       handleBlacklistingForGenericFailure()
       // Loggable because this is an attempt-specific problem:
       failAndAwaitPendingResponses(CopyAttemptError(failure), command, data)
@@ -251,28 +258,28 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
   }
 
   when(FailedState) {
-    case Event(f: IoReadForbiddenFailure[_], Some(data)) =>
+    case Event(f: IoReadForbiddenFailure[_], Some(data: CacheHitCopyingData)) =>
       handleBlacklistingForForbidden(
         path = f.forbiddenPath,
         andThen = stayOrStopInFailedState(f, data)
       )
-    case Event(fail: IoFailAck[_], Some(data)) =>
+    case Event(fail: IoFailAck[_], Some(data: CacheHitCopyingData)) =>
       handleBlacklistingForGenericFailure()
       stayOrStopInFailedState(fail, data)
     // At this point success or failure doesn't matter, we've already failed this hit
-    case Event(response: IoAck[_], Some(data)) =>
+    case Event(response: IoAck[_], Some(data: CacheHitCopyingData)) =>
       stayOrStopInFailedState(response, data)
   }
 
   whenUnhandled {
     case Event(AbortJobCommand, _) =>
       abort()
-    case Event(unexpected, _) =>
-      log.warning(s"Backend cache hit copying actor received an unexpected message: $unexpected in state $stateName")
+    case Event(unexpected, s) =>
+      log.warning(s"Backend cache hit copying actor received an unexpected message: $unexpected in state $stateName/$s")
       stay()
   }
 
-  private def stayOrStopInFailedState(response: IoAck[_], data: StandardCacheHitCopyingActorData): State = {
+  private def stayOrStopInFailedState(response: IoAck[_], data: CacheHitCopyingData): State = {
     val (newData, commandState) = data.commandComplete(response.command)
     commandState match {
       // If we're still waiting for some responses, stay
@@ -435,4 +442,92 @@ abstract class StandardCacheHitCopyingActor(val standardParams: StandardCacheHit
 
   def sourcePathFromCopyOutputsCommand(command: CopyOutputsCommand): String = command.jobDetritusFiles.values.head
 
+  private def issueSourceLocationCommand(copyCommand: CopyOutputsCommand): State = {
+    val sourcePath = sourcePathFromCopyOutputsCommand(copyCommand)
+    log.warning(s"Willy, in issueSourceLocationCommand, copyCommand.source is $sourcePath")
+    commandBuilder.locationCommand(getPath(sourcePath).get) match {
+      case Success(command) =>
+        sendIoCommand(command)
+        goto(CheckingCacheHitLocation)using
+          Option(SourceLocationCheckData(copyCommand))
+      case Failure(e) =>
+        failAndStop(CopyAttemptError(new Throwable(s"Error building location command for file path '$sourcePath''", e)))
+    }
+  }
+
+  private def issueDestinationLocationCommand(sourceLocation: String, copyCommand: CopyOutputsCommand): State = {
+    log.warning(s"Willy, in issueDestinationLocationCommand. We already found sourceLocation is $sourceLocation")
+    log.warning(s"Willy, JobPaths is $JobPaths")
+    log.warning(s"Willy, jobPaths is $jobPaths")
+    val dstRcPath = jobPaths.detritusPaths(JobPaths.ReturnCodePathKey)
+    log.warning(s"Willy, in issueDestinationLocationCommand, dstRcPath is $dstRcPath")
+    commandBuilder.locationCommand(dstRcPath) match {
+      case Success(command) =>
+        sendIoCommand(command)
+        goto(CheckingCacheHitLocation)using
+          Option(DestinationLocationCheckData(sourceLocation, copyCommand))
+      case Failure(e) =>
+        failAndStop(CopyAttemptError(new Throwable(s"Error building location command for rc file path '$dstRcPath''", e)))
+    }
+  }
+
+  // Code originally from `Idle` state refactored to also be callable from `CheckingCacheHitLocation`.
+  private def issueCopyCommands(command: CopyOutputsCommand) = {
+    val CopyOutputsCommand(simpletons, jobDetritus, cacheHit, returnCode) = command
+    lookupSourceCallRootPath(jobDetritus) match {
+      case Success(sourceCallRootPath) =>
+
+        // process simpletons and detritus to get updated paths and corresponding IoCommands
+        val processed = for {
+          (destinationCallOutputs, simpletonIoCommands) <- processSimpletons(simpletons, sourceCallRootPath)
+          (destinationDetritus, detritusIoCommands) <- processDetritus(jobDetritus)
+        } yield (destinationCallOutputs, destinationDetritus, simpletonIoCommands ++ detritusIoCommands)
+
+        processed match {
+          case Success((destinationCallOutputs, destinationDetritus, detritusAndOutputsIoCommands)) =>
+            duplicate(ioCommandsToCopyPairs(detritusAndOutputsIoCommands)) match {
+              // Use the duplicate override if exists
+              case Some(Success(_)) => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)
+              case Some(Failure(failure)) =>
+                // Something went wrong in the custom duplication code. We consider this loggable because it's most likely a user-permission error:
+                failAndStop(CopyAttemptError(failure))
+              // Otherwise send the first round of IoCommands (file outputs and detritus) if any
+              case None if detritusAndOutputsIoCommands.nonEmpty =>
+                detritusAndOutputsIoCommands foreach sendIoCommand
+
+                // Add potential additional commands to the list
+                val additionalCommandsTry =
+                  additionalIoCommands(
+                    sourceCallRootPath = sourceCallRootPath,
+                    originalSimpletons = simpletons,
+                    newOutputs = destinationCallOutputs,
+                    originalDetritus = jobDetritus,
+                    newDetritus = destinationDetritus,
+                  )
+                additionalCommandsTry match {
+                  case Success(additionalCommands) =>
+                    val allCommands = List(detritusAndOutputsIoCommands) ++ additionalCommands
+                    goto(WaitingForCopyIoResponses) using
+                      Option(CacheHitCopyingData(
+                        commandsToWaitFor = allCommands,
+                        newJobOutputs = destinationCallOutputs,
+                        newDetritus = destinationDetritus,
+                        cacheHit = cacheHit,
+                        returnCode = returnCode,
+                      ))
+                  // Something went wrong in generating duplication commands.
+                  // We consider this a loggable error because we don't expect this to happen:
+                  case Failure(failure) => failAndStop(CopyAttemptError(failure))
+                }
+              case _ => succeedAndStop(returnCode, destinationCallOutputs, destinationDetritus)
+            }
+
+          // Something went wrong in generating duplication commands. We consider this loggable error because we don't expect this to happen:
+          case Failure(failure) => failAndStop(CopyAttemptError(failure))
+        }
+
+      // Something went wrong in looking up the call root... loggable because we don't expect this to happen:
+      case Failure(failure) => failAndStop(CopyAttemptError(failure))
+    }
+  }
 }

--- a/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/DefaultIoCommand.scala
@@ -55,4 +55,8 @@ object DefaultIoCommand {
   case class DefaultIoIsDirectoryCommand(override val file: Path) extends IoIsDirectoryCommand(file) {
     override def commandDescription: String = s"DefaultIoIsDirectoryCommand file '$file'"
   }
+
+  case class DefaultIoLocationCommand(override val file: Path) extends IoLocationCommand(file) {
+    override def commandDescription: String = s"DefaultLocationCommand file '$file'"
+  }
 }

--- a/core/src/main/scala/cromwell/core/io/IoCommand.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommand.scala
@@ -184,3 +184,8 @@ abstract class IoIsDirectoryCommand(val file: Path) extends SingleFileIoCommand[
   override def toString = s"check whether ${file.pathAsString} is a directory"
   override lazy val name = "is directory"
 }
+
+abstract class IoLocationCommand(val file: Path) extends SingleFileIoCommand[String] {
+  override def toString = s"location of ${file.pathAsString}"
+  override lazy val name = "location"
+}

--- a/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
+++ b/core/src/main/scala/cromwell/core/io/IoCommandBuilder.scala
@@ -23,6 +23,7 @@ abstract class PartialIoCommandBuilder {
   def existsCommand: PartialFunction[Path, Try[IoExistsCommand]] = PartialFunction.empty
   def isDirectoryCommand: PartialFunction[Path, Try[IoIsDirectoryCommand]] = PartialFunction.empty
   def readLinesCommand: PartialFunction[Path, Try[IoReadLinesCommand]] = PartialFunction.empty
+  def locationCommand: PartialFunction[Path, Try[IoLocationCommand]] = PartialFunction.empty
 }
 
 object IoCommandBuilder {
@@ -98,6 +99,10 @@ class IoCommandBuilder(partialBuilders: List[PartialIoCommandBuilder] = List.emp
 
   def readLines(file: Path): Try[IoReadLinesCommand] = {
     buildOrDefault(_.readLinesCommand, file, DefaultIoReadLinesCommand(file))
+  }
+  
+  def locationCommand(file: Path): Try[IoLocationCommand] = {
+    buildOrDefault(_.locationCommand, file, DefaultIoLocationCommand(file))
   }
 }
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchCommandBuilder.scala
@@ -34,6 +34,10 @@ private case object PartialGcsBatchCommandBuilder extends PartialIoCommandBuilde
   override def isDirectoryCommand: PartialFunction[Path, Try[GcsBatchIsDirectoryCommand]] = {
     case gcsPath: GcsPath => GcsBatchIsDirectoryCommand.forPath(gcsPath)
   }
+
+  override def locationCommand: PartialFunction[Path, Try[GcsBatchLocationCommand]] = {
+    case gcsPath: GcsPath => GcsBatchLocationCommand.forPath(gcsPath)
+  }
 }
 
 case object GcsBatchCommandBuilder extends IoCommandBuilder(List(PartialGcsBatchCommandBuilder))

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommand.scala
@@ -4,7 +4,7 @@ import cats.implicits.catsSyntaxValidatedId
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.google.api.services.storage.StorageRequest
-import com.google.api.services.storage.model.{Objects, RewriteResponse, StorageObject}
+import com.google.api.services.storage.model.{Objects, RewriteResponse, StorageObject, Bucket}
 import com.google.cloud.storage.BlobId
 import common.util.StringUtil._
 import common.validation.ErrorOr.ErrorOr
@@ -240,6 +240,39 @@ case class GcsBatchIsDirectoryCommand(override val file: GcsPath,
 object GcsBatchIsDirectoryCommand {
   def forPath(file: GcsPath): Try[GcsBatchIsDirectoryCommand] = {
     file.bucketOrObjectBlobId.map(GcsBatchIsDirectoryCommand(file, _))
+  }
+}
+
+case class GcsBatchLocationCommand(override val file: GcsPath,
+                                   blob: BlobId,
+                                   setUserProject: Boolean = false,
+                                  )
+  extends IoLocationCommand(file) with SingleFileGcsBatchIoCommand[String, Bucket] {
+  override def mapGoogleResponse(response: Bucket): ErrorOr[String] = {
+    Option(response.getLocation) match {
+      case None => s"'${file.pathAsString}' in project '${file.projectId}' returned null location".invalidNel
+      case Some(location) =>
+        System.err.println("In mapGoogleResponse")
+        System.err.println(location)
+        location.validNel
+    }
+  }
+  override def operation: StorageRequest[Bucket] = {
+    System.err.println("Willy, in GcsBatchLocationCommand.operation")
+    file.apiStorage.buckets().get(blob.getBucket).setUserProject(userProject)
+  }
+
+  // override def operation: StorageRequest[StorageObject] = {
+  //   file.apiStorage.objects().get(blob.getBucket, blob.getName).setUserProject(userProject)
+  // }
+
+  override def withUserProject: GcsBatchLocationCommand = this.copy(setUserProject = true)
+  override def commandDescription: String = s"GcsBatchIsDirectoryCommand file '$file' setUserProject '$setUserProject'"
+}
+
+object GcsBatchLocationCommand {
+  def forPath(file: GcsPath): Try[GcsBatchLocationCommand] = {
+    file.bucketOrObjectBlobId.map(GcsBatchLocationCommand(file, _))
   }
 }
 

--- a/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommandSpec.scala
+++ b/filesystems/gcs/src/test/scala/cromwell/filesystems/gcs/batch/GcsBatchIoCommandSpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
-import com.google.api.services.storage.model.{Objects, RewriteResponse, StorageObject}
+import com.google.api.services.storage.model.{Bucket, Objects, RewriteResponse, StorageObject}
 import cromwell.filesystems.gcs.{GcsPathBuilder, MockGcsPathBuilder}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -83,6 +83,22 @@ class GcsBatchIoCommandSpec extends AnyFlatSpec with Matchers with BeforeAndAfte
     command.mapGoogleResponse(response) should be(Valid("aeiouy"))
 
     command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be("aeiouy")
+
+    command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
+  }
+
+  it should "test GcsBatchLocationCommand" in {
+    val command = PartialGcsBatchCommandBuilder.locationCommand(gcsPath).get
+
+    type commandType = com.google.api.services.storage.Storage#Buckets#Get
+    command.operation should be(a[commandType])
+
+    val response = new Bucket()
+    response.setLocation("US")
+
+    command.mapGoogleResponse(response) should be(Valid("US"))
+
+    command.onSuccess(response, new HttpHeaders()).toEither.right.get.left.get should be ("US")
 
     command.onFailure(new GoogleJsonError(), new HttpHeaders()) should be(None)
   }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActor.scala
@@ -21,7 +21,46 @@ class PipelinesApiBackendCacheHitCopyingActor(standardParams: StandardCacheHitCo
   private val cachingStrategy = BackendInitializationData
     .as[PipelinesApiBackendInitializationData](standardParams.backendInitializationDataOption)
     .papiConfiguration.papiAttributes.cacheHitDuplicationStrategy
-  
+
+  private def getBucketContinent(bucketLocation: String): String = {
+    val indexOf = bucketLocation.indexOf("-")
+    if (indexOf != -1) {
+      bucketLocation.substring(0, indexOf)
+    } else {
+      bucketLocation
+    }
+  }
+
+  override protected def locationCheckRequired: Boolean = {
+    val option = standardParams.jobDescriptor.workflowDescriptor.workflowOptions.getOrElse("call_cache_egress", "global")
+    val b = option != "global"
+    log.warning(s"WILLY, in locationCheckRequired, returning $b because call_cache_egress option is $option")
+    b
+  }
+
+  override protected def copyAllowedFromLocation(sourceLocation: String, destinationLocation: String): Boolean = {
+    val callCacheEgressOption = standardParams.jobDescriptor.workflowDescriptor.workflowOptions.getOrElse("call_cache_egress", "global")
+    log.warning(s"WILLY, in copyAllowedFromLocation, sourceLocation is $sourceLocation")
+    log.warning(s"WILLY, in copyAllowedFromLocation, destinationLocation is $destinationLocation")
+    log.warning(s"WILLY, in copyAllowedFromLocation, callCacheEgressOption is $callCacheEgressOption")
+    callCacheEgressOption match {
+      case "global" => true
+      case "continental" =>
+        val sourceContinent = getBucketContinent(sourceLocation)
+        val destinationContinent = getBucketContinent(destinationLocation)
+        val b = sourceContinent == destinationContinent
+        log.warning(s"WILLY, in copyAllowedFromLocation, case continental, returning $b")
+        b
+      case "none" =>
+        val b = sourceLocation == destinationLocation
+        log.warning(s"WILLY, in copyAllowedFromLocation, case none, returning $b")
+        b
+      case default =>
+        log.warning(s"WILLY, in copyAllowedFromLocation, did not match on callCacheEgressOption $default")
+        true
+    }    
+  }
+
   override def processSimpletons(womValueSimpletons: Seq[WomValueSimpleton],
                                  sourceCallRootPath: Path,
                                 ): Try[(CallOutputs, Set[IoCommand[_]])] =


### PR DESCRIPTION
Extending mcovarr's work in #6366 . Big shoutout to mcovarr!!!

[Per @mbookman]
This pull request is an initial update to address:

CROM-6718: FR: Add flag for minimizing chance of GCP cross-region network egress charges being incurred

This PR specifically focuses on the risks of egress charges incurred due to call caching. The framing of the approach here, which is a bit broader than originally noted in CROM-6718, is:
Make call caching location-aware, prioritizing copies that minimize egress charges.
Add a workflow option enabling control of what egress charges can be incurred for call cache copying.
The new workflow option would be:

call_cache_egress: [none, continental, global]

where the values affect whether call cache copies can incur egress charges:
none: only within-region copies are allowed, which generate no egress charges
continental: within content copies are allowed; within-content copies have reduced costs, such as $0.01 / GB in the US
global: copies across all regions are allowed. Cross-content egress charges can be much higher (ranging from $0.08 / GB up to $0.23 / GB)


### CURRENT STATUS OF PR:
With the changes in this PR, Cromwell successfully checks the location of the source and destination file to be copied, compares the location, and makes a decision of whether or not it should be copied based on the call_cache_egress option. If it should be copied, the files are copied as normal. If it should not be copied, the cache attempt fails and the workflow runs instead. 