### PR TITLE
WX-867 Translate crc32c hashes to b64 for getm

### DIFF
--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GetmChecksum.scala
@@ -50,7 +50,7 @@ case class Crc32c(override val rawValue: String) extends GetmChecksum {
     if (trimmed.matches("[A-Fa-f0-9]+")) {
       (trimmed |> decodeHex |> encodeBase64String).validNel
     } else
-      s"Invalid crc32c checksum value, expected hex string but got $rawValue".invalidNel
+      s"Invalid crc32c checksum value, expected hex string but got: $rawValue".invalidNel
   }
 
   override def getmAlgorithm: String = "gs_crc32c"

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
@@ -31,10 +31,9 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
     val results = Table(
       ("description", "algorithm", "expected"),
       ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef".validNel),
-      ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "--checksum-algorithm 'md5' --checksum 711f38957635cb5edcdeaeffeeb88b10".validNel),
-      ("md5 gibberish", Md5("what is this???"), "Invalid md5 checksum value is neither hex nor base64: what is this???".invalidNel),
+      ("md5 gibberish", Md5("what is this???"), "Invalid checksum value, expected hex but got: what is this???".invalidNel),
       ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum ASNF".validNel),
-      ("crc32c gibberish", Crc32c("????"), "Invalid crc32c checksum value, expected hex string but got: ????".invalidNel),
+      ("crc32c gibberish", Crc32c("????"), "Invalid checksum value, expected hex but got: ????".invalidNel),
       ("AWS ETag", AwsEtag("012345"), "--checksum-algorithm 's3_etag' --checksum 012345".validNel),
       // Escape checksum values constructed from unvalidated data returned by DRS servers.
       ("Unsupported", Unsupported("Robert'); DROP TABLE Students;\n --\\"), raw"--checksum-algorithm 'null' --checksum Robert\'\)\;\ DROP\ TABLE\ Students\;\ --\\".validNel),
@@ -45,6 +44,21 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
       it should s"produce the expected checksum arguments for $description" in {
         algorithm.args shouldBe expected
       }
+    }
+  }
+
+  it should "correctly validate hex strings" in {
+    val results = Table(
+      ("test string", "expected"),
+      ("", "Invalid checksum value, expected hex but got: ".invalidNel),
+      (" ", "Invalid checksum value, expected hex but got: ".invalidNel),
+      ("myfavoritestring", "Invalid checksum value, expected hex but got: myfavoritestring".invalidNel),
+      (" AbC123 ", "abc123".validNel),
+      ("456", "456".validNel),
+    )
+
+    forAll(results) { (testString, expected) =>
+      GetmChecksum.validateHex(testString) shouldBe expected
     }
   }
 }

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
@@ -33,7 +33,8 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
       ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef".validNel),
       ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "--checksum-algorithm 'md5' --checksum 711f38957635cb5edcdeaeffeeb88b10".validNel),
       ("md5 gibberish", Md5("what is this???"), "Invalid md5 checksum value is neither hex nor base64: what is this???".invalidNel),
-      ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum 012345".validNel),
+      ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum ASNF".validNel),
+      ("crc32c gibberish", Crc32c("????"), "Invalid crc32c checksum value, expected hex string but got: ????".invalidNel),
       ("AWS ETag", AwsEtag("012345"), "--checksum-algorithm 's3_etag' --checksum 012345".validNel),
       // Escape checksum values constructed from unvalidated data returned by DRS servers.
       ("Unsupported", Unsupported("Robert'); DROP TABLE Students;\n --\\"), raw"--checksum-algorithm 'null' --checksum Robert\'\)\;\ DROP\ TABLE\ Students\;\ --\\".validNel),

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GetmChecksumSpec.scala
@@ -31,6 +31,7 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
     val results = Table(
       ("description", "algorithm", "expected"),
       ("md5 hex", Md5("abcdef"), "--checksum-algorithm 'md5' --checksum abcdef".validNel),
+      ("md5 base64", Md5("cR84lXY1y17c3q7/7riLEA=="), "Invalid checksum value, expected hex but got: cR84lXY1y17c3q7/7riLEA==".invalidNel),
       ("md5 gibberish", Md5("what is this???"), "Invalid checksum value, expected hex but got: what is this???".invalidNel),
       ("crc32c", Crc32c("012345"), "--checksum-algorithm 'gs_crc32c' --checksum ASNF".validNel),
       ("crc32c gibberish", Crc32c("????"), "Invalid checksum value, expected hex but got: ????".invalidNel),
@@ -53,7 +54,7 @@ class GetmChecksumSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
       ("", "Invalid checksum value, expected hex but got: ".invalidNel),
       (" ", "Invalid checksum value, expected hex but got: ".invalidNel),
       ("myfavoritestring", "Invalid checksum value, expected hex but got: myfavoritestring".invalidNel),
-      (" AbC123 ", "abc123".validNel),
+      (" AbC123 ", "AbC123".validNel),
       ("456", "456".validNel),
     )
 


### PR DESCRIPTION
This change updates CromwellDRSLocalizer to bring it in line with the DRS spec, which says that all hashes should be hexadecimal strings. See ticket for further context.