### PR TITLE
WX-950 Upgrade Azure libs to probably fix extraneous log

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -205,7 +205,7 @@ object Dependencies {
     "com.azure" % "azure-identity" % azureIdentitySdkV
       exclude("jakarta.xml.bind", "jakarta.xml.bind-api")
       exclude("jakarta.activation", "jakarta.activation-api"),
-    "com.azure" % "azure-core-management" % "1.7.1",
+    "com.azure" % "azure-core-management" % "1.10.2",
     "com.azure.resourcemanager" % "azure-resourcemanager" % "2.18.0"
   )
 


### PR DESCRIPTION
We get noisy messages in our logs that seem to come from [this line of code](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/src/main/java/com/azure/core/util/serializer/SerializerEncoding.java#L62) in the Azure SDK.
```
2023-02-17 16:30:13 reactor-http-nio-2 WARN  - 'Content-Type' not found. Returning default encoding: JSON
```
Searching for the error, I found [an issue](https://github.com/Azure/azure-sdk-for-java/issues/32250) and [fix PR](https://github.com/Azure/azure-sdk-for-java/pull/32833) mentioning it (in rhyming but not identical circumstances).

I confirmed that going from `1.7.1` to `1.10.2` brings in the improved handling by examining the copy of `HttpResponseBodyDecoder.java` that SBT downloads. 