### PR TITLE
DRS Localizer Azure token strategy implementation [BT-436]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -385,7 +385,7 @@ lazy val perf = project
 lazy val `cromwell-drs-localizer` = project
   .withExecutableSettings("cromwell-drs-localizer", drsLocalizerDependencies, drsLocalizerSettings)
   .dependsOn(`cloud-nio-impl-drs`)
-  .dependsOn(common % "test->test")
+  .dependsOn(common)
   .dependsOn(`cloud-nio-impl-drs` % "test->test")
 
 lazy val server = project

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/CommandLineParser.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/CommandLineParser.scala
@@ -37,9 +37,12 @@ class CommandLineParser extends scopt.OptionParser[CommandLineArguments](Usage) 
       c.copy(azureIdentityClientId = Option(s)))
   checkConfig(c =>
     c.accessTokenStrategy match {
-      case Some(Azure) if c.googleRequesterPaysProject.isEmpty => Right(())
+      case Some(Azure) if c.googleRequesterPaysProject.nonEmpty =>
+        Left(s"Requester pays project is only valid with access token strategy '$Google'")
+      case Some(Azure) if List(c.azureVaultName, c.azureSecretName).exists(_.isEmpty) =>
+        Left(s"Both vault name and secret name must be specified for access token strategy $Azure")
+      case Some(Azure) => Right(())
       case Some(Google) if List(c.azureSecretName, c.azureVaultName, c.azureIdentityClientId).forall(_.isEmpty) => Right(())
-      case Some(Azure) => Left(s"Requester pays project is only valid with access token strategy '$Google'")
       case Some(Google) => Left(s"One or more specified options are only valid with access token strategy '$Azure'")
       case Some(huh) => Left(s"Unrecognized access token strategy '$huh'")
       case None => Left("Unspecified access token strategy")

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/CommandLineParser.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/CommandLineParser.scala
@@ -45,7 +45,6 @@ class CommandLineParser extends scopt.OptionParser[CommandLineArguments](Usage) 
       case Some(Google) if List(c.azureSecretName, c.azureVaultName, c.azureIdentityClientId).forall(_.isEmpty) => Right(())
       case Some(Google) => Left(s"One or more specified options are only valid with access token strategy '$Azure'")
       case Some(huh) => Left(s"Unrecognized access token strategy '$huh'")
-      case None => Left("Unspecified access token strategy")
     }
   )
 }

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/accesstokens/AzureB2CAccessTokenStrategy.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/accesstokens/AzureB2CAccessTokenStrategy.scala
@@ -1,10 +1,42 @@
 package drs.localizer.accesstokens
 
 import cats.syntax.validated._
-import common.validation.ErrorOr.ErrorOr
+import com.azure.identity.DefaultAzureCredentialBuilder
+import com.azure.security.keyvault.secrets.{SecretClient, SecretClientBuilder}
+import common.validation.ErrorOr
+import common.validation.ErrorOr.{ErrorOr,ShortCircuitingFlatMap}
 import drs.localizer.CommandLineArguments
 
 case class AzureB2CAccessTokenStrategy(commandLineArguments: CommandLineArguments) extends AccessTokenStrategy {
-  // Wire in logic to extract B2C token from KeyVault using UAMI
-  override def getAccessToken(): ErrorOr[String] = "Azure UAMI access token strategy not yet implemented".invalidNel
+  override def getAccessToken(): ErrorOr[String] = {
+    commandLineArguments match {
+      case CommandLineArguments(_, _, _, _, Some(vault), Some(secret), clientId) =>
+        AzureKeyVaultClient(vault, clientId) flatMap { _.getSecret(secret) }
+      case invalid => s"Invalid command line arguments: $invalid".invalidNel
+    }
+  }
+}
+
+// Note: The AzureKeyVaultClient here is a copy/paste of the code currently but perhaps very temporarily living in the
+// TES backend. All of this KeyVault interaction is probably quite temporary, but the code in the TES backend might
+// be even more temporary than this.
+class AzureKeyVaultClient(client: SecretClient) {
+  def getSecret(secretName: String): ErrorOr[String] = ErrorOr(client.getSecret(secretName).getValue)
+}
+
+object AzureKeyVaultClient {
+  def apply(vaultName: String, identityClientId: Option[String]): ErrorOr[AzureKeyVaultClient] = ErrorOr {
+    val defaultCreds = identityClientId.map(identityId =>
+      new DefaultAzureCredentialBuilder().managedIdentityClientId(identityId)
+    ).getOrElse(
+      new DefaultAzureCredentialBuilder()
+    ).build()
+
+    val client = new SecretClientBuilder()
+      .vaultUrl(s"https://${vaultName}.vault.azure.net")
+      .credential(defaultCreds)
+      .buildClient()
+
+    new AzureKeyVaultClient(client)
+  }
 }

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/AccessUrlDownloader.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/AccessUrlDownloader.scala
@@ -1,9 +1,12 @@
 package drs.localizer.downloaders
 
+import cats.data.Validated.{Invalid, Valid}
 import cats.effect.{ExitCode, IO}
 import cloud.nio.impl.drs.AccessUrl
 import com.typesafe.scalalogging.StrictLogging
+import common.exception.AggregatedMessageException
 import common.util.StringUtil._
+import common.validation.ErrorOr.ErrorOr
 import drs.localizer.downloaders.AccessUrlDownloader._
 
 import scala.sys.process.{Process, ProcessLogger}
@@ -12,25 +15,32 @@ import scala.util.matching.Regex
 case class GetmResult(returnCode: Int, stderr: String)
 
 case class AccessUrlDownloader(accessUrl: AccessUrl, downloadLoc: String, hashes: Hashes) extends Downloader with StrictLogging {
-  def generateDownloadScript(): String = {
+  def generateDownloadScript: ErrorOr[String] = {
     val signedUrl = accessUrl.url
-    val checksumArgs = GetmChecksum(hashes, accessUrl).args
-    s"""mkdir -p $$(dirname '$downloadLoc') && rm -f '$downloadLoc' && getm $checksumArgs --filepath '$downloadLoc' '$signedUrl'"""
+    GetmChecksum(hashes, accessUrl).args map { checksumArgs =>
+      s"""mkdir -p $$(dirname '$downloadLoc') && rm -f '$downloadLoc' && getm $checksumArgs --filepath '$downloadLoc' '$signedUrl'"""
+    }
   }
 
-  def runGetm: IO[GetmResult] = IO {
-    val copyCommand = Seq("bash", "-c", generateDownloadScript())
-    val copyProcess = Process(copyCommand)
+  def runGetm: IO[GetmResult] = {
+    generateDownloadScript match {
+      case Invalid(errors) =>
+        IO.raiseError(AggregatedMessageException("Error generating access URL download script", errors.toList))
+      case Valid(script) => IO {
+        val copyCommand = Seq("bash", "-c", script)
+        val copyProcess = Process(copyCommand)
 
-    val stderr = new StringBuilder()
-    val errorCapture: String => Unit = { s => stderr.append(s); () }
+        val stderr = new StringBuilder()
+        val errorCapture: String => Unit = { s => stderr.append(s); () }
 
-    // As of `getm` version 0.0.4 the contents of stdout do not appear to be interesting (only a progress bar
-    // with no option to suppress it), so ignore stdout for now. If stdout becomes interesting in future versions
-    // of `getm` it can be captured just like stderr is being captured here.
-    val returnCode = copyProcess ! ProcessLogger(_ => (), errorCapture)
+        // As of `getm` version 0.0.4 the contents of stdout do not appear to be interesting (only a progress bar
+        // with no option to suppress it), so ignore stdout for now. If stdout becomes interesting in future versions
+        // of `getm` it can be captured just like stderr is being captured here.
+        val returnCode = copyProcess ! ProcessLogger(_ => (), errorCapture)
 
-    GetmResult(returnCode, stderr.toString().trim())
+        GetmResult(returnCode, stderr.toString().trim())
+      }
+    }
   }
 
   override def download: IO[DownloadResult] = {

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
@@ -30,10 +30,10 @@ case class Md5(override val rawValue: String) extends GetmChecksum {
     val trimmed = rawValue.trim
     if (trimmed.matches("[A-Fa-f0-9]+"))
       trimmed.validNel
-    // Azure reports its md5's in base64, but `getm` knows only hex. For the sanity of humans storing data in Azure
+    // Azure reports its md5s in base64, but `getm` knows only hex. For the sanity of humans storing data in Azure
     // it's probably best if the DRS localizer does this conversion for `getm`.
     else if (isBase64(trimmed))
-      (decodeBase64(trimmed) |> encodeHexString).validNel
+      (trimmed |> decodeBase64 |> encodeHexString).validNel
     else
       s"Invalid md5 checksum value is neither hex nor base64: $rawValue".invalidNel
   }

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
@@ -31,7 +31,7 @@ case class Md5(override val rawValue: String) extends GetmChecksum {
     else if (isBase64(trimmed))
       decodeBase64(trimmed) |> encodeHexString
     else
-      // The baseline code was not doing anything special with hex / base64. It's not clear what throwing what do here
+      // The baseline code was not doing anything special with hex / base64. It's not clear what throwing would do here
       // so just return the raw value even though it's almost certainly going to lead to a checksum failure.
       rawValue
   }

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
@@ -30,8 +30,10 @@ case class Md5(override val rawValue: String) extends GetmChecksum {
     val trimmed = rawValue.trim
     if (trimmed.matches("[A-Fa-f0-9]+"))
       trimmed.validNel
-    // Azure reports its md5s in base64, but `getm` knows only hex. For the sanity of humans storing data in Azure
-    // it's probably best if the DRS localizer does this conversion for `getm`.
+    // TDR currently returns a base64-encoded MD5 because that's what Azure seems to do. However,
+    // the DRS spec does not specify that any checksums should be base64-encoded, and `getm` also
+    // does not expect base64. This case handles the current behavior in the short term until
+    // https://broadworkbench.atlassian.net/browse/DR-2259 is done.
     else if (isBase64(trimmed))
       (trimmed |> decodeBase64 |> encodeHexString).validNel
     else

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/CommandLineParserSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/CommandLineParserSpec.scala
@@ -93,6 +93,16 @@ class CommandLineParserSpec extends AnyFlatSpec with CromwellTimeoutSpec with Ma
     args shouldBe None
   }
 
+  it should "fail to parse an Azure invocation that specifies requester pays" in {
+    val args = parser.parse(Array(
+      "--access-token-strategy", AccessTokenStrategy.Azure,
+      "--secret-name", azureSecretName,
+      "--vault-name", azureVaultName,
+      drsObject, containerPath, requesterPaysProject), CommandLineArguments())
+
+    args shouldBe None
+  }
+
   it should "successfully parse an Azure invocation" in {
     val args = parser.parse(Array(
       "--access-token-strategy", AccessTokenStrategy.Azure,

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/CommandLineParserSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/CommandLineParserSpec.scala
@@ -67,15 +67,45 @@ class CommandLineParserSpec extends AnyFlatSpec with CromwellTimeoutSpec with Ma
     args.azureIdentityClientId shouldBe empty
   }
 
+  it should "fail to parse an Azure invocation missing vault name and secret name" in {
+    val args = parser.parse(Array(
+      "--access-token-strategy", AccessTokenStrategy.Azure,
+      drsObject, containerPath), CommandLineArguments())
+
+    args shouldBe None
+  }
+
+  it should "fail to parse an Azure invocation missing vault name" in {
+    val args = parser.parse(Array(
+      "--access-token-strategy", AccessTokenStrategy.Azure,
+      "--secret-name", azureSecretName,
+      drsObject, containerPath), CommandLineArguments())
+
+    args shouldBe None
+  }
+
+  it should "fail to parse an Azure invocation missing secret name" in {
+    val args = parser.parse(Array(
+      "--access-token-strategy", AccessTokenStrategy.Azure,
+      "--vault-name", azureVaultName,
+      drsObject, containerPath), CommandLineArguments())
+
+    args shouldBe None
+  }
+
   it should "successfully parse an Azure invocation" in {
-    val args = parser.parse(Array("--access-token-strategy", AccessTokenStrategy.Azure, drsObject, containerPath), CommandLineArguments()).get
+    val args = parser.parse(Array(
+      "--access-token-strategy", AccessTokenStrategy.Azure,
+      "--secret-name", azureSecretName,
+      "--vault-name", azureVaultName,
+      drsObject, containerPath), CommandLineArguments()).get
 
     args.drsObject.get shouldBe drsObject
     args.containerPath.get shouldBe containerPath
     args.accessTokenStrategy.get shouldBe AccessTokenStrategy.Azure
     args.googleRequesterPaysProject shouldBe empty
-    args.azureVaultName shouldBe empty
-    args.azureSecretName shouldBe empty
+    args.azureVaultName.get shouldBe azureVaultName
+    args.azureSecretName.get shouldBe azureSecretName
     args.azureIdentityClientId shouldBe empty
   }
 

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/AccessUrlDownloaderSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/AccessUrlDownloaderSpec.scala
@@ -1,6 +1,7 @@
 package drs.localizer.downloaders
 
 import cats.effect.ExitCode
+import cats.syntax.validated._
 import cloud.nio.impl.drs.AccessUrl
 import common.assertion.CromwellTimeoutSpec
 import org.scalatest.flatspec.AnyFlatSpec
@@ -18,7 +19,7 @@ class AccessUrlDownloaderSpec extends AnyFlatSpec with CromwellTimeoutSpec with 
       hashes = None
     )
 
-    val expected = s"""mkdir -p $$(dirname '$fakeDownloadLocation') && rm -f '$fakeDownloadLocation' && getm --checksum-algorithm 'null' --checksum null --filepath '$fakeDownloadLocation' '$fakeAccessUrl'"""
+    val expected = s"""mkdir -p $$(dirname '$fakeDownloadLocation') && rm -f '$fakeDownloadLocation' && getm --checksum-algorithm 'null' --checksum null --filepath '$fakeDownloadLocation' '$fakeAccessUrl'""".validNel
 
     downloader.generateDownloadScript shouldBe expected
   }

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/AccessUrlDownloaderSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/AccessUrlDownloaderSpec.scala
@@ -20,7 +20,7 @@ class AccessUrlDownloaderSpec extends AnyFlatSpec with CromwellTimeoutSpec with 
 
     val expected = s"""mkdir -p $$(dirname '$fakeDownloadLocation') && rm -f '$fakeDownloadLocation' && getm --checksum-algorithm 'null' --checksum null --filepath '$fakeDownloadLocation' '$fakeAccessUrl'"""
 
-    downloader.generateDownloadScript() shouldBe expected
+    downloader.generateDownloadScript shouldBe expected
   }
 
   {

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
@@ -29,7 +29,9 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
   {
     val results = Table(
       ("description", "algorithm", "expected"),
-      ("md5", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef"),
+      ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef"),
+      ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "--checksum-algorithm 'md5' --checksum 711f38957635cb5edcdeaeffeeb88b10"),
+      ("md5 gibberish", Md5("what is this???"), "--checksum-algorithm 'md5' --checksum what\\ is\\ this\\?\\?\\?"),
       ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum 012345"),
       ("AWS ETag", AwsEtag("012345"), "--checksum-algorithm 's3_etag' --checksum 012345"),
       // Escape checksum values constructed from unvalidated data returned by DRS servers.
@@ -39,7 +41,7 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
 
     forAll(results) { (description, algorithm, expected) =>
       it should s"produce the expected checksum arguments for $description" in {
-        algorithm.args shouldBe (expected)
+        algorithm.args shouldBe expected
       }
     }
   }

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
@@ -1,5 +1,6 @@
 package drs.localizer.downloaders
 
+import cats.syntax.validated._
 import common.assertion.CromwellTimeoutSpec
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -29,14 +30,14 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
   {
     val results = Table(
       ("description", "algorithm", "expected"),
-      ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef"),
-      ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "--checksum-algorithm 'md5' --checksum 711f38957635cb5edcdeaeffeeb88b10"),
-      ("md5 gibberish", Md5("what is this???"), "--checksum-algorithm 'md5' --checksum what\\ is\\ this\\?\\?\\?"),
-      ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum 012345"),
-      ("AWS ETag", AwsEtag("012345"), "--checksum-algorithm 's3_etag' --checksum 012345"),
+      ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef".validNel),
+      ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "--checksum-algorithm 'md5' --checksum 711f38957635cb5edcdeaeffeeb88b10".validNel),
+      ("md5 gibberish", Md5("what is this???"), "Invalid md5 checksum value is neither hex nor base64: what is this???".invalidNel),
+      ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum 012345".validNel),
+      ("AWS ETag", AwsEtag("012345"), "--checksum-algorithm 's3_etag' --checksum 012345".validNel),
       // Escape checksum values constructed from unvalidated data returned by DRS servers.
-      ("Unsupported", Unsupported("Robert'); DROP TABLE Students;\n --\\"), raw"--checksum-algorithm 'null' --checksum Robert\'\)\;\ DROP\ TABLE\ Students\;\ --\\"),
-      ("Null", Null, "--checksum-algorithm 'null' --checksum null"),
+      ("Unsupported", Unsupported("Robert'); DROP TABLE Students;\n --\\"), raw"--checksum-algorithm 'null' --checksum Robert\'\)\;\ DROP\ TABLE\ Students\;\ --\\".validNel),
+      ("Null", Null, "--checksum-algorithm 'null' --checksum null".validNel),
     )
 
     forAll(results) { (description, algorithm, expected) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -516,16 +516,16 @@ object Dependencies {
 
   val bcsBackendDependencies: List[ModuleID] = commonDependencies ++ refinedTypeDependenciesList ++ aliyunBatchComputeDependencies
 
-  val tesBackendAzureDependencies: List[ModuleID] = List(
+  val azureDependencies: List[ModuleID] = List(
     "com.azure" % "azure-identity" % azureIdentitySdkV
       exclude("jakarta.xml.bind", "jakarta.xml.bind-api")
       exclude("jakarta.activation", "jakarta.activation-api"),
-  "com.azure" % "azure-security-keyvault-secrets" % azureKeyVaultSdkV
+    "com.azure" % "azure-security-keyvault-secrets" % azureKeyVaultSdkV
       exclude("jakarta.xml.bind", "jakarta.xml.bind-api")
       exclude("jakarta.activation", "jakarta.activation-api")
   )
 
-  val tesBackendDependencies: List[ModuleID] = tesBackendAzureDependencies ++ akkaHttpDependencies
+  val tesBackendDependencies: List[ModuleID] = azureDependencies ++ akkaHttpDependencies
 
   val sfsBackendDependencies = List (
     "org.lz4" % "lz4-java" % lz4JavaV
@@ -559,7 +559,7 @@ object Dependencies {
     "com.iheart" %% "ficus" % ficusV,
     "com.softwaremill.sttp" %% "circe" % sttpV,
     "com.github.scopt" %% "scopt" % scoptV,
-  ) ++ circeDependencies ++ catsDependencies ++ slf4jBindingDependencies ++ languageFactoryDependencies
+  ) ++ circeDependencies ++ catsDependencies ++ slf4jBindingDependencies ++ languageFactoryDependencies ++ azureDependencies
 
   val allProjectDependencies: List[ModuleID] =
     backendDependencies ++

--- a/runConfigurations/Repo template_ Cromwell DRS Localizer.run.xml
+++ b/runConfigurations/Repo template_ Cromwell DRS Localizer.run.xml
@@ -1,0 +1,13 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Repo template: Cromwell DRS Localizer" type="Application" factoryName="Application">
+    <envs>
+      <env name="MARTHA_URL" value="https://us-central1-broad-dsde-dev.cloudfunctions.net/martha_v3" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="drs.localizer.DrsLocalizerMain" />
+    <module name="cromwell-drs-localizer" />
+    <option name="PROGRAM_PARAMETERS" value="--access-token-strategy azure drs://jade.datarepo-dev.broadinstitute.org/v1_f3c32ddd-20eb-4033-9716-46866521a3a4_8d651e95-38ce-4bc8-a8a4-8a4cd9513db1 $USER_HOME$/Downloads/NA12878_PLUMBING_wgs.g.vcf.gz.tbi --vault-name vault --secret-name secret --identity-client-id identity" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
Tested using the included DRS Localizer repo template. Follow Janet's instructions for getting a B2C token, setting up a Key Vault, and storing the former in a secret within the latter. You should then be able to run the repo template with the coordinates for vault name, secret name, and client id plugged in to the invocation. Assuming your token is fresh (mine expired several times in one day while testing this), everything should Just Work.

Oh and `getm` must be installed:

```
pip3 install getm==0.0.4
```