### PR TITLE
Accommodate "enhanced" Requester Pays error messages [CROM-6820]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Cromwell Change Log
 
+## 71 Release Notes
+
+### Bug Fixes
+
+* Fixed an issue handling data in Google Cloud Storage buckets with requester pays enabled.
+
 ## 70 Release Notes
 
 ### CWL security fix [#6510](https://github.com/broadinstitute/cromwell/pull/6510)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* Fixed an issue handling data in Google Cloud Storage buckets with requester pays enabled.
+* Fixed an issue handling data in Google Cloud Storage buckets with requester pays enabled that could sometimes cause I/O to fail.
 
 ## 70 Release Notes
 

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsEnhancedRequest.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/GcsEnhancedRequest.scala
@@ -1,12 +1,12 @@
 package cromwell.filesystems.gcs
 
-import java.io.FileNotFoundException
-
 import akka.http.scaladsl.model.StatusCodes
 import cats.effect.IO
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.cloud.storage.StorageException
 import cromwell.filesystems.gcs.RequesterPaysErrors.isProjectNotProvidedError
+
+import java.io.FileNotFoundException
 
 object GcsEnhancedRequest {
 
@@ -19,11 +19,11 @@ object GcsEnhancedRequest {
         // Use NoSuchFileException for better error reporting
         case e: StorageException if e.getCode == StatusCodes.NotFound.intValue =>
           IO.raiseError(new FileNotFoundException(s"File not found: ${path.pathAsString}"))
-        case e: GoogleJsonResponseException if isProjectNotProvidedError(e) => 
+        case e: GoogleJsonResponseException if isProjectNotProvidedError(e) =>
           IO(f(true))
         case e: GoogleJsonResponseException if e.getStatusCode == StatusCodes.NotFound.intValue =>
           IO.raiseError(new FileNotFoundException(s"File not found: ${path.pathAsString}"))
-        case e => 
+        case e =>
           IO.raiseError(e)
       })
   }

--- a/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/RequesterPaysErrors.scala
+++ b/filesystems/gcs/src/main/scala/cromwell/filesystems/gcs/RequesterPaysErrors.scala
@@ -2,6 +2,7 @@ package cromwell.filesystems.gcs
 
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.cloud.storage.StorageException
+import org.apache.commons.lang3.StringUtils
 
 object RequesterPaysErrors {
   val BucketIsRequesterPaysErrorCode = 400
@@ -9,15 +10,15 @@ object RequesterPaysErrors {
   val DoesNotHaveServiceUsePermissionErrorCode = 403
   val DoesNotHaveServiceUsePermissionErrorMessage = "does not have serviceusage.services.use"
 
-  def isProjectNotProvidedError(storageException: StorageException) = 
+  def isProjectNotProvidedError(storageException: StorageException) =
     storageException.getCode == BucketIsRequesterPaysErrorCode &&
-    storageException.getMessage == BucketIsRequesterPaysErrorMessage
+    StringUtils.contains(storageException.getMessage, BucketIsRequesterPaysErrorMessage)
 
   def isProjectNotProvidedError(googleJsonError: GoogleJsonError) =
     googleJsonError.getCode == BucketIsRequesterPaysErrorCode &&
-      googleJsonError.getMessage == BucketIsRequesterPaysErrorMessage
+      StringUtils.contains(googleJsonError.getMessage, BucketIsRequesterPaysErrorMessage)
 
   def isProjectNotProvidedError(googleJsonError: GoogleJsonResponseException) =
     googleJsonError.getStatusCode == BucketIsRequesterPaysErrorCode &&
-      googleJsonError.getContent == BucketIsRequesterPaysErrorMessage
+      StringUtils.contains(googleJsonError.getContent, BucketIsRequesterPaysErrorMessage)
 }


### PR DESCRIPTION
Cromwell's requester pays logic works by trying to perform GCS operations without specifying a project to bill. If the operation is successful, great, all done. If the operation is not successful and the error message looks like a requester pays error, the operation is retried with the project to bill specified.

IIRC this system is in place because always specifying the project to bill resulted in the project being billed even if the bucket was not requester pays. It's unfortunate this logic needs to be so clunky when GCS does have the concept of [provisional user projects](https://developers.google.com/resources/api-libraries/documentation/storage/v1/java/latest/com/google/api/services/storage/Storage.Buckets.GetIamPolicy.html#setProvisionalUserProject-java.lang.String-) but this concept is not supported in the Google Storage API used by the GCS filesystem.

Anyway the "is this requester pays" logic used to look for exact matches to an error message string, i.e. exactly this:
```
Bucket is requester pays bucket but no user project provided.
```
However with increasing probability (the `requester_pays_engine_functions` Centaur test fails about 50% of the time with the baseline Cromwell code) we are seeing error messages that actually look like this:
```
400 Bad Request
POST https://storage.googleapis.com/upload/storage/v1/b/cromwell_bucket_with_requester_pays/o?projection=full&uploadType=multipart
{
  "error": {
    "code": 400,
    "message": "Bucket is requester pays bucket but no user project provided.",
    "errors": [
      {
        "message": "Bucket is requester pays bucket but no user project provided.",
        "domain": "global",
        "reason": "required"
      }
    ]
  }
}
```

The changes here accommodate either version of the error message with a `null`-safe `contains` check courtesy Apache StringUtils.