### PR TITLE
 Scala-Steward: Update testcontainers-scala-mariadb, ... from 0.39.6 to 0.39.8   (BW-923).

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -133,7 +133,7 @@ object Dependencies {
   private val sttpV = "1.5.19" // scala-steward:off (CROM-6564)
   private val swaggerParserV = "1.0.55"
   private val swaggerUiV = "3.23.11" // scala-steward:off (CROM-6621)
-  private val testContainersScalaV = "0.39.6"
+  private val testContainersScalaV = "0.39.8"
   private val tikaV = "2.1.0"
   private val typesafeConfigV = "1.4.1"
   private val workbenchGoogleV = "0.21-5c9c4f6" // via: https://github.com/broadinstitute/workbench-libs/blob/develop/google/CHANGELOG.md


### PR DESCRIPTION
Local branch version of https://github.com/broadinstitute/cromwell/pull/6512