### PR TITLE
[WX-1669] Fix TES Status Polling Bug

### DIFF
--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -305,9 +305,10 @@ object TesAsyncBackendJobExecutionActor {
       }
     } else {
       val minimalTaskView = fetchMinimalTaskViewFn(handle)
+      val previousCostData = handle.previousState.flatMap(c => c.costData)
       minimalTaskView map { t =>
         val state = t.state
-        getTesStatusFn(Option(state), Option.empty, handle.pendingJob.jobId)
+        getTesStatusFn(Option(state), previousCostData, handle.pendingJob.jobId)
       }
     }
 }


### PR DESCRIPTION
In the logs, I noticed a few instances of `Changing status from Running to Running`. This turned out to be because `Running(None) != Running(someCostData)`. I updated the code so that the cost data from the old status is passed into the new status (which also improves the polling behavior that was happening) 