### PR TITLE
WX-1409 Upgrade Cromwell to Java 17

### DIFF
--- a/.github/set_up_cromwell_action/action.yml
+++ b/.github/set_up_cromwell_action/action.yml
@@ -44,4 +44,4 @@ runs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: Clone Cromwhelm
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
       # The following invocation should be as similar as possible to the one in chart_update_on_merge.yml
       # To state the obvious: This test should not publish anything. It should simply verify that the build completes.
       - name: Build Cromwell Docker

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       # set up SBT cache
       - uses: actions/cache@v2

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.23-tem
+java=17.0.9-tem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 88 Release Notes
 
+### Java 17
+
+As of this version, a distribution of Java 17 is required to run Cromwell. Cromwell is developed, tested, and
+containerized using [Eclipse Temurin](https://adoptium.net/temurin/releases/?version=17).
+
 ### Improved status reporting behavior
 
 When Cromwell restarts during a workflow that is failing, it no longer reports pending tasks as a reason for that failure. 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -19,8 +19,8 @@ Mac users with Homebrew can also get Cromwell with the command `brew install cro
 This documentation frequently refers to a "Cromwell jar" with a name like `cromwell-<version>.jar`. 
 This is the main artifact in Cromwell releases that contains all executable Cromwell code and default configuration.   
 
-A distribution of Java 11 is required to run Cromwell. Cromwell is developed, tested, and containerized using
-[AdoptOpenJDK 11 HotSpot](https://adoptopenjdk.net/).
+A distribution of Java 17 is required to run Cromwell. Cromwell is developed, tested, and containerized using
+[Eclipse Temurin](https://adoptium.net/temurin/releases/?version=17).
 
 For users running a Cromwell server [a docker image](https://hub.docker.com/r/broadinstitute/cromwell) has been made available.
 

--- a/docs/tutorials/FiveMinuteIntro.md
+++ b/docs/tutorials/FiveMinuteIntro.md
@@ -3,11 +3,11 @@
 ### Prerequisites:
 
 * A Unix-based operating system (yes, that includes Mac!)
-* A Java 11 runtime environment 
+* A Java 17 runtime environment 
     * You can see what you have by running `$ java -version` on a terminal.
     * If not, consider installing via conda or brew [as explained here](../Releases.md).
-    * We recommend [SDKMAN](https://sdkman.io/install) to install the latest 11 build of [Temurin](https://adoptium.net/temurin/releases/?version=11)
-      * `sdk install java 11.0.16-tem` as of the time of this writing
+    * We recommend [SDKMAN](https://sdkman.io/install) to install the latest 17 build of [Temurin](https://adoptium.net/temurin/releases/?version=17)
+        * `sdk install 17.0.9-tem` as of the time of this writing
     * You might need to update the `export JAVA_HOME` in your bash profile to point to your JAVA install location.
 * A sense of adventure!
 

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,4 +1,4 @@
-import Version.{Debug, Release, Snapshot, Standard, cromwellVersion}
+import Version.{cromwellVersion, Debug, Release, Snapshot, Standard}
 import org.apache.ivy.Ivy
 import org.apache.ivy.core.IvyPatternHelper
 import org.apache.ivy.core.module.descriptor.{DefaultModuleDescriptor, MDArtifact}
@@ -69,7 +69,7 @@ object Publishing {
       val additionalDockerInstr: Seq[Instruction] = (dockerCustomSettings ?? Nil).value
 
       new Dockerfile {
-        from("us.gcr.io/broad-dsp-gcr-public/base/jre:11-debian")
+        from("us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian")
         expose(8000)
         add(artifact, artifactTargetPath)
         runRaw(s"ln -s $artifactTargetPath /app/$projectName.jar")
@@ -210,7 +210,7 @@ object Publishing {
 
   val additionalResolvers = List(
     broadArtifactoryResolver,
-    broadArtifactoryResolverSnap,
+    broadArtifactoryResolverSnap
   ) ++ Resolver.sonatypeOssRepos("releases")
 
   private val artifactoryCredentialsFile =

--- a/publish/docker-setup.sh
+++ b/publish/docker-setup.sh
@@ -20,7 +20,7 @@ mkdir -p /etc/apt/keyrings
 wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc
 echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 apt update
-apt install -y temurin-11-jdk
+apt install -y temurin-17-jdk
 
 # Install jq 1.6 to ensure --rawfile is supported
 curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq

--- a/src/ci/docker-compose/cromwell-test/docker-setup.sh
+++ b/src/ci/docker-compose/cromwell-test/docker-setup.sh
@@ -50,7 +50,7 @@ add-apt-repository \
 # install packages that required setup
 apt-get update
 apt-get install -y \
-    temurin-11-jdk \
+    temurin-17-jdk \
     containerd.io \
     docker-ce \
     docker-ce-cli \

--- a/wom/src/test/scala/wom/util/YamlUtilsSpec.scala
+++ b/wom/src/test/scala/wom/util/YamlUtilsSpec.scala
@@ -80,7 +80,7 @@ class YamlUtilsSpec
       "a null yaml",
       null,
       refineMV[NonNegative](0),
-      null
+      "Cannot invoke \"String.length()\" because \"s\" is null"
     ),
     (
       "an empty yaml mapping when limited to zero nodes",


### PR DESCRIPTION
### Description

Combined with https://github.com/broadinstitute/cromwell/pull/7462, re-applies upgrade to Java 17 as seen in https://github.com/broadinstitute/cromwell/pull/7342. 

Requires these terra-helmfile changes: https://github.com/broadinstitute/terra-helmfile/pull/5721

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users