### PR TITLE
[WX-1393] Add Content Length to Curl request

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -100,11 +100,11 @@ object TesAsyncBackendJobExecutionActor {
        |    exit 1
        |  fi
        |fi
-       |
+       |curl --version
+       |jq --version
        |# Acquire bearer token, relying on the User Assigned Managed Identity of this VM.
        |echo Acquiring Bearer Token using User Assigned Managed Identity...
        |BEARER_TOKEN=$$(curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F' -H Metadata:true -s | jq .access_token)
-       |
        |# Remove the leading and trailing quotes
        |BEARER_TOKEN="$${BEARER_TOKEN#\\"}"
        |BEARER_TOKEN="$${BEARER_TOKEN%\\"}"
@@ -117,7 +117,9 @@ object TesAsyncBackendJobExecutionActor {
        |                    -X POST "$getSasWsmEndpoint" \\
        |                    -H "Content-Type: application/json" \\
        |                    -H "accept: */*" \\
-       |                    -H "Authorization: Bearer $${BEARER_TOKEN}")
+       |                    -H "Authorization: Bearer $${BEARER_TOKEN}" \\
+       |                    -H "Content-Length: 0" \\
+       |                    -d "")
        |
        |# Store token as environment variable
        |export $environmentVariableName=$$(echo "$${sas_response_json}" | jq -r '.token')

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -141,7 +141,9 @@ class TesAsyncBackendJobExecutionActorSpec extends AnyFlatSpec with Matchers wit
         |                    -X POST "$expectedEndpoint" \\
         |                    -H "Content-Type: application/json" \\
         |                    -H "accept: */*" \\
-        |                    -H "Authorization: Bearer $${BEARER_TOKEN}")
+        |                    -H "Authorization: Bearer $${BEARER_TOKEN}" \\
+        |                    -H "Content-Length: 0" \\
+        |                    -d "")
         |""".stripMargin
     val exportCommandSubstring = s"""export $mockEnvironmentVariableNameFromWom=$$(echo "$${sas_response_json}" | jq -r '.token')"""
     val echoCommandSubstring = s"""echo "Saving sas token: $${$mockEnvironmentVariableNameFromWom:0:4}**** to environment variable $mockEnvironmentVariableNameFromWom...""""


### PR DESCRIPTION
This fixes an issue where certain versions of `curl` don't automatically include a content-length of 0 for bodyless POST requests. 