### PR TITLE
WX-1103 Revert CI to old TES polling behavior

### DIFF
--- a/src/ci/resources/tes_application.conf
+++ b/src/ci/resources/tes_application.conf
@@ -51,7 +51,15 @@ backend {
         dockerRoot = "/cromwell-executions"
         endpoint = "http://127.0.0.1:9000/v1/tasks"
         concurrent-job-limit = 1000
-        transform-blob-to-local-path = false
+
+        # Override default polling to make it faster for speedy tests
+        poll-backoff {
+          min: "1 seconds"
+          max: "5 minutes"
+          multiplier: 1.1
+          randomization-factor: 0.5
+        }
+        
         filesystems {
           blob {
             enabled: false


### PR DESCRIPTION
Our new saner TES polling defaults noticeably increased the runtime of our TES integration tests. Reverting CI to old behavior with config update.