### PR TITLE
Automatically build Cromwell, update Cromwhelm on merge to develop [BW-1211]

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -1,0 +1,74 @@
+name: chart-update-on-merge
+
+on:
+  pull_request:
+    types:
+      - closed
+  push:
+    branches:
+      - aen_bw_1211
+
+jobs:
+  chart-update:
+    name: Cromwhelm Chart Auto Updater
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
+    steps:
+    - name: Clone Cromwell
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwell
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwell
+    - uses: olafurpg/setup-scala@v10
+      with:
+        java-version: adopt@1.11
+    - name: Clone Cromwhelm
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwhelm
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwhelm
+    - name: Find Cromwell short SHA
+      run: |
+        set -e
+        cd cromwell
+        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
+    - name: Find Cromwell release number
+      run: |
+        set -e
+        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
+        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
+          exit 1
+        fi
+        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
+    - name: Save complete image ID
+      run: |
+        echo "CROMWELL_SNAP_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA-SNAP"`" >> $GITHUB_ENV
+    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: dsdejenkins
+        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+    - name: Build Cromwell Docker
+      run: |
+        set -e
+        cd cromwell
+        sbt server/docker
+        docker push broadinstitute/cromwell:$CROMWELL_SNAP_VERSION
+    - name: Edit & push chart
+      env:
+        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+      run: |
+        set -e
+        cd cromwhelm
+        git checkout main
+        ls -la
+        sed -i "s/appVersion.*/appVersion: \"$CROMWELL_SNAP_VERSION\"/" cromwell-helm/Chart.yaml
+        sed -i "s/image: broadinstitute\/cromwell.*/image: broadinstitute\/cromwell:$CROMWELL_SNAP_VERSION/" cromwell-helm/templates/cromwell.yaml
+        git diff
+        git config --global user.name "broadbot"
+        git config --global user.email "broadbot@broadinstitute.org"
+        git commit -am "Auto update to Cromwell $CROMWELL_SNAP_VERSION"
+        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types:
       - closed
-  push:
-    branches:
-      - aen_bw_1211
 
 jobs:
   chart-update:


### PR DESCRIPTION
Input:

1. Cromwell commit [`53c4693a0508518e9a6f957fbba2b1afc7dc90b5`](https://github.com/broadinstitute/cromwell/pull/6739/commits/53c4693a0508518e9a6f957fbba2b1afc7dc90b5)
    - I ran the job on my own branch for testing, but I updated the job to point to `develop` by PR time

Outputs:

1. Commit to `main` in Cromwhelm: https://github.com/broadinstitute/cromwhelm/commit/0218cf0ccad9a7e9a74c785c2101ecb77ec56a13

2. [Image in Docker Hub](https://hub.docker.com/layers/cromwell/broadinstitute/cromwell/79-cba6c97-SNAP/images/sha256-9cd6b3e404efbd1a8610b45ae606dde056dd172e6f1a83fbae36e340fb0103ea?context=explore).

3. [Complete log output of action.](https://github.com/broadinstitute/cromwell/runs/6097432895?check_suite_focus=true)

---

The action runs on self-hosted instances created by devops (`runs-on: self-hosted`) which are 2x as powerful as Travis. The whole build takes ~7 minutes, including `sbt server/docker`. My high spec Broad laptop is just a little faster at ~5 minutes.

~There is a prequisite PR https://github.com/broadinstitute/terraform-ap-deployments/pull/616 that is very close pending a naming discussion.~ Merged.

---

Now we are cool like the other repos that deploy continuously. This is near and dear to my heart:

<img width="1159" alt="Screen Shot 2022-04-20 at 11 58 40 AM" src="https://user-images.githubusercontent.com/1087943/164273206-134f1b88-d1bb-447e-b56e-7d01c2e1cada.png">