### PR TITLE
CromIAM Swagger UI Restructuring  [CROM-6870]

### DIFF
--- a/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
@@ -27,8 +27,6 @@ import scala.concurrent.ExecutionContextExecutor
 
 trait SwaggerService extends SwaggerUiResourceHttpService {
   override def swaggerServiceName = "cromiam"
-  // TODO: Re-common-ize swagger out of cromwell's engine and reuse.
-  override def swaggerUiVersion = "3.23.11" // scala-steward:off
 }
 
 // NB: collection name *must* follow label value rules in cromwell. This needs to be documented somewhere. (although those restrictions are soon to die)

--- a/CromIAM/src/main/scala/cromiam/webservice/SwaggerUiHttpService.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/SwaggerUiHttpService.scala
@@ -147,19 +147,6 @@ trait SwaggerResourceHttpService {
   def swaggerResourceType = "yaml"
 
   /**
-   * Swagger UI sends HTTP OPTIONS before ALL requests, and expects a status 200 / OK. When true (the default) the
-   * swaggerResourceRoute will return 200 / OK for requests for OPTIONS.
-   *
-   * See also:
-   * - https://github.com/swagger-api/swagger-ui/issues/1209
-   * - https://github.com/swagger-api/swagger-ui/issues/161
-   * - https://groups.google.com/forum/#!topic/swagger-swaggersocket/S6_I6FBjdZ8
-   *
-   * @return True if status code 200 should be returned for HTTP OPTIONS requests for the swagger resource.
-   */
-  def swaggerAllOptionsOk = true
-
-  /**
    * @return The path to the swagger docs.
    */
   protected def swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
@@ -168,7 +155,8 @@ trait SwaggerResourceHttpService {
    * @return A route that returns the swagger resource.
    */
   final def swaggerResourceRoute = {
-    val swaggerDocsDirective = path(separateOnSlashes(swaggerDocsPath))
+    // Serve CromIAM API docs from either `/swagger/cromiam.yaml` or just `cromiam.yaml`.
+    val swaggerDocsDirective = path(separateOnSlashes(swaggerDocsPath)) | path(s"$swaggerServiceName.$swaggerResourceType")
     val route = get {
       swaggerDocsDirective {
         // Return /uiPath/serviceName.resourceType from the classpath resources.
@@ -176,12 +164,10 @@ trait SwaggerResourceHttpService {
       }
     }
 
-    if (swaggerAllOptionsOk) {
-      route ~ options {
-        // Also return status 200 / OK for all OPTIONS requests.
-        complete(StatusCodes.OK)
-      }
-    } else route
+    route ~ options {
+      // Also return status 200 / OK for all OPTIONS requests.
+      complete(StatusCodes.OK)
+    }
   }
 }
 

--- a/CromIAM/src/main/scala/cromiam/webservice/SwaggerUiHttpService.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/SwaggerUiHttpService.scala
@@ -1,14 +1,13 @@
 package cromiam.webservice
 
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Flow
 import akka.util.ByteString
+import common.util.VersionUtil
 import cromiam.server.config.SwaggerOauthConfig
-
-import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * Serves up the swagger UI from org.webjars/swagger-ui.
@@ -20,42 +19,21 @@ import scala.concurrent.{ExecutionContext, Future}
   * https://vimeo.com/215325495
  */
 trait SwaggerUiHttpService extends Directives {
-  /**
-   * @return The version of the org.webjars/swagger-ui artifact. For example "2.1.1".
-   */
-  def swaggerUiVersion: String
 
-  /**
-   * Informs the swagger UI of the base of the application url, as hosted on the server.
-   * If your entire app is served under "http://myserver/myapp", then the base URL is "/myapp".
-   * If the app is served at the root of the application, leave this value as the empty string.
-   *
-   * @return The base URL used by the application, or the empty string if there is no base URL. For example "/myapp".
-   */
-  def swaggerUiBaseUrl = ""
+  def oauthConfig: SwaggerOauthConfig
 
-  /**
-   * @return The path to the swagger UI html documents. For example "swagger"
-   */
-  def swaggerUiPath = "swagger"
+  private lazy val resourceDirectory = {
+    val swaggerUiVersion = VersionUtil.getVersion("swagger-ui", VersionUtil.sbtDependencyVersion("swaggerUi"))
+    s"META-INF/resources/webjars/swagger-ui/$swaggerUiVersion"
+  }
 
-  /**
-   * The path to the actual swagger documentation in either yaml or json, to be rendered by the swagger UI html.
-   *
-   * @return The path to the api documentation to render in the swagger UI.
-   *         For example "api-docs" or "swagger/lenthall.yaml".
-   */
-  def swaggerUiDocsPath = "api-docs"
-
-  /**
-   * @return When true, if someone requests / (or /baseUrl if setup), redirect to the swagger UI.
-   */
-  def swaggerUiFromRoot = true
-
-  private def routeFromRoot = get {
-    pathEndOrSingleSlash {
-      // Redirect / to the swagger UI
-      redirect(s"$swaggerUiBaseUrl/$swaggerUiPath", StatusCodes.TemporaryRedirect)
+  private val serveIndex: server.Route = {
+    mapResponseEntity { entityFromJar =>
+      entityFromJar.transformDataBytes(Flow.fromFunction[ByteString, ByteString] { original: ByteString =>
+        ByteString(rewriteSwaggerIndex(original.utf8String))
+      })
+    } {
+      getFromResource(s"$resourceDirectory/index.html")
     }
   }
 
@@ -64,65 +42,65 @@ trait SwaggerUiHttpService extends Directives {
    *
    * @return Route serving the swagger UI.
    */
-  final def swaggerUiRoute = {
-    // when the user hits the doc url, redirect to the index.html with api docs specified on the url
-    val indexRedirect: Route = pathEndOrSingleSlash {
-      redirect(
-        s"$swaggerUiBaseUrl/$swaggerUiPath/index.html?url=$swaggerUiBaseUrl/$swaggerUiDocsPath",
-        StatusCodes.TemporaryRedirect)
-    }
+  final def swaggerUiRoute: Route = {
+    pathEndOrSingleSlash {
+      get {
+        serveIndex
+      }
+    } ~
+      // We have to be explicit about the paths here since we're matching at the root URL and we don't
+      // want to catch all paths lest we circumvent Spray's not-found and method-not-allowed error
+      // messages.
+      (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2") | pathSuffixTest("js")
+        | pathSuffixTest("css") | pathPrefixTest("favicon")) {
+        get {
+          getFromResourceDirectory(resourceDirectory)
+        }
+      } ~
+      // Redirect legacy `/swagger` or `/swagger/index.html?url=/swagger/cromwell.yaml#fragment` requests to the root
+      // URL. The latter form is (somewhat magically) well-behaved in throwing away the `url` query parameter that was
+      // the subject of the CVE linked below while preserving any fragment identifiers to scroll to the right spot in
+      // the Swagger UI.
+      // https://github.com/swagger-api/swagger-ui/security/advisories/GHSA-qrmm-w75w-3wpx
+      (path("swagger" / "index.html") | path("swagger")) {
+        get {
+          redirect("/", StatusCodes.MovedPermanently)
 
-    /* Serve a resource from the swagger-ui webjar/bundle */
-    val resourceServe: Route = getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerUiVersion")
-
-    /* Mashup of mapResponseWith and mapResponseEntity */
-    def mapResponseEntityWith(f: ResponseEntity => Future[ResponseEntity]): Directive0 = {
-      extractExecutionContext flatMap { implicit executionContext =>
-        mapRouteResultWithPF {
-          case RouteResult.Complete(response) =>
-            f(response.entity) map { entity =>
-              RouteResult.Complete(response.withEntity(entity))
-            }
         }
       }
-    }
-
-    /* Serve up the index.html, after passing it through a function that rewrites the response. */
-    val indexServe: Route = {
-      pathPrefixTest("index.html") {
-        extractExecutionContext { implicit executionContext =>
-          extractMaterializer { implicit materializer =>
-            mapResponseEntityWith(rewriteSwaggerIndex) {
-              resourceServe
-            }
-          }
-        }
-      }
-    }
-
-    /* Redirect to the index, serve the rewritten index, or a resource from the swaggerUI webjar. */
-    val route = get {
-      pathPrefix(separateOnSlashes(swaggerUiPath)) {
-        concat(indexRedirect, indexServe, resourceServe)
-      }
-    }
-    if (swaggerUiFromRoot) route ~ routeFromRoot else route
-  }
-
-  private[this] final def rewriteSwaggerIndex(responseEntity: ResponseEntity)
-                                             (implicit
-                                              executionContext: ExecutionContext,
-                                              materializer: Materializer
-                                             ): Future[ResponseEntity] = {
-    val contentType = responseEntity.contentType
-    for {
-      data <- responseEntity.dataBytes.runWith(Sink.head) // Similar to responseEntity.toStrict, but without a timeout
-      replaced = rewriteSwaggerIndex(data.utf8String)
-    } yield HttpEntity.Strict(contentType, ByteString(replaced))
   }
 
   /** Rewrite the swagger index.html. Default passes through the origin data. */
-  protected def rewriteSwaggerIndex(data: String): String = data
+  protected def rewriteSwaggerIndex(original: String): String = {
+    val swaggerOptions =
+      s"""
+        |        validatorUrl: null,
+        |        apisSorter: "alpha",
+        |        oauth2RedirectUrl: window.location.origin + "/swagger/oauth2-redirect.html",
+        |        operationsSorter: "alpha"
+      """.stripMargin
+
+    val initOAuthOriginal = "window.ui = ui"
+
+    val initOAuthReplacement =
+      s"""|
+          |ui.initOAuth({
+          |    clientId: "${oauthConfig.clientId}",
+          |    realm: "${oauthConfig.realm}",
+          |    appName: "${oauthConfig.appName}",
+          |    scopeSeparator: " "
+          |  })
+          |
+          |$initOAuthOriginal
+          |""".stripMargin
+
+
+    original
+      .replace(initOAuthOriginal, initOAuthReplacement)
+      .replace("""url: "https://petstore.swagger.io/v2/swagger.json"""", "url: 'cromiam.yaml'")
+      .replace("""layout: "StandaloneLayout"""", s"""layout: "StandaloneLayout", $swaggerOptions""")
+
+  }
 }
 
 /**
@@ -149,12 +127,12 @@ trait SwaggerResourceHttpService {
   /**
    * @return The path to the swagger docs.
    */
-  protected def swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
+  private lazy val swaggerDocsPath = s"$swaggerDirectory/$swaggerServiceName.$swaggerResourceType"
 
   /**
    * @return A route that returns the swagger resource.
    */
-  final def swaggerResourceRoute = {
+  final def swaggerResourceRoute: Route = {
     // Serve CromIAM API docs from either `/swagger/cromiam.yaml` or just `cromiam.yaml`.
     val swaggerDocsDirective = path(separateOnSlashes(swaggerDocsPath)) | path(s"$swaggerServiceName.$swaggerResourceType")
     val route = get {
@@ -175,48 +153,9 @@ trait SwaggerResourceHttpService {
  * Extends the SwaggerUiHttpService and SwaggerResourceHttpService to serve up both.
  */
 trait SwaggerUiResourceHttpService extends SwaggerUiHttpService with SwaggerResourceHttpService {
-  override def swaggerUiDocsPath = swaggerDocsPath
-
-  def oauthConfig: SwaggerOauthConfig
 
   /**
    * @return A route that redirects to the swagger UI and returns the swagger resource.
    */
-  final def swaggerUiResourceRoute = swaggerUiRoute ~ swaggerResourceRoute
-
-  override protected def rewriteSwaggerIndex(data: String): String = {
-    // via https://github.com/swagger-api/swagger-ui/tree/v3.2.2#swaggeruibundle
-
-    val bundleOriginal       = """url: "http://petstore.swagger.io/v2/swagger.json","""
-    val bundleOriginalSecure = """url: "https://petstore.swagger.io/v2/swagger.json","""
-
-    val bundleReplacement =
-      s"""|url: "/$swaggerDocsPath",
-          |validatorUrl: null,
-          |oauth2RedirectUrl: window.location.origin + "/$swaggerDirectory/oauth2-redirect.html",
-          |tagsSorter: "alpha",
-          |operationsSorter: "alpha",
-          |""".stripMargin
-
-    // NOTE: Until engine and cromiam can re-common-ize the swagger code, this needs to be sync'ed with
-    //   cromiam.webservice.BasicSwaggerUiHttpServiceSpec.rewriteSwaggerIndex
-    val initOAuthOriginal = "window.ui = ui"
-
-    val initOAuthReplacement =
-      s"""|
-          |ui.initOAuth({
-          |    clientId: "${oauthConfig.clientId}",
-          |    realm: "${oauthConfig.realm}",
-          |    appName: "${oauthConfig.appName}",
-          |    scopeSeparator: " "
-          |  })
-          |
-          |$initOAuthOriginal
-          |""".stripMargin
-
-    data
-      .replace(initOAuthOriginal, initOAuthReplacement)
-      .replace(bundleOriginal, bundleReplacement)
-      .replace(bundleOriginalSecure, bundleReplacement)
-  }
+  final def swaggerUiResourceRoute: Route = swaggerUiRoute ~ swaggerResourceRoute
 }

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerServiceSpec.scala
@@ -77,20 +77,6 @@ class SwaggerServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Swagg
       }
   }
 
-  it should "return the index.html" in {
-    Get("/swagger/index.html") ~>
-      swaggerUiResourceRoute ~>
-      check {
-        assertResult(StatusCodes.OK) {
-          status
-        }
-        assertResult("<!-- HTML for static distribution bundle build -->") {
-          responseAs[String].take(50)
-        }
-        assertResult(ContentTypes.`text/html(UTF-8)`)(contentType)
-      }
-  }
-
   it should "return status OK when getting OPTIONS on paths" in {
     val pathExamples = Table("path", "/", "/swagger", "/swagger/cromwell.yaml", "/swagger/index.html", "/api",
       "/api/workflows/", "/api/workflows/v1", "/workflows/v1/outputs", "/workflows/v1/status",

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -78,41 +78,6 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   }
 }
 
-class NoRedirectRootSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
-  override def swaggerUiFromRoot = false
-
-  behavior of "SwaggerUiHttpService"
-
-  it should "not redirect / to /swagger" in {
-    Get() ~> Route.seal(swaggerUiRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-      contentType should be(ContentTypes.`text/plain(UTF-8)`)
-    }
-  }
-
-  it should "not return options for /" in {
-    Options() ~> Route.seal(swaggerUiRoute) ~> check {
-      status should be(StatusCodes.MethodNotAllowed)
-      contentType should be(ContentTypes.`text/plain(UTF-8)`)
-    }
-  }
-
-  it should "redirect /swagger to the index.html" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
-    }
-  }
-
-  it should "return index.html from the swagger-ui jar" in {
-    Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.OK)
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
-    }
-  }
-}
-
 class YamlSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec {
   override def swaggerServiceName = "testservice"
 
@@ -185,45 +150,6 @@ class JsonSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec 
       Options(path) ~> swaggerResourceRoute ~> check {
         status should be(StatusCodes.OK)
         responseAs[String] should be("OK")
-        contentType should be(ContentTypes.`text/plain(UTF-8)`)
-      }
-    }
-  }
-}
-
-class NoOptionsSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec {
-  override def swaggerServiceName = "testservice"
-
-  override def swaggerAllOptionsOk = false
-
-  behavior of "SwaggerResourceHttpService"
-
-  it should "service swagger yaml" in {
-    Get("/swagger/testservice.yaml") ~> swaggerResourceRoute ~> check {
-      status should be(StatusCodes.OK)
-      responseAs[String] should startWith("swagger: '2.0'\n")
-      contentType should be(ContentTypes.`application/octet-stream`)
-    }
-  }
-
-  it should "not service swagger json" in {
-    Get("/swagger/testservice.json") ~> Route.seal(swaggerResourceRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-      contentType should be(ContentTypes.`text/plain(UTF-8)`)
-    }
-  }
-
-  it should "not service /swagger" in {
-    Get("/swagger") ~> Route.seal(swaggerResourceRoute) ~> check {
-      status should be(StatusCodes.NotFound)
-      contentType should be(ContentTypes.`text/plain(UTF-8)`)
-    }
-  }
-
-  it should "not return options for all routes" in {
-    forAll(testPathsForOptions) { path =>
-      Options(path) ~> Route.seal(swaggerResourceRoute) ~> check {
-        status should be(StatusCodes.MethodNotAllowed)
         contentType should be(ContentTypes.`text/plain(UTF-8)`)
       }
     }

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -163,14 +163,6 @@ class YamlSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
 
   behavior of "SwaggerUiResourceHttpService"
 
-  it should "redirect /swagger to /swagger/index.html with yaml" in {
-    Get("/swagger") ~> swaggerUiResourceRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.yaml"))))
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
-    }
-  }
-
   it should "service swagger yaml" in {
     Get("/swagger/testservice.yaml") ~> swaggerUiResourceRoute ~> check {
       status should be(StatusCodes.OK)
@@ -206,14 +198,6 @@ class JsonSwaggerUiResourceHttpServiceSpec extends SwaggerUiResourceHttpServiceS
   override def swaggerResourceType = "json"
 
   behavior of "SwaggerUiResourceHttpService"
-
-  it should "redirect /swagger to /swagger/index.html with yaml with json" in {
-    Get("/swagger") ~> swaggerUiResourceRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/swagger/testservice.json"))))
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
-    }
-  }
 
   it should "service swagger json" in {
     Get("/swagger/testservice.json") ~> swaggerUiResourceRoute ~> check {

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import common.assertion.CromwellTimeoutSpec
 import cromiam.server.config.SwaggerOauthConfig
-import cromiam.webservice.SwaggerUiHttpServiceSpec._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -14,8 +13,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 trait SwaggerUiHttpServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalatestRouteTest with SwaggerUiHttpService {
   def actorRefFactory = system
-
-  override def swaggerUiVersion = TestSwaggerUiVersion
 }
 
 trait SwaggerResourceHttpServiceSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalatestRouteTest with
@@ -76,6 +73,10 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
       contentType should be(ContentTypes.`text/html(UTF-8)`)
     }
   }
+
+  override def oauthConfig: SwaggerOauthConfig = SwaggerOauthConfig(
+    clientId = "test-client-id", realm = "test-realm", appName = "test-appname"
+  )
 }
 
 class YamlSwaggerResourceHttpServiceSpec extends SwaggerResourceHttpServiceSpec {

--- a/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
+++ b/CromIAM/src/test/scala/cromiam/webservice/SwaggerUiHttpServiceSpec.scala
@@ -43,11 +43,18 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
   // Replace same magic string used in SwaggerUiResourceHttpService.rewriteSwaggerIndex
     data.replace("window.ui = ui", "replaced-client-id")
 
-  it should "redirect / to /swagger" in {
-    Get() ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger"))))
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
+  it should "redirect /swagger to /" in {
+    Get("/swagger") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
+    }
+  }
+
+  it should "redirect /swagger/index.html?url=/swagger/cromiam.yaml to /" in {
+    Get("/swagger/index.html?url=/swagger/cromiam.yaml") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.MovedPermanently)
+      header("Location") should be(Option(Location(Uri("/"))))
+      responseAs[String] shouldEqual """This and all future requests should be directed to <a href="/">this URI</a>."""
     }
   }
 
@@ -58,19 +65,17 @@ class BasicSwaggerUiHttpServiceSpec extends SwaggerUiHttpServiceSpec {
     }
   }
 
-  it should "redirect /swagger to the index.html" in {
-    Get("/swagger") ~> swaggerUiRoute ~> check {
-      status should be(StatusCodes.TemporaryRedirect)
-      header("Location") should be(Option(Location(Uri("/swagger/index.html?url=/api-docs"))))
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
+  it should "return index.html from the swagger-ui jar for /" in {
+    Get("/") ~> swaggerUiRoute ~> check {
+      status should be(StatusCodes.OK)
+      responseAs[String].take(15) should be("<!-- HTML for s")
     }
   }
 
-  it should "return index.html from the swagger-ui jar" in {
-    Get("/swagger/index.html") ~> swaggerUiRoute ~> check {
+  it should "return index.html from the swagger-ui jar for base url" in {
+    Get() ~> swaggerUiRoute ~> check {
       status should be(StatusCodes.OK)
-      responseAs[String] should include("replaced-client-id")
-      contentType should be(ContentTypes.`text/html(UTF-8)`)
+      responseAs[String].take(15) should be("<!-- HTML for s")
     }
   }
 


### PR DESCRIPTION
This is the CromIAM analog to CROM-6862: it does all the restructuring required for [CROM-6870] but does not actually update the swagger-ui dependency to >= 4.1.3 as the Cromwell Swagger code on the target branch has not yet been similarly restructured so that its tests would pass. These changes work fine with the latest swagger-ui 4.5.0 (tested on CaaS dev) so upgrading swagger-ui should be a [one line change](https://github.com/broadinstitute/cromwell/blob/690f9e7ae77924d99fc4c4a356e1d48ff2b659cd/project/Dependencies.scala#L129) when both Cromwell and CromIAM are ready for that.

[CROM-6870]: https://broadworkbench.atlassian.net/browse/CROM-6870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ