### PR TITLE
WX-755 On merge, build all images instead of just Cromwell

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -48,12 +48,12 @@ jobs:
       with:
         username: dsdejenkins
         password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
     - name: Build Cromwell Docker
       run: |
         set -e
         cd cromwell
-        sbt server/docker
-        docker push broadinstitute/cromwell:$CROMWELL_SNAP_VERSION
+        sbt dockerBuildAndPush
     - name: Edit & push chart
       env:
         BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes a minor oversight that became apparent on attempting to deploy `cromwell-drs-localizer` on the new weekly cycle.

To view the images that `dockerBuildAndPush` will make, issue this command. `perf` is designated ["build but don't push"](https://github.com/broadinstitute/cromwell/blob/95c550e0defdf653ba25f0528648e77b46148cae/build.sbt#L367) which is why it is not present in Docker Hub. (It may be completely obsolete at this point, but that's a story for a different day.)
```
> show docker::imageNames
[info] server / docker / imageNames
[info] 	ArrayBuffer(broadinstitute/cromwell:85, broadinstitute/cromwell:85-443a6fc)
[info] cromiam / docker / imageNames
[info] 	ArrayBuffer(broadinstitute/cromiam:85, broadinstitute/cromiam:85-443a6fc)
[info] perf / docker / imageNames
[info] 	ArrayBuffer(broadinstitute/perf:85, broadinstitute/perf:85-443a6fc)
[info] womtool / docker / imageNames
[info] 	ArrayBuffer(broadinstitute/womtool:85, broadinstitute/womtool:85-443a6fc)
[info] cromwell-drs-localizer / docker / imageNames
[info] 	ArrayBuffer(broadinstitute/cromwell-drs-localizer:85, broadinstitute/cromwell-drs-localizer:85-443a6fc)
```