### PR TITLE
WX-892 Hopefully stop log-related OOMs

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala
@@ -27,15 +27,10 @@ object ValueStore {
 case class ValueStore(store: Table[OutputPort, ExecutionIndex, WomValue]) {
 
   override def toString: String = {
-    import io.circe.syntax._
-    import io.circe.Printer
+    import common.util.StringUtil.EnhancedToStringable
 
-    val values = store.valuesTriplet.map {
-      case (node, None, value) => node.name -> value.valueString
-      case (node, index, value) => s"${node.name}:${index.fromIndex}" -> value.valueString
-    }.toMap
-
-    values.asJson.printWith(Printer.spaces2.copy(dropNullValues = true, colonLeft = ""))
+    // ValueStores can be large and have been known to cause OOMs during unbounded stringification
+    store.valuesTriplet.toPrettyElidedString(limit = 1000)
   }
 
   final def add(values: Map[ValueKey, WomValue]): ValueStore = {


### PR DESCRIPTION
Production is hitting an error handler [0] that attempts to stringify too large a value and causes the server to crash before it manages to emit the log. This is a common enough situation that we have a library function for it.

[0] https://github.com/broadinstitute/cromwell/blob/aen_wx_892/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ValueStore.scala#L117