### PR TITLE
BW-1228 Upgrade MySQL client to 8.0.29

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,7 @@ object Dependencies {
   private val mockitoV = "3.11.2"
   private val mockserverNettyV = "5.11.2"
   private val mouseV = "1.0.10"
-  private val mysqlV = "8.0.28"
+  private val mysqlV = "8.0.29"
   private val nettyV = "4.1.72.Final"
   private val owlApiV = "5.1.19"
   private val postgresV = "42.3.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,7 +79,11 @@ object Dependencies {
   private val mockitoV = "3.11.2"
   private val mockserverNettyV = "5.11.2"
   private val mouseV = "1.0.10"
-  private val mysqlV = "8.0.29"
+  /*
+  Newer version 8.0.29 fails `Control characters should work with metadata` Centaur tests, has charset changes mentioned in release notes
+  https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html#mysqld-8-0-29-charset
+   */
+  private val mysqlV = "8.0.28"
   private val nettyV = "4.1.72.Final"
   private val owlApiV = "5.1.19"
   private val postgresV = "42.3.3"
@@ -689,6 +693,10 @@ object Dependencies {
     "org.bouncycastle" % "bcprov-jdk15on" % "1.70",
   )
 
+  private val protobufJavaOverrides = List(
+    "com.google.protobuf" % "protobuf-java" % "3.21.2",
+  )
+
   /*
   If we use a version in one of our projects, that's the one we want all the libraries to use
   ...plus other groups of transitive dependencies shared across multiple projects
@@ -702,5 +710,6 @@ object Dependencies {
       scalaCollectionCompatOverrides ++
       asyncHttpClientOverrides ++
       nimbusdsOverrides ++
-      bouncyCastleOverrides
+      bouncyCastleOverrides ++
+      protobufJavaOverrides
 }


### PR DESCRIPTION
JDOM was removed in https://github.com/broadinstitute/cromwell/pull/6785 and this branch is updated from `develop`:

```
root(aen_bw_1228)> | 81> whatDependsOn org.jdom jdom2
[ ... ]
[error] whatDependsOn org.jdom jdom2
[error]                    ^
```

( This is the normal output when `whatDependsOn` does not find something, see https://github.com/broadinstitute/cromwell/pull/6775 https://github.com/broadinstitute/cromwell/pull/6776 )

For Protobuf, the new MySQL pulls in a safe version ≥ 3.16.1:

```
+-mysql:mysql-connector-java:8.0.29
| +-com.google.protobuf:protobuf-java:3.19.4
```

which evicts older versions used by other dependencies

```
+-io.opencensus:opencensus-proto:0.2.0
| +-com.google.protobuf:protobuf-java:3.19.4
| +-com.google.protobuf:protobuf-java:3.5.1 (evicted by: 3.19.4)
```