### PR TITLE
WX-1351 One weird trick to build 3x faster

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -77,8 +77,8 @@ object Settings {
     organization := "org.broadinstitute",
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
-    Compile / parallelExecution := true,
-    Default / parallelExecution := false,
+    Global / parallelExecution := true,
+    Test / parallelExecution := false,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
       Tags.exclusive(Tags.Test),
@@ -95,8 +95,7 @@ object Settings {
     Compile / console / scalacOptions --= consoleHostileSettings,
     excludeDependencies ++= List(
       "org.typelevel" % "simulacrum-scalafix-annotations_2.13"
-    ),
-    // Global / lintUnusedKeysOnLoad := false
+    )
   )
 
   val pact4sSettings = sharedSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -77,8 +77,8 @@ object Settings {
     organization := "org.broadinstitute",
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
-    Global / parallelExecution := true,
-    Test / parallelExecution := false,
+    Compile / parallelExecution := true,
+    Default / parallelExecution := false,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
       Tags.exclusive(Tags.Test),
@@ -95,7 +95,8 @@ object Settings {
     Compile / console / scalacOptions --= consoleHostileSettings,
     excludeDependencies ++= List(
       "org.typelevel" % "simulacrum-scalafix-annotations_2.13"
-    )
+    ),
+    // Global / lintUnusedKeysOnLoad := false
   )
 
   val pact4sSettings = sharedSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,7 +78,7 @@ object Settings {
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
     // Don't run tasks in parallel, especially helps in low CPU environments like Travis
-    Global / parallelExecution := false,
+    Global / parallelExecution := true,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
       Tags.exclusive(Tags.Test),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -81,9 +81,9 @@ object Settings {
     // Seems to cause race conditions in tests, that are not pertinent to what's being tested
     Test / parallelExecution := false,
     Global / concurrentRestrictions ++= List(
-      // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
+      // Don't run any other tasks while running tests
       Tags.exclusive(Tags.Test),
-      // Only run tests on one sub-project at a time, especially helps in low CPU environments like Travis
+      // Only run tests on one sub-project at a time
       Tags.limit(Tags.Test, 1)
     ),
     dependencyOverrides ++= cromwellDependencyOverrides,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,6 +78,7 @@ object Settings {
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
     Global / parallelExecution := true,
+    Test / parallelExecution := false,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis
       Tags.exclusive(Tags.Test),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -78,6 +78,7 @@ object Settings {
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
     Global / parallelExecution := true,
+    // Seems to cause race conditions in tests, that are not pertinent to what's being tested
     Test / parallelExecution := false,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -77,7 +77,6 @@ object Settings {
     organization := "org.broadinstitute",
     scalaVersion := ScalaVersion,
     resolvers ++= additionalResolvers,
-    // Don't run tasks in parallel, especially helps in low CPU environments like Travis
     Global / parallelExecution := true,
     Global / concurrentRestrictions ++= List(
       // Don't run any other tasks while running tests, especially helps in low CPU environments like Travis


### PR DESCRIPTION
Test environment is `sbt -mem 8192` with 3 cycles of `clean; compile` in order to warm up the JVM.

Before:
```
[info] compiling 23 Scala sources to /Users/anichols/Projects/cromwell/supportedBackends/google/pipelines/v2alpha1/target/scala-2.13/classes ...
[info] compiling 22 Scala sources to /Users/anichols/Projects/cromwell/supportedBackends/google/pipelines/v2beta/target/scala-2.13/classes ...
[info] compiling 4 Scala sources to /Users/anichols/Projects/cromwell/server/target/scala-2.13/classes ...
[success] Total time: 97 s (01:37), completed Dec 8, 2023, 4:04:43 PM
```

After:
```
[info] compiling 22 Scala sources to /Users/anichols/Projects/cromwell/supportedBackends/google/pipelines/v2beta/target/scala-2.13/classes ...
[info] compiling 23 Scala sources to /Users/anichols/Projects/cromwell/supportedBackends/google/pipelines/v2alpha1/target/scala-2.13/classes ...
[info] compiling 4 Scala sources to /Users/anichols/Projects/cromwell/server/target/scala-2.13/classes ...
[success] Total time: 34 s, completed Dec 8, 2023, 3:54:47 PM
```