### PR TITLE
WX-755 Fix environment variable syntax

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -60,14 +60,14 @@ jobs:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         repository: broadinstitute/terra-helmfile
         event-type: update-service
-        client-payload: '{"service": "cromwell", "version": "$CROMWELL_VERSION", "dev_only": false}'
+        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
     - name: Deploy to dev and board release train (CromIAM)
       uses: broadinstitute/repository-dispatch@master
       with:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         repository: broadinstitute/terra-helmfile
         event-type: update-service
-        client-payload: '{"service": "cromiam", "version": "$CROMWELL_VERSION", "dev_only": false}'
+        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
     - name: Edit & push chart
       env:
         BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
I missed that the value for `client-payload` is in single quotes and does not interpolate.

Consequently, `"version": "$CROMWELL_VERSION"` was passed as a literal to the `update-service` [action](https://github.com/broadinstitute/terra-helmfile/actions/runs/3190563369/jobs/5205838370).

There, it was evaluated in double quotes `VERSION="$CROMWELL_VERSION"`, found to be empty in that environment, and halted with `Error: empty version string`.