### PR TITLE
WX-1633 Parallelize `size()` lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Users reported cases where Life Sciences jobs failed due to insufficient quota, 
 quota is available (which is the expected behavior). Cromwell will now retry under these conditions, which present with errors
 such as "PAPI error code 9", "no available zones", and/or "quota too low".
 
+### Improved `size()` function performance on arrays
+
+Resolved a hotspot in Cromwell that could cause the WDL `size()` engine function to perform very slowly on arrays of files. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added support for arrays [0].
+
+
 ## 87 Release Notes
 
 ### GCP Batch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ such as "PAPI error code 9", "no available zones", and/or "quota too low".
 
 ### Improved `size()` function performance on arrays
 
-Resolved a hotspot in Cromwell that could cause the WDL `size()` engine function to perform very slowly on arrays of files. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added support for arrays [0].
+Resolved a hotspot in Cromwell to make the `size()` engine function perform much faster on file arrays. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added [support for arrays](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#acceptable-compound-input-types).
 
 
 ## 87 Release Notes

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -54,6 +54,7 @@ import wom.values.{WomString, WomValue}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
+import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success, Try}
 
 object MaterializeWorkflowDescriptorActor {
@@ -287,7 +288,7 @@ class MaterializeWorkflowDescriptorActor(override val serviceRegistryActor: Acto
   }
 
   private def workflowInitializationFailed(errors: NonEmptyList[String], replyTo: ActorRef) =
-    sender() ! MaterializeWorkflowDescriptorFailureResponse(new IllegalArgumentException with MessageAggregation {
+    sender() ! MaterializeWorkflowDescriptorFailureResponse(new IllegalArgumentException with MessageAggregation with NoStackTrace {
       val exceptionContext = "Workflow input processing failed"
       val errorMessages = errors.toList
     })

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/materialization/MaterializeWorkflowDescriptorActor.scala
@@ -288,10 +288,12 @@ class MaterializeWorkflowDescriptorActor(override val serviceRegistryActor: Acto
   }
 
   private def workflowInitializationFailed(errors: NonEmptyList[String], replyTo: ActorRef) =
-    sender() ! MaterializeWorkflowDescriptorFailureResponse(new IllegalArgumentException with MessageAggregation with NoStackTrace {
-      val exceptionContext = "Workflow input processing failed"
-      val errorMessages = errors.toList
-    })
+    sender() ! MaterializeWorkflowDescriptorFailureResponse(
+      new IllegalArgumentException with MessageAggregation with NoStackTrace {
+        val exceptionContext = "Workflow input processing failed"
+        val errorMessages = errors.toList
+      }
+    )
 
   private def workflowOptionsAndPathBuilders(
     sourceFiles: WorkflowSourceFilesCollection

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -666,14 +666,13 @@ object EngineFunctionEvaluators {
         case _ => false
       }
 
-      def parallelSize(paths: Seq[String]) = {
+      def parallelSize(paths: Seq[String]) =
         Try(
           Await.result(
             ioFunctionSet.parallelSize(paths),
             10 * ReadWaitTimeout
           )
         ).toErrorOr
-      }
 
       // Inner function: Get the file size, allowing for unpacking of optionals and arrays
       def optionalSafeFileSize(value: WomValue): ErrorOr[Long] = value match {

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -16,19 +16,7 @@ import wdl4s.parser.MemoryUnit
 import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values.WomArray.WomArrayLike
-import wom.values.{
-  WomArray,
-  WomBoolean,
-  WomFloat,
-  WomInteger,
-  WomMap,
-  WomObject,
-  WomOptionalValue,
-  WomPair,
-  WomSingleFile,
-  WomString,
-  WomValue
-}
+import wom.values.{WomArray, WomBoolean, WomFloat, WomInteger, WomMap, WomObject, WomOptionalValue, WomPair, WomSingleFile, WomString, WomValue}
 import wom.types.coercion.ops._
 import wom.types.coercion.defaults._
 import wom.types.coercion.WomTypeCoercer
@@ -40,6 +28,7 @@ import wom.CommandSetupSideEffectFile
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
+import scala.language.postfixOps
 import scala.util.Try
 
 object EngineFunctionEvaluators {
@@ -670,7 +659,7 @@ object EngineFunctionEvaluators {
         Try(
           Await.result(
             ioFunctionSet.parallelSize(paths),
-            10 * ReadWaitTimeout
+            60 minutes
           )
         ).toErrorOr
 

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -16,19 +16,7 @@ import wdl4s.parser.MemoryUnit
 import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values.WomArray.WomArrayLike
-import wom.values.{
-  WomArray,
-  WomBoolean,
-  WomFloat,
-  WomInteger,
-  WomMap,
-  WomObject,
-  WomOptionalValue,
-  WomPair,
-  WomSingleFile,
-  WomString,
-  WomValue
-}
+import wom.values.{WomArray, WomBoolean, WomFloat, WomInteger, WomMap, WomObject, WomOptionalValue, WomPair, WomSingleFile, WomString, WomValue}
 import wom.types.coercion.ops._
 import wom.types.coercion.defaults._
 import wom.types.coercion.WomTypeCoercer
@@ -670,12 +658,22 @@ object EngineFunctionEvaluators {
       def optionalSafeFileSize(value: WomValue): ErrorOr[Long] = value match {
         case f if f.isInstanceOf[WomSingleFile] || WomSingleFileType.isCoerceableFrom(f.womType) =>
           f.coerceToType[WomSingleFile] flatMap { file =>
-            Try(Await.result(ioFunctionSet.size(file.valueString), Duration.Inf)).toErrorOr
+            Try(Await.result(ioFunctionSet.size(file.valueString), ReadWaitTimeout)).toErrorOr
           }
         case WomOptionalValue(f, Some(o)) if isOptionalOfFileType(f) => optionalSafeFileSize(o)
         case WomOptionalValue(f, None) if isOptionalOfFileType(f) => 0L.validNel
-        case WomArray(WomArrayType(womType), values) if isOptionalOfFileType(womType) =>
-          values.toList.traverse(optionalSafeFileSize).map(_.sum)
+        case WomArray(WomArrayType(womType), values) if WomSingleFileType.isCoerceableFrom(womType) =>
+          // `Array[File]` optimization: parallelize the size calculation
+          Try(Await.result(
+            ioFunctionSet.parallelSize(values.map(_.valueString)),
+            10 * ReadWaitTimeout
+          )).toErrorOr
+        case WomArray(WomArrayType(womType), values) if WomOptionalType(WomSingleFileType).isCoerceableFrom(womType) =>
+          // `Array[File?]` optimization: parallelize the size calculation for defined files
+          Try(Await.result(
+            ioFunctionSet.parallelSize(values.flatMap(_.asInstanceOf[WomOptionalValue].value).map(_.valueString)),
+            10 * ReadWaitTimeout
+          )).toErrorOr
         case _ =>
           s"The 'size' method expects a 'File', 'File?', 'Array[File]' or Array[File?] argument but instead got ${value.womType.stableName}.".invalidNel
       }

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -16,7 +16,19 @@ import wdl4s.parser.MemoryUnit
 import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values.WomArray.WomArrayLike
-import wom.values.{WomArray, WomBoolean, WomFloat, WomInteger, WomMap, WomObject, WomOptionalValue, WomPair, WomSingleFile, WomString, WomValue}
+import wom.values.{
+  WomArray,
+  WomBoolean,
+  WomFloat,
+  WomInteger,
+  WomMap,
+  WomObject,
+  WomOptionalValue,
+  WomPair,
+  WomSingleFile,
+  WomString,
+  WomValue
+}
 import wom.types.coercion.ops._
 import wom.types.coercion.defaults._
 import wom.types.coercion.WomTypeCoercer
@@ -659,7 +671,7 @@ object EngineFunctionEvaluators {
         Try(
           Await.result(
             ioFunctionSet.parallelSize(paths),
-            60 minutes
+            1 hour
           )
         ).toErrorOr
 

--- a/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
+++ b/wdl/transforms/new-base/src/main/scala/wdl/transforms/base/linking/expression/values/EngineFunctionEvaluators.scala
@@ -16,7 +16,19 @@ import wdl4s.parser.MemoryUnit
 import wom.expression.IoFunctionSet
 import wom.types._
 import wom.values.WomArray.WomArrayLike
-import wom.values.{WomArray, WomBoolean, WomFloat, WomInteger, WomMap, WomObject, WomOptionalValue, WomPair, WomSingleFile, WomString, WomValue}
+import wom.values.{
+  WomArray,
+  WomBoolean,
+  WomFloat,
+  WomInteger,
+  WomMap,
+  WomObject,
+  WomOptionalValue,
+  WomPair,
+  WomSingleFile,
+  WomString,
+  WomValue
+}
 import wom.types.coercion.ops._
 import wom.types.coercion.defaults._
 import wom.types.coercion.WomTypeCoercer
@@ -664,16 +676,20 @@ object EngineFunctionEvaluators {
         case WomOptionalValue(f, None) if isOptionalOfFileType(f) => 0L.validNel
         case WomArray(WomArrayType(womType), values) if WomSingleFileType.isCoerceableFrom(womType) =>
           // `Array[File]` optimization: parallelize the size calculation
-          Try(Await.result(
-            ioFunctionSet.parallelSize(values.map(_.valueString)),
-            10 * ReadWaitTimeout
-          )).toErrorOr
+          Try(
+            Await.result(
+              ioFunctionSet.parallelSize(values.map(_.valueString)),
+              10 * ReadWaitTimeout
+            )
+          ).toErrorOr
         case WomArray(WomArrayType(womType), values) if WomOptionalType(WomSingleFileType).isCoerceableFrom(womType) =>
           // `Array[File?]` optimization: parallelize the size calculation for defined files
-          Try(Await.result(
-            ioFunctionSet.parallelSize(values.flatMap(_.asInstanceOf[WomOptionalValue].value).map(_.valueString)),
-            10 * ReadWaitTimeout
-          )).toErrorOr
+          Try(
+            Await.result(
+              ioFunctionSet.parallelSize(values.flatMap(_.asInstanceOf[WomOptionalValue].value).map(_.valueString)),
+              10 * ReadWaitTimeout
+            )
+          ).toErrorOr
         case _ =>
           s"The 'size' method expects a 'File', 'File?', 'Array[File]' or Array[File?] argument but instead got ${value.womType.stableName}.".invalidNel
       }


### PR DESCRIPTION
### Description

Testing with 1000 files, Montreal datacenter.

`develop` – **1:24:00**
```
2024-05-21 16:03:23 cromwell-system-akka.dispatchers.backend-dispatcher-350 INFO  - PipelinesApiAsyncBackendJobExecutionActor [UUID(f03ed299)lots_of_inputs.make_array:NA:1]: Status change from Running to Success
2024-05-21 17:27:23 cromwell-system-akka.dispatchers.engine-dispatcher-54 INFO  - WorkflowExecutionActor-f03ed299-99cb-4adc-b152-687783914ab2 [UUID(f03ed299)]: Workflow lots_of_inputs complete. Final Outputs:
{
  "lots_of_inputs.size_kb": 24.4609375
}
```

This branch – **0:00:08**
```
2024-05-21 17:38:26 cromwell-system-akka.dispatchers.backend-dispatcher-93 INFO  - PipelinesApiAsyncBackendJobExecutionActor [UUID(63400d25)lots_of_inputs.make_array:NA:1]: Status change from Running to Success
2024-05-21 17:38:34 cromwell-system-akka.dispatchers.engine-dispatcher-125 INFO  - WorkflowExecutionActor-63400d25-4351-467a-a557-b467033ec990 [UUID(63400d25)]: Workflow lots_of_inputs complete. Final Outputs:
{
  "lots_of_inputs.size_kb": 24.4609375
}
```

No IO backpressuring at this scale, that only seems to start in the 10,000 file range.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users