### PR TITLE
WX-1488 Supply cloud platform when making DRS requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -383,6 +383,7 @@ lazy val `cloud-nio-impl-ftp` = (project in cloudNio / "cloud-nio-impl-ftp")
 lazy val `cloud-nio-impl-drs` = (project in cloudNio / "cloud-nio-impl-drs")
   .withLibrarySettings(libraryName = "cloud-nio-impl-drs", dependencies = implDrsDependencies)
   .dependsOn(`cloud-nio-util`)
+  .dependsOn(cloudSupport)
   .dependsOn(common)
   .dependsOn(common % "test->test")
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileProvider.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileProvider.scala
@@ -11,7 +11,7 @@ import common.exception._
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.http.HttpStatus
 
-class DrsCloudNioFileProvider(drsPathResolver: EngineDrsPathResolver, drsReadInterpreter: DrsReadInterpreter)
+class DrsCloudNioFileProvider(drsPathResolver: DrsPathResolver, drsReadInterpreter: DrsReadInterpreter)
     extends CloudNioFileProvider {
 
   private def checkIfPathExistsThroughDrsResolver(drsPath: String): IO[Boolean] =

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileSystemProvider.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileSystemProvider.scala
@@ -15,8 +15,7 @@ class DrsCloudNioFileSystemProvider(rootConfig: Config,
     if (rootConfig.hasPath("resolver")) rootConfig.getConfig("resolver") else rootConfig.getConfig("martha")
   lazy val drsConfig: DrsConfig = DrsConfig.fromConfig(drsResolverConfig)
 
-  lazy val drsPathResolver: EngineDrsPathResolver =
-    EngineDrsPathResolver(drsConfig, drsCredentials)
+  lazy val drsPathResolver: DrsPathResolver = new DrsPathResolver(drsConfig, drsCredentials)
 
   override def config: Config = rootConfig
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -187,6 +187,10 @@ object DrsResolverField extends Enumeration {
   val LocalizationPath: DrsResolverField.Value = Value("localizationPath")
 }
 
+// We supply a cloud platform value to the DRS service. In cases where the DRS repository
+// has multiple cloud files associated with a DRS link, it will prefer sending a file on the same
+// platform as this Cromwell instance. That is, if a DRS file has copies on both GCP and Azure,
+// we'll get the GCP one when running on GCP and the Azure one when running on Azure.
 object DrsCloudPlatform extends Enumeration {
   val GoogleStorage: DrsCloudPlatform.Value = Value("gs")
   val Azure: DrsCloudPlatform.Value = Value("azure")

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/EngineDrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/EngineDrsPathResolver.scala
@@ -1,9 +1,0 @@
-package cloud.nio.impl.drs
-
-import common.validation.ErrorOr.ErrorOr
-
-case class EngineDrsPathResolver(drsConfig: DrsConfig, drsCredentials: DrsCredentials)
-    extends DrsPathResolver(drsConfig) {
-
-  override def getAccessToken: ErrorOr[String] = drsCredentials.getAccessToken
-}

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsCloudNioFileProviderSpec.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/DrsCloudNioFileProviderSpec.scala
@@ -77,7 +77,7 @@ class DrsCloudNioFileProviderSpec extends AnyFlatSpecLike with CromwellTimeoutSp
   }
 
   it should "return a file provider that can read bytes from gcs" in {
-    val drsPathResolver = new MockEngineDrsPathResolver() {
+    val drsPathResolver = new MockDrsPathResolver() {
       override def resolveDrs(drsPath: String, fields: NonEmptyList[DrsResolverField.Value]): IO[DrsResolverResponse] =
         IO(DrsResolverResponse(gsUri = Option("gs://bucket/object/path")))
     }
@@ -99,7 +99,7 @@ class DrsCloudNioFileProviderSpec extends AnyFlatSpecLike with CromwellTimeoutSp
   }
 
   it should "return a file provider that can read bytes from an access url" in {
-    val drsPathResolver = new MockEngineDrsPathResolver() {
+    val drsPathResolver = new MockDrsPathResolver() {
       override def resolveDrs(drsPath: String, fields: NonEmptyList[DrsResolverField.Value]): IO[DrsResolverResponse] =
         IO(DrsResolverResponse(accessUrl = Option(AccessUrl("https://host/object/path", None))))
     }
@@ -121,7 +121,7 @@ class DrsCloudNioFileProviderSpec extends AnyFlatSpecLike with CromwellTimeoutSp
   }
 
   it should "return a file provider that can return file attributes" in {
-    val drsPathResolver = new MockEngineDrsPathResolver() {
+    val drsPathResolver = new MockDrsPathResolver() {
       override def resolveDrs(drsPath: String,
                               fields: NonEmptyList[DrsResolverField.Value]
       ): IO[DrsResolverResponse] = {

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsCloudNioFileSystemProvider.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsCloudNioFileSystemProvider.scala
@@ -15,15 +15,15 @@ class MockDrsCloudNioFileSystemProvider(config: Config = mockConfig,
                                           IO.raiseError(
                                             new UnsupportedOperationException("mock did not specify a read interpreter")
                                           ),
-                                        mockResolver: Option[EngineDrsPathResolver] = None
+                                        mockResolver: Option[DrsPathResolver] = None
 ) extends DrsCloudNioFileSystemProvider(config,
                                         GoogleOauthDrsCredentials(NoCredentials.getInstance, config),
                                         drsReadInterpreter
     ) {
 
-  override lazy val drsPathResolver: EngineDrsPathResolver =
+  override lazy val drsPathResolver: DrsPathResolver =
     mockResolver getOrElse
-      new MockEngineDrsPathResolver(
+      new MockDrsPathResolver(
         drsConfig = drsConfig,
         httpClientBuilderOverride = httpClientBuilder,
         accessTokenAcceptableTTL = Duration.Inf

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsPathResolver.scala
@@ -10,12 +10,10 @@ import common.mock.MockSugar
 
 import scala.concurrent.duration.Duration
 
-class MockEngineDrsPathResolver(drsConfig: DrsConfig = MockDrsPaths.mockDrsConfig,
-                                httpClientBuilderOverride: Option[HttpClientBuilder] = None,
-                                accessTokenAcceptableTTL: Duration = Duration.Inf
-) extends EngineDrsPathResolver(drsConfig,
-                                GoogleOauthDrsCredentials(NoCredentials.getInstance, accessTokenAcceptableTTL)
-    ) {
+class MockDrsPathResolver(drsConfig: DrsConfig = MockDrsPaths.mockDrsConfig,
+                          httpClientBuilderOverride: Option[HttpClientBuilder] = None,
+                          accessTokenAcceptableTTL: Duration = Duration.Inf
+) extends DrsPathResolver(drsConfig, GoogleOauthDrsCredentials(NoCredentials.getInstance, accessTokenAcceptableTTL)) {
 
   override protected lazy val httpClientBuilder: HttpClientBuilder =
     httpClientBuilderOverride getOrElse MockSugar.mock[HttpClientBuilder]

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/azure/AzureCredentials.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/azure/AzureCredentials.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
   * If you need to disambiguate among multiple active user-assigned managed identities, pass
   * in the client id of the identity that should be used.
   */
-case object AzureCredentials {
+class AzureCredentials {
 
   final val tokenAcquisitionTimeout = 5.seconds
 

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerDrsPathResolver.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerDrsPathResolver.scala
@@ -1,9 +1,0 @@
-package drs.localizer
-
-import cloud.nio.impl.drs.{DrsConfig, DrsCredentials, DrsPathResolver}
-import common.validation.ErrorOr.ErrorOr
-
-class DrsLocalizerDrsPathResolver(drsConfig: DrsConfig, drsCredentials: DrsCredentials)
-    extends DrsPathResolver(drsConfig) {
-  override def getAccessToken: ErrorOr[String] = drsCredentials.getAccessToken
-}

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerMain.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerMain.scala
@@ -144,11 +144,11 @@ class DrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
     }
   }
 
-  def getDrsPathResolver: IO[DrsLocalizerDrsPathResolver] =
+  def getDrsPathResolver: IO[DrsPathResolver] =
     IO {
       val drsConfig = DrsConfig.fromEnv(sys.env)
       logger.info(s"Using ${drsConfig.drsResolverUrl} to resolve DRS Objects")
-      new DrsLocalizerDrsPathResolver(drsConfig, drsCredentials)
+      new DrsPathResolver(drsConfig, drsCredentials)
     }
 
   /**
@@ -182,9 +182,7 @@ class DrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
   /**
     * Runs a synchronous HTTP request to resolve the provided DRS URL with the provided resolver.
     */
-  def resolveSingleUrl(resolverObject: DrsLocalizerDrsPathResolver,
-                       drsUrlToResolve: UnresolvedDrsUrl
-  ): IO[ResolvedDrsUrl] = {
+  def resolveSingleUrl(resolverObject: DrsPathResolver, drsUrlToResolve: UnresolvedDrsUrl): IO[ResolvedDrsUrl] = {
     val fields = NonEmptyList.of(DrsResolverField.GsUri,
                                  DrsResolverField.GoogleServiceAccount,
                                  DrsResolverField.AccessUrl,
@@ -213,7 +211,7 @@ class DrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
       }
     }
 
-  def resolveWithRetries(resolverObject: DrsLocalizerDrsPathResolver,
+  def resolveWithRetries(resolverObject: DrsPathResolver,
                          drsUrlToResolve: UnresolvedDrsUrl,
                          resolutionRetries: Int,
                          backoff: Option[CloudNioBackoff],

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/DrsLocalizerMainSpec.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.effect.{ExitCode, IO}
 import cats.syntax.validated._
 import drs.localizer.MockDrsPaths.{fakeAccessUrls, fakeDrsUrlWithGcsResolutionOnly, fakeGoogleUrls}
-import cloud.nio.impl.drs.{AccessUrl, DrsConfig, DrsCredentials, DrsResolverField, DrsResolverResponse}
+import cloud.nio.impl.drs.{AccessUrl, DrsConfig, DrsCredentials, DrsPathResolver, DrsResolverField, DrsResolverResponse}
 import common.assertion.CromwellTimeoutSpec
 import common.validation.ErrorOr.ErrorOr
 import drs.localizer.MockDrsLocalizerDrsPathResolver.{FakeAccessTokenStrategy, FakeHashes}
@@ -372,11 +372,11 @@ class MockDrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
                            requesterPaysProjectIdOption
     ) {
 
-  override def getDrsPathResolver: IO[DrsLocalizerDrsPathResolver] =
+  override def getDrsPathResolver: IO[DrsPathResolver] =
     IO {
       new MockDrsLocalizerDrsPathResolver(cloud.nio.impl.drs.MockDrsPaths.mockDrsConfig)
     }
-  override def resolveSingleUrl(resolverObject: DrsLocalizerDrsPathResolver,
+  override def resolveSingleUrl(resolverObject: DrsPathResolver,
                                 drsUrlToResolve: UnresolvedDrsUrl
   ): IO[ResolvedDrsUrl] =
     IO {
@@ -391,7 +391,7 @@ class MockDrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
 }
 
 class MockDrsLocalizerDrsPathResolver(drsConfig: DrsConfig)
-    extends DrsLocalizerDrsPathResolver(drsConfig, FakeAccessTokenStrategy) {
+    extends DrsPathResolver(drsConfig, FakeAccessTokenStrategy) {
 
   override def resolveDrs(drsPath: String, fields: NonEmptyList[DrsResolverField.Value]): IO[DrsResolverResponse] = {
 

--- a/filesystems/drs/src/test/scala/cromwell/filesystems/drs/DrsReaderSpec.scala
+++ b/filesystems/drs/src/test/scala/cromwell/filesystems/drs/DrsReaderSpec.scala
@@ -1,6 +1,6 @@
 package cromwell.filesystems.drs
 
-import cloud.nio.impl.drs.{AccessUrl, DrsPathResolver, DrsResolverResponse, MockEngineDrsPathResolver}
+import cloud.nio.impl.drs.{AccessUrl, DrsPathResolver, DrsResolverResponse, MockDrsPathResolver}
 import common.assertion.CromwellTimeoutSpec
 import cromwell.cloudsupport.gcp.auth.MockAuthMode
 import cromwell.core.WorkflowOptions
@@ -26,7 +26,7 @@ class DrsReaderSpec extends AnyFlatSpecLike with CromwellTimeoutSpec with Matche
     val googleAuthMode = MockAuthMode("unused")
     val workflowOptions = WorkflowOptions.empty
     val requesterPaysProjectIdOption = None
-    val drsPathResolver = new MockEngineDrsPathResolver()
+    val drsPathResolver = new MockDrsPathResolver()
     val gsUri = "gs://bucket/object"
     val googleServiceAccount = None
     val drsResolverResponse = DrsResolverResponse(gsUri = Option(gsUri), googleServiceAccount = googleServiceAccount)
@@ -46,7 +46,7 @@ class DrsReaderSpec extends AnyFlatSpecLike with CromwellTimeoutSpec with Matche
     val googleAuthMode = MockAuthMode("unused")
     val workflowOptions = WorkflowOptions.empty
     val requesterPaysProjectIdOption = None
-    val drsPathResolver = new MockEngineDrsPathResolver()
+    val drsPathResolver = new MockDrsPathResolver()
     val accessUrl = AccessUrl("https://host/object/path", Option(Map("hello" -> "world")))
     val drsResolverResponse = DrsResolverResponse(accessUrl = Option(accessUrl))
     val readerIo =
@@ -65,7 +65,7 @@ class DrsReaderSpec extends AnyFlatSpecLike with CromwellTimeoutSpec with Matche
     val googleAuthMode = MockAuthMode("unused")
     val workflowOptions = WorkflowOptions.empty
     val requesterPaysProjectIdOption = None
-    val drsPathResolver = new MockEngineDrsPathResolver()
+    val drsPathResolver = new MockDrsPathResolver()
     val drsResolverResponse = DrsResolverResponse()
     val readerIo =
       DrsReader.reader(Option(googleAuthMode),
@@ -90,7 +90,7 @@ class DrsReaderSpec extends AnyFlatSpecLike with CromwellTimeoutSpec with Matche
     val httpClientBuilder = mock[HttpClientBuilder]
     httpClientBuilder.build() returns httpClient
 
-    val drsPathResolver = new MockEngineDrsPathResolver(httpClientBuilderOverride = Option(httpClientBuilder))
+    val drsPathResolver = new MockDrsPathResolver(httpClientBuilderOverride = Option(httpClientBuilder))
 
     val accessUrl = AccessUrl("https://host/object/path", Option(Map("hello" -> "world")))
     val drsResolverResponse = DrsResolverResponse(accessUrl = Option(accessUrl))


### PR DESCRIPTION
(Still working on adding tests, putting this up to check CI)

This PR adds `cloudPlatform` to DRS requests so we can prefer to use DRS files located in the same cloud as us.

I also did some cleanup:
 * `EngineDrsPathResolver` and `DrsLocalizerDrsPathResolver` had converged over time and were identical. Removed them and updated everything to use `DrsPathResolver` directly.
 * Azure credential acquisition logic started in DRS, then was copied out to a common `cloudSupport` location. Updated DRS credentials to use the same logic everything else does rather than keepings its own copy.