### PR TITLE
Fix submit-docker in LocalExample.conf

### DIFF
--- a/cromwell.example.backends/LocalExample.conf
+++ b/cromwell.example.backends/LocalExample.conf
@@ -65,7 +65,7 @@
           ${"--user " + docker_user} \
           --entrypoint ${job_shell} \
           -v ${cwd}:${docker_cwd} \
-          ${docker} ${script}
+          ${docker} ${docker_script}
         """
 
         # Root directory where Cromwell writes job results.  This directory must be


### PR DESCRIPTION
This was already fixed in [cromwell.examples.conf](https://github.com/broadinstitute/cromwell/blob/develop/cromwell.example.backends/cromwell.examples.conf) in https://github.com/broadinstitute/cromwell/commit/f0ae471331922b7302bffeeb2b01effe264973eb. It should also be fixed in this config.