### PR TITLE
ID-1276 Add azure cpu time to bard events

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -943,7 +943,9 @@ trait StandardAsyncExecutionActor
     * @param handle The handle of the running job.
     * @return A set of actions when the job is complete
     */
-  def onTaskComplete(runStatus: StandardAsyncRunState, handle: StandardAsyncPendingExecutionHandle): Unit = {}
+  def onTaskComplete(runStatus: StandardAsyncRunState, handle: StandardAsyncPendingExecutionHandle): Unit = tellBard(
+    runStatus
+  )
 
   /**
     * Attempts to abort a job when an abort signal is retrieved.
@@ -1332,7 +1334,6 @@ trait StandardAsyncExecutionActor
         val metadata = getTerminalMetadata(state)
         onTaskComplete(state, oldHandle)
         tellMetadata(metadata)
-        tellBard(state)
         handleExecutionResult(state, oldHandle)
       case s =>
         Future.successful(

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -324,7 +324,7 @@ object TesAsyncBackendJobExecutionActor {
                      tellMetadataFn: Map[String, Any] => Unit,
                      tellBardFn: StandardAsyncRunState => Unit,
                      logger: LoggingAdapter
-  )(implicit ec: ExecutionContext): Future[Option[String]] = {
+  )(implicit ec: ExecutionContext): Unit = {
     val logs = getTaskLogsFn(handle)
     val taskEndTime = getTaskEndTime(logs)
 
@@ -356,7 +356,6 @@ object TesAsyncBackendJobExecutionActor {
         }
       case Failure(e) => logger.error(e.getMessage)
     }
-    taskEndTime
   }
 
   def getStartAndEndTimes(runStatus: StandardAsyncRunState,

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -295,7 +295,7 @@ object TesAsyncBackendJobExecutionActor {
           responseLogs <- t.logs
           startTime <- responseLogs.headOption.map(_.start_time)
           vmCost <- responseLogs.headOption.map(_.metadata.flatMap(_.get("vm_price_per_hour_usd")))
-          // NB: End time is omitted here so we don't keep polling for it while the task runs. It will be acquired with a separate request when the task completes. 
+          // NB: End time is omitted here so we don't keep polling for it while the task runs. It will be acquired with a separate request when the task completes.
           tesVmCostData = TesVmCostData(startTime, None, vmCost)
         } yield tesVmCostData
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -321,7 +321,7 @@ object TesAsyncBackendJobExecutionActor {
                           logger: LoggingAdapter,
                           incrementFn: (InstrumentationPath, Option[String]) => Unit
   ): Option[StartAndEndTimes] = runStatus.costData match {
-    case Some(TesVmCostData(Some(_ @startTime), Some(_ @endTime), _)) =>
+    case Some(TesVmCostData(Some(startTime), Some(endTime), _)) =>
       Try {
         (OffsetDateTime.parse(startTime), OffsetDateTime.parse(endTime))
       } match {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -653,5 +653,17 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
         }
     } yield data
 
+  override def getStartAndEndTimes(runStatus: StandardAsyncRunState): Option[StartAndEndTimes] = runStatus.costData match {
+    case Some(TesVmCostData(Some(_@startTime), Some(_@endTime), _)) =>
+      try {
+        val parsedStartTime = OffsetDateTime.parse(startTime)
+        val parsedEndTime = OffsetDateTime.parse(endTime)
+        Some(StartAndEndTimes(parsedStartTime, Option(parsedStartTime), parsedEndTime))
+      } catch {
+        case dateTimeParseException: DateTimeParseException => log.error(s"Parsing TES task start and end time failed: $dateTimeParseException")
+          None
+      }
+    case _ => None
+  }
   override def platform: Option[Platform] = tesConfiguration.platform
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -295,6 +295,7 @@ object TesAsyncBackendJobExecutionActor {
           responseLogs <- t.logs
           startTime <- responseLogs.headOption.map(_.start_time)
           vmCost <- responseLogs.headOption.map(_.metadata.flatMap(_.get("vm_price_per_hour_usd")))
+          // NB: End time is omitted here so we don't keep polling for it while the task runs. It will be acquired with a separate request when the task completes. 
           tesVmCostData = TesVmCostData(startTime, None, vmCost)
         } yield tesVmCostData
 

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -474,11 +474,11 @@ class TesAsyncBackendJobExecutionActorSpec
       Future.successful(
         Some(
           TaskLog(Some("2024-04-04T20:20:32.240066+00:00"),
-            Some("2024-04-04T20:22:32.077818+00:00"),
-            None,
-            None,
-            None,
-            None
+                  Some("2024-04-04T20:22:32.077818+00:00"),
+                  None,
+                  None,
+                  None,
+                  None
           )
         )
       )
@@ -492,11 +492,11 @@ class TesAsyncBackendJobExecutionActorSpec
     )
 
     TesAsyncBackendJobExecutionActor.onTaskComplete(tesRunStatus,
-      handle,
-      getTaskLogsFn,
-      tellMetadataFn,
-      tellBardFn,
-      mockLogger
+                                                    handle,
+                                                    getTaskLogsFn,
+                                                    tellMetadataFn,
+                                                    tellBardFn,
+                                                    mockLogger
     )
 
     // Wait for any futures to complete, I tried using whenReady and it didn't work.

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActorSpec.scala
@@ -468,16 +468,17 @@ class TesAsyncBackendJobExecutionActorSpec
   }
 
   it should "call tellBard with Complete status containing task end time" in {
-    val mockHandle = mock[StandardAsyncPendingExecutionHandle]
+    val runId = StandardAsyncJob(UUID.randomUUID().toString)
+    val handle = new StandardAsyncPendingExecutionHandle(null, runId, None, None)
     val getTaskLogsFn = (_: StandardAsyncPendingExecutionHandle) =>
       Future.successful(
         Some(
           TaskLog(Some("2024-04-04T20:20:32.240066+00:00"),
-                  Some("2024-04-04T20:22:32.077818+00:00"),
-                  None,
-                  None,
-                  None,
-                  None
+            Some("2024-04-04T20:22:32.077818+00:00"),
+            None,
+            None,
+            None,
+            None
           )
         )
       )
@@ -491,11 +492,11 @@ class TesAsyncBackendJobExecutionActorSpec
     )
 
     TesAsyncBackendJobExecutionActor.onTaskComplete(tesRunStatus,
-                                                    mockHandle,
-                                                    getTaskLogsFn,
-                                                    tellMetadataFn,
-                                                    tellBardFn,
-                                                    mockLogger
+      handle,
+      getTaskLogsFn,
+      tellMetadataFn,
+      tellBardFn,
+      mockLogger
     )
 
     // Wait for any futures to complete, I tried using whenReady and it didn't work.


### PR DESCRIPTION
### Description

https://broadworkbench.atlassian.net/browse/ID-1276

This pr adds azure task cpu start and end time metrics for bard events. I referenced this merged pr to figure out how to get start and end time: https://github.com/broadinstitute/cromwell/pull/7415

terra helmfile pr:
https://github.com/broadinstitute/terra-helmfile/pull/5674

leo pr:
https://github.com/DataBiosphere/leonardo/pull/4664

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users