### PR TITLE
Single workflow runner

### DIFF
--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -275,7 +275,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
   def validOrFailSubmission[A](validation: ErrorOr[A]): A = {
     validation.valueOr(errors => throw new RuntimeException with MessageAggregation {
-      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell:"
+      override def exceptionContext: String = "Unable to submit workflow to Cromwell:"
       override def errorMessages: Iterable[String] = errors.toList
     })
   }

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -275,7 +275,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
   def validOrFailSubmission[A](validation: ErrorOr[A]): A = {
     validation.valueOr(errors => throw new RuntimeException with MessageAggregation {
-      override def exceptionContext: String = "Unable to submit workflow to Cromwell:"
+      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell:"
       override def errorMessages: Iterable[String] = errors.toList
     })
   }

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -275,7 +275,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
   def validOrFailSubmission[A](validation: ErrorOr[A]): A = {
     validation.valueOr(errors => throw new RuntimeException with MessageAggregation {
-      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell:"
+      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell: "
       override def errorMessages: Iterable[String] = errors.toList
     })
   }

--- a/server/src/main/scala/cromwell/CromwellEntryPoint.scala
+++ b/server/src/main/scala/cromwell/CromwellEntryPoint.scala
@@ -275,7 +275,7 @@ object CromwellEntryPoint extends GracefulStopSupport {
 
   def validOrFailSubmission[A](validation: ErrorOr[A]): A = {
     validation.valueOr(errors => throw new RuntimeException with MessageAggregation {
-      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell: "
+      override def exceptionContext: String = "ERROR: Unable to submit workflow to Cromwell:"
       override def errorMessages: Iterable[String] = errors.toList
     })
   }

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o pipefail
+set -o errexit -o nounset -o pipefail +x
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh
@@ -68,6 +68,7 @@ cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
+# Redirect stderr for the expected cromwell crash so we don't agitate CI.
 exec 3>&2
 exec 2> /dev/null
 java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -69,8 +69,7 @@ popd > /dev/null
 
 echo "::remove-matcher owner=setup-java::"
 # Test 3: program should exit with error in case if validation of command line arguments failed
-java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl \
-2>&1
+java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &
 pid=$!
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -67,9 +67,10 @@ jq '{
 cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
+echo "::remove-matcher owner=setup-java::"
 # Test 3: program should exit with error in case if validation of command line arguments failed
 java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl \
-2>&1 || echo "Successfully failed"
+2>&1
 pid=$!
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -68,7 +68,7 @@ cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
-java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl 2> /dev/null
+java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl & 2> /dev/null
 pid=$!
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -67,9 +67,8 @@ jq '{
 cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
-echo "::remove-matcher owner=setup-java::"
 # Test 3: program should exit with error in case if validation of command line arguments failed
-java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &
+java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl 2> /dev/null
 pid=$!
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -68,9 +68,11 @@ cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
+set +e
 java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &
 pid=$!
 sleep 10
+set -e
 if kill -0 $pid > /dev/null 2>&1; then
   echo "ERROR: Process still exists"
   kill $pid

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -69,7 +69,7 @@ popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
 java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl \
-2>&1 | tee console_output.txt
+2>&1 || echo "Successfully failed"
 pid=$!
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -68,11 +68,10 @@ cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
-set +e
-java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &
+java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl \
+2>&1 | tee console_output.txt
 pid=$!
 sleep 10
-set -e
 if kill -0 $pid > /dev/null 2>&1; then
   echo "ERROR: Process still exists"
   kill $pid

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -68,8 +68,11 @@ cmp <(jq -cS . actual.json) <(jq -cS . expected.json)
 popd > /dev/null
 
 # Test 3: program should exit with error in case if validation of command line arguments failed
-java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl & 2> /dev/null
+exec 3>&2
+exec 2> /dev/null
+java -jar "${CROMWELL_BUILD_CROMWELL_JAR}" run nonexistent.wdl &
 pid=$!
+exec 2>&3
 sleep 10
 if kill -0 $pid > /dev/null 2>&1; then
   echo "ERROR: Process still exists"

--- a/src/ci/bin/testSingleWorkflowRunner.sh
+++ b/src/ci/bin/testSingleWorkflowRunner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -o errexit -o nounset -o pipefail +x
+set -o errexit -o nounset -o pipefail
 # import in shellcheck / CI / IntelliJ compatible ways
 # shellcheck source=/dev/null
 source "${BASH_SOURCE%/*}/test.inc.sh" || source test.inc.sh


### PR DESCRIPTION
- Github Actions was throwing a warning because it detected a crash in the script it was running.
- The crash it was seeing was something intentional triggered by a test. We don't want a warning about it. 
- Temporarily redirected stderr so that Github Actions doesn't see the crash. 