### PR TITLE
WX-808 Host allowlist for HTTP imports

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -440,8 +440,8 @@ languages {
   default: WDL
   WDL {
     http-allow-list {
-      enabled: true
-      allowed-http-hosts: [ "githubusercontent.com" ]
+      enabled: false
+      allowed-http-hosts: []
     }
     versions {
       default: "draft-2"

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -439,6 +439,10 @@ engine {
 languages {
   default: WDL
   WDL {
+    http-allow-list {
+      enabled: true
+      allowed-http-hosts: [ "githubusercontent.com" ]
+    }
     versions {
       default: "draft-2"
       "draft-2" {

--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/ImportResolver.scala
@@ -187,7 +187,7 @@ object ImportResolver {
         else "Relative path".invalidNelCheck
     }
 
-    private def isAllowed(uri: Uri): Boolean = hostAllowlist match {
+    def isAllowed(uri: Uri): Boolean = hostAllowlist match {
       case Some(hosts) => hosts.contains(uri.host)
       case None => true
     }

--- a/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/NamespaceCacheSpec.scala
+++ b/languageFactories/wdl-draft2/src/test/scala/languages.wdl.draft2/NamespaceCacheSpec.scala
@@ -61,7 +61,7 @@ class NamespaceCacheSpec extends AnyFlatSpec with CromwellTimeoutSpec with Befor
     )
 
     var lookupCount = 0
-    val countingResolver = new HttpResolver() {
+    val countingResolver = new HttpResolver(None, Map.empty, None) {
       override def pathToLookup(str: String): Checked[String] = {
         lookupCount = lookupCount + 1
         super.pathToLookup(str)


### PR DESCRIPTION
Allow Cromwell system administrators to restrict WDL HTTP imports to specific, trusted hosts/domains. This prevents the import mechanism from being used to inappropriately access resources that the Cromwell instance has access to on its internal LAN, but which are not exposed to the end users.

Terra configuration here: https://github.com/broadinstitute/firecloud-develop/pull/3138