### PR TITLE
WX-1449 Add `latest` Docker tag

### DIFF
--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -41,11 +41,11 @@ object Publishing {
         version.value
       } else {
         if (Version.isRelease) {
-          // Tags look like `85`, `85-443a6fc`
-          s"$cromwellVersion,${version.value}"
+          // Tags look like `85`, `85-443a6fc`, `latest`
+          s"$cromwellVersion,${version.value},latest"
         } else {
-          // Tag looks like `85-443a6fc`
-          version.value
+          // Tag looks like `85-443a6fc`, `rolling`
+          s"${version.value},rolling"
         }
       }
 

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -41,11 +41,11 @@ object Publishing {
         version.value
       } else {
         if (Version.isRelease) {
-          // Tags look like `85`, `85-443a6fc`, `latest`
-          s"$cromwellVersion,${version.value},latest"
+          // Tags look like `85`, `85-443a6fc`
+          s"$cromwellVersion,${version.value}"
         } else {
-          // Tag looks like `85-443a6fc`, `rolling`
-          s"${version.value},rolling"
+          // Tag looks like `85-443a6fc`, `latest`
+          s"${version.value},latest"
         }
       }
 


### PR DESCRIPTION
We (possibly inadvertently) stopped updating the `dev` and `develop` tags a year ago, probably as part of some CI changes. `latest` has the same function but more accurately reflects our confidence that the tip of `develop` is ready for production. [User request Slack thread.](https://broadinstitute.slack.com/archives/C02H5JRN68J/p1706720259849509?thread_ts=1706718443.975639&cid=C02H5JRN68J)