### PR TITLE
WX-1444 Use MySQL LTS in DBMS tests

### DIFF
--- a/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
+++ b/services/src/test/scala/cromwell/services/database/DatabaseSystem.scala
@@ -53,7 +53,7 @@ case object MysqlEarliestDatabaseSystem extends NetworkDatabaseSystem {
 case object MysqlLatestDatabaseSystem extends NetworkDatabaseSystem {
   override val name: String = "MySQL (latest)"
   override val platform: MysqlDatabasePlatform.type = MysqlDatabasePlatform
-  override val dockerImageVersion: String = "latest"
+  override val dockerImageVersion: String = "8.0"
 }
 
 case object PostgresqlEarliestDatabaseSystem extends NetworkDatabaseSystem {


### PR DESCRIPTION
Starting last summer/fall, MySQL adopted a new release schedule that includes faster cycles with breaking changes [0]. We should stick to the 8.0.xx branch [1] as this is now considered LTS and will be best supported by tools like TestContainers and CloudSQL.

[0] https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/
[1] https://github.com/testcontainers/testcontainers-java/pull/8131