### PR TITLE
WX-1595 Add more cases to `GCPBatch` backend

### DIFF
--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
@@ -2,7 +2,7 @@ ignore: false
 name: abort.restart_abort_jes
 testFormat: ScheduledAbortWithRestart
 callMark: scheduled_abort.aborted
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: abort/scheduled_abort.wdl

--- a/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
+++ b/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
@@ -1,6 +1,6 @@
 name: bucket_name_with_no_trailing_slash
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: attempt_to_localize_bucket_as_file/attempt_to_localize_bucket_as_file.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
@@ -3,7 +3,7 @@
 # should not see the first's cache entries.
 name: call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi
 testFormat: runthriceexpectingcallcaching
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl

--- a/centaur/src/main/resources/standardTestCases/collections_delete.test
+++ b/centaur/src/main/resources/standardTestCases/collections_delete.test
@@ -2,7 +2,7 @@
 
 name: collections_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/collections_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_hash_gcr_private.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_gcr_private.test
@@ -1,6 +1,6 @@
 name: docker_hash_gcr_private
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: docker_hash/docker_hash_gcr_private.wdl

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -1,6 +1,6 @@
 name: draft3_call_cache_capoeira_jes
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [GCPBatch, Papi, Local]
 workflowType: WDL
 workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]

--- a/centaur/src/main/resources/standardTestCases/draft3_custom_mount_point.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_custom_mount_point.test
@@ -1,6 +1,6 @@
 name: draft3_custom_mount_point
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: wdl_draft3/custom_mount_point/custom_mount_point.wdl

--- a/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
+++ b/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
@@ -1,6 +1,6 @@
 name: error_10_preemptible
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: error_10_preemptible/error_10_preemptible.wdl

--- a/centaur/src/main/resources/standardTestCases/final_call_logs_dir_jes.test
+++ b/centaur/src/main/resources/standardTestCases/final_call_logs_dir_jes.test
@@ -1,7 +1,7 @@
 # Tests that a runtime option to save call logs is copying said logs appropriately.
 
 name: final_call_logs_dir_jes
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 testFormat: workflowsuccess
 

--- a/centaur/src/main/resources/standardTestCases/gcs_path_ending_with_newline.test
+++ b/centaur/src/main/resources/standardTestCases/gcs_path_ending_with_newline.test
@@ -1,6 +1,6 @@
 name: gcs_path_ending_with_newline
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: gcs_path_ending_with_newline/gcs_path_ending_with_newline.wdl

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -1,6 +1,6 @@
 name: google_labels_bad
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: google_labels/google_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/gpu_cuda_image.test
+++ b/centaur/src/main/resources/standardTestCases/gpu_cuda_image.test
@@ -1,6 +1,6 @@
 name: gpu_cuda_image
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [GCPBatch, Papi]
 ignore: true
 
 files {

--- a/centaur/src/main/resources/standardTestCases/gpu_on_papi_invalid.test
+++ b/centaur/src/main/resources/standardTestCases/gpu_on_papi_invalid.test
@@ -1,6 +1,6 @@
 name: gpu_on_papi_invalid
 testFormat: workflowfailure
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: gpu_on_papi/gpu_on_papi.wdl

--- a/centaur/src/main/resources/standardTestCases/hello_delete.test
+++ b/centaur/src/main/resources/standardTestCases/hello_delete.test
@@ -2,7 +2,7 @@
 
 name: hello_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/hello_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
+++ b/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
@@ -1,6 +1,6 @@
 name: hello_google_legacy_machine_selection
 testFormat: workflowsuccess
-backends: [ Papiv2 ]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: wdl_draft3/hello/hello.wdl

--- a/centaur/src/main/resources/standardTestCases/http_inputs.test
+++ b/centaur/src/main/resources/standardTestCases/http_inputs.test
@@ -1,5 +1,5 @@
 name: http_inputs
-backends: [Local, Papiv2]
+backends: [GCPBatch, Local, Papiv2]
 testFormat: workflowsuccess
 skipDescribeEndpointValidation: true
 

--- a/centaur/src/main/resources/standardTestCases/input_expressions.test
+++ b/centaur/src/main/resources/standardTestCases/input_expressions.test
@@ -1,6 +1,6 @@
 name: input_expressions
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [GCPBatch, Papi, Local]
 
 files {
   workflow: input_expressions/input_expressions.wdl

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
@@ -1,6 +1,6 @@
 name: invalidate_bad_caches_jes
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches.wdl

--- a/centaur/src/main/resources/standardTestCases/jes_labels.test
+++ b/centaur/src/main/resources/standardTestCases/jes_labels.test
@@ -1,7 +1,7 @@
 name: jes_labels
 testFormat: workflowsuccess
 tags: [ labels ]
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: labels/jes_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/local_gcs.test
+++ b/centaur/src/main/resources/standardTestCases/local_gcs.test
@@ -1,6 +1,6 @@
 name: local_gcs
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [GCPBatch, Papi, Local]
 
 files {
   workflow: local_gcs/local_gcs.wdl

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -4,7 +4,7 @@
 name: lots_of_inputs_papiv2
 testFormat: workflowsuccess
 tags: [ big_metadata ]
-backends: [ Papiv2 ]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: lots_of_inputs/lots_of_inputs.wdl

--- a/centaur/src/main/resources/standardTestCases/missing_delete.test
+++ b/centaur/src/main/resources/standardTestCases/missing_delete.test
@@ -2,7 +2,7 @@
 
 name: missing_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/missing_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/monitoring_script_localization_failure.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_script_localization_failure.test
@@ -1,6 +1,6 @@
 name: monitoring_script_localization_failure
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: monitoring_script_localization_failure/monitoring_script_localization_failure.wdl

--- a/centaur/src/main/resources/standardTestCases/no_output_delete.test
+++ b/centaur/src/main/resources/standardTestCases/no_output_delete.test
@@ -2,7 +2,7 @@
 
 name: no_output_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/no_output_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
@@ -1,6 +1,6 @@
 name: papi_cpu_platform
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: papi_cpu_platform/papi_cpu_platform.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_preemptible_and_max_retries.test
+++ b/centaur/src/main/resources/standardTestCases/papi_preemptible_and_max_retries.test
@@ -1,6 +1,6 @@
 name: papi_preemptible_and_max_retries
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: papi_preemptible_and_max_retries/papi_preemptible_and_max_retries.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_v2_log.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2_log.test
@@ -1,6 +1,6 @@
 name: papi_v2_log
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: papi_v2_log/papi_v2_log.wdl

--- a/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
+++ b/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
@@ -1,7 +1,7 @@
 name: restart_jes_with_recover
 testFormat: CromwellRestartWithRecover
 callMark: cromwell_restart.cromwell_killer
-backends: [Papi]
+backends: [GCPBatch, Papi]
 
 files {
   workflow: cromwell_restart/cromwell_restart.wdl

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory.test
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory.test
@@ -1,6 +1,6 @@
 name: retry_with_more_memory
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: retry_with_more_memory/retry_with_more_memory.wdl

--- a/centaur/src/main/resources/standardTestCases/scatter_delete.test
+++ b/centaur/src/main/resources/standardTestCases/scatter_delete.test
@@ -2,7 +2,7 @@
 
 name: scatter_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/scatter_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/stdout_delete.test
+++ b/centaur/src/main/resources/standardTestCases/stdout_delete.test
@@ -2,7 +2,7 @@
 
 name: stdout_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/stdout_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/sub_workflow_delete.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_delete.test
@@ -2,7 +2,7 @@
 
 name: sub_workflow_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: delete_intermediates/sub_workflow_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs_unsupported
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: wdl_optional_outputs/wdl_optional_outputs_unsupported.wdl

--- a/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
@@ -1,6 +1,6 @@
 name: workbench_health_monitor_check_papiv2
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [GCPBatch, Papiv2]
 
 files {
   workflow: workbench_health_monitor_check/workbench_health_monitor_check.wdl


### PR DESCRIPTION
### Description

The Batch integration test suite runs with the Local and GCPBatch backends. This means that any cases tagged `Local` would have been picked up and (perhaps counterintuitively) run on the GCPBatch backend, because that's the default.

We do have some extra cases that are not compatible with the Local backend for whatever reason, and weren't running on Batch. There's a good chance that many of them do work/should work on Batch, since it's similar to PAPI in a way that Local is not.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users