### PR TITLE
WX-1385 Reject blob URLs with external SAS tokens as unparsable

### DIFF
--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -75,7 +75,7 @@ object BlobPathBuilder {
   private def hasSasToken(uri: Uri) = {
     // These keys are required for all SAS tokens.
     // https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#construct-a-service-sas
-    val SignedVersionKey = "v"
+    val SignedVersionKey = "sv"
     val SignatureKey = "sig"
 
     val query = uri.query().toMap

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -59,14 +59,14 @@ object BlobPathBuilder {
       isBlobHost = testUri.getHost.contains(blobHostnameSuffix) && testUri.getScheme.contains("https")
       hasToken = hasSasToken(string)
       blobPathValidation = (isBlobHost, testContainer, hasToken) match {
-        case (_, _, true) =>
-          UnparsableBlobPath(new IllegalArgumentException(externalToken))
         case (true, Some(container), false) =>
           ValidBlobPath(testUri.getPath.replaceFirst("/" + container, ""), BlobContainerName(container), testEndpoint)
         case (false, _, false) =>
           UnparsableBlobPath(new MalformedURLException(invalidBlobHostMessage(testEndpoint)))
         case (true, None, false) =>
           UnparsableBlobPath(new MalformedURLException(invalidBlobContainerMessage(testEndpoint)))
+        case (_, _, true) =>
+          UnparsableBlobPath(new IllegalArgumentException(externalToken))
       }
     } yield blobPathValidation
     blobValidation recover { case t => UnparsableBlobPath(t) } get

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -1,5 +1,6 @@
 package cromwell.filesystems.blob
 
+import akka.http.scaladsl.model.Uri
 import com.azure.storage.blob.nio.AzureBlobFileAttributes
 import com.google.common.net.UrlEscapers
 import cromwell.core.path.{NioPath, Path, PathBuilder}
@@ -21,6 +22,8 @@ object BlobPathBuilder {
     s"Malformed Blob URL for this builder: The endpoint $endpoint doesn't contain the expected host string '{SA}.blob.core.windows.net/'"
   def invalidBlobContainerMessage(endpoint: EndpointURL) =
     s"Malformed Blob URL for this builder: Could not parse container"
+  val externalToken =
+    "Rejecting pre-signed SAS URL so that filesystem selection falls through to HTTP filesystem"
   def parseURI(string: String): Try[URI] = Try(URI.create(UrlEscapers.urlFragmentEscaper().escape(string)))
   def parseStorageAccount(uri: URI): Try[StorageAccountName] = uri.getHost
     .split("\\.")
@@ -50,18 +53,33 @@ object BlobPathBuilder {
   def validateBlobPath(string: String): BlobPathValidation = {
     val blobValidation = for {
       testUri <- parseURI(string)
-      testEndpoint = EndpointURL(testUri.getScheme + "://" + testUri.getHost())
-      testStorageAccount <- parseStorageAccount(testUri)
+      testEndpoint = EndpointURL(testUri.getScheme + "://" + testUri.getHost)
+      _ <- parseStorageAccount(testUri)
       testContainer = testUri.getPath.split("/").find(_.nonEmpty)
-      isBlobHost = testUri.getHost().contains(blobHostnameSuffix) && testUri.getScheme().contains("https")
-      blobPathValidation = (isBlobHost, testContainer) match {
-        case (true, Some(container)) =>
+      isBlobHost = testUri.getHost.contains(blobHostnameSuffix) && testUri.getScheme.contains("https")
+      hasToken = hasSasToken(string)
+      blobPathValidation = (isBlobHost, testContainer, hasToken) match {
+        case (_, _, true) =>
+          UnparsableBlobPath(new IllegalArgumentException(externalToken))
+        case (true, Some(container), false) =>
           ValidBlobPath(testUri.getPath.replaceFirst("/" + container, ""), BlobContainerName(container), testEndpoint)
-        case (false, _) => UnparsableBlobPath(new MalformedURLException(invalidBlobHostMessage(testEndpoint)))
-        case (true, None) => UnparsableBlobPath(new MalformedURLException(invalidBlobContainerMessage(testEndpoint)))
+        case (false, _, false) =>
+          UnparsableBlobPath(new MalformedURLException(invalidBlobHostMessage(testEndpoint)))
+        case (true, None, false) =>
+          UnparsableBlobPath(new MalformedURLException(invalidBlobContainerMessage(testEndpoint)))
       }
     } yield blobPathValidation
     blobValidation recover { case t => UnparsableBlobPath(t) } get
+  }
+
+  private def hasSasToken(uri: Uri) = {
+    // These keys are required for all SAS tokens.
+    // https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#construct-a-service-sas
+    val SignedVersionKey = "v"
+    val SignatureKey = "sig"
+
+    val query = uri.query().toMap
+    query.isDefinedAt(SignedVersionKey) && query.isDefinedAt(SignatureKey)
   }
 }
 

--- a/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderSpec.scala
+++ b/filesystems/blob/src/test/scala/cromwell/filesystems/blob/BlobPathBuilderSpec.scala
@@ -37,7 +37,9 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
       "?sv=2021-12-02&spr=https&st=2023-12-13T20%3A27%3A55Z&se=2023-12-14T04%3A42%3A55Z&sr=c&sp=racwdlt&sig=blah&rscd=foo"
     BlobPathBuilder.validateBlobPath(sasBlob).asInstanceOf[UnparsableBlobPath].errorMessage.getMessage should equal(
       UnparsableBlobPath(
-        new IllegalArgumentException("Rejecting pre-signed SAS URL so that filesystem selection falls through to HTTP filesystem")
+        new IllegalArgumentException(
+          "Rejecting pre-signed SAS URL so that filesystem selection falls through to HTTP filesystem"
+        )
       ).errorMessage.getMessage
     )
   }
@@ -54,8 +56,9 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
     testException should contain(exception)
   }
 
-  private def testBlobNioStringCleaning(input: String, expected: String) =
-    BlobPath.cleanedNioPathString(input) shouldBe expected
+  // The following tests use the `centaurtesting` account injected into CI. They depend on access to the
+  // container specified below. You may need to log in to az cli locally to get them to pass.
+  private val subscriptionId: SubscriptionId = SubscriptionId(UUID.fromString("62b22893-6bc1-46d9-8a90-806bb3cce3c9"))
 
   it should "clean the NIO path string when it has a garbled http protocol" in {
     testBlobNioStringCleaning(
@@ -84,10 +87,6 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
       ""
     )
   }
-
-  // The following tests use the `centaurtesting` account injected into CI. They depend on access to the
-  // container specified below. You may need to log in to az cli locally to get them to pass.
-  private val subscriptionId: SubscriptionId = SubscriptionId(UUID.fromString("62b22893-6bc1-46d9-8a90-806bb3cce3c9"))
   private val endpoint: EndpointURL = BlobPathBuilderSpec.buildEndpoint("centaurtesting")
   private val container: BlobContainerName = BlobContainerName("test-blob")
 
@@ -96,6 +95,9 @@ class BlobPathBuilderSpec extends AnyFlatSpec with Matchers with MockSugar {
     val fsm = new BlobFileSystemManager(10, blobTokenGenerator)
     new BlobPathBuilder()(fsm)
   }
+
+  private def testBlobNioStringCleaning(input: String, expected: String) =
+    BlobPath.cleanedNioPathString(input) shouldBe expected
 
   it should "read md5 from small files <5g" in {
     val builder = makeBlobPathBuilder()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -499,7 +499,7 @@ object Dependencies {
     List("scalatest", "mysql", "mariadb", "postgresql")
       .map(name => "com.dimafeng" %% s"testcontainers-scala-$name" % testContainersScalaV % Test)
 
-  val blobFileSystemDependencies: List[ModuleID] = azureDependencies ++ wsmDependencies
+  val blobFileSystemDependencies: List[ModuleID] = azureDependencies ++ wsmDependencies ++ akkaHttpDependencies
 
   val s3FileSystemDependencies: List[ModuleID] = junitDependencies
 


### PR DESCRIPTION
Tested by localizing a Blob file from Terra Prod, on a patched Cromwell in Terra Dev.

This PR with foreign Blob URL:

```
2023-12-20 18:12:17.197 Tes.Runner.Transfer.BlobOperationPipeline[0] Completed download. Total bytes: 7,811,366,912 Filename: /mnt/batch/tasks/workitems/TES-ybjxkg-D5_v2-4yab26tn3af2kf6dfa755sbg5oeqevqw-6cylhedz/job-1/a7123170_f41bbba17a6f4409940127a60234695d-1/wd/wd/cromwell-executions/localizer_workflow/a7123170-1652-45b8-a8ba-c7bef84acac4/call-localizer_task/inputs/lz304a1e79fd7359e5327eda.blob.core.windows.net/sc-705b830a-d699-478e-9da6-49661b326e77/inputs/Rocky-9.2-aarch64-dvd.iso
2023-12-20 18:12:17.200 Tes.Runner.Transfer.ProcessedPartsProcessor[0] All parts were successfully processed.
2023-12-20 18:12:17.200 Tes.Runner.Transfer.PartsReader[0] All part read operations completed successfully.
2023-12-20 18:12:17.201 Tes.Runner.Transfer.PartsWriter[0] All part write operations completed successfully.
2023-12-20 18:12:17.201 Tes.Runner.Transfer.BlobOperationPipeline[0] Pipeline processing completed.
2023-12-20 18:12:17.201 Tes.Runner.Transfer.BlobOperationPipeline[0] Waiting for processed part processor to complete.
2023-12-20 18:12:17.201 Tes.Runner.Transfer.BlobOperationPipeline[0] Processed parts completed.
2023-12-20 18:12:17.204 Tes.Runner.Executor[0] Executed Download. Time elapsed: 00:00:13.0435715 Bandwidth: 571.12 MiB/s
2023-12-20 18:12:17.208 Tes.RunnerCLI.Commands.CommandHandlers[0] Total bytes transferred: 7,811,369,114
/cromwell-executions/localizer_workflow/a7123170-1652-45b8-a8ba-c7bef84acac4/call-localizer_task/execution
```

This PR with a regular HTTPS URL from the 'net:
```
2023-12-20 18:42:08.430 Tes.Runner.Transfer.BlobOperationPipeline[0] Completed download. Total bytes: 1,553,924,096 Filename: /mnt/batch/tasks/workitems/TES-ybjxkg-D5_v2-4yab26tn3af2kf6dfa755sbg5oeqevqw-6cylhedz/job-1/f9b357bc_8d135cf26c4345599dbd046d5892d274-1/wd/wd/cromwell-executions/localizer_workflow/f9b357bc-4a13-4923-9b90-0f707ae9f435/call-localizer_task/inputs/download.rockylinux.org/pub/rocky/9/isos/aarch64/Rocky-9.3-aarch64-minimal.iso
2023-12-20 18:42:08.431 Tes.Runner.Transfer.ProcessedPartsProcessor[0] All parts were successfully processed.
2023-12-20 18:42:08.432 Tes.Runner.Transfer.PartsReader[0] All part read operations completed successfully.
2023-12-20 18:42:08.432 Tes.Runner.Transfer.PartsWriter[0] All part write operations completed successfully.
2023-12-20 18:42:08.433 Tes.Runner.Transfer.BlobOperationPipeline[0] Pipeline processing completed.
2023-12-20 18:42:08.433 Tes.Runner.Transfer.BlobOperationPipeline[0] Waiting for processed part processor to complete.
2023-12-20 18:42:08.433 Tes.Runner.Transfer.BlobOperationPipeline[0] Processed parts completed.
2023-12-20 18:42:08.436 Tes.Runner.Executor[0] Executed Download. Time elapsed: 00:00:05.5983839 Bandwidth: 264.71 MiB/s
2023-12-20 18:42:08.439 Tes.RunnerCLI.Commands.CommandHandlers[0] Total bytes transferred: 1,553,926,298
/cromwell-executions/localizer_workflow/f9b357bc-4a13-4923-9b90-0f707ae9f435/call-localizer_task/execution
```

`develop` with foreign Blob URL:

![Screenshot 2023-12-20 at 11 41 33](https://github.com/broadinstitute/cromwell/assets/1087943/b46da630-ad80-4388-9642-867e11516177)