### PR TITLE
WX-1611 Fix GHA ordering error

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -11,14 +11,14 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-    - id: get-jira-id
-      uses: ./.github/library/get_jira_id
     - name: Clone Cromwell
       uses: actions/checkout@v2
       with:
         repository: broadinstitute/cromwell
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
         path: cromwell
+    - id: get-jira-id
+      uses: ./.github/library/get_jira_id
     - uses: olafurpg/setup-scala@v10
       with:
         java-version: adopt@1.11


### PR DESCRIPTION
As soon as I merged https://github.com/broadinstitute/cromwell/pull/7423 Github [told me](https://github.com/broadinstitute/cromwell/actions/runs/9004215121/job/24736673102),
> Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/cromwell/cromwell/.github/library/get_jira_id'. Did you forget to run actions/checkout before running your local action?

Turns out you can't run an action before you check it out! 