### PR TITLE
WX-927 GCPBATCH IntelliJ run config

### DIFF
--- a/runConfigurations/Repo template_ Cromwell server GCPBATCH.run.xml
+++ b/runConfigurations/Repo template_ Cromwell server GCPBATCH.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Repo template: Cromwell server" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="$USER_HOME$/.sdkman/candidates/java/current" />
+    <envs>
+      <env name="CROMWELL_BUILD_CENTAUR_SLICK_PROFILE" value="slick.jdbc.MySQLProfile$" />
+      <env name="CROMWELL_BUILD_CENTAUR_JDBC_DRIVER" value="com.mysql.cj.jdbc.Driver" />
+      <env name="CROMWELL_BUILD_CENTAUR_JDBC_URL" value="jdbc:mysql://localhost:3306/cromwell_test?allowPublicKeyRetrieval=true&amp;useSSL=false&amp;rewriteBatchedStatements=true&amp;serverTimezone=UTC&amp;useInformationSchema=true" />
+      <env name="CROMWELL_BUILD_RESOURCES_DIRECTORY" value="target/ci/resources" />
+      <env name="CROMWELL_BUILD_PAPI_JSON_FILE" value="target/ci/resources/cromwell-centaur-service-account.json" />
+      <env name="CROMWELL_BUILD_CENTAUR_READ_LINES_LIMIT" value="128000" />
+      <env name="CROMWELL_BUILD_CENTAUR_256_BITS_KEY" value="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" />
+      <env name="GOOGLE_APPLICATION_CREDENTIALS" value="target/ci/resources/cromwell-centaur-service-account.json" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="cromwell.CromwellApp" />
+    <module name="root.cromwell" />
+    <option name="PROGRAM_PARAMETERS" value="server" />
+    <option name="VM_PARAMETERS" value="-Dconfig.file=target/ci/resources/gcp_batch_application.conf" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="renderCiResources" run_configuration_type="SbtRunConfiguration" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
### Description

Run config for developers to be easily able to exercise the GCP Batch backend locally. To use:

1. Start a mysql container by running `processes/release_processes/scripts/start_publish_mysql_docker.sh`
1. Run this config in IntelliJ: 'Repo template: Cromwell GCPBATCH server'

### Release Notes Confirmation

Dev-only, no release notes.
#### `CHANGELOG.md`

 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users