### PR TITLE
WX-1535 Change Docker root on Azure to match GCP

### DIFF
--- a/src/ci/resources/tes_application.conf
+++ b/src/ci/resources/tes_application.conf
@@ -34,7 +34,8 @@ backend {
         # Root of a blob storage container to use
         # Might look something like: https://lz813a3d637adefec2c6e88f.blob.core.windows.net/sc-d8143fd8-aa07-446d-9ba0-af72203f1794/some/path/"
         root = ""
-        dockerRoot = "/cromwell-executions"
+        # Match GCP default for workflow portability (WX-1535)
+        dockerRoot = "/cromwell_root"
         # TES Endpoint for cromwell to use. Might look something like: "https://lz7388ada396994bb48ea5c87a02eed673689c82c2af423d03.servicebus.windows.net/something/tes/v1/tasks
         endpoint = "http://127.0.0.1:9000/v1/tasks"
         platform = "azure"


### PR DESCRIPTION
This line has been unchanged since https://github.com/broadinstitute/cromwell/pull/1979 in 2017.

The author of that PR was with [Oregon Health and Science University](https://github.com/ohsu-comp-bio) at the time and was probably running on their local cluster. Indeed, the backend was [designed for a shared file system](https://github.com/broadinstitute/cromwell/pull/1979/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R990-R991) where tasks' working and output directories may be the same, and are shared between tasks.

Note that this PR does not change the global default, it merely updates our TES CI to match the prospective Terra change in https://github.com/broadinstitute/terra-helmfile/pull/5340.