### PR TITLE
Reduce likelihood of DRS hogging IoActor NIO threads [BT-341]

### DIFF
--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 final case class DrsConfig(marthaUrl: String,
                            numRetries: Int,
@@ -16,9 +17,9 @@ final case class DrsConfig(marthaUrl: String,
 object DrsConfig {
   // If you update these values also update Filesystems.md!
   private val DefaultNumRetries = 3
-  private val DefaultWaitInitial = 30.seconds
-  private val DefaultWaitMaximum = 5.minutes
-  private val DefaultWaitMultiplier = 2.0d
+  private val DefaultWaitInitial = 10 seconds
+  private val DefaultWaitMaximum = 30 seconds
+  private val DefaultWaitMultiplier = 1.5d
   private val DefaultWaitRandomizationFactor = 0.1
 
   private val EnvMarthaUrl = "MARTHA_URL"

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -21,15 +21,18 @@ import java.nio.ByteBuffer
 import java.nio.channels.{Channels, ReadableByteChannel}
 import scala.util.Try
 
-abstract class DrsPathResolver(drsConfig: DrsConfig) {
+abstract class DrsPathResolver(drsConfig: DrsConfig, retryInternally: Boolean = true) {
 
-  private lazy val retryHandler = new MarthaHttpRequestRetryStrategy(drsConfig)
-
-  protected lazy val httpClientBuilder: HttpClientBuilder =
-    HttpClientBuilder
-      .create()
-      .setRetryHandler(retryHandler)
-      .setServiceUnavailableRetryStrategy(retryHandler)
+  protected lazy val httpClientBuilder: HttpClientBuilder = {
+    val clientBuilder = HttpClientBuilder.create()
+    if (retryInternally) {
+      val retryHandler = new MarthaHttpRequestRetryStrategy(drsConfig)
+      clientBuilder
+        .setRetryHandler(retryHandler)
+        .setServiceUnavailableRetryStrategy(retryHandler)
+    }
+    clientBuilder
+  }
 
   def getAccessToken: String
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/EngineDrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/EngineDrsPathResolver.scala
@@ -9,7 +9,7 @@ case class EngineDrsPathResolver(drsConfig: DrsConfig,
                                  accessTokenAcceptableTTL: Duration,
                                  authCredentials: OAuth2Credentials,
                                 )
-  extends DrsPathResolver(drsConfig) {
+  extends DrsPathResolver(drsConfig, retryInternally = false) {
 
   //Based on method from GcrRegistry
   override def getAccessToken: String = {

--- a/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/CloudNioRetry.scala
+++ b/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/CloudNioRetry.scala
@@ -4,7 +4,6 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 class CloudNioRetry(config: Config) {

--- a/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/CloudNioRetry.scala
+++ b/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/CloudNioRetry.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
 class CloudNioRetry(config: Config) {
@@ -28,7 +29,7 @@ class CloudNioRetry(config: Config) {
       case Failure(exception: Exception) if isFatal(exception) => throw exception
       case Failure(exception: Exception) if !isFatal(exception) =>
         val retriesLeft = if (isTransient(exception)) maxRetries else maxRetries map { _ - 1 }
-        if (retriesLeft.forall(_ > 0)) {
+        if (retriesLeft.forall(_ >= 0)) {
           Thread.sleep(delay)
           fromTry(f, retriesLeft, backoff.next)
         } else {

--- a/docs/filesystems/Filesystems.md
+++ b/docs/filesystems/Filesystems.md
@@ -22,10 +22,10 @@ filesystems {
             url = "https://martha-url-here"
             # The number of times to retry failures connecting or HTTP 429 or HTTP 5XX responses, default 3.
             num-retries = 3
-            # How long to wait between retrying HTTP 429 or HTTP 5XX responses, default 30 seconds.
-            wait-initial = 30 seconds
-            # The maximum amount of time to wait between retrying HTTP 429 or HTTP 5XX responses, default 5 minutes.
-            wait-maximum = 5 minutes
+            # How long to wait between retrying HTTP 429 or HTTP 5XX responses, default 10 seconds.
+            wait-initial = 10 seconds
+            # The maximum amount of time to wait between retrying HTTP 429 or HTTP 5XX responses, default 30 seconds.
+            wait-maximum = 30 seconds
             # The amount to multiply the amount of time to wait between retrying HTTP or 429 or HTTP 5XX responses.
             # Default 2.0, and will never multiply the wait time more than wait-maximum.
             wait-mulitiplier = 2.0


### PR DESCRIPTION
The `DrsCloudNioFileSystemProvider` was wrapping the retries of the `DrsPathResolver` with another set of `CloudNioRetry` retries. The product of these two retries at the previous configuration values would wait around 35 minutes (~:20 + 10 x ~3:30) to fail for each doomed attempt. That combined with a fairly wide scatter and a typo'd DRS path for `file` in code like 

```
task size {
    input {
        File file
    }

    Int file_size = ceil(size(file))
...
}
```
would completely block all 10 of the `IoActor`s [NIO threads](https://github.com/broadinstitute/cromwell/blob/develop/engine/src/main/scala/cromwell/server/CromwellRootActor.scala#L108).

These changes remove the nested retries in the engine and dial back the patience for retries. If we want the retries to be more patient we'll probably have to make other code that is competing for `IoActor` threads more patient as well.

Utility files for reproducing this error can be cherry picked from commit `ff7bddc8830802f7a606177d0eaf19c8f47ca865`. I don't know how to programatically link Google accounts to NIH accounts in Bond to be able to include this Centaur test in CI, though maybe we don't need to be linked to make sure this negative case errors within a reasonable timeout?

Workflow`9635fbf0-00b1-4635-b482-5a782cda5cd5` induced this problem in production, its metadata shows multiple `HaplotypeCaller` shards erroring out with 
```
Failed to evaluate input 'disk_size' (reason 1 of 1): [Attempted 1 time(s)] - RuntimeException: Unexpected response during DRS resolution: RuntimeException: Could not access object 'drs://dg4.DFC/...'. Status: 500, reason: 'Internal Server Error', Martha location: 'https://.../martha_v3', message: 'Received error while resolving DRS URL. getaddrinfo ENOTFOUND dg4.dfc'
```