### PR TITLE
WX-1145 Fix minor regression introduced in WDL 1.1 foundation

### DIFF
--- a/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
+++ b/languageFactories/language-factory-core/src/main/scala/cromwell/languages/util/LanguageFactoryUtil.scala
@@ -94,7 +94,7 @@ object LanguageFactoryUtil {
     }
 
     val firstCodeLine = fileWithoutInitialWhitespace.headOption.map(_.dropWhile(_.isWhitespace))
-    firstCodeLine.exists { line => startsWithOptions.contains(line) }
+    firstCodeLine.exists { line => startsWithOptions.contains(line.trim) }
   }
 
   def chooseFactory(workflowSource: WorkflowSource, wsfc: WorkflowSourceFilesCollection): ErrorOr[LanguageFactory] = {

--- a/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
+++ b/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
@@ -52,6 +52,22 @@ class LooksParseableSpec extends AnyFlatSpec with Matchers {
     LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
   }
 
+  // This test technically contradicts the spec [0] but there is better hope of receiving a useful
+  // error if we try & fail to parse as 1.0, than if we fall back to the server default, `draft-2`
+  // > From draft-3 forward, the first line of all WDL files must be a version statement
+  // [0] https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#versioning
+  it should "work with `version 1.0` surrounded by comments" in {
+
+    val source =
+      """
+        |# My WDL does a cool thing
+        |version 1.0
+        |# Here we go...
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
+  }
+
   it should "reject Chris's idea of a version declaration" in {
 
     val source =

--- a/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
+++ b/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
@@ -52,4 +52,14 @@ class LooksParseableSpec extends AnyFlatSpec with Matchers {
     LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
   }
 
+  it should "reject Chris's idea of a version declaration" in {
+
+    val source =
+      """
+        |# Thank goodness this WDL is not version 1.1!
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe false
+  }
+
 }

--- a/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
+++ b/languageFactories/language-factory-core/src/test/scala/cromwell/languages/util/LooksParseableSpec.scala
@@ -1,0 +1,55 @@
+package cromwell.languages.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LooksParseableSpec extends AnyFlatSpec with Matchers {
+  behavior of "simpleLooksParseable"
+
+  it should "work with `version 1.0` followed by whitespace" in {
+
+    val source =
+      """
+        |version 1.0              
+        |# Programmer warning: make sure your editor does not trim the whitespace in the line above.
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
+  }
+
+  it should "work with `version 1.0` preceded by whitespace" in {
+
+    val source =
+      """
+        |              version 1.0
+        |# Programmer warning: make sure your editor does not trim the whitespace in the line above.
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
+  }
+
+  it should "work with `version 1.0` surrounded by whitespace" in {
+
+    val source =
+      """
+        |              version 1.0              
+        |# Programmer warning: make sure your editor does not trim the whitespace in the line above.
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
+  }
+
+  it should "work with `version 1.0` surrounded by whitespace on all sides" in {
+
+    val source =
+      """
+        |              
+        |              version 1.0              
+        |              
+        |# Programmer warning: make sure your editor does not trim the whitespace in the line above.
+        |""".stripMargin
+
+    LanguageFactoryUtil.simpleLooksParseable(List("version 1.0"), List("#"))(source) shouldBe true
+  }
+
+}


### PR DESCRIPTION
Introduced [here](https://github.com/broadinstitute/cromwell/pull/7105/files#diff-285a016e63c0e1914e8981320c01c262899bb48b7b03ed1e4c670eb77306a1a3). Prevented `version 1.0  ` with whitespace from correctly matching to the `1.0` parser.