### PR TITLE
Explicitly install pip for Travis [BT-451]

### DIFF
--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -850,6 +850,7 @@ cromwell::private::pip_install() {
 }
 
 cromwell::private::upgrade_pip() {
+    sudo apt-get install -y python3-pip
     cromwell::private::pip_install pip --upgrade
     cromwell::private::pip_install requests[security] --ignore-installed
 }


### PR DESCRIPTION
This appears to be required in Travis now as pip3 is no longer already on the image.