### PR TITLE
[WX-1361] Remove Confusing Error Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 88 Release Notes
 
+### Improved logging behavior
+When Cromwell restarts during a workflow that is failing, it no longer reports pending tasks as a reason for that failure. 
+
 ### Optional docker soft links
 
 Cromwell now allows opting into configured soft links on shared file systems such as HPC environments. More details can

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -189,7 +189,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
                                 benignException,
                                 None,
                                 Map.empty,
-                                omitFromWorkflowLevelFailures = true
+                                includeInWorkflowLevelFailures = false
       )
   }
 
@@ -478,13 +478,13 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
                                         reason: Throwable,
                                         returnCode: Option[Int] = None,
                                         jobExecutionMap: JobExecutionMap = Map.empty,
-                                        omitFromWorkflowLevelFailures: Boolean = false
+                                        includeInWorkflowLevelFailures: Boolean = true
   ) = {
     pushFailedCallMetadata(failedJobKey, returnCode, reason, retryableFailure = false)
 
     val dataWithFailure =
-      if (omitFromWorkflowLevelFailures) stateData
-      else stateData.executionFailure(failedJobKey, reason, jobExecutionMap)
+      if (includeInWorkflowLevelFailures) stateData.executionFailure(failedJobKey, reason, jobExecutionMap)
+      else stateData
     /*
      * If new calls are allowed don't seal the execution store as we want to go as far as possible.
      *

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -181,9 +181,16 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
     case Event(JobFailedNonRetryableResponse(jobKey, _: JobNotFoundException, _), _) if restarting =>
       val benignException =
         new Exception(
-          "Cromwell server was restarted while this workflow was running. As part of the restart process, Cromwell attempted to reconnect to this job, however it was never started in the first place. This is a benign failure and not the cause of failure for this workflow, it can be safely ignored."
+          "Task did not start because a previous job has already failed."
         ) with NoStackTrace
-      handleNonRetryableFailure(stateData, jobKey, benignException)
+
+      handleNonRetryableFailure(stateData,
+                                jobKey,
+                                benignException,
+                                None,
+                                Map.empty,
+                                omitFromWorkflowLevelFailures = true
+      )
   }
 
   /* ********************** */
@@ -470,11 +477,14 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
                                         failedJobKey: JobKey,
                                         reason: Throwable,
                                         returnCode: Option[Int] = None,
-                                        jobExecutionMap: JobExecutionMap = Map.empty
+                                        jobExecutionMap: JobExecutionMap = Map.empty,
+                                        omitFromWorkflowLevelFailures: Boolean = false
   ) = {
     pushFailedCallMetadata(failedJobKey, returnCode, reason, retryableFailure = false)
 
-    val dataWithFailure = stateData.executionFailure(failedJobKey, reason, jobExecutionMap)
+    val dataWithFailure =
+      if (omitFromWorkflowLevelFailures) stateData
+      else stateData.executionFailure(failedJobKey, reason, jobExecutionMap)
     /*
      * If new calls are allowed don't seal the execution store as we want to go as far as possible.
      *

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -305,9 +305,10 @@ object TesAsyncBackendJobExecutionActor {
       }
     } else {
       val minimalTaskView = fetchMinimalTaskViewFn(handle)
+      val previousCostData = handle.previousState.flatMap(c => c.costData)
       minimalTaskView map { t =>
         val state = t.state
-        getTesStatusFn(Option(state), Option.empty, handle.pendingJob.jobId)
+        getTesStatusFn(Option(state), previousCostData, handle.pendingJob.jobId)
       }
     }
 }


### PR DESCRIPTION
### Description

When Cromwell restarts during a failure, it must fail the 'next' upcoming tasks in order to cleanly terminate the workflow. During this process, it was logging an error that isn't really an error (and was very confusing to users). 

This PR: 
- Changes the failure reason to something more relevant.
- Removes the failure reason from the 'Workflow' level failures, since it was not the reason the workflow failed. The failure reason is still attached to the task that never ran. 

### Release Notes Confirmation
#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users