### PR TITLE
Add the fuse support for Google Batch backend

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -147,12 +147,14 @@ object RunnableBuilder {
                    scriptContainerPath: String,
                    jobShell: String,
                    volumes: List[Volume],
-                   dockerhubCredentials: (String, String)
+                   dockerhubCredentials: (String, String),
+                   fuseEnabled: Boolean
   ): Runnable.Builder = {
 
     val container = (dockerhubCredentials._1, dockerhubCredentials._2) match {
       case (username, password) if username.nonEmpty && password.nonEmpty =>
         Container.newBuilder
+          .setOptions(if(fuseEnabled) "--privileged" else "")
           .setImageUri(docker)
           .setEntrypoint(jobShell)
           .addCommands(scriptContainerPath)
@@ -160,6 +162,7 @@ object RunnableBuilder {
           .setPassword(password)
       case _ =>
         Container.newBuilder
+          .setOptions(if(fuseEnabled) "--privileged" else "")
           .setImageUri(docker)
           .setEntrypoint(jobShell)
           .addCommands(scriptContainerPath)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/UserRunnable.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/UserRunnable.scala
@@ -12,7 +12,8 @@ trait UserRunnable {
       scriptContainerPath = createParameters.commandScriptContainerPath.pathAsString,
       jobShell = "/bin/bash",
       volumes = volumes,
-      dockerhubCredentials = createParameters.dockerhubCredentials
+      dockerhubCredentials = createParameters.dockerhubCredentials,
+      fuseEnabled = createParameters.fuseEnabled
     )
 
     val describeRunnable = RunnableBuilder.describeDocker("user runnable", userRunnable)


### PR DESCRIPTION
Add the fuse support into the new Google Batch backend.  It works like the Life Scientist API beta 2.   I use the privileged mode, as we don't usually care about the security of the host OS.  I can revise to limited permission if needed. 

This function is useful to our team.  Thanks for reviewing the changes. 

Regards,
Zhili  