### PR TITLE
WM-2294: Allow role-setter action to run on change

### DIFF
--- a/database/migration/src/main/resources/metadata_changesets/set_table_role.xml
+++ b/database/migration/src/main/resources/metadata_changesets/set_table_role.xml
@@ -11,7 +11,7 @@
         This changeset will be applied whenever the 'sharedCromwellDbRole' property is set.
         It runs every time to ensure the role is set correctly after all other changesets.
      -->
-    <changeSet runAlways="true" author="sshah" id="set_table_role" dbms="postgresql">
+    <changeSet runAlways="true" runOnChange="true" author="sshah" id="set_table_role" dbms="postgresql">
         <preConditions onFail="MARK_RAN">
             <!-- check that 'sharedCromwellDbRole' role is set, and matches something in the pg_roles table -->
             <sqlCheck expectedResult="1">


### PR DESCRIPTION
This means that this changeset will always run (on postgres), and will succeed on subsequent runs even if the parameter given to the changelog has changed since the first time it was run.

Note that the precondition check (don't do anything active if there is no role supplied) still applies, so "always run" doesn't necessarily mean "always change anything"