### PR TITLE
ID-347 Remove Martha References

### DIFF
--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileSystemProvider.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsCloudNioFileSystemProvider.scala
@@ -11,8 +11,7 @@ class DrsCloudNioFileSystemProvider(rootConfig: Config,
                                     drsReadInterpreter: DrsReadInterpreter
 ) extends CloudNioFileSystemProvider {
 
-  lazy val drsResolverConfig =
-    if (rootConfig.hasPath("resolver")) rootConfig.getConfig("resolver") else rootConfig.getConfig("martha")
+  lazy val drsResolverConfig = rootConfig.getConfig("resolver")
   lazy val drsConfig: DrsConfig = DrsConfig.fromConfig(drsResolverConfig)
 
   lazy val drsPathResolver: EngineDrsPathResolver =

--- a/docs/filesystems/Filesystems.md
+++ b/docs/filesystems/Filesystems.md
@@ -19,7 +19,7 @@ filesystems {
         class = "cromwell.filesystems.drs.DrsFileSystemConfig"
         config {
           resolver {
-            url = "https://martha-url-here or https://drshub-url-here"
+            url = https://drshub-url-here"
             # The number of times to retry failures connecting or HTTP 429 or HTTP 5XX responses, default 3.
             num-retries = 3
             # How long to wait between retrying HTTP 429 or HTTP 5XX responses, default 10 seconds.


### PR DESCRIPTION
Martha is gone! Cromwell shouldn't have any more references to it in its codebase. https://broadworkbench.atlassian.net/browse/ID-347