### PR TITLE
Pass extra runtime attributes through as TES backend parameters [BT-458]

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
@@ -2,7 +2,19 @@ package cromwell.backend.impl.tes
 
 import cromwell.backend.BackendConfigurationDescriptor
 
+import net.ceedubs.ficus.Ficus._
+
 class TesConfiguration(val configurationDescriptor: BackendConfigurationDescriptor) {
+
   val endpointURL = configurationDescriptor.backendConfig.getString("endpoint")
   val runtimeConfig = configurationDescriptor.backendRuntimeAttributesConfig
+  val useBackendParameters =
+    configurationDescriptor
+      .backendConfig
+      .as[Option[Boolean]](TesConfiguration.useBackendParamtersKey)
+      .getOrElse(false)
+}
+
+object TesConfiguration {
+  final val useBackendParamtersKey = "use_tes_11_preview_backend_parameters"
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesInitializationActor.scala
@@ -63,6 +63,25 @@ class TesInitializationActor(params: TesInitializationActorParams)
     ).mapN((_, _, _) => ()).toTry
   }
 
+  // TODO Figure out how to exclude valid backend parameters from this warning
+  override def checkForUnsupportedRuntimeAttributes(): Try[Unit] = Try {
+    calls foreach { call =>
+      val runtimeAttributes = call.callable.runtimeAttributes.attributes
+//      val backendParameters = TesRuntimeAttributes.makeBackendParameters(runtimeAttributes, tesConfiguration).keySet
+      val notSupportedAttributes =
+        runtimeAttributesBuilder
+          .unsupportedKeys(runtimeAttributes.keys.toList)
+//          .filterNot(backendParameters.contains)
+
+      if (notSupportedAttributes.nonEmpty) {
+        val notSupportedAttrString = notSupportedAttributes mkString ", "
+        workflowLogger.warn(
+          s"Key/s [$notSupportedAttrString] is/are not supported by backend. " +
+            s"Unsupported attributes will not be part of job executions.")
+      }
+    }
+  }
+
   override def beforeAll(): Future[Option[BackendInitializationData]] = {
     workflowPaths map { paths =>
       publishWorkflowRoot(paths.workflowRoot.toString)

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
@@ -18,5 +18,6 @@ trait TesJobCachingActorHelper extends StandardCachingActorHelper {
 
   lazy val tesConfiguration: TesConfiguration = initializationData.tesConfiguration
 
-  lazy val runtimeAttributes = TesRuntimeAttributes(validatedRuntimeAttributes, tesConfiguration.runtimeConfig)
+  lazy val runtimeAttributes = TesRuntimeAttributes(validatedRuntimeAttributes, jobDescriptor.runtimeAttributes, tesConfiguration)
+
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -233,12 +233,13 @@ object TesTask {
     // TES server about which user identity to run tasks as.
     // Note that we validate the type of WorkflowExecutionIdentity
     // in TesInitializationActor.
-    val backendParameters = workflowDescriptor
-      .workflowOptions
-      .get(TesWorkflowOptionKeys.WorkflowExecutionIdentity)
-      .toOption
-      .map(TesWorkflowOptionKeys.WorkflowExecutionIdentity -> _)
-      .toMap
+    val backendParameters = runtimeAttributes.backendParameters ++
+      workflowDescriptor
+        .workflowOptions
+        .get(TesWorkflowOptionKeys.WorkflowExecutionIdentity)
+        .toOption
+        .map(TesWorkflowOptionKeys.WorkflowExecutionIdentity -> _)
+        .toMap
 
     val disk :: ram :: _ = Seq(runtimeAttributes.disk, runtimeAttributes.memory) map {
       case Some(x) =>

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
@@ -18,7 +18,8 @@ class TesTaskSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers wit
     None,
     None,
     None,
-    false
+    false,
+    Map.empty
   )
 
   def workflowDescriptorWithIdentity(excIdentity: Option[String]) = {

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
@@ -24,5 +24,27 @@ object TesTestConfig {
       |""".stripMargin
 
   val backendConfig = ConfigFactory.parseString(backendConfigString)
+
+  private val backendConfigStringWithBackendParams =
+    """
+      |root = "local-cromwell-executions"
+      |dockerRoot = "/cromwell-executions"
+      |endpoint = "http://127.0.0.1:9000/v1/jobs"
+      |use_tes_11_preview_backend_parameters = true
+      |
+      |default-runtime-attributes {
+      |  cpu: 1
+      |  failOnStderr: false
+      |  continueOnReturnCode: 0
+      |  memory: "2 GB"
+      |  disk: "2 GB"
+      |  preemptible: false
+      |  # The keys below have been commented out as they are optional runtime attributes.
+      |  # dockerWorkingDir
+      |  # docker
+      |}
+      |""".stripMargin
+
+  val backendConfigWithBackendParams = ConfigFactory.parseString(backendConfigStringWithBackendParams)
 }
 


### PR DESCRIPTION
Pre-holiday draft PR. I believe this is all working, except for the `unsupportedRuntimeAttributes` check in `TesInitializationActor`. I'd love some advice on how to deal with the `WomExpression`s there. 