### PR TITLE
[WX-1260] Acquire sas token from task runner

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -426,10 +426,12 @@ trait StandardAsyncExecutionActor
            |find . -type d -exec sh -c '[ -z "$$(ls -A '"'"'{}'"'"')" ] && touch '"'"'{}'"'"'/.file' \\;
            |)""".stripMargin)
 
+    val errorOrPreamble: ErrorOr[String] = scriptPreamble
+
     // The `tee` trickery below is to be able to redirect to known filenames for CWL while also streaming
     // stdout and stderr for PAPI to periodically upload to cloud storage.
     // https://stackoverflow.com/questions/692000/how-do-i-write-stderr-to-a-file-while-using-tee-with-a-pipe
-    (errorOrDirectoryOutputs, errorOrGlobFiles, scriptPreamble).mapN((directoryOutputs, globFiles, preamble) =>
+    (errorOrDirectoryOutputs, errorOrGlobFiles, errorOrPreamble).mapN((directoryOutputs, globFiles, preamble) =>
     s"""|#!$jobShell
         |DOCKER_OUTPUT_DIR_LINK
         |cd ${cwd.pathAsString}

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
@@ -244,15 +244,15 @@ class WSMBlobSasTokenGenerator(wsmClientProvider: WorkspaceManagerApiClientProvi
    * this function will make two REST requests. Otherwise, the relevant data is already cached locally.
    */
   def getWSMSasFetchEndpoint(blobPath: BlobPath, tokenDuration: Option[Duration] = None): Try[String] = {
-    val lifetimeSeconds: Int = tokenDuration.map(d => d.toSeconds.intValue).getOrElse(8*60*60)
     val wsmEndpoint = wsmClientProvider.getBaseWorkspaceManagerUrl
+    val lifetimeQueryParameters: String = tokenDuration.map(d => s"?sasExpirationDuration=${d.toSeconds.intValue}").getOrElse("")
     val terraInfo: Try[WSMTerraCoordinates] = for {
       workspaceId <- parseTerraWorkspaceIdFromPath(blobPath)
       containerResourceId <- getContainerResourceId(workspaceId, blobPath.container, None)
       coordinates = WSMTerraCoordinates(wsmEndpoint, workspaceId, containerResourceId)
     } yield coordinates
     terraInfo.map{terraCoordinates =>
-      s"${terraCoordinates.wsmEndpoint}/api/workspaces/v1/${terraCoordinates.workspaceId.toString}/resources/controlled/azure/storageContainer/${terraCoordinates.containerResourceId.toString}/getSasToken?sasExpirationDuration=$lifetimeSeconds"
+      s"${terraCoordinates.wsmEndpoint}/api/workspaces/v1/${terraCoordinates.workspaceId.toString}/resources/controlled/azure/storageContainer/${terraCoordinates.containerResourceId.toString}/getSasToken${lifetimeQueryParameters}"
     }
   }
 }

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
@@ -178,10 +178,7 @@ case class WSMBlobSasTokenGenerator(wsmClientProvider: WorkspaceManagerApiClient
     * @return an AzureSasCredential for accessing a blob container
     */
   def generateBlobSasToken(endpoint: EndpointURL, container: BlobContainerName): Try[AzureSasCredential] = {
-    val wsmAuthToken: Try[String] = overrideWsmAuthToken match {
-      case Some(t) => Success(t)
-      case None => AzureCredentials.getAccessToken(None).toTry
-    }
+    val wsmAuthToken: Try[String] = getWsmAuth
     container.workspaceId match {
       // If this is a Terra workspace, request a token from WSM
       case Success(workspaceId) => {
@@ -204,6 +201,13 @@ case class WSMBlobSasTokenGenerator(wsmClientProvider: WorkspaceManagerApiClient
  def getContainerResourceId(workspaceId: UUID, container: BlobContainerName, wsmAuth : String): Try[UUID] = {
     val wsmResourceClient = wsmClientProvider.getResourceApi(wsmAuth)
     wsmResourceClient.findContainerResourceId(workspaceId, container)
+  }
+
+  def getWsmAuth: Try[String] = {
+    overrideWsmAuthToken match {
+      case Some(t) => Success(t)
+      case None => AzureCredentials.getAccessToken(None).toTry
+    }
   }
 }
 

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
@@ -188,7 +188,7 @@ class WSMBlobSasTokenGenerator(wsmClientProvider: WorkspaceManagerApiClientProvi
         (for {
           wsmAuth <- wsmAuthToken
           wsmAzureResourceClient = wsmClientProvider.getControlledAzureResourceApi(wsmAuth)
-          resourceId <- getContainerResourceId(workspaceId, container, Some(wsmAuth))
+          resourceId <- getContainerResourceId(workspaceId, container, Option(wsmAuth))
           sasToken <- wsmAzureResourceClient.createAzureStorageContainerSasToken(workspaceId, resourceId)
         } yield sasToken).recoverWith {
           // If the storage account was still not found in WSM, this may be a public filesystem

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobFileSystemManager.scala
@@ -237,12 +237,11 @@ class WSMBlobSasTokenGenerator(wsmClientProvider: WorkspaceManagerApiClientProvi
   }
 
   /**
-   * If the provided blob path looks like it comes from a terra workspace, return an end point that, when called with GET
-   * and proper authentication, will return a sas token capable of accessing the container the blob path points to.
+   * Return a REST endpoint that will reply with a sas token for the blob storage container associated with the provided blob path.
    * @param blobPath A blob path of a file living in a blob container that WSM knows about (likely a workspace container).
    *
-   * NOTE: If requesting the sas endpoint of a container that *isn't* what this token generator was constructed for, this
-   * function may make two REST requests. Otherwise, it's safe to assume that the relevant data is already cached locally.
+   * NOTE: If a blobPath is provided for a file in a container other than what this token generator was constructed for,
+   * this function will make two REST requests. Otherwise, the relevant data is already cached locally.
    */
   def getWSMSasFetchEndpoint(blobPath: BlobPath): Try[String] = {
     val wsmEndpoint = wsmClientProvider.getBaseWorkspaceManagerUrl

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -185,6 +185,10 @@ case class BlobPath private[blob](pathString: String, endpoint: EndpointURL, con
     * @return Path string relative to the container root.
     */
   def pathWithoutContainer : String = pathString
-  
+
+  def parseTerraWorkspaceIdFromPath: Option[String] = {
+    if(container.value.startsWith("sc-")) Option(container.value.substring(3)) else None
+  }
+
   override def getSymlinkSafePath(options: LinkOption*): Path  = toAbsolutePath
 }

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -7,7 +7,6 @@ import cromwell.filesystems.blob.BlobPathBuilder._
 
 import java.net.{MalformedURLException, URI}
 import java.nio.file.{Files, LinkOption}
-import java.util.UUID
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -189,28 +188,7 @@ case class BlobPath private[blob](pathString: String, endpoint: EndpointURL, con
     */
   def pathWithoutContainer : String = pathString
 
-  def parseTerraWorkspaceIdFromPath: Try[UUID] = {
-    if(container.value.startsWith("sc-")) Try(UUID.fromString(container.value.substring(3))) else Failure(new Exception("Could not parse workspace ID from storage container"))
-  }
-
-  private def getWSMTokenGenerator: Try[WSMBlobSasTokenGenerator] = {
-    fsm.blobTokenGenerator match {
-      case wsmGenerator: WSMBlobSasTokenGenerator => Try(wsmGenerator)
-      case _: Any => Failure(new NoSuchElementException("This blob file does not have an associated WSMBlobSasTokenGenerator"))
-    }
-  }
-  def containerWSMResourceId: Try[UUID] = {
-    for {
-      generator <- getWSMTokenGenerator
-      workspaceId <- parseTerraWorkspaceIdFromPath
-      wsmAuth <- generator.getWsmAuth
-      resourceId <- generator.getContainerResourceId(workspaceId, container, wsmAuth)
-    } yield resourceId
-  }
-
-  def wsmEndpoint: Try[String] = {
-    getWSMTokenGenerator.map(generator => generator.wsmClientProvider.getBaseWorkspaceManagerUrl)
-  }
+  def getFilesystemManager: BlobFileSystemManager = fsm
 
   override def getSymlinkSafePath(options: LinkOption*): Path  = toAbsolutePath
 

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -15,7 +15,9 @@ import scala.util.{Failure, Success, Try}
 object BlobPathBuilder {
   private val blobHostnameSuffix = ".blob.core.windows.net"
   sealed trait BlobPathValidation
-  case class ValidBlobPath(path: String, container: BlobContainerName, endpoint: EndpointURL) extends BlobPathValidation
+  case class ValidBlobPath(path: String, container: BlobContainerName, endpoint: EndpointURL) extends BlobPathValidation {
+    def toUrl: String = endpoint.value + "/" + container.value + path
+  }
   case class UnparsableBlobPath(errorMessage: Throwable) extends BlobPathValidation
 
   def invalidBlobHostMessage(endpoint: EndpointURL) = s"Malformed Blob URL for this builder: The endpoint $endpoint doesn't contain the expected host string '{SA}.blob.core.windows.net/'"

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -14,9 +14,7 @@ import scala.util.{Failure, Success, Try}
 object BlobPathBuilder {
   private val blobHostnameSuffix = ".blob.core.windows.net"
   sealed trait BlobPathValidation
-  case class ValidBlobPath(path: String, container: BlobContainerName, endpoint: EndpointURL) extends BlobPathValidation {
-    def toUrl: String = endpoint.value + "/" + container.value + path
-  }
+  case class ValidBlobPath(path: String, container: BlobContainerName, endpoint: EndpointURL) extends BlobPathValidation
   case class UnparsableBlobPath(errorMessage: Throwable) extends BlobPathValidation
 
   def invalidBlobHostMessage(endpoint: EndpointURL) = s"Malformed Blob URL for this builder: The endpoint $endpoint doesn't contain the expected host string '{SA}.blob.core.windows.net/'"

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
@@ -29,7 +29,6 @@ final case class EndpointURL(value: String) {
   }
 }
 final case class WorkspaceId(value: UUID) {override def toString: String = value.toString}
-
 final case class ContainerResourceId(value: UUID) {override def toString: String = value.toString}
 final case class WorkspaceManagerURL(value: String) {override def toString: String = value}
 

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilderFactory.scala
@@ -29,6 +29,7 @@ final case class EndpointURL(value: String) {
   }
 }
 final case class WorkspaceId(value: UUID) {override def toString: String = value.toString}
+
 final case class ContainerResourceId(value: UUID) {override def toString: String = value.toString}
 final case class WorkspaceManagerURL(value: String) {override def toString: String = value}
 

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/WorkspaceManagerApiClientProvider.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/WorkspaceManagerApiClientProvider.scala
@@ -20,6 +20,7 @@ import scala.util.Try
 trait WorkspaceManagerApiClientProvider {
   def getControlledAzureResourceApi(token: String): WsmControlledAzureResourceApi
   def getResourceApi(token: String): WsmResourceApi
+  def getBaseWorkspaceManagerUrl: String
 }
 
 class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: WorkspaceManagerURL) extends WorkspaceManagerApiClientProvider {
@@ -39,6 +40,10 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: WorkspaceManag
     val apiClient = getApiClient
     apiClient.setAccessToken(token)
     WsmControlledAzureResourceApi(new ControlledAzureResourceApi(apiClient))
+  }
+
+  def getBaseWorkspaceManagerUrl: String = {
+    baseWorkspaceManagerUrl.value
   }
 }
 

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/WorkspaceManagerApiClientProvider.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/WorkspaceManagerApiClientProvider.scala
@@ -41,10 +41,7 @@ class HttpWorkspaceManagerClientProvider(baseWorkspaceManagerUrl: WorkspaceManag
     apiClient.setAccessToken(token)
     WsmControlledAzureResourceApi(new ControlledAzureResourceApi(apiClient))
   }
-
-  def getBaseWorkspaceManagerUrl: String = {
-    baseWorkspaceManagerUrl.value
-  }
+  def getBaseWorkspaceManagerUrl: String = baseWorkspaceManagerUrl.value
 }
 
 case class WsmResourceApi(resourcesApi : ResourceApi) {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -663,12 +663,12 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   private val DockerMonitoringLogPath: Path = GcpBatchWorkingDisk.MountPoint.resolve(gcpBatchCallPaths.batchMonitoringLogFilename)
   private val DockerMonitoringScriptPath: Path = GcpBatchWorkingDisk.MountPoint.resolve(gcpBatchCallPaths.batchMonitoringScriptFilename)
 
-  override def scriptPreamble: String = {
+  override def scriptPreamble: ErrorOr[String] = {
     if (monitoringOutput.isDefined) {
       s"""|touch $DockerMonitoringLogPath
           |chmod u+x $DockerMonitoringScriptPath
-          |$DockerMonitoringScriptPath > $DockerMonitoringLogPath &""".stripMargin
-    } else ""
+          |$DockerMonitoringScriptPath > $DockerMonitoringLogPath &""".stripMargin.valid
+    } else "".valid
   }
 
   private[actors] def generateInputs(jobDescriptor: BackendJobDescriptor): Set[GcpBatchInput] = {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiAsyncBackendJobExecutionActor.scala
@@ -380,12 +380,12 @@ class PipelinesApiAsyncBackendJobExecutionActor(override val standardParams: Sta
 
   private lazy val isDockerImageCacheUsageRequested = runtimeAttributes.useDockerImageCache.getOrElse(useDockerImageCache(jobDescriptor.workflowDescriptor))
 
-  override def scriptPreamble: String = {
+  override def scriptPreamble: ErrorOr[String] = {
     if (monitoringOutput.isDefined) {
       s"""|touch $DockerMonitoringLogPath
           |chmod u+x $DockerMonitoringScriptPath
           |$DockerMonitoringScriptPath > $DockerMonitoringLogPath &""".stripMargin
-    } else ""
+    }.valid else "".valid
   }
 
   override def globParentDirectory(womGlobFile: WomGlobFile): Path = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.{Unmarshal, Unmarshaller}
 import akka.stream.ActorMaterializer
 import akka.util.ByteString
-import cats.syntax.apply._
+import cats.implicits._
 import common.collections.EnhancedCollections._
 import common.exception.AggregatedMessageException
 import common.validation.ErrorOr.ErrorOr
@@ -22,8 +22,7 @@ import cromwell.core.logging.JobLogger
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import cromwell.core.retry.Retry._
 import cromwell.core.retry.SimpleExponentialBackoff
-import cromwell.filesystems.blob.BlobPathBuilder.ValidBlobPath
-import cromwell.filesystems.blob.{BlobContainerName, BlobPath, BlobPathBuilder, WSMBlobSasTokenGenerator}
+import cromwell.filesystems.blob.{BlobPath, WSMBlobSasTokenGenerator}
 import cromwell.filesystems.drs.{DrsPath, DrsResolver}
 import net.ceedubs.ficus.Ficus._
 import wom.values.WomFile
@@ -61,7 +60,8 @@ case object Cancelled extends TesRunStatus {
 
 object TesAsyncBackendJobExecutionActor {
   val JobIdKey = "tes_job_id"
-  private def generateLocalizedSasScriptPreamble(environmentVariableName: String, getSasWsmEndpoint: String) : String = {
+
+  def generateLocalizedSasScriptPreamble(environmentVariableName: String, getSasWsmEndpoint: String) : String = {
     // BEARER_TOKEN: https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token#get-a-token-using-http
     // NB: Scala string interpolation and bash variable substitution use similar syntax. $$ is an escaped $, much like \\ is an escaped \.
     s"""
@@ -131,10 +131,10 @@ object TesAsyncBackendJobExecutionActor {
   }
 
   /**
-   * Under certain situations (and only on Terra), we want the VM running a TES task to have the ability to acquire a
-   * fresh sas token for itself. In order to be able to do this, we provide it with a precomputed endpoint it can use.
+   * Computes an endpoint that can be used to retrieve a sas token for a particular blob storage container.
+   * This assumes that some of the task inputs are blob files, all blob files are in the same container, and we can get a sas
+   * token for this container from WSM.
    * The task VM will use the user assigned managed identity that it is running as in order to authenticate.
-   * We only return a value if at least one of the inputs is a BlobPath and //TODO flag specified in WDL.
    * @param taskInputs The inputs to this particular TesTask. If any are blob files, the first  will be used to
    *                   determine the storage container to retrieve the sas token for.
    * @param pathGetter A function to convert string filepath into a cromwell Path object.
@@ -147,32 +147,22 @@ object TesAsyncBackendJobExecutionActor {
                                         logger: JobLogger,
                                         blobConverter: Try[Path] => Try[BlobPath] = maybeConvertToBlob): Try[String] = {
     // Collect all of the inputs that are valid blob paths
-    val blobFiles = taskInputs.collect{
-      case Input(_, _, Some(url), _, _, _) => BlobPathBuilder.validateBlobPath(url)
-    }.collect{
-      case valid: BlobPathBuilder.ValidBlobPath => valid
-    }
+    val blobFiles = taskInputs
+      .collect{ case Input(_, _, Some(url), _, _, _) => blobConverter(pathGetter(url)) }
+      .collect{ case Success(blob) => blob }
 
     // Log if not all input files live in the same container.
-    // We'll do our best anyway, but will still only be able to retrieve a token for a single container.
-    if(blobFiles.forall(_.container == blobFiles.headOption.map(file => file.container).getOrElse(BlobContainerName("no_container")))) {
+    if (blobFiles.map(_.container).distinct.size > 1) {
       logger.info(s"While parsing blob inputs, found more than one container. Can only generate an environment sas token for a single blob container at once.")
     }
 
-    // We use the first blob file in the list as a template for determining the localized sas params
-    val headBlob: Try[ValidBlobPath] = blobFiles.headOption  match {
-      case Some(validBlob) => Try(validBlob)
-      case _ => Failure(new NoSuchElementException("No valid blob file for determining WSM end point found in task inputs."))
-    }
-
-    for {
-      blobFile <- headBlob
-      blob <- blobConverter(pathGetter(blobFile.toUrl))
-      endpoint <- blob.getFilesystemManager.blobTokenGenerator match {
-        case wsmGenerator: WSMBlobSasTokenGenerator => wsmGenerator.getWSMSasFetchEndpoint(blob)
-        case _ => Failure(new NoSuchElementException("This blob file does not have an associated WSMBlobSasTokenGenerator"))
+    // We use the first blob file in the list to determine the correct blob container.
+    blobFiles.headOption.map{blobPath =>
+      blobPath.getFilesystemManager.blobTokenGenerator match {
+        case wsmGenerator: WSMBlobSasTokenGenerator => wsmGenerator.getWSMSasFetchEndpoint(blobPath)
+        case _ => Failure(new UnsupportedOperationException("Blob file does not have an associated WSMBlobSasTokenGenerator"))
       }
-    } yield endpoint
+    }.getOrElse(Failure(new NoSuchElementException("Could not infer blob storage container from task inputs: No valid blob files provided.")))
   }
 }
 
@@ -204,20 +194,36 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     )
   }
 
-  override def scriptPreamble: String = {
-    val tesTaskPreamble: String = runtimeAttributes.localizedSasEnvVar match {
-      case Some(environmentVariableName) =>
+  /**
+   * This script preamble is bash code that is executed at the start of a task inside the user's container.
+   * It is executed directly before the user's instantiated command is, which gives cromwell a chance to adjust the
+   * container environment before the actual task runs. See commandScriptContents in StandardAsyncExecutionActor for more context.
+   *
+   * For TES tasks, we sometimes want to acquire and save an azure sas token to an environment variable.
+   * If the user provides a value for runtimeAttributes.localizedSasEnvVar, we will add the relevant bash code to the preamble
+   * that acquires/exports the sas token to an environment variable. Once there, it will be visible to the user's task code.
+   *
+   * If runtimeAttributes.localizedSasEnvVar is provided in the WDL (and determineWSMSasEndpointFromInputs is successful),
+   * we will export the sas token to an environment variable named to be the value of runtimeAttributes.localizedSasEnvVar.
+   * Otherwise, we won't alter the preamble.
+   *
+   * See determineWSMSasEndpointFromInputs to see how we use taskInputs to infer *which* container to get a sas token for.
+   *
+   * @return Bash code to run at the start of a task.
+   */
+  override def scriptPreamble: ErrorOr[String] = {
+    runtimeAttributes.localizedSasEnvVar match {
+      case Some(environmentVariableName) => { // Case: user wants a sas token. Return the computed preamble or die trying.
         val workflowName = workflowDescriptor.callable.name
         val callInputFiles = jobDescriptor.fullyQualifiedInputs.safeMapValues {
-        _.collectAsSeq { case w: WomFile => w }
+          _.collectAsSeq { case w: WomFile => w }
         }
         val taskInputs: List[Input] = TesTask.buildTaskInputs(callInputFiles, workflowName, mapCommandLineWomFile)
-        determineWSMSasEndpointFromInputs(taskInputs, getPath, jobLogger).map { endpoint =>
-        generateLocalizedSasScriptPreamble(environmentVariableName, endpoint)
-        }.getOrElse("")
-    case _ => ""
+        val computedEndpoint = determineWSMSasEndpointFromInputs(taskInputs, getPath, jobLogger)
+        computedEndpoint.map(endpoint => generateLocalizedSasScriptPreamble(environmentVariableName, endpoint))
+      }.toErrorOr
+      case _ => "".valid // Case: user doesn't want a sas token. Empty preamble is the correct preamble.
     }
-    super.scriptPreamble ++ tesTaskPreamble
   }
 
   override def mapCommandLineWomFile(womFile: WomFile): WomFile = {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -89,7 +89,7 @@ object TesAsyncBackendJobExecutionActor {
        |export AZURE_STORAGE_SAS_TOKEN=$$(echo "$${sas_response_json}" | jq -r '.token')
        |
        |# Echo the first characters for logging/debugging purposes. "null" indicates something went wrong.
-       |echo Acquired sas token: "$${AZURE_STORAGE_SAS_TOKEN:0:3}****"
+       |echo Acquired sas token: "$${AZURE_STORAGE_SAS_TOKEN:0:4}****"
        |### END ACQUIRE LOCAL SAS TOKEN ###
        |""".stripMargin
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -67,9 +67,39 @@ object TesAsyncBackendJobExecutionActor {
     s"""
        |### BEGIN ACQUIRE LOCAL SAS TOKEN ###
        |# Install dependencies
-       |apt-get -y update
-       |apt-get -y install curl
-       |apt-get -y install jq
+       |
+       |# Function to check if a command exists
+       |command_exists() {
+       |  command -v "$$1" > /dev/null 2>&1
+       |}
+       |
+       |# Check if curl exists; install if not
+       |if ! command_exists curl; then
+       |  if command_exists apt-get; then
+       |    apt-get -y update && apt-get -y install curl
+       |    if [ $$? -ne 0 ]; then
+       |      echo "Error: Failed to install curl via apt-get."
+       |      exit 1
+       |    fi
+       |  else
+       |    echo "Error: apt-get is not available, and curl is not installed."
+       |    exit 1
+       |  fi
+       |fi
+       |
+       |# Check if jq exists; install if not
+       |if ! command_exists jq; then
+       |  if command_exists apt-get; then
+       |    apt-get -y update && apt-get -y install jq
+       |    if [ $$? -ne 0 ]; then
+       |      echo "Error: Failed to install jq via apt-get."
+       |      exit 1
+       |    fi
+       |  else
+       |    echo "Error: apt-get is not available, and jq is not installed."
+       |    exit 1
+       |  fi
+       |fi
        |
        |# Acquire bearer token, relying on the User Assigned Managed Identity of this VM.
        |echo Acquiring Bearer Token using User Assigned Managed Identity...

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -155,7 +155,7 @@ object TesAsyncBackendJobExecutionActor {
 
     // Log if not all input files live in the same container.
     if (blobFiles.map(_.container).distinct.size > 1) {
-      logger.info(s"While parsing blob inputs, found more than one container. Can only generate an environment sas token for a single blob container at once.")
+      logger.info(s"While parsing blob inputs, found more than one container. Generating SAS token based on first file in the list.")
     }
 
     // We use the first blob file in the list to determine the correct blob container.

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -29,6 +29,8 @@ import wom.values.WomFile
 
 import java.io.FileNotFoundException
 import java.nio.file.FileAlreadyExistsException
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 sealed trait TesRunStatus {
@@ -159,7 +161,7 @@ object TesAsyncBackendJobExecutionActor {
     // We use the first blob file in the list to determine the correct blob container.
     blobFiles.headOption.map{blobPath =>
       blobPath.getFilesystemManager.blobTokenGenerator match {
-        case wsmGenerator: WSMBlobSasTokenGenerator => wsmGenerator.getWSMSasFetchEndpoint(blobPath)
+        case wsmGenerator: WSMBlobSasTokenGenerator => wsmGenerator.getWSMSasFetchEndpoint(blobPath, Some(Duration.of(24, ChronoUnit.HOURS)))
         case _ => Failure(new UnsupportedOperationException("Blob file does not have an associated WSMBlobSasTokenGenerator"))
       }
     }.getOrElse(Failure(new NoSuchElementException("Could not infer blob storage container from task inputs: No valid blob files provided.")))

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -70,6 +70,7 @@ object TesAsyncBackendJobExecutionActor {
        |apt-get -y install jq
        |
        |# Acquire bearer token, relying on the User Assigned Managed Identity of this VM.
+       |echo Acquiring Bearer Token using User Assigned Managed Identity...
        |BEARER_TOKEN=$$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true -s | jq .access_token)
        |
        |# Remove the leading and trailing quotes
@@ -77,6 +78,7 @@ object TesAsyncBackendJobExecutionActor {
        |BEARER_TOKEN="$${BEARER_TOKEN%\\"}"
        |
        |# Use the precomputed endpoint from cromwell + WSM to acquire a sas token
+       |echo Requesting sas token from WSM...
        |sas_response_json=$$(curl -s \\
        |                    --retry 3 \\
        |                    --retry-delay 2 \\
@@ -89,7 +91,7 @@ object TesAsyncBackendJobExecutionActor {
        |export $environmentVariableName=$$(echo "$${sas_response_json}" | jq -r '.token')
        |
        |# Echo the first characters for logging/debugging purposes. "null" indicates something went wrong.
-       |echo Acquired sas token: "$${$environmentVariableName:0:4}****"
+       |echo Saving sas token: $${$environmentVariableName:0:4}**** to environment variable $environmentVariableName...
        |### END ACQUIRE LOCAL SAS TOKEN ###
        |""".stripMargin
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -66,9 +66,7 @@ object TesAsyncBackendJobExecutionActor {
     // NB: Scala string interpolation and bash variable substitution use similar syntax. $$ is an escaped $, much like \\ is an escaped \.
     s"""
        |### BEGIN ACQUIRE LOCAL SAS TOKEN ###
-       |# Install dependencies
-       |
-       |# Function to check if a command exists
+       |# Function to check if a command exists on this machine
        |command_exists() {
        |  command -v "$$1" > /dev/null 2>&1
        |}

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -156,7 +156,7 @@ object TesAsyncBackendJobExecutionActor {
     // Log if not all input files live in the same container.
     // We'll do our best anyway, but will still only be able to retrieve a token for a single container.
     if(blobFiles.forall(_.container == blobFiles.headOption.map(file => file.container).getOrElse(BlobContainerName("no_container")))) {
-      logger.warn(s"While parsing blob inputs, found more than one container. Can only generate an environment sas token for a single blob container at once.")
+      logger.info(s"While parsing blob inputs, found more than one container. Can only generate an environment sas token for a single blob container at once.")
     }
 
     // We use the first blob file in the list as a template for determining the localized sas params

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
@@ -33,7 +33,7 @@ object TesRuntimeAttributes {
   val DockerWorkingDirKey = "dockerWorkingDir"
   val DiskSizeKey = "disk"
   val PreemptibleKey = "preemptible"
-  val LocalizedSasKey = "sasEnvironmentVariable"
+  val LocalizedSasKey = "azureSasEnvironmentVariable"
 
   private def cpuValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[Int Refined Positive] = CpuValidation.optional
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -81,7 +81,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
     }
 
   lazy val inputs: Seq[Input] = {
-    val result = TesTask.buildTaskInputs(callInputFiles ++ writeFunctionFiles, workflowName, commandScript, mapCommandLineWomFile)
+    val result = TesTask.buildTaskInputs(callInputFiles ++ writeFunctionFiles, workflowName, mapCommandLineWomFile) ++ Seq(commandScript)
     jobLogger.info(s"Calculated TES inputs (found ${result.size}): " + result.mkString(System.lineSeparator(),System.lineSeparator(),System.lineSeparator()))
     result
   }
@@ -273,7 +273,7 @@ object TesTask {
     )
   }
 
-  def buildTaskInputs(taskFiles: Map[FullyQualifiedName, Seq[WomFile]], workflowName: String, commandScript: Input, womMapFn: WomFile => WomFile): Seq[Input] = {
+  def buildTaskInputs(taskFiles: Map[FullyQualifiedName, Seq[WomFile]], workflowName: String, womMapFn: WomFile => WomFile): List[Input] = {
     taskFiles.flatMap {
       case (fullyQualifiedName, files) => files.flatMap(_.flattenFiles).zipWithIndex.map {
         case (f, index) =>
@@ -291,7 +291,7 @@ object TesTask {
             content = None
           )
       }
-    }.toList ++ Seq(commandScript)
+    }.toList
   }
 
   def makeTags(workflowDescriptor: BackendWorkflowDescriptor): Map[String, Option[String]] = {

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -72,6 +72,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockFsm.blobTokenGenerator returns mockTokenGenerator
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
+  mockPath.normalize() returns mockPath
   val mockNioPath: path.NioPath = mock[path.NioPath]
   val mockJavaPath: Path = mock[java.nio.file.Path]
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -72,7 +72,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockFsm.blobTokenGenerator returns mockTokenGenerator
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
-  mockPath.normalize returns mockPath
+  mockPath.normalize() returns mockPath
 
   val mockNioPath: path.NioPath = mock[path.NioPath]
   val mockJavaPath: Path = mock[java.nio.file.Path]

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -2,7 +2,6 @@ package cromwell.backend.impl.tes
 
 import common.mock.MockSugar
 import cromwell.core.logging.JobLogger
-import cromwell.core.path
 import cromwell.filesystems.blob.{BlobFileSystemManager, BlobPath, WSMBlobSasTokenGenerator}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -70,14 +69,12 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockTokenGenerator.getWSMSasFetchEndpoint(mockBlobPath) returns  Try(s"$mockWsmEndpoint/api/workspaces/v1/$mockWorkspaceId/resources/controlled/azure/storageContainer/$mockContainerResourceId/getSasToken")
   mockFsm.blobTokenGenerator returns mockTokenGenerator
 
-  val mockNioPath: path.NioPath = mock[path.NioPath]
+  val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
 
   mockBlobPath.getFilesystemManager returns mockFsm
-  mockBlobPath.toAbsolutePath returns mockBlobPath
+  mockBlobPath.toAbsolutePath returns mockPath
   mockBlobPath.md5 returns "MOCK_MD5"
 
-
-  val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
   def mockPathGetter(pathString: String): Try[cromwell.core.path.Path] = {
     val foundBlobPath: Success[BlobPath] = Success(mockBlobPath)
     val foundNonBlobPath: Success[cromwell.core.path.Path] = Success(mockPath)

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -77,7 +77,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   val mockNioPath: path.NioPath = mock[path.NioPath]
   val mockJavaPath: Path = mock[java.nio.file.Path]
   mockNioPath.toAbsolutePath returns mockJavaPath
-  mockNioPath.normalize returns mockNioPath
+  mockNioPath.normalize() returns mockNioPath
 
   mockBlobPath.getFilesystemManager returns mockFsm
   mockBlobPath.nioPath returns mockNioPath

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -70,6 +70,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockBlobPath.containerWSMResourceId returns Try(UUID.fromString(mockContainerResourceId))
   mockBlobPath.nioPath returns mockNioPath
   mockBlobPath.md5 returns "BLOB_MD5"
+  mockBlobPath.toAbsolutePath returns mockBlobPath
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
   def mockPathGetter(pathString: String): Try[cromwell.core.path.Path] = {

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -2,10 +2,12 @@ package cromwell.backend.impl.tes
 
 import common.mock.MockSugar
 import cromwell.core.logging.JobLogger
+import cromwell.core.path
 import cromwell.filesystems.blob.{BlobFileSystemManager, BlobPath, WSMBlobSasTokenGenerator}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.file.Path
 import scala.util.{Failure, Success, Try}
 
 class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers with MockSugar {
@@ -70,8 +72,12 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockFsm.blobTokenGenerator returns mockTokenGenerator
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
+  val mockNioPath: path.NioPath = mock[path.NioPath]
+  val mockJavaPath: Path = mock[java.nio.file.Path]
 
+  mockNioPath.toAbsolutePath returns mockJavaPath
   mockBlobPath.getFilesystemManager returns mockFsm
+  mockBlobPath.nioPath returns mockNioPath
   mockBlobPath.toAbsolutePath returns mockPath
   mockBlobPath.md5 returns "MOCK_MD5"
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -76,7 +76,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers {
     val mockWorkspaceId = "1111-2222-3333-4444"
     val mockContainerId = "5678-who-do-we-appreciate"
     val mockSasParams: LocalizedSasTokenParams = LocalizedSasTokenParams(mockEndpoint, mockWorkspaceId, mockContainerId)
-    TesAsyncBackendJobExecutionActor.generateLocalizedSasScriptPreammble(mockSasParams) shouldBe
+    TesAsyncBackendJobExecutionActor.generateLocalizedSasScriptPreamble(mockSasParams) shouldBe
       s"""
          |WSM_ENDPOINT="${mockEndpoint}"
          |WORKSPACE_ID="${mockWorkspaceId}"

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -1,0 +1,15 @@
+package cromwell.backend.impl.tes
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+
+class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers {
+  behavior of "TesAsyncBackendJobExecutionActor"
+
+  it should "compile" in {
+    1==1 shouldBe true
+  }
+
+  if should ""
+}

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -1,15 +1,86 @@
 package cromwell.backend.impl.tes
 
+import com.fasterxml.jackson.databind.ext.NioPathSerializer
+import cromwell.core.path.{NioPath, Path}
+import cromwell.filesystems.blob.{BlobPath, BlobPathBuilderFactory, EndpointURL}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.tools.nsc.io.Path
 
 
 class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers {
   behavior of "TesAsyncBackendJobExecutionActor"
 
-  it should "compile" in {
-    1==1 shouldBe true
+  val fullyQualifiedName = "this.name.is.more.than.qualified"
+  val workflowName = "mockWorkflow"
+  val someBlobUrl = "https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-d8143fd8-aa07-446d-9ba0-af72203f1794/nyxp6c/tes-internal/configuration/supported-vm-sizes?sv=sasToken"
+  val someNotBlobUrl = "https://www.google.com/path/to/exile"
+  var index = 0
+
+  val blobInput_0 = Input(
+    name = Option(fullyQualifiedName + "." + index),
+    description = Option(workflowName + "." + fullyQualifiedName + "." + index),
+    url = Option(someBlobUrl),
+    path = someBlobUrl,
+    `type` = Option("FILE"),
+    content = None
+  )
+  index = index+1
+
+  val blobInput_1 = Input(
+    name = Option(fullyQualifiedName + "." + index),
+    description = Option(workflowName + "." + fullyQualifiedName + "." + index),
+    url = Option(someBlobUrl),
+    path = someBlobUrl,
+    `type` = Option("FILE"),
+    content = None
+  )
+  index = index+1
+
+  val notBlobInput_1 = Input(
+    name = Option(fullyQualifiedName + "." + index),
+    description = Option(workflowName + "." + fullyQualifiedName + "." + index),
+    url = Option(someNotBlobUrl + index),
+    path = someNotBlobUrl + index,
+    `type` = Option("FILE"),
+    content = None
+  )
+  index = index+1
+
+  val notBlobInput_2 = Input(
+    name = Option(fullyQualifiedName + "." + index),
+    description = Option(workflowName + "." + fullyQualifiedName + "." + index),
+    url = Option(someNotBlobUrl + index),
+    path = someNotBlobUrl + index,
+    `type` = Option("FILE"),
+    content = None
+  )
+
+  def pathGetter(pathString: String): Path = {
+    /*
+    val factory: BlobPathBuilderFactory = BlobPathBuilderFactory()
+    val nioPath: java.nio.file.Path = NioPathSerializer()
+    val endpoint: EndpointURL = EndpointURL("www.some.blob.endpoint/url")
+    if(pathString.startsWith(someBlobUrl)) BlobPath("someBlobPath",endpoint,)
+     */
   }
 
-  if should ""
+  it should "not generate sas params when no blob paths are provided" in {
+    val inputs = List[Input]
+    //TesAsyncBackendJobExecutionActor.getLocalizedSasTokenParams(inputs,)
+  }
+
+  it should "generate proper script preamble" in {
+    val mockEndpoint = "www.workspacemanager.com"
+    val mockWorkspaceId = "1111-2222-3333-4444"
+    val mockContainerId = "5678-who-do-we-appreciate"
+    val mockSasParams: LocalizedSasTokenParams = LocalizedSasTokenParams(mockEndpoint, mockWorkspaceId, mockContainerId)
+    TesAsyncBackendJobExecutionActor.generateLocalizedSasScriptPreammble(mockSasParams) shouldBe
+      s"""
+         |WSM_ENDPOINT="${mockEndpoint}"
+         |WORKSPACE_ID="${mockWorkspaceId}"
+         |CONTAINER_RESOURCE_ID="${mockContainerId}"
+         |""".stripMargin
+  }
 }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -1,11 +1,11 @@
 package cromwell.backend.impl.tes
 
 import common.mock.MockSugar
-import cromwell.core.path.Path
 import cromwell.filesystems.blob.{BlobContainerName, BlobPath}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.nio.file.Paths
 import java.util.UUID
 import scala.util.{Failure, Success, Try}
 
@@ -68,17 +68,18 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockBlobPath.wsmEndpoint returns Try(mockWsmEndpoint)
   mockBlobPath.parseTerraWorkspaceIdFromPath returns Try(UUID.fromString(mockWorkspaceId))
   mockBlobPath.containerWSMResourceId returns Try(UUID.fromString(mockContainerResourceId))
+  mockBlobPath.nioPath returns Paths.get("dummy/path")
   mockBlobPath.md5 returns "BLOB_MD5"
 
-  val mockPath: Path = mock[Path]
-  def mockPathGetter(pathString: String): Try[Path] = {
+  val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
+  def mockPathGetter(pathString: String): Try[cromwell.core.path.Path] = {
     val foundBlobPath: Success[BlobPath] = Success(mockBlobPath)
-    val foundNonBlobPath: Success[Path] = Success(mockPath)
+    val foundNonBlobPath: Success[cromwell.core.path.Path] = Success(mockPath)
     if (pathString.equals(blobInput_0.url.get) || pathString.equals(blobInput_1.url.get)) return foundBlobPath
     foundNonBlobPath
   }
 
-  def mockBlobConverter(pathToConvert: Try[Path]): Try[BlobPath] = {
+  def mockBlobConverter(pathToConvert: Try[cromwell.core.path.Path]): Try[BlobPath] = {
     //using a stubbed md5 rather than matching on type because type matching of mocked types at runtime causes problems
     if (pathToConvert.get.md5.equals("BLOB_MD5")) pathToConvert.asInstanceOf[Try[BlobPath]] else Failure(new Exception("failed"))
   }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -68,7 +68,7 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockBlobPath.wsmEndpoint returns Try(mockWsmEndpoint)
   mockBlobPath.parseTerraWorkspaceIdFromPath returns Try(UUID.fromString(mockWorkspaceId))
   mockBlobPath.containerWSMResourceId returns Try(UUID.fromString(mockContainerResourceId))
-  mockBlobPath.nioPath returns Paths.get("dummy/path")
+  mockBlobPath.nioPath returns Paths.get(".")
   mockBlobPath.md5 returns "BLOB_MD5"
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -72,11 +72,13 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   mockFsm.blobTokenGenerator returns mockTokenGenerator
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]
-  mockPath.normalize() returns mockPath
+  mockPath.normalize returns mockPath
+
   val mockNioPath: path.NioPath = mock[path.NioPath]
   val mockJavaPath: Path = mock[java.nio.file.Path]
-
   mockNioPath.toAbsolutePath returns mockJavaPath
+  mockNioPath.normalize returns mockNioPath
+
   mockBlobPath.getFilesystemManager returns mockFsm
   mockBlobPath.nioPath returns mockNioPath
   mockBlobPath.toAbsolutePath returns mockPath

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -2,10 +2,12 @@ package cromwell.backend.impl.tes
 
 import common.mock.MockSugar
 import cromwell.core.logging.JobLogger
+import cromwell.core.path.NioPath
 import cromwell.filesystems.blob.{BlobFileSystemManager, BlobPath, WSMBlobSasTokenGenerator}
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import scala.util.{Failure, Try}
@@ -79,11 +81,14 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   def generateMockBlobPath: BlobPath = {
     val mockBlobPath = mock[BlobPath]
     mockBlobPath.md5 returns "BLOB_MD5"
+
     val mockFsm = generateMockFsm
     mockBlobPath.getFilesystemManager returns mockFsm
+
+    val mockNioPath: NioPath = mock[NioPath]
+    mockBlobPath.nioPath returns mockNioPath
     mockBlobPath
   }
-
 
   //Path to a file that isn't a blob file
   def generateMockDefaultPath: cromwell.core.path.Path = {

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -1,14 +1,12 @@
 package cromwell.backend.impl.tes
 
 import common.mock.MockSugar
+import cromwell.core.path
 import cromwell.filesystems.blob.{BlobContainerName, BlobPath}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
-import java.nio.file.Paths
 import java.util.UUID
 import scala.util.{Failure, Success, Try}
-
 
 class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers with MockSugar {
   behavior of "TesAsyncBackendJobExecutionActor"
@@ -64,11 +62,13 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
   val mockContainerResourceId = "e58ed763-928c-4155-1111-fdbaaadc15f3"
 
   val mockBlobPath: BlobPath = mock[BlobPath]
+  val mockNioPath: path.NioPath = mock[path.NioPath]
+
   mockBlobPath.container returns BlobContainerName("1234")
   mockBlobPath.wsmEndpoint returns Try(mockWsmEndpoint)
   mockBlobPath.parseTerraWorkspaceIdFromPath returns Try(UUID.fromString(mockWorkspaceId))
   mockBlobPath.containerWSMResourceId returns Try(UUID.fromString(mockContainerResourceId))
-  mockBlobPath.nioPath returns Paths.get(".")
+  mockBlobPath.nioPath returns mockNioPath
   mockBlobPath.md5 returns "BLOB_MD5"
 
   val mockPath: cromwell.core.path.Path = mock[cromwell.core.path.Path]

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
@@ -63,7 +63,7 @@ class TesInitializationActorSpec extends TestKitSuite
       |    # The keys below have been commented out as they are optional runtime attributes.
       |    # dockerWorkingDir
       |    # docker
-      |    # sasEnvironmentVariable
+      |    # azureSasEnvironmentVariable
       |}
       |""".stripMargin
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesInitializationActorSpec.scala
@@ -63,6 +63,7 @@ class TesInitializationActorSpec extends TestKitSuite
       |    # The keys below have been commented out as they are optional runtime attributes.
       |    # dockerWorkingDir
       |    # docker
+      |    # sasEnvironmentVariable
       |}
       |""".stripMargin
 
@@ -107,6 +108,7 @@ class TesInitializationActorSpec extends TestKitSuite
     }
 
     def nonStringErrorMessage(key: String) = s"Workflow option $key must be a string"
+
     val bothRequiredErrorMessage = s"Workflow options ${TesWorkflowOptionKeys.WorkflowExecutionIdentity} and ${TesWorkflowOptionKeys.DataAccessIdentity} are both required if one is provided"
 
     "fail when WorkflowExecutionIdentity is not a string and DataAccessIdentity is missing" in {
@@ -120,7 +122,7 @@ class TesInitializationActorSpec extends TestKitSuite
           case InitializationFailed(failure) =>
             val expectedMsg = nonStringErrorMessage(TesWorkflowOptionKeys.WorkflowExecutionIdentity)
             if (!(failure.getMessage.contains(expectedMsg) &&
-                  failure.getMessage.contains(bothRequiredErrorMessage))) {
+              failure.getMessage.contains(bothRequiredErrorMessage))) {
               fail(s"Exception message did not contain both '$expectedMsg' and '$bothRequiredErrorMessage'. Was '$failure'")
             }
         }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -72,13 +72,13 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
     }
 
-    "validate a valid sasEnvironmentVariable entry" in {
+    "validate a valid azureSasEnvironmentVariable entry" in {
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), TesRuntimeAttributes.LocalizedSasKey -> WomString("THIS_IS_VALID"))
       val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(localizedSasEnvVar = Some("THIS_IS_VALID"))
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
     }
 
-    "fail to validate an invalid sasEnvironmentVariable entry" in {
+    "fail to validate an invalid azureSasEnvironmentVariable entry" in {
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), TesRuntimeAttributes.LocalizedSasKey -> WomString("THIS IS INVALID"))
       assertFailure(runtimeAttributes, "Value must be a string containing only letters, numbers, and underscores.")
     }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -73,13 +73,13 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
     }
 
     "validate a valid sasEnvironmentVariable entry" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "sasEnvironmentVariable" -> WomString("THIS_IS_VALID"))
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), TesRuntimeAttributes.LocalizedSasKey -> WomString("THIS_IS_VALID"))
       val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(localizedSasEnvVar = Some("THIS_IS_VALID"))
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
     }
 
     "fail to validate an invalid sasEnvironmentVariable entry" in {
-      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "sasEnvironmentVariable" -> WomString("THIS IS INVALID"))
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), TesRuntimeAttributes.LocalizedSasKey -> WomString("THIS IS INVALID"))
       assertFailure(runtimeAttributes, "Value must be a string containing only letters, numbers, and underscores.")
     }
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -25,6 +25,7 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
     None,
     None,
     false,
+    None,
     Map.empty
   )
 
@@ -69,6 +70,17 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "preemptible" -> WomBoolean(true))
       val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(preemptible = true)
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "validate a valid sasEnvironmentVariable entry" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "sasEnvironmentVariable" -> WomString("THIS_IS_VALID"))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(localizedSasEnvVar = Some("THIS_IS_VALID"))
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "fail to validate an invalid sasEnvironmentVariable entry" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "sasEnvironmentVariable" -> WomString("THIS IS INVALID"))
+      assertFailure(runtimeAttributes, "Value must be a string containing only letters, numbers, and underscores.")
     }
 
     "convert a positive integer preemptible entry to true boolean" in {

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
@@ -31,6 +31,7 @@ class TesTaskSpec
     None,
     None,
     false,
+    None,
     Map.empty
   )
   val internalPathPrefix = Option("mock/path/to/tes/task")


### PR DESCRIPTION
- Added functionality to Cromwell so that a sas token can be provided as an environment variable to TES tasks 
- Added some functionality to BlobPath to help with WSM stuff
  - Acknowledging that adding Terra specific stuff to a generic Azure concept isn't ideal. This seems like the least invasive way of getting the required data, since it allows us to take advantage of the already instantiated filesystems + their configuration. 