### PR TITLE
BT-732 Checksum validation for blobs read by engine

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -131,12 +131,12 @@ class NioFlow(parallelism: Int,
       for {
         fileHash <- getStoredHash(command.file)
         uncheckedValue <- readFile
-        checksumResult = fileHash match {
+        checksumResult <- fileHash match {
           case Some(hash) => checkHash(uncheckedValue, hash)
           // If there is no stored checksum, don't attempt to validate.
           // If the missing checksum is itself an error condition, that
           // should be detected by the code that gets the FileHash.
-          case None => ChecksumSkipped
+          case None => IO.pure(ChecksumSkipped)
         }
         verifiedValue <- checksumResult match {
           case _: ChecksumSkipped => IO.pure(uncheckedValue)

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -143,7 +143,11 @@ class NioFlow(parallelism: Int,
           case _: ChecksumSuccess => IO.pure(uncheckedValue)
           case failure: ChecksumFailure => IO.raiseError(
             ChecksumFailedException(
-              s"Failed checksum for '${command.file}'. Expected '${fileHash.map(_.hashType).getOrElse("<MISSING>")}' hash of '${fileHash.map(_.hash).getOrElse("<MISSING>")}'. Calculated hash '${failure.calculatedHash}'")
+              fileHash match {
+                case Some(hash) => s"Failed checksum for '${command.file}'. Expected '${hash.hashType}' hash of '${hash.hash}'. Calculated hash '${failure.calculatedHash}'"
+                case None => s"Failed checksum for '${command.file}'. Couldn't find stored file hash." // This should never happen
+              }
+            )
           )
         }
       } yield verifiedValue

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -20,13 +20,14 @@ import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.flatspec.AsyncFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import common.mock.MockSugar
+import cromwell.filesystems.blob.BlobPath
 
 import java.nio.file.NoSuchFileException
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Failure
+import scala.util.{Failure, Success}
 import scala.util.control.NoStackTrace
 
 class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with MockSugar {
@@ -168,6 +169,25 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
         case (ack, _) =>
           fail(s"read returned an unexpected message:\n$ack\n\n")
       }
+    }
+  }
+
+  it should "succeed if a BlobPath is missing a stored hash" in {
+    val testPath = mock[BlobPath]
+    when(testPath.limitFileContent(any[Option[Int]], any[Boolean])(any[ExecutionContext]))
+      .thenReturn("hello there".getBytes)
+    when(testPath.getMd5)
+      .thenReturn(Success(None))
+
+    val context = DefaultCommandContext(contentAsStringCommand(testPath, Option(100), failOnOverflow = true).get, replyTo)
+    val testSource = Source.single(context)
+
+    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
+
+    stream.run() map {
+      case (success: IoSuccess[_], _) => assert(success.result.asInstanceOf[String] == "hello there")
+      case (ack, _) =>
+        fail(s"read returned an unexpected message:\n$ack\n\n")
     }
   }
 

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -22,12 +22,13 @@ import org.scalatest.matchers.should.Matchers
 import common.mock.MockSugar
 import cromwell.filesystems.blob.BlobPath
 
+import java.io.ByteArrayInputStream
 import java.nio.file.NoSuchFileException
 import java.util.UUID
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.util.control.NoStackTrace
 
 class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with MockSugar {
@@ -128,6 +129,42 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     }
   }
 
+  it should "get hash from a BlobPath when stored hash exists" in {
+    val testPath = mock[BlobPath]
+    val hashString = "2d01d5d9c24034d54fe4fba0ede5182d" // echo "hello there" | md5sum
+    testPath.md5HexString returns Try(Option(hashString))
+
+    val context = DefaultCommandContext(hashCommand(testPath).get, replyTo)
+    val testSource = Source.single(context)
+
+    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
+
+    stream.run() map {
+      case (success: IoSuccess[_], _) => assert(success.result.asInstanceOf[String] == hashString)
+      case (ack, _) =>
+        fail(s"read returned an unexpected message:\n$ack\n\n")
+    }
+  }
+
+  // TODO working on this
+  ignore should "get hash from a BlobPath when stored hash does not exist" in {
+    val testPath = mock[BlobPath]
+    val hashString = "2d01d5d9c24034d54fe4fba0ede5182d" // echo "hello there" | md5sum
+    testPath.md5HexString returns Try(None)
+    testPath.newInputStream returns new ByteArrayInputStream("hello there".getBytes)
+
+    val context = DefaultCommandContext(hashCommand(testPath).get, replyTo)
+    val testSource = Source.single(context)
+
+    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
+
+    stream.run() map {
+      case (success: IoSuccess[_], _) => assert(success.result.asInstanceOf[String] == hashString)
+      case (ack, _) =>
+        fail(s"read returned an unexpected message:\n$ack\n\n")
+    }
+  }
+
   it should "fail if DrsPath hash doesn't match checksum" in {
     val testPath = mock[DrsPath]
     when(testPath.limitFileContent(any[Option[Int]], any[Boolean])(any[ExecutionContext])).thenReturn("hello".getBytes)
@@ -176,7 +213,7 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     val testPath = mock[BlobPath]
     when(testPath.limitFileContent(any[Option[Int]], any[Boolean])(any[ExecutionContext]))
       .thenReturn("hello there".getBytes)
-    when(testPath.getMd5)
+    when(testPath.md5HexString)
       .thenReturn(Success(None))
 
     val context = DefaultCommandContext(contentAsStringCommand(testPath, Option(100), failOnOverflow = true).get, replyTo)

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -146,25 +146,6 @@ class NioFlowSpec extends TestKitSuite with AsyncFlatSpecLike with Matchers with
     }
   }
 
-  // TODO working on this
-  ignore should "get hash from a BlobPath when stored hash does not exist" in {
-    val testPath = mock[BlobPath]
-    val hashString = "2d01d5d9c24034d54fe4fba0ede5182d" // echo "hello there" | md5sum
-    testPath.md5HexString returns Try(None)
-    testPath.newInputStream returns new ByteArrayInputStream("hello there".getBytes)
-
-    val context = DefaultCommandContext(hashCommand(testPath).get, replyTo)
-    val testSource = Source.single(context)
-
-    val stream = testSource.via(flow).toMat(readSink)(Keep.right)
-
-    stream.run() map {
-      case (success: IoSuccess[_], _) => assert(success.result.asInstanceOf[String] == hashString)
-      case (ack, _) =>
-        fail(s"read returned an unexpected message:\n$ack\n\n")
-    }
-  }
-
   it should "fail if DrsPath hash doesn't match checksum" in {
     val testPath = mock[DrsPath]
     when(testPath.limitFileContent(any[Option[Int]], any[Boolean])(any[ExecutionContext])).thenReturn("hello".getBytes)

--- a/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/nio/NioFlowSpec.scala
@@ -22,7 +22,6 @@ import org.scalatest.matchers.should.Matchers
 import common.mock.MockSugar
 import cromwell.filesystems.blob.BlobPath
 
-import java.io.ByteArrayInputStream
 import java.nio.file.NoSuchFileException
 import java.util.UUID
 import scala.concurrent.ExecutionContext

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -91,12 +91,12 @@ case class BlobPath private[blob](nioPath: NioPath, endpoint: String, container:
 
   override def pathWithoutScheme: String = parseURI(endpoint).getHost + "/" + container + "/" + nioPath.toString()
 
-  def getMd5: Option[String] = {
-    val headers = Files.readAttributes(nioPath, classOf[AzureBlobFileAttributes]).blobHttpHeaders()
-    Option(headers.getContentMd5) match {
-      case None => None
-      case Some(arr) if arr.isEmpty => None
-      case Some(bytes) => Some(bytes.map("%02x".format(_)).mkString)
-    }
+  def getMd5: Try[Option[String]] = {
+    Try(Files.readAttributes(nioPath, classOf[AzureBlobFileAttributes]).blobHttpHeaders())
+      .map(h => Option(h.getContentMd5) match {
+        case None => None
+        case Some(arr) if arr.isEmpty => None
+        case Some(bytes) => Option(bytes.map("%02x".format(_)).mkString)
+      })
   }
 }

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -94,11 +94,13 @@ case class BlobPath private[blob](nioPath: NioPath, endpoint: String, container:
   def blobFileAttributes: Try[AzureBlobFileAttributes] =
     Try(Files.readAttributes(nioPath, classOf[AzureBlobFileAttributes]))
 
-  def getMd5: Try[Option[String]] = {
+  def md5HexString: Try[Option[String]] = {
     blobFileAttributes.map(h =>
       Option(h.blobHttpHeaders().getContentMd5) match {
         case None => None
         case Some(arr) if arr.isEmpty => None
+        // Convert the bytes to a hex-encoded string. Note that this value
+        // is rendered in base64 in the Azure web portal.
         case Some(bytes) => Option(bytes.map("%02x".format(_)).mkString)
       }
     )


### PR DESCRIPTION
In addition to automated testing I tested workflow execution locally with an engine-read file. I confirmed we get the expected results:
 * Matching md5 -> workflow succeeds
 * Absent md5 -> workflow succeeds
 * Mismatched md5 -> workflow fails
 * Manually restored correct md5 -> workflow succeeds