### PR TITLE
WX-1566 Fix Morgan's call cache file hash CPU thrash Cromwell crash

### DIFF
--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -172,9 +172,8 @@ class NioFlow(parallelism: Int,
       case nioPath => IO(nioPath.size)
     }
 
-  private def hash(hash: IoHashCommand): IO[String] = {
+  private def hash(hash: IoHashCommand): IO[String] =
     NioHashing.hash(hash.file)
-  }
 
   private def touch(touch: IoTouchCommand) = IO {
     touch.file.touch()

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
@@ -27,7 +27,7 @@ object NioHashing {
           else
             IO.raiseError(
               new Exception(
-                s"File of type ${file.getClass.getSimpleName} requires hash in object metadata, not present for ${file.pathAsString.maskSensitiveUri}"
+                s"File of type ${file.getClass.getSimpleName} requires an associated hash, not present for ${file.pathAsString.maskSensitiveUri}"
               )
             )
       }

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 
 object NioHashing {
 
-  def hash(file: Path): IO[String] = {
+  def hash(file: Path): IO[String] =
     // If there is no hash accessible from the file storage system,
     // we'll read the file and generate the hash ourselves if we can.
     getStoredHash(file)
@@ -26,13 +26,14 @@ object NioHashing {
             generateMd5FileHashForPath(file)
           else
             IO.raiseError(
-              new Exception(s"Files of type ${file.getClass.getSimpleName} require hash in object metadata, not present for file ${file.pathAsString.maskSensitiveUri}")
+              new Exception(
+                s"Files of type ${file.getClass.getSimpleName} require hash in object metadata, not present for file ${file.pathAsString.maskSensitiveUri}"
+              )
             )
       }
       .map(_.hash)
-  }
 
-  def getStoredHash(file: Path): IO[Option[FileHash]] = {
+  def getStoredHash(file: Path): IO[Option[FileHash]] =
     file match {
       case gcsPath: GcsPath => getFileHashForGcsPath(gcsPath).map(Option(_))
       case blobPath: BlobPath => getFileHashForBlobPath(blobPath)
@@ -48,7 +49,6 @@ object NioHashing {
         }
       case _ => IO.pure(None)
     }
-  }
 
   /**
     * In some scenarios like SFS it is appropriate for Cromwell to hash files using its own CPU power.
@@ -60,13 +60,12 @@ object NioHashing {
     *
     * @param file The path to consider for local hashing
     */
-  private def canHashLocally(file: Path) = {
+  private def canHashLocally(file: Path) =
     file match {
       case _: HttpPath => false
       case _: BlobPath => false
       case _ => true
     }
-  }
 
   private def generateMd5FileHashForPath(path: Path): IO[FileHash] = delayedIoFromTry {
     tryWithResource(() => path.newInputStream) { inputStream =>

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
@@ -1,0 +1,65 @@
+package cromwell.engine.io.nio
+
+import cats.effect.IO
+import cloud.nio.spi.{FileHash, HashType}
+import cromwell.core.path.Path
+import cromwell.filesystems.blob.BlobPath
+import cromwell.filesystems.drs.DrsPath
+import cromwell.filesystems.gcs.GcsPath
+import cromwell.filesystems.s3.S3Path
+import cromwell.util.TryWithResource.tryWithResource
+
+import scala.util.Try
+
+object NioHashing {
+
+  def hash(file: Path): IO[String] =
+    // If there is no hash accessible from the file storage system,
+    // we'll read the file and generate the hash ourselves.
+    getStoredHash(file)
+      .flatMap {
+        case Some(storedHash) => IO.pure(storedHash)
+        case None => generateMd5FileHashForPath(file)
+      }
+      .map(_.hash)
+
+  def getStoredHash(file: Path): IO[Option[FileHash]] = {
+    file match {
+      case gcsPath: GcsPath => getFileHashForGcsPath(gcsPath).map(Option(_))
+      case blobPath: BlobPath => getFileHashForBlobPath(blobPath)
+      case drsPath: DrsPath =>
+        IO {
+          // We assume all DRS files have a stored hash; this will throw
+          // if the file does not.
+          drsPath.getFileHash
+        }.map(Option(_))
+      case s3Path: S3Path =>
+        IO {
+          Option(FileHash(HashType.S3Etag, s3Path.eTag))
+        }
+      case _ => IO.pure(None)
+    }
+  }
+
+  private def generateMd5FileHashForPath(path: Path): IO[FileHash] = delayedIoFromTry {
+    tryWithResource(() => path.newInputStream) { inputStream =>
+      FileHash(HashType.Md5, org.apache.commons.codec.digest.DigestUtils.md5Hex(inputStream))
+    }
+  }
+
+  private def getFileHashForGcsPath(gcsPath: GcsPath): IO[FileHash] = delayedIoFromTry {
+    gcsPath.objectBlobId.map(id => FileHash(HashType.GcsCrc32c, gcsPath.cloudStorage.get(id).getCrc32c))
+  }
+
+  private def getFileHashForBlobPath(blobPath: BlobPath): IO[Option[FileHash]] = delayedIoFromTry {
+    blobPath.md5HexString.map(md5 => md5.map(FileHash(HashType.Md5, _)))
+  }
+
+  /**
+    * Lazy evaluation of a Try in a delayed IO. This avoids accidentally eagerly evaluating the Try.
+    *
+    * IMPORTANT: Use this instead of IO.fromTry to make sure the Try will be reevaluated if the
+    * IoCommand is retried.
+    */
+  private def delayedIoFromTry[A](t: => Try[A]): IO[A] = IO[A](t.get)
+}

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
@@ -27,7 +27,7 @@ object NioHashing {
           else
             IO.raiseError(
               new Exception(
-                s"Files of type ${file.getClass.getSimpleName} require hash in object metadata, not present for file ${file.pathAsString.maskSensitiveUri}"
+                s"File of type ${file.getClass.getSimpleName} requires hash in object metadata, not present for ${file.pathAsString.maskSensitiveUri}"
               )
             )
       }

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioHashing.scala
@@ -54,7 +54,8 @@ object NioHashing {
     * In some scenarios like SFS it is appropriate for Cromwell to hash files using its own CPU power.
     *
     * In cloud scenarios, we don't want this because the files are huge, downloading them is slow & expensive,
-    * and the extreme CPU usage destabilizes the instance. [WX-1566]
+    * and the extreme CPU usage destabilizes the instance (WX-1566). For more context, see also comments
+    * on `cromwell.filesystems.blob.BlobPath#largeBlobFileMetadataKey()`.
     *
     * Cromwell is fundamentally supposed to be a job scheduler, and heavy computation should take place elsewhere.
     *

--- a/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
+++ b/filesystems/blob/src/main/scala/cromwell/filesystems/blob/BlobPathBuilder.scala
@@ -110,12 +110,12 @@ object BlobPath {
   // They do this for all files they touch, regardless of size, and the root/metadata property is authoritative over native.
   //
   // N.B. most if not virtually all large files in the wild will NOT have this key populated because they were not created
-  // by TES or its associated upload utility [4].
+  // by TES or its associated upload utility [3].
   //
   // [0] https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets
   // [1] https://learn.microsoft.com/en-us/rest/api/storageservices/version-2019-12-12
   // [2] https://github.com/microsoft/ga4gh-tes/blob/03feb746bb961b72fa91266a56db845e3b31be27/src/Tes.Runner/Transfer/BlobBlockApiHttpUtils.cs#L25
-  // [4] https://github.com/microsoft/ga4gh-tes/blob/main/src/Tes.RunnerCLI/scripts/roothash.sh
+  // [3] https://github.com/microsoft/ga4gh-tes/blob/main/src/Tes.RunnerCLI/scripts/roothash.sh
   private val largeBlobFileMetadataKey = "md5_4mib_hashlist_root_hash"
 
   def cleanedNioPathString(nioString: String): String = {


### PR DESCRIPTION
One of Morgan's input files was missing an md5 in its object metadata. Cromwell was dutifully falling back to our backup option, which is to read every byte of the file into memory and calculate the hash itself.

This resulted in extraordinary network and CPU usage that destabilized the instance and caused a continual crash/reboot cycle. We think this is also what Lori ran into with the featured workspaces.

Now, we detect & avoid this condition, print a warning, and carry on without call caching:
```
41183c60:ImputationBeagle.SubsetVcfToRegion:3:1:
  Hash error ([Attempted 1 time(s)] - Exception:
  File of type BlobPath requires hash in object metadata, not present for
  https://lz8b0d07a4d28c13150a1a12.blob.core.windows.net/sc-94fd136b-4231-4e80-ab0c-76d8a2811066/hg38/inputs/palantir_merged_input_samples.liftedover.vcf.gz),
  disabling call caching for this job.
```

Obviously, we'd like to enhance this in the future so that call caching is still possible for these jobs, but we have to walk before we can run.

---

Visualization eye candy section!

Swiftly downloading a file on the datacenter multi-gigabit LAN:

![Screenshot 2024-05-02 at 19 24 04](https://github.com/broadinstitute/cromwell/assets/1087943/46484bbd-30e0-4f88-8f6c-05b50649c557)

Telltale CPU curve as we chew through one file after another:

![Screenshot 2024-05-03 at 11 32 13](https://github.com/broadinstitute/cromwell/assets/1087943/7916ce63-8d4c-46f7-a86a-b3313edf0d77)

Flame graph showing the smoking gun, `generateMd5FileHashForPath`:

![Screenshot 2024-05-02 at 14 02 25](https://github.com/broadinstitute/cromwell/assets/1087943/0d06f3ad-8155-4b43-bef7-6d9ccce35132)