### PR TITLE
Don't retry tests that expect cache hits from specific workflows [CROM-6807]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/backendWithNoDocker.test
+++ b/centaur/src/main/resources/standardTestCases/backendWithNoDocker.test
@@ -2,6 +2,9 @@ name: backendWithNoDocker
 backends: [LocalNoDocker]
 testFormat: runtwiceexpectingcallcaching
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: backendWithNoDocker/backendWithNoDocker.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/cacheBetweenWf.test
+++ b/centaur/src/main/resources/standardTestCases/cacheBetweenWf.test
@@ -1,6 +1,9 @@
 name: cacheBetweenWF
 testFormat: runtwiceexpectingcallcaching
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: cacheBetweenWF/cacheBetweenWF.wdl
   options: common_options/cache_read_off_write_on.options

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
@@ -3,6 +3,9 @@ name: call_cache_hit_prefixes_empty_hint_papi
 testFormat: runtwiceexpectingcallcaching
 backends: [Papi]
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
   inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_empty_hint.inputs

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_no_hint.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_no_hint.test
@@ -2,6 +2,9 @@
 name: call_cache_hit_prefixes_no_hint
 testFormat: runtwiceexpectingcallcaching
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
   inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_no_hint.inputs

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
@@ -5,6 +5,9 @@ name: call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi
 testFormat: runthriceexpectingcallcaching
 backends: [Papi]
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl
   inputs: call_cache_hit_prefixes/call_cache_hit_prefixes_two_roots_empty_hint_hit_papi.inputs

--- a/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows.test
+++ b/centaur/src/main/resources/standardTestCases/cwl_cache_between_workflows.test
@@ -5,6 +5,9 @@ workflowType: CWL
 workflowTypeVersion: v1.0
 skipDescribeEndpointValidation: true
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: cwl_cache_between_workflows/cwl_cache_between_workflows.cwl
   inputs: cwl_cache_between_workflows/cwl_cache_between_workflows.json

--- a/centaur/src/main/resources/standardTestCases/floating_tags.test
+++ b/centaur/src/main/resources/standardTestCases/floating_tags.test
@@ -1,6 +1,9 @@
 name: floating_tags
 testFormat: runtwiceexpectingcallcaching
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: floating_tags/floating_tags.wdl
   options: floating_tags/floating_tags.options

--- a/centaur/src/main/resources/standardTestCases/fofn_caching.test
+++ b/centaur/src/main/resources/standardTestCases/fofn_caching.test
@@ -2,6 +2,9 @@ name: fofn_caching
 testFormat: runtwiceexpectingcallcaching
 backends: [Papi-Caching-No-Copy]
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: fofn_caching/fofn_caching.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/google_artifact_registry.test
+++ b/centaur/src/main/resources/standardTestCases/google_artifact_registry.test
@@ -1,6 +1,9 @@
 name: google_artifact_registry
 testFormat: runtwiceexpectingcallcaching
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: google_artifact_registry/google_artifact_registry.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/hello_private_repo.test
+++ b/centaur/src/main/resources/standardTestCases/hello_private_repo.test
@@ -2,6 +2,9 @@ name: hello_private_repo
 testFormat: runtwiceexpectingcallcaching
 backends: [LocalDockerSecure]
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: hello_private_repo/hello_private_repo.wdl
   inputs: hello_private_repo/hello_private_repo.inputs.json

--- a/centaur/src/main/resources/standardTestCases/use_cacheCopy_dir.test
+++ b/centaur/src/main/resources/standardTestCases/use_cacheCopy_dir.test
@@ -2,6 +2,9 @@ name: use_cache_copy_dir
 testFormat: runtwiceexpectingcallcaching
 backends: [Papiv2]
 
+# CROM-6807 Don't retry failures, subsequent runs with fail because of unexpected cache hits from the initial run
+retryTestFailures: false
+
 files {
   workflow: use_cacheCopy_dir/use_cacheCopy_dir.wdl
 }


### PR DESCRIPTION
Retrying these will always fail because they'll get cache hits from the initial attempt, rather than the workflow they expect.

(Just triggering Jenkins tests for now...)