### PR TITLE
Add cron run integrations each day of the week

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,6 +7,8 @@ run-name: ${{ github.actor }} Integration Testing.
 
 #What will trigger the workflow to run. 
 on:
+  schedule:
+    - cron: '0 0 * * 1-5'
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,6 +10,10 @@ inputs:
   target-branch:
     description: 'The branch to run integration tests against'
     required: 'false'
+  slack-alert: 
+    description: 'A flag to enable slack alerts. True if this should alert via slack'
+    required: 'true'
+    default: 'false'
 
 #What will trigger the workflow to run. 
 on:
@@ -96,6 +100,14 @@ jobs:
         set -e
         echo Running test.sh
         ./src/ci/bin/test.sh
+    - uses: ravsamhq/notify-slack-action@v2
+      if: ${{ slack-alert }}
+      with:
+        status: ${{ job.status }}
+        notify_when: "failure"
+      env: 
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
     #The "shell: ..."" line is a way to force the Github Action Runner to use a bash shell that thinks it has a TTY.
     #The issue and solution are described here: https://github.com/actions/runner/issues/241#issuecomment-842566950
     #This is only needed for ReferenceDiskManifestBuilderApp test. 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,14 +12,15 @@ on:
   workflow_call:
     inputs:
       target-branch:
-        type: 'string'
+        type: string
         description: 'The branch to run integration tests against'
         required: 'false'
       slack-alert:
-        type: 'boolean' 
+        type: boolean 
         description: 'A flag to enable slack alerts. True if this should alert via slack'
         required: 'true'
         default: 'false'
+      
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -108,6 +108,7 @@ jobs:
       run: |
         set -e
         echo Running test.sh
+        exit 1
         ./src/ci/bin/test.sh
     - uses: ravsamhq/notify-slack-action@v2
       if: inputs.slack-alert

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,20 +6,20 @@ name: 'Integration Tests'
 run-name: ${{ github.actor }} Integration Testing.
 
 #Inputs parameters for this workflow
-inputs:
-  target-branch:
-    type: 'string'
-    description: 'The branch to run integration tests against'
-    required: 'false'
-  slack-alert:
-    type: 'boolean' 
-    description: 'A flag to enable slack alerts. True if this should alert via slack'
-    required: 'true'
-    default: 'false'
 
 #What will trigger the workflow to run. 
 on:
   workflow_call:
+    inputs:
+      target-branch:
+        type: 'string'
+        description: 'The branch to run integration tests against'
+        required: 'false'
+      slack-alert:
+        type: 'boolean' 
+        description: 'A flag to enable slack alerts. True if this should alert via slack'
+        required: 'true'
+        default: 'false'
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,6 +20,18 @@ on:
         required: 'true'
         default: 'false'
         type: boolean
+    secrets:
+      VAULT_ROLE_ID_CI:
+        required: 'true'
+        default: 
+      VAULT_SECRET_ID_CI:
+        required: 'true'
+      BROADBOT_GITHUB_TOKEN:
+        required: 'true'
+      SLACK_WEBHOOK_URL:
+        required: 'false'
+        
+      
       
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,9 +8,11 @@ run-name: ${{ github.actor }} Integration Testing.
 #Inputs parameters for this workflow
 inputs:
   target-branch:
+    type: 'string'
     description: 'The branch to run integration tests against'
     required: 'false'
-  slack-alert: 
+  slack-alert:
+    type: 'boolean' 
     description: 'A flag to enable slack alerts. True if this should alert via slack'
     required: 'true'
     default: 'false'
@@ -88,7 +90,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
       with: 
-        ref: ${{target-branch}}
+        ref: ${{ target-branch }}
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,14 +12,14 @@ on:
   workflow_call:
     inputs:
       target-branch:
-        type: string
         description: 'The branch to run integration tests against'
         required: 'false'
+        type: string
       slack-alert:
-        type: boolean 
         description: 'A flag to enable slack alerts. True if this should alert via slack'
         required: 'true'
         default: 'false'
+        type: boolean
       
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
       with:
-        ref: target-branch
+        ref: ${{ inputs.target-branch }}
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
         echo Running test.sh
         ./src/ci/bin/test.sh
     - uses: ravsamhq/notify-slack-action@v2
-      if: slack-alert
+      if: inputs.slack-alert
       with:
         status: ${{ job.status }}
         notify_when: "failure"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -108,13 +108,12 @@ jobs:
       run: |
         set -e
         echo Running test.sh
-        exit 1
         ./src/ci/bin/test.sh
     - uses: ravsamhq/notify-slack-action@v2
       if: inputs.slack-alert
       with:
         status: ${{ job.status }}
-        notify_when: "failure"
+        notify_when: "failure,success"
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     #The "shell: ..."" line is a way to force the Github Action Runner to use a bash shell that thinks it has a TTY.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,8 +5,6 @@ name: 'Integration Tests'
 #This is what shows up in the github workflows page as the title. 
 run-name: ${{ github.actor }} Integration Testing.
 
-#Inputs parameters for this workflow
-
 #What will trigger the workflow to run. 
 on:
   workflow_call:
@@ -118,7 +116,6 @@ jobs:
         notify_when: "failure"
       env: 
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
     #The "shell: ..."" line is a way to force the Github Action Runner to use a bash shell that thinks it has a TTY.
     #The issue and solution are described here: https://github.com/actions/runner/issues/241#issuecomment-842566950
     #This is only needed for ReferenceDiskManifestBuilderApp test. 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,43 +2,43 @@ name: 'Integration Tests'
 
 #This github action runs all of Cromwell's integration tests.
 
-#This is what shows up in the github workflows page as the title. 
+#This is what shows up in the github workflows page as the title.
 run-name: ${{ github.actor }} Integration Testing.
 
-#What will trigger the workflow to run. 
+#What will trigger the workflow to run.
 on:
   workflow_call:
     inputs:
       target-branch:
         description: 'The branch to run integration tests against'
-        required: 'false'
+        required: false
         type: string
       slack-alert:
         description: 'A flag to enable slack alerts. True if this should alert via slack'
-        required: 'true'
-        default: 'false'
+        required: true
+        default: false
         type: boolean
     secrets:
       VAULT_ROLE_ID_CI:
-        required: 'true'
+        required: true
       VAULT_SECRET_ID_CI:
-        required: 'true'
+        required: true
       BROADBOT_GITHUB_TOKEN:
-        required: 'true'
+        required: true
       SLACK_WEBHOOK_URL:
-        required: 'false'
+        required: false
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:
 
-permissions: 
+permissions:
   contents: read
 
 jobs:
   integration-tests:
     strategy:
       fail-fast: false #disabling fail-fast means that even if one test fails, the others will still try to complete.
-      #Each entry below is a single integration test that lives in /src/ci/bin/. 
+      #Each entry below is a single integration test that lives in /src/ci/bin/.
       #Each will be launched on its own runner so they can occur in parallel.
       #Friendly names are displayed on the Github UI and aren't used anywhere else.
       matrix:
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
-      with: 
+      with:
         ref: ${{ target-branch }}
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
@@ -110,14 +110,14 @@ jobs:
         echo Running test.sh
         ./src/ci/bin/test.sh
     - uses: ravsamhq/notify-slack-action@v2
-      if: ${{ slack-alert }}
+      if: slack-alert
       with:
         status: ${{ job.status }}
         notify_when: "failure"
-      env: 
+      env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     #The "shell: ..."" line is a way to force the Github Action Runner to use a bash shell that thinks it has a TTY.
     #The issue and solution are described here: https://github.com/actions/runner/issues/241#issuecomment-842566950
-    #This is only needed for ReferenceDiskManifestBuilderApp test. 
+    #This is only needed for ReferenceDiskManifestBuilderApp test.
     #This test uses fancy colors in the output, which likely causes the problem.
-    #See WX-938. 
+    #See WX-938.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,8 +7,7 @@ run-name: ${{ github.actor }} Integration Testing.
 
 #What will trigger the workflow to run. 
 on:
-  schedule:
-    - cron: '0 0 * * 1-5'
+  workflow_call:
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -113,7 +113,7 @@ jobs:
       if: inputs.slack-alert
       with:
         status: ${{ job.status }}
-        notify_when: "failure,success"
+        notify_when: "failure"
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     #The "shell: ..."" line is a way to force the Github Action Runner to use a bash shell that thinks it has a TTY.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -23,16 +23,12 @@ on:
     secrets:
       VAULT_ROLE_ID_CI:
         required: 'true'
-        default: 
       VAULT_SECRET_ID_CI:
         required: 'true'
       BROADBOT_GITHUB_TOKEN:
         required: 'true'
       SLACK_WEBHOOK_URL:
         required: 'false'
-        
-      
-      
   workflow_dispatch: #Manual trigger from GitHub UI
   push: #git push
   merge_group:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,6 +5,12 @@ name: 'Integration Tests'
 #This is what shows up in the github workflows page as the title. 
 run-name: ${{ github.actor }} Integration Testing.
 
+#Inputs parameters for this workflow
+inputs:
+  target-branch:
+    description: 'The branch to run integration tests against'
+    required: 'false'
+
 #What will trigger the workflow to run. 
 on:
   workflow_call:
@@ -77,6 +83,8 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
+      with: 
+        ref: ${{target-branch}}
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -97,7 +97,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
       with:
-        ref: ${{ target-branch }}
+        ref: target-branch
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -7,6 +7,7 @@ run-name: Nightly ${{ github.actor }} Integration Testing.
 #What will trigger the workflow to run.
 on:
   workflow_dispatch:
+  push:
   schedule:
     - cron: '0 0 * * 1-5'
 

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -7,6 +7,7 @@ run-name: Nightly ${{ github.actor }} Integration Testing.
 
 #What will trigger the workflow to run. 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1-5'
     
@@ -15,13 +16,15 @@ permissions:
 
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
+    steps:
+    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
+      with:
+        target-branch: 'develop'
+    - uses: ravsamhq/notify-slack-action@v2
+      if: always()
+      with:
+        status: ${{ job.status }}
+        notify_when: "failure"
+      env: 
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-steps:
-  - uses: ravsamhq/notify-slack-action@v2
-    if: always()
-    with:
-      status: ${{ job.status }}
-      notify_when: "failure"
-    env: 
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -14,17 +14,11 @@ on:
 permissions: 
   contents: read
 
+# Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
     steps:
     - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
       with:
         target-branch: 'develop'
-    - uses: ravsamhq/notify-slack-action@v2
-      if: always()
-      with:
-        status: ${{ job.status }}
-        notify_when: "failure"
-      env: 
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
+        slack-alert: 'true'

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,7 +17,7 @@ permissions:
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@90cc46dfa1d1ed75300f0ef25607076c08151b09
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@develop
     with:
       target-branch: 'develop'
       slack-alert: true

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,8 +17,8 @@ permissions:
 jobs:
   integration-tests:
     uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
-      with:
-        target-branch: 'develop'
+    with:
+      target-branch: 'develop'
     steps:
     - uses: ravsamhq/notify-slack-action@v2
       if: always()

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,9 +17,8 @@ permissions:
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
-      with:
-        target-branch: 'develop'
-        slack-alert: true
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@0b024972c5c7b80b37bda48fccb61cb25dfe355d
+    with:
+      target-branch: 'develop'
+      slack-alert: true
+    secrets: inherit

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,7 +17,7 @@ permissions:
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@a3c229401306477a9f2047cc2063efbffbfa7002
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@90cc46dfa1d1ed75300f0ef25607076c08151b09
     with:
       target-branch: 'develop'
       slack-alert: true

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -1,6 +1,5 @@
-name: 'Nightly Integration Tests'
-
 #This github action runs all of Cromwell's integration tests nightly.
+name: 'Nightly Integration Tests'
 
 #This is what shows up in the github workflows page as the title.
 run-name: Nightly ${{ github.actor }} Integration Testing.

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -20,5 +20,5 @@ jobs:
     uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@a3c229401306477a9f2047cc2063efbffbfa7002
     with:
       target-branch: 'develop'
-      slack-alert: true
+      slack-alert: 'true'
     secrets: inherit

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -7,7 +7,6 @@ run-name: Nightly ${{ github.actor }} Integration Testing.
 #What will trigger the workflow to run.
 on:
   workflow_dispatch:
-  push:
   schedule:
     - cron: '0 0 * * 1-5'
 

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -1,0 +1,27 @@
+name: 'Nightly Integration Tests'
+
+#This github action runs all of Cromwell's integration tests nightly.
+
+#This is what shows up in the github workflows page as the title. 
+run-name: Nightly ${{ github.actor }} Integration Testing.
+
+#What will trigger the workflow to run. 
+on:
+  schedule:
+    - cron: '0 0 * * 1-5'
+    
+permissions: 
+  contents: read
+
+jobs:
+  integration-tests:
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
+
+steps:
+  - uses: ravsamhq/notify-slack-action@v2
+    if: always()
+    with:
+      status: ${{ job.status }}
+      notify_when: "failure"
+    env: 
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,8 +17,7 @@ permissions:
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    steps:
-    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
-      with:
-        target-branch: 'develop'
-        slack-alert: 'true'
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
+    with:
+      target-branch: 'develop'
+      slack-alert: 'true'

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -2,22 +2,24 @@ name: 'Nightly Integration Tests'
 
 #This github action runs all of Cromwell's integration tests nightly.
 
-#This is what shows up in the github workflows page as the title. 
+#This is what shows up in the github workflows page as the title.
 run-name: Nightly ${{ github.actor }} Integration Testing.
 
-#What will trigger the workflow to run. 
+#What will trigger the workflow to run.
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1-5'
-    
-permissions: 
+
+permissions:
   contents: read
 
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
-    with:
-      target-branch: 'develop'
-      slack-alert: 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
+      with:
+        target-branch: 'develop'
+        slack-alert: true

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -20,5 +20,5 @@ jobs:
     uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@a3c229401306477a9f2047cc2063efbffbfa7002
     with:
       target-branch: 'develop'
-      slack-alert: 'true'
+      slack-alert: true
     secrets: inherit

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
-    with:
-      target-branch: 'develop'
     steps:
+    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
+      with:
+        target-branch: 'develop'
     - uses: ravsamhq/notify-slack-action@v2
       if: always()
       with:

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,7 +17,7 @@ permissions:
 # Use if as arg to only send slack notifications on nightly
 jobs:
   integration-tests:
-    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@0b024972c5c7b80b37bda48fccb61cb25dfe355d
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@a3c229401306477a9f2047cc2063efbffbfa7002
     with:
       target-branch: 'develop'
       slack-alert: true

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -16,11 +16,10 @@ permissions:
 
 jobs:
   integration-tests:
-    steps:
-    - uses: actions/checkout@v3
-    - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
+    uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml@fd10d3a5b5474c39ff9d101cca6ea887bafc2068
       with:
         target-branch: 'develop'
+    steps:
     - uses: ravsamhq/notify-slack-action@v2
       if: always()
       with:

--- a/.github/workflows/nightly_integration_tests.yml
+++ b/.github/workflows/nightly_integration_tests.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   integration-tests:
     steps:
+    - uses: actions/checkout@v3
     - uses: broadinstitute/cromwell/.github/workflows/integration_tests.yml
       with:
         target-branch: 'develop'


### PR DESCRIPTION
Adds a cron trigger for the centaur integration tests that cause the integration tests to run at midnight each weekday and post failures to slack at #cromwell-integration-action