### PR TITLE
Use best practice YAML parsing. Add security contact to README. [BW-833]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Fixed an issue that could allow submission of an untrusted CWL file to initiate 
 
 CWL execution is enabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/resources/reference.conf#L460-L482) is present in the configuration that specifies `enabled: false`. Cromwell instances with CWL disabled were not affected. Consequently, users who wish to mitigate the vulnerability without upgrading Cromwell may do so via this config change.
 
-- Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
+- Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project [CVE-2021-41110 ](https://github.com/common-workflow-language/cwlviewer/security/advisories/GHSA-7g7j-f5g3-fqp7) and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
 
 ## 68 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Fixed an issue that could allow submission of an untrusted CWL file to initiate 
 
 CWL execution is enabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/resources/reference.conf#L460-L482) is present in the configuration that specifies `enabled: false`. Cromwell instances with CWL disabled were not affected. Consequently, users who wish to mitigate the vulnerability without upgrading Cromwell may do so via this config change.
 
-- Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project [CVE-2021-41110 ](https://github.com/common-workflow-language/cwlviewer/security/advisories/GHSA-7g7j-f5g3-fqp7) and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
+- Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project ([CVE-2021-41110](https://github.com/common-workflow-language/cwlviewer/security/advisories/GHSA-7g7j-f5g3-fqp7)) and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
 
 ## 68 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Cromwell Change Log
 
+## 70 Release Notes
+
+### CWL security fix [#6510](https://github.com/broadinstitute/cromwell/pull/6510)
+
+Fixed an issue that could allow submission of an untrusted CWL file to initiate remote code execution. The vector was improper deserialization of the YAML file.
+
+Cromwell instances with CWL execution disabled were not affected. CWL is disabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.example.backends/cromwell.examples.conf#L319-L329) is present in the configuration.
+
+- Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
+
 ## 68 Release Notes
 
 ### Virtual Private Cloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 Fixed an issue that could allow submission of an untrusted CWL file to initiate remote code execution. The vector was improper deserialization of the YAML source file.
 
-CWL execution is enabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/resources/reference.conf#L460-L482) is present in the configuration that specifies `enabled: false`. Cromwell instances with CWL disabled were not affected.
+CWL execution is enabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/resources/reference.conf#L460-L482) is present in the configuration that specifies `enabled: false`. Cromwell instances with CWL disabled were not affected. Consequently, users who wish to mitigate the vulnerability without upgrading Cromwell may do so via this config change.
 
 - Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### CWL security fix [#6510](https://github.com/broadinstitute/cromwell/pull/6510)
 
-Fixed an issue that could allow submission of an untrusted CWL file to initiate remote code execution. The vector was improper deserialization of the YAML file.
+Fixed an issue that could allow submission of an untrusted CWL file to initiate remote code execution. The vector was improper deserialization of the YAML source file.
 
-Cromwell instances with CWL execution disabled were not affected. CWL is disabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.example.backends/cromwell.examples.conf#L319-L329) is present in the configuration.
+CWL execution is enabled by default unless a `CWL` [stanza](https://github.com/broadinstitute/cromwell/blob/develop/core/src/main/resources/reference.conf#L460-L482) is present in the configuration that specifies `enabled: false`. Cromwell instances with CWL disabled were not affected.
 
 - Thank you to [Bruno P. Kinoshita](https://github.com/kinow) who first found the issue in a different CWL project and [Michael R. Crusoe](https://github.com/mr-c) who suggested we investigate ours.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Users with specialized needs who wish to install and maintain their own Cromwell
 
 Cromwell [supports](https://cromwell.readthedocs.io/en/stable/LanguageSupport/) the WDL and CWL workflow languages. The Cromwell team is actively developing WDL, while maintenance for CWL is primarily community-based.  
 
+### Security reports
+
+If you believe you have found a security issue please contact `infosec@broadinstitute.org`.
+
 ### Issue tracking in JIRA
 
 <!--

--- a/wom/src/main/scala/wom/util/YamlUtils.scala
+++ b/wom/src/main/scala/wom/util/YamlUtils.scala
@@ -13,7 +13,7 @@ import net.ceedubs.ficus.readers.ValueReader
 import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.comments.CommentLine
 import org.yaml.snakeyaml.composer.Composer
-import org.yaml.snakeyaml.constructor.Constructor
+import org.yaml.snakeyaml.constructor.SafeConstructor
 import org.yaml.snakeyaml.nodes.{MappingNode, Node, NodeTuple}
 import org.yaml.snakeyaml.parser.ParserImpl
 import org.yaml.snakeyaml.reader.StreamReader
@@ -38,7 +38,7 @@ object YamlUtils {
             maxDepth: Int Refined NonNegative = defaultMaxDepth
            ): Either[ParsingFailure, Json] = {
     try {
-      val yamlConstructor = new Constructor()
+      val yamlConstructor = new SafeConstructor()
       val yamlComposer = new MaxDepthComposer(yaml, maxDepth)
       yamlConstructor.setComposer(yamlComposer)
       val parsed = yamlConstructor.getSingleData(classOf[AnyRef])


### PR DESCRIPTION
It looks like upgrading from `Constructor` to `SafeConstructor` does not make much difference, Cromwell errors out and refuses to proceed with a similar message in both cases. But it seems like a good move anyway.

With `SafeConstructor`:

`java -jar /Users/anichols/Projects/cromwell/server/target/scala-2.12/cromwell-70-1a6c161-SNAP.jar run test3.cwl`
```
could not determine a constructor for the tag tag:yaml.org,2002:javax.script.ScriptEngineManager
```

With `Constructor`:

`java -jar cromwell-69.jar run test3.cwl`:
```
could not determine a constructor for the tag '!!javax.script.ScriptEngineManager'
```