### PR TITLE
BW-1227 Upgrade org.bouncycastle:bcprov-jdk15on:1.67 [due 6/17]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -703,6 +703,10 @@ object Dependencies {
     "org.asynchttpclient" % "async-http-client" % "2.10.5",
   )
 
+  private val bouncyCastleOverrides = List(
+    "org.bouncycastle" % "bcprov-jdk15on" % "1.70",
+  )
+
   /*
   If we use a version in one of our projects, that's the one we want all the libraries to use
   ...plus other groups of transitive dependencies shared across multiple projects
@@ -714,5 +718,6 @@ object Dependencies {
       rdf4jDependencyOverrides ++
       grpcDependencyOverrides ++
       scalaCollectionCompatOverrides ++
-      asyncHttpClientOverrides
+      asyncHttpClientOverrides ++
+      bouncyCastleOverrides
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,4 @@ addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
+addDependencyTreePlugin


### PR DESCRIPTION
Version 1.67 is vulnerable and versions 1.69+ are safe. Upgraded to latest version 1.70. `sbt assembly` succeeds.

The line
```
addDependencyTreePlugin
```
enables a handy new command
```
whatDependsOn org.bouncycastle bcprov-jdk15on 1.67
```
shows what chain of artifacts uses a leaf-node dependency – an inversion of the traditional dependency tree:
```
[info] org.bouncycastle:bcprov-jdk15on:1.67
[info]   +-org.bouncycastle:bcpkix-jdk15on:1.67
[info]     +-io.grpc:grpc-xds:1.46.0
[info]       +-io.grpc:grpc-googleapis:1.46.0
[info]         +-com.google.api:gax-grpc:2.18.1
[info]           +-com.google.cloud:google-cloud-resourcemanager:1.4.0
[info]             +-org.broadinstitute:cloud-nio-spi_2.13:80-d24645a-SNAP [S]
[info]               +-org.broadinstitute:cloud-nio-util_2.13:80-d24645a-SNAP [S]
```

With this PR's fix in place, the output is a gratifying "this isn't used anywhere" error:
```
root(aen_bw_1227)> | 80> whatDependsOn org.bouncycastle bcprov-jdk15on 1.67
[error] Expected 'org.broadinstitute'
[error] Expected '1.70'
[error] whatDependsOn org.bouncycastle bcprov-jdk15on 1.67
[error]                                                 ^
```
