### PR TITLE
[DDO-2190] Strip Host header in CromIAM's forwarding

### DIFF
--- a/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
+++ b/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
@@ -66,6 +66,7 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
       val cromwellRequest = httpRequest
         .copy(uri = httpRequest.uri.withAuthority(interface, port).withScheme(scheme))
         .withHeaders(headers)
+      println("Running forwardToCromwell and resolved the following URI: " + cromwellRequest.uri.toString())
       Http().singleRequest(cromwellRequest)
     } recoverWith {
       case e => Future.failed(CromwellConnectionFailure(e))

--- a/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
+++ b/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
@@ -115,7 +115,8 @@ object CromwellClient {
 
   // Header that all clients will add before they send a request.
   // If we don't strip this header out and let Akka replace it automatically before forwarding
-  // requests to Cromwell, any host-based routing in front of Cromwell will fail.
+  // requests to Cromwell, any host-based routing in front of Cromwell will fail because the
+  // header will still contain CromIAM's host, not Cromwell's.
   // See: https://broadworkbench.atlassian.net/browse/DDO-2190
   val HostHeader = "Host"
 

--- a/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
+++ b/CromIAM/src/main/scala/cromiam/cromwell/CromwellClient.scala
@@ -62,11 +62,11 @@ class CromwellClient(scheme: String, interface: String, port: Int, log: LoggingA
 
   def forwardToCromwell(httpRequest: HttpRequest): FailureResponseOrT[HttpResponse] = {
     val future = {
-      val headers = httpRequest.headers.filterNot(_.name == TimeoutAccessHeader)
+      // See CromwellClient's companion object for info on these header modifications
+      val headers = httpRequest.headers.filterNot(header => header.name == TimeoutAccessHeader || header.name == HostHeader)
       val cromwellRequest = httpRequest
         .copy(uri = httpRequest.uri.withAuthority(interface, port).withScheme(scheme))
         .withHeaders(headers)
-      println("Running forwardToCromwell and resolved the following URI: " + cromwellRequest.uri.toString())
       Http().singleRequest(cromwellRequest)
     } recoverWith {
       case e => Future.failed(CromwellConnectionFailure(e))
@@ -112,6 +112,12 @@ object CromwellClient {
   // HTTP header ‘Timeout-Access: <function1>’ is not allowed in requests
   // See: https://github.com/akka/akka-http/issues/64
   val TimeoutAccessHeader = "Timeout-Access"
+
+  // Header that all clients will add before they send a request.
+  // If we don't strip this header out and let Akka replace it automatically before forwarding
+  // requests to Cromwell, any host-based routing in front of Cromwell will fail.
+  // See: https://broadworkbench.atlassian.net/browse/DDO-2190
+  val HostHeader = "Host"
 
   final case class CromwellConnectionFailure(f: Throwable) extends Exception(s"Unable to connect to Cromwell (${f.getMessage})", f)
 


### PR DESCRIPTION
[The ticket](https://broadworkbench.atlassian.net/browse/DDO-2190) has a ton more info and I talked with @aednichols about this--the short version is:
- Whatever is doing the HTTP request to Cromwell (Akka?) does not set the Host header ([per MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host)) if it has been customized beforehand
- We've accidentally been doing that by copying the _request's_ headers that came into CromIAM, which obviously include the Host header correlating to CromIAM itself
- Thus CromIAM sends requests to Cromwell with an incorrect Host header
- This hasn't mattered before because Cromwell's Layer 4 load balancer doesn't care and Cromwell's Apache proxy didn't actually need to do host-based routing because it just forwards everything to one app, Cromwell
- This suddenly matters a lot now because BEEs use an Nginx controller for ingress instead of a GCP Layer 4 load balancer, and _it_ needs to use host-based routing
- TL;DR: CromIAM is proxying to Cromwell wrong-ish and it very much does not work in BEEs

Solution: strip out the Host header just like CromIAM already does for Timeout-Access, and everything is happy. The impact to live environments should be zero because they clearly didn't care about the header before. If this fails anywhere, Argo sees the failure immediately like it did for BEEs, and it sees it in a way that any deployment or promotion would be halted because CromIAM would fail to come online from Argo's perspective.