### PR TITLE
[WX-1108] Disable drs tests

### DIFF
--- a/src/ci/bin/testCentaurHoricromtalPapiV2beta.sh
+++ b/src/ci/bin/testCentaurHoricromtalPapiV2beta.sh
@@ -25,5 +25,7 @@ cromwell::build::run_centaur \
     -e relative_output_paths_colliding \
     -e standard_output_paths_colliding_prevented \
     -e papi_v2alpha1_gcsa \
+    -e drs_usa_jdr \
+    -e drs_usa_jdr_preresolve
 
 cromwell::build::generate_code_coverage

--- a/src/ci/bin/testCentaurPapiV2beta.sh
+++ b/src/ci/bin/testCentaurPapiV2beta.sh
@@ -23,6 +23,7 @@ cromwell::build::run_centaur \
     -e relative_output_paths_colliding \
     -e standard_output_paths_colliding_prevented \
     -e papi_v2alpha1_gcsa \
-    -e drs_usa_jdr
+    -e drs_usa_jdr \
+    -e drs_usa_jdr_preresolve
 
 cromwell::build::generate_code_coverage

--- a/src/ci/bin/testCentaurPapiV2beta.sh
+++ b/src/ci/bin/testCentaurPapiV2beta.sh
@@ -23,5 +23,6 @@ cromwell::build::run_centaur \
     -e relative_output_paths_colliding \
     -e standard_output_paths_colliding_prevented \
     -e papi_v2alpha1_gcsa \
+    -e drs_usa_jdr
 
 cromwell::build::generate_code_coverage


### PR DESCRIPTION
This is a temporary stopgap do get our CI up-and-running again while we work through the issues described [here](https://broadinstitute.slack.com/archives/C01KXE68J5D/p1684245171656659).  We will leave [WX-1108](https://broadworkbench.atlassian.net/browse/WX-1108?atlOrigin=eyJpIjoiYWViZWIwOWI3ZGY3NDhiNzk2ZTYyNDBlMTZiMTg3OWMiLCJwIjoiaiJ9) open until this PR is reverted and the tests are fixed again. 


[WX-1108]: https://broadworkbench.atlassian.net/browse/WX-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ