### PR TITLE
WX-1676 Drop workflow store status index `IX_WORKFLOW_STORE_ENTRY_WS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ such as "PAPI error code 9", "no available zones", and/or "quota too low".
 
 Resolved a hotspot in Cromwell to make the `size()` engine function perform much faster on file arrays. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added [support for arrays](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#acceptable-compound-input-types).
 
+### Removed `IX_WORKFLOW_STORE_ENTRY_WS` on `WORKFLOW_STORE`
+
+This low-cardinality index counterintuitively slowed down workflow pickup queries.
 
 ## 87 Release Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ such as "PAPI error code 9", "no available zones", and/or "quota too low".
 
 Resolved a hotspot in Cromwell to make the `size()` engine function perform much faster on file arrays. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added [support for arrays](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#acceptable-compound-input-types).
 
-### Removed `IX_WORKFLOW_STORE_ENTRY_WS` on `WORKFLOW_STORE`
+### Removed `IX_WORKFLOW_STORE_ENTRY_WS` on `WORKFLOW_STORE_ENTRY`
 
 This low-cardinality index counterintuitively slowed down workflow pickup queries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@ such as "PAPI error code 9", "no available zones", and/or "quota too low".
 
 Resolved a hotspot in Cromwell to make the `size()` engine function perform much faster on file arrays. Common examples of file arrays could include globs or scatter-gather results. This enhancement applies only to WDL 1.0 and later, because that's when `size()` added [support for arrays](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#acceptable-compound-input-types).
 
-### Removed `IX_WORKFLOW_STORE_ENTRY_WS` on `WORKFLOW_STORE_ENTRY`
+### Database migration
 
-This low-cardinality index counterintuitively slowed down workflow pickup queries.
+The `IX_WORKFLOW_STORE_ENTRY_WS` index is removed from `WORKFLOW_STORE_ENTRY`.
+
+The index had low cardinality and workflow pickup is faster without it. Migration time depends on workflow store size, but should be very fast for most installations. Terminal workflows are removed from the workflow store, so only running workflows contribute to the cost.
 
 ## 87 Release Notes
 

--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -90,6 +90,7 @@
     <include file="changesets/enlarge_docker_hash_store_entry_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_workflow_store_entry_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_sub_workflow_store_entry_id.xml" relativeToChangelogFile="true" />
+    <include file="changesets/workflow_store_drop_state_index.xml" relativeToChangelogFile="true" />
     <!-- WARNING!
       This changeset should always be last.
       It is always run (and should always run last) to set table ownership correctly.

--- a/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
+++ b/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
@@ -6,7 +6,7 @@
 
     <!-- This index had low cardinality, we found that ignoring it yielded empirically better performance -->
     <changeSet author="anichols" id="workflow_store_drop_state_index" dbms="mysql,hsqldb,postgresql,mariadb">
-        <dropIndex tableName="WORKFLOW_STORE_ENTRY" indexName="WORKFLOW_STORE_STATE_IDX"/>
+        <dropIndex tableName="WORKFLOW_STORE_ENTRY" indexName="IX_WORKFLOW_STORE_ENTRY_WS"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
+++ b/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
@@ -6,7 +6,7 @@
 
     <!-- This index had low cardinality, we found that ignoring it yielded empirically better performance -->
     <changeSet author="anichols" id="workflow_store_drop_state_index" dbms="mysql,hsqldb,postgresql,mariadb">
-        <dropIndex tableName="WORKFLOW_STORE" indexName="WORKFLOW_STORE_STATE_IDX"/>
+        <dropIndex tableName="WORKFLOW_STORE_ENTRY" indexName="WORKFLOW_STORE_STATE_IDX"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
+++ b/database/migration/src/main/resources/changesets/workflow_store_drop_state_index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <!-- This index had low cardinality, we found that ignoring it yielded empirically better performance -->
+    <changeSet author="anichols" id="workflow_store_drop_state_index" dbms="mysql,hsqldb,postgresql,mariadb">
+        <dropIndex tableName="WORKFLOW_STORE" indexName="WORKFLOW_STORE_STATE_IDX"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/WorkflowStoreEntryComponent.scala
@@ -62,8 +62,6 @@ trait WorkflowStoreEntryComponent {
     ) <> ((WorkflowStoreEntry.apply _).tupled, WorkflowStoreEntry.unapply)
 
     def ucWorkflowStoreEntryWeu = index("UC_WORKFLOW_STORE_ENTRY_WEU", workflowExecutionUuid, unique = true)
-
-    def ixWorkflowStoreEntryWs = index("IX_WORKFLOW_STORE_ENTRY_WS", workflowState, unique = false)
   }
 
   protected val workflowStoreEntries = TableQuery[WorkflowStoreEntries]


### PR DESCRIPTION
### Description

- Ignoring this index results in empirically better performance
- If we were going to design an index from scratch for this table, it would not be this one

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users