### PR TITLE
WX-1179 DRS image build updates

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -9,7 +9,7 @@ jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
     if: github.event.pull_request.merged == true
-    runs-on: self-hosted # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
+    runs-on: ubuntu-latest
     steps:
     - name: Clone Cromwell
       uses: actions/checkout@v2

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   sbt-build:
     name: sbt docker build
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Clone Cromwell
         uses: actions/checkout@v2

--- a/.github/workflows/make_publish_prs.yml
+++ b/.github/workflows/make_publish_prs.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   make-firecloud-develop-pr:
     name: Create firecloud-develop PR
-    runs-on: self-hosted # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
+    runs-on: ubuntu-latest
     steps:
       - name: Clone firecloud-develop
         uses: actions/checkout@v2
@@ -70,4 +70,3 @@ jobs:
                 'It updates cromwell from version ${{ github.event.inputs.old_cromwell_version }} to ${{ github.event.inputs.new_cromwell_version }}.'
               ].join('\n')
             });
-

--- a/centaur/src/main/resources/standardTestCases/drs_tests/drs_usa_jdr.wdl
+++ b/centaur/src/main/resources/standardTestCases/drs_tests/drs_usa_jdr.wdl
@@ -61,7 +61,7 @@ task localize_jdr_drs_with_usa {
     }
 
     runtime {
-        docker: "ubuntu"
+        docker: "ubuntu:latest"
         backend: "papi-v2-usa"
     }
 }
@@ -88,7 +88,7 @@ task skip_localize_jdr_drs_with_usa {
     }
 
     runtime {
-        docker: "ubuntu"
+        docker: "ubuntu:latest"
         backend: "papi-v2-usa"
     }
 }
@@ -109,7 +109,7 @@ task read_drs_with_usa {
     }
 
     runtime {
-        docker: "ubuntu"
+        docker: "ubuntu:latest"
         backend: "papi-v2-usa"
     }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -127,12 +127,13 @@ object Settings {
    */
   val installLocalizerSettings: List[Setting[Seq[Instruction]]] = List(
     dockerCustomSettings := List(
+      Instructions.From("ubuntu:latest"),
       Instructions.Env("PATH", "$PATH:/usr/local/gcloud/google-cloud-sdk/bin"),
       // instructions to install `crcmod`
       Instructions.Run("apt-get -y update"),
       Instructions.Run("apt-get -y install python3.11"),
-      Instructions.Run("apt -y install python3-pip"),
-      Instructions.Run("apt-get -y install gcc python3-dev python3-setuptools"),
+      Instructions.Run("apt-get -y install python3-pip"),
+      Instructions.Run("apt-get -y install curl gcc python3-dev python3-setuptools"),
       Instructions.Run("pip3 uninstall crcmod"),
       Instructions.Run("pip3 install --no-cache-dir -U crcmod"),
       Instructions.Run("update-alternatives --install /usr/bin/python python /usr/bin/python3 1"),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -127,19 +127,18 @@ object Settings {
    */
   val installLocalizerSettings: List[Setting[Seq[Instruction]]] = List(
     dockerCustomSettings := List(
-      Instructions.From("ubuntu:latest"),
       Instructions.Env("PATH", "$PATH:/usr/local/gcloud/google-cloud-sdk/bin"),
       // instructions to install `crcmod`
       Instructions.Run("apt-get -y update"),
       Instructions.Run("apt-get -y install python3.11"),
       Instructions.Run("apt-get -y install python3-pip"),
-      Instructions.Run("apt-get -y install curl gcc python3-dev python3-setuptools"),
+      Instructions.Run("apt-get -y install wget gcc python3-dev python3-setuptools"),
       Instructions.Run("pip3 uninstall crcmod"),
       Instructions.Run("pip3 install --no-cache-dir -U crcmod"),
       Instructions.Run("update-alternatives --install /usr/bin/python python /usr/bin/python3 1"),
       Instructions.Env("CLOUDSDK_PYTHON", "python3"),
       // instructions to install Google Cloud SDK
-      Instructions.Run("curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz"),
+      Instructions.Run("wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz -O /tmp/google-cloud-sdk.tar.gz"),
       Instructions.Run("""mkdir -p /usr/local/gcloud \
                          | && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
                          | && /usr/local/gcloud/google-cloud-sdk/install.sh""".stripMargin),


### PR DESCRIPTION
The GCP Batch PR has seen a number of seemingly unrelated failures building the DRS localizer [(Github actions link)](https://github.com/broadinstitute/cromwell/actions/runs/5580938822/jobs/10198518044?pr=7177) and I saw them locally too, both on `develop` and the Batch branch [(Slack link)](https://broadinstitute.slack.com/archives/G01D73CM63S/p1689702982488299?thread_ts=1689702892.491819&cid=G01D73CM63S).

```
W: GPG error: http://security.ubuntu.com/ubuntu jammy-security InRelease: At least one invalid signature was encountered.
E: The repository 'http://security.ubuntu.com/ubuntu jammy-security InRelease' is not signed.

process "/bin/sh -c apt-get -y update" did not complete successfully
```

It seems that specifying the OS explicitly instead of implicitly helps work around the problem. I confirmed that yesterday's build of the localizer uses the same base so this is not a radical change.

[Nightly:](https://hub.docker.com/layers/broadinstitute/cromwell-drs-localizer/86-af9660e/images/sha256-ee39681ef7287e904fdde01874b5dfa80b045aed28b9cc4b017554bdb40015f1?context=repo)
```
docker inspect broadinstitute/cromwell-drs-localizer:86-af9660e
"Labels": {
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.version": "22.04"
}
```
Local:
```
docker inspect broadinstitute/cromwell-drs-localizer:86-813fc98-SNAP
"Labels": {
    "org.opencontainers.image.ref.name": "ubuntu",
    "org.opencontainers.image.version": "22.04"
}
```