### PR TITLE
Centaur: print complete metadata instead of JSON diff [CROM-6735]

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -750,8 +750,7 @@ object Operations extends StrictLogging {
         }
       }
 
-      val jsonDiff = diff(expected: JsValue, actual: JsValue).toJson.prettyPrint
-      IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Diff (changes to mutate from 'expected' to 'actual'): $jsonDiff", workflow, submittedWorkflow))
+      IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Expected: $expected Actual: $actual", workflow, submittedWorkflow))
     }
   }
 

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -712,7 +712,6 @@ object Operations extends StrictLogging {
     } else {
       import diffson._
       import diffson.jsonpatch._
-      import diffson.jsonpatch.lcsdiff._
       import diffson.lcs._
       import diffson.sprayJson._
 

--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -712,6 +712,7 @@ object Operations extends StrictLogging {
     } else {
       import diffson._
       import diffson.jsonpatch._
+      import diffson.jsonpatch.lcsdiff._
       import diffson.lcs._
       import diffson.sprayJson._
 
@@ -749,7 +750,8 @@ object Operations extends StrictLogging {
         }
       }
 
-      IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Expected: $expected Actual: $actual", workflow, submittedWorkflow))
+      val jsonDiff = diff(expected: JsValue, actual: JsValue).toJson.prettyPrint
+      IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Diff: $jsonDiff Expected: $expected Actual: $actual", workflow, submittedWorkflow))
     }
   }
 

--- a/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
+++ b/centaur/src/main/scala/centaur/test/formulas/TestFormulas.scala
@@ -80,7 +80,7 @@ object TestFormulas extends StrictLogging {
     _ <- timingVerificationNotSupported(workflowDefinition.maximumAllowedTime)
     submittedWorkflow <- runFailingWorkflow(workflowDefinition)
     metadata <- fetchAndValidateNonSubworkflowMetadata(submittedWorkflow, workflowDefinition)
-    _ <- fetchAndValidateJobManagerStyleMetadata(submittedWorkflow, workflowDefinition, Option(metadata.value))
+    _ <- fetchAndValidateJobManagerStyleMetadata(submittedWorkflow, workflowDefinition, prefetchedOriginalNonSubWorkflowMetadata = Option(metadata.value))
     _ = cromwellTracker.track(metadata)
     _ <- validateDirectoryContentsCounts(workflowDefinition, submittedWorkflow, metadata)
   } yield SubmitResponse(submittedWorkflow)


### PR DESCRIPTION
I realize this may seem like a regression but hear my plea:

The output of `diff(expected, actual)` looks like
```
[
    {
        "op": "replace",
        "path": "Chain(Left(calls), Left(test_custom_cacheworthy_attributes.custom_cacheworthy_attributes_task_should_not_cache), Right(0), Left(executionStatus))",
        "value": "Done"
    }
]
```
which is to say that the value at path
```
/calls/test_custom_cacheworthy_attributes.custom_cacheworthy_attributes_task_should_not_cache/0/executionStatus
```
is `Done` in `actual` and something else in `expected`.

The problem is that `Done` sounds right and there is no way to tell what is in `expected`! In this style of tests `expected` is computed from actual metadata and I think it's the cause of the flakiness. Perhaps we are retrieving `expected` metadata before the task finishes, or it is being call-cached when it should not be.