### PR TITLE
GCS `download_as_string` stopped working, use preferred `download_as_bytes` [BT-339]

### DIFF
--- a/scripts/metadata_comparison/metadata_comparison/lib/comparison_paths.py
+++ b/scripts/metadata_comparison/metadata_comparison/lib/comparison_paths.py
@@ -67,7 +67,7 @@ class GcsPath(ComparisonPath):
         return self._storage_blob
 
     def read_text(self, encoding: AnyStr = 'utf_8') -> AnyStr:
-        return self.__storage_blob().download_as_string()
+        return self.__storage_blob().download_as_bytes()
 
     def __truediv__(self, other) -> ComparisonPath:
         return GcsPath(bucket=self._bucket,


### PR DESCRIPTION
Google's docs say `download_as_string` is only [deprecated](https://googleapis.dev/python/storage/latest/blobs.html#:~:text=Deprecated%20alias%20for%20download_as_bytes().) but not broken, Travis tells a different story.