### PR TITLE
BW-1295 Disable conformance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,15 +76,6 @@ env:
     - >-
       BUILD_TYPE=checkPublish
     - >-
-      BUILD_TYPE=conformanceLocal
-      BUILD_MYSQL=5.7
-    - >-
-      BUILD_TYPE=conformancePapiV2beta
-      BUILD_MYSQL=5.7
-    - >-
-      BUILD_TYPE=conformanceTesk
-      BUILD_MYSQL=5.7
-    - >-
       BUILD_TYPE=horicromtalDeadlock
     - >-
       BUILD_TYPE=dockerScripts


### PR DESCRIPTION
I have gone through a few cycles of opening Travis and thinking "those are still running? why?".