### PR TITLE
Log workflows producing large metadata counts [BW-969]

### DIFF
--- a/common/src/test/scala/common/assertion/package.scala
+++ b/common/src/test/scala/common/assertion/package.scala
@@ -5,6 +5,7 @@ package object assertion {
     implicit class intWithTimes(n: Int) {
       def times(f: => Unit) = 1 to n foreach { _ => f }
       def indexedTimes(f: Int => Unit) = 0 until n foreach { i => f(i) }
+      def of[A](f: () => A) = (0 until n map { _ => f() }).toVector
     }
   }
 }

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -517,6 +517,25 @@ services {
     #   # request parameters; only the rows required to be retrieved from the database to compose the response
     #   # count against this limit.
     #   metadata-read-row-number-safety-threshold = 1000000
+    #
+    #  metadata-write-statistics {
+    #    # Not strictly necessary since the 'metadata-write-statistics' section itself is enough for statistics to be recorded.
+    #    # However, this can be set to 'false' to disable statistics collection without deleting the section.
+    #    enabled: true
+    #
+    #    # How many workflows to maintain statistics for concurrently. At ~4x "max-concurrent-workflows", this would be
+    #    # *relatively* resilient to large scatters of subworkflows without risking an uncapped expansion in memory usage.
+    #    # Note that cache entries expire after 4h of not being accessed, regardless of whether this limit is reached or not.
+    #    cache-size = 20000
+    #
+    #    # How many metadata rows to alert at each increment of. At 100k, there will be alert messages every time a
+    #    # workflow publishes another 100k rows of metadata.
+    #    metadata-row-alert-interval = 100000
+    #
+    #    # Whether to include subworkflow rows in both individual counts and also include them in their parent counts
+    #    # (and their parent's parent, and so on up to the root)
+    #    sub-workflow-bundling = true
+    #  }
     # }
 
     # Alternative 1: Pub sub implementation:

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -14,6 +14,7 @@ import cromwell.services.instrumentation.CromwellInstrumentation
 import cromwell.services.metadata.MetadataArchiveStatus
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata.impl.MetadataDatabaseAccess.WorkflowArchiveStatusAndEndTimestamp
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder.MetadataStatisticsRecorderSettings
 import cromwell.services.metadata.impl.MetadataSummaryRefreshActor.{MetadataSummaryFailure, MetadataSummarySuccess, SummarizeMetadata}
 import cromwell.services.metadata.impl.archiver.{ArchiveMetadataConfig, ArchiveMetadataSchedulerActor}
 import cromwell.services.metadata.impl.builder.MetadataBuilderActor
@@ -84,7 +85,8 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
 
   val dbFlushRate = serviceConfig.getOrElse("db-flush-rate", 5.seconds)
   val dbBatchSize = serviceConfig.getOrElse("db-batch-size", 200)
-  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate, serviceRegistryActor, LoadConfig.MetadataWriteThreshold), "WriteMetadataActor")
+  val metadataWriteStatisticsConfig = MetadataStatisticsRecorderSettings(serviceConfig.as[Option[Config]]("metadata-write-statistics"))
+  val writeActor = context.actorOf(WriteMetadataActor.props(dbBatchSize, dbFlushRate, serviceRegistryActor, LoadConfig.MetadataWriteThreshold, metadataWriteStatisticsConfig), "WriteMetadataActor")
 
   implicit val ec = context.dispatcher
   //noinspection ActorMutableStateInspection

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
@@ -1,0 +1,77 @@
+package cromwell.services.metadata.impl
+
+import java.util.UUID
+import java.util.concurrent.Callable
+
+import com.google.common.cache.CacheBuilder
+import cromwell.core.WorkflowId
+import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataString, MetadataValue}
+import java.time.{Duration => JDuration}
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder._
+import scala.concurrent.duration._
+import scala.util.Try
+
+object MetadataStatisticsRecorder {
+  final case class HeavyMetadataAlert(workflowId: WorkflowId, count: Long)
+  final case class WorkflowMetadataWriteStatistics(workflowId: WorkflowId, totalWrites: Long, lastLogged: Long, knownParent: Option[WorkflowId])
+}
+
+final class MetadataStatisticsRecorder(workflowCacheSize: Long = 100000L, // 100,000
+                                       metadataAlertInterval: Long = 1L * 1000000, // 1 million
+                                       bundleSubworkflowsIntoParents: Boolean = false
+                                      ) {
+
+  // Statistics for each workflow
+  private val metadataWriteStatisticsCache = CacheBuilder.newBuilder()
+    .concurrencyLevel(2)
+    .expireAfterAccess(JDuration.ofSeconds(4.hours.toSeconds))
+    .maximumSize(workflowCacheSize)
+    .build[WorkflowId, WorkflowMetadataWriteStatistics]()
+
+  def writeStatisticsLoader(workflowId: WorkflowId): Callable[WorkflowMetadataWriteStatistics] = () => WorkflowMetadataWriteStatistics(workflowId, 0L, 0L, None)
+
+  def processEvents(putEvents: Iterable[MetadataEvent]): Vector[HeavyMetadataAlert] = {
+    putEvents.groupBy(_.key.workflowId).toVector.flatMap { case (id, list) => processEventsForWorkflow(id, list)}
+  }
+
+  private def processEventsForWorkflow(workflowId: WorkflowId, events: Iterable[MetadataEvent]): Vector[HeavyMetadataAlert] = {
+    val workflowWriteStats = metadataWriteStatisticsCache.get(workflowId, writeStatisticsLoader(workflowId))
+
+    // Find a new parent record if one exists and update the statistics to record it:
+    val parentallyUpdatedStatistics = {
+      if (!bundleSubworkflowsIntoParents) workflowWriteStats
+      else if (workflowWriteStats.knownParent.isDefined) workflowWriteStats
+      else {
+        val newParentId = events.collectFirst {
+          case MetadataEvent(MetadataKey(_, None, "parentWorkflowId"), Some(MetadataValue(value, MetadataString)), _) => Try(WorkflowId(UUID.fromString(value))).toOption
+        }.flatten
+        workflowWriteStats.copy(knownParent = newParentId)
+      }
+    }
+
+    updateStatisticsCacheAndGenerateAlerts(parentallyUpdatedStatistics, events.size.longValue)
+  }
+
+  private def updateStatisticsCacheAndGenerateAlerts(workflowWriteStats: WorkflowMetadataWriteStatistics, count: Long): Vector[HeavyMetadataAlert] = {
+    val writesForWorkflow = workflowWriteStats.totalWrites + count
+
+    val myAlerts = if (writesForWorkflow >= workflowWriteStats.lastLogged + metadataAlertInterval) {
+      metadataWriteStatisticsCache.put(workflowWriteStats.workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow, lastLogged = writesForWorkflow))
+      Vector(HeavyMetadataAlert(workflowWriteStats.workflowId, writesForWorkflow))
+    }
+    else {
+      metadataWriteStatisticsCache.put(workflowWriteStats.workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow))
+      Vector.empty
+    }
+
+    val parentalAlerts = workflowWriteStats.knownParent.toVector.flatMap { parentId =>
+      val parentStatistics = metadataWriteStatisticsCache.get(parentId, writeStatisticsLoader(parentId))
+      updateStatisticsCacheAndGenerateAlerts(parentStatistics, count)
+    }
+
+    myAlerts ++ parentalAlerts
+  }
+
+  // For testing/debugging only...:
+  def statusString(): String = metadataWriteStatisticsCache.asMap().values().toString
+}

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -16,8 +16,6 @@ import java.time.{Duration => JDuration}
 import java.util.UUID
 import java.util.concurrent.Callable
 
-import cats.Monoid
-import cats.syntax.monoid._
 import cromwell.services.metadata.impl.WriteMetadataActor.MetadataStatisticsRecorder
 
 import scala.util.{Failure, Success, Try}
@@ -46,10 +44,8 @@ class WriteMetadataActor(override val batchSize: Int,
     val allPutEvents: Iterable[MetadataEvent] = putWithoutResponse ++ putWithResponse.flatMap(_._1)
     val dbAction = addMetadataEvents(allPutEvents)
     allPutEvents.groupBy(_.key.workflowId).foreach { case (id, list) =>
-      val update = statsRecorder.recordNewRows(id, list)
-      update match {
-        case
-      }
+      val alerts = statsRecorder.recordNewRows(id, list)
+      alerts.foreach(a => log.warning(s"${a.workflowId} has logged a heavy amount of metadata (${a.count} rows)"))
     }
 
     dbAction onComplete {
@@ -110,13 +106,13 @@ object WriteMetadataActor {
       .withDispatcher(ServiceDispatcher)
       .withMailbox(PriorityMailbox)
 
+  final case class WorkflowMetadataWriteStatistics(totalWrites: Long, lastLogged: Long, knownParent: Option[WorkflowId])
+  final case class HeavyMetadataAlert(workflowId: WorkflowId, count: Long)
+
   final class MetadataStatisticsRecorder() {
 
     val workflowCacheSize = 10L * 1000000 // TODO: Replace with the configured max workflows value (or max workflows x 2?)
     val metadataAlertInterval = 10L // TODO: Replace with our current understanding of a good metadata size
-
-    final case class WorkflowMetadataWriteStatistics(totalWrites: Long, lastLogged: Long, knownParent: Option[WorkflowId])
-    final case class HeavyMetadataAlert(workflowId: WorkflowId, count: Long)
 
     // Statistics for each workflow
     private val metadataWriteStatisticsCache = CacheBuilder.newBuilder()
@@ -127,23 +123,26 @@ object WriteMetadataActor {
 
     val writeStatisticsLoader: Callable[WorkflowMetadataWriteStatistics] = () => WorkflowMetadataWriteStatistics(0L, 0L, None)
 
-    def recordNewRows(workflowId: WorkflowId, events: Iterable[MetadataEvent]): Vector[HeavyMetadataAlert] = {
+    def recordNewRows(workflowId: WorkflowId, events: Iterable[MetadataEvent], fromSubworkflow: Boolean = false): Vector[HeavyMetadataAlert] = {
       val workflowWriteStats = metadataWriteStatisticsCache.get(workflowId, writeStatisticsLoader)
       val writesForWorkflow = workflowWriteStats.totalWrites + events.size.longValue()
-      val knownParent: Option[WorkflowId] = workflowWriteStats.knownParent.orElse( events.collectFirst {
-        case MetadataEvent(MetadataKey(_, None, "parentWorkflowId"), Some(MetadataValue(value, MetadataString)), _) => Try(UUID.fromString(value)).toOption
+      val knownParent: Option[WorkflowId] = workflowWriteStats.knownParent.orElse( if(fromSubworkflow) None else events.collectFirst {
+        case MetadataEvent(MetadataKey(_, None, "parentWorkflowId"), Some(MetadataValue(value, MetadataString)), _) => Try(WorkflowId(UUID.fromString(value))).toOption
       }.flatten )
 
+      knownParent.foreach(p => recordNewRows(p, events))
+
       if (writesForWorkflow > workflowWriteStats.lastLogged + metadataAlertInterval) {
-        metadataWriteStatisticsCache.put(workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow, lastLogged = writesForWorkflow))
+        metadataWriteStatisticsCache.put(workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow, lastLogged = writesForWorkflow, knownParent = knownParent))
         Vector(HeavyMetadataAlert(workflowId, writesForWorkflow))
       } else {
-        metadataWriteStatisticsCache.put(workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow))
+        metadataWriteStatisticsCache.put(workflowId, workflowWriteStats.copy(totalWrites = writesForWorkflow, knownParent = knownParent))
         Vector.empty
       }
     }
 
+    def recordSubworkflowRows(workflowId: WorkflowId, count: Long) = {
+
+    }
   }
 }
-
-

--- a/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import common.assertion.ManyTimes.intWithTimes
 import cromwell.core.WorkflowId
-import cromwell.services.metadata.impl.MetadataStatisticsRecorder
+import cromwell.services.metadata.impl.ActiveMetadataStatisticsRecorder
 import cromwell.services.metadata.impl.MetadataStatisticsRecorder.HeavyMetadataAlert
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -23,7 +23,7 @@ class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
   )
 
   it should "count rows for one workflow and create alerts every interval" in {
-    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val recorder = new ActiveMetadataStatisticsRecorder(10, 10)
     val workflowId = WorkflowId(UUID.randomUUID())
 
     (1 to 10) foreach { i =>
@@ -34,7 +34,7 @@ class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be able to reset counters from odd values" in {
-    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val recorder = new ActiveMetadataStatisticsRecorder(10, 10)
     val workflowId = WorkflowId(UUID.randomUUID())
 
     var runningCounter: Long = 0L
@@ -49,7 +49,7 @@ class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "count rows for multiple workflow and create alerts every interval" in {
-    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val recorder = new ActiveMetadataStatisticsRecorder(10, 10)
     val workflowId1 = WorkflowId(UUID.randomUUID())
     val workflowId2 = WorkflowId(UUID.randomUUID())
     val workflowId3 = WorkflowId(UUID.randomUUID())
@@ -80,7 +80,7 @@ class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "be able to accumulate counts from subworkflows" in {
-    val recorder = new MetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = true)
+    val recorder = new ActiveMetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = true)
     val rootWorkflowId = WorkflowId(UUID.randomUUID())
     val subWorkflow1Id = WorkflowId(UUID.randomUUID())
     val subWorkflow2Id = WorkflowId(UUID.randomUUID())
@@ -130,7 +130,7 @@ class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not accumulate counts from subworkflows if disabled" in {
-    val recorder = new MetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = false)
+    val recorder = new ActiveMetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = false)
     val rootWorkflowId = WorkflowId(UUID.randomUUID())
     val subWorkflow1Id = WorkflowId(UUID.randomUUID())
     val subWorkflow2Id = WorkflowId(UUID.randomUUID())

--- a/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
@@ -1,0 +1,150 @@
+package cromwell.services.metadata
+
+import java.util.UUID
+
+import common.assertion.ManyTimes.intWithTimes
+import cromwell.core.WorkflowId
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder.HeavyMetadataAlert
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wom.values.{WomInteger, WomString}
+
+import scala.util.Random
+
+class MetadataStatisticsRecorderSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "MetadataStatisticsRecorder"
+
+  def uninterestingWriteEvent(workflowId: WorkflowId)(): MetadataEvent = MetadataEvent(MetadataKey(workflowId, None, "foo"), MetadataValue(WomInteger(1)))
+  def parentNotificationEvent(rootWorkflowId: WorkflowId, parentWorkflowId: WorkflowId, subWorkflowId: WorkflowId): Vector[MetadataEvent] = Vector(
+    MetadataEvent(MetadataKey(subWorkflowId, None, "rootWorkflowId"), MetadataValue(WomString(rootWorkflowId.toString))),
+    MetadataEvent(MetadataKey(subWorkflowId, None, "parentWorkflowId"), MetadataValue(WomString(parentWorkflowId.toString)))
+  )
+
+  it should "count rows for one workflow and create alerts every interval" in {
+    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val workflowId = WorkflowId(UUID.randomUUID())
+
+    (1 to 10) foreach { i =>
+      recorder.processEvents(9 of uninterestingWriteEvent(workflowId)) should be(Vector.empty)
+      recorder.processEvents(1 of uninterestingWriteEvent(workflowId)) should be(Vector(HeavyMetadataAlert(workflowId, 10L * i)))
+      ()
+    }
+  }
+
+  it should "be able to reset counters from odd values" in {
+    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val workflowId = WorkflowId(UUID.randomUUID())
+
+    var runningCounter: Long = 0L
+    (1 to 10) foreach { i =>
+      val bigMetadataDump = Math.abs(Random.nextInt(101)) + 10
+      val expectedCountAfterProcessing = runningCounter + bigMetadataDump
+
+      recorder.processEvents(bigMetadataDump of uninterestingWriteEvent(workflowId)) should be(Vector(HeavyMetadataAlert(workflowId, expectedCountAfterProcessing)))
+      runningCounter = expectedCountAfterProcessing
+      ()
+    }
+  }
+
+  it should "count rows for multiple workflow and create alerts every interval" in {
+    val recorder = new MetadataStatisticsRecorder(10, 10)
+    val workflowId1 = WorkflowId(UUID.randomUUID())
+    val workflowId2 = WorkflowId(UUID.randomUUID())
+    val workflowId3 = WorkflowId(UUID.randomUUID())
+
+    recorder.processEvents(
+      (3 of uninterestingWriteEvent(workflowId1)) ++
+        (5 of uninterestingWriteEvent(workflowId2)) ++
+        (7 of uninterestingWriteEvent(workflowId3))
+    ) should be(Vector.empty)
+
+    recorder.processEvents(
+      (3 of uninterestingWriteEvent(workflowId1)) ++
+        (5 of uninterestingWriteEvent(workflowId2)) ++
+        (7 of uninterestingWriteEvent(workflowId3))
+    ).toSet should be(Set(HeavyMetadataAlert(workflowId2, 10), HeavyMetadataAlert(workflowId3, 14)))
+
+    recorder.processEvents(
+      (3 of uninterestingWriteEvent(workflowId1)) ++
+        (5 of uninterestingWriteEvent(workflowId2)) ++
+        (7 of uninterestingWriteEvent(workflowId3))
+    ) should be(Vector.empty)
+
+    recorder.processEvents(
+      (3 of uninterestingWriteEvent(workflowId1)) ++
+        (5 of uninterestingWriteEvent(workflowId2)) ++
+        (7 of uninterestingWriteEvent(workflowId3))
+    ).toSet should be(Set(HeavyMetadataAlert(workflowId1, 12), HeavyMetadataAlert(workflowId2, 20), HeavyMetadataAlert(workflowId3, 28)))
+  }
+
+  it should "be able to accumulate counts from subworkflows" in {
+    val recorder = new MetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = true)
+    val rootWorkflowId = WorkflowId(UUID.randomUUID())
+    val subWorkflow1Id = WorkflowId(UUID.randomUUID())
+    val subWorkflow2Id = WorkflowId(UUID.randomUUID())
+
+    // This one is easy to get lost in, hence the liberal comments and scattering of clues
+
+    // Recording SW1 parentage adds 2 events against subWorkflowId1 (and thus rootWorkflowId)
+    withClue(recorder.statusString()) {
+      recorder.processEvents(parentNotificationEvent(rootWorkflowId, rootWorkflowId, subWorkflow1Id)) should be(Vector.empty)
+    }
+
+    // Recording SW2 parentage adds 2 events against subWorkflowId2 (and thus subWorkflow1Id and thus rootWorkflowId)
+    withClue(recorder.statusString()) {
+      recorder.processEvents(parentNotificationEvent(rootWorkflowId, subWorkflow1Id, subWorkflow2Id)) should be(Vector.empty)
+    }
+
+    // To get started, add 7 events to the root subworkflow:
+    withClue(recorder.statusString()) {
+      recorder.processEvents(7 of uninterestingWriteEvent(rootWorkflowId)) should be(Vector(HeavyMetadataAlert(rootWorkflowId, 11)))
+    }
+
+    // Current standing: root: 11, sub1: 4, sub2: 2
+
+    withClue(recorder.statusString()) {
+      recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow1Id)) should be(Vector(HeavyMetadataAlert(subWorkflow1Id, 11)))
+    }
+
+    // Current standing: root: 18, sub1: 11, sub2: 2
+
+    withClue(recorder.statusString()) {
+      recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow2Id)) should be(Vector(HeavyMetadataAlert(rootWorkflowId, 25)))
+    }
+
+    // Current standing: root: 25, sub1: 18, sub2: 9
+
+    withClue(recorder.statusString()) {
+      recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow1Id)) should be(Vector(HeavyMetadataAlert(subWorkflow1Id, 25)))
+    }
+
+    // Current standing: root: 32, sub1: 25, sub2: 9
+
+    withClue(recorder.statusString()) {
+      recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow2Id)).toSet should be(Set(HeavyMetadataAlert(rootWorkflowId, 39), HeavyMetadataAlert(subWorkflow2Id, 16)))
+    }
+
+    // Current standing: root: 39, sub1: 32, sub2: 16
+  }
+
+  it should "not accumulate counts from subworkflows if disabled" in {
+    val recorder = new MetadataStatisticsRecorder(10, 10, bundleSubworkflowsIntoParents = false)
+    val rootWorkflowId = WorkflowId(UUID.randomUUID())
+    val subWorkflow1Id = WorkflowId(UUID.randomUUID())
+    val subWorkflow2Id = WorkflowId(UUID.randomUUID())
+
+    recorder.processEvents(parentNotificationEvent(rootWorkflowId, rootWorkflowId, subWorkflow1Id)) should be(Vector.empty)
+    recorder.processEvents(parentNotificationEvent(rootWorkflowId, subWorkflow1Id, subWorkflow2Id)) should be(Vector.empty)
+
+    // If we were accumulating these would alert, but we see nothing if not accumulating:
+    recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow1Id)) should be(Vector.empty)
+    recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow2Id)) should be(Vector.empty)
+
+    // When we trip the limits, we should only see alerts for individual workflows.
+    // Note: it's 16 not 14 because of the two parent notification entries above
+    recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow1Id)) should be(Vector(HeavyMetadataAlert(subWorkflow1Id, 16)))
+    recorder.processEvents(7 of uninterestingWriteEvent(subWorkflow2Id)) should be(Vector(HeavyMetadataAlert(subWorkflow2Id, 16)))
+  }
+}

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorBenchmark.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorBenchmark.scala
@@ -7,6 +7,7 @@ import cromwell.core.{TestKitSuite, WorkflowId}
 import cromwell.database.slick.MetadataSlickDatabase
 import cromwell.services.database.{DatabaseTestKit, MetadataDatabaseType, MysqlEarliestDatabaseSystem}
 import cromwell.services.metadata.MetadataService.PutMetadataAction
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder.MetadataStatisticsDisabled
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -44,7 +45,7 @@ class WriteMetadataActorBenchmark extends TestKitSuite with AnyFlatSpecLike with
   }
 
   it should "provide good throughput" taggedAs IntegrationTest in {
-    val writeActor = TestFSMRef(new WriteMetadataActor(1000, 5.seconds, registry, Int.MaxValue) {
+    val writeActor = TestFSMRef(new WriteMetadataActor(1000, 5.seconds, registry, Int.MaxValue, MetadataStatisticsDisabled) {
       override val metadataDatabaseInterface: MetadataSlickDatabase = dataAccess
     })
 

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -11,6 +11,7 @@ import cromwell.database.sql.joins.MetadataJobQueryValue
 import cromwell.database.sql.tables.{InformationSchemaEntry, MetadataEntry, WorkflowMetadataSummaryEntry}
 import cromwell.database.sql.{MetadataSqlDatabase, SqlDatabase}
 import cromwell.services.metadata.MetadataService.{MetadataWriteAction, MetadataWriteFailure, MetadataWriteSuccess, PutMetadataAction, PutMetadataActionAndRespond}
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder.MetadataStatisticsDisabled
 import cromwell.services.metadata.impl.WriteMetadataActorSpec.BatchSizeCountingWriteMetadataActor
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataValue}
 import org.scalatest.concurrent.Eventually
@@ -317,7 +318,7 @@ object WriteMetadataActorSpec {
   class BatchSizeCountingWriteMetadataActor(override val batchSize: Int,
                                             override val flushRate: FiniteDuration,
                                             override val serviceRegistryActor: ActorRef,
-                                            override val threshold: Int) extends WriteMetadataActor(batchSize, flushRate, serviceRegistryActor, threshold) {
+                                            override val threshold: Int) extends WriteMetadataActor(batchSize, flushRate, serviceRegistryActor, threshold, MetadataStatisticsDisabled) {
 
     var batchSizes: Vector[Int] = Vector.empty
     var failureCount: Int = 0

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -51,4 +51,12 @@ system {
   memory-retry-error-keys = ["OutOfMemory", "Killed"]
 }
 
+# See documentation for these values in cromwell.examples.conf
+services.MetadataService.config.metadata-write-statistics {
+  enabled = true
+  cache-size = 20000
+  metadata-row-alert-interval = 5000 # Quite low... but we don't expect much metadata from test workflows, right?
+  sub-workflow-bundling = true
+}
+
 include "cromwell_database.inc.conf"


### PR DESCRIPTION
Description:
* Adds a statistics recorder into the WriteMetadataActor to count rows being sent per workflow. If the counter goes about a given limit, we get an alert back which the write actor converts into a log message. 

Food for reviewers' thoughts:

* Does the set of configuration options make sense?
  * And what might be sensible default values?
* I'm not a huge fan of how subworkflows' parents are detected here. Is there a more direct way to find out a parent?