### PR TITLE
Ignore valid new values when asserting against JM metadata pulls [CROM-6740]

### DIFF
--- a/centaur/src/main/scala/centaur/test/Test.scala
+++ b/centaur/src/main/scala/centaur/test/Test.scala
@@ -706,7 +706,8 @@ object Operations extends StrictLogging {
                            expected: JsObject,
                            actual: JsObject,
                            submittedWorkflow: SubmittedWorkflow,
-                           workflow: Workflow): IO[Unit] = {
+                           workflow: Workflow,
+                           allowableAddedOneWordFields: List[String]): IO[Unit] = {
     if (actual.equals(expected)) {
       IO.unit
     } else {
@@ -718,40 +719,57 @@ object Operations extends StrictLogging {
 
       implicit val lcs: Patience[JsValue] = new Patience[JsValue]
 
-      implicit val writer: JsonWriter[JsonPatch[JsValue]] = new JsonWriter[JsonPatch[JsValue]] {
-        def processOperation(op: Operation[JsValue]): JsValue = op match {
-          case Add(path, value) => JsObject(Map[String, JsValue](
-            "op" -> JsString("add"),
-            "path" -> JsString(path.toString),
-            "value" -> value))
-          case Copy(from, path) => JsObject(Map[String, JsValue](
-            "op" -> JsString("copy"),
-            "from" -> JsString(from.toString),
-            "path" -> JsString(path.toString)))
-          case Move(from, path) => JsObject(Map[String, JsValue](
-            "op" -> JsString("move"),
-            "from" -> JsString(from.toString),
-            "path" -> JsString(path.toString)))
-          case Remove(path, old) => JsObject(Map[String, JsValue](
-            "op" -> JsString("remove"),
-            "path" -> JsString(path.toString)) ++ old.map(o => "old" -> o))
-          case Replace(path, value, old) => JsObject(Map[String, JsValue](
-            "op" -> JsString("replace"),
-            "path" -> JsString(path.toString),
-            "value" -> value) ++ old.map(o => "old" -> o))
-          case diffson.jsonpatch.Test(path, value) => JsObject(Map[String, JsValue](
-            "op" -> JsString("test"),
-            "path" -> JsString(path.toString),
-            "value" -> value))
-        }
-
-        override def write(obj: JsonPatch[JsValue]): JsValue = {
-          JsArray(obj.ops.toVector.map(processOperation))
-        }
+      // Sometimes new metadata is allowed to be added between the diffs. Account for that here:
+      def isAllowableAddition(pointer: jsonpointer.Pointer): Boolean = pointer.parts.toList match {
+        case Left(x) :: _ if allowableAddedOneWordFields.contains(x) => true
+        case Left("calls") :: Left(_) :: Right(_) :: Left(x) :: _ if allowableAddedOneWordFields.contains(x) => true
+        case _ => false
       }
 
-      val jsonDiff = diff(expected: JsValue, actual: JsValue).toJson.prettyPrint
-      IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Diff: $jsonDiff Expected: $expected Actual: $actual", workflow, submittedWorkflow))
+      val filteredDifferences = diff(expected: JsValue, actual: JsValue).ops.toVector filter {
+        case Add(path, _) if isAllowableAddition(path) => false // Exclude valid additions
+        case _ => true // Include anything else
+      }
+
+      if (filteredDifferences.isEmpty) {
+        IO.unit
+      } else {
+        val writer: JsonWriter[Vector[Operation[JsValue]]] = new JsonWriter[Vector[Operation[JsValue]]] {
+          def processOperation(op: Operation[JsValue]): JsValue = op match {
+            case Add(path, value) => JsObject(Map[String, JsValue](
+              "description" -> JsString("Unexpected value found"),
+              "path" -> JsString(path.toString),
+              "value" -> value))
+            case Copy(from, path) => JsObject(Map[String, JsValue](
+              "description" -> JsString("Value(s) unexpectedly copied"),
+              "expected_at" -> JsString(from.toString),
+              "also_at" -> JsString(path.toString)))
+            case Move(from, path) => JsObject(Map[String, JsValue](
+              "description" -> JsString("Value(s) unexpectedly moved"),
+              "expected_location" -> JsString(from.toString),
+              "actual_location" -> JsString(path.toString)))
+            case Remove(path, old) => JsObject(Map[String, JsValue](
+              "description" -> JsString("Value missing"),
+              "expected_location" -> JsString(path.toString)) ++
+              old.map(o => "expected_value" -> o))
+            case Replace(path, value, old) => JsObject(Map[String, JsValue](
+              "description" -> JsString("Incorrect value found"),
+              "path" -> JsString(path.toString),
+              "found_value" -> value) ++ old.map(o => "expected_value" -> o))
+            case diffson.jsonpatch.Test(path, value) => JsObject(Map[String, JsValue](
+              "op" -> JsString("test"),
+              "path" -> JsString(path.toString),
+              "value" -> value))
+          }
+
+          override def write(vector: Vector[Operation[JsValue]]): JsValue = {
+            JsArray(vector.map(processOperation))
+          }
+        }
+
+        val jsonDiff = filteredDifferences.toJson(writer).prettyPrint
+        IO.raiseError(CentaurTestException(s"Error during $testType metadata comparison. Diff: $jsonDiff Expected: $expected Actual: $actual", workflow, submittedWorkflow))
+      }
     }
   }
 
@@ -772,12 +790,11 @@ object Operations extends StrictLogging {
         Option(CentaurCromwellClient.defaultMetadataArgs.getOrElse(Map.empty) ++ jmArgs))
       jmMetadataObject <- IO.fromTry(Try(jmMetadata.value.parseJson.asJsObject))
       expectation <- IO.fromTry(Try(extractJmStyleMetadataFields(originalMetadata.parseJson.asJsObject)))
-
-      _ <- validateMetadataJson(testType = s"fetchAndValidateJobManagerStyleMetadata (initial fetch)", expectation, jmMetadataObject, submittedWorkflow, workflow)
+      _ <- validateMetadataJson(testType = s"fetchAndValidateJobManagerStyleMetadata", expectation, jmMetadataObject, submittedWorkflow, workflow, allowableOneWordAdditionsInJmMetadata)
     } yield jmMetadata
   }
 
-  val oneWordIncludeKeys = List(
+  val oneWordJmIncludeKeys = List(
     "attempt", "callRoot", "end",
     "executionStatus", "failures", "inputs", "jobId",
     "calls", "outputs", "shardIndex", "start", "stderr", "stdout",
@@ -785,8 +802,15 @@ object Operations extends StrictLogging {
     "returnCode", "status", "submission", "subWorkflowId", "workflowName"
   )
 
+  // Our Job Manager metadata validation works by comparing the first pull of metadata which satisfies all test requirements
+  // against what we get when we pull metadata again specifying the job-manager-specific fields.
+  // It's possible for new values to trickle in after the first metadata pull, because our validation wasn't specifically looking for them.
+  // In those cases, the second pull (for Job Manager metadata) may include new values not present in the original.
+  // That's not a sign of an error, so allow additions in these fields when comparing original vs "job-manager only" metadata:
+  val allowableOneWordAdditionsInJmMetadata = List("outputs", "executionEvents", "end")
+
   val jmArgs = Map(
-    "includeKey" -> (oneWordIncludeKeys :+ "callCaching:hit"),
+    "includeKey" -> (oneWordJmIncludeKeys :+ "callCaching:hit"),
     "excludeKey" -> List("callCaching:hitFailures"),
     "expandSubWorkflows" -> List("false")
   )
@@ -801,7 +825,7 @@ object Operations extends StrictLogging {
 
     // NB: this filter to remove "calls" is because - although it is a single word in the JM request,
     // it gets treated specially by the API (so has to be treated specially here too)
-    def processOneWordIncludes(json: JsObject) = (oneWordIncludeKeys.filterNot(_ == "calls") :+ "id").foldRight(JsObject.empty) { (toInclude, current) =>
+    def processOneWordIncludes(json: JsObject) = (oneWordJmIncludeKeys.filterNot(_ == "calls") :+ "id").foldRight(JsObject.empty) { (toInclude, current) =>
       json.fields.get(toInclude) match {
         case Some(jsonToInclude) => JsObject(current.fields + (toInclude -> jsonToInclude))
         case None => current

--- a/centaur/src/test/scala/centaur/test/CentaurOperationsSpec.scala
+++ b/centaur/src/test/scala/centaur/test/CentaurOperationsSpec.scala
@@ -30,8 +30,8 @@ class CentaurOperationsSpec extends AnyFlatSpec with Matchers {
     Await.ready(validation, atMost = 10.seconds)
     validation.value.get match {
       case Success(()) if expectMatching => // great
-      case Success(_) if !expectMatching => fail("Metadata unexpected decided as matching")
-      case Failure(e) if expectMatching  => fail("Metadata unexpected decided as mismatching", e)
+      case Success(_) if !expectMatching => fail("Metadata unexpectedly matches")
+      case Failure(e) if expectMatching  => fail("Metadata unexpectedly mismatches", e)
       case Failure(_) if !expectMatching => // great
     }
   }

--- a/centaur/src/test/scala/centaur/test/CentaurOperationsSpec.scala
+++ b/centaur/src/test/scala/centaur/test/CentaurOperationsSpec.scala
@@ -1,0 +1,120 @@
+package centaur.test
+
+import java.util.UUID
+
+import centaur.test.workflow.Workflow
+import cromwell.api.model.{SubmittedWorkflow, WorkflowId}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import spray.json._
+
+import scala.util.{Failure, Success}
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class CentaurOperationsSpec extends AnyFlatSpec with Matchers {
+  behavior of "validateMetadataJson"
+
+  val placeholderSubmittedWorkflow: SubmittedWorkflow = SubmittedWorkflow(id = WorkflowId(UUID.randomUUID()), null, null)
+  val placeholderWorkflow: Workflow = Workflow(testName = "", null, null, null, null, null, false, false, false, null)
+
+  val allowableOneWordAdditions = List("farmer")
+
+  def runTest(json1: String, json2: String, expectMatching: Boolean): Unit = {
+    val validation = Operations.validateMetadataJson("",
+      json1.parseJson.asJsObject,
+      json2.parseJson.asJsObject,
+      placeholderSubmittedWorkflow,
+      placeholderWorkflow,
+      allowableAddedOneWordFields = allowableOneWordAdditions).unsafeToFuture()
+    Await.ready(validation, atMost = 10.seconds)
+    validation.value.get match {
+      case Success(()) if expectMatching => // great
+      case Success(_) if !expectMatching => fail("Metadata unexpected decided as matching")
+      case Failure(e) if expectMatching  => fail("Metadata unexpected decided as mismatching", e)
+      case Failure(_) if !expectMatching => // great
+    }
+  }
+
+  it should "decide identical JSON as matching" in {
+    val json1 =
+      """{
+        |  "id": "foobar",
+        |  "calls": {
+        |    "workflow.callname": [
+        |      {
+        |        "callfield1": "x",
+        |        "callfield2": "y"
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+
+    val json2 = json1
+    runTest(json1, json2, expectMatching = true)
+  }
+
+  it should "decide different JSON as non-matching" in {
+    val json1 =
+      """{
+        |  "id": "foobar",
+        |  "calls": {
+        |    "workflow.callname": [
+        |      {
+        |        "callfield1": "x",
+        |        "callfield2": "y"
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+
+    val json2 =
+      """{
+        |  "id": "foobar",
+        |  "calls": {
+        |    "workflow.callname": [
+        |      {
+        |        "callfield1": "x",
+        |        "callfield2": "y",
+        |        "foo": "this is bad"
+        |      }
+        |    ]
+        |  },
+        |  "foo": "this is also bad"
+        |}""".stripMargin
+
+    runTest(json1, json2, expectMatching = false)
+  }
+
+  it should "ignore allowable additions at the root level and within calls" in {
+    val json1 =
+      """{
+        |  "id": "foobar",
+        |  "calls": {
+        |    "workflow.callname": [
+        |      {
+        |        "callfield1": "x",
+        |        "callfield2": "y"
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+
+    val json2 =
+      """{
+        |  "id": "foobar",
+        |  "calls": {
+        |    "workflow.callname": [
+        |      {
+        |        "callfield1": "x",
+        |        "callfield2": "y",
+        |        "farmer": "hoggett"
+        |      }
+        |    ]
+        |  },
+        |  "farmer": "hoggett"
+        |}""".stripMargin
+
+    runTest(json1, json2, expectMatching = true)
+  }
+}


### PR DESCRIPTION
The large "lines changed" values are inflated by moving one long list of lines around, and adding test cases.

Brief explanation:
- Most tests in our CI have metadata expectations. We keep polling the rest API until the metadata we get back matches our expectation.
- However, it's possible for extra values we aren't validating against to trickle in even after we validate it successfully.
- Our tests check "job manager style metadata requests" by re-polling the rest API, and making sure what we get back is only the fields we ask for, but otherwise exactly the same as the original poll.
- The primary change here is allowing values to trickle into fields which JM asks for and which weren't included in our original metadata validation. We should no longer be failing tests just because some extra metadata has arrived in a field and Cromwell has correctly returned it to us.

Note: Also makes those long obnoxious JSON diffs very slightly less obnoxious.