### PR TITLE
Allow basename lookups for DRS paths [BW-790, SUP-534]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Cromwell Change Log
 
+## 69 Release Notes
+
+### Bug Fixes
+
+### DRS/`basename` Fix
+
+The WDL `basename` function should now work as expected with DRS paths, giving the basename of the
+resolved file, not just a substring of the DRS path.
+
 ## 68 Release Notes
 
 ### Virtual Private Cloud

--- a/backend/src/main/scala/cromwell/backend/ReadLikeFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/ReadLikeFunctions.scala
@@ -2,12 +2,18 @@ package cromwell.backend
 
 import cromwell.core.io.AsyncIoFunctions
 import cromwell.core.path.PathFactory
+import cromwell.filesystems.drs.{DrsPath, DrsResolver}
 import wom.expression.IoFunctionSet
 
 import scala.concurrent.Future
 import scala.util.Try
 
 trait ReadLikeFunctions extends PathFactory with IoFunctionSet with AsyncIoFunctions {
+
+  override def resolvedPath(value: String): Future[String] = buildPath(value) match {
+    case drsPath: DrsPath => DrsResolver.getSimpleGsUri(drsPath).unsafeToFuture().map(_.getOrElse(value))
+    case path => Future.successful(path.pathAsString)
+  }
 
   override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean): Future[String] =
     Future.fromTry(Try(buildPath(path))) flatMap { p => asyncIo.contentAsStringAsync(p, maxBytes, failOnOverflow) }

--- a/backend/src/main/scala/cromwell/backend/ReadLikeFunctions.scala
+++ b/backend/src/main/scala/cromwell/backend/ReadLikeFunctions.scala
@@ -10,9 +10,12 @@ import scala.util.Try
 
 trait ReadLikeFunctions extends PathFactory with IoFunctionSet with AsyncIoFunctions {
 
-  override def resolvedPath(value: String): Future[String] = buildPath(value) match {
-    case drsPath: DrsPath => DrsResolver.getSimpleGsUri(drsPath).unsafeToFuture().map(_.getOrElse(value))
-    case path => Future.successful(path.pathAsString)
+  override def resolvedFileBasename(value: String): Future[String] = buildPath(value) match {
+    case drsPath: DrsPath => DrsResolver.getResolvedBasename(drsPath).unsafeToFuture()
+    case path =>
+      val name = path.name
+      if (name.nonEmpty) Future.successful(name)
+      else Future.failed(new Exception(s"No resolvable basename for $value. Was it a directory?"))
   }
 
   override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean): Future[String] =

--- a/backend/src/test/scala/cromwell/backend/io/DirectoryFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/DirectoryFunctionsSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wom.expression.IoFunctionSet.{IoDirectory, IoFile}
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.Duration
 
 class DirectoryFunctionsSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers {
@@ -18,7 +18,8 @@ class DirectoryFunctionsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
     override def copyFile(source: String, destination: String) = throw new UnsupportedOperationException()
     override def glob(pattern: String) = throw new UnsupportedOperationException()
     override def size(path: String) = throw new UnsupportedOperationException()
-    override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean)  = throw new UnsupportedOperationException()
+    override def resolvedPath(path: String): Future[String] = throw new UnsupportedOperationException()
+    override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean) = throw new UnsupportedOperationException()
     override def pathFunctions = throw new UnsupportedOperationException()
     override def writeFile(path: String, content: String) = throw new UnsupportedOperationException()
     override implicit def ec = throw new UnsupportedOperationException()
@@ -32,7 +33,7 @@ class DirectoryFunctionsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
     val innerDir = (rootDir / "innerDir").createDirectories()
     val link = innerDir / "linkToRootDirInInnerDir"
     link.symbolicLinkTo(rootDir)
-    
+
     def listRecursively(path: String)(visited: Vector[String] = Vector.empty): Iterator[String] = {
       Await.result(functions.listDirectory(path)(visited), Duration.Inf) flatMap {
         case IoFile(v) => List(v)

--- a/backend/src/test/scala/cromwell/backend/io/DirectoryFunctionsSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/io/DirectoryFunctionsSpec.scala
@@ -18,7 +18,7 @@ class DirectoryFunctionsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
     override def copyFile(source: String, destination: String) = throw new UnsupportedOperationException()
     override def glob(pattern: String) = throw new UnsupportedOperationException()
     override def size(path: String) = throw new UnsupportedOperationException()
-    override def resolvedPath(path: String): Future[String] = throw new UnsupportedOperationException()
+    override def resolvedFileBasename(path: String): Future[String] = throw new UnsupportedOperationException()
     override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean) = throw new UnsupportedOperationException()
     override def pathFunctions = throw new UnsupportedOperationException()
     override def writeFile(path: String, content: String) = throw new UnsupportedOperationException()

--- a/build.sbt
+++ b/build.sbt
@@ -195,6 +195,7 @@ lazy val backend = project
   .dependsOn(services)
   .dependsOn(core % "test->test")
   .dependsOn(common % "test->test")
+  .dependsOn(drsFileSystem)
 
 lazy val googlePipelinesCommon = (project in backendRoot / "google" / "pipelines" / "common")
   .withLibrarySettings("cromwell-pipelines-common")

--- a/centaur/src/main/resources/standardTestCases/drs_basename.test
+++ b/centaur/src/main/resources/standardTestCases/drs_basename.test
@@ -14,4 +14,9 @@ files {
 metadata {
   workflowName: drs_basename
   status: Succeeded
+  "outputs.drs_basename.basenames.0": "E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz"
+  "outputs.drs_basename.basenames.1": "E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz"
+  "outputs.drs_basename.basenames.2": "E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz"
+  "outputs.drs_basename.basenames.3": "E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz"
+  "outputs.drs_basename.basenames.4": "E18_20161004_Neurons_Sample_49_S048_L004_R2_005.foo.bar"
 }

--- a/centaur/src/main/resources/standardTestCases/drs_basename.test
+++ b/centaur/src/main/resources/standardTestCases/drs_basename.test
@@ -1,0 +1,17 @@
+name: drs_basename
+testFormat: WorkflowSuccess
+backends: ["papi-v2-usa"]
+skipDescribeEndpointValidation: true
+
+files {
+  workflow: drs_tests/drs_basename.wdl
+  options-dir: "Error: BA-6546 The environment variable CROMWELL_BUILD_RESOURCES_DIRECTORY must be set/export pointing to a valid path such as '${YOUR_CROMWELL_DIR}/target/ci/resources'"
+  options-dir: ${?CROMWELL_BUILD_RESOURCES_DIRECTORY}
+  options: ${files.options-dir}/papi_v2_usa.options.json
+  inputs: drs_tests/drs_basename.inputs
+}
+
+metadata {
+  workflowName: drs_basename
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.inputs
+++ b/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.inputs
@@ -1,0 +1,7 @@
+{
+    # This comment and file path were copied from drs_usa_hca.inputs:
+    # Are you here because HCA DRS data moved, again? Do not rage `rm -f` this test without first
+    # reading BT-182 for the multiple reasons why HCA is different from a "hello world"!
+    "drs_basename.file":
+        "drs://jade.datarepo-dev.broadinstitute.org/v1_4641bafb-5190-425b-aea9-9c7b125515c8_e37266ba-790d-4641-aa76-854d94be2fbe"
+}

--- a/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.wdl
+++ b/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.wdl
@@ -1,0 +1,50 @@
+version 1.0
+
+workflow drs_basename {
+    input {
+        File file
+    }
+
+    String workflow_level_basename = basename(file)
+
+    call pump_up_the_base { input:
+        file = file,
+        pre_basenamed = workflow_level_basename,
+        basednamed_at_call_site = basename(file)
+    }
+
+    output {
+        Array[String] basenames = pump_up_the_base.basenames
+    }
+}
+
+task pump_up_the_base {
+    input {
+        File file
+        String pre_basenamed
+        String basednamed_at_call_site
+    }
+
+    String task_level_basename = basename(file)
+
+    command <<<
+        echo ~{pre_basenamed}
+        echo ~{basednamed_at_call_site}
+        echo ~{task_level_basename}
+        echo ~{basename(file)}
+    >>>
+
+    output {
+        Array[String] basenames = read_lines(stdout())
+    }
+
+    runtime {
+        docker: "ubuntu"
+        backend: "papi-v2-usa"
+    }
+
+    parameter_meta {
+        # We don't actually want to use this file, just play around with its basename:
+        file: { localization_optional: true }
+    }
+}

--- a/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.wdl
+++ b/centaur/src/main/resources/standardTestCases/drs_tests/drs_basename.wdl
@@ -32,6 +32,8 @@ task pump_up_the_base {
         echo ~{basednamed_at_call_site}
         echo ~{task_level_basename}
         echo ~{basename(file)}
+        # Also validate the two-parameter version of the function with a DRS input for file extension replacements:
+        echo ~{basename(file, ".fastq.gz")}.foo.bar
     >>>
 
     output {

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/taskless_engine_functions/taskless_engine_functions.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/taskless_engine_functions/taskless_engine_functions.wdl
@@ -6,7 +6,9 @@ workflow taskless_engine_functions {
 
   Array[String] strings = ["a", "b"]
 
-  String filepath = "gs://not/a/real/file.txt"
+  # This is a local file path so that all test backends can interpret it. In Cromwell instances without a local
+  # backend, we might expect this to fail because "that doesn't look like a path"
+  String filepath = "/not/a/real/file.txt"
 
   Array[Array[Int]] matrix = [
     [1, 0],

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
@@ -32,18 +32,18 @@ object DrsResolver {
     } yield drsFileSystemProvider.drsPathResolver
   }
 
-  final case class GsUriFileNameAndBondProvider(gsUri: Option[String], fileName: Option[String], bondProvider: Option[String])
+  final case class PartialMarthaResponse(gsUri: Option[String], fileName: Option[String], bondProvider: Option[String])
   private def getGsUriFileNameBondProvider(pathAsString: String,
                                            drsPathResolver: DrsPathResolver
-                                          ): IO[GsUriFileNameAndBondProvider] = {
+                                          ): IO[PartialMarthaResponse] = {
     val fields = NonEmptyList.of(MarthaField.GsUri, MarthaField.FileName, MarthaField.BondProvider)
     for {
       marthaResponse <- drsPathResolver.resolveDrsThroughMartha(pathAsString, fields)
-    } yield GsUriFileNameAndBondProvider(marthaResponse.gsUri, marthaResponse.fileName, marthaResponse.bondProvider)
+    } yield PartialMarthaResponse(marthaResponse.gsUri, marthaResponse.fileName, marthaResponse.bondProvider)
   }
 
   /** Returns the `gsUri` if it ends in the `fileName` and the `bondProvider` is empty. */
-  private def getSimpleGsUri(gsUriFileNameAndBondProvider: GsUriFileNameAndBondProvider): Option[String] = {
+  private def getSimpleGsUri(gsUriFileNameAndBondProvider: PartialMarthaResponse): Option[String] = {
     for {
       // Only return gsUri that do not use Bond
       gsUri <- if (gsUriFileNameAndBondProvider.bondProvider.isEmpty) gsUriFileNameAndBondProvider.gsUri else None

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsResolver.scala
@@ -32,37 +32,31 @@ object DrsResolver {
     } yield drsFileSystemProvider.drsPathResolver
   }
 
+  final case class GsUriFileNameAndBondProvider(gsUri: Option[String], fileName: Option[String], bondProvider: Option[String])
   private def getGsUriFileNameBondProvider(pathAsString: String,
                                            drsPathResolver: DrsPathResolver
-                                          ): IO[(Option[String], Option[String], Option[String])] = {
+                                          ): IO[GsUriFileNameAndBondProvider] = {
     val fields = NonEmptyList.of(MarthaField.GsUri, MarthaField.FileName, MarthaField.BondProvider)
     for {
       marthaResponse <- drsPathResolver.resolveDrsThroughMartha(pathAsString, fields)
-    } yield (marthaResponse.gsUri, marthaResponse.fileName, marthaResponse.bondProvider)
+    } yield GsUriFileNameAndBondProvider(marthaResponse.gsUri, marthaResponse.fileName, marthaResponse.bondProvider)
   }
 
   /** Returns the `gsUri` if it ends in the `fileName` and the `bondProvider` is empty. */
-  private def getSimpleGsUri(gsUriOption: Option[String],
-                             fileNameOption: Option[String],
-                             bondProviderOption: Option[String],
-                            ): Option[String] = {
+  private def getSimpleGsUri(gsUriFileNameAndBondProvider: GsUriFileNameAndBondProvider): Option[String] = {
     for {
       // Only return gsUri that do not use Bond
-      gsUri <- if (bondProviderOption.isEmpty) gsUriOption else None
+      gsUri <- if (gsUriFileNameAndBondProvider.bondProvider.isEmpty) gsUriFileNameAndBondProvider.gsUri else None
       // Only return the gsUri if there is no fileName or if gsUri ends in /fileName
-      if fileNameOption.forall(fileName => gsUri.endsWith(s"/$fileName"))
+      if gsUriFileNameAndBondProvider.fileName.forall(fileName => gsUri.endsWith(s"/$fileName"))
     } yield gsUri
   }
 
   /** Returns the `gsUri` if it ends in the `fileName` and the `bondProvider` is empty. */
   def getSimpleGsUri(pathAsString: String,
                      drsPathResolver: DrsPathResolver): IO[Option[String]] = {
-    val gsUriIO = for {
-      tuple <- getGsUriFileNameBondProvider(pathAsString, drsPathResolver)
-      (gsUriOption, fileNameOption, bondProviderOption) = tuple
-    } yield getSimpleGsUri(gsUriOption, fileNameOption, bondProviderOption)
-
-    gsUriIO.handleErrorWith(resolveError(pathAsString))
+    getGsUriFileNameBondProvider(pathAsString, drsPathResolver).map(getSimpleGsUri)
+      .handleErrorWith(resolveError(pathAsString))
   }
 
   /** Returns the `gsUri` if it ends in the `fileName` and the `bondProvider` is empty. */
@@ -76,20 +70,27 @@ object DrsResolver {
   def getContainerRelativePath(drsPath: DrsPath): IO[String] = {
     val pathIO = for {
       drsPathResolver <- getDrsPathResolver(drsPath)
-      tuple <- getGsUriFileNameBondProvider(drsPath.pathAsString, drsPathResolver)
-      (gsUriOption, fileNameOption, _) = tuple
+      gsUriFileNameAndBondProvider <- getGsUriFileNameBondProvider(drsPath.pathAsString, drsPathResolver)
       /*
       In the DOS/DRS spec file names are safe for file systems but not necessarily the DRS URIs.
       Reuse the regex defined for ContentsObject.name, plus add "/" for directory separators.
       https://ga4gh.github.io/data-repository-service-schemas/preview/release/drs-1.0.0/docs/#_contentsobject
        */
       rootPath = DefaultPathBuilder.get(drsPath.pathWithoutScheme.replaceAll("[^/A-Za-z0-9._-]", "_"))
-      fileName <- getFileName(fileNameOption, gsUriOption)
+      fileName <- getFileName(gsUriFileNameAndBondProvider.fileName, gsUriFileNameAndBondProvider.gsUri)
       fullPath = rootPath.resolve(fileName)
       fullPathString = fullPath.pathAsString
     } yield fullPathString
 
     pathIO.handleErrorWith(resolveError(drsPath.pathAsString))
+  }
+
+  def getResolvedBasename(drsPath: DrsPath): IO[String] = {
+    for {
+      drsPathResolver <- getDrsPathResolver(drsPath)
+      gsUriFileNameAndBondProvider <- getGsUriFileNameBondProvider(drsPath.pathAsString, drsPathResolver)
+      filename <- getFileName(gsUriFileNameAndBondProvider.fileName, gsUriFileNameAndBondProvider.gsUri)
+    } yield filename
   }
 
   /**

--- a/runConfigurations/Cromwell_server.run.xml
+++ b/runConfigurations/Cromwell_server.run.xml
@@ -8,6 +8,7 @@
       <env name="CROMWELL_BUILD_RESOURCES_DIRECTORY" value="target/ci/resources" />
       <env name="CROMWELL_BUILD_PAPI_JSON_FILE" value="target/ci/resources/cromwell-centaur-service-account.json" />
       <env name="CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT" value="128000" />
+      <env name="CROMWELL_BUILD_CENTAUR_256_BITS_KEY" value="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="cromwell.CromwellApp" />
     <module name="cromwell" />

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -601,12 +601,12 @@ object EngineFunctionEvaluators {
 
       a.suffixToRemove match {
         case None => processValidatedSingleValue[WomString, WomString](a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { name =>
-          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename), Seq.empty)).toErrorOrWithContext(s"Unable to interpret '${name.valueString}' as a file path input for basename")
+          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename), Seq.empty)).toErrorOrWithContext(s"interpret '${name.valueString}' as a file path input for basename")
         }
         case Some(suffixToRemove) => processTwoValidatedValues[WomString, WomString, WomString](
           a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions),
           suffixToRemove.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { (name, suffix) =>
-          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename.stripSuffix(suffix.valueString)), Seq.empty)).toErrorOrWithContext(s"Unable to interpret '${name.valueString}' as a file path input for basename")
+          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename.stripSuffix(suffix.valueString)), Seq.empty)).toErrorOrWithContext(s"interpret '${name.valueString}' as a file path input for basename")
           }
       }
     }

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -595,7 +595,10 @@ object EngineFunctionEvaluators {
                                ioFunctionSet: IoFunctionSet,
                                forCommandInstantiationOptions: Option[ForCommandInstantiationOptions])
                               (implicit expressionValueEvaluator: ValueEvaluator[ExpressionElement]): ErrorOr[EvaluatedValue[WomString]] = {
-      def simpleBasename(fileNameAsString: WomString) = fileNameAsString.valueString.split('/').last
+      def simpleBasename(fileNameAsString: WomString) = {
+        val resolvedPath = Await.result(ioFunctionSet.resolvedPath(fileNameAsString.valueString), 10.seconds)
+        resolvedPath.split('/').last
+      }
 
       a.suffixToRemove match {
         case None => processValidatedSingleValue[WomString, WomString](a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { str =>

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -596,18 +596,18 @@ object EngineFunctionEvaluators {
                                forCommandInstantiationOptions: Option[ForCommandInstantiationOptions])
                               (implicit expressionValueEvaluator: ValueEvaluator[ExpressionElement]): ErrorOr[EvaluatedValue[WomString]] = {
       def simpleBasename(fileNameAsString: WomString): Try[String] = {
-        Try(Await.result(ioFunctionSet.resolvedPath(fileNameAsString.valueString), 60.seconds)).map(_.split('/').last)
+        Try(Await.result(ioFunctionSet.resolvedFileBasename(fileNameAsString.valueString), 60.seconds))
       }
 
       a.suffixToRemove match {
-        case None => processValidatedSingleValue[WomString, WomString](a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { name =>
-          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename), Seq.empty)).toErrorOrWithContext(s"interpret '${name.valueString}' as a file path input for basename")
+        case None => processValidatedSingleValue[WomString, WomString](a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { filePathString =>
+          simpleBasename(filePathString).map(basename => EvaluatedValue(WomString(basename), Seq.empty)).toErrorOrWithContext(s"interpret '${filePathString.valueString}' as a file path input for basename")
         }
         case Some(suffixToRemove) => processTwoValidatedValues[WomString, WomString, WomString](
           a.param.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions),
-          suffixToRemove.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { (name, suffix) =>
-          simpleBasename(name).map(basename => EvaluatedValue(WomString(basename.stripSuffix(suffix.valueString)), Seq.empty)).toErrorOrWithContext(s"interpret '${name.valueString}' as a file path input for basename")
-          }
+          suffixToRemove.evaluateValue(inputs, ioFunctionSet, forCommandInstantiationOptions)) { (filePathString, suffix) =>
+          simpleBasename(filePathString).map(basename => EvaluatedValue(WomString(basename.stripSuffix(suffix.valueString)), Seq.empty)).toErrorOrWithContext(s"interpret '${filePathString.valueString}' as a file path input for basename")
+        }
       }
     }
   }

--- a/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
+++ b/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
@@ -3,7 +3,7 @@ import scala.concurrent.Future
 
 class IoFunctionSetAdapter(delegate: IoFunctionSet) extends IoFunctionSet {
   override def pathFunctions: PathFunctionSet = delegate.pathFunctions
-  override def resolvedPath(path: String): Future[String] = delegate.resolvedPath(path)
+  override def resolvedFileBasename(path: String): Future[String] = delegate.resolvedFileBasename(path)
   override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean): Future[String] = delegate.readFile(path, maxBytes, failOnOverflow)
   override def writeFile(path: String, content: String) = delegate.writeFile(path, content)
   override def createTemporaryDirectory(name: Option[String]) = delegate.createTemporaryDirectory(name)

--- a/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
+++ b/wom/src/main/scala/wom/expression/IoFunctionSetAdapter.scala
@@ -1,8 +1,10 @@
 package wom.expression
+import scala.concurrent.Future
 
 class IoFunctionSetAdapter(delegate: IoFunctionSet) extends IoFunctionSet {
-  override def pathFunctions = delegate.pathFunctions
-  override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean) = delegate.readFile(path, maxBytes, failOnOverflow)
+  override def pathFunctions: PathFunctionSet = delegate.pathFunctions
+  override def resolvedPath(path: String): Future[String] = delegate.resolvedPath(path)
+  override def readFile(path: String, maxBytes: Option[Int], failOnOverflow: Boolean): Future[String] = delegate.readFile(path, maxBytes, failOnOverflow)
   override def writeFile(path: String, content: String) = delegate.writeFile(path, content)
   override def createTemporaryDirectory(name: Option[String]) = delegate.createTemporaryDirectory(name)
   override def copyFile(source: String, destination: String) = delegate.copyFile(source, destination)

--- a/wom/src/main/scala/wom/expression/NoIoFunctionSet.scala
+++ b/wom/src/main/scala/wom/expression/NoIoFunctionSet.scala
@@ -11,6 +11,8 @@ object EmptyIoFunctionSet {
 }
 
 class EmptyIoFunctionSet extends IoFunctionSet {
+
+  override def resolvedPath(path: String): Future[String] = Future.failed(new UnsupportedOperationException("resolvedPath is not available here"))
   override def readFile(path: String, maxBytes: Option[Int] = None, failOnOverflow: Boolean = false): Future[String] = Future.failed(new UnsupportedOperationException("readFile is not available here"))
 
   override def writeFile(path: String, content: String): Future[WomSingleFile] = {

--- a/wom/src/main/scala/wom/expression/NoIoFunctionSet.scala
+++ b/wom/src/main/scala/wom/expression/NoIoFunctionSet.scala
@@ -12,7 +12,7 @@ object EmptyIoFunctionSet {
 
 class EmptyIoFunctionSet extends IoFunctionSet {
 
-  override def resolvedPath(path: String): Future[String] = Future.failed(new UnsupportedOperationException("resolvedPath is not available here"))
+  override def resolvedFileBasename(path: String): Future[String] = Future.failed(new UnsupportedOperationException("resolvedPath is not available here"))
   override def readFile(path: String, maxBytes: Option[Int] = None, failOnOverflow: Boolean = false): Future[String] = Future.failed(new UnsupportedOperationException("readFile is not available here"))
 
   override def writeFile(path: String, content: String): Future[WomSingleFile] = {

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -92,7 +92,9 @@ trait PathFunctionSet {
   def relativeToHostCallRoot(path: String): String
 
   /**
-    * Similar to java.nio.Path.getFileName
+    * Similar to java.nio.Path.getFileName.
+    *
+    * Note: Does NOT run DRS resolution so will return the wrong value for DRS files.
     */
   def name(path: String): String
 

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -128,6 +128,8 @@ trait IoFunctionSet {
   // Functions that do NOT necessitate network I/O but are only manipulating paths
   def pathFunctions: PathFunctionSet
 
+  def resolvedPath(path: String): Future[String]
+
   // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
   /**
     * Read the content of a file
@@ -187,7 +189,7 @@ trait IoFunctionSet {
     * To map/flatMap over IO results
     */
   implicit def ec: ExecutionContext
-  
+
   implicit def cs = IO.contextShift(ec)
 
   /**

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -128,7 +128,12 @@ trait IoFunctionSet {
   // Functions that do NOT necessitate network I/O but are only manipulating paths
   def pathFunctions: PathFunctionSet
 
-  def resolvedPath(path: String): Future[String]
+  /**
+    * Get the basename of this path. If a DRS path, resolve to a real URL and get the basename
+    * @param path The input path
+    * @return The base filename of the object at the (fully resolved) path
+    */
+  def resolvedFileBasename(path: String): Future[String]
 
   // Functions that (possibly) necessitate I/O operation (on local, network, or cloud filesystems)
   /**


### PR DESCRIPTION
Might need some fix-up or consideration around "how to handle inputs that Cromwell can't Path-ify". Right now the workflow fails, but that could quite easily have less than delightful side-effects.