### PR TITLE
File size parallel traverse test (Jira later)

### DIFF
--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -1,5 +1,6 @@
 package wdl.transforms.base.linking.expression.values
 
+import cats.implicits.catsSyntaxParallelTraverse1
 import cats.syntax.traverse._
 import cats.syntax.validated._
 import cats.instances.list._
@@ -675,7 +676,7 @@ object EngineFunctionEvaluators {
         case WomOptionalValue(f, Some(o)) if isOptionalOfFileType(f) => optionalSafeFileSize(o)
         case WomOptionalValue(f, None) if isOptionalOfFileType(f) => 0L.validNel
         case WomArray(WomArrayType(womType), values) if isOptionalOfFileType(womType) =>
-          values.toList.traverse(optionalSafeFileSize).map(_.sum)
+          values.toList.parTraverse(optionalSafeFileSize).map(_.sum)
         case _ =>
           s"The 'size' method expects a 'File', 'File?', 'Array[File]' or Array[File?] argument but instead got ${value.womType.stableName}.".invalidNel
       }


### PR DESCRIPTION
### Description

When evaluating a list of file sizes to compute its sum, perform the IO requests in parallel instead of in sequence. This prevents instances from asplode.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users