### PR TITLE
Temporarily disable ssh access test [CROM-6872]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/ssh_access.test
+++ b/centaur/src/main/resources/standardTestCases/ssh_access.test
@@ -1,6 +1,8 @@
 name: ssh_access
 testFormat: workflowsuccess
 backends: [Papiv2]
+# CROM-6872: ignoring for now until we figure out the problem
+ignore: true
 
 files {
   workflow: ssh_access/ssh_access.wdl


### PR DESCRIPTION
This will allow us to make other changes to Cromwell and have the tests pass while we figure out what's wrong with SSH access.