### PR TITLE
WX-1156 Fix internal_path_prefix

### DIFF
--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -142,5 +142,13 @@ case class BlobPath private[blob](pathString: String, endpoint: EndpointURL, con
     else pathString
   }
 
+  /**
+    * Returns the path relative to the container root.
+    * For example, https://{storageAccountName}.blob.core.windows.net/{containerid}/path/to/my/file
+    * will be returned as path/to/my/file.
+    * @return Path string relative to the container root.
+    */
+  def pathWithoutContainer : String = pathString
+  
   override def getSymlinkSafePath(options: LinkOption*): Path  = toAbsolutePath
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -36,7 +36,8 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
    * This is not a standard TES feature, but rather related to the Azure TES implementation that Terra uses.
    * While passing it outside of terra won't do any harm, we could consider making this optional and/or configurable.
    */
-  val tesTaskRoot : String = callRoot match {
+  private val taskFullPath = callRoot./("execution")./("tes_task")
+  val tesTaskRoot : String = taskFullPath match {
     case blob: BlobPath => blob.pathWithoutContainer
     case anyOtherPath: Path => anyOtherPath.pathAsString
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -36,7 +36,7 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
    * This is not a standard TES feature, but rather related to the Azure TES implementation that Terra uses.
    * While passing it outside of terra won't do any harm, we could consider making this optional and/or configurable.
    */
-  private val taskFullPath = callRoot./("execution")./("tes_task")
+  private val taskFullPath = callRoot./("tes_task")
   val tesTaskRoot : String = taskFullPath match {
     case blob: BlobPath => blob.pathWithoutContainer
     case anyOtherPath: Path => anyOtherPath.pathAsString

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.Config
 import cromwell.backend.io.{JobPaths, WorkflowPaths}
 import cromwell.backend.{BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.path._
+import cromwell.filesystems.blob.BlobPath
 
 object TesJobPaths {
   def apply(jobKey: BackendJobDescriptorKey,
@@ -30,12 +31,15 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
 
   /*
    * tesTaskRoot: This is the root directory that TES will use for files related to this task.
-   * We provide it to TES as a k/v pair where the key is "internal_path_prefix" (specified in TesWorkflowOptionKeys.scala)
-   * and the value is a blob path.
+   * TES expects a path relative to the root of the storage container.
+   * We provide it to TES as a k/v pair where the key is "internal_path_prefix" and the value is the relative path string.
    * This is not a standard TES feature, but rather related to the Azure TES implementation that Terra uses.
    * While passing it outside of terra won't do any harm, we could consider making this optional and/or configurable.
    */
-  val tesTaskRoot : Path = callExecutionRoot.resolve("tes_task")
+  val tesTaskRoot : String = callRoot match {
+    case blob: BlobPath => blob.pathWithoutContainer
+    case anyOtherPath: Path => anyOtherPath.pathAsString
+  }
 
   // Given an output path, return a path localized to the storage file system
   def storageOutput(path: String): String = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -242,7 +242,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
   val resources: Resources = TesTask.makeResources(
     runtimeAttributes,
     preferedWorkflowExecutionIdentity,
-    Option(tesPaths.tesTaskRoot.pathAsString)
+    Option(tesPaths.tesTaskRoot)
   )
 }
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
@@ -101,7 +101,7 @@ class TesTaskSpec
       TestConfig.emptyConfig)
 
     val expectedKey = "internal_path_prefix"
-    val expectedValue = Option(tesPaths.tesTaskRoot.pathAsString)
+    val expectedValue = Option(tesPaths.tesTaskRoot)
 
     //Assert path correctly ends up in the resources
     val wei = Option("abc123")


### PR DESCRIPTION
My [last PR](https://github.com/broadinstitute/cromwell/pull/7190) used a path that didn't work with TES 4.4. This branch is the fix. 

Unlike other paths we use with TES, this one needs to be relative to the root of the storage container and not a full blob path. 