### PR TITLE
New backend status AwaitingCloudQuota [BW-1012]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,27 @@
 
 ### New `AwaitingCloudQuota` backend status
 
-For Cloud Life Sciences v2beta only, Cromwell emits a new backend status to indicate that a job is waiting for GCP quota.
+For Cloud Life Sciences v2beta only.
 
-This status is informational and does not require any action. Users wishing to maximize throughput can use `AwaitingCloudQuota` as an indication they should check quota in Cloud Console and submit quota increase requests to GCP.
+When a user's GCP project reaches a quota limit, Cromwell continues to submit jobs and Life Sciences acknowledges them as created even if the physical VM cannot yet start. Cromwell now detects this condition in the backend and reports `AwaitingCloudQuota`.
 
-When a job encounters quota delays within the backend, its metadata will show the following lifecycle:
-```
-"backendStatus": "Initializing"
-"backendStatus": "AwaitingCloudQuota"
-"backendStatus": "Running"
-"backendStatus": "Success"
-```
-When there are no quota delays the `AwaitingCloudQuota` status is skipped:
-```
-"backendStatus": "Initializing"
-"backendStatus": "Running"
-"backendStatus": "Success"
-```
+The status is informational and does not require any action. Users wishing to maximize throughput can use `AwaitingCloudQuota` as an indication they should check quota in Cloud Console and request a quota increase from GCP.
 
-There is no change to how Cromwell reports execution status for jobs or workflows (`executionStatus` in metadata).
+`AwaitingCloudQuota` will appear between the `Initializing` and `Running` backend statuses, and will be skipped if not applicable.
+
+Now:
+
+| Status in metadata |Quota normal| Quota delay          | Status meaning                                    |
+|--------------------|----|----------------------|---------------------------------------------------|
+| `executionStatus`    |`Running`| `Running`            | Job state Cromwell is requesting from the backend |
+| `backendStatus`      |`Running`| `AwaitingCloudQuota` | Job state reported by backend                          |
+
+Previously:
+
+| Status in metadata |Quota normal|Quota delay| Status meaning                                            |
+|--------------------|----|----|-----------------------------------------------------------|
+| `executionStatus`    |`Running`|`Running`| Job state Cromwell is requesting from the backend |
+| `backendStatus`      |`Running`|`Running`| Job state reported by backend |
 
 ## 73 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Cromwell Change Log
 
-## 74 Release Notes
+## 75 Release Notes
 
 ### New `AwaitingCloudQuota` backend status
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Cromwell Change Log
 
+## 74 Release Notes
+
+### New `AwaitingCloudQuota` backend status
+
+For Cloud Life Sciences v2beta only, Cromwell emits a new backend status to indicate that a job is waiting for GCP quota.
+
+This status is informational and does not require any action. Users wishing to maximize throughput can use `AwaitingCloudQuota` as an indication they should check quota in Cloud Console and submit quota increase requests to GCP.
+
+When a job encounters quota delays within the backend, its metadata will show the following lifecycle:
+```
+"backendStatus": "Initializing"
+"backendStatus": "AwaitingCloudQuota"
+"backendStatus": "Running"
+"backendStatus": "Success"
+```
+When there are no quota delays the `AwaitingCloudQuota` status is skipped:
+```
+"backendStatus": "Initializing"
+"backendStatus": "Running"
+"backendStatus": "Success"
+```
+
+There is no change to how Cromwell reports execution status for jobs or workflows (`executionStatus` in metadata).
+
 ## 73 Release Notes
 
 ### Workflow Restart Performance Improvements

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/RunStatus.scala
@@ -6,18 +6,11 @@ import cromwell.core.ExecutionEvent
 
 import scala.util.Try
 
-sealed trait RunStatus {
-  import RunStatus._
-
-  // Could be defined as false for Initializing and true otherwise, but this is more defensive.
-  def isRunningOrComplete = this match {
-    case Running | _: TerminalRunStatus => true
-    case _ => false
-  }
-}
+sealed trait RunStatus
 
 object RunStatus {
   case object Initializing extends RunStatus
+  case object AwaitingCloudQuota extends RunStatus
   case object Running extends RunStatus
 
   sealed trait TerminalRunStatus extends RunStatus {

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/Deserialization.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/Deserialization.scala
@@ -28,6 +28,9 @@ private [api] object Deserialization {
   implicit class OperationDeserialization(val operation: Operation) extends AnyVal {
     /**
       * Deserializes the events to com.google.api.services.genomics.v2beta.model.Event
+      *
+      * There could also be entries of `com.google.api.services.lifesciences.v2beta.model.DelayedEvent`
+      * They are effectively upcast to regular `Event` even though they're unrelated types
       */
     def events: ErrorOr[List[Event]] = {
       val eventsErrorOrOption = for {

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandler.scala
@@ -1,6 +1,7 @@
 package cromwell.backend.google.pipelines.v2beta.api.request
 
 import java.time.OffsetDateTime
+
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandler.scala
@@ -1,7 +1,6 @@
 package cromwell.backend.google.pipelines.v2beta.api.request
 
 import java.time.OffsetDateTime
-
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
@@ -10,7 +9,7 @@ import common.validation.Validation._
 import cromwell.backend.google.pipelines.common.action.ActionLabels._
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.RunStatus
-import cromwell.backend.google.pipelines.common.api.RunStatus.{Initializing, Running, Success, UnsuccessfulRunStatus}
+import cromwell.backend.google.pipelines.common.api.RunStatus.{AwaitingCloudQuota, Initializing, Running, Success, UnsuccessfulRunStatus}
 import cromwell.backend.google.pipelines.v2beta.PipelinesConversions._
 import cromwell.backend.google.pipelines.v2beta.api.Deserialization._
 import cromwell.backend.google.pipelines.v2beta.api.request.ErrorReporter._
@@ -53,10 +52,10 @@ trait GetRequestHandler { this: RequestHandler =>
       UnsuccessfulRunStatus(Status.UNKNOWN, Option(errorMessage), Nil, None, None, None, wasPreemptible = false)
     } else {
       try {
+        val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
         if (operation.getDone) {
           val metadata = Try(operation.getMetadata.asScala.toMap).getOrElse(Map[String, AnyRef]())
           // Deserialize the response
-          val events: List[Event] = operation.events.fallBackTo(List.empty)(pollingRequest.workflowId -> operation)
           val pipeline: Option[Pipeline] = operation.pipeline.flatMap(
             _.toErrorOr.fallBack(pollingRequest.workflowId -> operation)
           )
@@ -108,6 +107,8 @@ trait GetRequestHandler { this: RequestHandler =>
               errorReporter.toUnsuccessfulRunStatus(error, events)
             case None => Success(executionEvents, machineType, zone, instanceName)
           }
+        } else if (isQuotaDelayed(events)) {
+          AwaitingCloudQuota
         } else if (operation.hasStarted) {
           Running
         } else {
@@ -164,4 +165,26 @@ trait GetRequestHandler { this: RequestHandler =>
 
     starterEvent.toList ++ filteredExecutionEvents ++ completionEvent
   }
+
+  // Future enhancement: parse as `com.google.api.services.lifesciences.v2beta.model.DelayedEvent` instead of
+  // generic `Event` and take advantage of `getMetrics` which has a string array of problem quota(s):
+  //   "metrics": [
+  //     "CPUS"
+  //   ]
+  private def isQuotaDelayed(events: List[Event]): Boolean = {
+    events.sortBy(_.getTimestamp).reverse.headOption match {
+      case Some(event) =>
+        quotaMessages.exists(event.getDescription.contains)
+      case None =>
+        // If the events list is empty, we're not waiting for quota yet
+        false
+    }
+  }
+
+  private val quotaMessages = List(
+    "A resource limit has delayed the operation",
+    "usage too high",
+    "no available zones",
+    "resource_exhausted"
+  )
 }

--- a/supportedBackends/google/pipelines/v2beta/src/test/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandlerSpec.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/test/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandlerSpec.scala
@@ -291,7 +291,372 @@ class GetRequestHandlerSpec extends AnyFlatSpec with CromwellTimeoutSpec with Ma
         None,
         None
       )
+    ),
+
+    // As of 2022-01 the zone `us-west3` in `broad-dsde-cromwell-dev` has its CPU quota purposely de-rated to 1 for testing
+    ("check that a job is AwaitingCloudQuota if its most recent event is quota exhaustion",
+      """{
+        |  "metadata": {
+        |    "@type": "type.googleapis.com/google.cloud.lifesciences.v2beta.Metadata",
+        |    "createTime": "2022-01-19T21:53:55.138960Z",
+        |    "events": [
+        |      {
+        |        "delayed": {
+        |          "cause": "generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |          "metrics": [
+        |            "CPUS"
+        |          ]
+        |        },
+        |        "description": "A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |        "timestamp": "2022-01-19T21:54:07.717679160Z"
+        |      }
+        |    ],
+        |    "labels": {
+        |      "cromwell-workflow-id": "cromwell-ac888b4e-2e6b-4dcc-a537-3c6db7764037",
+        |      "wdl-task-name": "sleep"
+        |    },
+        |    "pipeline": {
+        |      "actions": [
+        |        {
+        |          "commands": [
+        |            "-c",
+        |            "printf '%s %s\\n' \"$(date -u '+%Y/%m/%d %H:%M:%S')\" Starting\\ container\\ setup."
+        |          ],
+        |          "entrypoint": "/bin/sh",
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine",
+        |          "labels": {
+        |            "logging": "ContainerSetup"
+        |          },
+        |          "timeout": "300s"
+        |        }
+        |      ],
+        |      "environment": {
+        |        "MEM_SIZE": "2.0",
+        |        "MEM_UNIT": "GB"
+        |      },
+        |      "resources": {
+        |        "virtualMachine": {
+        |          "bootDiskSizeGb": 12,
+        |          "bootImage": "projects/cos-cloud/global/images/family/cos-stable",
+        |          "disks": [
+        |            {
+        |              "name": "local-disk",
+        |              "sizeGb": 10,
+        |              "type": "pd-ssd"
+        |            }
+        |          ],
+        |          "labels": {
+        |            "cromwell-workflow-id": "cromwell-ac888b4e-2e6b-4dcc-a537-3c6db7764037",
+        |            "goog-pipelines-worker": "true",
+        |            "wdl-task-name": "sleep"
+        |          },
+        |          "machineType": "custom-1-2048",
+        |          "network": {},
+        |          "nvidiaDriverVersion": "450.51.06",
+        |          "serviceAccount": {
+        |            "email": "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com",
+        |            "scopes": [
+        |              "https://www.googleapis.com/auth/compute",
+        |              "https://www.googleapis.com/auth/devstorage.full_control",
+        |              "https://www.googleapis.com/auth/cloudkms",
+        |              "https://www.googleapis.com/auth/userinfo.email",
+        |              "https://www.googleapis.com/auth/userinfo.profile",
+        |              "https://www.googleapis.com/auth/monitoring.write",
+        |              "https://www.googleapis.com/auth/bigquery",
+        |              "https://www.googleapis.com/auth/cloud-platform"
+        |            ]
+        |          },
+        |          "volumes": [
+        |            {
+        |              "persistentDisk": {
+        |                "sizeGb": 10,
+        |                "type": "pd-ssd"
+        |              },
+        |              "volume": "local-disk"
+        |            }
+        |          ]
+        |        },
+        |        "zones": [
+        |          "us-west3-a",
+        |          "us-west3-b",
+        |          "us-west3-c"
+        |        ]
+        |      },
+        |      "timeout": "604800s"
+        |    }
+        |  },
+        |  "name": "projects/1005074806481/locations/us-central1/operations/3874882033889365536"
+        |}""".stripMargin,
+      AwaitingCloudQuota
+    ),
+    ("check that a job is Running and no longer AwaitingCloudQuota once a worker assigns",
+      """{
+        |  "metadata": {
+        |    "@type": "type.googleapis.com/google.cloud.lifesciences.v2beta.Metadata",
+        |    "createTime": "2022-01-19T21:53:55.138960Z",
+        |    "events": [
+        |      {
+        |        "description": "Started pulling \"gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine\"",
+        |        "pullStarted": {
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine"
+        |        },
+        |        "timestamp": "2022-01-19T22:09:55.410251187Z"
+        |      },
+        |      {
+        |        "description": "Worker \"google-pipelines-worker-e6c8bf8035860b2cd69488497bd602d8\" assigned in \"us-west3-c\" on a \"custom-1-2048\" machine",
+        |        "timestamp": "2022-01-19T22:09:20.363771714Z",
+        |        "workerAssigned": {
+        |          "instance": "google-pipelines-worker-e6c8bf8035860b2cd69488497bd602d8",
+        |          "machineType": "custom-1-2048",
+        |          "zone": "us-west3-c"
+        |        }
+        |      },
+        |      {
+        |        "delayed": {
+        |          "cause": "generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |          "metrics": [
+        |            "CPUS"
+        |          ]
+        |        },
+        |        "description": "A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |        "timestamp": "2022-01-19T21:54:07.717679160Z"
+        |      }
+        |    ],
+        |    "labels": {
+        |      "cromwell-workflow-id": "cromwell-ac888b4e-2e6b-4dcc-a537-3c6db7764037",
+        |      "wdl-task-name": "sleep"
+        |    },
+        |    "pipeline": {
+        |      "actions": [
+        |        {
+        |          "commands": [
+        |            "-c",
+        |            "printf '%s %s\\n' \"$(date -u '+%Y/%m/%d %H:%M:%S')\" Starting\\ container\\ setup."
+        |          ],
+        |          "entrypoint": "/bin/sh",
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine",
+        |          "labels": {
+        |            "logging": "ContainerSetup"
+        |          },
+        |          "timeout": "300s"
+        |        }
+        |      ],
+        |      "environment": {
+        |        "MEM_SIZE": "2.0",
+        |        "MEM_UNIT": "GB"
+        |      },
+        |      "resources": {
+        |        "virtualMachine": {
+        |          "bootDiskSizeGb": 12,
+        |          "bootImage": "projects/cos-cloud/global/images/family/cos-stable",
+        |          "disks": [
+        |            {
+        |              "name": "local-disk",
+        |              "sizeGb": 10,
+        |              "type": "pd-ssd"
+        |            }
+        |          ],
+        |          "labels": {
+        |            "cromwell-workflow-id": "cromwell-ac888b4e-2e6b-4dcc-a537-3c6db7764037",
+        |            "goog-pipelines-worker": "true",
+        |            "wdl-task-name": "sleep"
+        |          },
+        |          "machineType": "custom-1-2048",
+        |          "network": {},
+        |          "nvidiaDriverVersion": "450.51.06",
+        |          "serviceAccount": {
+        |            "email": "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com",
+        |            "scopes": [
+        |              "https://www.googleapis.com/auth/compute",
+        |              "https://www.googleapis.com/auth/devstorage.full_control",
+        |              "https://www.googleapis.com/auth/cloudkms",
+        |              "https://www.googleapis.com/auth/userinfo.email",
+        |              "https://www.googleapis.com/auth/userinfo.profile",
+        |              "https://www.googleapis.com/auth/monitoring.write",
+        |              "https://www.googleapis.com/auth/bigquery",
+        |              "https://www.googleapis.com/auth/cloud-platform"
+        |            ]
+        |          },
+        |          "volumes": [
+        |            {
+        |              "persistentDisk": {
+        |                "sizeGb": 10,
+        |                "type": "pd-ssd"
+        |              },
+        |              "volume": "local-disk"
+        |            }
+        |          ]
+        |        },
+        |        "zones": [
+        |          "us-west3-a",
+        |          "us-west3-b",
+        |          "us-west3-c"
+        |        ]
+        |      },
+        |      "timeout": "604800s"
+        |    },
+        |    "startTime": "2022-01-19T22:09:20.363771714Z"
+        |  },
+        |  "name": "projects/1005074806481/locations/us-central1/operations/3874882033889365536"
+        |}
+        |
+        |
+        |""".stripMargin,
+      Running
+    ),
+    ("check that a job is no longer AwaitingCloudQuota once it finishes",
+      """{
+        |  "done": true,
+        |  "metadata": {
+        |    "@type": "type.googleapis.com/google.cloud.lifesciences.v2beta.Metadata",
+        |    "createTime": "2022-01-19T19:17:13.175579Z",
+        |    "endTime": "2022-01-19T19:37:22.764120036Z",
+        |    "events": [
+        |      {
+        |        "description": "Worker released",
+        |        "timestamp": "2022-01-19T19:37:22.764120036Z",
+        |        "workerReleased": {
+        |          "instance": "google-pipelines-worker-8eff543e6858c204c8f67520aee75432",
+        |          "zone": "us-west3-c"
+        |        }
+        |      },
+        |      {
+        |        "containerStopped": {
+        |          "actionId": 19
+        |        },
+        |        "description": "Stopped running shortened for test",
+        |        "timestamp": "2022-01-19T19:37:19.822873814Z"
+        |      },
+        |      {
+        |        "description": "Started pulling \"gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine\"",
+        |        "pullStarted": {
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine"
+        |        },
+        |        "timestamp": "2022-01-19T19:32:55.709674372Z"
+        |      },
+        |      {
+        |        "description": "Worker \"google-pipelines-worker-8eff543e6858c204c8f67520aee75432\" assigned in \"us-west3-c\" on a \"custom-1-2048\" machine",
+        |        "timestamp": "2022-01-19T19:32:19.204055448Z",
+        |        "workerAssigned": {
+        |          "instance": "google-pipelines-worker-8eff543e6858c204c8f67520aee75432",
+        |          "machineType": "custom-1-2048",
+        |          "zone": "us-west3-c"
+        |        }
+        |      },
+        |      {
+        |        "delayed": {
+        |          "cause": "generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |          "metrics": [
+        |            "CPUS"
+        |          ]
+        |        },
+        |        "description": "A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high",
+        |        "timestamp": "2022-01-19T19:17:14.948193837Z"
+        |      }
+        |    ],
+        |    "labels": {
+        |      "cromwell-workflow-id": "cromwell-058bff35-4a55-4c0f-9113-0885f4119cd9",
+        |      "wdl-task-name": "sleep"
+        |    },
+        |    "pipeline": {
+        |      "actions": [
+        |        {
+        |          "commands": [
+        |            "-c",
+        |            "printf '%s %s\\n' \"$(date -u '+%Y/%m/%d %H:%M:%S')\" Starting\\ container\\ setup."
+        |          ],
+        |          "entrypoint": "/bin/sh",
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine",
+        |          "labels": {
+        |            "logging": "ContainerSetup"
+        |          },
+        |          "timeout": "300s"
+        |        },
+        |        {
+        |          "alwaysRun": true,
+        |          "commands": [
+        |            "-c",
+        |            "python3 -c 'import base64; shortened for test"
+        |          ],
+        |          "entrypoint": "/bin/sh",
+        |          "imageUri": "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine",
+        |          "labels": {
+        |            "tag": "Delocalization"
+        |          }
+        |        }
+        |      ],
+        |      "environment": {
+        |        "MEM_SIZE": "2.0",
+        |        "MEM_UNIT": "GB"
+        |      },
+        |      "resources": {
+        |        "virtualMachine": {
+        |          "bootDiskSizeGb": 12,
+        |          "bootImage": "projects/cos-cloud/global/images/family/cos-stable",
+        |          "disks": [
+        |            {
+        |              "name": "local-disk",
+        |              "sizeGb": 10,
+        |              "type": "pd-ssd"
+        |            }
+        |          ],
+        |          "labels": {
+        |            "cromwell-workflow-id": "cromwell-058bff35-4a55-4c0f-9113-0885f4119cd9",
+        |            "goog-pipelines-worker": "true",
+        |            "wdl-task-name": "sleep"
+        |          },
+        |          "machineType": "custom-1-2048",
+        |          "network": {},
+        |          "nvidiaDriverVersion": "450.51.06",
+        |          "serviceAccount": {
+        |            "email": "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com",
+        |            "scopes": [
+        |              "https://www.googleapis.com/auth/compute",
+        |              "https://www.googleapis.com/auth/devstorage.full_control",
+        |              "https://www.googleapis.com/auth/cloudkms",
+        |              "https://www.googleapis.com/auth/userinfo.email",
+        |              "https://www.googleapis.com/auth/userinfo.profile",
+        |              "https://www.googleapis.com/auth/monitoring.write",
+        |              "https://www.googleapis.com/auth/bigquery",
+        |              "https://www.googleapis.com/auth/cloud-platform"
+        |            ]
+        |          },
+        |          "volumes": [
+        |            {
+        |              "persistentDisk": {
+        |                "sizeGb": 10,
+        |                "type": "pd-ssd"
+        |              },
+        |              "volume": "local-disk"
+        |            }
+        |          ]
+        |        },
+        |        "zones": [
+        |          "us-west3-a",
+        |          "us-west3-b",
+        |          "us-west3-c"
+        |        ]
+        |      },
+        |      "timeout": "604800s"
+        |    },
+        |    "startTime": "2022-01-19T19:32:19.204055448Z"
+        |  },
+        |  "name": "projects/1005074806481/locations/us-central1/operations/5001350794958839237",
+        |  "response": {
+        |    "@type": "type.googleapis.com/cloud.lifesciences.pipelines.RunPipelineResponse"
+        |  }
+        |}""".stripMargin,
+      Success(List(
+        new ExecutionEvent("waiting for quota", OffsetDateTime.parse("2022-01-19T19:17:13.175579Z"), None),
+        new ExecutionEvent("Worker released", OffsetDateTime.parse("2022-01-19T19:37:22.764120036Z"), None),
+        new ExecutionEvent("Stopped running shortened for test", OffsetDateTime.parse("2022-01-19T19:37:19.822873814Z"), None),
+        new ExecutionEvent("Started pulling \"gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine\"", OffsetDateTime.parse("2022-01-19T19:32:55.709674372Z"), Option("Pulling \"gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine\"")),
+        new ExecutionEvent("Worker \"google-pipelines-worker-8eff543e6858c204c8f67520aee75432\" assigned in \"us-west3-c\" on a \"custom-1-2048\" machine", OffsetDateTime.parse("2022-01-19T19:32:19.204055448Z"), None),
+        new ExecutionEvent("A resource limit has delayed the operation: generic::resource_exhausted: allocating: selecting resources: selecting region and zone: no available zones: us-west3: 1 CPUS (0/1 available) usage too high", OffsetDateTime.parse("2022-01-19T19:17:14.948193837Z"), None),
+        new ExecutionEvent("Complete in GCE / Cromwell Poll Interval", OffsetDateTime.parse("2022-01-19T19:37:22.764120036Z"), None)
+      ), Option("custom-1-2048"), Option("us-west3-c"), Option("google-pipelines-worker-8eff543e6858c204c8f67520aee75432"))
     )
+
   )
 
   forAll(interpretedStatus) { (description, json, expectedStatus) =>

--- a/supportedBackends/google/pipelines/v2beta/src/test/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandlerSpec.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/test/scala/cromwell/backend/google/pipelines/v2beta/api/request/GetRequestHandlerSpec.scala
@@ -292,7 +292,6 @@ class GetRequestHandlerSpec extends AnyFlatSpec with CromwellTimeoutSpec with Ma
         None
       )
     ),
-
     // As of 2022-01 the zone `us-west3` in `broad-dsde-cromwell-dev` has its CPU quota purposely de-rated to 1 for testing
     ("check that a job is AwaitingCloudQuota if its most recent event is quota exhaustion",
       """{
@@ -656,7 +655,6 @@ class GetRequestHandlerSpec extends AnyFlatSpec with CromwellTimeoutSpec with Ma
         new ExecutionEvent("Complete in GCE / Cromwell Poll Interval", OffsetDateTime.parse("2022-01-19T19:37:22.764120036Z"), None)
       ), Option("custom-1-2048"), Option("us-west3-c"), Option("google-pipelines-worker-8eff543e6858c204c8f67520aee75432"))
     )
-
   )
 
   forAll(interpretedStatus) { (description, json, expectedStatus) =>


### PR DESCRIPTION
Since this is fairly backend-specific I've implemented as a `cromwell.backend.google.pipelines.common.api.RunStatus` instead of a `cromwell.core.ExecutionStatus`. It also reduces the scope of changes. Feedback welcome.

Looks like this in metadata requests:
```
"calls": {
    "sleepy_sleep.sleep": [
      {
        "preemptible": false,
        "executionStatus": "Running",
        "stdout": "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/sleepy_sleep/058bff35-4a55-4c0f-9113-0885f4119cd9/call-sleep/stdout",
        "backendStatus": "AwaitingCloudQuota",
        "compressedDockerSize": 28566425,
        "commandLine": "sleep 180;\nls -la",
        "shardIndex": -1,
        "jes": {
          "executionBucket": "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci",
          "endpointUrl": "https://lifesciences.googleapis.com/",
          "googleProject": "broad-dsde-cromwell-dev"
        },
```
The Terra UI workflow dashboard currently makes calls that look like
```
https://rawls.dsde-dev.broadinstitute.org/api/workspaces/general-dev-billing-account/anichols-post-ppw/submissions/a7cfb487-9c30-4fd7-b10f-19d6f3c1d192/workflows/f52e4e4b-0299-44b7-a16f-904d2ee3f1e9
  ?includeKey=end
  &includeKey=executionStatus
  &includeKey=failures
  &includeKey=start
  &includeKey=status
  &includeKey=submittedFiles:workflow
  &includeKey=workflowLog
  &includeKey=workflowName
  &includeKey=callCaching:result
  &includeKey=callCaching:effectiveCallCachingMode
```
so it would be easy to add a `&includeKey=backendStatus` and logic to evaluate something like
```
if (executionStatus == "Running" && backendStatus == "AwaitingCloudQuota") {
  msg = "Trying to run but needs quota"
}
```