### PR TITLE
[WX-1136] Self Hosted

### DIFF
--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   sbt-build:
     name: sbt docker build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Clone Cromwell
         uses: actions/checkout@v2


### PR DESCRIPTION
Follow up to [this PR](https://github.com/broadinstitute/cromwell/pull/7151). Forgot to to set the runner to be `self-hosted` like it is in our release pipeline.