### PR TITLE
WX-863 Turn off Azure NIO logging

### DIFF
--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -106,4 +106,7 @@
     <logger name="HikariPool" level="ERROR"/>
     <logger name="com.google.cloud.hadoop.gcsio.GoogleCloudStorageReadChannel" level="ERROR"/>
     <logger name="org.semanticweb.owlapi.utilities.Injector" level="ERROR"/>
+
+    <!-- Guilty of logging ERROR under non-erroneous conditions -->
+    <logger name="com.azure.storage.blob.nio" level="OFF"/>
 </configuration>


### PR DESCRIPTION
This removes several classes of confusing `ERROR` log messages that we're receiving under healthy conditions. For example, when calling `checkAccess` in the filesystem provider, which is intended to be used to detect whether a path exists, the library would log an error containing the path string. This resulted in several `ERROR` level log messages every time we created a directory structure.