### PR TITLE
[WX-1317] Remove Akka 'server' header from all HTTP responses

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -22,13 +22,6 @@ akka {
         illegal-header-warnings = off
       }
     }
-    server {
-      # By default, akka includes an HTTP header in responses that looks like:
-      # server=akka-http/10.20.1
-      # For better app sec, we suppress this to make it harder for attackers to learn about our system.
-      # Akka doc: https://doc.akka.io/docs/akka-http/current/configuration.html
-      server-header = ""
-    }
   }
   actor.default-dispatcher.fork-join-executor {
     # Number of threads = min(parallelism-factor * cpus, parallelism-max)

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -22,8 +22,14 @@ akka {
         illegal-header-warnings = off
       }
     }
+    server {
+      # By default, akka includes an HTTP header in responses that looks like:
+      # server=akka-http/10.20.1
+      # For better app sec, we suppress this to make it harder for attackers to learn about our system.
+      # Akka doc: https://doc.akka.io/docs/akka-http/current/configuration.html
+      server-header = ""
+    }
   }
-
   actor.default-dispatcher.fork-join-executor {
     # Number of threads = min(parallelism-factor * cpus, parallelism-max)
     # Below are the default values set by Akka, uncomment to tune these

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -23,6 +23,7 @@ akka {
       }
     }
   }
+
   actor.default-dispatcher.fork-join-executor {
     # Number of threads = min(parallelism-factor * cpus, parallelism-max)
     # Below are the default values set by Akka, uncomment to tune these

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -8,8 +8,12 @@ akka {
     server {
       request-timeout = 40s
       bind-timeout = 5s
+      # By default, akka includes an HTTP header in responses that looks like:
+      # server=akka-http/10.20.1
+      # For better app sec, we suppress this to make it harder for attackers to learn about our system.
+      # Akka doc: https://doc.akka.io/docs/akka-http/current/configuration.html
+      server-header = ""
     }
-
     client.connecting-timeout = 40s
 
     # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738


### PR DESCRIPTION
[WX-1317](https://broadworkbench.atlassian.net/jira/software/c/projects/WX/boards/174?selectedIssue=WX-1317).

Changed an Akka configuration setting so it no longer includes information about itself in all of Cromwell's HTTP responses. 

before:
```
 content-length: 108 
 content-type: text/plain; charset=UTF-8 
 date: Mon,04 Mar 2024 18:39:50 GMT 
 server: akka-http/10.1.15 
 ```

after:
```
 content-length: 108 
 content-type: text/plain; charset=UTF-8 
 date: Mon,04 Mar 2024 18:39:50 GMT 
```

I figure omitting the `server` header altogether is better than including just the string `akka` or `akka-http`. I don't think the `server` header is required by anything (see [mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server)), but I plan to test this out in `dev` on both Azure and GCP to make sure the setting propagates correctly and we can complete workflows. 

[WX-1317]: https://broadworkbench.atlassian.net/browse/WX-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ