### PR TITLE
Loosen criteria for retrying PAPI initialization errors [CROM-6808]

### DIFF
--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendLifecycleActorFactorySpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/PipelinesApiBackendLifecycleActorFactorySpec.scala
@@ -39,17 +39,14 @@ class PipelinesApiBackendLifecycleActorFactorySpec extends AnyFlatSpecLike with 
   }
 
   {
-    // The message string Cromwell keys off to retry construction.
-    val baseRetryMessage = "Please try again."
     // The message string actually observed during construction failure.
-    val actualRetryMessage = s"We encountered an internal error. $baseRetryMessage"
+    val actualRetryMessage = s"We encountered an internal error. Please try again."
     val fails = Table(
       ("attempts", "description", "function"),
-      (1, "no exception message", () => throw new RuntimeException()),
-      (1, "not a retryable message", () => throw new RuntimeException("non retryable failure")),
-      (3, "retryable message", () => throw new RuntimeException(actualRetryMessage)),
-      (1, "error not exception", () => throw new Error(actualRetryMessage)),
-      (3, "error not exception", () => throw new RuntimeException(s"Heavens to Betsy something most unfortunate has occurred. $baseRetryMessage"))
+      (3, "no exception message", () => throw new RuntimeException()),
+      (3, "exception message", () => throw new RuntimeException(actualRetryMessage)),
+      (1, "error not exception, no message", () => throw new Error()),
+      (1, "error not exception", () => throw new Error(actualRetryMessage))
     )
     forAll(fails) { (attempts, description, function) =>
       it should s"$description: make $attempts attribute creation attempts before giving up" in {


### PR DESCRIPTION
The report in CROM-6808 includes two cases, these changes would only address the second. I'm not sure what would be causing the first case (an `Exception` with message text containing the text `Please try again.` that wasn't retried), so this PR may not be the final word on PAPI initialization failures.