### PR TITLE
Fix Horicromtal Deadlock Test

### DIFF
--- a/src/ci/bin/get_cromwell_hosts.py
+++ b/src/ci/bin/get_cromwell_hosts.py
@@ -1,9 +1,9 @@
 # Based on https://stackoverflow.com/a/39895650
 from __future__ import print_function
-from docker import Client
+from docker import APIClient
 import os
 
-cli = Client(base_url='unix://var/run/docker.sock')
+cli = APIClient(base_url='unix://var/run/docker.sock')
 
 our_hostname = os.environ.get("HOSTNAME")
 

--- a/src/ci/bin/test-deadlock.sh
+++ b/src/ci/bin/test-deadlock.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 pip3 install docker-py
+# Workaround for issue described https://github.com/docker/docker-py/issues/3113. 
+# This is a temporary fix until the next release of docker-py
 pip3 install --force-reinstall -v "requests<2.2.29"
 
 cromwell_hosts_file="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell_hosts.txt"

--- a/src/ci/bin/test-deadlock.sh
+++ b/src/ci/bin/test-deadlock.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 pip3 install docker-py
+pip3 install --force-reinstall -v "requests<2.2.29"
 
 cromwell_hosts_file="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell_hosts.txt"
 

--- a/src/ci/bin/test-deadlock.sh
+++ b/src/ci/bin/test-deadlock.sh
@@ -2,10 +2,7 @@
 
 set -euo pipefail
 
-pip3 install docker-py
-# Workaround for issue described https://github.com/docker/docker-py/issues/3113. 
-# This is a temporary fix until the next release of docker-py
-pip3 install --force-reinstall -v "requests<2.2.29"
+pip3 install docker
 
 cromwell_hosts_file="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/cromwell_hosts.txt"
 

--- a/src/ci/docker-compose/cromwell-test/docker-setup.sh
+++ b/src/ci/docker-compose/cromwell-test/docker-setup.sh
@@ -87,3 +87,4 @@ update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
 pip3 install --upgrade --force-reinstall pyopenssl
+pip3 install --force-reinstall -v "requests<2.2.29"

--- a/src/ci/docker-compose/cromwell-test/docker-setup.sh
+++ b/src/ci/docker-compose/cromwell-test/docker-setup.sh
@@ -87,4 +87,3 @@ update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
 pip3 install --upgrade --force-reinstall pyopenssl
-pip3 install --force-reinstall -v "requests<2.2.29"


### PR DESCRIPTION
[WX-1107](https://broadworkbench.atlassian.net/browse/WX-1107?atlOrigin=eyJpIjoiNTM5ZGY2MzMyYWM5NGE2MThjMzg3NDAzOTY0YjZmMzYiLCJwIjoiaiJ9). One of our Integration Tests was failing due to a python dependency issue described [here](https://github.com/docker/docker-py/issues/3113). Long story short, using an older version of `requests` is a workaround to an issue that exists in the python `docker` package. Until that package gets updated, our script will fail due to the docker library passing an invalid argument to the requests library. 

This fix forces the github runner that is running the HoricromtalDeadlock test to downgrade its `requests` package, resolving the issue. This change will not affect anything other than that one test. 

[WX-1107]: https://broadworkbench.atlassian.net/browse/WX-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ