### PR TITLE
WX-767 Upgrade Cloud SDK to 461.0.0

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -16,30 +16,16 @@ object RunnableUtils {
   /** Port mappings for the ssh container. */
   val sshPortMappings = Map("22" -> Int.box(22))
 
-  /*
-   * At the moment, cloud-sdk (924MB for 276.0.0-slim) and stedolan/jq (182MB) decompressed ~= 1.1 GB
-   */
-  val cromwellImagesSizeRoundedUpInGB = 1
-
   private val config = ConfigFactory.load().getConfig("google")
 
   /**
     * An image with the Google Cloud SDK installed.
     * http://gcr.io/google.com/cloudsdktool/cloud-sdk
     *
-    * FYI additional older versions are available on DockerHub at:
-    * https://hub.docker.com/r/google/cloud-sdk
-    *
-    * When updating this value, also consider updating the CromwellImagesSizeRoundedUpInGB below.
+    * Also update `cromwell.backend.google.pipelines.common.action.ActionUtils`
     */
   val CloudSdkImage: String =
-    // config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine")
-    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:434.0.0-alpine")
-  /*
-   * At the moment, cloud-sdk (584MB for 354.0.0-alpine) and stedolan/jq (182MB) decompressed ~= 0.8 GB
-   */
-  val CromwellImagesSizeRoundedUpInGB: Int =
-    config.getOrElse("cloud-sdk-image-size-gb", 1)
+    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:461.0.0-alpine")
 
   /** Quotes a string such that it's compatible as a string argument in the shell. */
   def shellEscaped(any: Any): String = {

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/action/ActionUtils.scala
@@ -15,30 +15,23 @@ object ActionUtils {
   /** Port mappings for the ssh container. */
   val sshPortMappings = Map("22" -> Int.box(22))
 
-  /*
-   * At the moment, cloud-sdk (924MB for 276.0.0-slim) and stedolan/jq (182MB) decompressed ~= 1.1 GB
-   */
-  val cromwellImagesSizeRoundedUpInGB = 1
-
   private val config = ConfigFactory.load().getConfig("google")
 
   /**
     * An image with the Google Cloud SDK installed.
     * http://gcr.io/google.com/cloudsdktool/cloud-sdk
     *
-    * FYI additional older versions are available on DockerHub at:
-    * https://hub.docker.com/r/google/cloud-sdk
+    * When updating this value, also consider updating the `cromwellImagesSizeRoundedUpInGB` below.
     *
-    * When updating this value, also consider updating the CromwellImagesSizeRoundedUpInGB below.
+    * Also update `cromwell.backend.google.batch.runnable.RunnableUtils`
     */
   val CloudSdkImage: String =
-    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:354.0.0-alpine")
+    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:461.0.0-alpine")
 
   /*
-   * At the moment, cloud-sdk (584MB for 354.0.0-alpine) and stedolan/jq (182MB) decompressed ~= 0.8 GB
+   * At the moment, cloud-sdk (955MB for 460.0.0-alpine) ~= 1.0 GB
    */
-  val CromwellImagesSizeRoundedUpInGB: Int =
-    config.getOrElse("cloud-sdk-image-size-gb", 1)
+  val cromwellImagesSizeRoundedUpInGB: Int = config.getOrElse("cloud-sdk-image-size-gb", 1)
 
   /** Quotes a string such that it's compatible as a string argument in the shell. */
   def shellEscaped(any: Any): String = {


### PR DESCRIPTION
Subset of https://github.com/broadinstitute/cromwell/pull/7359 concerned with upgrading the Google Cloud SDK only, in order to deploy separately & de-risk.