### PR TITLE
WX-952 Fix Cromwell version update in Helm chart

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -76,8 +76,8 @@ jobs:
         cd cromwhelm
         git checkout main
         ls -la
-        sed -i "s/appVersion.*/appVersion: \"$CROMWELL_VERSION\"/" cromwell-helm/Chart.yaml
-        sed -i "s/image: broadinstitute\/cromwell.*/image: broadinstitute\/cromwell:$CROMWELL_VERSION/" cromwell-helm/templates/cromwell.yaml
+        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
+
         git diff
         git config --global user.name "broadbot"
         git config --global user.email "broadbot@broadinstitute.org"


### PR DESCRIPTION
This had not been updated since we changed how we stored the Cromwell version in Cromwhelm. There is now a single value that both charts use; this PR updates it.

See also https://github.com/broadinstitute/cromwhelm/pull/197