### PR TITLE
[WX-1283] Add Support for Intel Ice Lake and Sapphire Rapids CPUs

### DIFF
--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
@@ -8,9 +8,11 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.cpus.cascadeLake.cpuPlatform": "Intel Cascade Lake"
   "outputs.cpus.broadwell.cpuPlatform": "Intel Broadwell"
   "outputs.cpus.haswell.cpuPlatform": "Intel Haswell"
+  "outputs.cpus.cascadeLake.cpuPlatform": "Intel Cascade Lake"
+  "outputs.cpus.iceLake.cpuPlatform": "Intel Ice Lake"
+  "outputs.cpus.sapphireRapids.cpuPlatform": "Intel Sapphire Rapids"
   "outputs.cpus.rome.cpuPlatform": "AMD Rome"
 }
 

--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform/papi_cpu_platform.wdl
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform/papi_cpu_platform.wdl
@@ -24,8 +24,10 @@ task cpu_platform {
 }
 
 workflow cpus {
-   call cpu_platform as haswell { input: cpu_platform = "Intel Haswell" }
-   call cpu_platform as broadwell { input: cpu_platform = "Intel Broadwell" }
-   call cpu_platform as cascadeLake { input: cpu_platform = "Intel Cascade Lake" }
-   call cpu_platform as rome {input: cpu_platform = "AMD Rome" }
+    call cpu_platform as haswell { input: cpu_platform = "Intel Haswell" }
+    call cpu_platform as broadwell { input: cpu_platform = "Intel Broadwell" }
+    call cpu_platform as cascadeLake { input: cpu_platform = "Intel Cascade Lake" }
+    call cpu_platform as iceLake { input: cpu_platform = "Intel Ice Lake" }
+    call cpu_platform as sapphireRapids { input: cpu_platform = "Intel Sapphire Rapids" }
+    call cpu_platform as rome { input: cpu_platform = "AMD Rome" }
 }

--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform/papi_cpu_platform.wdl
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform/papi_cpu_platform.wdl
@@ -5,7 +5,8 @@ task cpu_platform {
         String cpu_platform
     }
     command {
-       apt-get install --assume-yes jq > /dev/null
+       apt-get update
+       apt-get install --assume-yes jq
        NAME=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name)
        FULLY_QUALIFIED_ZONE=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone)
        ZONE=$(basename "$FULLY_QUALIFIED_ZONE")

--- a/docs/RuntimeAttributes.md
+++ b/docs/RuntimeAttributes.md
@@ -429,6 +429,8 @@ runtime {
 Note that when this options is specified, make sure the requested CPU platform is [available](https://cloud.google.com/compute/docs/regions-zones/#available) in the `zones` you selected.
 
 The following CPU platforms are currently supported by the Google Cloud backend:
+- `Intel Sapphire Rapids`
+- `Intel Ice Lake`
 - `Intel Cascade Lake`
 - `Intel Skylake`     
 - `Intel Broadwell`   

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/MachineConstraints.scala
@@ -25,7 +25,7 @@ object MachineConstraints {
       // The below logic infers the machine type from the requested CPU. We're assuming that users want  the newest
       // "General Purpose" machine type that is compatible with the requested CPU. For example, if someone requests
       // Intel Cascade Lake as their CPU platform, then infer the n2 machine type. AMD Rome -> n2d.
-      // The heuristic we're using is "find the newest 'General Purpose' type that supports the given CPU.
+      // The heuristic we're using is: find the newest 'General Purpose' type that supports the given CPU.
       // https://cloud.google.com/compute/docs/machine-resource
       val customMachineType =
         cpuPlatformOption match {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/MachineConstraints.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/MachineConstraints.scala
@@ -15,11 +15,21 @@ object MachineConstraints {
                  ): String = {
     if (googleLegacyMachineSelection) {
       s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.intValue()}"
+    }
+    else if (cpuPlatformOption.contains(PipelinesApiRuntimeAttributes.CpuPlatformIntelSapphireRapidsValue)) {
+      // As of 11/2023, C3 machine types (the general purpose platform for the Intel Sapphire Rapids CPU)
+      // cannot be customized like other general purpose platforms can. Select one of a few legal options.
+      PredefinedMachineType.getClosestC3Machine(memory, cpu, jobLogger)
     } else {
-      // If someone requests Intel Cascade Lake as their CPU platform then switch the machine type to n2.
-      // Similarly, CPU platform of AMD Rome corresponds to the machine type n2d.  
+      // Users specify a CPU platform in their WDL, but GCP also needs to know which machine type to use.
+      // The below logic infers the machine type from the requested CPU. We're assuming that users want  the newest
+      // "General Purpose" machine type that is compatible with the requested CPU. For example, if someone requests
+      // Intel Cascade Lake as their CPU platform, then infer the n2 machine type. AMD Rome -> n2d.
+      // The heuristic we're using is "find the newest 'General Purpose' type that supports the given CPU.
+      // https://cloud.google.com/compute/docs/machine-resource
       val customMachineType =
         cpuPlatformOption match {
+          case Some(PipelinesApiRuntimeAttributes.CpuPlatformIntelIceLakeValue) => N2CustomMachineType
           case Some(PipelinesApiRuntimeAttributes.CpuPlatformIntelCascadeLakeValue) => N2CustomMachineType
           case Some(PipelinesApiRuntimeAttributes.CpuPlatformAMDRomeValue)          => N2DCustomMachineType 
           case _ => N1CustomMachineType

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
@@ -78,6 +78,8 @@ object PipelinesApiRuntimeAttributes {
   // via `gcloud compute zones describe us-central1-a`
   val CpuPlatformIntelCascadeLakeValue = "Intel Cascade Lake"
   val CpuPlatformAMDRomeValue = "AMD Rome"
+  val CpuPlatformIntelIceLakeValue = "Intel Ice Lake"
+  val CpuPlatformIntelSapphireRapidsValue = "Intel Sapphire Rapids"
 
   val UseDockerImageCacheKey = "useDockerImageCache"
   private val useDockerImageCacheValidationInstance = new BooleanRuntimeAttributesValidation(UseDockerImageCacheKey).optional

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
@@ -17,10 +17,15 @@ object PredefinedMachineType {
   val c3Standard_176 = PredefinedMachineType(176, "c3-standard-176")
 
   def getClosestC3Machine(requestedMemory: MemorySize, requestedCpu: Refined[Int, Positive],  jobLogger: Logger): String = {
+    val c3DebugString = "Intel Sapphire Rapids C3 machine type"
+
+    // Memory isn't configurable for c3 machines: it's always 4x the CPU count. Adjust memory to match requested CPU count.
     val adjustedMemory: MemorySize = MemorySize(requestedCpu.value * 4.0, MemoryUnit.GB)
     if (adjustedMemory != requestedMemory) {
-      jobLogger.info(s"Adjusting memory from ${requestedMemory.toString} to ${adjustedMemory.toString} in order to match GCP requirements for the requested CPU.")
+      jobLogger.info(s"Adjusting memory from ${requestedMemory.toString} to ${adjustedMemory.toString} in order to match GCP requirements for the requested ${c3DebugString}.")
     }
+
+    // Always round up requested CPU to next smallest size.
     val machine = requestedCpu.value match {
       case cpu if cpu <= 4 => c3Standard_4
       case cpu if cpu > 4 && cpu <= 8 => c3Standard_8
@@ -31,7 +36,7 @@ object PredefinedMachineType {
     }
 
     if(machine.cpuCount != requestedCpu.value) {
-      jobLogger.info(s"Rounding up CPU count from ${requestedCpu} to ${machine.cpuCount} in order to match GCP requirements for the requested CPU.")
+      jobLogger.info(s"Rounding up CPU count from ${requestedCpu} to ${machine.cpuCount} in order to match GCP requirements for the requested ${c3DebugString}.")
     }
     machine.gcpString
   }

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
@@ -1,17 +1,14 @@
 package cromwell.backend.google.pipelines.common
 
-import cromwell.backend.google.pipelines.common.CustomMachineType._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import eu.timepit.refined.refineV
-import mouse.all._
 import org.slf4j.Logger
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
-import math.{log, pow}
 
 case class PredefinedMachineType(cpuCount: Int, gcpString: String)
 object PredefinedMachineType {
+  // hardcoded values from: https://cloud.google.com/compute/docs/general-purpose-machines#c3-standard
   val c3Standard_4 = PredefinedMachineType(4, "c3-standard-4")
   val c3Standard_8 = PredefinedMachineType(8, "c3-standard-8")
   val c3Standard_22 = PredefinedMachineType(22, "c3-standard-22")
@@ -22,7 +19,7 @@ object PredefinedMachineType {
   def getClosestC3Machine(requestedMemory: MemorySize, requestedCpu: Refined[Int, Positive],  jobLogger: Logger): String = {
     val adjustedMemory: MemorySize = MemorySize(requestedCpu.value * 4.0, MemoryUnit.GB)
     if (adjustedMemory != requestedMemory) {
-      jobLogger.info(s"Adjusting memory from ${requestedMemory.amount} to ${adjustedMemory.amount} in order to match GCP requirements for the requested CPU.")
+      jobLogger.info(s"Adjusting memory from ${requestedMemory.toString} to ${adjustedMemory.toString} in order to match GCP requirements for the requested CPU.")
     }
     val machine = requestedCpu.value match {
       case cpu if cpu <= 4 => c3Standard_4

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PredefinedMachineType.scala
@@ -1,0 +1,41 @@
+package cromwell.backend.google.pipelines.common
+
+import cromwell.backend.google.pipelines.common.CustomMachineType._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.refineV
+import mouse.all._
+import org.slf4j.Logger
+import wdl4s.parser.MemoryUnit
+import wom.format.MemorySize
+import math.{log, pow}
+
+case class PredefinedMachineType(cpuCount: Int, gcpString: String)
+object PredefinedMachineType {
+  val c3Standard_4 = PredefinedMachineType(4, "c3-standard-4")
+  val c3Standard_8 = PredefinedMachineType(8, "c3-standard-8")
+  val c3Standard_22 = PredefinedMachineType(22, "c3-standard-22")
+  val c3Standard_44 = PredefinedMachineType(44, "c3-standard-44")
+  val c3Standard_88 = PredefinedMachineType(88, "c3-standard-88")
+  val c3Standard_176 = PredefinedMachineType(176, "c3-standard-176")
+
+  def getClosestC3Machine(requestedMemory: MemorySize, requestedCpu: Refined[Int, Positive],  jobLogger: Logger): String = {
+    val adjustedMemory: MemorySize = MemorySize(requestedCpu.value * 4.0, MemoryUnit.GB)
+    if (adjustedMemory != requestedMemory) {
+      jobLogger.info(s"Adjusting memory from ${requestedMemory.amount} to ${adjustedMemory.amount} in order to match GCP requirements for the requested CPU.")
+    }
+    val machine = requestedCpu.value match {
+      case cpu if cpu <= 4 => c3Standard_4
+      case cpu if cpu > 4 && cpu <= 8 => c3Standard_8
+      case cpu if cpu > 8 && cpu <= 22 => c3Standard_22
+      case cpu if cpu > 22 && cpu <= 44 => c3Standard_44
+      case cpu if cpu > 44 && cpu <= 88 => c3Standard_88
+      case cpu if cpu > 88 => c3Standard_176
+    }
+
+    if(machine.cpuCount != requestedCpu.value) {
+      jobLogger.info(s"Rounding up CPU count from ${requestedCpu} to ${machine.cpuCount} in order to match GCP requirements for the requested CPU.")
+    }
+    machine.gcpString
+  }
+}

--- a/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/MachineConstraintsSpec.scala
+++ b/supportedBackends/google/pipelines/common/src/test/scala/cromwell/backend/google/pipelines/common/MachineConstraintsSpec.scala
@@ -14,9 +14,13 @@ import wom.format.MemorySize
 class MachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers {
   behavior of "MachineConstraints"
 
-  private val n2Option = Option(PipelinesApiRuntimeAttributes.CpuPlatformIntelCascadeLakeValue)
+  private val n2OptionCascade = Option(PipelinesApiRuntimeAttributes.CpuPlatformIntelCascadeLakeValue)
 
-  private val n2dOption = Option(PipelinesApiRuntimeAttributes.CpuPlatformAMDRomeValue) 
+  private val n2dOption = Option(PipelinesApiRuntimeAttributes.CpuPlatformAMDRomeValue)
+
+  private val n2OptionIceLake = Option(PipelinesApiRuntimeAttributes.CpuPlatformIntelIceLakeValue)
+
+  private val c3OptionSapphireRapids = Option(PipelinesApiRuntimeAttributes.CpuPlatformIntelSapphireRapidsValue)
 
   it should "generate valid machine types" in {
     val validTypes = Table(
@@ -40,7 +44,6 @@ class MachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
 
       // Same tests as above but with legacy machine type selection (cpu and memory as specified. No 'custom machine
       // requirement' adjustments are expected this time, except float->int)
-
       (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
       (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, true, "predefined-3-4096"),
       (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-1024"),
@@ -52,15 +55,26 @@ class MachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
       (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, true, "predefined-33-2048"),
 
       // Same tests but with cascade lake (n2)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2Option, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2Option, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2Option, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2Option, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2Option, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascade, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascade, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascade, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascade, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascade, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascade, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascade, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascade, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascade, false, "n2-custom-36-36864"),
+
+      // Same tests, but with ice lake. Should produce same results as cascade lake since they're both n2.
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, false, "n2-custom-36-36864"),
 
       // Same tests but with AMD Rome (n2d) #cpu > 16 are in increments of 16  
       (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
@@ -73,7 +87,24 @@ class MachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
       (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
       (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2dOption, false, "n2d-custom-48-24576"), 
       (MemorySize(2, MemoryUnit.GB), refineMV[Positive](81), n2dOption, false, "n2d-custom-96-49152"),
-      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, false, "n2d-custom-96-262144")
+      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, false, "n2d-custom-96-262144"),
+
+      // Sapphire Rapids (c3). Unlike the above, this machine isn't customizable, so we expect one of six options.
+      // MemorySize is ignored since it must always be a multiple of the CPU count for c3 machines.
+      (MemorySize(1, MemoryUnit.MB), refineMV[Positive](1), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(10, MemoryUnit.GB), refineMV[Positive](1), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(100, MemoryUnit.TB), refineMV[Positive](1), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(1, MemoryUnit.MB), refineMV[Positive](2), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(10, MemoryUnit.GB), refineMV[Positive](3), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(100, MemoryUnit.TB), refineMV[Positive](4), c3OptionSapphireRapids, false, "c3-standard-4"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](5), c3OptionSapphireRapids, false, "c3-standard-8"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](21), c3OptionSapphireRapids, false, "c3-standard-22"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](22), c3OptionSapphireRapids, false, "c3-standard-22"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](23), c3OptionSapphireRapids, false, "c3-standard-44"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](50), c3OptionSapphireRapids, false, "c3-standard-88"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](100), c3OptionSapphireRapids, false, "c3-standard-176"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](200), c3OptionSapphireRapids, false, "c3-standard-176"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](300), c3OptionSapphireRapids, false, "c3-standard-176"),
     )
 
     forAll(validTypes) { (memory, cpu, cpuPlatformOption, googleLegacyMachineSelection, expected) =>


### PR DESCRIPTION
Added support for two more CPU types. Recommended reading: [machine types](https://cloud.google.com/compute/docs/machine-resource).
- `Ice Lake` was very simple to support since it is a customizable N2 machine like `Cascade Lake` is, and therefore can use identical logic.
- `Sapphire Rapids` was slightly more involved since it is not customizable like the other machine types are. Added `PredefinedMachineType.scala` to support this endeavor and leave room for future platforms. 

I ran some workflows with my local cromwell and confirmed that the VMs created in Google Cloud are appropriately provisioned. A centaur test should also confirm that this is working as expected. 