### PR TITLE
WX-1672 Fix Docker-related CI failures

### DIFF
--- a/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha.wdl
+++ b/centaur/src/main/resources/engineUpgradeTestCases/call_cache_cha_cha/call_cache_cha_cha.wdl
@@ -395,7 +395,7 @@ task read_files_different_docker {
         Boolean done = true
         String s = read_string("out") }
     runtime {
-        docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+        docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
         continueOnReturnCode: 0
         failOnStderr: false
     }

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira/call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira/call_cache_capoeira_jes.wdl
@@ -251,7 +251,7 @@ task read_files_different_docker {
         Boolean done = true
         String s = read_string("out") }
     runtime {
-        docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+        docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
         continueOnReturnCode: 0
         failOnStderr: false
     }

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira/call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira/call_cache_capoeira_tes.wdl
@@ -257,7 +257,7 @@ task read_files_different_docker {
         Boolean done = true
         String s = read_string("out") }
     runtime {
-        docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+        docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
         continueOnReturnCode: 0
         failOnStderr: false
     }

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
@@ -3,7 +3,7 @@ task quay {
         echo "hello"
     }
     runtime {
-        docker: "quay.io/broadinstitute/cromwell-docker-test:centaur"
+        docker: "quay.io/broadinstitute/cromwell-tools:v2.4.1"
     }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
@@ -3,7 +3,7 @@ task quay {
         echo "hello"
     }
     runtime {
-        docker: "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
+        docker: "quay.io/fedora/fedora-minimal@sha256:8236b62386e5a4c34b6363bcf64b20147771b4e4b9c0a24f71a4e8fa5b8703f9"
     }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
+++ b/centaur/src/main/resources/standardTestCases/docker_hash/docker_hash_quay.wdl
@@ -3,7 +3,7 @@ task quay {
         echo "hello"
     }
     runtime {
-        docker: "quay.io/broadinstitute/cromwell-tools:v2.4.1"
+        docker: "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
     }
 }
 

--- a/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
@@ -8,6 +8,6 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/broadinstitute/cromwell-docker-test:centaur",
-  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/broadinstitute/cromwell-docker-test@sha256:80f7fd06fa8dcebbcf92eb3e26bf8163fe8341d60009e50a0c36cf3fbadd30a6"
+  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/broadinstitute/cromwell-tools:v2.4.1",
+  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/broadinstitute/cromwell-tools@sha256:c85fa32e75fa83acd31f50aae6adcaf952e465e36570336d12437a1f10a56b93"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
@@ -8,6 +8,6 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3",
+  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3",
   "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
@@ -8,6 +8,6 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/broadinstitute/cromwell-tools:v2.4.1",
-  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/broadinstitute/cromwell-tools@sha256:c85fa32e75fa83acd31f50aae6adcaf952e465e36570336d12437a1f10a56b93"
+  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3",
+  "calls.docker_hash_quay.quay.dockerImageUsed": "sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
@@ -8,6 +8,6 @@ files {
 }
 
 metadata {
-  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3",
-  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
+  "calls.docker_hash_quay.quay.runtimeAttributes.docker": "quay.io/fedora/fedora-minimal@sha256:8236b62386e5a4c34b6363bcf64b20147771b4e4b9c0a24f71a4e8fa5b8703f9",
+  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/fedora/fedora-minimal@sha256:8236b62386e5a4c34b6363bcf64b20147771b4e4b9c0a24f71a4e8fa5b8703f9"
 }

--- a/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_quay.test
@@ -9,5 +9,5 @@ files {
 
 metadata {
   "calls.docker_hash_quay.quay.runtimeAttributes.docker": "sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3",
-  "calls.docker_hash_quay.quay.dockerImageUsed": "sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
+  "calls.docker_hash_quay.quay.dockerImageUsed": "quay.io/fedora/fedora-minimal@sha256:63f785bf6185a63332fd9ccdaaabc66f47bc63564e2cecc6f99194002ca73ac3"
 }

--- a/centaur/src/main/resources/standardTestCases/read_write_map/read_write_map.wdl
+++ b/centaur/src/main/resources/standardTestCases/read_write_map/read_write_map.wdl
@@ -22,7 +22,7 @@ task read_map {
     Map[String, Int] out_map = read_map(stdout())
   }
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 

--- a/centaur/src/main/resources/standardTestCases/scattergather/scattergather.wdl
+++ b/centaur/src/main/resources/standardTestCases/scattergather/scattergather.wdl
@@ -6,7 +6,7 @@ task prepare {
     Array[String] array = read_lines(stdout())
   }
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 
@@ -19,7 +19,7 @@ task analysis {
     File out = "a.txt"
   }
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 

--- a/centaur/src/main/resources/standardTestCases/wdl_biscayne/read_functions_windows_line_endings/read_functions_windows_line_endings.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_biscayne/read_functions_windows_line_endings/read_functions_windows_line_endings.wdl
@@ -33,7 +33,7 @@ task read_map {
   }
 
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 
@@ -49,7 +49,7 @@ task read_lines {
   }
 
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 
@@ -65,7 +65,7 @@ task read_tsv {
   }
 
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }
 
@@ -81,6 +81,6 @@ task read_json {
   }
 
   runtime {
-    docker: "python:3.5.0"
+    docker: "python:3.12.4"
   }
 }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
@@ -306,7 +306,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl
@@ -306,7 +306,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
@@ -316,7 +316,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_local.wdl
@@ -316,7 +316,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
@@ -314,7 +314,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
+    docker: "ubuntu@sha256:c279a739b31ead4ebc3e9ce04937eb8b612799b52c26133eb3b4a056d08c31a6"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
@@ -314,7 +314,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:f0e91d9bc9a7a5bea3bb3a985f790da4c54b8a71459b9a05889b8bca94136dce"
+    docker: "ubuntu@sha256:71cd81252a3563a03ad8daee81047b62ab5d892ebbfbf71cf53415f29c130950"
     continueOnReturnCode: 0
     failOnStderr: false
   }

--- a/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
+++ b/centaur/src/main/resources/standardTestCases/wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_tes.wdl
@@ -314,7 +314,7 @@ task read_files_different_docker {
     Boolean done = true
     String s = read_string("out") }
   runtime {
-    docker: "ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+    docker: "ubuntu@sha256:f0e91d9bc9a7a5bea3bb3a985f790da4c54b8a71459b9a05889b8bca94136dce"
     continueOnReturnCode: 0
     failOnStderr: false
   }


### PR DESCRIPTION
### Description

Fixes CI failures caused by errors like:
```
$ docker pull quay.io/broadinstitute/cromwell-docker-test:centaur
centaur: Pulling from broadinstitute/cromwell-docker-test
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of quay.io/broadinstitute/cromwell-docker-test:centaur to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

The very old images need to be updated to get around this. For Python, we can use a newer version. For the Quay image we manage, using a different one because I fear push access to the current one has been lost in the mists of time.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [X] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [X] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users