### PR TITLE
WX-927 GCPBATCH retry with more memory and error message fixes, Centaur tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ be found [here](https://cromwell.readthedocs.io/en/stable/backends/HPC/#optional
 
 - The `genomics` configuration entry was renamed to `batch`, see [ReadTheDocs](https://cromwell.readthedocs.io/en/stable/backends/GCPBatch/) for more information.
 - Fixes the preemption error handling, now, the correct error message is printed, this also handles the other potential exit codes.
+- Fixes error message reporting for failed jobs.
+- Fixes the "retry with more memory" feature.
 - Fixes pulling Docker image metadata from private GCR repositories.
 - Fixed `google_project` and `google_compute_service_account` workflow options not taking effect when using GCP Batch backend
 

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_do_not_retry_rc0.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_do_not_retry_rc0.test
@@ -1,0 +1,15 @@
+name: gcpbatch_do_not_retry_rc0
+testFormat: workflowsuccess
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/do_not_retry_rc0.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: do_not_retry_rc0
+  status: Succeeded
+  "calls.do_not_retry_rc0.imitate_oom_error.executionStatus": "Done"
+  "calls.do_not_retry_rc0.imitate_oom_error.runtimeAttributes.memory": "1 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_do_not_retry_rc1.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_do_not_retry_rc1.test
@@ -1,0 +1,15 @@
+name: gcpbatch_do_not_retry_rc1
+testFormat: workflowsuccess
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/do_not_retry_rc1.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: do_not_retry_rc1
+  status: Succeeded
+  "calls.do_not_retry_rc1.imitate_oom_error.executionStatus": "Done"
+  "calls.do_not_retry_rc1.imitate_oom_error.runtimeAttributes.memory": "1 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
@@ -2,7 +2,7 @@ name: gcpbatch_preemptible_and_memory_retry
 testFormat: workflowfailure
 # The original version of this test seems to have been tailored to the quirks of Papi v2 in depending on the misdiagnosis of its own VM deletion as a preemption event. GCP Batch perhaps more correctly diagnoses the VM deletion as a weird non-preemption happening, but that frustrates the logic of this test.
 # Disabling this as it's not possible to induce a real preemption.
-enabled: false
+ignore: true
 backends: [GCPBATCH]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
@@ -1,5 +1,8 @@
 name: gcpbatch_preemptible_and_memory_retry
 testFormat: workflowfailure
+# The original version of this test seems to have been tailored to the quirks of Papi v2 in depending on the misdiagnosis of its own VM deletion as a preemption event. GCP Batch perhaps more correctly diagnoses the VM deletion as a weird non-preemption happening, but that frustrates the logic of this test.
+# Disabling this as it's not possible to induce a real preemption.
+enabled: false
 backends: [GCPBATCH]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_preemptible_and_memory_retry.test
@@ -1,0 +1,24 @@
+name: gcpbatch_preemptible_and_memory_retry
+testFormat: workflowfailure
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/preemptible_and_memory_retry.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: preemptible_and_memory_retry
+  status: Failed
+  "failures.0.message": "Workflow failed"
+  "failures.0.causedBy.0.message": "stderr for job `preemptible_and_memory_retry.imitate_oom_error_on_preemptible:NA:3` contained one of the `memory-retry-error-keys: [OutOfMemory,Killed]` specified in the Cromwell config. Job might have run out of memory."
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.1.preemptible": "true"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.1.executionStatus": "RetryableFailure"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.1.runtimeAttributes.memory": "1 GB"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.2.preemptible": "false"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.2.executionStatus": "RetryableFailure"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.2.runtimeAttributes.memory": "1 GB"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.3.preemptible": "false"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.3.executionStatus": "Failed"
+  "preemptible_and_memory_retry.imitate_oom_error_on_preemptible.-1.3.runtimeAttributes.memory": "1.1 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
@@ -1,5 +1,9 @@
 name: gcpbatch_retry_same_memory_output_failure
 testFormat: workflowfailure
+# WX-927 GCPBATCH
+enabled: false
+# This test *seems * to run mostly okay except for the "causedBy" message which is both mismatched and inappropriately benign-sounding.
+# -Metadata mismatch for failures.0.causedBy.0.message - Actual value "Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed: Job state is set from QUEUED to SCHEDULED for job projects/1005074806481/locations/us-central1/jobs/job-951a202d-6d57-4211-b37e-77737666df04." does not contain Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed. Job exit code 1.
 backends: [GCPBATCH]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
@@ -1,0 +1,21 @@
+name: gcpbatch_retry_same_memory_output_failure
+testFormat: workflowfailure
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/retry_same_memory_output_failure.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: retry_same_memory_output_failure
+  status: Failed
+  "failures.0.message": "Workflow failed"
+  "failures.0.causedBy.0.message": ~~"Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed. Job exit code 1."
+  "retry_same_memory_output_failure.imitate_oom_error.-1.1.executionStatus": "RetryableFailure"
+  "retry_same_memory_output_failure.imitate_oom_error.-1.1.runtimeAttributes.memory": "1 GB"
+  "retry_same_memory_output_failure.imitate_oom_error.-1.2.executionStatus": "RetryableFailure"
+  "retry_same_memory_output_failure.imitate_oom_error.-1.2.runtimeAttributes.memory": "1 GB"
+  "retry_same_memory_output_failure.imitate_oom_error.-1.3.executionStatus": "Failed"
+  "retry_same_memory_output_failure.imitate_oom_error.-1.3.runtimeAttributes.memory": "1 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
@@ -1,7 +1,7 @@
 name: gcpbatch_retry_same_memory_output_failure
 testFormat: workflowfailure
 # WX-927 GCPBATCH
-enabled: false
+ignore: true
 # This test *seems * to run mostly okay except for the "causedBy" message which is both mismatched and inappropriately benign-sounding.
 # -Metadata mismatch for failures.0.causedBy.0.message - Actual value "Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed: Job state is set from QUEUED to SCHEDULED for job projects/1005074806481/locations/us-central1/jobs/job-951a202d-6d57-4211-b37e-77737666df04." does not contain Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed. Job exit code 1.
 backends: [GCPBATCH]

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_same_memory_output_failure.test
@@ -1,9 +1,5 @@
 name: gcpbatch_retry_same_memory_output_failure
 testFormat: workflowfailure
-# WX-927 GCPBATCH
-ignore: true
-# This test *seems * to run mostly okay except for the "causedBy" message which is both mismatched and inappropriately benign-sounding.
-# -Metadata mismatch for failures.0.causedBy.0.message - Actual value "Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed: Job state is set from QUEUED to SCHEDULED for job projects/1005074806481/locations/us-central1/jobs/job-951a202d-6d57-4211-b37e-77737666df04." does not contain Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed. Job exit code 1.
 backends: [GCPBATCH]
 
 files {
@@ -15,7 +11,7 @@ metadata {
   workflowName: retry_same_memory_output_failure
   status: Failed
   "failures.0.message": "Workflow failed"
-  "failures.0.causedBy.0.message": ~~"Task retry_same_memory_output_failure.imitate_oom_error:NA:3 failed. Job exit code 1."
+  "failures.0.causedBy.0.message": ~~"exit code 1."
   "retry_same_memory_output_failure.imitate_oom_error.-1.1.executionStatus": "RetryableFailure"
   "retry_same_memory_output_failure.imitate_oom_error.-1.1.runtimeAttributes.memory": "1 GB"
   "retry_same_memory_output_failure.imitate_oom_error.-1.2.executionStatus": "RetryableFailure"

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory.test
@@ -1,0 +1,21 @@
+name: gcpbatch_retry_with_more_memory
+testFormat: workflowfailure
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/retry_with_more_memory.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: retry_with_more_memory
+  status: Failed
+  "failures.0.message": "Workflow failed"
+  "failures.0.causedBy.0.message": "stderr for job `retry_with_more_memory.imitate_oom_error:NA:3` contained one of the `memory-retry-error-keys: [OutOfMemory,Killed]` specified in the Cromwell config. Job might have run out of memory."
+  "retry_with_more_memory.imitate_oom_error.-1.1.executionStatus": "RetryableFailure"
+  "retry_with_more_memory.imitate_oom_error.-1.1.runtimeAttributes.memory": "1 GB"
+  "retry_with_more_memory.imitate_oom_error.-1.2.executionStatus": "RetryableFailure"
+  "retry_with_more_memory.imitate_oom_error.-1.2.runtimeAttributes.memory": "1.1 GB"
+  "retry_with_more_memory.imitate_oom_error.-1.3.executionStatus": "Failed"
+  "retry_with_more_memory.imitate_oom_error.-1.3.runtimeAttributes.memory": "1.2100000000000002 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_after_137.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_after_137.test
@@ -1,0 +1,21 @@
+name: gcpbatch_retry_with_more_memory_after_137
+testFormat: workflowfailure
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/retry_with_more_memory_after_137.wdl
+  options: retry_with_more_memory/retry_with_more_memory.options
+}
+
+metadata {
+  workflowName: retry_with_more_memory_after_137
+  status: Failed
+  "failures.0.message": "Workflow failed"
+  "failures.0.causedBy.0.message": "stderr for job `retry_with_more_memory_after_137.imitate_oom_error:NA:3` contained one of the `memory-retry-error-keys: [OutOfMemory,Killed]` specified in the Cromwell config. Job might have run out of memory."
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.1.executionStatus": "RetryableFailure"
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.1.runtimeAttributes.memory": "1 GB"
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.2.executionStatus": "RetryableFailure"
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.2.runtimeAttributes.memory": "1.1 GB"
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.3.executionStatus": "Failed"
+  "retry_with_more_memory_after_137.imitate_oom_error.-1.3.runtimeAttributes.memory": "1.2100000000000002 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_no_wf_option.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_no_wf_option.test
@@ -4,7 +4,6 @@ backends: [GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/gcpbatch/retry_with_more_memory.wdl
-  inputs: gcpbatch/batch_backend.inputs
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_no_wf_option.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_retry_with_more_memory_no_wf_option.test
@@ -1,0 +1,20 @@
+name: gcpbatch_retry_with_more_memory_no_wf_option
+testFormat: workflowfailure
+backends: [GCPBATCH]
+
+files {
+  workflow: retry_with_more_memory/gcpbatch/retry_with_more_memory.wdl
+  inputs: gcpbatch/batch_backend.inputs
+}
+
+metadata {
+  workflowName: retry_with_more_memory
+  status: Failed
+  "failures.0.message": "Workflow failed"
+  "retry_with_more_memory.imitate_oom_error.-1.1.executionStatus": "RetryableFailure"
+  "retry_with_more_memory.imitate_oom_error.-1.1.runtimeAttributes.memory": "1 GB"
+  "retry_with_more_memory.imitate_oom_error.-1.2.executionStatus": "RetryableFailure"
+  "retry_with_more_memory.imitate_oom_error.-1.2.runtimeAttributes.memory": "1 GB"
+  "retry_with_more_memory.imitate_oom_error.-1.3.executionStatus": "Failed"
+  "retry_with_more_memory.imitate_oom_error.-1.3.runtimeAttributes.memory": "1 GB"
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/do_not_retry_rc0.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/do_not_retry_rc0.wdl
@@ -1,0 +1,21 @@
+version 1.0
+
+task imitate_oom_error {
+  command {
+    # This task mimics printing an exception that would cause it to retry with increased memory, but
+    # because there is no non-zero return code, the task does not retry.
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2
+  }
+  output {
+  }
+  runtime {
+    docker: "python:latest"
+    memory: "1 GB"
+    maxRetries: 2
+    backend: "GCPBATCH"
+  }
+}
+
+workflow do_not_retry_rc0 {
+  call imitate_oom_error
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/do_not_retry_rc1.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/do_not_retry_rc1.wdl
@@ -1,0 +1,22 @@
+version 1.0
+
+task imitate_oom_error {
+  command {
+    # This task mimics printing an exception that would cause it to retry with increased memory, but
+    # because the return code is 1 and continueOnReturnCode is true, the task does not retry.
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2 && (exit 1)
+  }
+  output {
+  }
+  runtime {
+    docker: "python:latest"
+    memory: "1 GB"
+    continueOnReturnCode: true
+    maxRetries: 2
+    backend: "GCPBATCH"
+  }
+}
+
+workflow do_not_retry_rc1 {
+  call imitate_oom_error
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/preemptible_and_memory_retry.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/preemptible_and_memory_retry.wdl
@@ -1,0 +1,40 @@
+version 1.0
+
+task imitate_oom_error_on_preemptible {
+  command {
+    # This task simulates a scenario where the tool is running and almost running OOM but before it does, the VM is
+    # preempted. On the next attempt, Cromwell will use a non-preemptible VM because `preemptible: 1` in runtime
+    # attributes. Since the VM was preempted on first attempt, Cromwell should not increase the memory on for second attempt.
+    # However, on second attempt, the VM won't preempt leading to a OOM exception simulation. And hence on the
+    # third attempt, Cromwell should have retried with more memory.
+
+    echo "Doing meaningful work..."
+
+    preemptible=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/scheduling/preemptible")
+
+    # Delete self if running on a preemptible VM
+    # Since `preemptible: 1` the job should be restarted on a non-preemptible VM.
+    if [ "$preemptible" = "TRUE" ]; then
+      fully_qualified_zone=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/zone)
+      zone=$(basename "$fully_qualified_zone")
+
+      gcloud compute instances delete $(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google") --zone=$zone -q
+    fi
+
+    # Should reach here on the second attempt
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2
+    exit 1
+  }
+
+  runtime {
+    preemptible: 1
+    docker: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+    memory: "1 GB"
+    maxRetries: 1
+    backend: "GCPBATCH"
+  }
+}
+
+workflow preemptible_and_memory_retry {
+  call imitate_oom_error_on_preemptible
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_same_memory_output_failure.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_same_memory_output_failure.wdl
@@ -1,0 +1,27 @@
+version 1.0
+
+task imitate_oom_error {
+  command {
+    # This task mimics printing an exception that would cause it to retry with increased memory, but
+    # because the return code is 1 and continueOnReturnCode is true, the task does not retry with more memory.
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2 && (exit 1)
+    # As a simulation of an OOM condition, do not create the 'foo' file. Cromwell should still be able to delocalize important detritus.
+    # touch foo
+  }
+  output {
+    # Since the file does not exist, this will cause the status to be Failed. The task will end up retrying,
+    # but memory does not increase.
+    File foo = "foo"
+  }
+  runtime {
+    docker: "python:latest"
+    memory: "1 GB"
+    continueOnReturnCode: true
+    maxRetries: 2
+    backend: "GCPBATCH"
+  }
+}
+
+workflow retry_same_memory_output_failure {
+  call imitate_oom_error
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_with_more_memory.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_with_more_memory.wdl
@@ -1,0 +1,22 @@
+version 1.0
+
+task imitate_oom_error {
+  command {
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2 && (exit 1)
+    # As a simulation of an OOM condition, do not create the 'foo' file. Cromwell should still be able to delocalize important detritus.
+    # touch foo
+  }
+  output {
+    File foo = "foo"
+  }
+  runtime {
+    docker: "python:latest"
+    memory: "1 GB"
+    maxRetries: 2
+    backend: "GCPBATCH"
+  }
+}
+
+workflow retry_with_more_memory {
+  call imitate_oom_error
+}

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_with_more_memory_after_137.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/retry_with_more_memory_after_137.wdl
@@ -1,0 +1,22 @@
+version 1.0
+
+task imitate_oom_error {
+  command {
+    printf "Exception in thread "main" java.lang.OutOfMemoryError: testing\n\tat Test.main(Test.java:1)\n" >&2
+    touch foo
+    exit 137
+  }
+  output {
+    File foo = "foo"
+  }
+  runtime {
+    docker: "python:latest"
+    memory: "1 GB"
+    maxRetries: 2
+    backend: "GCPBATCH"
+  }
+}
+
+workflow retry_with_more_memory_after_137 {
+  call imitate_oom_error
+}

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1154,8 +1154,8 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     womFile.mapFile { value =>
       (getPath(value), asAdHocFile(womFile)) match {
         case (Success(gcsPath: GcsPath), Some(adHocFile)) =>
-          // Ad hoc files will be placed directly at the root ("/cromwell_root/ad_hoc_file.txt") unlike other input files
-          // for which the full path is being propagated ("/cromwell_root/path/to/input_file.txt")
+          // Ad hoc files will be placed directly at the root ("/mnt/disks/cromwell_root/ad_hoc_file.txt") unlike other input files
+          // for which the full path is being propagated ("/mnt/disks/cromwell_root/path/to/input_file.txt")
           workingDisk.mountPoint.resolve(adHocFile.alternativeName.getOrElse(gcsPath.name)).pathAsString
         case (Success(path @ (_: GcsPath | _: HttpPath)), _) =>
           workingDisk.mountPoint.resolve(path.pathWithoutScheme).pathAsString
@@ -1200,9 +1200,9 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           /*
            * Strip the prefixes in RuntimeOutputMapping.prefixFilters from the path, one at a time.
            * For instance
-           * file:///cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt will progressively become
+           * file:///mnt/disks/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt will progressively become
            *
-           * /cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+           * /mnt/disks/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
            * bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
            * call-A/file.txt
            *

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -670,7 +670,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
                                             disks: Seq[GcpBatchAttachedDisk]
   ): (Path, GcpBatchAttachedDisk) = {
     val absolutePath = DefaultPathBuilder.get(path) match {
-      case p if !p.isAbsolute => GcpBatchWorkingDisk.MountPoint.resolve(p)
+      case p if !p.isAbsolute => GcpBatchWorkingDisk.MountPointPath.resolve(p)
       case p => p
     }
 
@@ -729,9 +729,9 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     }
 
   private val DockerMonitoringLogPath: Path =
-    GcpBatchWorkingDisk.MountPoint.resolve(gcpBatchCallPaths.batchMonitoringLogFilename)
+    GcpBatchWorkingDisk.MountPointPath.resolve(gcpBatchCallPaths.batchMonitoringLogFilename)
   private val DockerMonitoringScriptPath: Path =
-    GcpBatchWorkingDisk.MountPoint.resolve(gcpBatchCallPaths.batchMonitoringScriptFilename)
+    GcpBatchWorkingDisk.MountPointPath.resolve(gcpBatchCallPaths.batchMonitoringScriptFilename)
 
   // noinspection ActorMutableStateInspection
   @scala.annotation.unused
@@ -861,7 +861,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     )
   }
 
-  override lazy val commandDirectory: Path = GcpBatchWorkingDisk.MountPoint
+  override lazy val commandDirectory: Path = GcpBatchWorkingDisk.MountPointPath
 
   // Primary entry point for cromwell to run GCP Batch job
   override def executeAsync(): Future[ExecutionHandle] = {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
@@ -6,6 +6,7 @@ import cats.syntax.validated._
 import common.exception.MessageAggregation
 import common.validation.ErrorOr._
 import cromwell.backend.DiskPatterns._
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import wom.values._
 
@@ -72,7 +73,7 @@ case class BatchApiEmptyMountedDisk(diskType: DiskType, sizeGb: Int, mountPoint:
 }
 
 object GcpBatchWorkingDisk {
-  val MountPoint: Path = DefaultPathBuilder.get("/mnt/disks/cromwell_root")
+  val MountPoint: Path = DefaultPathBuilder.get(MountPointPath)
   val Name = "local-disk"
   val Default = GcpBatchWorkingDisk(DiskType.SSD, 10)
 }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/io/GcpBatchAttachedDisk.scala
@@ -6,7 +6,7 @@ import cats.syntax.validated._
 import common.exception.MessageAggregation
 import common.validation.ErrorOr._
 import cromwell.backend.DiskPatterns._
-import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPoint
 import cromwell.core.path.{DefaultPathBuilder, Path}
 import wom.values._
 
@@ -73,13 +73,13 @@ case class BatchApiEmptyMountedDisk(diskType: DiskType, sizeGb: Int, mountPoint:
 }
 
 object GcpBatchWorkingDisk {
-  val MountPoint: Path = DefaultPathBuilder.get(MountPointPath)
+  val MountPointPath: Path = DefaultPathBuilder.get(MountPoint)
   val Name = "local-disk"
   val Default = GcpBatchWorkingDisk(DiskType.SSD, 10)
 }
 
 case class GcpBatchWorkingDisk(diskType: DiskType, sizeGb: Int) extends GcpBatchAttachedDisk {
-  val mountPoint: Path = GcpBatchWorkingDisk.MountPoint
+  val mountPoint: Path = GcpBatchWorkingDisk.MountPointPath
   val name: String = GcpBatchWorkingDisk.Name
 
   override def toString: String = s"$name $sizeGb ${diskType.diskTypeName}"

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchParameters.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchParameters.scala
@@ -32,7 +32,7 @@ sealed trait BatchParameter {
   /**
     * Path in the docker container. It must be mounted on the docker from / to its hostPath
     *
-    * e.g: /cromwell_root/root_bucket/input_data/my_input.bam
+    * e.g: /mnt/disks/cromwell_root/root_bucket/input_data/my_input.bam
     */
   def containerPath: Path = mount.mountPoint.resolve(relativeHostPath)
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/RunStatus.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/RunStatus.scala
@@ -47,7 +47,8 @@ object RunStatus {
               "A VM for a job is unexpectedly recreated during run time"
           }
         case None =>
-          eventList.headOption
+          // Take the last event as that is more likely to be indicative of what killed the job than the first event.
+          eventList.lastOption
             .map(_.name)
             .getOrElse(
               "The job has failed but the exit code couldn't be derived, there isn't an event message either, please review the logs and report a bug"

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/ContainerSetup.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/ContainerSetup.scala
@@ -6,7 +6,7 @@ trait ContainerSetup {
   import RunnableLabels._
 
   def containerSetupRunnables(volumes: List[Volume]): List[Runnable] = {
-    val containerRoot = RunnableUtils.MountPointPath
+    val containerRoot = RunnableUtils.MountPoint
 
     // As opposed to V1, the container root does not have a 777 umask, which can cause issues for docker running as non root
     // Run a first action to create the root and give it the right permissions

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/ContainerSetup.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/ContainerSetup.scala
@@ -1,13 +1,12 @@
 package cromwell.backend.google.batch.runnable
 
 import com.google.cloud.batch.v1.{Runnable, Volume}
-import cromwell.backend.google.batch.io.GcpBatchWorkingDisk
 
 trait ContainerSetup {
   import RunnableLabels._
 
   def containerSetupRunnables(volumes: List[Volume]): List[Runnable] = {
-    val containerRoot = GcpBatchWorkingDisk.MountPoint.pathAsString
+    val containerRoot = RunnableUtils.MountPointPath
 
     // As opposed to V1, the container root does not have a 777 umask, which can cause issues for docker running as non root
     // Run a first action to create the root and give it the right permissions

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
@@ -163,7 +163,7 @@ object RunnableCommands {
 
   def checkIfStderrContainsRetryKeys(retryLookupKeys: List[String]): String = {
     val lookupKeysAsString = retryLookupKeys.mkString("|")
-    s"grep -E -q '$lookupKeysAsString' /cromwell_root/stderr ; echo $$? > /cromwell_root/memory_retry_rc"
+    s"grep -E -q '$lookupKeysAsString' /mnt/disks/cromwell_root/stderr ; echo $$? > /mnt/disks/cromwell_root/memory_retry_rc"
   }
 
   def multiLineCommandTransformer(shell: String)(commandString: String): String = {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
@@ -163,7 +163,7 @@ object RunnableCommands {
 
   def checkIfStderrContainsRetryKeys(retryLookupKeys: List[String]): String = {
     val lookupKeysAsString = retryLookupKeys.mkString("|")
-    s"grep -E -q '$lookupKeysAsString' $MountPointPath/stderr ; echo $$? > $MountPointPath/memory_retry_rc"
+    s"grep -E -q '$lookupKeysAsString' $MountPoint/stderr ; echo $$? > $MountPoint/memory_retry_rc"
   }
 
   def multiLineCommandTransformer(shell: String)(commandString: String): String = {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableCommands.scala
@@ -163,7 +163,7 @@ object RunnableCommands {
 
   def checkIfStderrContainsRetryKeys(retryLookupKeys: List[String]): String = {
     val lookupKeysAsString = retryLookupKeys.mkString("|")
-    s"grep -E -q '$lookupKeysAsString' /mnt/disks/cromwell_root/stderr ; echo $$? > /mnt/disks/cromwell_root/memory_retry_rc"
+    s"grep -E -q '$lookupKeysAsString' $MountPointPath/stderr ; echo $$? > $MountPointPath/memory_retry_rc"
   }
 
   def multiLineCommandTransformer(shell: String)(commandString: String): String = {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -9,6 +9,8 @@ object RunnableUtils {
 
   private val config = ConfigFactory.load().getConfig("google")
 
+  val MountPointPath: String = "/mnt/disks/cromwell_root"
+
   /**
     * An image with the Google Cloud SDK installed.
     * http://gcr.io/google.com/cloudsdktool/cloud-sdk

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -9,7 +9,7 @@ object RunnableUtils {
 
   private val config = ConfigFactory.load().getConfig("google")
 
-  val MountPointPath: String = "/mnt/disks/cromwell_root"
+  val MountPoint: String = "/mnt/disks/cromwell_root"
 
   /**
     * An image with the Google Cloud SDK installed.

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/RuntimeOutputMapping.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/RuntimeOutputMapping.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.google.batch.util
 
 import common.util.StringUtil._
-import cromwell.backend.google.batch.io.GcpBatchWorkingDisk
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
 import cromwell.core.path.Path
 
 object RuntimeOutputMapping {
@@ -14,19 +14,19 @@ object RuntimeOutputMapping {
    *
    * For instance:
    *
-   * file:///cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+   * file:///mnt/disks/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
    * ->
    * call-A/file.txt
    *
    * Which will be delocalized to
    * gs://bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-B/call-A/file.txt
    * instead of
-   * gs://bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-B/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
+   * gs://bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-B/mnt/disks/cromwell_root/bucket/workflow_name/6d777414-5ee7-4c60-8b9e-a02ec44c398e/call-A/file.txt
    */
   def prefixFilters(workflowRoot: Path): List[String] = List(
     "file://",
     "/",
-    GcpBatchWorkingDisk.MountPoint.pathAsString.relativeDirectory,
+    MountPointPath.relativeDirectory,
     workflowRoot.pathWithoutScheme.relativeDirectory
   )
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/RuntimeOutputMapping.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/RuntimeOutputMapping.scala
@@ -1,7 +1,7 @@
 package cromwell.backend.google.batch.util
 
 import common.util.StringUtil._
-import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPoint
 import cromwell.core.path.Path
 
 object RuntimeOutputMapping {
@@ -26,7 +26,7 @@ object RuntimeOutputMapping {
   def prefixFilters(workflowRoot: Path): List[String] = List(
     "file://",
     "/",
-    MountPointPath.relativeDirectory,
+    MountPoint.relativeDirectory,
     workflowRoot.pathWithoutScheme.relativeDirectory
   )
 

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -20,7 +20,11 @@ import cromwell.backend.google.batch.models._
 import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
 import cromwell.backend.google.batch.util.BatchExpressionFunctions
 import cromwell.backend.io.JobPathsSpecHelper._
-import cromwell.backend.standard.{DefaultStandardAsyncExecutionActorParams, StandardAsyncExecutionActorParams, StandardExpressionFunctionsParams}
+import cromwell.backend.standard.{
+  DefaultStandardAsyncExecutionActorParams,
+  StandardAsyncExecutionActorParams,
+  StandardExpressionFunctionsParams
+}
 import cromwell.core._
 import cromwell.core.callcaching.NoDocker
 import cromwell.core.labels.Labels

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -17,13 +17,10 @@ import cromwell.backend._
 import cromwell.backend.google.batch.api.GcpBatchRequestFactory
 import cromwell.backend.google.batch.io.{DiskType, GcpBatchWorkingDisk}
 import cromwell.backend.google.batch.models._
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
 import cromwell.backend.google.batch.util.BatchExpressionFunctions
 import cromwell.backend.io.JobPathsSpecHelper._
-import cromwell.backend.standard.{
-  DefaultStandardAsyncExecutionActorParams,
-  StandardAsyncExecutionActorParams,
-  StandardExpressionFunctionsParams
-}
+import cromwell.backend.standard.{DefaultStandardAsyncExecutionActorParams, StandardAsyncExecutionActorParams, StandardExpressionFunctionsParams}
 import cromwell.core._
 import cromwell.core.callcaching.NoDocker
 import cromwell.core.labels.Labels
@@ -279,7 +276,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     )
 
     GcpBatchAsyncBackendJobExecutionActor.generateDrsLocalizerManifest(inputs) shouldEqual
-      "drs://drs.example.org/aaa,/mnt/disks/cromwell_root/path/to/aaa.bai\r\ndrs://drs.example.org/bbb,/mnt/disks/cromwell_root/path/to/bbb.bai\r\n"
+      s"drs://drs.example.org/aaa,$MountPointPath/path/to/aaa.bai\r\ndrs://drs.example.org/bbb,$MountPointPath/path/to/bbb.bai\r\n"
   }
 
   it should "map GCS paths and *only* GCS paths to local" in {
@@ -372,7 +369,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
         }
 
         mappedInputs(gcsFileKey) match {
-          case wdlFile: WomSingleFile => wdlFile.value shouldBe "/mnt/disks/cromwell_root/blah/abc"
+          case wdlFile: WomSingleFile => wdlFile.value shouldBe s"$MountPointPath/blah/abc"
           case _ => fail("test setup error")
         }
       case Left(badtimes) => fail(badtimes.toList.mkString(", "))
@@ -843,54 +840,54 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
 
     val batchOutputs = Set(
       GcpBatchFileOutput(
-        "/cromwell_root/path/to/file1",
+        s"$MountPointPath/path/to/file1",
         gcsPath("gs://path/to/file1"),
-        DefaultPathBuilder.get("/cromwell_root/path/to/file1"),
+        DefaultPathBuilder.get(s"$MountPointPath/path/to/file1"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        "/cromwell_root/path/to/file2",
+        s"$MountPointPath/path/to/file2",
         gcsPath("gs://path/to/file2"),
-        DefaultPathBuilder.get("/cromwell_root/path/to/file2"),
+        DefaultPathBuilder.get(s"$MountPointPath/path/to/file2"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        "/cromwell_root/path/to/file3",
+        s"$MountPointPath/path/to/file3",
         gcsPath("gs://path/to/file3"),
-        DefaultPathBuilder.get("/cromwell_root/path/to/file3"),
+        DefaultPathBuilder.get(s"$MountPointPath/path/to/file3"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        "/cromwell_root/path/to/file4",
+        s"$MountPointPath/path/to/file4",
         gcsPath("gs://path/to/file4"),
-        DefaultPathBuilder.get("/cromwell_root/path/to/file4"),
+        DefaultPathBuilder.get(s"$MountPointPath/path/to/file4"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        "/cromwell_root/path/to/file5",
+        s"$MountPointPath/path/to/file5",
         gcsPath("gs://path/to/file5"),
-        DefaultPathBuilder.get("/cromwell_root/path/to/file5"),
+        DefaultPathBuilder.get(s"$MountPointPath/path/to/file5"),
         workingDisk,
         optional = false,
         secondary = false
       )
     )
     val outputValues = Seq(
-      WomSingleFile("/cromwell_root/path/to/file1"),
+      WomSingleFile(s"$MountPointPath/path/to/file1"),
       WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile("/cromwell_root/path/to/file2"), WomSingleFile("/cromwell_root/path/to/file3"))
+               Seq(WomSingleFile(s"$MountPointPath/path/to/file2"), WomSingleFile(s"$MountPointPath/path/to/file3"))
       ),
       WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
              Map(
-               WomSingleFile("/cromwell_root/path/to/file4") -> WomSingleFile("/cromwell_root/path/to/file5")
+               WomSingleFile(s"$MountPointPath/path/to/file4") -> WomSingleFile(s"$MountPointPath/path/to/file5")
              )
       )
     )

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -17,7 +17,7 @@ import cromwell.backend._
 import cromwell.backend.google.batch.api.GcpBatchRequestFactory
 import cromwell.backend.google.batch.io.{DiskType, GcpBatchWorkingDisk}
 import cromwell.backend.google.batch.models._
-import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPoint
 import cromwell.backend.google.batch.util.BatchExpressionFunctions
 import cromwell.backend.io.JobPathsSpecHelper._
 import cromwell.backend.standard.{
@@ -280,7 +280,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     )
 
     GcpBatchAsyncBackendJobExecutionActor.generateDrsLocalizerManifest(inputs) shouldEqual
-      s"drs://drs.example.org/aaa,$MountPointPath/path/to/aaa.bai\r\ndrs://drs.example.org/bbb,$MountPointPath/path/to/bbb.bai\r\n"
+      s"drs://drs.example.org/aaa,$MountPoint/path/to/aaa.bai\r\ndrs://drs.example.org/bbb,$MountPoint/path/to/bbb.bai\r\n"
   }
 
   it should "map GCS paths and *only* GCS paths to local" in {
@@ -373,7 +373,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
         }
 
         mappedInputs(gcsFileKey) match {
-          case wdlFile: WomSingleFile => wdlFile.value shouldBe s"$MountPointPath/blah/abc"
+          case wdlFile: WomSingleFile => wdlFile.value shouldBe s"$MountPoint/blah/abc"
           case _ => fail("test setup error")
         }
       case Left(badtimes) => fail(badtimes.toList.mkString(", "))
@@ -844,54 +844,54 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
 
     val batchOutputs = Set(
       GcpBatchFileOutput(
-        s"$MountPointPath/path/to/file1",
+        s"$MountPoint/path/to/file1",
         gcsPath("gs://path/to/file1"),
-        DefaultPathBuilder.get(s"$MountPointPath/path/to/file1"),
+        DefaultPathBuilder.get(s"$MountPoint/path/to/file1"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPointPath/path/to/file2",
+        s"$MountPoint/path/to/file2",
         gcsPath("gs://path/to/file2"),
-        DefaultPathBuilder.get(s"$MountPointPath/path/to/file2"),
+        DefaultPathBuilder.get(s"$MountPoint/path/to/file2"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPointPath/path/to/file3",
+        s"$MountPoint/path/to/file3",
         gcsPath("gs://path/to/file3"),
-        DefaultPathBuilder.get(s"$MountPointPath/path/to/file3"),
+        DefaultPathBuilder.get(s"$MountPoint/path/to/file3"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPointPath/path/to/file4",
+        s"$MountPoint/path/to/file4",
         gcsPath("gs://path/to/file4"),
-        DefaultPathBuilder.get(s"$MountPointPath/path/to/file4"),
+        DefaultPathBuilder.get(s"$MountPoint/path/to/file4"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPointPath/path/to/file5",
+        s"$MountPoint/path/to/file5",
         gcsPath("gs://path/to/file5"),
-        DefaultPathBuilder.get(s"$MountPointPath/path/to/file5"),
+        DefaultPathBuilder.get(s"$MountPoint/path/to/file5"),
         workingDisk,
         optional = false,
         secondary = false
       )
     )
     val outputValues = Seq(
-      WomSingleFile(s"$MountPointPath/path/to/file1"),
+      WomSingleFile(s"$MountPoint/path/to/file1"),
       WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile(s"$MountPointPath/path/to/file2"), WomSingleFile(s"$MountPointPath/path/to/file3"))
+               Seq(WomSingleFile(s"$MountPoint/path/to/file2"), WomSingleFile(s"$MountPoint/path/to/file3"))
       ),
       WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
              Map(
-               WomSingleFile(s"$MountPointPath/path/to/file4") -> WomSingleFile(s"$MountPointPath/path/to/file5")
+               WomSingleFile(s"$MountPoint/path/to/file4") -> WomSingleFile(s"$MountPoint/path/to/file5")
              )
       )
     )

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
@@ -4,7 +4,7 @@ import com.google.cloud.batch.v1.{Runnable, Volume}
 import common.assertion.CromwellTimeoutSpec
 import cromwell.backend.google.batch.runnable.RunnableBuilder.EnhancedRunnableBuilder
 import cromwell.backend.google.batch.runnable.RunnableLabels._
-import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPoint
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -68,7 +68,7 @@ class RunnableBuilderSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matc
   def memoryRetryExpectedCommand(lookupString: String): List[String] =
     List(
       "-c",
-      s"grep -E -q '$lookupString' $MountPointPath/stderr ; echo $$? > $MountPointPath/memory_retry_rc"
+      s"grep -E -q '$lookupString' $MountPoint/stderr ; echo $$? > $MountPoint/memory_retry_rc"
     )
 
   val volumes = List(

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
@@ -4,6 +4,7 @@ import com.google.cloud.batch.v1.{Runnable, Volume}
 import common.assertion.CromwellTimeoutSpec
 import cromwell.backend.google.batch.runnable.RunnableBuilder.EnhancedRunnableBuilder
 import cromwell.backend.google.batch.runnable.RunnableLabels._
+import cromwell.backend.google.batch.runnable.RunnableUtils.MountPointPath
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -67,7 +68,7 @@ class RunnableBuilderSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matc
   def memoryRetryExpectedCommand(lookupString: String): List[String] =
     List(
       "-c",
-      s"grep -E -q '$lookupString' /mnt/disks/cromwell_root/stderr ; echo $$? > /mnt/disks/cromwell_root/memory_retry_rc"
+      s"grep -E -q '$lookupString' $MountPointPath/stderr ; echo $$? > $MountPointPath/memory_retry_rc"
     )
 
   val volumes = List(

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/runnable/RunnableBuilderSpec.scala
@@ -67,7 +67,7 @@ class RunnableBuilderSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matc
   def memoryRetryExpectedCommand(lookupString: String): List[String] =
     List(
       "-c",
-      s"grep -E -q '$lookupString' /cromwell_root/stderr ; echo $$? > /cromwell_root/memory_retry_rc"
+      s"grep -E -q '$lookupString' /mnt/disks/cromwell_root/stderr ; echo $$? > /mnt/disks/cromwell_root/memory_retry_rc"
     )
 
   val volumes = List(


### PR DESCRIPTION
### Description

The PR exercises the "retry with more memory" Centaur tests on the GCP Batch backend. Minimal changes to production code, all of which are in the GCP Batch backend:

- The constant`RunnableUtils#MountPoint` was created with value `/mnt/disks/cromwell_root` and applied where appropriate.
- A copy/paste bug in code brought over from PAPIv2 was corrected (the `/cromwell_root` of PAPIv2 has become `/mnt/disks/cromwell_root` in Batch), using the constant described above.
- If a job fails, the *last* event message is now propagated rather than the first event message. The first event message is often a benign state transition, while the last event message is more likely to contain the actual reason for job failure.
 
Unfortunately Cromwell does not allow for dynamic backend selection (i.e. the backend name cannot be a variable), which necessitated copy/paste/renaming the Centaur test WDLs from their PAPIv2 versions, hence the magnitude of these diffs.

The existing `preemptible_and_memory_retry ` Centaur test is heavily tailored to the quirks of Papi v2: a preemptible PAPI VM deletes itself and depends on the Lifesciences system mistaking that for a preemption event. tbh this is kind of a weird test and as I don't know how to induce a preemption on demand, I simply `ignore`d the GCPBATCH version.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users