### PR TITLE
Revert "Revert sorting by METADATA_TIMESTAMP for archiving and deletion" [BW-842]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -128,7 +128,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   }
 
   override def streamMetadataEntries(workflowExecutionUuid: String): DatabasePublisher[MetadataEntry] = {
-    val action = dataAccess.metadataEntriesForWorkflowExecutionUuid(workflowExecutionUuid)
+    val action = dataAccess.metadataEntriesForWorkflowSortedById(workflowExecutionUuid)
       .result
       .withStatementParameters(
         rsType = ResultSetType.ForwardOnly,
@@ -463,7 +463,7 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   override def deleteAllMetadataForWorkflowAndUpdateArchiveStatus(workflowId: String, newArchiveStatus: Option[String])(implicit ec: ExecutionContext): Future[Int] = {
     runTransaction {
       for {
-        numDeleted <- dataAccess.metadataEntriesForWorkflowExecutionUuid(workflowId).delete
+        numDeleted <- dataAccess.metadataEntriesForWorkflowSortedById(workflowId).delete
         _ <- dataAccess.metadataArchiveStatusByWorkflowId(workflowId).update(newArchiveStatus)
       } yield numDeleted
     }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -63,6 +63,13 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataTimestamp)
   )
 
+  val metadataEntriesForWorkflowSortedById = Compiled(
+    (workflowExecutionUuid: Rep[String]) => (for {
+      metadataEntry <- metadataEntries
+      if metadataEntry.workflowExecutionUuid === workflowExecutionUuid
+    } yield metadataEntry).sortBy(_.metadataEntryId)
+  )
+
   val countMetadataEntriesForWorkflowExecutionUuid = Compiled(
     (rootWorkflowId: Rep[String], expandSubWorkflows: Rep[Boolean]) => {
       val targetWorkflowIds = for {


### PR DESCRIPTION
We thought we were changing the primary key such that metadata timestamp would be a better sort than journal ID. But we ended up bailing on that change to simplify things, so this change made in preparation needs undoing.

Reverts broadinstitute/cromwell#6492