### PR TITLE
WX-1445 Update docker image regex to handle python:3 correctly

### DIFF
--- a/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
@@ -56,7 +56,7 @@ object DockerImageIdentifier {
 
        (                                        # Begin capturing group for name
           [a-z0-9]+(?:[._-][a-z0-9]+)*          # API v2 name component regex - see https://docs.docker.com/registry/spec/api/#/overview
-          (?::[0-9]{4,5})?                      # Optional port (expect 4 or 5 digits)
+          (?::[0-9]{4,5}|:443)?                 # Optional port (expect 4 or 5 digits OR :443)
           (?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*    # Optional additional name components separated by /
        )                                        # End capturing group for name
 

--- a/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
+++ b/dockerHashing/src/main/scala/cromwell/docker/DockerImageIdentifier.scala
@@ -56,7 +56,7 @@ object DockerImageIdentifier {
 
        (                                        # Begin capturing group for name
           [a-z0-9]+(?:[._-][a-z0-9]+)*          # API v2 name component regex - see https://docs.docker.com/registry/spec/api/#/overview
-          (?::[0-9]+)?                          # Optional port
+          (?::[0-9]{4,5})?                      # Optional port (expect 4 or 5 digits)
           (?:/[a-z0-9]+(?:[._-][a-z0-9]+)*)*    # Optional additional name components separated by /
        )                                        # End capturing group for name
 

--- a/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
@@ -41,6 +41,7 @@ class DockerImageIdentifierSpec
        "0.8.1.1--htslib1.5_0"
       ),
       ("terrabatchdev.azurecr.io/postgres:latest", Option("terrabatchdev.azurecr.io"), None, "postgres", "latest"),
+      ("python:3", None, None, "python", "3"),
       // Very long tags with trailing spaces cause problems for the re engine
       ("someuser/someimage:supercalifragilisticexpialidociouseventhoughthesoundofitissomethingquiteatrociousifyousayitloudenoughyoullalwayssoundprecocious ",
        None,

--- a/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
+++ b/dockerHashing/src/test/scala/cromwell/docker/DockerImageIdentifierSpec.scala
@@ -42,6 +42,7 @@ class DockerImageIdentifierSpec
       ),
       ("terrabatchdev.azurecr.io/postgres:latest", Option("terrabatchdev.azurecr.io"), None, "postgres", "latest"),
       ("python:3", None, None, "python", "3"),
+      ("localhost:443/ubuntu", Option("localhost:443"), None, "ubuntu", "latest"),
       // Very long tags with trailing spaces cause problems for the re engine
       ("someuser/someimage:supercalifragilisticexpialidociouseventhoughthesoundofitissomethingquiteatrociousifyousayitloudenoughyoullalwayssoundprecocious ",
        None,


### PR DESCRIPTION
Update the Docker image regex to expect port numbers to have 4 or 5 digits. Interested in thoughts on this approach, because it's not bulletproof in either direction:
 * 1-3 digit port numbers are technically possible, though I've never observed one associated with a Docker repo
 * 4-5 digit numeric image tags are technically possible

If this doesn't feel like a safe solution, I can take a stab at a more aggressive update to this regex.