### PR TITLE
[WX-1568] Bump Akka max-response-reason-length limit

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -17,7 +17,7 @@ akka {
     client.connecting-timeout = 40s
     // The default limit (64) for this is too low, which makes akka throw an error when a response exceeds this limit.
     // Bumping higher so that we can accept and log longer error messages that may come back from a server.
-    client.parsing.max-response-reason-length = 2048
+    client.parsing.max-response-reason-length = 1024
     # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
     # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini
     # This gives the logger a little more than 5 seconds to startup. 5s was *almost* always enough, so a safe 30s should be *plenty* of time:

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -15,6 +15,8 @@ akka {
       server-header = ""
     }
     client.connecting-timeout = 40s
+    // The default limit (64) for this is too low, which makes akka throw an error when a response exceeds this limit.
+    // Bumping higher so that we can accept and log longer error messages that may come back from a server.
     client.parsing.max-response-reason-length = 2048
     # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
     # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -15,7 +15,7 @@ akka {
       server-header = ""
     }
     client.connecting-timeout = 40s
-
+    client.parsing.max-response-reason-length = 2048
     # Inspired by https://broadworkbench.atlassian.net/browse/CROM-6738
     # and copied from https://stackoverflow.com/questions/27910526/logger-log1-slf4jlogger-did-not-respond-within-timeout5000-milliseconds-to-ini
     # This gives the logger a little more than 5 seconds to startup. 5s was *almost* always enough, so a safe 30s should be *plenty* of time:


### PR DESCRIPTION
Certain error messages that Cromwell receives are longer than the default limit, which is a big pain when debugging. Going from 64 to 1024 characters (1kb) doesn't seem unreasonable and solves this issue. For context, the error message below is 364 characters. 

[Relevant Akka Doc](https://doc.akka.io/docs/akka-http/10.0/configuration.html). 

Before:
```
2024-04-12 14:58:18 cromwell-system-akka.actor.default-dispatcher-26 ERROR - Error in stage [akka.http.impl.engine.client.OutgoingConnectionBlueprint$PrepareResponse@71a2a20e]: Response reason phrase exceeds the configured limit of 64 characters
akka.http.scaladsl.model.IllegalResponseException: Response reason phrase exceeds the configured limit of 64 characters
	at akka.http.impl.engine.client.OutgoingConnectionBlueprint$PrepareResponse$$anon$3.onPush(OutgoingConnectionBlueprint.scala:191)
	at akka.stream.impl.fusing.GraphInterpreter.processPush(GraphInterpreter.scala:523)
	at akka.stream.impl.fusing.GraphInterpreter.execute(GraphInterpreter.scala:409)
	at akka.stream.impl.fusing.GraphInterpreterShell.runBatch(ActorGraphInterpreter.scala:606)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute(ActorGraphInterpreter.scala:47)
	at akka.stream.impl.fusing.ActorGraphInterpreter$SimpleBoundaryEvent.execute$(ActorGraphInterpreter.scala:43)
	at akka.stream.impl.fusing.ActorGraphInterpreter$BatchingActorInputBoundary$OnNext.execute(ActorGraphInterpreter.scala:85)
	at akka.stream.impl.fusing.GraphInterpreterShell.processEvent(ActorGraphInterpreter.scala:581)
	at 
...
```

After: 
```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>401 Unauthorized</title>
</head><body>
<h1>Unauthorized</h1>
<p>This server could not verify that you
are authorized to access the document
requested.  Either you supplied the wrong
credentials (e.g., bad password), or your
browser doesn't understand how to supply
the credentials required.</p>
</body></html>
```