### PR TITLE
WX-1210 Added JIRA ID for Cromwhelm auto commit message

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
-        echo {name}={JIRA_ID} >> $GITHUB_OUTPUT
+        echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
     - name: Clone Cromwell
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -88,5 +88,5 @@ jobs:
         git diff
         git config --global user.name "broadbot"
         git config --global user.email "broadbot@broadinstitute.org"
-        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update Cromwell to $HELM_NEW_TAG"
+        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
         git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -11,6 +11,12 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: self-hosted # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
     steps:
+    - name: Fetch Jira ID from the commit message
+      id: fetch-jira-id
+      run: |
+        JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
+        [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
+        echo {name}={JIRA_ID} >> $GITHUB_OUTPUT
     - name: Clone Cromwell
       uses: actions/checkout@v2
       with:
@@ -82,5 +88,5 @@ jobs:
         git diff
         git config --global user.name "broadbot"
         git config --global user.email "broadbot@broadinstitute.org"
-        git commit -am "Auto update to Cromwell $CROMWELL_VERSION"
+        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update Cromwell to $HELM_NEW_TAG"
         git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main


### PR DESCRIPTION
Addresses [WX-1210](https://broadworkbench.atlassian.net/browse/WX-1210)

PR adds the JIRA ticket ID to the auto-commit message we make on the `Cromwhelm` repo on merge. That repo performs checks for a JIRA ID as a step on the `Update and publish new cromwell-helm chart` action. Without the id, the action will always fail.

[WX-1210]: https://broadworkbench.atlassian.net/browse/WX-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ