### PR TITLE
WX-1339 Make `throwExceptionOnExecuteError` false for PAPI aborts

### DIFF
--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.v2beta.api.request
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.client.http.{ByteArrayContent, HttpHeaders}
+import com.google.api.client.http.HttpHeaders
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.v2beta.api.request
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.{ByteArrayContent, HttpHeaders}
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}
@@ -35,7 +35,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   // The Genomics batch endpoint doesn't seem to be able to handle abort requests on V2 operations at the moment
   // For now, don't batch the request and execute it on its own
   def handleRequest(abortQuery: PAPIAbortRequest, batch: BatchRequest, pollingManager: ActorRef)(implicit ec: ExecutionContext): Future[Try[Unit]] = {
-    Future(abortQuery.httpRequest.execute()) map {
+    Future(abortQuery.httpRequest.setThrowExceptionOnExecuteError(false).execute()) map {
       case response if response.isSuccessStatusCode =>
         abortQuery.requester ! PAPIAbortRequestSuccessful(abortQuery.jobId.jobId)
         Success(())


### PR DESCRIPTION
Adding `setThrowExceptionOnExecuteError(false)` call causes execution flow to go into the path we want that inspects the error more precisely in `handleGoogleError`.

I tested this by deliberately breaking the request so it always gets a `400` back. With the existing code, the log looks just like what we see in prod:

```
2023-11-01 19:54:12 cromwell-system-akka.dispatchers.backend-dispatcher-91 WARN  - PAPI request worker had 2 failures making 5 requests: 
400 Bad Request
POST https://lifesciences.googleapis.com/v2beta/projects/1005074806481/locations/us-central1/operations/6175597626605185257:cancel
{
  "code": 400,
  "errors": [
    {
      "domain": "global",
      "message": "Invalid JSON payload received. Unexpected token.\nasdf\n^ Payload appears to be compressed. It may either be corrupt or uncompressed data may be too large for the server to handle.",
      "reason": "parseError"
    }
  ],
  "message": "Invalid JSON payload received. Unexpected token.\nasdf\n^ Payload appears to be compressed. It may either be corrupt or uncompressed data may be too large for the server to handle.",
  "status": "INVALID_ARGUMENT"
}
```

<img width="1238" alt="Screenshot 2023-11-01 at 15 43 59" src="https://github.com/broadinstitute/cromwell/assets/1087943/63e4e788-517f-4f1e-a4ff-4075cec3e6d3">

---

Changing `throwExceptionOnExecuteError` to `false`, we see that we no longer throw an exception and we get the expected "no longer running" message in the log!

```
2023-11-01 19:57:48 cromwell-system-akka.dispatchers.backend-dispatcher-162 INFO  - PAPI declined to abort job projects/1005074806481/locations/us-central1/operations/5250112889402522122 in workflow b70eafc9-66a7-4b22-b9bc-621c22b5a4ed, most likely because it is no longer running. Marking as finished. Message: Invalid JSON payload received. Unexpected token.
asdf
^ Payload appears to be compressed. It may either be corrupt or uncompressed data may be too large for the server to handle.
```

<img width="1239" alt="Screenshot 2023-11-01 at 15 45 48" src="https://github.com/broadinstitute/cromwell/assets/1087943/5ce424c4-c3e0-4ffc-b078-f46e065da586">
