### PR TITLE
WX-1110-query-fix Corrected Query to pull in attributes outside of executionStatus and backendStatus

### DIFF
--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -274,7 +274,9 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with CromwellTimeoutSpec wit
           WorkflowMetadataSummaryEntry(failedParentWorkflowId, Option("failedParentWorkflow"), Option("Failed"), Option(now), Option(now), Option(now), None, None, None, None),
           WorkflowMetadataSummaryEntry(failedChildWorkflowId, Option("failedChildWorkflow"), Option("Failed"), Option(now), Option(now), Option(now), Option(failedParentWorkflowId), Option(failedParentWorkflowId), None, None),
           WorkflowMetadataSummaryEntry(successfulParentWorkflowId, Option("successfulParentWorkflow"), Option("Succeeded"), Option(now), Option(now), Option(now), None, None, None, None),
-          WorkflowMetadataSummaryEntry(successfulChildWorkflowId, Option("successfulChildWorkflow"), Option("Succeeded"), Option(now), Option(now), Option(now), Option(successfulParentWorkflowId), Option(successfulParentWorkflowId), None, None)
+          WorkflowMetadataSummaryEntry(successfulChildWorkflowId, Option("successfulChildWorkflow"), Option("Succeeded"), Option(now), Option(now), Option(now), Option(successfulParentWorkflowId), Option(successfulParentWorkflowId), None, None),
+          WorkflowMetadataSummaryEntry(ignoredFailedParentWorkflowId, Option("ignoredFailedParentWorkflow"), Option("Failed"), Option(now), Option(now), Option(now), Option(ignoredFailedParentWorkflowId), Option(ignoredFailedParentWorkflowId), None, None),
+          WorkflowMetadataSummaryEntry(ignoredFailedChildWorkflowId, Option("ignoredFailedChildWorkflow"), Option("Failed"), Option(now), Option(now), Option(now), Option(ignoredFailedChildWorkflowId), Option(ignoredFailedChildWorkflowId), None, None)
         )
       ).futureValue(Timeout(10.seconds))
 


### PR DESCRIPTION
Fix for [WX-1110](https://broadworkbench.atlassian.net/browse/WX-1110)

PR corrects the query so that all attributes on a failed task are pulled in. While the earlier PR did pull in all of the tasks, a `WHERE` clause that checked against `METADATA_KEY = 'executionStatus' or 'backendStatus'` made the query only fetch those attributes, making the fetched data rather uninformative. 

Rather than handle the max/failed scatter, max/failed attempt, and metadata_value query on one subquery the calculations are divided up into three distinct sub-queries that are inner joined agains the `METADATA_ENTRY` table. Doing so allows the outer `WHERE` clause to compare the entry's `CALL_FQN`, `JOB_SCATTER_INDEX`, and `JOB_RETRY_ATTEMPT` against the calculated values on the sub-queries. Values that line up across all the tables indicate a match for the result set.

[WX-1110]: https://broadworkbench.atlassian.net/browse/WX-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ