### PR TITLE
WX-1210-fix Swapped out self-hosted with ubuntu latest

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -9,7 +9,7 @@ jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
     if: github.event.pull_request.merged == true
-    runs-on: self-hosted # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
+    runs-on: ubuntu:latest # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
     steps:
     - name: Fetch Jira ID from the commit message
       id: fetch-jira-id

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -9,7 +9,7 @@ jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu:latest # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
+    runs-on: ubuntu-latest # Faster machines; see https://github.com/broadinstitute/cromwell/settings/actions/runners
     steps:
     - name: Fetch Jira ID from the commit message
       id: fetch-jira-id


### PR DESCRIPTION
Attempting a fix for [WX-1210](https://broadworkbench.atlassian.net/browse/WX-1210)

The initial PR failed to execute the JIRA ID parse step. Upon frequent local testing, we're trying to use `ubuntu-latest` rather than `self-hosted` to see if the task works.

[WX-1210]: https://broadworkbench.atlassian.net/browse/WX-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ