### PR TITLE
In TES backend, convert int preemptible attrs to bool [BT-559]

### DIFF
--- a/docs/backends/TES.md
+++ b/docs/backends/TES.md
@@ -63,6 +63,7 @@ This backend supports CPU, memory and disk size configuration through the use of
     * Type: String (ex: "1 GB" or "1024 MB")
 * `preemptible` defines whether or not to use preemptible VMs. 
     * Type: Boolean (ex: "true" or "false")
+    * Integers are accepted and will be converted to boolean (true if > 0)
 
 If they are not set, the TES backend may use default values.
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
@@ -9,7 +9,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import wom.RuntimeAttributesKeys
 import wom.format.MemorySize
-import wom.types.WomStringType
+import wom.types.{WomIntegerType, WomStringType}
 import wom.values._
 
 case class TesRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode,
@@ -151,6 +151,26 @@ object PreemptibleValidation {
 class PreemptibleValidation extends BooleanRuntimeAttributesValidation(TesRuntimeAttributes.PreemptibleKey) {
   override def usedInCallCaching: Boolean = false
 
+  override protected def validateExpression: PartialFunction[WomValue, Boolean] = {
+    case womBoolValue if womType.coerceRawValue(womBoolValue).isSuccess => true
+    case womIntValue if WomIntegerType.coerceRawValue(womIntValue).isSuccess => true
+  }
+
+  override protected def validateValue: PartialFunction[WomValue, ErrorOr[Boolean]] = {
+    case value if womType.coerceRawValue(value).isSuccess =>
+      validateCoercedValue(womType.coerceRawValue(value).get.asInstanceOf[WomBoolean])
+    // The TES spec requires a boolean preemptible value, but many WDLs written originally
+    // for other backends use an integer. Interpret integers > 0 as true, others as false.
+    case value if WomIntegerType.coerceRawValue(value).isSuccess =>
+      validateCoercedValue(WomBoolean(WomIntegerType.coerceRawValue(value).get.asInstanceOf[WomInteger].value > 0))
+    case value if womType.coerceRawValue(value.valueString).isSuccess =>
+      /*
+      NOTE: This case statement handles WdlString("true") coercing to WdlBoolean(true).
+      For some reason "true" as String is coercable... but not the WdlString.
+       */
+      validateCoercedValue(womType.coerceRawValue(value.valueString).get.asInstanceOf[WomBoolean])
+  }
+
   override protected def missingValueMessage: String =
-    s"Expecting $key runtime attribute to be a Boolean or a String with values of 'true' or 'false'"
+    s"Expecting $key runtime attribute to be an Integer, Boolean, or a String with values of 'true' or 'false'"
 }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -71,9 +71,32 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
     }
 
-    "fail to validate an invalid preemptible entry" in {
+    "convert a positive integer preemptible entry to true boolean" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomInteger(3))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(preemptible = true)
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "convert a nonpositive integer preemptible entry to false boolean" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomInteger(-1))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(preemptible = false)
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "convert a valid string preemptible entry to boolean" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomString("true"))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(preemptible = true)
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "fail to validate an invalid string preemptible entry" in {
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomString("yes"))
-      assertFailure(runtimeAttributes, "Expecting preemptible runtime attribute to be a Boolean or a String with values of 'true' or 'false'")
+      assertFailure(runtimeAttributes, "Expecting preemptible runtime attribute to be an Integer, Boolean, or a String with values of 'true' or 'false'")
+    }
+
+    "fail to validate an invalid type preemptible entry" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomFloat(3.14))
+      assertFailure(runtimeAttributes, "Expecting preemptible runtime attribute to be an Integer, Boolean, or a String with values of 'true' or 'false'")
     }
 
     "validate a valid continueOnReturnCode entry" in {


### PR DESCRIPTION
This makes WDLs developed for GCP, which takes an int `preemptible` value, possible to run in TES without modification.