### PR TITLE
WX-1417 New database role strategy

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -90,6 +90,12 @@
     <include file="changesets/enlarge_docker_hash_store_entry_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_workflow_store_entry_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_sub_workflow_store_entry_id.xml" relativeToChangelogFile="true" />
+    <!-- WARNING!
+      This changeset should always be last.
+      It is always run (and should always run last) to set table ownership correctly.
+      If your changeset adds a new table, make sure it is also owned by the sharedCromwellDbRole.
+    -->
+    <include file="changesets/set_table_role.xml" relativeToChangelogFile="true" />
     <!-- REMINDER!
       Before appending here, did you remember to include the 'objectQuotingStrategy="QUOTE_ALL_OBJECTS"' line in your changeset/xyz.xml...?
     -->

--- a/database/migration/src/main/resources/changesets/set_table_role.xml
+++ b/database/migration/src/main/resources/changesets/set_table_role.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- The 'engineSharedCromwellDbRole' can be set via JAVA_OPTS if desired (eg -DengineSharedCromwellDbRole=...). -->
+    <property  name="engineSharedCromwellDbRole" value=""/>
+
+    <!--
+        This changeset will be applied whenever the 'sharedCromwellDbRole' property is set.
+        It runs every time to ensure the role is set correctly after all other changesets.
+     -->
+    <changeSet runAlways="true" runOnChange="true" author="jdewar" id="set_table_role" dbms="postgresql">
+        <preConditions onFail="MARK_RAN">
+            <!-- check that 'engineSharedCromwellDbRole' role is set, and matches something in the pg_roles table -->
+            <sqlCheck expectedResult="1">
+                SELECT count(1)
+                FROM pg_roles
+                where '${engineSharedCromwellDbRole}' != '' and pg_roles.rolname = '${engineSharedCromwellDbRole}';
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            ALTER TABLE "CALL_CACHING_AGGREGATION_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "CALL_CACHING_DETRITUS_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "CALL_CACHING_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "CALL_CACHING_HASH_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "CALL_CACHING_SIMPLETON_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "DOCKER_HASH_STORE_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "JOB_KEY_VALUE_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "JOB_STORE_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "JOB_STORE_SIMPLETON_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "SUB_WORKFLOW_STORE_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "WORKFLOW_STORE_ENTRY" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "databasechangelog" OWNER TO ${engineSharedCromwellDbRole};
+            ALTER TABLE "databasechangeloglock" OWNER TO ${engineSharedCromwellDbRole};
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -324,6 +324,34 @@ database {
 }
 ```
 
+If you want multiple database users to be able to read Cromwell's data from a Postgresql database, you'll need to create a
+role that all relevant users have access to, and adjust Cromwell to use this role. This is because each Large Object is owned
+by, and only readable by, the role that wrote it.
+
+First, pass these options when executing Cromwell. They will ensure that Cromwell's database tables are 
+owned by the role, not the initial login user.
+ * `-DengineSharedCromwellDbRole=your_role` to control the role that owns the engine tables
+ * `-DsharedCromwellDbRole=your_role` to control the role that owns the metadata tables
+
+Next, use the config key `pgLargeObjectWriteRole` to set the role that should own all large objects, as shown below. 
+This config will have no effect if you aren't using Postgresql. The configured login user can be any user that is
+granted the shared role.
+
+```hocon
+database {
+  profile = "slick.jdbc.PostgresProfile$"
+  pgLargeObjectWriteRole = "your_role"
+  db {
+    driver = "org.postgresql.Driver"
+    url = "jdbc:postgresql://localhost:5432/cromwell"
+    user = "user"
+    password = "pass"
+    port = 5432
+    connectionTimeout = 5000
+  }
+}
+```
+
 **Using Cromwell with file-based database (No server required)**
 
 SQLite is currently not supported. However, HSQLDB does support running with a persistence file.


### PR DESCRIPTION
This changeset extends our metadata large object write strategy to the engine database. There are two pieces, both of which come into play only when using PostgreSQL and only when the relevant configuration is present:
 * At the end of the liquibase migration, make all tables owned by a configured role.
 * Add a `SET LOCAL ROLE` to the beginning of all transactions, to ensure the transaction runs as the right role. 

Associated terra-helmfile PR: https://github.com/broadinstitute/terra-helmfile/pull/5081