### PR TITLE
Enable preflight Liquibase migrations by removing custom log code [BW-875]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -242,10 +242,7 @@ object Dependencies {
   )
 
   private val liquibaseDependencies = List(
-    "org.liquibase" % "liquibase-core" % liquibaseV,
-    // This is to stop liquibase from being so noisy by default
-    // See: http://stackoverflow.com/questions/20880783/how-to-get-liquibase-to-log-using-slf4j
-    "com.mattbertolini" % "liquibase-slf4j" % liquibaseSlf4jV
+    "org.liquibase" % "liquibase-core" % liquibaseV
   )
 
   private val akkaDependencies = List(


### PR DESCRIPTION
A commit with that changes with `force ci` ran the whole suite of tests and passed ([Build #37935](https://app.travis-ci.com/github/broadinstitute/cromwell/builds/240798649)). Removing this library should unblock DevOps.

Closes https://broadworkbench.atlassian.net/browse/BW-875