### PR TITLE
Shift update poll date by 2 months [BW-1156]

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,7 +25,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 1,4,7,10 ?" # Run at 00:00 on the 1st day of Jan,Apr,Jul,Oct (whatever day that is)
+pullRequests.frequency = "0 0 1 3,6,9,12 ?" # Run at 00:00 on the 1st day of Jan,Apr,Jul,Oct (whatever day that is)
 
 # Only these dependencies which match the given patterns are updated.
 #

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,7 +25,7 @@
 #
 # Default: @asap
 #
-pullRequests.frequency = "0 0 1 3,6,9,12 ?" # Run at 00:00 on the 1st day of Jan,Apr,Jul,Oct (whatever day that is)
+pullRequests.frequency = "0 0 1 3,6,9,12 ?" # Run at 00:00 on the 1st day of Mar,Jun,Sep,Dec (whatever day of the week that is)
 
 # Only these dependencies which match the given patterns are updated.
 #


### PR DESCRIPTION
Moves the time of the update poll closer to when the updates will actually be worked on for incorporation by the team.