### PR TITLE
WX-878 Single shared BlobFileSystemManager

### DIFF
--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
@@ -17,41 +17,11 @@ final case class WorkspaceId(value: UUID) {override def toString: String = value
 final case class ContainerResourceId(value: UUID) {override def toString: String = value.toString}
 final case class WorkspaceManagerURL(value: String) {override def toString: String = value}
 
-final case class BlobPathBuilderFactory(globalConfig: Config, instanceConfig: Config, singletonConfig: BlobFileSystemConfigWrapper) extends PathBuilderFactory {
-
-  private val config = singletonConfig.config
-  private val container = config.blobContainerName
-  private val endpoint = config.endpointURL
-  private val subscription = config.subscriptionId
-  private val expiryBufferMinutes = config.expiryBufferMinutes
-
-  /**
-   * This generator is responsible for producing a valid SAS token for use in accessing a Azure blob storage container
-   * Two types of generators can be produced here:
-   * > Workspace Manager (WSM) mediated SAS token generator, used to create SAS tokens that allow access for
-   * blob containers mediated by the WSM, and is enabled when a WSM config is provided. This is what is intended for use inside Terra
-   *    OR
-   * > Native SAS token generator, which obtains a valid SAS token from your local environment to reach blob containers
-   * your local azure identity has access to and is the default if a WSM config is not found. This is intended for use outside of Terra
-   *
-   * Both of these generators require an authentication token to authorize the generation of the SAS token.
-   * See BlobSasTokenGenerator for more information on how these generators work.
-   */
-  val blobSasTokenGenerator: BlobSasTokenGenerator = config.workspaceManagerConfig.map { wsmConfig =>
-    val wsmClient: WorkspaceManagerApiClientProvider = new HttpWorkspaceManagerClientProvider(wsmConfig.url)
-    // WSM-mediated mediated SAS token generator
-    // parameterizing client instead of URL to make injecting mock client possible
-    BlobSasTokenGenerator.createBlobTokenGenerator(container, endpoint, wsmConfig.workspaceId, wsmConfig.containerResourceId, wsmClient, wsmConfig.overrideWsmAuthToken)
-  }.getOrElse(
-    // Native SAS token generator
-    BlobSasTokenGenerator.createBlobTokenGenerator(container, endpoint, subscription)
-  )
-
-  val fsm: BlobFileSystemManager = BlobFileSystemManager(container, endpoint, expiryBufferMinutes, blobSasTokenGenerator)
+final case class BlobPathBuilderFactory(globalConfig: Config, instanceConfig: Config, fsm: BlobFileSystemManager) extends PathBuilderFactory {
 
   override def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[BlobPathBuilder] = {
     Future {
-      new BlobPathBuilder(container, endpoint)(fsm)
+      new BlobPathBuilder(fsm.container, fsm.endpoint)(fsm)
     }
   }
 

--- a/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderFactorySpec.scala
+++ b/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderFactorySpec.scala
@@ -74,7 +74,7 @@ class BlobPathBuilderFactorySpec extends AnyFlatSpec with Matchers with MockSuga
     val blobTokenGenerator = mock[BlobSasTokenGenerator]
     when(blobTokenGenerator.generateBlobSasToken).thenReturn(Try(sasToken))
 
-    val fsm = BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(expiredToken))
+    val fsm = new BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(expiredToken))
     fsm.getExpiry should contain(expiredToken)
     fsm.isTokenExpired shouldBe true
     fsm.retrieveFilesystem()
@@ -103,7 +103,7 @@ class BlobPathBuilderFactorySpec extends AnyFlatSpec with Matchers with MockSuga
     val blobTokenGenerator = mock[BlobSasTokenGenerator]
     when(blobTokenGenerator.generateBlobSasToken).thenReturn(Try(sasToken))
 
-    val fsm = BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(initialToken))
+    val fsm = new BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(initialToken))
     fsm.getExpiry should contain(initialToken)
     fsm.isTokenExpired shouldBe false
     fsm.retrieveFilesystem()
@@ -128,7 +128,7 @@ class BlobPathBuilderFactorySpec extends AnyFlatSpec with Matchers with MockSuga
     val blobTokenGenerator = mock[BlobSasTokenGenerator]
     when(blobTokenGenerator.generateBlobSasToken).thenReturn(Try(sasToken))
 
-    val fsm = BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(refreshedToken))
+    val fsm = new BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems, Some(refreshedToken))
     fsm.getExpiry.isDefined shouldBe true
     fsm.isTokenExpired shouldBe false
     fsm.retrieveFilesystem()
@@ -152,7 +152,7 @@ class BlobPathBuilderFactorySpec extends AnyFlatSpec with Matchers with MockSuga
     val blobTokenGenerator = mock[BlobSasTokenGenerator]
     when(blobTokenGenerator.generateBlobSasToken).thenReturn(Try(sasToken))
 
-    val fsm = BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems)
+    val fsm = new BlobFileSystemManager(container, endpoint, 10L, blobTokenGenerator, fileSystems)
     fsm.getExpiry.isDefined shouldBe false
     fsm.isTokenExpired shouldBe false
     fsm.retrieveFilesystem()

--- a/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderSpec.scala
+++ b/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderSpec.scala
@@ -63,7 +63,7 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
     val store = BlobContainerName("inputs")
     val evalPath = "/test/inputFile.txt"
     val blobTokenGenerator = NativeBlobSasTokenGenerator(store, endpoint)
-    val fsm: BlobFileSystemManager = BlobFileSystemManager(store, endpoint, 10L, blobTokenGenerator)
+    val fsm: BlobFileSystemManager = new BlobFileSystemManager(store, endpoint, 10L, blobTokenGenerator)
     val testString = endpoint.value + "/" + store + evalPath
     val blobPath: BlobPath = new BlobPathBuilder(store, endpoint)(fsm) build testString getOrElse fail()
 
@@ -81,7 +81,7 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
     val store = BlobContainerName("inputs")
     val evalPath = "/test/inputFile.txt"
     val blobTokenGenerator = NativeBlobSasTokenGenerator(store, endpoint)
-    val fsm: BlobFileSystemManager = BlobFileSystemManager(store, endpoint, 10, blobTokenGenerator)
+    val fsm: BlobFileSystemManager = new BlobFileSystemManager(store, endpoint, 10, blobTokenGenerator)
     val testString = endpoint.value + "/" + store + evalPath
     val blobPath1: BlobPath = new BlobPathBuilder(store, endpoint)(fsm) build testString getOrElse fail()
     blobPath1.nioPath.getFileSystem.close()
@@ -96,7 +96,7 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
     val endpoint = BlobPathBuilderSpec.buildEndpoint("coaexternalstorage")
     val store = BlobContainerName("inputs")
     val blobTokenGenerator = NativeBlobSasTokenGenerator(store, endpoint)
-    val fsm: BlobFileSystemManager = BlobFileSystemManager(store, endpoint, 10, blobTokenGenerator)
+    val fsm: BlobFileSystemManager = new BlobFileSystemManager(store, endpoint, 10, blobTokenGenerator)
 
     val rootString = s"${endpoint.value}/${store.value}/cromwell-execution"
     val blobRoot: BlobPath = new BlobPathBuilder(store, endpoint)(fsm) build rootString getOrElse fail()

--- a/src/ci/resources/tes_application.conf
+++ b/src/ci/resources/tes_application.conf
@@ -5,7 +5,8 @@ filesystems {
   blob {
     class = "cromwell.filesystems.blob.BlobPathBuilderFactory"
     global {
-      class = "cromwell.filesystems.blob.BlobFileSystemConfigWrapper"
+      # One BFSM is shared across all BlobPathBuilders
+      class = "cromwell.filesystems.blob.BlobFileSystemManager"
       config {
         container: "cromwell"
         endpoint: "https://<storage-account>.blob.core.windows.net"


### PR DESCRIPTION
This should ensure that we manage a single blob SAS token among all `BlobPathBuilder` objects, which will prevent unnecessary token refresh.