### PR TITLE
[WX-1168] TES Log Paths

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
@@ -19,6 +19,6 @@ trait TesJobCachingActorHelper extends StandardCachingActorHelper {
   lazy val tesConfiguration: TesConfiguration = initializationData.tesConfiguration
 
   lazy val runtimeAttributes = TesRuntimeAttributes(validatedRuntimeAttributes, jobDescriptor.runtimeAttributes, tesConfiguration)
-  override protected def nonStandardMetadata: Map[String, Any] = super.nonStandardMetadata ++ tesJobPaths.getAzureLogPathsForMetadata
+  override protected def nonStandardMetadata: Map[String, Any] = super.nonStandardMetadata ++ tesJobPaths.azureLogPathsForMetadata
 
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
@@ -19,5 +19,6 @@ trait TesJobCachingActorHelper extends StandardCachingActorHelper {
   lazy val tesConfiguration: TesConfiguration = initializationData.tesConfiguration
 
   lazy val runtimeAttributes = TesRuntimeAttributes(validatedRuntimeAttributes, jobDescriptor.runtimeAttributes, tesConfiguration)
+  override protected def nonStandardMetadata: Map[String, Any] = super.nonStandardMetadata ++ tesJobPaths.getAzureLogPathsForMetadata
 
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -30,9 +30,10 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
   val callInputsRoot = callRoot.resolve("inputs")
 
   /*
-   * tesTaskRoot: This is the root directory that TES will use for files related to this task.
-   * TES expects a path relative to the root of the storage container.
-   * We provide it to TES as a k/v pair where the key is "internal_path_prefix" and the value is the relative path string.
+   * tesTaskRoot: The Azure TES implementation allows us to specify a working directory that it should use for its own files.
+   * Once the task finishes, this directory will contain stderr.txt, stdout.txt, and some other misc files.
+   * Unlike other paths we provide, this one is expected as a path relative to the root of the storage container.
+   * We provide it as a k/v pair where the key is "internal_path_prefix" and the value is the relative path string.
    * This is not a standard TES feature, but rather related to the Azure TES implementation that Terra uses.
    * While passing it outside of terra won't do any harm, we could consider making this optional and/or configurable.
    */
@@ -41,6 +42,13 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
     case blob: BlobPath => blob.pathWithoutContainer
     case anyOtherPath: Path => anyOtherPath.pathAsString
   }
+
+  // Like above: Nothing should rely on these files existing, since only the Azure TES implementation will actually create them.
+  // Used to send the Azure TES log paths to the frontend.
+  def getAzureLogPathsForMetadata : Map[String, Any] = Map(
+    "tes_stdout" -> taskFullPath./("stdout.txt").pathAsString,
+    "tes_stderr" -> taskFullPath./("stderr.txt").pathAsString
+  )
 
   // Given an output path, return a path localized to the storage file system
   def storageOutput(path: String): String = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobPaths.scala
@@ -45,7 +45,7 @@ case class TesJobPaths private[tes] (override val workflowPaths: TesWorkflowPath
 
   // Like above: Nothing should rely on these files existing, since only the Azure TES implementation will actually create them.
   // Used to send the Azure TES log paths to the frontend.
-  def getAzureLogPathsForMetadata : Map[String, Any] = Map(
+  val azureLogPathsForMetadata : Map[String, Any] = Map(
     "tes_stdout" -> taskFullPath./("stdout.txt").pathAsString,
     "tes_stderr" -> taskFullPath./("stderr.txt").pathAsString
   )

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesJobPathsSpec.scala
@@ -35,6 +35,11 @@ class TesJobPathsSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers
       File(s"/cromwell-executions/wf_hello/$id/call-hello").pathAsString
     jobPaths.callExecutionDockerRoot.toString shouldBe
       File(s"/cromwell-executions/wf_hello/$id/call-hello/execution").pathAsString
+    jobPaths.azureLogPathsForMetadata shouldBe
+      Map(
+        "tes_stdout" -> File(s"local-cromwell-executions/wf_hello/$id/call-hello/tes_task/stdout.txt").pathAsString,
+        "tes_stderr" -> File(s"local-cromwell-executions/wf_hello/$id/call-hello/tes_task/stderr.txt").pathAsString
+      )
 
     val jobKeySharded = BackendJobDescriptorKey(call, Option(0), 1)
     val jobPathsSharded = TesJobPaths(jobKeySharded, wd, TesTestConfig.backendConfig)


### PR DESCRIPTION
When using a TES backend, Cromwell will now include two additional paths in the call metadata. These paths point to log files that Azure TES creates during call execution. 