### PR TITLE
Add support for custom logs group and tags

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -30,8 +30,6 @@
  */
 package cromwell.backend.impl.aws
 
-import java.security.MessageDigest
-
 import cats.data.ReaderT._
 import cats.data.{Kleisli, ReaderT}
 import cats.effect.{Async, Timer}
@@ -53,8 +51,10 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, NoSuchKeyException, PutObjectRequest}
 import wdl4s.parser.MemoryUnit
 
-import scala.jdk.CollectionConverters._
+import java.security.MessageDigest
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+import scala.jdk.javaapi.CollectionConverters.asJava
 import scala.util.{Random, Try}
 
 /**
@@ -256,7 +256,6 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
           SubmitJobRequest.builder()
             .jobName(sanitize(jobDescriptor.taskCall.fullyQualifiedName))
             .parameters(parameters.collect({ case i: AwsBatchInput => i.toStringString }).toMap.asJava)
-
             //provide job environment variables, vcpu and memory
             .containerOverrides(
               ContainerOverrides.builder
@@ -276,6 +275,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
                 )
                 .build()
             )
+            .tags(asJava(runtimeAttributes.resourceTags))
             .jobQueue(runtimeAttributes.queueArn)
             .jobDefinition(definitionArn)
             .build
@@ -462,7 +462,7 @@ final case class AwsBatchJob(jobDescriptor: BackendJobDescriptor, // WDL/CWL
   def output(detail: JobDetail): String = {
     val events: Seq[OutputLogEvent] = cloudWatchLogsClient.getLogEvents(GetLogEventsRequest.builder
       // http://aws-java-sdk-javadoc.s3-website-us-west-2.amazonaws.com/latest/software/amazon/awssdk/services/batch/model/ContainerDetail.html#logStreamName--
-      .logGroupName("/aws/batch/job")
+      .logGroupName(runtimeAttributes.logsGroup)
       .logStreamName(detail.container.logStreamName)
       .startFromHead(true)
       .build).events.asScala.toList

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -34,7 +34,7 @@ package cromwell.backend.impl.aws
 import scala.collection.mutable.ListBuffer
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.io.JobPaths
-import software.amazon.awssdk.services.batch.model.{ContainerProperties, Host, KeyValuePair, MountPoint, ResourceRequirement, ResourceType, Volume}
+import software.amazon.awssdk.services.batch.model.{ContainerProperties, Host, KeyValuePair, LogConfiguration, MountPoint, ResourceRequirement, ResourceType, Volume}
 import cromwell.backend.impl.aws.io.AwsBatchVolume
 
 import scala.jdk.CollectionConverters._
@@ -42,6 +42,8 @@ import java.security.MessageDigest
 import org.apache.commons.lang3.builder.{ToStringBuilder, ToStringStyle}
 import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.parser.MemoryUnit
+
+import scala.jdk.javaapi.CollectionConverters.asJava
 
 
 /**
@@ -148,6 +150,12 @@ trait AwsBatchJobDefinitionBuilder {
     val packedCommand = packCommand("/bin/bash", "-c", cmdName)
     val volumes =  buildVolumes( context.runtimeAttributes.disks )
     val mountPoints = buildMountPoints( context.runtimeAttributes.disks)
+    val logConfiguration = LogConfiguration.builder()
+      .logDriver("awslogs")
+      .options(asJava(Map(
+        "awslogs-group" -> context.runtimeAttributes.logsGroup
+      )))
+      .build()
     val jobDefinitionName = buildName(
       context.runtimeAttributes.dockerImage,
       packedCommand.mkString(","),
@@ -158,16 +166,17 @@ trait AwsBatchJobDefinitionBuilder {
 
     (builder
        .command(packedCommand.asJava)
-      .resourceRequirements(
-        ResourceRequirement.builder()
-          .`type`(ResourceType.MEMORY)
-          .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
-          .build(),
-        ResourceRequirement.builder()
-          .`type`(ResourceType.VCPU)
-          .value(context.runtimeAttributes.cpu.value.toString)
-          .build(),
-      )
+        .resourceRequirements(
+          ResourceRequirement.builder()
+            .`type`(ResourceType.MEMORY)
+            .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
+            .build(),
+          ResourceRequirement.builder()
+            .`type`(ResourceType.VCPU)
+            .value(context.runtimeAttributes.cpu.value.toString)
+            .build(),
+        )
+        .logConfiguration(logConfiguration)
         .volumes( volumes.asJava)
         .mountPoints( mountPoints.asJava)
         .environment(environment.asJava),

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -61,7 +61,8 @@ import scala.util.matching.Regex
  * @param noAddress is there no address
  * @param scriptS3BucketName the s3 bucket where the execution command or script will be written and, from there, fetched into the container and executed
  * @param fileSystem the filesystem type, default is "s3"
- * @param logsGroup the log group
+ * @param logsGroup the CloudWatch log group name to write logs to
+ * @param resourceTags a map of tags to add to the AWS Batch job submission
  */
 case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      zones: Vector[String],

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -112,7 +112,9 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       continueOnReturnCode = ContinueOnReturnCodeFlag(false),
       noAddress = false,
       scriptS3BucketName = "script-bucket",
-      fileSystem = "s3")
+      fileSystem = "s3",
+      logsGroup = "/aws/batch/job",
+      resourceTags = Map("tag" -> "value"))
 
   private def generateBasicJob: AwsBatchJob = {
     val job = AwsBatchJob(null, runtimeAttributes, "commandLine", script,

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -56,18 +56,22 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     )))
   }
 
-  val expectedDefaults = new AwsBatchRuntimeAttributes(refineMV[Positive](1), Vector("us-east-1a", "us-east-1b"),
-
+  val expectedDefaults = new AwsBatchRuntimeAttributes(
+    refineMV[Positive](1),
+    Vector("us-east-1a", "us-east-1b"),
     MemorySize(2, MemoryUnit.GB), Vector(AwsBatchWorkingDisk()),
     "ubuntu:latest",
     "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue",
     false,
     ContinueOnReturnCodeSet(Set(0)),
     false,
-    "my-stuff")
+    "my-stuff",
+    "/Cromwell/job/",
+    Map("tag1" -> "value1"))
 
-  val expectedDefaultsLocalFS = new AwsBatchRuntimeAttributes(refineMV[Positive](1), Vector("us-east-1a", "us-east-1b"),
-
+  val expectedDefaultsLocalFS = new AwsBatchRuntimeAttributes(
+    refineMV[Positive](1),
+    Vector("us-east-1a", "us-east-1b"),
     MemorySize(2, MemoryUnit.GB), Vector(AwsBatchWorkingDisk()),
     "ubuntu:latest",
     "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue",
@@ -75,6 +79,8 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     ContinueOnReturnCodeSet(Set(0)),
     false,
     "",
+    "/Cromwell/job/",
+    Map(),
     "local")
 
   "AwsBatchRuntimeAttributes" should {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchTestConfig.scala
@@ -61,6 +61,10 @@ object AwsBatchTestConfig {
       |    zones:["us-east-1a", "us-east-1b"]
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: "my-bucket"
+      |    logsGroup: "/Cromwell/job/"
+      |    resourceTags {
+      |       tag1: "value1"
+      |    }
       |}
       |
       |""".stripMargin
@@ -140,6 +144,7 @@ object AwsBatchTestConfigForLocalFS {
       |    zones:["us-east-1a", "us-east-1b"]
       |    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
       |    scriptBucketName: ""
+      |    logsGroup: "/Cromwell/job/"
       |}
       |
       |""".stripMargin


### PR DESCRIPTION
Add the `logsGroup` and `resourceTags` config option to the `default-runtime-attributes` section of the AWS Batch configuration.

This enables you to send the logs to a custom log group name and tag the jobs that Cromwell submits.

Sample usage:
```
default-runtime-attributes {
    queueArn: "arn:aws:batch:us-east-1:111222333444:job-queue/job-queue"
    logsGroup: "/Cromwell/job/"
    resourceTags {
       projectid: "project1"
    }
}
```