### PR TITLE
BW-1393 Traditional post-release doc updates

### DIFF
--- a/processes/release_processes/README.MD
+++ b/processes/release_processes/README.MD
@@ -45,7 +45,8 @@ The release WDL uses a github token to perform actions on your behalf.
 Make or copy the following files into a temporary `release/` directory outside the Cromwell repository. This removes any chance of committing your token.
 
 * A copy of the workflow file to run (https://github.com/broadinstitute/cromwell/blob/develop/publish/publish_workflow.wdl)
-* An inputs json like this:
+* An inputs json like this one.
+  * `publishHomebrew` is `false` due to Homebrew taking on this part themselves. Homebrew remains an active distribution channel. 
 
 ```json
 {

--- a/publish/publish_inputs.json
+++ b/publish/publish_inputs.json
@@ -1,7 +1,7 @@
 {
-  "publish_workflow.githubToken": "<<REQUIRED: GithubAPIToken (value, not path)>>",
-  "publish_workflow.organization": "<<REQUIRED: broadinstitute for a real release, your github username if testing>>",
-  "publish_workflow.publishDocker": <<OPTIONAL: the docker image to use for publishing, default broadinstitute/cromwell-publish:latest>>,
-  "publish_workflow.majorRelease": <<OPTIONAL: true for a major release, false for a minor release, default true>>,
-  "publish_workflow.publishHomebrew": <<OPTIONAL: true to publish release to homebrew, false to skip, default true>>
+  "publish_workflow.githubToken": "<<GITHUB TOKEN VALUE>>",
+  "publish_workflow.majorRelease": true,
+  "publish_workflow.publishHomebrew": false,
+  "publish_workflow.publishDocker": "broadinstitute/cromwell-publish:latest",
+  "publish_workflow.organization": "broadinstitute"
 }


### PR DESCRIPTION
- Align `publish_inputs.json` file in repo with contents of README
- Clarify meaning of `publishHomebrew` key