### PR TITLE
WX-755 Cromwell automatically deploys to dev & boards train on merge

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -41,7 +41,7 @@ jobs:
         echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
     - name: Save complete image ID
       run: |
-        echo "CROMWELL_SNAP_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA-SNAP"`" >> $GITHUB_ENV
+        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
     # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
     - name: Login to Docker Hub
       uses: docker/login-action@v1
@@ -54,6 +54,20 @@ jobs:
         set -e
         cd cromwell
         sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
+    - name: Deploy to dev and board release train (Cromwell)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromwell", "version": "$CROMWELL_VERSION", "dev_only": false}'
+    - name: Deploy to dev and board release train (CromIAM)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromiam", "version": "$CROMWELL_VERSION", "dev_only": false}'
     - name: Edit & push chart
       env:
         BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
@@ -62,10 +76,10 @@ jobs:
         cd cromwhelm
         git checkout main
         ls -la
-        sed -i "s/appVersion.*/appVersion: \"$CROMWELL_SNAP_VERSION\"/" cromwell-helm/Chart.yaml
-        sed -i "s/image: broadinstitute\/cromwell.*/image: broadinstitute\/cromwell:$CROMWELL_SNAP_VERSION/" cromwell-helm/templates/cromwell.yaml
+        sed -i "s/appVersion.*/appVersion: \"$CROMWELL_VERSION\"/" cromwell-helm/Chart.yaml
+        sed -i "s/image: broadinstitute\/cromwell.*/image: broadinstitute\/cromwell:$CROMWELL_VERSION/" cromwell-helm/templates/cromwell.yaml
         git diff
         git config --global user.name "broadbot"
         git config --global user.email "broadbot@broadinstitute.org"
-        git commit -am "Auto update to Cromwell $CROMWELL_SNAP_VERSION"
+        git commit -am "Auto update to Cromwell $CROMWELL_VERSION"
         git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main


### PR DESCRIPTION
Thanks to a good tip from Devops [(Slack link)](https://broadinstitute.slack.com/archives/CADM7MZ35/p1664898679060499), Cromwell and CromIAM adopt the current recommended pattern for services that go to dev on merge. [Code adapted from how Workspace Manager does it](https://github.com/DataBiosphere/terra-workspace-manager/actions/runs/3176595248/workflow#L142-L149).

Also, clean up a missed `-SNAP` reference to make things consistent.