### PR TITLE
Centaur reference image test should validate symlinks [VS-796]

### DIFF
--- a/centaur/src/main/resources/standardTestCases/reference_disk/reference_disk_test.wdl
+++ b/centaur/src/main/resources/standardTestCases/reference_disk/reference_disk_test.wdl
@@ -1,26 +1,38 @@
 version 1.0
 
-task check_if_localized_as_symlink {
+task check_if_localized_with_valid_symlink {
   input {
     File broad_reference_file_input
     File nirvana_reference_file_input
     File nirvana_reference_file_metachar_input
   }
-  String broad_input_symlink = "broad_input_symlink.txt"
-  String nirvana_input_symlink = "nirvana_input_symlink.txt"
-  String nirvana_metachar_input_symlink = "nirvana_metachar_input_symlink.txt"
-  command {
-    # Print true if input is a symlink, otherwise print false.
-    if test -h ~{broad_reference_file_input}; then echo true; else echo false; fi > ~{broad_input_symlink}
-    if test -h ~{nirvana_reference_file_input}; then echo true; else echo false; fi > ~{nirvana_input_symlink}
+  String broad_input_valid_symlink = "broad_input_valid_symlink.txt"
+  String nirvana_input_valid_symlink = "nirvana_input_valid_symlink.txt"
+  String nirvana_metachar_input_valid_symlink = "nirvana_metachar_input_valid_symlink.txt"
+  command <<<
+      PS4='\D{+%F %T} \w $ '
+      set -o nounset -o pipefail -o xtrace
 
-    # Quotes added here due to the metachar in the filename.
-    if test -h "~{nirvana_reference_file_metachar_input}"; then echo true; else echo false; fi > ~{nirvana_metachar_input_symlink}
-  }
+      # Echo true to stdout if the argument is a symlink pointing to an extant file, otherwise echo false.
+      check_if_valid_symlink() {
+          local reference_input="$1"
+
+          if [[ -h "${reference_input}" && -f $(readlink "${reference_input}") ]]; then
+              echo true
+          else
+              echo false
+          fi
+      }
+
+      check_if_valid_symlink "~{broad_reference_file_input}" > ~{broad_input_valid_symlink}
+      check_if_valid_symlink "~{nirvana_reference_file_input}" > ~{nirvana_input_valid_symlink}
+      check_if_valid_symlink "~{nirvana_reference_file_metachar_input}" > ~{nirvana_metachar_input_valid_symlink}
+
+  >>>
   output {
-    Boolean is_broad_input_symlink = read_boolean("~{broad_input_symlink}")
-    Boolean is_nirvana_input_symlink = read_boolean("~{nirvana_input_symlink}")
-    Boolean is_nirvana_metachar_input_symlink = read_boolean("~{nirvana_metachar_input_symlink}")
+    Boolean is_broad_input_valid_symlink = read_boolean("~{broad_input_valid_symlink}")
+    Boolean is_nirvana_input_valid_symlink = read_boolean("~{nirvana_input_valid_symlink}")
+    Boolean is_nirvana_metachar_input_valid_symlink = read_boolean("~{nirvana_metachar_input_valid_symlink}")
   }
   runtime {
     docker: "ubuntu:latest"
@@ -34,15 +46,15 @@ workflow wf_reference_disk_test {
     File nirvana_reference_file_input
     File nirvana_reference_file_metachar_input
   }
-  call check_if_localized_as_symlink {
+  call check_if_localized_with_valid_symlink {
     input:
       broad_reference_file_input = broad_reference_file_input,
       nirvana_reference_file_input = nirvana_reference_file_input,
       nirvana_reference_file_metachar_input = nirvana_reference_file_metachar_input
   }
   output {
-    Boolean is_broad_input_file_a_symlink = check_if_localized_as_symlink.is_broad_input_symlink
-    Boolean is_nirvana_input_file_a_symlink = check_if_localized_as_symlink.is_nirvana_input_symlink
-    Boolean is_nirvana_metachar_input_file_a_symlink = check_if_localized_as_symlink.is_nirvana_metachar_input_symlink
+    Boolean is_broad_input_file_a_valid_symlink = check_if_localized_with_valid_symlink.is_broad_input_valid_symlink
+    Boolean is_nirvana_input_file_a_valid_symlink = check_if_localized_with_valid_symlink.is_nirvana_input_valid_symlink
+    Boolean is_nirvana_metachar_input_file_a_valid_symlink = check_if_localized_with_valid_symlink.is_nirvana_metachar_input_valid_symlink
   }
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_false_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_false_options.test
@@ -11,6 +11,6 @@ files {
 metadata {
   workflowName: wf_reference_disk_test
   status: Succeeded
-  "outputs.wf_reference_disk_test.is_broad_input_file_a_symlink": false
-  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_symlink": false
+  "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": false
+  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": false
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_false_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_false_options.test
@@ -13,4 +13,5 @@ metadata {
   status: Succeeded
   "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": false
   "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": false
+  "outputs.wf_reference_disk_test.is_nirvana_metachar_input_file_a_valid_symlink": false
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_true_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_true_options.test
@@ -13,4 +13,5 @@ metadata {
   status: Succeeded
   "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": true
   "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": true
+  "outputs.wf_reference_disk_test.is_nirvana_metachar_input_file_a_valid_symlink": true
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_true_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_true_options.test
@@ -11,6 +11,6 @@ files {
 metadata {
   workflowName: wf_reference_disk_test
   status: Succeeded
-  "outputs.wf_reference_disk_test.is_broad_input_file_a_symlink": true
-  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_symlink": true
+  "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": true
+  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": true
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_unspecified_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_unspecified_options.test
@@ -11,6 +11,6 @@ files {
 metadata {
   workflowName: wf_reference_disk_test
   status: Succeeded
-  "outputs.wf_reference_disk_test.is_broad_input_file_a_symlink": false
-  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_symlink": false
+  "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": false
+  "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": false
 }

--- a/centaur/src/main/resources/standardTestCases/reference_disk_unspecified_options.test
+++ b/centaur/src/main/resources/standardTestCases/reference_disk_unspecified_options.test
@@ -13,4 +13,5 @@ metadata {
   status: Succeeded
   "outputs.wf_reference_disk_test.is_broad_input_file_a_valid_symlink": false
   "outputs.wf_reference_disk_test.is_nirvana_input_file_a_valid_symlink": false
+  "outputs.wf_reference_disk_test.is_nirvana_metachar_input_file_a_valid_symlink": false
 }

--- a/src/ci/resources/papi_v2_reference_image_manifest.conf
+++ b/src/ci/resources/papi_v2_reference_image_manifest.conf
@@ -192,7 +192,7 @@ reference-disk-localization-manifests = [
     ]
   },
   {
-    "imageIdentifier" : "projects/broad-dsde-cromwell-dev/global/images/nirvana-3-18-1-references-2023-01-03",
+    "imageIdentifier" : "projects/broad-dsde-cromwell-dev/global/images/nirvana-3-18-1-references-2023-02-01",
     "diskSizeGb" : 55,
     "files" : [ {
       "path" : "broad-public-datasets/gvs/vat-annotations/Nirvana/3.18.1/SupplementaryAnnotation/GRCh38/phyloP_hg38.npd",


### PR DESCRIPTION
The Nirvana reference image I made about a month ago had all the right files on it, but due to some last minute updates the paths where they were located on the image were not consistent with the firecloud-develop manifest. The Centaur test did not catch this because it only checked that reference image usage had been activated and that inputs were symlinks as opposed to regular files; unfortunately the test did not check that the symlinks pointed to files that actually existed. 

These changes harden the Centaur reference image test to validate the symlinks and update the manifest to point to a corrected Nirvana image I made today. I confirmed locally that this test fails on the 2023-01-03 Nirvana image and succeeds on the 2023-02-01 Nirvana image.

Associated firecloud-develop [PR](https://github.com/broadinstitute/firecloud-develop/pull/3232/files)
