### PR TITLE
Sub workflow end state consistency [BW-728]

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -3,7 +3,7 @@ package cromwell.engine.workflow.lifecycle.execution
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.SupervisorStrategy.Escalate
-import akka.actor.{ActorRef, FSM, LoggingFSM, OneForOneStrategy, Props, SupervisorStrategy}
+import akka.actor.{ActorRef, LoggingFSM, OneForOneStrategy, Props, SupervisorStrategy}
 import com.typesafe.config.Config
 import cromwell.backend.standard.callcaching.BlacklistCache
 import cromwell.backend.{AllBackendInitializationData, BackendLifecycleActorFactory, BackendWorkflowDescriptor}
@@ -26,6 +26,8 @@ import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import cromwell.subworkflowstore.SubWorkflowStoreActor._
 import wom.values.WomEvaluatedCallInputs
+
+import scala.util.control.NoStackTrace
 
 class SubWorkflowExecutionActor(key: SubWorkflowKey,
                                 parentWorkflow: EngineWorkflowDescriptor,
@@ -54,7 +56,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   override val workflowIdForCallMetadata = parentWorkflow.id
   override def jobTag: String = key.tag
 
-  startWith(SubWorkflowPendingState, SubWorkflowExecutionActorData.empty)
+  startWith(SubWorkflowPendingState,   SubWorkflowExecutionActorData.empty)
 
   override def preStart(): Unit = {
     context.system.eventStream.publish(SubWorkflowStart(self))
@@ -90,7 +92,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     * subworkflow and would lead to memory leaks.
     */
   when(WaitingForValueStore) {
-    case Event(valueStore: ValueStore, SubWorkflowExecutionActorData(Some(subWorkflowId), _)) =>
+    case Event(valueStore: ValueStore, SubWorkflowExecutionActorLiveData(Some(subWorkflowId), _)) =>
       prepareSubWorkflow(subWorkflowId, valueStore)
     case Event(_: ValueStore, _) =>
       context.parent ! SubWorkflowFailedResponse(key, Map.empty, new IllegalStateException(
@@ -103,30 +105,41 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   when(SubWorkflowPreparingState) {
     case Event(SubWorkflowPreparationSucceeded(subWorkflowEngineDescriptor, inputs), data) =>
       startSubWorkflow(subWorkflowEngineDescriptor, inputs, data)
-    case Event(failure: CallPreparationFailed, _) =>
-      context.parent ! SubWorkflowFailedResponse(key, Map.empty, failure.throwable)
-      context stop self
-      stay()
+    case Event(failure: CallPreparationFailed, data) =>
+      goto(SubWorkflowFailedState) using SubWorkflowExecutionActorTerminalData(data.subWorkflowId, SubWorkflowFailedResponse(key, Map.empty, failure.throwable))
   }
 
   when(SubWorkflowRunningState) {
-    case Event(WorkflowExecutionSucceededResponse(executedJobKeys, rootAndSubworklowIds, outputs, cumulativeOutputs), _) =>
-      context.parent ! SubWorkflowSucceededResponse(key, executedJobKeys, rootAndSubworklowIds, outputs, cumulativeOutputs)
-      goto(SubWorkflowSucceededState)
-    case Event(WorkflowExecutionFailedResponse(executedJobKeys, reason), _) =>
-      context.parent ! SubWorkflowFailedResponse(key, executedJobKeys, reason)
-      goto(SubWorkflowFailedState)
-    case Event(WorkflowExecutionAbortedResponse(executedJobKeys), _) =>
-      context.parent ! SubWorkflowAbortedResponse(key, executedJobKeys)
-      goto(SubWorkflowAbortedState)
-    case Event(EngineLifecycleActorAbortCommand, SubWorkflowExecutionActorData(_, Some(actorRef))) =>
+    case Event(WorkflowExecutionSucceededResponse(executedJobKeys, rootAndSubworklowIds, outputs, cumulativeOutputs), data) =>
+      goto(SubWorkflowSucceededState) using SubWorkflowExecutionActorTerminalData(data.subWorkflowId, SubWorkflowSucceededResponse(key, executedJobKeys, rootAndSubworklowIds, outputs, cumulativeOutputs))
+    case Event(WorkflowExecutionFailedResponse(executedJobKeys, reason), data) =>
+      goto(SubWorkflowFailedState) using SubWorkflowExecutionActorTerminalData(data.subWorkflowId, SubWorkflowFailedResponse(key, executedJobKeys, reason))
+    case Event(WorkflowExecutionAbortedResponse(executedJobKeys), data) =>
+      goto(SubWorkflowAbortedState) using SubWorkflowExecutionActorTerminalData(data.subWorkflowId, SubWorkflowAbortedResponse(key, executedJobKeys))
+    case Event(EngineLifecycleActorAbortCommand, SubWorkflowExecutionActorLiveData(_, Some(actorRef))) =>
       actorRef ! EngineLifecycleActorAbortCommand
       stay()
   }
 
-  when(SubWorkflowSucceededState) { FSM.NullFunction }
-  when(SubWorkflowFailedState) { FSM.NullFunction }
-  when(SubWorkflowAbortedState) { FSM.NullFunction }
+  val terminalMetadataWriteResponseHandler: StateFunction = {
+    case Event(MetadataWriteSuccess(_), terminalData: SubWorkflowExecutionActorTerminalData) =>
+      // All set
+      context.parent ! terminalData.terminalStateResponse
+      context.stop(self)
+      stay()
+    case Event(MetadataWriteFailure(reason, _), terminalData: SubWorkflowExecutionActorTerminalData) =>
+      // We don't have a great answer here if the final subworkflow state failed to be written.
+      // If the final state can't be written, it's fairly likely that other metadata has also been lost, so
+      // the best answer may unfortunately be to fail the workflow rather than retry. Assuming the call cache is working
+      // correctly, a retry of the workflow should at least cache-hit instead of having to re-run the work:
+      recordTerminalState(SubWorkflowFailedState, terminalData.copy(terminalStateResponse = SubWorkflowFailedResponse(key,
+        terminalData.terminalStateResponse.jobExecutionMap,
+        new Exception("Sub workflow execution actor unable to write final state to metadata", reason) with NoStackTrace)))
+  }
+
+  when(SubWorkflowSucceededState) { terminalMetadataWriteResponseHandler }
+  when(SubWorkflowFailedState) { terminalMetadataWriteResponseHandler }
+  when(SubWorkflowAbortedState) { terminalMetadataWriteResponseHandler }
 
   whenUnhandled {
     case Event(SubWorkflowStoreRegisterSuccess(_), _) =>
@@ -135,29 +148,35 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     case Event(SubWorkflowStoreFailure(command, reason), _) =>
       jobLogger.error(reason, s"SubWorkflowStore failure for command $command")
       stay()
-    case Event(EngineLifecycleActorAbortCommand, _) =>
-      context.parent ! SubWorkflowAbortedResponse(key, Map.empty)
-      goto(SubWorkflowAbortedState)
+    case Event(EngineLifecycleActorAbortCommand, data) =>
+      recordTerminalState(SubWorkflowAbortedState, SubWorkflowExecutionActorTerminalData(data.subWorkflowId, SubWorkflowAbortedResponse(key, Map.empty)))
+  }
+
+  def recordTerminalState(terminalState: SubWorkflowTerminalState, stateData: SubWorkflowExecutionActorTerminalData): State = {
+    stateData.subWorkflowId match {
+      case Some(id) =>
+        pushWorkflowEnd(id)
+        pushExecutionEventsToMetadataService(key, eventList)
+        pushCurrentStateToMetadataService(id, terminalState.workflowState, confirmTo = Option(self))
+        goto(terminalState) using stateData
+      case _ =>
+        jobLogger.error("Programmer Error: Sub workflow completed without ever having a Sub Workflow UUID.")
+        // Same situation as if we fail to write the final state metadata. Bail out and hope the workflow is more
+        // successful next time:
+        context.parent ! SubWorkflowFailedResponse(key,
+          Map.empty,
+          new Exception("Programmer Error: Sub workflow completed without ever having a Sub Workflow UUID") with NoStackTrace)
+        context.stop(self)
+        stay()
+    }
   }
 
   onTransition {
     case (_, toState) =>
-      stateData.subWorkflowId foreach { id => pushCurrentStateToMetadataService(id, toState.workflowState) }
-  }
-
-  onTransition {
-    case (_, _: SubWorkflowTerminalState) =>
-      stateData.subWorkflowId match {
-        case Some(id) =>
-          pushWorkflowEnd(id)
-          pushExecutionEventsToMetadataService(key, eventList)
-        case None => jobLogger.error("Sub workflow completed without a Sub Workflow UUID.")
+      eventList :+= ExecutionEvent(toState.toString)
+      if (!toState.isInstanceOf[SubWorkflowTerminalState]) {
+        stateData.subWorkflowId foreach { id => pushCurrentStateToMetadataService(id, toState.workflowState) }
       }
-      context stop self
-  }
-
-  onTransition {
-    case _ -> toState => eventList :+= ExecutionEvent(toState.toString)
   }
 
   private def startSubWorkflow(subWorkflowEngineDescriptor: EngineWorkflowDescriptor, inputs: WomEvaluatedCallInputs, data: SubWorkflowExecutionActorData) = {
@@ -167,7 +186,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     context.parent ! JobRunning(key, inputs)
     pushWorkflowRunningMetadata(subWorkflowEngineDescriptor.backendDescriptor, inputs)
 
-    goto(SubWorkflowRunningState) using data.copy(subWorkflowActor = Option(subWorkflowActor))
+    goto(SubWorkflowRunningState) using SubWorkflowExecutionActorLiveData(data.subWorkflowId, Option(subWorkflowActor))
   }
 
   private def prepareSubWorkflow(subWorkflowId: WorkflowId, valueStore: ValueStore) = {
@@ -175,12 +194,12 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     context.parent ! JobStarting(key)
     pushCurrentStateToMetadataService(subWorkflowId, WorkflowRunning)
     pushWorkflowStart(subWorkflowId)
-    goto(SubWorkflowPreparingState) using SubWorkflowExecutionActorData(Option(subWorkflowId), None)
+    goto(SubWorkflowPreparingState) using   SubWorkflowExecutionActorLiveData(Option(subWorkflowId), None)
   }
 
   private def requestValueStore(workflowId: WorkflowId) = {
     context.parent ! RequestValueStore
-    goto(WaitingForValueStore) using SubWorkflowExecutionActorData(Option(workflowId), None)
+    goto(WaitingForValueStore) using   SubWorkflowExecutionActorLiveData(Option(workflowId), None)
   }
 
   def createSubWorkflowPreparationActor(subWorkflowId: WorkflowId) = {
@@ -297,9 +316,13 @@ object SubWorkflowExecutionActor {
   }
 
   object SubWorkflowExecutionActorData {
-    def empty = SubWorkflowExecutionActorData(None, None)
+    def empty = SubWorkflowExecutionActorLiveData(None, None)
   }
-  case class SubWorkflowExecutionActorData(subWorkflowId: Option[WorkflowId], subWorkflowActor: Option[ActorRef])
+  sealed trait SubWorkflowExecutionActorData {
+    def subWorkflowId: Option[WorkflowId]
+  }
+  final case class SubWorkflowExecutionActorLiveData(subWorkflowId: Option[WorkflowId], subWorkflowActor: Option[ActorRef]) extends SubWorkflowExecutionActorData
+  final case class SubWorkflowExecutionActorTerminalData(subWorkflowId: Option[WorkflowId], terminalStateResponse: SubWorkflowTerminalStateResponse) extends SubWorkflowExecutionActorData
 
   sealed trait EngineWorkflowExecutionActorCommand
   case object Execute

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActor.scala
@@ -56,7 +56,7 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
   override val workflowIdForCallMetadata = parentWorkflow.id
   override def jobTag: String = key.tag
 
-  startWith(SubWorkflowPendingState,   SubWorkflowExecutionActorData.empty)
+  startWith(SubWorkflowPendingState, SubWorkflowExecutionActorData.empty)
 
   override def preStart(): Unit = {
     context.system.eventStream.publish(SubWorkflowStart(self))
@@ -195,12 +195,12 @@ class SubWorkflowExecutionActor(key: SubWorkflowKey,
     context.parent ! JobStarting(key)
     pushCurrentStateToMetadataService(subWorkflowId, WorkflowRunning)
     pushWorkflowStart(subWorkflowId)
-    goto(SubWorkflowPreparingState) using   SubWorkflowExecutionActorLiveData(Option(subWorkflowId), None)
+    goto(SubWorkflowPreparingState) using SubWorkflowExecutionActorLiveData(Option(subWorkflowId), None)
   }
 
   private def requestValueStore(workflowId: WorkflowId) = {
     context.parent ! RequestValueStore
-    goto(WaitingForValueStore) using   SubWorkflowExecutionActorLiveData(Option(workflowId), None)
+    goto(WaitingForValueStore) using SubWorkflowExecutionActorLiveData(Option(workflowId), None)
   }
 
   def createSubWorkflowPreparationActor(subWorkflowId: WorkflowId) = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -814,15 +814,17 @@ object WorkflowExecutionActor {
     */
   private case object ExecutionHeartBeatKey
 
+  sealed trait SubWorkflowTerminalStateResponse { def jobExecutionMap: JobExecutionMap }
+
   case class SubWorkflowSucceededResponse(key: SubWorkflowKey,
                                           jobExecutionMap: JobExecutionMap,
                                           rootAndSubworklowIds: Set[WorkflowId],
                                           outputs: CallOutputs,
-                                          cumulativeOutputs: Set[WomValue] = Set.empty)
+                                          cumulativeOutputs: Set[WomValue] = Set.empty) extends SubWorkflowTerminalStateResponse
 
-  case class SubWorkflowFailedResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap, reason: Throwable)
+  case class SubWorkflowFailedResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap, reason: Throwable) extends SubWorkflowTerminalStateResponse
 
-  case class SubWorkflowAbortedResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap)
+  case class SubWorkflowAbortedResponse(key: SubWorkflowKey, jobExecutionMap: JobExecutionMap) extends SubWorkflowTerminalStateResponse
 
   case class WorkflowExecutionActorParams(
                                            workflowDescriptor: EngineWorkflowDescriptor,

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
@@ -281,7 +281,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
       case PutMetadataActionAndRespond(events, _, _) => swea ! MetadataWriteSuccess(events)
     }
 
-    // The workflow is now considered failed (since lots of metadata is probably lost:
+    // The workflow is now considered failed since lots of metadata is probably lost:
     parentProbe.expectMsgPF(awaitTimeout) {
       case SubWorkflowFailedResponse(`subKey`, `jobExecutionMap`, reason) =>
         reason.getMessage should be("Sub workflow execution actor unable to write final state to metadata")

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/SubWorkflowExecutionActorSpec.scala
@@ -34,7 +34,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with Mockito with Eventually {
-  
+
   behavior of "SubWorkflowExecutionActor"
 
   val serviceRegistryProbe = TestProbe()
@@ -94,7 +94,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
         override def createSubWorkflowActor(createSubWorkflowActor: EngineWorkflowDescriptor) = subWorkflowActor.ref
       }), parentProbe.ref, s"SubWorkflowExecutionActorSpec-${UUID.randomUUID()}")
   }
-  
+
   it should "Check the sub workflow store when restarting" in {
     val ewea = buildEWEA(startState = RestartableRunning)
     ewea.setState(SubWorkflowPendingState)
@@ -108,14 +108,14 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
 
   it should "Reuse sub workflow id if found in the store" in {
     import cromwell.core.ExecutionIndex._
-    
+
     val ewea = buildEWEA(startState = RestartableRunning)
     ewea.setState(SubWorkflowCheckingStoreState)
-    
+
     val subWorkflowUuid = WorkflowId.randomId()
     ewea ! SubWorkflowFound(SubWorkflowStoreEntry(Option(0), parentWorkflowId.toString, subKey.node.fullyQualifiedName, subKey.index.fromIndex, subKey.attempt, subWorkflowUuid.toString, None))
     parentProbe.expectMsg(RequestValueStore)
-    
+
     eventually {
       ewea.stateName shouldBe WaitingForValueStore
       ewea.stateData.subWorkflowId shouldBe Some(subWorkflowUuid)
@@ -128,19 +128,19 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
 
     ewea ! SubWorkflowNotFound(QuerySubWorkflow(parentWorkflowId, subKey))
     parentProbe.expectMsg(RequestValueStore)
-    
+
     eventually {
       ewea.stateName shouldBe WaitingForValueStore
       ewea.stateData.subWorkflowId should not be empty
     }
   }
-  
+
   it should "Request output store" in {
     val ewea = buildEWEA()
     val subWorkflowId = WorkflowId.randomId()
-    ewea.setState(WaitingForValueStore, SubWorkflowExecutionActorData(Option(subWorkflowId), None))
+    ewea.setState(WaitingForValueStore, SubWorkflowExecutionActorLiveData(Option(subWorkflowId), None))
     val valueStore = ValueStore.empty
-    
+
     ewea ! valueStore
     preparationActor.expectMsg(CallPreparation.Start(valueStore))
     parentProbe.expectMsg(JobStarting(subKey))
@@ -148,12 +148,12 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
       ewea.stateName shouldBe SubWorkflowPreparingState
     }
   }
-  
+
   it should "Prepare a sub workflow"
 
   it should "Run a sub workflow" in {
     val ewea = buildEWEA()
-    ewea.setState(SubWorkflowPreparingState, SubWorkflowExecutionActorData(Some(WorkflowId.randomId()), None))
+    ewea.setState(SubWorkflowPreparingState, SubWorkflowExecutionActorLiveData(Some(WorkflowId.randomId()), None))
 
     val subWorkflowId = WorkflowId.randomId()
     val subBackendDescriptor = mock[BackendWorkflowDescriptor]
@@ -166,7 +166,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
       List.empty,
       CallCachingOff
     )
-    
+
     ewea ! SubWorkflowPreparationSucceeded(subWorkflowDescriptor, Map.empty)
     subWorkflowActor.expectMsg(WorkflowExecutionActor.ExecuteWorkflowCommand)
     parentProbe.expectMsg(JobRunning(subKey, Map.empty))
@@ -187,11 +187,11 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
     parentProbe.expectMsg(SubWorkflowFailedResponse(subKey, Map.empty, throwable))
     deathWatch.expectTerminated(ewea, awaitTimeout)
   }
-  
+
   it should "Relay Workflow Successful message" in {
     val ewea = buildEWEA()
     val subworkflowId = WorkflowId.randomId()
-    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorData(Some(subworkflowId), None))
+    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorLiveData(Some(subworkflowId), None))
 
     deathWatch watch ewea
 
@@ -205,13 +205,13 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
 
   it should "Relay Workflow Failed message" in {
     val ewea = buildEWEA()
-    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorData(Some(WorkflowId.randomId()), None))
+    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorLiveData(Some(WorkflowId.randomId()), None))
 
     deathWatch watch ewea
 
     val jobExecutionMap: JobExecutionMap = Map.empty
     val expectedException: Exception = new Exception("Expected test exception")
-    
+
     val workflowSuccessfulMessage = WorkflowExecutionFailedResponse(jobExecutionMap, expectedException)
     ewea ! workflowSuccessfulMessage
     parentProbe.expectMsg(SubWorkflowFailedResponse(subKey, jobExecutionMap, expectedException))
@@ -220,7 +220,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
 
   it should "Relay Workflow Aborted message" in {
     val ewea = buildEWEA()
-    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorData(Some(WorkflowId.randomId()), None))
+    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorLiveData(Some(WorkflowId.randomId()), None))
 
     deathWatch watch ewea
 
@@ -233,7 +233,7 @@ class SubWorkflowExecutionActorSpec extends TestKitSuite with AnyFlatSpecLike wi
 
   it should "Relay Workflow Abort command message" in {
     val ewea = buildEWEA()
-    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorData(Some(WorkflowId.randomId()), Option(subWorkflowActor.ref)))
+    ewea.setState(SubWorkflowRunningState, SubWorkflowExecutionActorLiveData(Some(WorkflowId.randomId()), Option(subWorkflowActor.ref)))
 
     deathWatch watch ewea
 


### PR DESCRIPTION
Tested locally with a long pause inserted into the metadata write actor. Shutting down and restarting after the subworkflow "finished" but before the final state metadata was written did not cause inconsistency in statuses written to the DB.