### PR TITLE
WX-1210-action-fix Use PR title to find JIRA ID for cromwhelm commit message

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -3,12 +3,12 @@ name: chart-update-on-merge
 on:
   pull_request:
     types:
-      - closed
+      - opened
 
 jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
-    if: github.event.pull_request.merged == true
+#    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Jira ID from the commit message
@@ -17,76 +17,76 @@ jobs:
         JIRA_ID=$(echo '${{ github.event.pull_request.title }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
         echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
-    - name: Clone Cromwell
-      uses: actions/checkout@v2
-      with:
-        repository: broadinstitute/cromwell
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-        path: cromwell
-    - uses: olafurpg/setup-scala@v10
-      with:
-        java-version: adopt@1.11
-    - name: Clone Cromwhelm
-      uses: actions/checkout@v2
-      with:
-        repository: broadinstitute/cromwhelm
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-        path: cromwhelm
-    - name: Find Cromwell short SHA
-      run: |
-        set -e
-        cd cromwell
-        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
-    - name: Find Cromwell release number
-      run: |
-        set -e
-        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
-        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
-          exit 1
-        fi
-        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
-    - name: Save complete image ID
-      run: |
-        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
-    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: dsdejenkins
-        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
-    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
-    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
-    - name: Build Cromwell Docker
-      run: |
-        set -e
-        cd cromwell
-        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
-    - name: Deploy to dev and board release train (Cromwell)
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-    - name: Deploy to dev and board release train (CromIAM)
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-    - name: Edit & push chart
-      env:
-        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-      run: |
-        set -e
-        cd cromwhelm
-        git checkout main
-        ls -la
-        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
-
-        git diff
-        git config --global user.name "broadbot"
-        git config --global user.email "broadbot@broadinstitute.org"
-        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
-        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+#    - name: Clone Cromwell
+#      uses: actions/checkout@v2
+#      with:
+#        repository: broadinstitute/cromwell
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+#        path: cromwell
+#    - uses: olafurpg/setup-scala@v10
+#      with:
+#        java-version: adopt@1.11
+#    - name: Clone Cromwhelm
+#      uses: actions/checkout@v2
+#      with:
+#        repository: broadinstitute/cromwhelm
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+#        path: cromwhelm
+#    - name: Find Cromwell short SHA
+#      run: |
+#        set -e
+#        cd cromwell
+#        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
+#    - name: Find Cromwell release number
+#      run: |
+#        set -e
+#        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
+#        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
+#          exit 1
+#        fi
+#        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
+#    - name: Save complete image ID
+#      run: |
+#        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
+#    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
+#    - name: Login to Docker Hub
+#      uses: docker/login-action@v1
+#      with:
+#        username: dsdejenkins
+#        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+#    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
+#    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
+#    - name: Build Cromwell Docker
+#      run: |
+#        set -e
+#        cd cromwell
+#        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
+#    - name: Deploy to dev and board release train (Cromwell)
+#      uses: broadinstitute/repository-dispatch@master
+#      with:
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#        repository: broadinstitute/terra-helmfile
+#        event-type: update-service
+#        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+#    - name: Deploy to dev and board release train (CromIAM)
+#      uses: broadinstitute/repository-dispatch@master
+#      with:
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#        repository: broadinstitute/terra-helmfile
+#        event-type: update-service
+#        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+#    - name: Edit & push chart
+#      env:
+#        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#      run: |
+#        set -e
+#        cd cromwhelm
+#        git checkout main
+#        ls -la
+#        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
+#
+#        git diff
+#        git config --global user.name "broadbot"
+#        git config --global user.email "broadbot@broadinstitute.org"
+#        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
+#        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -3,12 +3,12 @@ name: chart-update-on-merge
 on:
   pull_request:
     types:
-      - opened
+      - closed
 
 jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
-#    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Jira ID from the commit message
@@ -17,76 +17,76 @@ jobs:
         JIRA_ID=$(echo '${{ github.event.pull_request.title }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
         echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
-#    - name: Clone Cromwell
-#      uses: actions/checkout@v2
-#      with:
-#        repository: broadinstitute/cromwell
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-#        path: cromwell
-#    - uses: olafurpg/setup-scala@v10
-#      with:
-#        java-version: adopt@1.11
-#    - name: Clone Cromwhelm
-#      uses: actions/checkout@v2
-#      with:
-#        repository: broadinstitute/cromwhelm
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-#        path: cromwhelm
-#    - name: Find Cromwell short SHA
-#      run: |
-#        set -e
-#        cd cromwell
-#        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
-#    - name: Find Cromwell release number
-#      run: |
-#        set -e
-#        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
-#        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
-#          exit 1
-#        fi
-#        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
-#    - name: Save complete image ID
-#      run: |
-#        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
-#    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
-#    - name: Login to Docker Hub
-#      uses: docker/login-action@v1
-#      with:
-#        username: dsdejenkins
-#        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
-#    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
-#    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
-#    - name: Build Cromwell Docker
-#      run: |
-#        set -e
-#        cd cromwell
-#        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
-#    - name: Deploy to dev and board release train (Cromwell)
-#      uses: broadinstitute/repository-dispatch@master
-#      with:
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#        repository: broadinstitute/terra-helmfile
-#        event-type: update-service
-#        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-#    - name: Deploy to dev and board release train (CromIAM)
-#      uses: broadinstitute/repository-dispatch@master
-#      with:
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#        repository: broadinstitute/terra-helmfile
-#        event-type: update-service
-#        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-#    - name: Edit & push chart
-#      env:
-#        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#      run: |
-#        set -e
-#        cd cromwhelm
-#        git checkout main
-#        ls -la
-#        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
-#
-#        git diff
-#        git config --global user.name "broadbot"
-#        git config --global user.email "broadbot@broadinstitute.org"
-#        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
-#        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+    - name: Clone Cromwell
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwell
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwell
+    - uses: olafurpg/setup-scala@v10
+      with:
+        java-version: adopt@1.11
+    - name: Clone Cromwhelm
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwhelm
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwhelm
+    - name: Find Cromwell short SHA
+      run: |
+        set -e
+        cd cromwell
+        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
+    - name: Find Cromwell release number
+      run: |
+        set -e
+        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
+        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
+          exit 1
+        fi
+        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
+    - name: Save complete image ID
+      run: |
+        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
+    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: dsdejenkins
+        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
+    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
+    - name: Build Cromwell Docker
+      run: |
+        set -e
+        cd cromwell
+        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
+    - name: Deploy to dev and board release train (Cromwell)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+    - name: Deploy to dev and board release train (CromIAM)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+    - name: Edit & push chart
+      env:
+        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+      run: |
+        set -e
+        cd cromwhelm
+        git checkout main
+        ls -la
+        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
+
+        git diff
+        git config --global user.name "broadbot"
+        git config --global user.email "broadbot@broadinstitute.org"
+        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
+        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -3,12 +3,12 @@ name: chart-update-on-merge
 on:
   pull_request:
     types:
-      - closed
+      - reopened
 
 jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
-    if: github.event.pull_request.merged == true
+#    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Jira ID from the commit message
@@ -17,76 +17,76 @@ jobs:
         JIRA_ID=$(echo '${{ github.event.pull_request.title }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
         echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
-    - name: Clone Cromwell
-      uses: actions/checkout@v2
-      with:
-        repository: broadinstitute/cromwell
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-        path: cromwell
-    - uses: olafurpg/setup-scala@v10
-      with:
-        java-version: adopt@1.11
-    - name: Clone Cromwhelm
-      uses: actions/checkout@v2
-      with:
-        repository: broadinstitute/cromwhelm
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-        path: cromwhelm
-    - name: Find Cromwell short SHA
-      run: |
-        set -e
-        cd cromwell
-        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
-    - name: Find Cromwell release number
-      run: |
-        set -e
-        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
-        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
-          exit 1
-        fi
-        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
-    - name: Save complete image ID
-      run: |
-        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
-    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: dsdejenkins
-        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
-    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
-    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
-    - name: Build Cromwell Docker
-      run: |
-        set -e
-        cd cromwell
-        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
-    - name: Deploy to dev and board release train (Cromwell)
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-    - name: Deploy to dev and board release train (CromIAM)
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-    - name: Edit & push chart
-      env:
-        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-      run: |
-        set -e
-        cd cromwhelm
-        git checkout main
-        ls -la
-        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
-
-        git diff
-        git config --global user.name "broadbot"
-        git config --global user.email "broadbot@broadinstitute.org"
-        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
-        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+#    - name: Clone Cromwell
+#      uses: actions/checkout@v2
+#      with:
+#        repository: broadinstitute/cromwell
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+#        path: cromwell
+#    - uses: olafurpg/setup-scala@v10
+#      with:
+#        java-version: adopt@1.11
+#    - name: Clone Cromwhelm
+#      uses: actions/checkout@v2
+#      with:
+#        repository: broadinstitute/cromwhelm
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+#        path: cromwhelm
+#    - name: Find Cromwell short SHA
+#      run: |
+#        set -e
+#        cd cromwell
+#        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
+#    - name: Find Cromwell release number
+#      run: |
+#        set -e
+#        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
+#        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
+#          exit 1
+#        fi
+#        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
+#    - name: Save complete image ID
+#      run: |
+#        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
+#    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
+#    - name: Login to Docker Hub
+#      uses: docker/login-action@v1
+#      with:
+#        username: dsdejenkins
+#        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+#    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
+#    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
+#    - name: Build Cromwell Docker
+#      run: |
+#        set -e
+#        cd cromwell
+#        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
+#    - name: Deploy to dev and board release train (Cromwell)
+#      uses: broadinstitute/repository-dispatch@master
+#      with:
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#        repository: broadinstitute/terra-helmfile
+#        event-type: update-service
+#        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+#    - name: Deploy to dev and board release train (CromIAM)
+#      uses: broadinstitute/repository-dispatch@master
+#      with:
+#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#        repository: broadinstitute/terra-helmfile
+#        event-type: update-service
+#        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+#    - name: Edit & push chart
+#      env:
+#        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+#      run: |
+#        set -e
+#        cd cromwhelm
+#        git checkout main
+#        ls -la
+#        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
+#
+#        git diff
+#        git config --global user.name "broadbot"
+#        git config --global user.email "broadbot@broadinstitute.org"
+#        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
+#        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -3,12 +3,12 @@ name: chart-update-on-merge
 on:
   pull_request:
     types:
-      - reopened
+      - closed
 
 jobs:
   chart-update:
     name: Cromwhelm Chart Auto Updater
-#    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Fetch Jira ID from the commit message
@@ -17,76 +17,76 @@ jobs:
         JIRA_ID=$(echo '${{ github.event.pull_request.title }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
         echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
-#    - name: Clone Cromwell
-#      uses: actions/checkout@v2
-#      with:
-#        repository: broadinstitute/cromwell
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-#        path: cromwell
-#    - uses: olafurpg/setup-scala@v10
-#      with:
-#        java-version: adopt@1.11
-#    - name: Clone Cromwhelm
-#      uses: actions/checkout@v2
-#      with:
-#        repository: broadinstitute/cromwhelm
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
-#        path: cromwhelm
-#    - name: Find Cromwell short SHA
-#      run: |
-#        set -e
-#        cd cromwell
-#        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
-#    - name: Find Cromwell release number
-#      run: |
-#        set -e
-#        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
-#        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
-#          exit 1
-#        fi
-#        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
-#    - name: Save complete image ID
-#      run: |
-#        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
-#    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
-#    - name: Login to Docker Hub
-#      uses: docker/login-action@v1
-#      with:
-#        username: dsdejenkins
-#        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
-#    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
-#    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
-#    - name: Build Cromwell Docker
-#      run: |
-#        set -e
-#        cd cromwell
-#        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
-#    - name: Deploy to dev and board release train (Cromwell)
-#      uses: broadinstitute/repository-dispatch@master
-#      with:
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#        repository: broadinstitute/terra-helmfile
-#        event-type: update-service
-#        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-#    - name: Deploy to dev and board release train (CromIAM)
-#      uses: broadinstitute/repository-dispatch@master
-#      with:
-#        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#        repository: broadinstitute/terra-helmfile
-#        event-type: update-service
-#        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
-#    - name: Edit & push chart
-#      env:
-#        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-#      run: |
-#        set -e
-#        cd cromwhelm
-#        git checkout main
-#        ls -la
-#        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
-#
-#        git diff
-#        git config --global user.name "broadbot"
-#        git config --global user.email "broadbot@broadinstitute.org"
-#        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
-#        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+    - name: Clone Cromwell
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwell
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwell
+    - uses: olafurpg/setup-scala@v10
+      with:
+        java-version: adopt@1.11
+    - name: Clone Cromwhelm
+      uses: actions/checkout@v2
+      with:
+        repository: broadinstitute/cromwhelm
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        path: cromwhelm
+    - name: Find Cromwell short SHA
+      run: |
+        set -e
+        cd cromwell
+        echo "CROMWELL_SHORT_SHA=`git rev-parse --short $GITHUB_SHA`" >> $GITHUB_ENV
+    - name: Find Cromwell release number
+      run: |
+        set -e
+        previous_version=$(curl -X GET https://api.github.com/repos/broadinstitute/cromwell/releases/latest | jq .tag_name | xargs)
+        if ! [[ "${previous_version}" =~ ^[0-9][0-9]+$ ]]; then
+          exit 1
+        fi
+        echo "CROMWELL_NUMBER=$((previous_version + 1))" >> $GITHUB_ENV
+    - name: Save complete image ID
+      run: |
+        echo "CROMWELL_VERSION=`echo "$CROMWELL_NUMBER-$CROMWELL_SHORT_SHA"`" >> $GITHUB_ENV
+    # `DSDEJENKINS_PASSWORD` auto syncs from vault with https://github.com/broadinstitute/terraform-ap-deployments/pull/614
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: dsdejenkins
+        password: ${{ secrets.DSDEJENKINS_PASSWORD }}
+    # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
+    # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
+    - name: Build Cromwell Docker
+      run: |
+        set -e
+        cd cromwell
+        sbt -Dproject.isSnapshot=false -Dproject.isRelease=false dockerBuildAndPush
+    - name: Deploy to dev and board release train (Cromwell)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+    - name: Deploy to dev and board release train (CromIAM)
+      uses: broadinstitute/repository-dispatch@master
+      with:
+        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        repository: broadinstitute/terra-helmfile
+        event-type: update-service
+        client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
+    - name: Edit & push chart
+      env:
+        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+      run: |
+        set -e
+        cd cromwhelm
+        git checkout main
+        ls -la
+        sed -i "s|image: broadinstitute/cromwell:.*|image: broadinstitute/cromwell:$CROMWELL_VERSION|" terra-batch-libchart/values.yaml
+
+        git diff
+        git config --global user.name "broadbot"
+        git config --global user.email "broadbot@broadinstitute.org"
+        git commit -am "${{ steps.fetch-jira-id.outputs.JIRA_ID }}: Auto update to Cromwell $CROMWELL_VERSION"
+        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Fetch Jira ID from the commit message
       id: fetch-jira-id
       run: |
-        JIRA_ID=$(echo '${{ github.event.head_commit.message }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
+        JIRA_ID=$(echo '${{ github.event.pull_request.title }}' | grep -Eo '\[?[A-Z][A-Z]+-[0-9]+\]?')
         [[ -z "$JIRA_ID" ]] && { echo "No Jira ID found in $1" ; exit 1; }
         echo "JIRA_ID=$JIRA_ID" >> $GITHUB_OUTPUT
     - name: Clone Cromwell


### PR DESCRIPTION
Fix/update for [WX-1210](https://broadworkbench.atlassian.net/browse/WX-1210)

Turns out that the `head_commit` attribute is not available on `pull_request` actions, which is why the JIRA ID check kept failing. I'm opting to use `github.event.pull_request.title` which is accessible on `pull_request`

[WX-1210]: https://broadworkbench.atlassian.net/browse/WX-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ