### PR TITLE
Fix WorkflowQueryParameter typing for arrays in swagger

### DIFF
--- a/engine/src/main/resources/swagger/cromwell.yaml
+++ b/engine/src/main/resources/swagger/cromwell.yaml
@@ -1444,8 +1444,9 @@ definitions:
           Returns only workflows with the specified workflow id.  If specified multiple times,
           returns workflows with any of the specified workflow ids.
       excludeLabelAnd:
-        type: string
-        format: array
+        type: array
+        items:
+          type: string
         pattern: ^([a-z][-a-z0-9]*[a-z0-9])?[:]([a-z][-a-z0-9]*[a-z0-9])?$
         description: >
           Excludes workflows with the specified label.  If specified multiple times,
@@ -1453,8 +1454,9 @@ definitions:
           and label value pair as separated with
           "label-key:label-value"
       excludeLabelOr:
-        type: string
-        format: array
+        type: array
+        items:
+          type: string
         pattern: ^([a-z][-a-z0-9]*[a-z0-9])?[:]([a-z][-a-z0-9]*[a-z0-9])?$
         description: >
           Excludes workflows with the specified label.  If specified multiple times,


### PR DESCRIPTION
Current swagger was generating invalid typescript typings in codegen. Issue is arrays are missing required items: https://swagger.io/docs/specification/data-models/data-types/#array

