### PR TITLE
ScalaSteward: liquibase upgrade to 4.6.1 (BW-938).

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   private val kindProjectorV = "0.10.0"
   private val kittensV = "2.3.2"
   private val liquibaseSlf4jV = "4.0.0"
-  private val liquibaseV = "4.4.0" // 4.4.1+ needs https://github.com/liquibase/liquibase/pull/2001
+  private val liquibaseV = "4.6.1"
   private val logbackV = "1.2.6"
   private val lz4JavaV = "1.8.0"
   private val mariadbV = "2.7.4"


### PR DESCRIPTION
Original ScalaSteward PR was https://github.com/broadinstitute/cromwell/pull/6527. Note though that it was only to version 4.4.3, but 4.4.3 still has the postgres unique constraint bug. Upgrading instead to the most recent release, which contains the bug fix.