### PR TITLE
Add option to use hard links instead of copying outputs.

### DIFF
--- a/centaur/src/main/resources/resultsCopyingTestCases/localWdlResultsCopyingRelativeHardlink.test
+++ b/centaur/src/main/resources/resultsCopyingTestCases/localWdlResultsCopyingRelativeHardlink.test
@@ -4,7 +4,7 @@ tags: ["copyLocal"]
 
 files {
   workflow: wdlResultsCopying/simpleWorkflow.wdl
-  options: wdlResultsCopying/local/optionsRelative.json
+  options: wdlResultsCopying/local/optionsRelativeHardlink.json
 }
 
 metadata {

--- a/centaur/src/main/resources/resultsCopyingTestCases/localWdlResultsCopyingRelativeHardlink.test
+++ b/centaur/src/main/resources/resultsCopyingTestCases/localWdlResultsCopyingRelativeHardlink.test
@@ -1,0 +1,20 @@
+name: localWdlResultsCopyingRelativeHardlink
+testFormat: workflowsuccess
+tags: ["copyLocal"]
+
+files {
+  workflow: wdlResultsCopying/simpleWorkflow.wdl
+  options: wdlResultsCopying/local/optionsRelative.json
+}
+
+metadata {
+  status: Succeeded
+}
+
+fileSystemCheck: "local"
+outputExpectations: {
+    "<<local-path-placeholder>>/wf_results/output.txt": 2
+    "<<local-path-placeholder>>/wf_logs/workflow.<<UUID>>.log": 1
+    "<<local-path-placeholder>>/cl_logs/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/execution/stderr": 1
+    "<<local-path-placeholder>>/cl_logs/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/execution/stdout": 1
+}

--- a/centaur/src/main/resources/resultsCopyingTestCases/wdlResultsCopying/local/optionsRelativeHardlink.json
+++ b/centaur/src/main/resources/resultsCopyingTestCases/wdlResultsCopying/local/optionsRelativeHardlink.json
@@ -3,5 +3,8 @@
   "use_relative_output_paths": true,
   "final_workflow_outputs_dir":"<<local-path-placeholder>>/wf_results",
   "final_workflow_log_dir":"<<local-path-placeholder>>/wf_logs",
-  "final_call_logs_dir":"<<local-path-placeholder>>/cl_logs"
+  "final_call_logs_dir":"<<local-path-placeholder>>/cl_logs",
+  "default_runtime_attributes": {
+    "docker_user": "$EUID"
+  }
 }

--- a/centaur/src/main/resources/resultsCopyingTestCases/wdlResultsCopying/local/optionsRelativeHardlink.json
+++ b/centaur/src/main/resources/resultsCopyingTestCases/wdlResultsCopying/local/optionsRelativeHardlink.json
@@ -1,0 +1,7 @@
+{
+  "hardlink_output_paths": true,
+  "use_relative_output_paths": true,
+  "final_workflow_outputs_dir":"<<local-path-placeholder>>/wf_results",
+  "final_workflow_log_dir":"<<local-path-placeholder>>/wf_logs",
+  "final_call_logs_dir":"<<local-path-placeholder>>/cl_logs"
+}

--- a/core/src/main/scala/cromwell/core/WorkflowOptions.scala
+++ b/core/src/main/scala/cromwell/core/WorkflowOptions.scala
@@ -56,6 +56,7 @@ object WorkflowOptions {
   case object FinalCallLogsDir extends WorkflowOption("final_call_logs_dir")
   case object FinalWorkflowOutputsDir extends WorkflowOption("final_workflow_outputs_dir")
   case object UseRelativeOutputPaths extends WorkflowOption(name="use_relative_output_paths")
+  case object HardlinkOutputPaths extends WorkflowOption(name="hardlink_output_paths")
 
   // Misc.
   case object DefaultRuntimeOptions extends WorkflowOption("default_runtime_attributes")

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -79,8 +79,8 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
           false
         }
         catch {
-          case _: java.nio.file.FileSystemException =>
-            log.error(s"Could not hardlink $src to $dest. Trying copying instead.")
+          case error: java.nio.file.FileSystemException =>
+            log.error(s"Could not hardlink $src to $dest. Error: ${error.toString}. Trying copying instead.")
             true
         }
       }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -72,6 +72,9 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
     val outputPaths = if (hardlinkOutputs) {
       outputFilePaths filter {
         case (src, dest) =>  try {
+          if(!dest.parent.exists()){
+            dest.parent.createDirectories()
+          }
           Files.createLink(src.nioPath, dest.nioPath)
           false
         }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -15,6 +15,7 @@ import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import wom.values.{WomSingleFile, WomValue}
 
+import java.nio.file.Files
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
@@ -49,6 +50,7 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
   private def copyWorkflowOutputs(workflowOutputsFilePath: String): Future[Seq[Unit]] = {
     val workflowOutputsPath = buildPath(workflowOutputsFilePath)
     val outputFilePaths = getOutputFilePaths(workflowOutputsPath)
+    val hardlinkOutputs: Boolean = workflowDescriptor.getWorkflowOption(HardlinkOutputPaths).contains("true")
 
     // Check if there are duplicated destination paths and throw an exception if that is the case.
     // This creates a map of destinations and source paths which point to them in cases where there are multiple
@@ -67,7 +69,23 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId, override val ioActor: Act
         "Cannot copy output files to given final_workflow_outputs_dir" +
           s" as multiple files will be copied to the same path: \n${formattedCollidingCopyOptions.mkString("\n")}")}
 
-    val copies = outputFilePaths map {
+    val outputPaths = if (hardlinkOutputs) {
+      outputFilePaths filter {
+        case (src, dest) =>  try {
+          Files.createLink(src.nioPath, dest.nioPath)
+          false
+        }
+        catch {
+          case _: java.nio.file.FileSystemException =>
+            log.error(s"Could not hardlink $src to $dest. Trying copying instead.")
+            true
+        }
+      }
+    } else {
+      outputFilePaths
+    }
+
+    val copies = outputPaths map {
       case (srcPath, dstPath) => asyncIo.copyAsync(srcPath, dstPath)
     }
     


### PR DESCRIPTION
The CopyWorkflowActor regularly gets timeouts when trying to copy the gigabytes of data that are typically associated with production workflows. Also this duplicates the amount of disk space used for a workflow. 

This remedies that problem by hardlinking the files. It is much much faster, and the cromwell-executions folder can be safely removed afterward.

This is very beneficial for people who run cromwell on a cluster backend in `run` mode. Ping @illusional .

I have included a test case.