### PR TITLE
WX-1333 Improve logging visibility for load management

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -136,7 +136,7 @@ final class IoActor(ioConfig: IoConfig,
 
   override def onBackpressure(scale: Option[Double] = None): Unit = {
     incrementBackpressure()
-    log.info("IoActor notifying HighLoad")
+    log.warning("IoActor notifying HighLoad")
     serviceRegistryActor ! LoadMetric("IO", HighLoad)
 
     val uncappedDelay = scale.getOrElse(1.0d) * LoadConfig.IoNormalWindowMinimum

--- a/engine/src/main/scala/cromwell/engine/io/IoActor.scala
+++ b/engine/src/main/scala/cromwell/engine/io/IoActor.scala
@@ -136,6 +136,7 @@ final class IoActor(ioConfig: IoConfig,
 
   override def onBackpressure(scale: Option[Double] = None): Unit = {
     incrementBackpressure()
+    log.info("IoActor notifying HighLoad")
     serviceRegistryActor ! LoadMetric("IO", HighLoad)
 
     val uncappedDelay = scale.getOrElse(1.0d) * LoadConfig.IoNormalWindowMinimum

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -114,6 +114,8 @@ class ServiceRegistryActor(globalConfig: Config) extends Actor with ActorLogging
     msg match {
       case msg: LoadMetric =>
         log.debug(s"Service Registry Actor receiving $msg message from $sender")
+      case _ =>
+        ()
     }
   }
 

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -112,10 +112,8 @@ class ServiceRegistryActor(globalConfig: Config) extends Actor with ActorLogging
 
   private def debugLogLoadMessages(msg: ServiceRegistryMessage, sender: ActorRef): Unit = {
     msg match {
-      case msg: LoadMetric if msg.loadLevel == HighLoad =>
-        log.debug(s"Service Registry Actor receiving HighLoad messages from $sender")
-      case _: LoadMetric =>
-        log.debug(s"Service Registry Actor receiving NormalLoad messages from $sender")
+      case msg: LoadMetric =>
+        log.debug(s"Service Registry Actor receiving $msg message from $sender")
     }
   }
 

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -6,7 +6,7 @@ import akka.routing.Listen
 import cats.data.NonEmptyList
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import cromwell.core.Dispatcher.ServiceDispatcher
-import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric}
+import cromwell.services.loadcontroller.LoadControllerService.LoadMetric
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import net.ceedubs.ficus.Ficus._

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -6,6 +6,7 @@ import akka.routing.Listen
 import cats.data.NonEmptyList
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import cromwell.core.Dispatcher.ServiceDispatcher
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import net.ceedubs.ficus.Ficus._
@@ -82,7 +83,9 @@ class ServiceRegistryActor(globalConfig: Config) extends Actor with ActorLogging
   def receive = {
     case msg: ServiceRegistryMessage =>
       services.get(msg.serviceName) match {
-        case Some(ref) => ref.tell(transform(msg, sender()), sender())
+        case Some(ref) =>
+          debugLogLoadMessages(msg, sender())
+          ref.tell(transform(msg, sender()), sender())
         case None =>
           log.error("Received ServiceRegistryMessage requesting service '{}' for which no service is configured.  Message: {}", msg.serviceName, msg)
           sender() ! ServiceRegistryFailure(msg.serviceName)
@@ -105,6 +108,15 @@ class ServiceRegistryActor(globalConfig: Config) extends Actor with ActorLogging
     case fool =>
       log.error("Received message which is not a ServiceRegistryMessage: {}", fool)
       sender() ! ServiceRegistryFailure("Message is not a ServiceRegistryMessage: " + fool)
+  }
+
+  private def debugLogLoadMessages(msg: ServiceRegistryMessage, sender: ActorRef): Unit = {
+    msg match {
+      case msg: LoadMetric => if (msg.loadLevel == HighLoad)
+        log.debug(s"Service Registry Actor receiving HighLoad messages from $sender")
+      case _: LoadMetric =>
+        log.debug(s"Service Registry Actor receiving NormalLoad messages from $sender")
+    }
   }
 
   /**

--- a/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
+++ b/services/src/main/scala/cromwell/services/ServiceRegistryActor.scala
@@ -6,7 +6,7 @@ import akka.routing.Listen
 import cats.data.NonEmptyList
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import cromwell.core.Dispatcher.ServiceDispatcher
-import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric, NormalLoad}
+import cromwell.services.loadcontroller.LoadControllerService.{HighLoad, LoadMetric}
 import cromwell.util.GracefulShutdownHelper
 import cromwell.util.GracefulShutdownHelper.ShutdownCommand
 import net.ceedubs.ficus.Ficus._
@@ -112,7 +112,7 @@ class ServiceRegistryActor(globalConfig: Config) extends Actor with ActorLogging
 
   private def debugLogLoadMessages(msg: ServiceRegistryMessage, sender: ActorRef): Unit = {
     msg match {
-      case msg: LoadMetric => if (msg.loadLevel == HighLoad)
+      case msg: LoadMetric if msg.loadLevel == HighLoad =>
         log.debug(s"Service Registry Actor receiving HighLoad messages from $sender")
       case _: LoadMetric =>
         log.debug(s"Service Registry Actor receiving NormalLoad messages from $sender")

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestManager.scala
@@ -96,7 +96,13 @@ class PipelinesApiRequestManager(val qps: Int Refined Positive, requestWorkers: 
   }
 
   def monitorQueueSize() = {
-    val load = if (workQueue.size > LoadConfig.PAPIThreshold) HighLoad else NormalLoad
+    val load = if (workQueue.size > LoadConfig.PAPIThreshold) {
+      log.warning(s"PAPI Request Manager notifying HighLoad with queue size ${workQueue.size} exceeding limit of ${LoadConfig.PAPIThreshold}")
+      HighLoad
+    } else {
+      log.debug("PAPI Request Manager notifying NormaLoad")
+      NormalLoad
+    }
     serviceRegistryActor ! LoadMetric("PAPIQueryManager", load)
     updateQueueSize(workQueue.size)
   }

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.v2beta.api.request
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.client.http.{ByteArrayContent, HttpHeaders}
+import com.google.api.client.http.HttpHeaders
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/api/request/AbortRequestHandler.scala
@@ -3,7 +3,7 @@ package cromwell.backend.google.pipelines.v2beta.api.request
 import akka.actor.ActorRef
 import com.google.api.client.googleapis.batch.BatchRequest
 import com.google.api.client.googleapis.json.GoogleJsonError
-import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.{ByteArrayContent, HttpHeaders}
 import com.typesafe.scalalogging.LazyLogging
 import cromwell.backend.google.pipelines.common.api.PipelinesApiRequestManager._
 import cromwell.backend.google.pipelines.common.api.clients.PipelinesApiAbortClient.{PAPIAbortRequestSuccessful, PAPIOperationIsAlreadyTerminal}
@@ -35,7 +35,7 @@ trait AbortRequestHandler extends LazyLogging { this: RequestHandler =>
   // The Genomics batch endpoint doesn't seem to be able to handle abort requests on V2 operations at the moment
   // For now, don't batch the request and execute it on its own
   def handleRequest(abortQuery: PAPIAbortRequest, batch: BatchRequest, pollingManager: ActorRef)(implicit ec: ExecutionContext): Future[Try[Unit]] = {
-    Future(abortQuery.httpRequest.execute()) map {
+    Future(abortQuery.httpRequest.setThrowExceptionOnExecuteError(false).execute()) map {
       case response if response.isSuccessStatusCode =>
         abortQuery.requester ! PAPIAbortRequestSuccessful(abortQuery.jobId.jobId)
         Success(())


### PR DESCRIPTION
- Add load status logging where previously there was none for `PipelinesApiRequestManager.scala`
- Add high load logging to `IOActor`, which previously only had [back-to-normal logging](https://github.com/broadinstitute/cromwell/compare/develop...aen_wx_1333#diff-0be95c10972997df38906d44327436c1149e0c1a3df513bb49a43b9916ecd505R212)
- Add load logging to `ServiceRegistryActor` which collects the load messages from their various sources and routes them to the sinks like `JobTokenDispenserActor`