### PR TITLE
BW-1224 Security upgrade for jackson-databind

### DIFF
--- a/CromwellRefdiskManifestCreator/pom.xml
+++ b/CromwellRefdiskManifestCreator/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.1</version>
+            <version>2.13.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
I did not have any experience with this little Maven-based utility so I performed the following steps for post-upgrade verification.
```
sdk install maven
mvn compile
mvn test
mvn package // I think this is a superset of `compile` and `test` but they all take just a few seconds so 🤷‍♂️ 
```
Closing automatic PR https://github.com/broadinstitute/cromwell/pull/6743 in favor of this one because we can trivially upgrade to the latest version, not just a security-hotfixed older version.