### PR TITLE
WX-1256 Temporarily turn off engine hashing for blob files

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -183,7 +183,8 @@ class NioFlow(parallelism: Int,
   private def getStoredHash(file: Path): IO[Option[FileHash]] = {
     file match {
       case gcsPath: GcsPath => getFileHashForGcsPath(gcsPath).map(Option(_))
-      case blobPath: BlobPath => getFileHashForBlobPath(blobPath)
+      // Temporarily disable since our hashing algorithm doesn't match the stored hash
+      case blobPath: BlobPath => IO.pure(None) //getFileHashForBlobPath(blobPath)
       case drsPath: DrsPath => IO {
         // We assume all DRS files have a stored hash; this will throw
         // if the file does not.

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -184,6 +184,7 @@ class NioFlow(parallelism: Int,
     file match {
       case gcsPath: GcsPath => getFileHashForGcsPath(gcsPath).map(Option(_))
       // Temporarily disable since our hashing algorithm doesn't match the stored hash
+      // https://broadworkbench.atlassian.net/browse/WX-1257
       case blobPath: BlobPath => IO.pure(None) //getFileHashForBlobPath(blobPath)
       case drsPath: DrsPath => IO {
         // We assume all DRS files have a stored hash; this will throw

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -185,7 +185,7 @@ class NioFlow(parallelism: Int,
       case gcsPath: GcsPath => getFileHashForGcsPath(gcsPath).map(Option(_))
       // Temporarily disable since our hashing algorithm doesn't match the stored hash
       // https://broadworkbench.atlassian.net/browse/WX-1257
-      case blobPath: BlobPath => IO.pure(None) //getFileHashForBlobPath(blobPath)
+      case _: BlobPath => IO.pure(None) //getFileHashForBlobPath(blobPath)
       case drsPath: DrsPath => IO {
         // We assume all DRS files have a stored hash; this will throw
         // if the file does not.
@@ -230,9 +230,10 @@ class NioFlow(parallelism: Int,
     gcsPath.objectBlobId.map(id => FileHash(HashType.GcsCrc32c, gcsPath.cloudStorage.get(id).getCrc32c))
   }
 
-  private def getFileHashForBlobPath(blobPath: BlobPath): IO[Option[FileHash]] = delayedIoFromTry {
-    blobPath.md5HexString.map(md5 => md5.map(FileHash(HashType.Md5, _)))
-  }
+  // Restore with https://broadworkbench.atlassian.net/browse/WX-1257
+//  private def getFileHashForBlobPath(blobPath: BlobPath): IO[Option[FileHash]] = delayedIoFromTry {
+//    blobPath.md5HexString.map(md5 => md5.map(FileHash(HashType.Md5, _)))
+//  }
 
   private def generateMd5FileHashForPath(path: Path): IO[FileHash] = delayedIoFromTry {
     tryWithResource(() => path.newInputStream) { inputStream =>

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -230,7 +230,6 @@ class NioFlow(parallelism: Int,
     gcsPath.objectBlobId.map(id => FileHash(HashType.GcsCrc32c, gcsPath.cloudStorage.get(id).getCrc32c))
   }
 
-  // Restore with https://broadworkbench.atlassian.net/browse/WX-1257
   private def getFileHashForBlobPath(blobPath: BlobPath): IO[Option[FileHash]] = delayedIoFromTry {
     blobPath.md5HexString.map(md5 => md5.map(FileHash(HashType.Md5, _)))
   }


### PR DESCRIPTION
This broke because the stored blob hash doesn't match our hashing algorithm when reading a file in an engine function.