### PR TITLE
WX-1252 Runtime attributes cleanup – CWL runtime attributes

### DIFF
--- a/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
+++ b/backend/src/main/scala/cromwell/backend/RuntimeEnvironment.scala
@@ -3,7 +3,7 @@ package cromwell.backend
 import java.util.UUID
 
 import cromwell.backend.io.JobPaths
-import cromwell.backend.validation.{CpuValidation, MemoryValidation}
+import cromwell.backend.validation.MemoryValidation
 import cromwell.core.path.Path
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
@@ -27,7 +27,8 @@ object RuntimeEnvironmentBuilder {
       callRoot.resolve(s"tmp.$hash").pathAsString
     }
 
-    val cores: Int Refined Positive = CpuValidation.instanceMin.validate(runtimeAttributes).getOrElse(minimums.cores)
+    // This class is going away in https://github.com/broadinstitute/cromwell/pull/7369
+    val cores: Int Refined Positive = minimums.cores
 
     val memoryInMB: Double =
       MemoryValidation

--- a/backend/src/main/scala/cromwell/backend/validation/CpuValidation.scala
+++ b/backend/src/main/scala/cromwell/backend/validation/CpuValidation.scala
@@ -24,10 +24,6 @@ import wom.values.{WomInteger, WomValue}
 object CpuValidation {
   lazy val instance: RuntimeAttributesValidation[Int Refined Positive] = new CpuValidation(CpuKey)
   lazy val optional: OptionalRuntimeAttributesValidation[Int Refined Positive] = instance.optional
-  lazy val instanceMin: RuntimeAttributesValidation[Int Refined Positive] = new CpuValidation(CpuMinKey)
-  lazy val optionalMin: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMin.optional
-  lazy val instanceMax: RuntimeAttributesValidation[Int Refined Positive] = new CpuValidation(CpuMaxKey)
-  lazy val optionalMax: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMax.optional
 
   lazy val defaultMin: WomValue = WomInteger(1)
   def configDefaultWomValue(config: Option[Config]): Option[WomValue] = instance.configDefaultWomValue(config)

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -97,10 +97,6 @@ object AwsBatchRuntimeAttributes {
     CpuValidation.instance
       .withDefault(CpuValidation.configDefaultWomValue(runtimeConfig) getOrElse CpuValidation.defaultMin)
 
-  private def cpuMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int Refined Positive] =
-    CpuValidation.instanceMin
-      .withDefault(CpuValidation.configDefaultWomValue(runtimeConfig) getOrElse CpuValidation.defaultMin)
-
   private def failOnStderrValidation(runtimeConfig: Option[Config]) = FailOnStderrValidation.default(runtimeConfig)
 
   private def continueOnReturnCodeValidation(runtimeConfig: Option[Config]) =
@@ -118,13 +114,6 @@ object AwsBatchRuntimeAttributes {
     MemoryValidation.withDefaultMemory(
       RuntimeAttributesKeys.MemoryKey,
       MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryKey, runtimeConfig) getOrElse MemoryDefaultValue
-    )
-
-  private def memoryMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[MemorySize] =
-    MemoryValidation.withDefaultMemory(RuntimeAttributesKeys.MemoryMinKey,
-                                       MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryMinKey,
-                                                                            runtimeConfig
-                                       ) getOrElse MemoryDefaultValue
     )
 
   private def noAddressValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Boolean] =
@@ -152,11 +141,9 @@ object AwsBatchRuntimeAttributes {
       .default(runtimeConfig)
       .withValidation(
         cpuValidation(runtimeConfig),
-        cpuMinValidation(runtimeConfig),
         disksValidation(runtimeConfig),
         zonesValidation(runtimeConfig),
         memoryValidation(runtimeConfig),
-        memoryMinValidation(runtimeConfig),
         noAddressValidation(runtimeConfig),
         dockerValidation,
         queueArnValidation(runtimeConfig),
@@ -166,11 +153,9 @@ object AwsBatchRuntimeAttributes {
       .default(runtimeConfig)
       .withValidation(
         cpuValidation(runtimeConfig),
-        cpuMinValidation(runtimeConfig),
         disksValidation(runtimeConfig),
         zonesValidation(runtimeConfig),
         memoryValidation(runtimeConfig),
-        memoryMinValidation(runtimeConfig),
         noAddressValidation(runtimeConfig),
         dockerValidation,
         queueArnValidation(runtimeConfig)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
@@ -80,7 +80,7 @@ object GcpBatchRequestFactory {
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreateBatchDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],
-                                      adjustedSizeDisks: Seq[GcpBatchAttachedDisk],
+                                      disks: Seq[GcpBatchAttachedDisk],
                                       virtualPrivateCloudConfiguration: VirtualPrivateCloudConfiguration,
                                       retryWithMoreMemoryKeys: Option[List[String]],
                                       fuseEnabled: Boolean,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -161,7 +161,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val createParameters = data.createParameters
     val retryCount = data.gcpBatchParameters.runtimeAttributes.preemptible
     val allDisksToBeMounted: Seq[GcpBatchAttachedDisk] =
-      createParameters.adjustedSizeDisks ++ createParameters.referenceDisksForLocalizationOpt.getOrElse(List.empty)
+      createParameters.disks ++ createParameters.referenceDisksForLocalizationOpt.getOrElse(List.empty)
     val gcpBootDiskSizeMb = convertGbToMib(runtimeAttributes)
 
     // set parent for metadata storage of job information

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
@@ -7,8 +7,6 @@ import common.exception.MessageAggregation
 import common.validation.ErrorOr._
 import cromwell.backend.DiskPatterns._
 import cromwell.core.path.{DefaultPathBuilder, Path}
-import wdl4s.parser.MemoryUnit
-import wom.format.MemorySize
 import wom.values._
 
 import scala.util.Try
@@ -58,15 +56,6 @@ object GcpBatchAttachedDisk {
       case _: IllegalArgumentException => s"$value not convertible to a Long".invalidNel
     }
 
-  implicit class EnhancedDisks(val disks: Seq[GcpBatchAttachedDisk]) extends AnyVal {
-    def adjustWorkingDiskWithNewMin(minimum: MemorySize, onAdjustment: => Unit): Seq[GcpBatchAttachedDisk] = disks map {
-      case disk: GcpBatchWorkingDisk
-          if disk == GcpBatchWorkingDisk.Default && disk.sizeGb < minimum.to(MemoryUnit.GB).amount.toInt =>
-        onAdjustment
-        disk.copy(sizeGb = minimum.to(MemoryUnit.GB).amount.toInt)
-      case other => other
-    }
-  }
 }
 
 trait GcpBatchAttachedDisk {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -11,7 +11,6 @@ import cromwell.backend.validation._
 import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import wdl4s.parser.MemoryUnit
 import wom.RuntimeAttributesKeys
 import wom.format.MemorySize
 import wom.types.{WomArrayType, WomStringType, WomType}
@@ -79,10 +78,6 @@ object GcpBatchRuntimeAttributes {
   val CpuPlatformIntelCascadeLakeValue = "Intel Cascade Lake"
   val CpuPlatformAMDRomeValue = "AMD Rome"
 
-  private def cpuMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int Refined Positive] =
-    CpuValidation.instanceMin
-      .withDefault(CpuValidation.configDefaultWomValue(runtimeConfig) getOrElse CpuValidation.defaultMin)
-
   val UseDockerImageCacheKey = "useDockerImageCache"
   private val useDockerImageCacheValidationInstance = new BooleanRuntimeAttributesValidation(
     UseDockerImageCacheKey
@@ -111,9 +106,6 @@ object GcpBatchRuntimeAttributes {
   private def gpuCountValidation(
     runtimeConfig: Option[Config]
   ): OptionalRuntimeAttributesValidation[Int Refined Positive] = GpuValidation.optional
-  private def gpuMinValidation(
-    runtimeConfig: Option[Config]
-  ): OptionalRuntimeAttributesValidation[Int Refined Positive] = GpuValidation.optionalMin
 
   private val dockerValidation: RuntimeAttributesValidation[String] = DockerValidation.instance
 
@@ -143,13 +135,6 @@ object GcpBatchRuntimeAttributes {
       MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryKey, runtimeConfig) getOrElse MemoryDefaultValue
     )
 
-  private def memoryMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[MemorySize] =
-    MemoryValidation.withDefaultMemory(
-      RuntimeAttributesKeys.MemoryMinKey,
-      MemoryValidation
-        .configDefaultString(RuntimeAttributesKeys.MemoryMinKey, runtimeConfig) getOrElse MemoryDefaultValue
-    )
-
   private def bootDiskSizeValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     bootDiskValidationInstance
       .withDefault(bootDiskValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse BootDiskDefaultValue)
@@ -166,15 +151,6 @@ object GcpBatchRuntimeAttributes {
   ): OptionalRuntimeAttributesValidation[Boolean] =
     useDockerImageCacheValidationInstance
 
-  private val outDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.OutDirMinKey, MemoryUnit.MB, allowZero = true)
-
-  private val tmpDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.TmpDirMinKey, MemoryUnit.MB, allowZero = true)
-
-  private val inputDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.DnaNexusInputDirMinKey, MemoryUnit.MB, allowZero = true)
-
   def runtimeAttributesBuilder(batchConfiguration: GcpBatchConfiguration): StandardValidatedRuntimeAttributesBuilder = {
     val runtimeConfig = batchConfiguration.runtimeConfig
     StandardValidatedRuntimeAttributesBuilder
@@ -185,21 +161,15 @@ object GcpBatchRuntimeAttributes {
         gpuDriverValidation(runtimeConfig),
         cpuValidation(runtimeConfig),
         cpuPlatformValidation(runtimeConfig),
-        cpuMinValidation(runtimeConfig),
-        gpuMinValidation(runtimeConfig),
         disksValidation(runtimeConfig),
         noAddressValidation(runtimeConfig),
         zonesValidation(runtimeConfig),
         preemptibleValidation(runtimeConfig),
         memoryValidation(runtimeConfig),
-        memoryMinValidation(runtimeConfig),
         bootDiskSizeValidation(runtimeConfig),
         useDockerImageCacheValidation(runtimeConfig),
         checkpointFileValidationInstance,
         dockerValidation,
-        outDirMinValidation,
-        tmpDirMinValidation,
-        inputDirMinValidation
       )
   }
 
@@ -257,21 +227,6 @@ object GcpBatchRuntimeAttributes {
       validatedRuntimeAttributes
     )
 
-    val outDirMin: Option[MemorySize] = RuntimeAttributesValidation
-      .extractOption(outDirMinValidation.key, validatedRuntimeAttributes)
-    val tmpDirMin: Option[MemorySize] = RuntimeAttributesValidation
-      .extractOption(tmpDirMinValidation.key, validatedRuntimeAttributes)
-    val inputDirMin: Option[MemorySize] = RuntimeAttributesValidation
-      .extractOption(inputDirMinValidation.key, validatedRuntimeAttributes)
-
-    val totalExecutionDiskSizeBytes = List(inputDirMin.map(_.bytes),
-                                           outDirMin.map(_.bytes),
-                                           tmpDirMin.map(_.bytes)
-    ).flatten.fold(MemorySize(0, MemoryUnit.Bytes).bytes)(_ + _)
-    val totalExecutionDiskSize = MemorySize(totalExecutionDiskSizeBytes, MemoryUnit.Bytes)
-
-    val adjustedDisks = disks.adjustWorkingDiskWithNewMin(totalExecutionDiskSize, ())
-
     new GcpBatchRuntimeAttributes(
       cpu,
       cpuPlatform,
@@ -280,7 +235,7 @@ object GcpBatchRuntimeAttributes {
       preemptible,
       bootDiskSize,
       memory,
-      adjustedDisks,
+      disks,
       docker,
       failOnStderr,
       continueOnReturnCode,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GpuValidation.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GpuValidation.scala
@@ -13,17 +13,13 @@ import cromwell.backend.validation.{
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
-import wom.RuntimeAttributesKeys.{GpuKey, GpuMaxKey, GpuMinKey}
+import wom.RuntimeAttributesKeys.GpuKey
 import wom.types.WomIntegerType
 import wom.values.{WomInteger, WomValue}
 
 object GpuValidation {
   lazy val instance: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuKey)
   lazy val optional: OptionalRuntimeAttributesValidation[Int Refined Positive] = instance.optional
-  lazy val instanceMin: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuMinKey)
-  lazy val optionalMin: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMin.optional
-  lazy val instanceMax: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuMaxKey)
-  lazy val optionalMax: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMax.optional
 
   lazy val defaultMin: WomValue = WomInteger(0)
   def configDefaultWomValue(config: Option[Config]): Option[WomValue] = instance.configDefaultWomValue(config)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GpuValidation.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/GpuValidation.scala
@@ -13,17 +13,13 @@ import cromwell.backend.validation.{
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
-import wom.RuntimeAttributesKeys.{GpuKey, GpuMaxKey, GpuMinKey}
+import wom.RuntimeAttributesKeys.GpuKey
 import wom.types.WomIntegerType
 import wom.values.{WomInteger, WomValue}
 
 object GpuValidation {
   lazy val instance: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuKey)
   lazy val optional: OptionalRuntimeAttributesValidation[Int Refined Positive] = instance.optional
-  lazy val instanceMin: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuMinKey)
-  lazy val optionalMin: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMin.optional
-  lazy val instanceMax: RuntimeAttributesValidation[Int Refined Positive] = new GpuValidation(GpuMaxKey)
-  lazy val optionalMax: OptionalRuntimeAttributesValidation[Int Refined Positive] = instanceMax.optional
 
   lazy val defaultMin: WomValue = WomInteger(0)
   def configDefaultWomValue(config: Option[Config]): Option[WomValue] = instance.configDefaultWomValue(config)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
@@ -13,7 +13,6 @@ import cromwell.backend.validation.{BooleanRuntimeAttributesValidation, _}
 import eu.timepit.refined._
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import wdl4s.parser.MemoryUnit
 import wom.RuntimeAttributesKeys
 import wom.format.MemorySize
 import wom.types._
@@ -101,10 +100,6 @@ object PipelinesApiRuntimeAttributes {
   private def cpuPlatformValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[String] =
     cpuPlatformValidationInstance
 
-  private def cpuMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int Refined Positive] =
-    CpuValidation.instanceMin
-      .withDefault(CpuValidation.configDefaultWomValue(runtimeConfig) getOrElse CpuValidation.defaultMin)
-
   private def gpuTypeValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[GpuType] =
     GpuTypeValidation.optional
 
@@ -115,10 +110,6 @@ object PipelinesApiRuntimeAttributes {
   private def gpuCountValidation(
     runtimeConfig: Option[Config]
   ): OptionalRuntimeAttributesValidation[Int Refined Positive] = GpuValidation.optional
-
-  private def gpuMinValidation(
-    runtimeConfig: Option[Config]
-  ): OptionalRuntimeAttributesValidation[Int Refined Positive] = GpuValidation.optionalMin
 
   private def failOnStderrValidation(runtimeConfig: Option[Config]) = FailOnStderrValidation.default(runtimeConfig)
 
@@ -144,13 +135,6 @@ object PipelinesApiRuntimeAttributes {
       MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryKey, runtimeConfig) getOrElse MemoryDefaultValue
     )
 
-  private def memoryMinValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[MemorySize] =
-    MemoryValidation.withDefaultMemory(RuntimeAttributesKeys.MemoryMinKey,
-                                       MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryMinKey,
-                                                                            runtimeConfig
-                                       ) getOrElse MemoryDefaultValue
-    )
-
   private def bootDiskSizeValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     bootDiskValidationInstance
       .withDefault(bootDiskValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse BootDiskDefaultValue)
@@ -166,15 +150,6 @@ object PipelinesApiRuntimeAttributes {
 
   private val dockerValidation: RuntimeAttributesValidation[String] = DockerValidation.instance
 
-  private val outDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.OutDirMinKey, MemoryUnit.MB, allowZero = true)
-
-  private val tmpDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.TmpDirMinKey, MemoryUnit.MB, allowZero = true)
-
-  private val inputDirMinValidation: OptionalRuntimeAttributesValidation[MemorySize] =
-    InformationValidation.optional(RuntimeAttributesKeys.DnaNexusInputDirMinKey, MemoryUnit.MB, allowZero = true)
-
   def runtimeAttributesBuilder(
     jesConfiguration: PipelinesApiConfiguration
   ): StandardValidatedRuntimeAttributesBuilder = {
@@ -186,22 +161,16 @@ object PipelinesApiRuntimeAttributes {
         gpuTypeValidation(runtimeConfig),
         gpuDriverValidation(runtimeConfig),
         cpuValidation(runtimeConfig),
-        cpuMinValidation(runtimeConfig),
-        gpuMinValidation(runtimeConfig),
         disksValidation(runtimeConfig),
         zonesValidation(runtimeConfig),
         preemptibleValidation(runtimeConfig),
         memoryValidation(runtimeConfig),
-        memoryMinValidation(runtimeConfig),
         bootDiskSizeValidation(runtimeConfig),
         noAddressValidation(runtimeConfig),
         cpuPlatformValidation(runtimeConfig),
         useDockerImageCacheValidation(runtimeConfig),
         checkpointFileValidationInstance,
         dockerValidation,
-        outDirMinValidation,
-        tmpDirMinValidation,
-        inputDirMinValidation
       )
   }
 
@@ -261,21 +230,6 @@ object PipelinesApiRuntimeAttributes {
       validatedRuntimeAttributes
     )
 
-    val outDirMin: Option[MemorySize] =
-      RuntimeAttributesValidation.extractOption(outDirMinValidation.key, validatedRuntimeAttributes)
-    val tmpDirMin: Option[MemorySize] =
-      RuntimeAttributesValidation.extractOption(tmpDirMinValidation.key, validatedRuntimeAttributes)
-    val inputDirMin: Option[MemorySize] =
-      RuntimeAttributesValidation.extractOption(inputDirMinValidation.key, validatedRuntimeAttributes)
-
-    val totalExecutionDiskSizeBytes = List(inputDirMin.map(_.bytes),
-                                           outDirMin.map(_.bytes),
-                                           tmpDirMin.map(_.bytes)
-    ).flatten.fold(MemorySize(0, MemoryUnit.Bytes).bytes)(_ + _)
-    val totalExecutionDiskSize = MemorySize(totalExecutionDiskSizeBytes, MemoryUnit.Bytes)
-
-    val adjustedDisks = disks.adjustWorkingDiskWithNewMin(totalExecutionDiskSize, ())
-
     new PipelinesApiRuntimeAttributes(
       cpu,
       cpuPlatform,
@@ -284,7 +238,7 @@ object PipelinesApiRuntimeAttributes {
       preemptible,
       bootDiskSize,
       memory,
-      adjustedDisks,
+      disks,
       docker,
       failOnStderr,
       continueOnReturnCode,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/api/PipelinesApiRequestFactory.scala
@@ -83,7 +83,7 @@ object PipelinesApiRequestFactory {
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreatePipelineDockerKeyAndToken],
                                       womOutputRuntimeExtractor: Option[WomOutputRuntimeExtractor],
-                                      adjustedSizeDisks: Seq[PipelinesApiAttachedDisk],
+                                      disks: Seq[PipelinesApiAttachedDisk],
                                       virtualPrivateCloudConfiguration: VirtualPrivateCloudConfiguration,
                                       retryWithMoreMemoryKeys: Option[List[String]],
                                       fuseEnabled: Boolean,

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/io/PipelinesApiAttachedDisk.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/io/PipelinesApiAttachedDisk.scala
@@ -7,8 +7,6 @@ import common.exception.MessageAggregation
 import common.validation.ErrorOr._
 import cromwell.backend.DiskPatterns._
 import cromwell.core.path.{DefaultPathBuilder, Path}
-import wdl4s.parser.MemoryUnit
-import wom.format.MemorySize
 import wom.values._
 
 import scala.util.Try
@@ -55,16 +53,6 @@ object PipelinesApiAttachedDisk {
       case _: IllegalArgumentException => s"$value not convertible to a Long".invalidNel
     }
 
-  implicit class EnhancedDisks(val disks: Seq[PipelinesApiAttachedDisk]) extends AnyVal {
-    def adjustWorkingDiskWithNewMin(minimum: MemorySize, onAdjustment: => Unit): Seq[PipelinesApiAttachedDisk] =
-      disks map {
-        case disk: PipelinesApiWorkingDisk
-            if disk == PipelinesApiWorkingDisk.Default && disk.sizeGb < minimum.to(MemoryUnit.GB).amount.toInt =>
-          onAdjustment
-          disk.copy(sizeGb = minimum.to(MemoryUnit.GB).amount.toInt)
-        case other => other
-      }
-  }
 }
 
 trait PipelinesApiAttachedDisk {

--- a/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
+++ b/supportedBackends/google/pipelines/v2alpha1/src/main/scala/cromwell/backend/google/pipelines/v2alpha1/GenomicsFactory.scala
@@ -69,7 +69,7 @@ case class GenomicsFactory(applicationName: String, authMode: GoogleAuthMode, en
           case _ => new Network().setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
         }
 
-      val allDisksToBeMounted = createPipelineParameters.adjustedSizeDisks ++
+      val allDisksToBeMounted = createPipelineParameters.disks ++
         createPipelineParameters.referenceDisksForLocalizationOpt.getOrElse(List.empty)
 
       // Disks defined in the runtime attributes and reference-files-localization disks

--- a/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
+++ b/supportedBackends/google/pipelines/v2beta/src/main/scala/cromwell/backend/google/pipelines/v2beta/LifeSciencesFactory.scala
@@ -75,7 +75,7 @@ case class LifeSciencesFactory(applicationName: String, authMode: GoogleAuthMode
           case _ => new Network().setUsePrivateAddress(createPipelineParameters.runtimeAttributes.noAddress)
         }
 
-      val allDisksToBeMounted = createPipelineParameters.adjustedSizeDisks ++
+      val allDisksToBeMounted = createPipelineParameters.disks ++
         createPipelineParameters.referenceDisksForLocalizationOpt.getOrElse(List.empty)
 
       // Disks defined in the runtime attributes and reference-files-localization disks

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigConstants.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ConfigConstants.scala
@@ -25,11 +25,7 @@ object ConfigConstants {
   /*
   Runtime attributes that may be specified within the RuntimeAttributesConfig.
    */
-  val DockerRuntimeAttribute = RuntimeAttributesKeys.DockerKey
-  val CpuRuntimeAttribute = RuntimeAttributesKeys.CpuKey
   val MemoryRuntimeAttribute = RuntimeAttributesKeys.MemoryKey
-  val MemoryMinRuntimeAttribute = RuntimeAttributesKeys.MemoryMinKey
-  val MemoryMaxRuntimeAttribute = RuntimeAttributesKeys.MemoryMaxKey
   // See: MemoryDeclarationValidation
   val MemoryRuntimeAttributePrefix = "memory_"
   val MemoryMinRuntimeAttributePrefix = "memoryMin_"

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
@@ -33,8 +33,6 @@ object DeclarationValidation {
       case name if name == DockerValidation.instance.key =>
         new DeclarationValidation(declaration, DockerValidation.instance, usedInCallCachingOverride = None)
       case RuntimeAttributesKeys.CpuKey => new CpuDeclarationValidation(declaration, CpuValidation.instance)
-      case RuntimeAttributesKeys.CpuMinKey => new CpuDeclarationValidation(declaration, CpuValidation.instanceMin)
-      case RuntimeAttributesKeys.CpuMaxKey => new CpuDeclarationValidation(declaration, CpuValidation.instanceMax)
       // See MemoryDeclarationValidation for more info
       case name
           if MemoryDeclarationValidation.isMemoryDeclaration(name,
@@ -42,18 +40,6 @@ object DeclarationValidation {
                                                              MemoryRuntimeAttributePrefix
           ) =>
         new MemoryDeclarationValidation(declaration, MemoryRuntimeAttribute, MemoryRuntimeAttributePrefix)
-      case name
-          if MemoryDeclarationValidation.isMemoryDeclaration(name,
-                                                             MemoryMinRuntimeAttribute,
-                                                             MemoryRuntimeAttributePrefix
-          ) =>
-        new MemoryDeclarationValidation(declaration, MemoryMinRuntimeAttribute, MemoryMinRuntimeAttributePrefix)
-      case name
-          if MemoryDeclarationValidation.isMemoryDeclaration(name,
-                                                             MemoryMaxRuntimeAttribute,
-                                                             MemoryRuntimeAttributePrefix
-          ) =>
-        new MemoryDeclarationValidation(declaration, MemoryMaxRuntimeAttribute, MemoryMaxRuntimeAttributePrefix)
       case name
           if MemoryDeclarationValidation.isMemoryDeclaration(name, DiskRuntimeAttribute, DiskRuntimeAttributePrefix) =>
         new MemoryDeclarationValidation(declaration, DiskRuntimeAttribute, DiskRuntimeAttributePrefix)

--- a/wom/src/main/scala/wom/RuntimeAttributes.scala
+++ b/wom/src/main/scala/wom/RuntimeAttributes.scala
@@ -6,33 +6,13 @@ object RuntimeAttributesKeys {
   val DockerKey = "docker"
   val MaxRetriesKey = "maxRetries"
 
-  /**
-    * Equivalent to CPUMinKey
-    */
   val CpuKey = "cpu"
   val CpuPlatformKey = "cpuPlatform"
-  val CpuMinKey = "cpuMin"
-  val CpuMaxKey = "cpuMax"
 
-  /**
-    * Equivalent to GPUMinKey
-    */
   val GpuKey = "gpuCount"
-  val GpuMinKey = "gpuCountMin"
-  val GpuMaxKey = "gpuCountMax"
   val GpuTypeKey = "gpuType"
-  val DnaNexusInputDirMinKey = "dnaNexusInputDirMin"
 
-  /**
-    * Equivalent to MemoryMinKey
-    */
   val MemoryKey = "memory"
-  val MemoryMinKey = "memoryMin"
-  val MemoryMaxKey = "memoryMax"
-  val TmpDirMinKey = "tmpDirMin"
-  val TmpDirMaxKey = "tmpDirMax"
-  val OutDirMinKey = "outDirMin"
-  val OutDirMaxKey = "outDirMax"
   val FailOnStderrKey = "failOnStderr"
   val ContinueOnReturnCodeKey = "continueOnReturnCode"
 }


### PR DESCRIPTION
CWL really likes the concept of default, min, max for various things. It also wanted the engine to read the sizes of inputs and adjust disk sizes, which used to populate `sizeOption`. Both of these behaviors were tightly enmeshed in the runtime attribute system and it seemed wise to delete them at this juncture.

As confirmatory evidence, the statement `to account for input files` appears in the prod logs zero times in the last 90 days.