### PR TITLE
Cromwell Swagger UI Restructuring [CROM-6862]

### DIFF
--- a/engine/src/main/scala/cromwell/webservice/SwaggerService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerService.scala
@@ -1,9 +1,5 @@
 package cromwell.webservice
 
-import cromwell.webservice.routes.CromwellApiService
-
 trait SwaggerService extends SwaggerUiResourceHttpService {
   override def swaggerServiceName = "cromwell"
-
-  override def swaggerUiVersion = CromwellApiService.swaggerUiVersion
 }

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -36,7 +36,6 @@ trait SwaggerUiHttpService {
     }
   }
 
-
   /**
    * Serves up the swagger UI only. Redirects requests to the root of the UI path to the index.html.
    *
@@ -82,7 +81,7 @@ trait SwaggerResourceHttpService {
   /**
    * @return The directory for the resource under the classpath, and in the url
    */
-  lazy val swaggerDirectory: String = "swagger"
+  val swaggerDirectory: String = "swagger"
 
   /**
    * @return Name of the service, used to map the documentation resource at "/uiPath/serviceName.resourceType".

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -56,11 +56,12 @@ trait SwaggerUiHttpService {
           getFromResourceDirectory(resourceDirectory)
         }
       } ~
-      // Redirect legacy `/swagger/index.html?url=/swagger/cromwell.yaml#fragment` requests to the root URL. This is
-      // (somewhat magically) well-behaved in throwing away the `url` query parameter that was the subject of the CVE
-      // linked below while preserving any fragment identifiers to scroll to the right spot in the Swagger UI.
+      // Redirect legacy `/swagger` or `/swagger/index.html?url=/swagger/cromwell.yaml#fragment` requests to the root
+      // URL. The latter form is (somewhat magically) well-behaved in throwing away the `url` query parameter that was
+      // the subject of the CVE linked below while preserving any fragment identifiers to scroll to the right spot in
+      // the Swagger UI.
       // https://github.com/swagger-api/swagger-ui/security/advisories/GHSA-qrmm-w75w-3wpx
-      path("swagger" / "index.html") {
+      (path("swagger" / "index.html") | path ("swagger")) {
         get {
           redirect("/", StatusCodes.MovedPermanently)
         }

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -92,19 +92,6 @@ trait SwaggerResourceHttpService {
   def swaggerResourceType: String = "yaml"
 
   /**
-   * Swagger UI sends HTTP OPTIONS before ALL requests, and expects a status 200 / OK. When true (the default) the
-   * swaggerResourceRoute will return 200 / OK for requests for OPTIONS.
-   *
-   * See also:
-   * - https://github.com/swagger-api/swagger-ui/issues/1209
-   * - https://github.com/swagger-api/swagger-ui/issues/161
-   * - https://groups.google.com/forum/#!topic/swagger-swaggersocket/S6_I6FBjdZ8
-   *
-   * @return True if status code 200 should be returned for HTTP OPTIONS requests for the swagger resource.
-   */
-  def swaggerAllOptionsOk: Boolean = true
-
-  /**
    * @return The path to the swagger docs.
    */
   protected def swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
@@ -133,12 +120,10 @@ trait SwaggerResourceHttpService {
       }
     }
 
-    if (swaggerAllOptionsOk) {
-      route ~ options {
-        // Also return status 200 / OK for all OPTIONS requests.
-        complete(StatusCodes.OK)
-      }
-    } else route
+    route ~ options {
+      // Also return status 200 / OK for all OPTIONS requests.
+      complete(StatusCodes.OK)
+    }
   }
 }
 

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -82,7 +82,7 @@ trait SwaggerResourceHttpService {
   /**
    * @return The directory for the resource under the classpath, and in the url
    */
-  val swaggerDirectory: String = "swagger"
+  private val swaggerDirectory: String = "swagger"
 
   /**
    * @return Name of the service, used to map the documentation resource at "/uiPath/serviceName.resourceType".
@@ -97,7 +97,7 @@ trait SwaggerResourceHttpService {
   /**
    * @return The path to the swagger docs.
    */
-  protected lazy val swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
+  private lazy val swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
 
   /**
    * @return A route that returns the swagger resource.

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -6,30 +6,12 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
+import cromwell.webservice.routes.CromwellApiService
 
 /**
  * Serves up the swagger UI from org.webjars/swagger-ui.
  */
 trait SwaggerUiHttpService {
-  /**
-   * @return The version of the org.webjars/swagger-ui artifact. For example "2.1.1".
-   */
-  def swaggerUiVersion: String
-
-  /**
-   * Informs the swagger UI of the base of the application url, as hosted on the server.
-   * If your entire app is served under "http://myserver/myapp", then the base URL is "/myapp".
-   * If the app is served at the root of the application, leave this value as the empty string.
-   *
-   * @return The base URL used by the application, or the empty string if there is no base URL. For example "/myapp".
-   */
-  def swaggerUiBaseUrl: String = ""
-
-  /**
-   * @return The path to the swagger UI html documents. For example "swagger"
-   */
-  def swaggerUiPath: String = "swagger"
-
   /**
    * The path to the actual swagger documentation in either yaml or json, to be rendered by the swagger UI html.
    *
@@ -38,7 +20,7 @@ trait SwaggerUiHttpService {
    */
   def swaggerUiDocsPath: String = "api-docs"
 
-  private lazy val resourceDirectory = s"META-INF/resources/webjars/swagger-ui/$swaggerUiVersion"
+  private lazy val resourceDirectory = s"META-INF/resources/webjars/swagger-ui/${CromwellApiService.swaggerUiVersion}"
 
   private val serveIndex: server.Route = {
     val swaggerOptions =

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -82,7 +82,7 @@ trait SwaggerResourceHttpService {
   /**
    * @return The directory for the resource under the classpath, and in the url
    */
-  def swaggerDirectory: String = "swagger"
+  lazy val swaggerDirectory: String = "swagger"
 
   /**
    * @return Name of the service, used to map the documentation resource at "/uiPath/serviceName.resourceType".
@@ -97,12 +97,13 @@ trait SwaggerResourceHttpService {
   /**
    * @return The path to the swagger docs.
    */
-  protected def swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
+  protected lazy val swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
 
   /**
    * @return A route that returns the swagger resource.
    */
   final def swaggerResourceRoute: Route = {
+    // Serve Cromwell API docs from either `/swagger/cromwell.yaml` or just `cromwell.yaml`.
     val swaggerDocsDirective = path(separateOnSlashes(swaggerDocsPath)) | path(s"$swaggerServiceName.$swaggerResourceType")
 
     def injectBasePath(basePath: Option[String])(response: HttpResponse): HttpResponse = {

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -37,11 +37,6 @@ trait SwaggerUiHttpService {
    */
   def swaggerUiDocsPath: String = "api-docs"
 
-  /**
-   * @return When true, if someone requests / (or /baseUrl if setup), redirect to the swagger UI.
-   */
-  def swaggerUiFromRoot: Boolean = true
-
   private def routeFromRoot: Route = get {
     pathEndOrSingleSlash {
       // Redirect / to the swagger UI
@@ -65,7 +60,7 @@ trait SwaggerUiHttpService {
         } ~ getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerUiVersion")
       }
     }
-    if (swaggerUiFromRoot) route ~ routeFromRoot else route
+    route ~ routeFromRoot
   }
 
 }

--- a/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
+++ b/engine/src/main/scala/cromwell/webservice/SwaggerUiHttpService.scala
@@ -43,7 +43,7 @@ trait SwaggerUiHttpService {
    * @return Route serving the swagger UI.
    */
   final def swaggerUiRoute: Route = {
-    path("") {
+    pathEndOrSingleSlash {
       get {
         serveIndex
       }
@@ -55,6 +55,15 @@ trait SwaggerUiHttpService {
         | pathSuffixTest("css") | pathPrefixTest("favicon")) {
         get {
           getFromResourceDirectory(resourceDirectory)
+        }
+      } ~
+      // Redirect legacy `/swagger/index.html?url=/swagger/cromwell.yaml#fragment` requests to the root URL. This is
+      // (somewhat magically) well-behaved in throwing away the `url` query parameter that was the subject of the CVE
+      // linked below while preserving any fragment identifiers to scroll to the right spot in the Swagger UI.
+      // https://github.com/swagger-api/swagger-ui/security/advisories/GHSA-qrmm-w75w-3wpx
+      path("swagger" / "index.html") {
+        get {
+          redirect("/", StatusCodes.MovedPermanently)
         }
       }
   }

--- a/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
@@ -73,12 +73,10 @@ class SwaggerServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Swagg
     Get("/swagger/index.html?url=/swagger/cromwell.yaml") ~>
       swaggerUiResourceRoute ~>
       check {
-        assertResult(StatusCodes.OK) {
+        assertResult(StatusCodes.MovedPermanently) {
           status
         }
-        assertResult("<!-- HTML for s") {
-          responseAs[String].take(15)
-        }
+        responseAs[String] shouldEqual """This and all future requests should be directed to <a href="/">this URI</a>."""
       }
   }
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
@@ -1,7 +1,6 @@
 package cromwell.webservice
 
-import akka.http.scaladsl.model.{StatusCodes, Uri}
-import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import common.assertion.CromwellTimeoutSpec
 import io.swagger.models.properties.RefProperty

--- a/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerServiceSpec.scala
@@ -1,6 +1,7 @@
 package cromwell.webservice
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import common.assertion.CromwellTimeoutSpec
 import io.swagger.models.properties.RefProperty
@@ -66,17 +67,6 @@ class SwaggerServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Swagg
             case _ => /* ignore */
           }
         }
-      }
-  }
-
-  it should "return the index.html" in {
-    Get("/swagger/index.html?url=/swagger/cromwell.yaml") ~>
-      swaggerUiResourceRoute ~>
-      check {
-        assertResult(StatusCodes.MovedPermanently) {
-          status
-        }
-        responseAs[String] shouldEqual """This and all future requests should be directed to <a href="/">this URI</a>."""
       }
   }
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -160,41 +160,6 @@ class JsonSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
   }
 }
 
-class NoOptionsSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec {
-  override def swaggerServiceName = "testservice"
-
-  override def swaggerAllOptionsOk = false
-
-  behavior of "SwaggerResourceHttpService"
-
-  it should "service swagger yaml" in {
-    Get("/swagger/testservice.yaml") ~> swaggerResourceRoute ~> check {
-      status should be(StatusCodes.OK)
-      responseAs[String] should startWith("swagger: '2.0'\n")
-    }
-  }
-
-  it should "not service swagger json" in {
-    Get("/swagger/testservice.json") ~> Route.seal(swaggerResourceRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-    }
-  }
-
-  it should "not service /swagger" in {
-    Get("/swagger") ~> Route.seal(swaggerResourceRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-    }
-  }
-
-  it should "not return options for all routes" in {
-    forAll(testPathsForOptions) { path =>
-      Options(path) ~> Route.seal(swaggerResourceRoute) ~> check {
-        status should be(StatusCodes.MethodNotAllowed)
-      }
-    }
-  }
-}
-
 class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceSpec {
   override def swaggerServiceName = "testservice"
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -171,13 +171,6 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
 
   behavior of "SwaggerUiResourceHttpService"
 
-  it should "redirect /swagger to /" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.MovedPermanently)
-      header("Location") should be(Option(Location(Uri("/"))))
-    }
-  }
-
   it should "service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
@@ -208,13 +201,6 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
   override def swaggerResourceType = "json"
 
   behavior of "SwaggerUiResourceHttpService"
-
-  it should "redirect /swagger to /" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.MovedPermanently)
-      header("Location") should be(Option(Location(Uri("/"))))
-    }
-  }
 
   it should "service swagger json" in {
     Get("/swagger/testservice.json") ~> swaggerUiResourceRoute ~> check {

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -68,6 +68,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   it should "return index.html from the swagger-ui jar for /" in {
     Get("/") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
+      responseAs[String].take(15) should be("<!-- HTML for s")
     }
   }
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -44,6 +44,13 @@ object SwaggerUiHttpServiceSpec {
 class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   behavior of "SwaggerUiHttpService"
 
+  it should "redirect /swagger to /" in {
+    Get("/swagger") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
+    }
+  }
+
   it should "redirect /swagger/index.html?url=/swagger/cromwell.yaml to /" in {
     Get("/swagger/index.html?url=/swagger/cromwell.yaml") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.MovedPermanently)
@@ -161,6 +168,13 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
 
   behavior of "SwaggerUiResourceHttpService"
 
+  it should "redirect /swagger to /" in {
+    Get("/swagger") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
+    }
+  }
+
   it should "service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
@@ -191,6 +205,13 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
   override def swaggerResourceType = "json"
 
   behavior of "SwaggerUiResourceHttpService"
+
+  it should "redirect /swagger to /" in {
+    Get("/swagger") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
+    }
+  }
 
   it should "service swagger json" in {
     Get("/swagger/testservice.json") ~> swaggerUiResourceRoute ~> check {

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -89,36 +89,6 @@ class OverrideBasePathSwaggerUiHttpServiceSpec extends SwaggerResourceHttpServic
   }
 }
 
-class NoRedirectRootSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
-  override def swaggerUiFromRoot = false
-
-  behavior of "SwaggerUiHttpService"
-
-  it should "not redirect / to /swagger" in {
-    Get() ~> Route.seal(swaggerUiRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-    }
-  }
-
-  it should "not return options for /" in {
-    Options() ~> Route.seal(swaggerUiRoute) ~> check {
-      status should be(StatusCodes.MethodNotAllowed)
-    }
-  }
-
-  it should "redirect /swagger to the index.html" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
-    }
-  }
-
-  it should "return index.html from the swagger-ui jar" in {
-    Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.OK)
-    }
-  }
-}
 
 class YamlSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec {
   override def swaggerServiceName = "testservice"

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -75,6 +75,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   it should "return index.html from the swagger-ui jar for base url" in {
     Get() ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
+      responseAs[String].take(15) should be("<!-- HTML for s")
     }
   }
 }

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -55,6 +55,7 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     Get("/swagger/index.html?url=/swagger/cromwell.yaml") ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.MovedPermanently)
       header("Location") should be(Option(Location(Uri("/"))))
+      responseAs[String] shouldEqual """This and all future requests should be directed to <a href="/">this URI</a>."""
     }
   }
 

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -5,16 +5,13 @@ import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import common.assertion.CromwellTimeoutSpec
-import cromwell.webservice.routes.CromwellApiService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 import scala.concurrent.duration._
 
-trait SwaggerUiHttpServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalatestRouteTest with SwaggerUiHttpService {
-  override def swaggerUiVersion = CromwellApiService.swaggerUiVersion
-}
+trait SwaggerUiHttpServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalatestRouteTest with SwaggerUiHttpService
 
 trait SwaggerResourceHttpServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalatestRouteTest with
 TableDrivenPropertyChecks with SwaggerResourceHttpService {

--- a/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/SwaggerUiHttpServiceSpec.scala
@@ -44,10 +44,10 @@ object SwaggerUiHttpServiceSpec {
 class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   behavior of "SwaggerUiHttpService"
 
-  it should "redirect / to /swagger" in {
-    Get() ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger"))))
+  it should "redirect /swagger/index.html?url=/swagger/cromwell.yaml to /" in {
+    Get("/swagger/index.html?url=/swagger/cromwell.yaml") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
     }
   }
 
@@ -57,15 +57,14 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     }
   }
 
-  it should "redirect /swagger to the index.html" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
+  it should "return index.html from the swagger-ui jar for /" in {
+    Get("/") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.OK)
     }
   }
 
-  it should "return index.html from the swagger-ui jar" in {
-    Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
+  it should "return index.html from the swagger-ui jar for base url" in {
+    Get() ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
     }
   }
@@ -162,13 +161,6 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
 
   behavior of "SwaggerUiResourceHttpService"
 
-  it should "redirect /swagger to /swagger/index.html with yaml" in {
-    Get("/swagger") ~> swaggerUiResourceRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.yaml"))))
-    }
-  }
-
   it should "service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
@@ -199,13 +191,6 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
   override def swaggerResourceType = "json"
 
   behavior of "SwaggerUiResourceHttpService"
-
-  it should "redirect /swagger to /swagger/index.html with yaml with json" in {
-    Get("/swagger") ~> swaggerUiResourceRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.json"))))
-    }
-  }
 
   it should "service swagger json" in {
     Get("/swagger/testservice.json") ~> swaggerUiResourceRoute ~> check {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,7 @@ object Dependencies {
   private val sprayJsonV = "1.3.6"
   private val sttpV = "1.5.19" // scala-steward:off (CROM-6564)
   private val swaggerParserV = "1.0.56"
-  private val swaggerUiV = "4.5.0"
+  private val swaggerUiV = "3.23.11" // scala-steward:off (CROM-6621)
   private val testContainersScalaV = "0.39.8"
   private val tikaV = "2.1.0"
   private val typesafeConfigV = "1.4.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -126,7 +126,7 @@ object Dependencies {
   private val sprayJsonV = "1.3.6"
   private val sttpV = "1.5.19" // scala-steward:off (CROM-6564)
   private val swaggerParserV = "1.0.56"
-  private val swaggerUiV = "3.23.11" // scala-steward:off (CROM-6621)
+  private val swaggerUiV = "4.5.0"
   private val testContainersScalaV = "0.39.8"
   private val tikaV = "2.1.0"
   private val typesafeConfigV = "1.4.1"


### PR DESCRIPTION
This does all the Cromwell restructuring required for CROM-6862 but does *not* actually update the `swagger-ui` dependency to >= 4.1.3 as CromIAM has not yet been similarly restructured so that its tests would pass. The Cromwell changes here work fine with the latest `swagger-ui` 4.5.0 ([earlier Travis run](https://app.travis-ci.com/github/broadinstitute/cromwell/builds/246599360) with only related CromIAM tests failing) so upgrading `swagger-ui` should be a [one line change](https://github.com/broadinstitute/cromwell/blob/690f9e7ae77924d99fc4c4a356e1d48ff2b659cd/project/Dependencies.scala#L129) when both Cromwell and CromIAM are ready for that.