### PR TITLE
PROD-707 Embiggen PK of tables related to call caching 

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -82,6 +82,7 @@
     <include file="changesets/mariadb_engine_schema.xml" relativeToChangelogFile="true" />
     <include file="changesets/resync_engine_schema.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_job_store_ids.xml" relativeToChangelogFile="true" />
+    <include file="changesets/enlarge_call_cache_entry_ids.xml" relativeToChangelogFile="true" />
     <!-- REMINDER!
       Before appending here, did you remember to include the 'objectQuotingStrategy="QUOTE_ALL_OBJECTS"' line in your changeset/xyz.xml...?
     -->

--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -83,6 +83,10 @@
     <include file="changesets/resync_engine_schema.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_job_store_ids.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_call_cache_entry_ids.xml" relativeToChangelogFile="true" />
+    <include file="changesets/enlarge_call_caching_aggregation_entry_id.xml" relativeToChangelogFile="true" />
+    <include file="changesets/enlarge_call_caching_detritus_entry_id.xml" relativeToChangelogFile="true" />
+    <include file="changesets/enlarge_call_caching_simpleton_entry_id.xml" relativeToChangelogFile="true" />
+    <include file="changesets/reset_call_caching_hash_entry_id_autoincrement.xml" relativeToChangelogFile="true" />
     <!-- REMINDER!
       Before appending here, did you remember to include the 'objectQuotingStrategy="QUOTE_ALL_OBJECTS"' line in your changeset/xyz.xml...?
     -->

--- a/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- BEGIN dropping FKs -->
+    <!-- Drop the foreign key constraint from CALL_CACHING_AGGREGATION_ENTRY to CALL_CACHING_ENTRY to allow for the latter's PK to be widened. -->
+    <changeSet author="sshah" id="drop_call_caching_aggregation_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <dropForeignKeyConstraint
+                baseTableName="CALL_CACHING_AGGREGATION_ENTRY"
+                constraintName="FK_CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_ENTRY_ID"
+        />
+    </changeSet>
+
+    <!-- Drop the foreign key constraint from CALL_CACHING_DETRITUS_ENTRY to CALL_CACHING_ENTRY to allow for the latter's PK to be widened. -->
+    <changeSet author="sshah" id="drop_call_caching_detritus_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <dropForeignKeyConstraint
+                baseTableName="CALL_CACHING_DETRITUS_ENTRY"
+                constraintName="FK_CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_ENTRY_ID"
+        />
+    </changeSet>
+
+    <!-- Drop the foreign key constraint from CALL_CACHING_HASH_ENTRY to CALL_CACHING_ENTRY to allow for the latter's PK to be widened. -->
+    <changeSet author="sshah" id="drop_call_caching_hash_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <dropForeignKeyConstraint
+                baseTableName="CALL_CACHING_HASH_ENTRY"
+                constraintName="FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID"
+        />
+    </changeSet>
+
+    <!-- Drop the foreign key constraint from CALL_CACHING_SIMPLETON_ENTRY to CALL_CACHING_ENTRY to allow for the latter's PK to be widened. -->
+    <changeSet author="sshah" id="drop_call_caching_simpleton_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <dropForeignKeyConstraint
+                baseTableName="CALL_CACHING_SIMPLETON_ENTRY"
+                constraintName="FK_CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_ENTRY_ID"
+        />
+    </changeSet>
+    <!-- END dropping FKs -->
+
+    <!-- BEGIN CALL_CACHING_ENTRY_ID PK widening -->
+    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. -->
+    <changeSet author="sshah" id="enlarge_call_cache_entry_id" dbms="mysql,hsqldb,mariadb">
+        <addAutoIncrement
+                columnName="CALL_CACHING_ENTRY_ID"
+                columnDataType="BIGINT"
+                incrementBy="1"
+                tableName="CALL_CACHING_ENTRY"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_cache_entry_id" dbms="postgresql">
+        <modifyDataType
+                columnName="CALL_CACHING_ENTRY_ID"
+                tableName="CALL_CACHING_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_cache_entry_id_seq" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- idempotency check (noop if the sequence is present and already consistent what the alter would do) -->
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM information_schema.sequences
+                WHERE sequence_name = 'CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq'
+                AND data_type = 'bigint';
+            </sqlCheck>
+        </preConditions>
+        <sql>alter sequence "CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq" as bigint;</sql>
+    </changeSet>
+    <!-- END CALL_CACHING_ENTRY PK widening -->
+
+    <!-- BEGIN widening FKs to match PK -->
+    <changeSet author="sshah" id="enlarge_call_caching_aggregation_entry_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <modifyDataType
+                tableName="CALL_CACHING_AGGREGATION_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="enlarge_call_caching_detritus_entry_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <modifyDataType
+                tableName="CALL_CACHING_DETRITUS_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="enlarge_call_caching_hash_entry_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <modifyDataType
+                tableName="CALL_CACHING_HASH_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="enlarge_call_caching_simpleton_entry_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <modifyDataType
+                tableName="CALL_CACHING_SIMPLETON_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+    <!-- END widening FKs to match PK -->
+
+    <!-- MariaDB's FK NotNull constraint does not survive the widening above and must be recreated explicitly. -->
+    <!-- BEGIN Restoring FK NotNull constraint -->
+    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_aggregation_entry_fk" dbms="mariadb">
+        <addNotNullConstraint
+                tableName="CALL_CACHING_AGGREGATION_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                columnDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_detritus_entry_fk" dbms="mariadb">
+        <addNotNullConstraint
+                tableName="CALL_CACHING_DETRITUS_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                columnDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_hash_entry_fk" dbms="mariadb">
+        <addNotNullConstraint
+                tableName="CALL_CACHING_HASH_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                columnDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_simpleton_entry_fk" dbms="mariadb">
+        <addNotNullConstraint
+                tableName="CALL_CACHING_SIMPLETON_ENTRY"
+                columnName="CALL_CACHING_ENTRY_ID"
+                columnDataType="BIGINT"
+        />
+    </changeSet>
+    <!-- END Restoring FK NotNull constraint -->
+
+    <!-- BEGIN Restoring the FKs -->
+    <changeSet author="sshah" id="recreate_call_caching_aggregation_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <addForeignKeyConstraint
+                constraintName="FK_CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_ENTRY_ID"
+                baseColumnNames="CALL_CACHING_ENTRY_ID"
+                baseTableName="CALL_CACHING_AGGREGATION_ENTRY"
+                referencedTableName="CALL_CACHING_ENTRY"
+                referencedColumnNames="CALL_CACHING_ENTRY_ID"
+                onDelete="CASCADE"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="recreate_call_caching_detritus_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <addForeignKeyConstraint
+                constraintName="FK_CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_ENTRY_ID"
+                baseColumnNames="CALL_CACHING_ENTRY_ID"
+                baseTableName="CALL_CACHING_DETRITUS_ENTRY"
+                referencedTableName="CALL_CACHING_ENTRY"
+                referencedColumnNames="CALL_CACHING_ENTRY_ID"
+                onDelete="CASCADE"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="recreate_call_caching_hash_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <addForeignKeyConstraint
+                constraintName="FK_CALL_CACHING_HASH_ENTRY_CALL_CACHING_ENTRY_ID"
+                baseColumnNames="CALL_CACHING_ENTRY_ID"
+                baseTableName="CALL_CACHING_HASH_ENTRY"
+                referencedTableName="CALL_CACHING_ENTRY"
+                referencedColumnNames="CALL_CACHING_ENTRY_ID"
+                onDelete="CASCADE"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="recreate_call_caching_simpleton_entry_call_caching_entry_id_fk" dbms="mysql,hsqldb,postgresql,mariadb">
+        <addForeignKeyConstraint
+                constraintName="FK_CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_ENTRY_ID"
+                baseColumnNames="CALL_CACHING_ENTRY_ID"
+                baseTableName="CALL_CACHING_SIMPLETON_ENTRY"
+                referencedTableName="CALL_CACHING_ENTRY"
+                referencedColumnNames="CALL_CACHING_ENTRY_ID"
+                onDelete="CASCADE"
+        />
+    </changeSet>
+    <!-- END Restoring the FKs -->
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
@@ -40,12 +40,13 @@
 
     <!-- BEGIN CALL_CACHING_ENTRY_ID PK widening -->
     <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
-         The other DBs can be refactored similarly with a single addAutoIncrement changeset. -->
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
     <changeSet author="sshah" id="enlarge_call_cache_entry_id" dbms="mysql,hsqldb,mariadb">
         <addAutoIncrement
                 columnName="CALL_CACHING_ENTRY_ID"
                 columnDataType="BIGINT"
                 incrementBy="1"
+                startWith="2147483648"
                 tableName="CALL_CACHING_ENTRY"
         />
     </changeSet>
@@ -68,7 +69,7 @@
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>alter sequence "CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq" as bigint;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
     </changeSet>
     <!-- END CALL_CACHING_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
@@ -39,14 +39,22 @@
     <!-- END dropping FKs -->
 
     <!-- BEGIN CALL_CACHING_ENTRY_ID PK widening -->
-    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
-         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
-    <changeSet author="sshah" id="enlarge_call_cache_entry_id" dbms="mysql,hsqldb,mariadb">
+    <!-- For HSQLDB and Postgres database there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. The start of autoincrement is set at 20,000,000,000. -->
+    <changeSet author="sshah" id="enlarge_call_cache_entry_id" dbms="hsqldb">
+        <modifyDataType
+                columnName="CALL_CACHING_ENTRY_ID"
+                tableName="CALL_CACHING_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="reset_call_cache_entry_id_autoincrement" dbms="mysql,hsqldb,mariadb">
         <addAutoIncrement
                 columnName="CALL_CACHING_ENTRY_ID"
                 columnDataType="BIGINT"
                 incrementBy="1"
-                startWith="2147483648"
+                startWith="20000000000"
                 tableName="CALL_CACHING_ENTRY"
         />
     </changeSet>
@@ -69,7 +77,7 @@
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_ENTRY_CALL_CACHING_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
@@ -117,7 +117,7 @@
 
     <!-- MariaDB's FK NotNull constraint does not survive the widening above and must be recreated explicitly. -->
     <!-- BEGIN Restoring FK NotNull constraint -->
-    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_aggregation_entry_fk" dbms="mariadb">
+    <changeSet author="sshah" id="mariadb_not_null_constraint_call_caching_aggregation_entry_fk" dbms="mariadb,mysql">
         <addNotNullConstraint
                 tableName="CALL_CACHING_AGGREGATION_ENTRY"
                 columnName="CALL_CACHING_ENTRY_ID"

--- a/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_cache_entry_ids.xml
@@ -158,7 +158,6 @@
                 baseTableName="CALL_CACHING_AGGREGATION_ENTRY"
                 referencedTableName="CALL_CACHING_ENTRY"
                 referencedColumnNames="CALL_CACHING_ENTRY_ID"
-                onDelete="CASCADE"
         />
     </changeSet>
 
@@ -169,7 +168,6 @@
                 baseTableName="CALL_CACHING_DETRITUS_ENTRY"
                 referencedTableName="CALL_CACHING_ENTRY"
                 referencedColumnNames="CALL_CACHING_ENTRY_ID"
-                onDelete="CASCADE"
         />
     </changeSet>
 
@@ -180,7 +178,6 @@
                 baseTableName="CALL_CACHING_HASH_ENTRY"
                 referencedTableName="CALL_CACHING_ENTRY"
                 referencedColumnNames="CALL_CACHING_ENTRY_ID"
-                onDelete="CASCADE"
         />
     </changeSet>
 
@@ -191,7 +188,6 @@
                 baseTableName="CALL_CACHING_SIMPLETON_ENTRY"
                 referencedTableName="CALL_CACHING_ENTRY"
                 referencedColumnNames="CALL_CACHING_ENTRY_ID"
-                onDelete="CASCADE"
         />
     </changeSet>
     <!-- END Restoring the FKs -->

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- BEGIN CALL_CACHING_AGGREGATION_ENTRY PK widening -->
+    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
+    <changeSet author="sshah" id="enlarge_call_caching_aggregation_entry_id" dbms="mysql,hsqldb,mariadb">
+        <addAutoIncrement
+                columnName="CALL_CACHING_AGGREGATION_ENTRY_ID"
+                columnDataType="BIGINT"
+                incrementBy="1"
+                startWith="2147483648"
+                tableName="CALL_CACHING_AGGREGATION_ENTRY"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_aggregation_entry_id" dbms="postgresql">
+        <modifyDataType
+                columnName="CALL_CACHING_AGGREGATION_ENTRY_ID"
+                tableName="CALL_CACHING_AGGREGATION_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_aggregation_entry_id_seq" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- idempotency check (noop if the sequence is present and already consistent what the alter would do) -->
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM information_schema.sequences
+                WHERE sequence_name = 'CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq'
+                AND data_type = 'bigint';
+            </sqlCheck>
+        </preConditions>
+        <sql>ALTER SEQUENCE "CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+    </changeSet>
+    <!-- END CALL_CACHING_AGGREGATION_ENTRY PK widening -->
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
@@ -5,14 +5,22 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <!-- BEGIN CALL_CACHING_AGGREGATION_ENTRY PK widening -->
-    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
-         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
-    <changeSet author="sshah" id="enlarge_call_caching_aggregation_entry_id" dbms="mysql,hsqldb,mariadb">
+    <!-- For HSQLDB and Postgres database there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. The start of autoincrement is set at 20,000,000,000. -->
+    <changeSet author="sshah" id="enlarge_call_cache_aggregation_entry_id" dbms="hsqldb">
+        <modifyDataType
+                columnName="CALL_CACHING_AGGREGATION_ENTRY_ID"
+                tableName="CALL_CACHING_AGGREGATION_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="reset_call_caching_aggregation_entry_id_autoincrement" dbms="mysql,hsqldb,mariadb">
         <addAutoIncrement
                 columnName="CALL_CACHING_AGGREGATION_ENTRY_ID"
                 columnDataType="BIGINT"
                 incrementBy="1"
-                startWith="2147483648"
+                startWith="20000000000"
                 tableName="CALL_CACHING_AGGREGATION_ENTRY"
         />
     </changeSet>
@@ -35,7 +43,7 @@
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_AGGREGATION_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
@@ -39,11 +39,11 @@
             <sqlCheck expectedResult="0">
                 SELECT count(*)
                 FROM information_schema.sequences
-                WHERE sequence_name = 'CC_AGGREGATION_ENTRY_CC_AGGREGATION_ENTRY_ID_seq'
+                WHERE sequence_name = 'CALL_CACHING_AGGREGATION_ENTR_CALL_CACHING_AGGREGATION_ENTR_seq'
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CC_AGGREGATION_ENTRY_CC_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_AGGREGATION_ENTR_CALL_CACHING_AGGREGATION_ENTR_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_AGGREGATION_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_aggregation_entry_id.xml
@@ -39,11 +39,11 @@
             <sqlCheck expectedResult="0">
                 SELECT count(*)
                 FROM information_schema.sequences
-                WHERE sequence_name = 'CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq'
+                WHERE sequence_name = 'CC_AGGREGATION_ENTRY_CC_AGGREGATION_ENTRY_ID_seq'
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_AGGREGATION_ENTRY_CALL_CACHING_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
+        <sql>ALTER SEQUENCE "CC_AGGREGATION_ENTRY_CC_AGGREGATION_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_AGGREGATION_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_detritus_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_detritus_entry_id.xml
@@ -5,14 +5,22 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <!-- BEGIN CALL_CACHING_DETRITUS_ENTRY PK widening -->
-    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
-         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
-    <changeSet author="sshah" id="enlarge_call_caching_detritus_entry_id" dbms="mysql,hsqldb,mariadb">
+    <!-- For HSQLDB and Postgres database there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. The start of autoincrement is set at 20,000,000,000. -->
+    <changeSet author="sshah" id="enlarge_call_cache_detritus_entry_id" dbms="hsqldb">
+        <modifyDataType
+                columnName="CALL_CACHING_DETRITUS_ENTRY_ID"
+                tableName="CALL_CACHING_DETRITUS_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="reset_call_caching_detritus_entry_id_autoincrement" dbms="mysql,hsqldb,mariadb">
         <addAutoIncrement
                 columnName="CALL_CACHING_DETRITUS_ENTRY_ID"
                 columnDataType="BIGINT"
                 incrementBy="1"
-                startWith="2147483648"
+                startWith="20000000000"
                 tableName="CALL_CACHING_DETRITUS_ENTRY"
         />
     </changeSet>
@@ -35,7 +43,7 @@
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_DETRITUS_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_DETRITUS_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_DETRITUS_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_detritus_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_detritus_entry_id.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- BEGIN CALL_CACHING_DETRITUS_ENTRY PK widening -->
+    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
+    <changeSet author="sshah" id="enlarge_call_caching_detritus_entry_id" dbms="mysql,hsqldb,mariadb">
+        <addAutoIncrement
+                columnName="CALL_CACHING_DETRITUS_ENTRY_ID"
+                columnDataType="BIGINT"
+                incrementBy="1"
+                startWith="2147483648"
+                tableName="CALL_CACHING_DETRITUS_ENTRY"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_detritus_entry_id" dbms="postgresql">
+        <modifyDataType
+                columnName="CALL_CACHING_DETRITUS_ENTRY_ID"
+                tableName="CALL_CACHING_DETRITUS_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_detritus_entry_id_seq" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- idempotency check (noop if the sequence is present and already consistent what the alter would do) -->
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM information_schema.sequences
+                WHERE sequence_name = 'CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_DETRITUS_ENTRY_ID_seq'
+                AND data_type = 'bigint';
+            </sqlCheck>
+        </preConditions>
+        <sql>ALTER SEQUENCE "CALL_CACHING_DETRITUS_ENTRY_CALL_CACHING_DETRITUS_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+    </changeSet>
+    <!-- END CALL_CACHING_DETRITUS_ENTRY PK widening -->
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
@@ -5,14 +5,22 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <!-- BEGIN CALL_CACHING_SIMPLETON_ENTRY PK widening -->
-    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
-         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
-    <changeSet author="sshah" id="enlarge_call_caching_simpleton_entry_id" dbms="mysql,hsqldb,mariadb">
+    <!-- For HSQLDB and Postgres database there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. The start of autoincrement is set at 20,000,000,000. -->
+    <changeSet author="sshah" id="enlarge_call_cache_simpleton_entry_id" dbms="hsqldb">
+        <modifyDataType
+                columnName="CALL_CACHING_SIMPLETON_ENTRY_ID"
+                tableName="CALL_CACHING_SIMPLETON_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="reset_call_caching_simpleton_entry_id_autoincrement" dbms="mysql,hsqldb,mariadb">
         <addAutoIncrement
                 columnName="CALL_CACHING_SIMPLETON_ENTRY_ID"
                 columnDataType="BIGINT"
                 incrementBy="1"
-                startWith="2147483648"
+                startWith="20000000000"
                 tableName="CALL_CACHING_SIMPLETON_ENTRY"
         />
     </changeSet>
@@ -35,7 +43,7 @@
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_SIMPLETON_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
@@ -39,11 +39,11 @@
             <sqlCheck expectedResult="0">
                 SELECT count(*)
                 FROM information_schema.sequences
-                WHERE sequence_name = 'CC_SIMPLETON_ENTRY_CC_SIMPLETON_ENTRY_ID_seq'
+                WHERE sequence_name = 'CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_I_seq'
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CC_SIMPLETON_ENTRY_CC_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_I_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_SIMPLETON_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
@@ -39,11 +39,11 @@
             <sqlCheck expectedResult="0">
                 SELECT count(*)
                 FROM information_schema.sequences
-                WHERE sequence_name = 'CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq'
+                WHERE sequence_name = 'CC_SIMPLETON_ENTRY_CC_SIMPLETON_ENTRY_ID_seq'
                 AND data_type = 'bigint';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
+        <sql>ALTER SEQUENCE "CC_SIMPLETON_ENTRY_CC_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_SIMPLETON_ENTRY PK widening -->
 

--- a/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
+++ b/database/migration/src/main/resources/changesets/enlarge_call_caching_simpleton_entry_id.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- BEGIN CALL_CACHING_SIMPLETON_ENTRY PK widening -->
+    <!-- For Postgresql there are 2 changesets: one for modifying the table column type, and another one for altering the autoincrementing sequence.
+         The other DBs can be refactored similarly with a single addAutoIncrement changeset. We also set the start of autoincrement at MAX_INT + 1. -->
+    <changeSet author="sshah" id="enlarge_call_caching_simpleton_entry_id" dbms="mysql,hsqldb,mariadb">
+        <addAutoIncrement
+                columnName="CALL_CACHING_SIMPLETON_ENTRY_ID"
+                columnDataType="BIGINT"
+                incrementBy="1"
+                startWith="2147483648"
+                tableName="CALL_CACHING_SIMPLETON_ENTRY"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_simpleton_entry_id" dbms="postgresql">
+        <modifyDataType
+                columnName="CALL_CACHING_SIMPLETON_ENTRY_ID"
+                tableName="CALL_CACHING_SIMPLETON_ENTRY"
+                newDataType="BIGINT"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_enlarge_call_caching_simpleton_entry_id_seq" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- idempotency check (noop if the sequence is present and already consistent what the alter would do) -->
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM information_schema.sequences
+                WHERE sequence_name = 'CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq'
+                AND data_type = 'bigint';
+            </sqlCheck>
+        </preConditions>
+        <sql>ALTER SEQUENCE "CALL_CACHING_SIMPLETON_ENTRY_CALL_CACHING_SIMPLETON_ENTRY_ID_seq" as bigint RESTART WITH 2147483648;</sql>
+    </changeSet>
+    <!-- END CALL_CACHING_SIMPLETON_ENTRY PK widening -->
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/reset_call_caching_hash_entry_id_autoincrement.xml
+++ b/database/migration/src/main/resources/changesets/reset_call_caching_hash_entry_id_autoincrement.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- BEGIN CALL_CACHING_HASH_ENTRY PK autoincrement reset -->
+    <!-- For Postgresql there is a different changeset for altering the autoincrementing sequence.
+         The other DBs can be refactored with a single addAutoIncrement changeset. The start of autoincrement is set at 20,000,000,000. -->
+    <changeSet author="sshah" id="reset_call_caching_hash_entry_id_autoincrement" dbms="mysql,hsqldb,mariadb">
+        <addAutoIncrement
+                columnName="CALL_CACHING_HASH_ENTRY_ID"
+                columnDataType="BIGINT"
+                incrementBy="1"
+                startWith="20000000000"
+                tableName="CALL_CACHING_HASH_ENTRY"
+        />
+    </changeSet>
+
+    <changeSet author="sshah" id="postgresql_reset_call_caching_hash_entry_id_autoincrement_seq" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- idempotency check (noop if the sequence is present and already consistent what the alter would do) -->
+            <sqlCheck expectedResult="0">
+                SELECT count(*)
+                FROM information_schema.sequences
+                WHERE sequence_name = 'RESET_CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq';
+            </sqlCheck>
+        </preConditions>
+        <sql>ALTER SEQUENCE "RESET_CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq" RESTART WITH 20000000000;</sql>
+    </changeSet>
+    <!-- END CALL_CACHING_HASH_ENTRY PK autoincrement reset -->
+
+</databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/reset_call_caching_hash_entry_id_autoincrement.xml
+++ b/database/migration/src/main/resources/changesets/reset_call_caching_hash_entry_id_autoincrement.xml
@@ -23,10 +23,10 @@
             <sqlCheck expectedResult="0">
                 SELECT count(*)
                 FROM information_schema.sequences
-                WHERE sequence_name = 'RESET_CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq';
+                WHERE sequence_name = 'CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq';
             </sqlCheck>
         </preConditions>
-        <sql>ALTER SEQUENCE "RESET_CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq" RESTART WITH 20000000000;</sql>
+        <sql>ALTER SEQUENCE "CALL_CACHING_HASH_ENTRY_CALL_CACHING_HASH_ENTRY_ID_seq" RESTART WITH 20000000000;</sql>
     </changeSet>
     <!-- END CALL_CACHING_HASH_ENTRY PK autoincrement reset -->
 

--- a/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/CallCachingSlickDatabase.scala
@@ -26,7 +26,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
       (List(j.callCachingEntry), List(j.callCachingHashEntries), List(j.callCachingSimpletonEntries), List(j.callCachingDetritusEntries), List(j.callCachingAggregationEntry.toList)) }
 
     // Use the supplied `assigner` function to assign parent entry row IDs into the parallel `Seq` of children entities.
-    def assignEntryIdsToChildren[C](ids: Seq[Int], groupingsOfChildren: Seq[Seq[C]], assigner: (Int, C) => C): Seq[C] = {
+    def assignEntryIdsToChildren[C](ids: Seq[Long], groupingsOfChildren: Seq[Seq[C]], assigner: (Long, C) => C): Seq[C] = {
       (ids zip groupingsOfChildren) flatMap { case (id, children) => children.map(assigner(id, _)) }
     }
 
@@ -36,10 +36,10 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     }
 
     // Functions to assign call cache entry IDs into child hash entry, simpleton, and detritus rows.
-    def hashAssigner(id: Int, hash: CallCachingHashEntry) = hash.copy(callCachingEntryId = Option(id))
-    def simpletonAssigner(id: Int, simpleton: CallCachingSimpletonEntry) = simpleton.copy(callCachingEntryId = Option(id))
-    def detritusAssigner(id: Int, detritus: CallCachingDetritusEntry) = detritus.copy(callCachingEntryId = Option(id))
-    def aggregationAssigner(id: Int, aggregation: CallCachingAggregationEntry) = aggregation.copy(callCachingEntryId = Option(id))
+    def hashAssigner(id: Long, hash: CallCachingHashEntry) = hash.copy(callCachingEntryId = Option(id))
+    def simpletonAssigner(id: Long, simpleton: CallCachingSimpletonEntry) = simpleton.copy(callCachingEntryId = Option(id))
+    def detritusAssigner(id: Long, detritus: CallCachingDetritusEntry) = detritus.copy(callCachingEntryId = Option(id))
+    def aggregationAssigner(id: Long, aggregation: CallCachingAggregationEntry) = aggregation.copy(callCachingEntryId = Option(id))
 
     val action = for {
       entryIds <- dataAccess.callCachingEntryIdsAutoInc ++= entries
@@ -85,8 +85,8 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
-  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Int])
-                                         (implicit ec: ExecutionContext): Future[Option[Int]] = {
+  override def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Long])
+                                         (implicit ec: ExecutionContext): Future[Option[Long]] = {
 
     val action = callCachePathPrefixes match {
       case None =>
@@ -104,7 +104,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
-  override def queryResultsForCacheId(callCachingEntryId: Int)
+  override def queryResultsForCacheId(callCachingEntryId: Long)
                                      (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]] = {
     val action = for {
       callCachingEntryOption <- dataAccess.
@@ -149,7 +149,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action)
   }
 
-  override def invalidateCall(callCachingEntryId: Int)
+  override def invalidateCall(callCachingEntryId: Long)
                              (implicit ec: ExecutionContext): Future[Option[CallCachingEntry]] = {
     val action = for {
       _ <- dataAccess.allowResultReuseForCallCachingEntryId(callCachingEntryId).update(false)
@@ -165,7 +165,7 @@ trait CallCachingSlickDatabase extends CallCachingSqlDatabase {
     runTransaction(action).void
   }
 
-  override def callCacheEntryIdsForWorkflowId(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Seq[Int]] = {
+  override def callCacheEntryIdsForWorkflowId(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Seq[Long]] = {
     val action = dataAccess.callCachingEntryIdsForWorkflowId(workflowExecutionUuid).result
     runTransaction(action)
   }

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -16,7 +16,7 @@ trait CallCachingAggregationEntryComponent {
 
     def inputFilesAggregation = column[Option[String]]("INPUT_FILES_AGGREGATION", O.Length(255))
 
-    def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
+    def callCachingEntryId = column[Long]("CALL_CACHING_ENTRY_ID")
 
     override def * = (baseAggregation, inputFilesAggregation, callCachingEntryId.?, callCachingAggregationEntryId.?) <>
       (CallCachingAggregationEntry.tupled, CallCachingAggregationEntry.unapply)
@@ -34,7 +34,7 @@ trait CallCachingAggregationEntryComponent {
     callCachingAggregationEntries.map(_.callCachingAggregationEntryId)
   
   val callCachingAggregationForCacheEntryId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingAggregationEntry <- callCachingAggregationEntries 
       if callCachingAggregationEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingAggregationEntry
@@ -69,7 +69,7 @@ trait CallCachingAggregationEntryComponent {
         (detritusPath.substring(0, prefix3Length) === prefix3)} yield ()).exists
   )
 
-  def callCachingEntriesForAggregatedHashes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]], excludedIds: Set[Int]) = {
+  def callCachingEntriesForAggregatedHashes(baseAggregation: Rep[String], inputFilesAggregation: Rep[Option[String]], excludedIds: Set[Long]) = {
     (for {
       callCachingEntry <- callCachingEntries
       if callCachingEntry.allowResultReuse && !(callCachingEntry.callCachingEntryId inSet excludedIds)
@@ -85,7 +85,7 @@ trait CallCachingAggregationEntryComponent {
                                                         prefix1: Rep[String], prefix1Length: Rep[Int],
                                                         prefix2: Rep[String], prefix2Length: Rep[Int],
                                                         prefix3: Rep[String], prefix3Length: Rep[Int],
-                                                        excludedIds: Set[Int]) = {
+                                                        excludedIds: Set[Long]) = {
     (for {
       callCachingEntry <- callCachingEntries
       if callCachingEntry.allowResultReuse && !(callCachingEntry.callCachingEntryId inSet excludedIds)

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingAggregationEntryComponent.scala
@@ -10,7 +10,7 @@ trait CallCachingAggregationEntryComponent {
   import driver.api._
 
   class CallCachingAggregationEntries(tag: Tag) extends Table[CallCachingAggregationEntry](tag, "CALL_CACHING_AGGREGATION_ENTRY") {
-    def callCachingAggregationEntryId = column[Int]("CALL_CACHING_AGGREGATION_ENTRY_ID", O.PrimaryKey, O.AutoInc)
+    def callCachingAggregationEntryId = column[Long]("CALL_CACHING_AGGREGATION_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
     def baseAggregation = column[String]("BASE_AGGREGATION", O.Length(255))
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
@@ -18,7 +18,7 @@ trait CallCachingDetritusEntryComponent {
 
     def detritusValue = column[Option[SerialClob]]("DETRITUS_VALUE")
 
-    def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
+    def callCachingEntryId = column[Long]("CALL_CACHING_ENTRY_ID")
 
     override def * = (detritusKey, detritusValue, callCachingEntryId.?, callCachingDetritusEntryId.?) <>
       (CallCachingDetritusEntry.tupled, CallCachingDetritusEntry.unapply)
@@ -37,7 +37,7 @@ trait CallCachingDetritusEntryComponent {
     callCachingDetritusEntries returning callCachingDetritusEntries.map(_.callCachingDetritusEntryId)
 
   val callCachingDetritusEntriesForCallCachingEntryId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingDetritusEntry <- callCachingDetritusEntries
       if callCachingDetritusEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingDetritusEntry

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingDetritusEntryComponent.scala
@@ -12,7 +12,7 @@ trait CallCachingDetritusEntryComponent {
 
   class CallCachingDetritusEntries(tag: Tag)
     extends Table[CallCachingDetritusEntry](tag, "CALL_CACHING_DETRITUS_ENTRY") {
-    def callCachingDetritusEntryId = column[Int]("CALL_CACHING_DETRITUS_ENTRY_ID", O.PrimaryKey, O.AutoInc)
+    def callCachingDetritusEntryId = column[Long]("CALL_CACHING_DETRITUS_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
     def detritusKey = column[String]("DETRITUS_KEY", O.Length(255))
 

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -9,7 +9,7 @@ trait CallCachingEntryComponent {
   import driver.api._
 
   class CallCachingEntries(tag: Tag) extends Table[CallCachingEntry](tag, "CALL_CACHING_ENTRY") {
-    def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID", O.PrimaryKey, O.AutoInc)
+    def callCachingEntryId = column[Long]("CALL_CACHING_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
     def workflowExecutionUuid = column[String]("WORKFLOW_EXECUTION_UUID", O.Length(255))
 
@@ -36,14 +36,14 @@ trait CallCachingEntryComponent {
   val callCachingEntryIdsAutoInc = callCachingEntries returning callCachingEntries.map(_.callCachingEntryId)
 
   val callCachingEntriesForId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingEntry <- callCachingEntries
       if callCachingEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingEntry
   )
 
   val allowResultReuseForCallCachingEntryId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingEntry <- callCachingEntries
       if callCachingEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingEntry.allowResultReuse

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingHashEntryComponent.scala
@@ -15,7 +15,7 @@ trait CallCachingHashEntryComponent {
 
     def hashValue = column[String]("HASH_VALUE", O.Length(255))
 
-    def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
+    def callCachingEntryId = column[Long]("CALL_CACHING_ENTRY_ID")
 
     override def * = (hashKey, hashValue, callCachingEntryId.?, callCachingHashEntryId.?) <>
       (CallCachingHashEntry.tupled, CallCachingHashEntry.unapply)
@@ -36,7 +36,7 @@ trait CallCachingHashEntryComponent {
     * Find all hashes for a CALL_CACHING_ENTRY_ID
     */
   val callCachingHashEntriesForCallCachingEntryId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingHashEntry <- callCachingHashEntries
       if callCachingHashEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingHashEntry

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
@@ -20,7 +20,7 @@ trait CallCachingSimpletonEntryComponent {
 
     def wdlType = column[String]("WDL_TYPE", O.Length(255))
 
-    def callCachingEntryId = column[Int]("CALL_CACHING_ENTRY_ID")
+    def callCachingEntryId = column[Long]("CALL_CACHING_ENTRY_ID")
 
     override def * = (simpletonKey, simpletonValue, wdlType, callCachingEntryId.?, callCachingSimpletonEntryId.?) <>
       (CallCachingSimpletonEntry.tupled, CallCachingSimpletonEntry.unapply)
@@ -41,7 +41,7 @@ trait CallCachingSimpletonEntryComponent {
     * Find all result simpletons which match a given CALL_CACHING_ENTRY_ID
     */
   val callCachingSimpletonEntriesForCallCachingEntryId = Compiled(
-    (callCachingEntryId: Rep[Int]) => for {
+    (callCachingEntryId: Rep[Long]) => for {
       callCachingSimpletonEntry <- callCachingSimpletonEntries
       if callCachingSimpletonEntry.callCachingEntryId === callCachingEntryId
     } yield callCachingSimpletonEntry

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingSimpletonEntryComponent.scala
@@ -12,7 +12,7 @@ trait CallCachingSimpletonEntryComponent {
 
   class CallCachingSimpletonEntries(tag: Tag)
     extends Table[CallCachingSimpletonEntry](tag, "CALL_CACHING_SIMPLETON_ENTRY") {
-    def callCachingSimpletonEntryId = column[Int]("CALL_CACHING_SIMPLETON_ENTRY_ID", O.PrimaryKey, O.AutoInc)
+    def callCachingSimpletonEntryId = column[Long]("CALL_CACHING_SIMPLETON_ENTRY_ID", O.PrimaryKey, O.AutoInc)
 
     def simpletonKey = column[String]("SIMPLETON_KEY", O.Length(255))
 

--- a/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/CallCachingSqlDatabase.scala
@@ -11,20 +11,20 @@ trait CallCachingSqlDatabase {
   def hasMatchingCallCachingEntriesForBaseAggregation(baseAggregationHash: String, callCachePathPrefixes: Option[List[String]])
                                                      (implicit ec: ExecutionContext): Future[Boolean]
 
-  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Int])
-                                (implicit ec: ExecutionContext): Future[Option[Int]]
+  def findCacheHitForAggregation(baseAggregationHash: String, inputFilesAggregationHash: Option[String], callCachePathPrefixes: Option[List[String]], excludedIds: Set[Long])
+                                (implicit ec: ExecutionContext): Future[Option[Long]]
 
-  def queryResultsForCacheId(callCachingEntryId: Int)
+  def queryResultsForCacheId(callCachingEntryId: Long)
                             (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
   
   def callCacheJoinForCall(workflowExecutionUuid: String, callFqn: String, index: Int)
                           (implicit ec: ExecutionContext): Future[Option[CallCachingJoin]]
 
-  def invalidateCall(callCachingEntryId: Int)
+  def invalidateCall(callCachingEntryId: Long)
                     (implicit ec: ExecutionContext): Future[Option[CallCachingEntry]]
 
   def invalidateCallCacheEntryIdsForWorkflowId(workflowExecutionUuid: String)
                                               (implicit ec: ExecutionContext): Future[Unit]
 
-  def callCacheEntryIdsForWorkflowId(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Seq[Int]]
+  def callCacheEntryIdsForWorkflowId(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Seq[Long]]
 }

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingAggregationEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingAggregationEntry.scala
@@ -4,6 +4,6 @@ case class CallCachingAggregationEntry
 (
   baseAggregation: String,
   inputFilesAggregation: Option[String],
-  callCachingEntryId: Option[Int] = None,
+  callCachingEntryId: Option[Long] = None,
   callCachingAggregationEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingAggregationEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingAggregationEntry.scala
@@ -5,5 +5,5 @@ case class CallCachingAggregationEntry
   baseAggregation: String,
   inputFilesAggregation: Option[String],
   callCachingEntryId: Option[Long] = None,
-  callCachingAggregationEntryId: Option[Int] = None
+  callCachingAggregationEntryId: Option[Long] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
@@ -6,6 +6,6 @@ case class CallCachingDetritusEntry
 (
   detritusKey: String,
   detritusValue: Option[SerialClob],
-  callCachingEntryId: Option[Int] = None,
+  callCachingEntryId: Option[Long] = None,
   callCachingDetritusEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingDetritusEntry.scala
@@ -7,5 +7,5 @@ case class CallCachingDetritusEntry
   detritusKey: String,
   detritusValue: Option[SerialClob],
   callCachingEntryId: Option[Long] = None,
-  callCachingDetritusEntryId: Option[Int] = None
+  callCachingDetritusEntryId: Option[Long] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingEntry.scala
@@ -8,5 +8,5 @@ case class CallCachingEntry
   jobAttempt: Option[Int],
   returnCode: Option[Int],
   allowResultReuse: Boolean,
-  callCachingEntryId: Option[Int] = None
+  callCachingEntryId: Option[Long] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingHashEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingHashEntry.scala
@@ -4,6 +4,6 @@ case class CallCachingHashEntry
 (
   hashKey: String,
   hashValue: String,
-  callCachingEntryId: Option[Int] = None,
+  callCachingEntryId: Option[Long] = None,
   callCachingHashEntryId: Option[Long] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
@@ -7,6 +7,6 @@ case class CallCachingSimpletonEntry
   simpletonKey: String,
   simpletonValue: Option[SerialClob],
   wdlType: String,
-  callCachingEntryId: Option[Int] = None,
+  callCachingEntryId: Option[Long] = None,
   callCachingSimpletonEntryId: Option[Int] = None
 )

--- a/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/tables/CallCachingSimpletonEntry.scala
@@ -8,5 +8,5 @@ case class CallCachingSimpletonEntry
   simpletonValue: Option[SerialClob],
   wdlType: String,
   callCachingEntryId: Option[Long] = None,
-  callCachingSimpletonEntryId: Option[Int] = None
+  callCachingSimpletonEntryId: Option[Long] = None
 )

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/deletion/DeleteWorkflowFilesActor.scala
@@ -206,7 +206,7 @@ class DeleteWorkflowFilesActor(rootWorkflowId: RootWorkflowId,
   }
 
 
-  private def fetchCallCacheEntries(callCache: CallCache): Future[Set[Int]] = {
+  private def fetchCallCacheEntries(callCache: CallCache): Future[Set[Long]] = {
     val callCacheEntryIdsFuture = rootAndSubworkflowIds.map(x => callCache.callCacheEntryIdsForWorkflowId(x.toString)).map { f =>
       f.map { Success(_) }.recover { case t => Failure(t) }}
 
@@ -265,7 +265,7 @@ object DeleteWorkflowFilesActor {
   object StartWorkflowFilesDeletion extends DeleteWorkflowFilesActorMessage
   object DeleteFiles extends DeleteWorkflowFilesActorMessage
   object InvalidateCallCache extends DeleteWorkflowFilesActorMessage
-  case class RetrievedCallCacheIds(ids: Set[Int]) extends DeleteWorkflowFilesActorMessage
+  case class RetrievedCallCacheIds(ids: Set[Long]) extends DeleteWorkflowFilesActorMessage
   case class FailedRetrieveCallCacheIds(throwable: Throwable) extends DeleteWorkflowFilesActorMessage
 
   // Actor states
@@ -319,18 +319,18 @@ object DeleteWorkflowFilesActor {
     }
   }
 
-  case class WaitingForInvalidateCCResponsesData(commandsToWaitFor: Set[Int],
+  case class WaitingForInvalidateCCResponsesData(commandsToWaitFor: Set[Long],
                                                  deleteErrors: List[Throwable],
                                                  filesNotFound: List[Path],
                                                  callCacheInvalidationErrors: List[Throwable] = List.empty)
-    extends WaitingForResponseFromActorData[Int](commandsToWaitFor) with DeleteWorkflowFilesActorStateData {
+    extends WaitingForResponseFromActorData[Long](commandsToWaitFor) with DeleteWorkflowFilesActorStateData {
 
     override def assertionFailureMsg(expectedSize: Int, requiredSize: Int): String = {
       s"Found updated call cache entries set size as $expectedSize instead of $requiredSize. The updated set of call cache entries" +
         s" that DeleteWorkflowFilesActor has to wait for should be 1 less after a call cache entry is invalidated."
     }
 
-    override def setCommandsToWaitFor(updatedCommandsToWaitFor: Set[Int]): WaitingForResponseFromActorData[Int] = {
+    override def setCommandsToWaitFor(updatedCommandsToWaitFor: Set[Long]): WaitingForResponseFromActorData[Long] = {
       this.copy(commandsToWaitFor = updatedCommandsToWaitFor)
     }
   }

--- a/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaMultipleCallCacheCopyAttemptsSpec.scala
+++ b/server/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ejea/EjeaMultipleCallCacheCopyAttemptsSpec.scala
@@ -31,7 +31,7 @@ class EjeaMultipleCallCacheCopyAttemptsSpec
     // Arbitrary.
     // When we attempt the nth copy attempt, we'll say that the cache entry ID is 'n' plus this offset.
     // Just makes sure that we're treating the copy attempt and the hit ID as separate numbers.
-    def cacheEntryIdFromCopyAttempt(attempt: Int) = CallCachingEntryId(75 + attempt)
+    def cacheEntryIdFromCopyAttempt(attempt: Int) = CallCachingEntryId(75L + attempt.toLong)
 
     def ejhaSendsHitIdToEjeaAndEjeaReacts(copyAttemptNumber: Int) = {
       val callCachingEntryId = cacheEntryIdFromCopyAttempt(copyAttemptNumber)

--- a/services/src/main/scala/cromwell/services/CallCaching.scala
+++ b/services/src/main/scala/cromwell/services/CallCaching.scala
@@ -1,5 +1,5 @@
 package cromwell.services
 
 object CallCaching {
-  final case class CallCachingEntryId(id: Int)
+  final case class CallCachingEntryId(id: Long)
 }

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/callcaching/PipelinesApiBackendCacheHitCopyingActorSpec.scala
@@ -518,7 +518,7 @@ class PipelinesApiBackendCacheHitCopyingActorSpec extends TestKitSuite
     actorUnderTest
   }
 
-  private def buildCopyCommand(hitId: Int, bucket: String): CopyOutputsCommand = {
+  private def buildCopyCommand(hitId: Long, bucket: String): CopyOutputsCommand = {
     val callRoot = s"gs://$bucket/workflow-id/call-name"
     val rcFile = callRoot + "/rc"
 


### PR DESCRIPTION
This PR:
- embiggens PK of  `CALL_CACHING_ENTRY` table updates it's associated FK constraints
- embiggens PK of  `CALL_CACHING_AGGREGATION_ENTRY` table
- embiggens PK of  `CALL_CACHING_DETRITUS_ENTRY` table
- embiggens PK of  `CALL_CACHING_SIMPLETON_ENTRY` table

And sets the auto-increment counter of above tables and `CALL_CACHING_HASH_ENTRY` table to 20,000,000,000.

See more details for this change in [this document](https://docs.google.com/document/d/1AyWVVf2pHA6BukYo3yPG2f3CZ8dTWk7F-c9KZC9WMjg/edit#heading=h.a69ivurg93m6).

Reference - https://github.com/broadinstitute/cromwell/pull/5379

Remediation for https://broadworkbench.atlassian.net/browse/PROD-707