### PR TITLE
Update FiveMinuteIntro: Java 11 requirement

### DIFF
--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -6,8 +6,9 @@ You are strongly encouraged to use the latest release of Cromwell whenever possi
 Cromwell is distributed as a conda package on [conda-forge](https://conda-forge.org/).
 These instructions need to be followed for [installing the miniconda distribution](https://docs.conda.io/en/latest/miniconda.html) and 
 [activating the conda-forge channel](https://conda-forge.org/#about). After this Cromwell can be installed in the 
-base environment with `conda install cromwell` or a separate environment for Cromwell can be created with 
-`conda create -n cromwell cromwell`. If you are using Cromwell for bioinformatics workflows, you might like to take
+base environment with `conda install -c conda-forge cromwell` or a separate environment for Cromwell can be created with 
+`conda create -n cromwell cromwell` (be sure to activate the conda-forge channel first). 
+If you are using Cromwell for bioinformatics workflows, you might like to take
 a look at [bioconda](http://bioconda.github.io)  as well. 
 The conda installation of Cromwell comes with a wrapper that locates the jar for you and allows for running Cromwell or Womtool with a 
 `cromwell run`, `womtool validate` or other command. Conda also installs the required Java dependency 

--- a/docs/tutorials/FiveMinuteIntro.md
+++ b/docs/tutorials/FiveMinuteIntro.md
@@ -4,7 +4,7 @@
 
 * A Unix-based operating system (yes, that includes Mac!)
 * A Java 11 runtime environment 
-    * You can see what you have by running `$ java -version` on a terminal. You're looking for a version that's at least `1.11` or higher.
+    * You can see what you have by running `$ java -version` on a terminal.
     * If not, consider installing via conda or brew [as explained here](../Releases.md).
     * We recommend [SDKMAN](https://sdkman.io/install) to install the latest 11 build of [Temurin](https://adoptium.net/temurin/releases/?version=11)
       * `sdk install java 11.0.16-tem` as of the time of this writing

--- a/docs/tutorials/FiveMinuteIntro.md
+++ b/docs/tutorials/FiveMinuteIntro.md
@@ -4,9 +4,9 @@
 
 * A Unix-based operating system (yes, that includes Mac!)
 * A Java 11 runtime environment 
-	* You can see what you have by running `$ java -version` on a terminal. 
-	* If not, you can download Java [here](https://adoptopenjdk.net/).
-	* You might need to update the `export JAVA_HOME` in your bash profile to point to your JAVA install location.
+    * You can see what you have by running `$ java -version` on a terminal. You're looking for a version that's at least `1.11` or higher.
+    * If not, consider installing via conda or brew [as explained here](https://github.com/broadinstitute/cromwell/blob/83/docs/Releases.md), or you can download Java [here](https://adoptopenjdk.net/).
+    * You might need to update the `export JAVA_HOME` in your bash profile to point to your JAVA install location.
 * A sense of adventure!
 
 ### Goals

--- a/docs/tutorials/FiveMinuteIntro.md
+++ b/docs/tutorials/FiveMinuteIntro.md
@@ -5,7 +5,9 @@
 * A Unix-based operating system (yes, that includes Mac!)
 * A Java 11 runtime environment 
     * You can see what you have by running `$ java -version` on a terminal. You're looking for a version that's at least `1.11` or higher.
-    * If not, consider installing via conda or brew [as explained here](https://github.com/broadinstitute/cromwell/blob/83/docs/Releases.md), or you can download Java [here](https://adoptopenjdk.net/).
+    * If not, consider installing via conda or brew [as explained here](../Releases.md).
+    * We recommend [SDKMAN](https://sdkman.io/install) to install the latest 11 build of [Temurin](https://adoptium.net/temurin/releases/?version=11)
+      * `sdk install java 11.0.16-tem` as of the time of this writing
     * You might need to update the `export JAVA_HOME` in your bash profile to point to your JAVA install location.
 * A sense of adventure!
 


### PR DESCRIPTION
I have 
```
java version "1.8.0_172"
Java(TM) SE Runtime Environment (build 1.8.0_172-b11)
```
and I was getting 
```
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/hsqldb/jdbcDriver has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at com.zaxxer.hikari.HikariConfig.attemptFromContextLoader(HikariConfig.java:970)
	at com.zaxxer.hikari.HikariConfig.setDriverClassName(HikariConfig.java:480)
	at slick.jdbc.hikaricp.HikariCPJdbcDataSource$.$anonfun$forConfig$3(HikariCPJdbcDataSource.scala:33)
	at slick.jdbc.hikaricp.HikariCPJdbcDataSource$.$anonfun$forConfig$3$adapted(HikariCPJdbcDataSource.scala:33)
	at scala.Option.foreach(Option.scala:437)
	at slick.jdbc.hikaricp.HikariCPJdbcDataSource$.forConfig(HikariCPJdbcDataSource.scala:33)
	at slick.jdbc.hikaricp.HikariCPJdbcDataSource$.forConfig(HikariCPJdbcDataSource.scala:21)
	at slick.jdbc.JdbcDataSource$.forConfig(JdbcDataSource.scala:47)
	at slick.jdbc.JdbcBackend$DatabaseFactoryDef.forConfig(JdbcBackend.scala:341)
	at slick.jdbc.JdbcBackend$DatabaseFactoryDef.forConfig$(JdbcBackend.scala:337)
	at slick.jdbc.JdbcBackend$$anon$1.forConfig(JdbcBackend.scala:32)
	at slick.jdbc.JdbcBackend.createDatabase(JdbcBackend.scala:35)
	at slick.jdbc.JdbcBackend.createDatabase$(JdbcBackend.scala:35)
	at slick.jdbc.JdbcBackend$.createDatabase(JdbcBackend.scala:574)
	at slick.jdbc.JdbcBackend$.createDatabase(JdbcBackend.scala:574)
	at slick.basic.DatabaseConfig$$anon$1.db$lzycompute(DatabaseConfig.scala:103)
	at slick.basic.DatabaseConfig$$anon$1.db(DatabaseConfig.scala:102)
	at cromwell.database.slick.SlickDatabase.<init>(SlickDatabase.scala:73)
	at cromwell.database.slick.EngineSlickDatabase.<init>(EngineSlickDatabase.scala:15)
	at cromwell.database.slick.EngineSlickDatabase$.fromParentConfig(EngineSlickDatabase.scala:10)
	at cromwell.services.EngineServicesStore$.engineDatabaseInterface$lzycompute(EngineServicesStore.scala:13)
	at cromwell.services.EngineServicesStore$.engineDatabaseInterface(EngineServicesStore.scala:12)
	at cromwell.server.CromwellSystem.$init$(CromwellSystem.scala:27)
	at cromwell.CromwellEntryPoint$$anon$1.<init>(CromwellEntryPoint.scala:122)
	at cromwell.CromwellEntryPoint$.$anonfun$buildCromwellSystem$1(CromwellEntryPoint.scala:122)
	at scala.util.Try$.apply(Try.scala:210)
	at cromwell.CromwellEntryPoint$.buildCromwellSystem(CromwellEntryPoint.scala:122)
	at cromwell.CromwellEntryPoint$.runSingle(CromwellEntryPoint.scala:65)
	at cromwell.CromwellApp$.runCromwell(CromwellApp.scala:14)
	at cromwell.CromwellApp$.delayedEndpoint$cromwell$CromwellApp$1(CromwellApp.scala:25)
	at cromwell.CromwellApp$delayedInit$body.apply(CromwellApp.scala:3)
	at scala.Function0.apply$mcV$sp(Function0.scala:39)
	at scala.Function0.apply$mcV$sp$(Function0.scala:39)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
	at scala.App.$anonfun$main$1(App.scala:76)
	at scala.App.$anonfun$main$1$adapted(App.scala:76)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at scala.App.main(App.scala:76)
	at scala.App.main$(App.scala:74)
	at cromwell.CromwellApp$.main(CromwellApp.scala:3)
	at cromwell.CromwellApp.main(CromwellApp.scala)
```
when trying to run Cromwell 83.  I see that the Java requirement has been updated to 1.11, but it's still listed as Java 1.8 in this documentation.