### PR TITLE
PROD-976 Vanity stack trace cleanup

### DIFF
--- a/core/src/main/scala/cromwell/core/core.scala
+++ b/core/src/main/scala/cromwell/core/core.scala
@@ -31,7 +31,6 @@ case class CromwellAggregatedException(throwables: Seq[Throwable], exceptionCont
     with ThrowableAggregation
     with NoStackTrace
 
-
 case class CacheConfig(concurrency: Int, size: Long, ttl: FiniteDuration)
 
 import net.ceedubs.ficus.Ficus._

--- a/core/src/main/scala/cromwell/core/core.scala
+++ b/core/src/main/scala/cromwell/core/core.scala
@@ -6,6 +6,7 @@ import cromwell.core.path.Path
 import mouse.boolean._
 
 import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NoStackTrace
 
 case class StandardPaths(output: Path, error: Path)
 
@@ -28,6 +29,8 @@ class CromwellFatalException(val exception: Throwable) extends Exception(excepti
 case class CromwellAggregatedException(throwables: Seq[Throwable], exceptionContext: String = "")
     extends Exception
     with ThrowableAggregation
+    with NoStackTrace
+
 
 case class CacheConfig(concurrency: Int, size: Long, ttl: FiniteDuration)
 


### PR DESCRIPTION
### Description

An exception that aggregates throwables that originate somewhere else pretty much by definition carries no value in its stack trace. It just causes clutter and looks ugly.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users