### PR TITLE
WX-755 Add `isRelease` option for Docker builds

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         set -e
         cd cromwell
-        sbt -Dproject.isSnapshot=false -Dproject.skipRelease=true dockerBuildAndPush
+        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
     - name: Edit & push chart
       env:
         BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         set -e
         cd cromwell
-        sbt dockerBuildAndPush
+        sbt -Dproject.isSnapshot=false -Dproject.skipRelease=true dockerBuildAndPush
     - name: Edit & push chart
       env:
         BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -40,12 +40,12 @@ object Publishing {
         // Tag looks like `85-443a6fc-SNAP`
         version.value
       } else {
-        if (Version.skipRelease) {
-          // Tag looks like `85-443a6fc`
-          version.value
-        } else {
+        if (Version.isRelease) {
           // Tags look like `85`, `85-443a6fc`
           s"$cromwellVersion,${version.value}"
+        } else {
+          // Tag looks like `85-443a6fc`
+          version.value
         }
       }
 

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -36,7 +36,19 @@ object Publishing {
       ArrayBuffer(broadinstitute/cromwell:dev, broadinstitute/cromwell:develop)
     */
     dockerTags := {
-      val versionsCsv = if (Version.isSnapshot) version.value else s"$cromwellVersion,${version.value}"
+      val versionsCsv = if (Version.isSnapshot) {
+        // Tag looks like `85-443a6fc-SNAP`
+        version.value
+      } else {
+        if (Version.skipRelease) {
+          // Tag looks like `85-443a6fc`
+          version.value
+        } else {
+          // Tags look like `85`, `85-443a6fc`
+          s"$cromwellVersion,${version.value}"
+        }
+      }
+
       sys.env.getOrElse("CROMWELL_SBT_DOCKER_TAGS", versionsCsv).split(",")
     },
     docker / imageNames := dockerTags.value map { tag =>

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -49,6 +49,7 @@ object Publishing {
         }
       }
 
+      // Travis applies (as of 10/22) the `dev` and `develop` tags on merge to `develop`
       sys.env.getOrElse("CROMWELL_SBT_DOCKER_TAGS", versionsCsv).split(",")
     },
     docker / imageNames := dockerTags.value map { tag =>

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -23,9 +23,9 @@ object Version {
     *
     * Has no effect when `isSnapshot` is `true`.
     *
-    * Default `false`.
+    * Default `true`.
     */
-  val skipRelease: Boolean = !sys.props.get("project.skipRelease").forall(_.toBoolean)
+  val isRelease: Boolean = sys.props.get("project.skipRelease").forall(_.toBoolean)
 
   // Adapted from SbtGit.versionWithGit
   def cromwellVersionWithGit: Seq[Setting[_]] =

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -25,7 +25,7 @@ object Version {
     *
     * Default `true`.
     */
-  val isRelease: Boolean = sys.props.get("project.skipRelease").forall(_.toBoolean)
+  val isRelease: Boolean = sys.props.get("project.isRelease").forall(_.toBoolean)
 
   // Adapted from SbtGit.versionWithGit
   def cromwellVersionWithGit: Seq[Setting[_]] =

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -13,8 +13,19 @@ object Version {
     *
     * The value is read in directly from the system property `project.isSnapshot` as there were confusing issues with
     * the multi-project and sbt.Keys#isSnapshot().
+    *
+    * Default `true`.
     */
-  val isSnapshot = sys.props.get("project.isSnapshot").forall(_.toBoolean)
+  val isSnapshot: Boolean = sys.props.get("project.isSnapshot").forall(_.toBoolean)
+
+  /**
+    * Returns `true` if this project should NOT tag a release like `85` in addition to a hash like `85-443a6fc`.
+    *
+    * Has no effect when `isSnapshot` is `true`.
+    *
+    * Default `false`.
+    */
+  val skipRelease: Boolean = !sys.props.get("project.skipRelease").forall(_.toBoolean)
 
   // Adapted from SbtGit.versionWithGit
   def cromwellVersionWithGit: Seq[Setting[_]] =

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -19,7 +19,7 @@ object Version {
   val isSnapshot: Boolean = sys.props.get("project.isSnapshot").forall(_.toBoolean)
 
   /**
-    * Returns `true` if this project should NOT tag a release like `85` in addition to a hash like `85-443a6fc`.
+    * Returns `true` if this project should tag a release like `85` in addition to a hash like `85-443a6fc`.
     *
     * Has no effect when `isSnapshot` is `true`.
     *


### PR DESCRIPTION
Adds support for automatically publishing Docker images that are less formal than numbered releases but are suitable for production due to their non-designation as development snapshots `-SNAP`.

- `85-443a6fc-SNAP` for testing images of code not merged to develop
  - Explicit: `sbt -Dproject.isSnapshot=true -Dproject.isRelease=<ANY> dockerBuildAndPush`
  - [Accepting defaults: `sbt dockerBuildAndPush`](https://github.com/broadinstitute/cromwell/blob/b432e640e6978030c8a111119a267bdfc564c36c/src/ci/bin/test.inc.sh#L1216)
- **New** `85-443a6fc` for images of commits merged to develop and ready for Terra
  - Explicit: `sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush`
- `85` for full shrink-wrapped releases
  - Explicit: `sbt -Dproject.isSnapshot=false -Dproject.isRelease=true dockerBuildAndPush`
  - [Accepting defaults: `sbt -Dproject.isSnapshot=false dockerBuildAndPush`](https://github.com/broadinstitute/cromwell/blob/e28dcb12257f82f340d5db4edb4e7d1ca6e6dbc9/publish/publish_workflow.wdl#L55)

I went out of my way to make sure existing invocations keep working the same via defaults. Updating the whole codebase, Travis, Jenkins, and who knows what else is not something I want to sign up for at the moment.