### PR TITLE
Revert changes introducing workflow pickup failures [BW-1128]

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/WorkflowStoreSlickDatabase.scala
@@ -59,8 +59,7 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
                                      heartbeatTimestampTo: Timestamp,
                                      workflowStateFrom: String,
                                      workflowStateTo: String,
-                                     workflowStateExcluded: String,
-                                     excludedGroups: Set[String])
+                                     workflowStateExcluded: String)
                                     (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]] = {
 
     def updateForFetched(cromwellId: String,
@@ -90,7 +89,7 @@ trait WorkflowStoreSlickDatabase extends WorkflowStoreSqlDatabase {
 
     val action = for {
       workflowStoreEntries <- dataAccess.fetchStartableWorkflows(
-        limit.toLong, heartbeatTimestampTimedOut, workflowStateExcluded, excludedGroups
+        (limit.toLong, heartbeatTimestampTimedOut, workflowStateExcluded)
       ).result
       _ <- DBIO.sequence(
         workflowStoreEntries map updateForFetched(cromwellId, heartbeatTimestampTo, workflowStateFrom, workflowStateTo)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -73,92 +73,31 @@ trait WorkflowStoreEntryComponent {
   )
 
   /**
-   * Return hog group with the lowest count of actively running workflows
-   */
-  def getHogGroupWithLowestRunningWfs(heartbeatTimestampTimedOut: Timestamp,
-                                      excludeWorkflowState: String,
-                                      excludedGroups: Set[String]): Query[Rep[Option[String]], Option[String], Seq] = {
-    val startableWorkflows = for {
-      row <- workflowStoreEntries
-      /*
-        This looks for:
-        1) Workflows with no heartbeat (newly submitted or from a cleanly shut down Cromwell).
-        2) Workflows with old heartbeats, presumably abandoned by a defunct Cromwell.
-        3) Workflows not in "OnHold" state
-        4) Workflows that don't belong to hog groups in excludedGroups
-      */
-      if (row.heartbeatTimestamp.isEmpty || row.heartbeatTimestamp < heartbeatTimestampTimedOut) &&
-        (row.workflowState =!= excludeWorkflowState) &&
-        !(row.hogGroup inSet excludedGroups)
-    } yield row
-
-    // calculates the count of startable workflows per hog group
-    val numOfStartableWfsByHogGroup = startableWorkflows
-      .groupBy(_.hogGroup)
-      .map { case (hogGroupName, groups) => (hogGroupName, groups.length) }
-      .sortBy(_._2.asc)
-
-    val totalWorkflows = for {
-      row <- workflowStoreEntries
-      /*
-        This looks for:
-        1) Workflows not in "OnHold" state
-        2) Workflows that don't belong to hog groups in excludedGroups
-      */
-      if row.workflowState =!= excludeWorkflowState &&
-        !(row.hogGroup inSet excludedGroups)
-    } yield row
-
-    // calculates the count of total workflows per hog group
-    val totalWorkflowsByHogGroup = totalWorkflows
-      .groupBy(_.hogGroup)
-      .map { case (hogGroupName, groups) => (hogGroupName, groups.length) }
-      .sortBy(_._2.asc)
-
-    // calculates the number of actively running workflows for each hog group. If a hog group
-    // has all it's workflows that are either actively running or in "OnHold" status it is not
-    // included in the list. Hog groups that have no workflows actively running return count as 0
-    val wfsRunningPerHogGroup = for {
-      (t_group, t_ct) <- totalWorkflowsByHogGroup
-      (s_group, s_ct) <- numOfStartableWfsByHogGroup if t_group === s_group
-    } yield (t_group, t_ct - s_ct)
-
-    // sort the above calculated result set first by the count of actively running workflows and then sort it
-    // alphabetically by hog group. Then take the first row of the result and return the hog group name.
-    wfsRunningPerHogGroup.sortBy { case (hogGroupName, ct) => (ct.asc, hogGroupName) }.take(1).map(_._1)
-  }
-
-  /**
-   * Returns up to "limit" startable workflows, sorted by submission time, that belong to
-   * given hog group and are not in "OnHold" status.
-   */
-  val fetchStartableWfsForHogGroup = Compiled(
-    (limit: ConstColumn[Long],
-     heartbeatTimestampTimedOut: ConstColumn[Timestamp],
-     excludeWorkflowState: Rep[String],
-     hogGroup: Rep[Option[String]]) => {
-
-      val workflowsToStart = for {
+    * Returns up to "limit" startable workflows, sorted by submission time.
+    */
+  def fetchStartableWorkflows(limit: Long,
+     heartbeatTimestampTimedOut: Timestamp,
+     excludeWorkflowState: String,
+     excludedGroups: Set[String]
+    ): Query[WorkflowStoreEntries, WorkflowStoreEntry, Seq] = {
+      val query = for {
         row <- workflowStoreEntries
         /*
-          This looks for:
-          1) Workflows with no heartbeat (newly submitted or from a cleanly shut down Cromwell).
-          2) Workflows with old heartbeats, presumably abandoned by a defunct Cromwell.
-          3) Workflows not in "OnHold" state
-          4) Workflows that belong to included hog group
-        */
+        This looks for:
+
+        1) Workflows with no heartbeat (newly submitted or from a cleanly shut down Cromwell).
+        2) Workflows with old heartbeats, presumably abandoned by a defunct Cromwell.
+
+        Workflows are taken by submission time, oldest first. This is a "query for update", meaning rows are
+        locked such that readers are blocked since we will do an update subsequent to this select in the same
+        transaction that we know will impact those readers.
+         */
         if (row.heartbeatTimestamp.isEmpty || row.heartbeatTimestamp < heartbeatTimestampTimedOut) &&
           (row.workflowState =!= excludeWorkflowState) &&
-          (row.hogGroup === hogGroup)
+          !(row.hogGroup inSet excludedGroups)
       } yield row
-
-      /*
-        This is a "query for update", meaning rows are locked such that readers are blocked since we will
-        do an update subsequent to this select in the same transaction that we know will impact those readers.
-       */
-      workflowsToStart.forUpdate.sortBy(_.submissionTime.asc).take(limit)
+      query.forUpdate.sortBy(_.submissionTime.asc).take(limit)
     }
-  )
 
   /**
     * Useful for counting workflows in a given state.

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -75,11 +75,11 @@ trait WorkflowStoreEntryComponent {
   /**
     * Returns up to "limit" startable workflows, sorted by submission time.
     */
-  def fetchStartableWorkflows(limit: Long,
-     heartbeatTimestampTimedOut: Timestamp,
-     excludeWorkflowState: String,
-     excludedGroups: Set[String]
-    ): Query[WorkflowStoreEntries, WorkflowStoreEntry, Seq] = {
+  val fetchStartableWorkflows = Compiled(
+    (limit: ConstColumn[Long],
+     heartbeatTimestampTimedOut: ConstColumn[Timestamp],
+     excludeWorkflowState: Rep[String]
+    ) => {
       val query = for {
         row <- workflowStoreEntries
         /*
@@ -93,11 +93,11 @@ trait WorkflowStoreEntryComponent {
         transaction that we know will impact those readers.
          */
         if (row.heartbeatTimestamp.isEmpty || row.heartbeatTimestamp < heartbeatTimestampTimedOut) &&
-          (row.workflowState =!= excludeWorkflowState) &&
-          !(row.hogGroup inSet excludedGroups)
+          (row.workflowState =!= excludeWorkflowState)
       } yield row
       query.forUpdate.sortBy(_.submissionTime.asc).take(limit)
     }
+  )
 
   /**
     * Useful for counting workflows in a given state.

--- a/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/WorkflowStoreSqlDatabase.scala
@@ -74,8 +74,7 @@ ____    __    ____  ______   .______       __  ___  _______  __        ______   
                             heartbeatTimestampTo: Timestamp,
                             workflowStateFrom: String,
                             workflowStateTo: String,
-                            workflowStateExcluded: String,
-                            excludedGroups: Set[String])
+                            workflowStateExcluded: String)
                            (implicit ec: ExecutionContext): Future[Seq[WorkflowStoreEntry]]
 
   def writeWorkflowHeartbeats(workflowExecutionUuids: Seq[String],

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -173,7 +173,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
         Determine the number of available workflow slots and request the smaller of that number and maxWorkflowsToLaunch.
        */
       val maxNewWorkflows = maxWorkflowsToLaunch min (maxWorkflowsRunning - stateData.workflows.size - stateData.subWorkflows.size)
-      params.workflowStore ! WorkflowStoreActor.FetchRunnableWorkflows(maxNewWorkflows, excludedGroups = Set.empty)
+      params.workflowStore ! WorkflowStoreActor.FetchRunnableWorkflows(maxNewWorkflows)
       stay()
     case Event(WorkflowStoreEngineActor.NoNewWorkflowsToStart, _) =>
       log.debug("WorkflowStore provided no new workflows to start")

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/InMemoryWorkflowStore.scala
@@ -1,6 +1,7 @@
 package cromwell.engine.workflow.workflowstore
 
 import java.time.OffsetDateTime
+
 import cats.data.NonEmptyList
 import cromwell.core.{HogGroup, WorkflowId, WorkflowSourceFilesCollection}
 import cromwell.engine.workflow.workflowstore.SqlWorkflowStore.WorkflowStoreAbortResponse.WorkflowStoreAbortResponse
@@ -31,10 +32,7 @@ class InMemoryWorkflowStore extends WorkflowStore {
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
-    if (excludedGroups.nonEmpty)
-      throw new UnsupportedOperationException("Programmer Error: group filtering not supported for single-tenant/in-memory workflow store")
-
+  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
     val startableWorkflows = workflowStore filter { _._2 == WorkflowStoreState.Submitted } take n
     val updatedWorkflows = startableWorkflows map { _._1 -> WorkflowStoreState.Running }
     workflowStore = workflowStore ++ updatedWorkflows

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStore.scala
@@ -96,7 +96,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase, metadataSqlDa
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
+  override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
     import cats.syntax.traverse._
     import common.validation.Validation._
     sqlDatabase.fetchWorkflowsInState(
@@ -106,8 +106,7 @@ case class SqlWorkflowStore(sqlDatabase: WorkflowStoreSqlDatabase, metadataSqlDa
       OffsetDateTime.now.toSystemTimestamp,
       WorkflowStoreState.Submitted.toString,
       WorkflowStoreState.Running.toString,
-      WorkflowStoreState.OnHold.toString,
-      excludedGroups: Set[String]
+      WorkflowStoreState.OnHold.toString
     ) map {
       // .get on purpose here to fail the future if something went wrong
       _.toList.traverse(fromWorkflowStoreEntry).toTry.get

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStore.scala
@@ -38,7 +38,7 @@ trait WorkflowStore {
     * Retrieves up to n workflows which have not already been pulled into the engine and sets their pickedUp
     * flag to true
     */
-  def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
+  def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)(implicit ec: ExecutionContext): Future[List[WorkflowToStart]]
 
   def writeWorkflowHeartbeats(workflowIds: Set[(WorkflowId, OffsetDateTime)],
                               heartbeatDateTime: OffsetDateTime)

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreAccess.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreAccess.scala
@@ -27,7 +27,7 @@ sealed trait WorkflowStoreAccess {
                               heartbeatDateTime: OffsetDateTime)
                              (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[Int]
 
-  def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+  def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                              (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[List[WorkflowToStart]]
 
   def abort(workflowId: WorkflowId)
@@ -50,9 +50,9 @@ case class UncoordinatedWorkflowStoreAccess(store: WorkflowStore) extends Workfl
     store.writeWorkflowHeartbeats(workflowIds.toVector.toSet, heartbeatDateTime)
   }
 
-  override def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+  override def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                                       (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[List[WorkflowToStart]] = {
-    store.fetchStartableWorkflows(maxWorkflows, cromwellId, heartbeatTtl, excludedGroups)
+    store.fetchStartableWorkflows(maxWorkflows, cromwellId, heartbeatTtl)
   }
 
   override def deleteFromStore(workflowId: WorkflowId)(implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[Int] = {
@@ -79,9 +79,9 @@ case class CoordinatedWorkflowStoreAccess(coordinatedWorkflowStoreAccessActor: A
     )
   }
 
-  override def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+  override def fetchStartableWorkflows(maxWorkflows: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                                       (implicit actorSystem: ActorSystem, ec: ExecutionContext): Future[List[WorkflowToStart]] = {
-    val message = WorkflowStoreCoordinatedAccessActor.FetchStartableWorkflows(maxWorkflows, cromwellId, heartbeatTtl, excludedGroups)
+    val message = WorkflowStoreCoordinatedAccessActor.FetchStartableWorkflows(maxWorkflows, cromwellId, heartbeatTtl)
     withRetryForTransactionRollback(
       () => coordinatedWorkflowStoreAccessActor.ask(message).mapTo[List[WorkflowToStart]]
     )

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreActor.scala
@@ -61,7 +61,7 @@ final case class WorkflowStoreActor private(
 
 object WorkflowStoreActor {
   sealed trait WorkflowStoreActorEngineCommand
-  final case class FetchRunnableWorkflows(n: Int, excludedGroups: Set[String]) extends WorkflowStoreActorEngineCommand
+  final case class FetchRunnableWorkflows(n: Int) extends WorkflowStoreActorEngineCommand
   final case class AbortWorkflowCommand(id: WorkflowId) extends WorkflowStoreActorEngineCommand
   final case class WorkflowOnHoldToSubmittedCommand(id: WorkflowId) extends WorkflowStoreActorEngineCommand
   case object InitializerCommand extends WorkflowStoreActorEngineCommand

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActor.scala
@@ -33,8 +33,8 @@ class WorkflowStoreCoordinatedAccessActor(workflowStore: WorkflowStore) extends 
   override def receive: Receive = {
     case WriteHeartbeats(ids, heartbeatDateTime) =>
       workflowStore.writeWorkflowHeartbeats(ids.toVector.toSet, heartbeatDateTime) |> run
-    case FetchStartableWorkflows(count, cromwellId, heartbeatTtl, excludedGroups) =>
-      workflowStore.fetchStartableWorkflows(count, cromwellId, heartbeatTtl, excludedGroups) |> run
+    case FetchStartableWorkflows(count, cromwellId, heartbeatTtl) =>
+      workflowStore.fetchStartableWorkflows(count, cromwellId, heartbeatTtl) |> run
     case DeleteFromStore(workflowId) =>
       workflowStore.deleteFromStore(workflowId) |> run
     case Abort(workflowId) =>
@@ -45,7 +45,7 @@ class WorkflowStoreCoordinatedAccessActor(workflowStore: WorkflowStore) extends 
 object WorkflowStoreCoordinatedAccessActor {
   final case class WriteHeartbeats(workflowIds: NonEmptyVector[(WorkflowId, OffsetDateTime)],
                                    heartbeatDateTime: OffsetDateTime)
-  final case class FetchStartableWorkflows(count: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+  final case class FetchStartableWorkflows(count: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
   final case class DeleteFromStore(workflowId: WorkflowId)
   final case class Abort(workflowId: WorkflowId)
 

--- a/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreEngineActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreEngineActor.scala
@@ -100,8 +100,8 @@ final case class WorkflowStoreEngineActor private(store: WorkflowStore,
 
   private def startNewWork(command: WorkflowStoreActorEngineCommand, sndr: ActorRef, nextData: WorkflowStoreActorData) = {
     val work: Future[Any] = command match {
-      case FetchRunnableWorkflows(count, excludedGroups) =>
-        newWorkflowMessage(count, excludedGroups) map { response =>
+      case FetchRunnableWorkflows(count) =>
+        newWorkflowMessage(count) map { response =>
           response match {
             case NewWorkflowsToStart(workflows) =>
               val workflowsIds = workflows.map(_.id).toList
@@ -185,10 +185,10 @@ final case class WorkflowStoreEngineActor private(store: WorkflowStore,
   /**
     * Fetches at most n workflows, and builds the correct response message based on if there were any workflows or not
     */
-  private def newWorkflowMessage(maxWorkflows: Int, excludedGroups: Set[String]): Future[WorkflowStoreEngineActorResponse] = {
+  private def newWorkflowMessage(maxWorkflows: Int): Future[WorkflowStoreEngineActorResponse] = {
     def fetchStartableWorkflowsIfNeeded = {
       if (maxWorkflows > 0) {
-        workflowStoreAccess.fetchStartableWorkflows(maxWorkflows, workflowHeartbeatConfig.cromwellId, workflowHeartbeatConfig.ttl, excludedGroups)
+        workflowStoreAccess.fetchStartableWorkflows(maxWorkflows, workflowHeartbeatConfig.cromwellId, workflowHeartbeatConfig.ttl)
       } else {
         Future.successful(List.empty[WorkflowToStart])
       }

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/SqlWorkflowStoreSpec.scala
@@ -13,16 +13,17 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.enablers.Emptiness._
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.specs2.mock.Mockito
 import spray.json.{JsObject, JsString}
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
 
 class SqlWorkflowStoreSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with ScalaFutures with BeforeAndAfterAll with Mockito {
   implicit val ec = ExecutionContext.global
-  implicit val defaultPatience = PatienceConfig(scaled(Span(20, Seconds)), scaled(Span(100, Millis)))
+  implicit val defaultPatience = PatienceConfig(scaled(Span(10, Seconds)), scaled(Span(100, Millis)))
 
   val onHoldSourceFilesCollection = NonEmptyList.of(
     WorkflowSourceFilesCollection(
@@ -119,16 +120,6 @@ class SqlWorkflowStoreSpec extends AnyFlatSpec with CromwellTimeoutSpec with Mat
     lazy val metadataDataAccess = DatabaseTestKit.initializeDatabaseByContainerOptTypeAndSystem(containerOpt, MetadataDatabaseType, databaseSystem)
 
     lazy val workflowStore = SqlWorkflowStore(dataAccess, metadataDataAccess)
-
-    def updateWfToRunning(startableWorkflows: List[WorkflowToStart]): Unit = {
-      startableWorkflows.foreach { wf =>
-        Await.result(workflowStore.sqlDatabase.updateWorkflowState(
-          wf.id.toString,
-          WorkflowStoreState.Submitted.toString,
-          WorkflowStoreState.Running.toString
-        ), 5.seconds)
-      }
-    }
 
     it should "start container if required" taggedAs DbmsTest in {
       containerOpt.foreach {
@@ -253,128 +244,22 @@ class SqlWorkflowStoreSpec extends AnyFlatSpec with CromwellTimeoutSpec with Mat
       } yield ()).futureValue
     }
 
-    it should "start workflows from hog group with lowest count of running workflows" taggedAs DbmsTest in {
-      // first submission of 50 workflows for hogGroup "Goldfinger"
-      val goldFingerWorkflowIds = (for (_ <- 1 to 50) yield Await.result(workflowStore.add(includedGroupSourceFilesCollection1), 5.seconds)).flatMap(_.map(_.id).toList)
-
-      // second submission of 50 workflows for hogGroup "Highlander"
-      val highlanderWorkflowIds = (for (_ <- 1 to 50) yield Await.result(workflowStore.add(includedGroupSourceFilesCollection2), 5.seconds)).flatMap(_.map(_.id).toList)
-
-      for (_ <- 1 to 10) yield {
-        (for {
-          // since both hog groups have 0 workflows running, the hog groups are sorted alphabetically and first one is picked
-          startableWorkflows1 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, Set.empty[String])
-          _ = startableWorkflows1.map(_.hogGroup.value).toSet.head should be("Goldfinger")
-          _ = startableWorkflows1.map(_.id).foreach(x => goldFingerWorkflowIds.toList should contain(x))
-          _ = updateWfToRunning(startableWorkflows1)
-
-          startableWorkflows2 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, Set.empty[String])
-          _ = startableWorkflows2.map(_.hogGroup.value).toSet.head should be("Highlander")
-          _ = startableWorkflows2.map(_.id).foreach(x => highlanderWorkflowIds.toList should contain(x))
-          _ = updateWfToRunning(startableWorkflows2)
-        } yield ()).futureValue
-      }
-
-      // remove entries from WorkflowStore
-      (goldFingerWorkflowIds ++ highlanderWorkflowIds).foreach(id => Await.result(workflowStore.deleteFromStore(id), 5.seconds))
-    }
-
-    it should "respect excludedHogGroups and start workflows from hog group with lowest count of running workflows" taggedAs DbmsTest in {
+    it should "select appropriately with the excludedGroups parameter" taggedAs DbmsTest in {
       (for {
-        // first submission of 10 workflows for hogGroup "Goldfinger"
-        goldFingerSubmissions <- Future.sequence(for (_ <- 1 to 10) yield workflowStore.add(includedGroupSourceFilesCollection1))
-        goldFingerWorkflowIds = goldFingerSubmissions.flatMap(_.map(_.id).toList)
-
-        // second submission of 10 workflows for hogGroup "Zardoz"
-        zardozSubmissions <- Future.sequence(for (_ <- 1 to 10) yield workflowStore.add(excludedGroupSourceFilesCollection))
-        zardozWorkflowIds = zardozSubmissions.flatMap(_.map(_.id).toList)
-
-        startableWorkflows1 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set("Zardoz"))
-        _ = startableWorkflows1.map(_.hogGroup.value).toSet.head should be("Goldfinger")
-        _ = startableWorkflows1.map(_.id).foreach(x => goldFingerWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows1)
-
-        startableWorkflows2 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set("Zardoz"))
-        _ = startableWorkflows2.map(_.hogGroup.value).toSet.head should be("Goldfinger")
-        _ = startableWorkflows2.map(_.id).foreach(x => goldFingerWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows2)
-
-        // there are 10 workflows from hog group "Zardoz" in the store, but since the group is excluded, 0 workflows are returned here
-        startableWorkflows3 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set("Zardoz"))
-        _ = startableWorkflows3.size should be(0)
-
-        // hog group "Zardoz" has tokens to run workflows, hence don't exclude it
-        startableWorkflows4 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, Set.empty[String])
-        _ = startableWorkflows4.map(_.hogGroup.value).toSet.head should be("Zardoz")
-        _ = startableWorkflows4.map(_.id).foreach(x => zardozWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows4)
-
-        startableWorkflows5 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, Set.empty[String])
-        _ = startableWorkflows5.map(_.hogGroup.value).toSet.head should be("Zardoz")
-        _ = startableWorkflows5.map(_.id).foreach(x => zardozWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows5)
-
-        // remove entries from WorkflowStore
-        workflowsList = goldFingerWorkflowIds ++ zardozWorkflowIds
-        _ = workflowsList.foreach(id => Await.result(workflowStore.deleteFromStore(id), 5.seconds))
-      } yield()).futureValue
-    }
-
-    it should "start workflows from hog group with lowest count of running workflows for multiple hog groups" taggedAs DbmsTest in {
-      (for {
-        // first submission of 10 workflows for hogGroup "Goldfinger"
-        goldFingerSubmissions <- Future.sequence(for (_ <- 1 to 10) yield workflowStore.add(includedGroupSourceFilesCollection1))
-        goldFingerWorkflowIds = goldFingerSubmissions.flatMap(_.map(_.id).toList)
-
-        // second submission of 10 workflows for hogGroup "Highlander"
-        highlanderSubmissions <- Future.sequence(for (_ <- 1 to 15) yield workflowStore.add(includedGroupSourceFilesCollection2))
-        highlanderWorkflowIds = highlanderSubmissions.flatMap(_.map(_.id).toList)
-
-        // since both hog groups have 0 workflows running, the hog groups are sorted alphabetically and first one is picked
-        startableWorkflows1 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows1.map(_.hogGroup.value).toSet.head should be("Goldfinger")
-        _ = startableWorkflows1.map(_.id).foreach(x => goldFingerWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows1)
-
-        startableWorkflows2 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows2.map(_.hogGroup.value).toSet.head should be("Highlander")
-        _ = startableWorkflows2.map(_.id).foreach(x => highlanderWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows2)
-
-        // new submission for hog group "Finding Forrester"
-        foresterSubmissions <- Future.sequence(for (_ <- 1 to 10) yield workflowStore.add(includedGroupSourceFilesCollection3))
-        foresterWorkflowIds = foresterSubmissions.flatMap(_.map(_.id).toList)
-
-        // now hog group "Finding Forrester" has 0 workflows running, hence it is picked to run
-        startableWorkflows3 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows3.map(_.hogGroup.value).toSet.head should be("Finding Forrester")
-        _ = startableWorkflows3.map(_.id).foreach(x => foresterWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows3)
-
-        // since all 3 hog groups have 5 workflows running each, the hog groups are sorted alphabetically and first one is picked
-        startableWorkflows4 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows4.map(_.hogGroup.value).toSet.head should be("Finding Forrester")
-        _ = startableWorkflows4.map(_.id).foreach(x => foresterWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows4)
-
-        startableWorkflows5 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows5.map(_.hogGroup.value).toSet.head should be("Goldfinger")
-        _ = startableWorkflows5.map(_.id).foreach(x => goldFingerWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows5)
-
-        startableWorkflows6 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows6.map(_.hogGroup.value).toSet.head should be("Highlander")
-        _ = startableWorkflows6.map(_.id).foreach(x => highlanderWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows6)
-
-        startableWorkflows7 <- workflowStore.fetchStartableWorkflows(5, "A08", 5.minutes, excludedGroups = Set.empty[String])
-        _ = startableWorkflows7.map(_.hogGroup.value).toSet.head should be("Highlander")
-        _ = startableWorkflows7.map(_.id).foreach(x => highlanderWorkflowIds.toList should contain(x))
-        _ = updateWfToRunning(startableWorkflows7)
-
-        // remove entries from WorkflowStore
-        workflowsList = goldFingerWorkflowIds ++ highlanderWorkflowIds ++ foresterWorkflowIds
-        _ = workflowsList.foreach(id => Await.result(workflowStore.deleteFromStore(id), 5.seconds))
+        submissionResponsesExcluded <- workflowStore.add(excludedGroupSourceFilesCollection)
+        submissionResponsesIncluded1 <- workflowStore.add(includedGroupSourceFilesCollection1)
+        submissionResponsesIncluded2 <- workflowStore.add(includedGroupSourceFilesCollection2)
+        submissionResponsesIncluded3 <- workflowStore.add(includedGroupSourceFilesCollection3)
+        startableWorkflows <- workflowStore.fetchStartableWorkflows(3, "A08", 1.second, excludedGroups = Set("Zardoz"))
+        _ = startableWorkflows.map(_.id).intersect(submissionResponsesExcluded.map(_.id).toList).size should be(0)
+        _ = startableWorkflows.map(_.id).intersect(submissionResponsesIncluded1.map(_.id).toList).size should be(1)
+        _ = startableWorkflows.map(_.id).intersect(submissionResponsesIncluded2.map(_.id).toList).size should be(1)
+        _ = startableWorkflows.map(_.id).intersect(submissionResponsesIncluded3.map(_.id).toList).size should be(1)
+        _ = startableWorkflows.map(_.id).size should be(3)
+        _ <- workflowStore.deleteFromStore(submissionResponsesExcluded.head.id) // Tidy up
+        _ <- workflowStore.deleteFromStore(submissionResponsesIncluded1.head.id) // Tidy up
+        _ <- workflowStore.deleteFromStore(submissionResponsesIncluded2.head.id) // Tidy up
+        _ <- workflowStore.deleteFromStore(submissionResponsesIncluded3.head.id) // Tidy up
       } yield ()).futureValue
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/workflowstore/WorkflowStoreCoordinatedAccessActorSpec.scala
@@ -66,13 +66,13 @@ class WorkflowStoreCoordinatedAccessActorSpec extends TestKitSuite
     val now = OffsetDateTime.now()
     val expected: List[WorkflowToStart] = List(WorkflowToStart(WorkflowId.randomId(), now, collection, Submitted, HogGroup("foo")))
     val workflowStore = new InMemoryWorkflowStore {
-      override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+      override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                                           (implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
         Future.successful(expected)
       }
     }
     val actor = TestActorRef(new WorkflowStoreCoordinatedAccessActor(workflowStore))
-    val request = FetchStartableWorkflows(1, "test fetchStartableWorkflows success", 1.second, Set.empty)
+    val request = FetchStartableWorkflows(1, "test fetchStartableWorkflows success", 1.second)
     implicit val timeout: Timeout = Timeout(2.seconds.dilated)
     actor.ask(request).mapTo[List[WorkflowToStart]] map { actual =>
       actual should be(expected)
@@ -97,13 +97,13 @@ class WorkflowStoreCoordinatedAccessActorSpec extends TestKitSuite
     val now = OffsetDateTime.now()
     val expected: List[WorkflowToStart] = List(WorkflowToStart(WorkflowId.randomId(), now, collection, Submitted, HogGroup("foo")))
     val workflowStore = new InMemoryWorkflowStore {
-      override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+      override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                                           (implicit ec: ExecutionContext): Future[List[WorkflowToStart]] = {
         Future.successful(expected)
       }
     }
     val actor = TestActorRef(new WorkflowStoreCoordinatedAccessActor(workflowStore))
-    val request = FetchStartableWorkflows(1, "test fetchStartableWorkflows with workflow url success", 1.second, Set.empty)
+    val request = FetchStartableWorkflows(1, "test fetchStartableWorkflows with workflow url success", 1.second)
     implicit val timeout: Timeout = Timeout(2.seconds.dilated)
     actor.ask(request).mapTo[List[WorkflowToStart]] map { actual =>
       actual should be(expected)
@@ -166,14 +166,14 @@ class WorkflowStoreCoordinatedAccessActorSpec extends TestKitSuite
 
     it should s"fail to fetchStartableWorkflows due to $description" in {
       val workflowStore = new InMemoryWorkflowStore {
-        override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration, excludedGroups: Set[String])
+        override def fetchStartableWorkflows(n: Int, cromwellId: String, heartbeatTtl: FiniteDuration)
                                             (implicit ec: ExecutionContext): Future[Nothing] = {
           result()
         }
       }
       val actor = TestActorRef(new WorkflowStoreCoordinatedAccessActor(workflowStore))
       val heartbeatTtlNotReallyUsed = 1.second
-      val request = FetchStartableWorkflows(1, s"test $description fetchStartableWorkflows", heartbeatTtlNotReallyUsed, Set.empty)
+      val request = FetchStartableWorkflows(1, s"test $description fetchStartableWorkflows", heartbeatTtlNotReallyUsed)
       implicit val timeout: Timeout = Timeout(2.seconds.dilated)
       actor.ask(request).failed map { actual =>
         actual.getMessage should startWith(expectedMessagePrefix)

--- a/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -129,7 +129,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloCwlWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
-      storeActor ! FetchRunnableWorkflows(2, Set.empty)
+      storeActor ! FetchRunnableWorkflows(2)
       expectMsgPF(10 seconds) {
         case NewWorkflowsToStart(workflowNel) =>
           workflowNel.toList.size shouldBe 2
@@ -142,7 +142,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
           }
       }
 
-      storeActor ! FetchRunnableWorkflows(1, Set.empty)
+      storeActor ! FetchRunnableWorkflows(1)
       expectMsgPF(10 seconds) {
         case NewWorkflowsToStart(workflowNel) =>
           workflowNel.toList.size shouldBe 1
@@ -182,7 +182,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(optionedSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
-      storeActor ! FetchRunnableWorkflows(1, Set.empty)
+      storeActor ! FetchRunnableWorkflows(1)
       expectMsgPF(10 seconds) {
         case NewWorkflowsToStart(workflowNel) =>
           workflowNel.toList.size should be(1)
@@ -232,7 +232,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
       storeActor ! BatchSubmitWorkflows(NonEmptyList.of(helloWorldSourceFiles, helloWorldSourceFiles, helloWorldSourceFiles))
       val insertedIds = expectMsgType[WorkflowsBatchSubmittedToStore](10 seconds).workflowIds.toList
 
-      storeActor ! FetchRunnableWorkflows(100, Set.empty)
+      storeActor ! FetchRunnableWorkflows(100)
       expectMsgPF(10 seconds) {
         case NewWorkflowsToStart(workflowNel) =>
           workflowNel.toList.size shouldBe 3
@@ -260,7 +260,7 @@ class WorkflowStoreActorSpec extends CromwellTestKitWordSpec with CoordinatedWor
         "WorkflowStoreActor-RemainResponsiveForUnknown"
       )
 
-      storeActor ! FetchRunnableWorkflows(100, Set.empty)
+      storeActor ! FetchRunnableWorkflows(100)
       expectMsgPF(10 seconds) {
         case NoNewWorkflowsToStart => // Great
         case x => fail(s"Unexpected response from supposedly empty WorkflowStore: $x")

--- a/services/src/test/scala/cromwell/services/database/LobSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/LobSpec.scala
@@ -175,8 +175,7 @@ class LobSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with Sc
           heartbeatTimestampTo = OffsetDateTime.now.toSystemTimestamp,
           workflowStateFrom = "Submitted",
           workflowStateTo = "Running",
-          workflowStateExcluded = "On Hold",
-          excludedGroups = Set.empty
+          workflowStateExcluded = "On Hold"
         )
 
         _ = {

--- a/services/src/test/scala/cromwell/services/database/LobSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/LobSpec.scala
@@ -122,7 +122,7 @@ class LobSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with Sc
         submissionTime = OffsetDateTime.now.toSystemTimestamp,
         importsZip = Option(Array.empty[Byte]).toBlobOption,
         customLabels = clob,
-        hogGroup = Option("abc-1"),
+        hogGroup = None,
       )
 
       val noneWorkflowUuid = WorkflowId.randomId().toString
@@ -141,7 +141,7 @@ class LobSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with Sc
         submissionTime = OffsetDateTime.now.toSystemTimestamp,
         importsZip = None,
         customLabels = clob,
-        hogGroup = Option("abc-1"),
+        hogGroup = None,
       )
 
       val aByte = 'a'.toByte
@@ -161,7 +161,7 @@ class LobSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with Sc
         submissionTime = OffsetDateTime.now.toSystemTimestamp,
         importsZip = Option(Array(aByte)).toBlobOption,
         customLabels = clob,
-        hogGroup = Option("abc-1"),
+        hogGroup = None,
       )
 
       val workflowStoreEntries = Seq(emptyWorkflowStoreEntry, noneWorkflowStoreEntry, aByteWorkflowStoreEntry)


### PR DESCRIPTION
The changes in #6668 and #6680 appear to have introduced consistent issues with workflow pickup in the horicromtal tests. This temporarily reverts both of those PRs until BW finds a way to roll this forward. More info in BW-1128.