### PR TITLE
Robustify aborts to PRECONDITION_FAILED [BT-450] [CROM-6829]

### DIFF
--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/clients/PipelinesApiAbortClient.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/clients/PipelinesApiAbortClient.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef}
 import cromwell.backend.google.pipelines.common.PapiInstrumentation
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestFactory
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager.{PAPIAbortRequest, PipelinesApiAbortQueryFailed}
-import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationAlreadyCancelled, PAPIOperationHasAlreadyFinished}
+import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationHasAlreadyFinished}
 import cromwell.backend.standard.StandardAsyncJob
 import cromwell.core.WorkflowId
 import cromwell.core.logging.JobLogging
@@ -12,7 +12,6 @@ import cromwell.core.logging.JobLogging
 object PipelinesApiAbortClient {
   sealed trait PAPIAbortRequestSuccess
   case class PAPIAbortRequestSuccessful(operationId: String) extends PAPIAbortRequestSuccess
-  case class PAPIOperationAlreadyCancelled(operationId: String) extends PAPIAbortRequestSuccess
   case class PAPIOperationHasAlreadyFinished(operationId: String) extends PAPIAbortRequestSuccess
 }
 
@@ -21,20 +20,15 @@ trait PipelinesApiAbortClient { this: Actor with ActorLogging with JobLogging wi
 
   val papiApiActor: ActorRef
   val requestFactory: PipelinesApiRequestFactory
-  
+
   def abortJob(jobId: StandardAsyncJob) = {
     papiApiActor ! PAPIAbortRequest(workflowId, self, requestFactory.cancelRequest(jobId), jobId)
   }
 
   def abortActorClientReceive: Actor.Receive = {
-    /* When we deprecate PAPIv1: v2+ do not seem to distinguish between cancelled and finished, unify into "terminated" or similar [PROD-444] */
-
     case PAPIAbortRequestSuccessful(jobId) =>
       abortSuccess()
       jobLogger.info(s"Successfully requested cancellation of $jobId")
-    // In this case we could immediately return an aborted handle and spare ourselves a round of polling
-    case PAPIOperationAlreadyCancelled(jobId) =>
-      jobLogger.info(s"Operation $jobId was already cancelled")
     // In this case we could immediately return an aborted handle and spare ourselves a round of polling
     case PAPIOperationHasAlreadyFinished(jobId) =>
       jobLogger.info(s"Operation $jobId has already finished")

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
@@ -18,7 +18,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
     // No need to fail the request if the job already terminated, we're all good
     // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
     // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
-    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage,"Precondition check failed")) {
+    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage, "Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
       abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)
       Success(())

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
@@ -6,8 +6,9 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
-import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationHasAlreadyFinished}
+import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
+import org.apache.commons.lang3.StringUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -17,9 +18,9 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
     // No need to fail the request if the job already terminated, we're all good
     // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
     // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
-    if (Option(e.getCode).contains(400)) {
+    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage,"Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
-      abortQuery.requester ! PAPIOperationHasAlreadyFinished(abortQuery.jobId.jobId)
+      abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)
       Success(())
     } else {
       pollingManager ! PipelinesApiAbortQueryFailed(abortQuery, new SystemPAPIApiException(GoogleJsonException(e, responseHeaders)))
@@ -28,7 +29,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   }
 
   // The Genomics batch endpoint doesn't seem to be able to handle abort requests on V2 operations at the moment
-  // For now, don't batch the request and execute it on its own 
+  // For now, don't batch the request and execute it on its own
   def handleRequest(abortQuery: PAPIAbortRequest, batch: BatchRequest, pollingManager: ActorRef)(implicit ec: ExecutionContext): Future[Try[Unit]] = {
     Future(abortQuery.httpRequest.execute()) map {
       case response if response.isSuccessStatusCode =>

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/api/request/AbortRequestHandler.scala
@@ -15,9 +15,13 @@ import scala.util.{Failure, Success, Try}
 
 trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   protected def handleGoogleError(abortQuery: PAPIAbortRequest, pollingManager: ActorRef, e: GoogleJsonError, responseHeaders: HttpHeaders): Try[Unit] = {
-    // No need to fail the request if the job already terminated, we're all good
-    // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
-    // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
+    // This condition is telling us that the job we tried to cancel is already in a terminal state. Technically PAPI
+    // was not able to cancel the job because the job could not be transitioned from 'Running' to 'Cancelled'. But from
+    // Cromwell's perspective a job cancellation is really just a request for the job to be in a terminal state, so
+    // Cromwell is okay with seeing this condition.
+    // Currently PAPI v2 cannot distinguish between "the job was already cancelled" and "the job already ran to completion".
+    // If/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833 we could break these cases
+    // out and make our logging more specific if we wanted to.
     if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage, "Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
       abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -18,7 +18,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
     // No need to fail the request if the job already terminated, we're all good
     // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
     // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
-    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage,"Precondition check failed")) {
+    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage, "Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
       abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)
       Success(())

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -6,8 +6,9 @@ import com.google.api.client.googleapis.json.GoogleJsonError
 import com.google.api.client.http.HttpHeaders
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
-import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationHasAlreadyFinished}
+import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}
 import cromwell.cloudsupport.gcp.auth.GoogleAuthMode
+import org.apache.commons.lang3.StringUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -17,9 +18,9 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
     // No need to fail the request if the job already terminated, we're all good
     // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
     // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
-    if (Option(e.getCode).contains(400) || Option(e.getMessage).exists(_.contains("Precondition check failed"))) {
+    if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage,"Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
-      abortQuery.requester ! PAPIOperationHasAlreadyFinished(abortQuery.jobId.jobId)
+      abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)
       Success(())
     } else {
       pollingManager ! PipelinesApiAbortQueryFailed(abortQuery, new SystemPAPIApiException(GoogleJsonException(e, responseHeaders)))

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -15,9 +15,13 @@ import scala.util.{Failure, Success, Try}
 
 trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   protected def handleGoogleError(abortQuery: PAPIAbortRequest, pollingManager: ActorRef, e: GoogleJsonError, responseHeaders: HttpHeaders): Try[Unit] = {
-    // No need to fail the request if the job already terminated, we're all good
-    // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
-    // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
+    // This condition is telling us that the job we tried to cancel is already in a terminal state. Technically PAPI
+    // was not able to cancel the job because the job could not be transitioned from 'Running' to 'Cancelled'. But from
+    // Cromwell's perspective a job cancellation is really just a request for the job to be in a terminal state, so
+    // Cromwell is okay with seeing this condition.
+    // Currently PAPI v2 cannot distinguish between "the job was already cancelled" and "the job already ran to completion".
+    // If/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833 we could break these cases
+    // out and make our logging more specific if we wanted to.
     if (Option(e.getCode).contains(400) || StringUtils.contains(e.getMessage, "Precondition check failed")) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
       abortQuery.requester ! PAPIOperationIsAlreadyTerminal(abortQuery.jobId.jobId)

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -17,7 +17,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
     // No need to fail the request if the job already terminated, we're all good
     // As seen in `cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient` the difference between "finished" and "cancelled" only affects logging
     // Enhance to be more specific if/when Google implements https://partnerissuetracker.corp.google.com/issues/171993833
-    if (Option(e.getCode).contains(400)) {
+    if (Option(e.getCode).contains(400) || Option(e.getMessage).exists(_.contains("Precondition check failed"))) {
       logger.info(s"PAPI declined to abort job ${abortQuery.jobId.jobId} in workflow ${abortQuery.workflowId}, most likely because it is no longer running. Marking as finished. Message: ${e.getMessage}")
       abortQuery.requester ! PAPIOperationHasAlreadyFinished(abortQuery.jobId.jobId)
       Success(())
@@ -28,7 +28,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   }
 
   // The Genomics batch endpoint doesn't seem to be able to handle abort requests on V2 operations at the moment
-  // For now, don't batch the request and execute it on its own 
+  // For now, don't batch the request and execute it on its own
   def handleRequest(abortQuery: PAPIAbortRequest, batch: BatchRequest, pollingManager: ActorRef)(implicit ec: ExecutionContext): Future[Try[Unit]] = {
     Future(abortQuery.httpRequest.execute()) map {
       case response if response.isSuccessStatusCode =>


### PR DESCRIPTION
See CROM-6829 for details regarding the production incident from earlier this week. These changes let Cromwell fall back to searching the exception message for PRECONDITION_FAILED states if for some reason the code is not conveying that condition. Also removed a little vestigial v1 cruft while I was in here.