### PR TITLE
BW-1317 Upgrade `googleCloudNioV` to latest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,9 +40,7 @@ object Dependencies {
   // latest date via: https://github.com/googleapis/google-api-java-client-services/blob/main/clients/google-api-services-cloudkms/v1.metadata.json
   private val googleCloudKmsV = "v1-rev20220104-1.32.1"
   private val googleCloudMonitoringV = "3.2.5"
-  // BW-808 Pinning googleCloudNioV to this tried-and-true old version and quieting Scala Steward.
-  // 0.121.2 is the most recent version currently known to work.
-  private val googleCloudNioV = "0.61.0-alpha" // scala-steward:off
+  private val googleCloudNioV = "0.124.8"
   private val googleCloudStorageV = "2.9.2"
   private val googleGaxGrpcV = "2.12.2"
   // latest date via: https://mvnrepository.com/artifact/com.google.apis/google-api-services-genomics


### PR DESCRIPTION
Last time we tried to upgrade this we [ran into a bug](https://github.com/googleapis/java-storage-nio/issues/691), but it [has now been fixed](https://github.com/googleapis/java-storage-nio/pull/719) and we have a [unit test](https://github.com/broadinstitute/cromwell/pull/6491) for the library that verifies the fix.

Besides generally keeping important libraries up to date, there is a chance that recent fixes to requester pays ([Google PR](https://github.com/googleapis/java-storage-nio/pull/858), [GATK PR](https://github.com/broadinstitute/gatk/pull/7730)) implemented by our own very Methods team may solve an issue users are seeing in Terra:
```
User project specified in the request is invalid.
```

[Terra User Liaison Slack link.](https://broadinstitute.slack.com/archives/CBJJ7U293/p1657731546766919)
[DSP Methods Slack link.](https://broadinstitute.slack.com/archives/C1H82GH41/p1647028919917549?thread_ts=1645714642.593619&cid=C1H82GH41)