### PR TITLE
WX-927 Lots of Centaur tests for GCPBATCH

### DIFF
--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
@@ -2,7 +2,7 @@ ignore: false
 name: abort.restart_abort_jes
 testFormat: ScheduledAbortWithRestart
 callMark: scheduled_abort.aborted
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: abort/scheduled_abort.wdl

--- a/centaur/src/main/resources/standardTestCases/attempt_to_call_size_function_on_bucket.test
+++ b/centaur/src/main/resources/standardTestCases/attempt_to_call_size_function_on_bucket.test
@@ -1,6 +1,6 @@
 name: attempt_to_call_size_function_on_bucket
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: attempt_to_call_size_function_on_bucket/attempt_to_call_size_function_on_bucket.wdl

--- a/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
+++ b/centaur/src/main/resources/standardTestCases/bucket_name_with_no_trailing_slash.test
@@ -1,6 +1,6 @@
 name: bucket_name_with_no_trailing_slash
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: attempt_to_localize_bucket_as_file/attempt_to_localize_bucket_as_file.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
@@ -1,6 +1,6 @@
 name: call_cache_capoeira_jes
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [Papi, Local, GCPBATCH]
 retryTestFailures: false
 
 files {

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_empty_hint_papi.test
@@ -1,7 +1,7 @@
 # A list of call cache hint prefixes is explicitly specified but empty.
 name: call_cache_hit_prefixes_empty_hint_papi
 testFormat: runtwiceexpectingcallcaching
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi.test
@@ -3,7 +3,7 @@
 # should not see the first's cache entries.
 name: call_cache_hit_prefixes_two_roots_empty_hint_cache_hit_papi
 testFormat: runthriceexpectingcallcaching
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi.test
@@ -2,7 +2,7 @@
 # Each run has different "jes_gcs_root"s so they should not see each other's cache entries.
 name: call_cache_hit_prefixes_two_roots_empty_hint_cache_miss_papi
 testFormat: runtwiceexpectingnocallcaching
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: call_cache_hit_prefixes/call_cache_hit_prefixes.wdl

--- a/centaur/src/main/resources/standardTestCases/checkpointing.test
+++ b/centaur/src/main/resources/standardTestCases/checkpointing.test
@@ -1,6 +1,6 @@
 name: checkpointing
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: checkpointing/checkpointing.wdl

--- a/centaur/src/main/resources/standardTestCases/collections_delete.test
+++ b/centaur/src/main/resources/standardTestCases/collections_delete.test
@@ -2,7 +2,7 @@
 
 name: collections_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/collections_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/confirm_preemptible.test
+++ b/centaur/src/main/resources/standardTestCases/confirm_preemptible.test
@@ -1,6 +1,6 @@
 name: confirm_preemptible
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: confirm_preemptible/confirm_preemptible.wdl

--- a/centaur/src/main/resources/standardTestCases/copy_workflow_outputs_scattered_papi.test
+++ b/centaur/src/main/resources/standardTestCases/copy_workflow_outputs_scattered_papi.test
@@ -1,5 +1,5 @@
 name: copy_workflow_outputs_scattered_papi
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 testFormat: workflowsuccess
 
 files {

--- a/centaur/src/main/resources/standardTestCases/copy_workflow_outputs_unscattered_papi.test
+++ b/centaur/src/main/resources/standardTestCases/copy_workflow_outputs_unscattered_papi.test
@@ -1,5 +1,5 @@
 name: copy_workflow_outputs_unscattered_papi
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 testFormat: workflowsuccess
 
 files {

--- a/centaur/src/main/resources/standardTestCases/custom_entrypoint.test
+++ b/centaur/src/main/resources/standardTestCases/custom_entrypoint.test
@@ -1,6 +1,6 @@
 name: custom_entrypoint
 testFormat: workflowsuccess
-backends: [Papi, Papiv2]
+backends: [Papi, Papiv2, GCPBATCH]
 
 files {
   workflow: custom_entrypoint/custom_entrypoint.wdl

--- a/centaur/src/main/resources/standardTestCases/custom_mount_point.test
+++ b/centaur/src/main/resources/standardTestCases/custom_mount_point.test
@@ -1,6 +1,6 @@
 name: custom_mount_point
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: custom_mount_point/custom_mount_point.wdl

--- a/centaur/src/main/resources/standardTestCases/dedup_localizations_papi_v2.test
+++ b/centaur/src/main/resources/standardTestCases/dedup_localizations_papi_v2.test
@@ -1,6 +1,6 @@
 name: dedup_localizations_papi_v2
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: dedup_localizations_papi_v2/dedup_localizations_papi_v2.wdl

--- a/centaur/src/main/resources/standardTestCases/directory_type_output_papi.test
+++ b/centaur/src/main/resources/standardTestCases/directory_type_output_papi.test
@@ -1,7 +1,7 @@
 name: directory_type_output_papi
 testFormat: workflowsuccess
 tags: ["wdl_cascades"]
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: wdl_cascades/directory_type_output/directory_type_output.wdl

--- a/centaur/src/main/resources/standardTestCases/directory_type_papi.test
+++ b/centaur/src/main/resources/standardTestCases/directory_type_papi.test
@@ -1,7 +1,7 @@
 name: directory_type_papi
 testFormat: workflowsuccess
 tags: ["wdl_cascades"]
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: wdl_cascades/directory_type/directory_type.wdl

--- a/centaur/src/main/resources/standardTestCases/do_not_retry_rc1.test
+++ b/centaur/src/main/resources/standardTestCases/do_not_retry_rc1.test
@@ -1,6 +1,6 @@
 name: do_not_retry_rc1
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/do_not_retry_rc1.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private.test
@@ -1,6 +1,6 @@
 name: docker_hash_dockerhub_private
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_hash_gcr_private.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_gcr_private.test
@@ -1,6 +1,6 @@
 name: docker_hash_gcr_private
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: docker_hash/docker_hash_gcr_private.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
@@ -1,6 +1,6 @@
 name: docker_size_dockerhub
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: docker_size/docker_size_dockerhub.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
@@ -1,6 +1,6 @@
 name: docker_size_gcr
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: docker_size/docker_size_gcr.wdl

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -1,6 +1,6 @@
 name: draft3_call_cache_capoeira_jes
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [Papi, Local, GCPBATCH]
 workflowType: WDL
 workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]

--- a/centaur/src/main/resources/standardTestCases/draft3_custom_mount_point.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_custom_mount_point.test
@@ -1,6 +1,6 @@
 name: draft3_custom_mount_point
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: wdl_draft3/custom_mount_point/custom_mount_point.wdl

--- a/centaur/src/main/resources/standardTestCases/draft3_nio_file_papi2.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_nio_file_papi2.test
@@ -3,7 +3,7 @@ testFormat: workflowsuccess
 workflowType: WDL
 workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: wdl_draft3/draft3_nio_file/draft3_nio_file_papi2.wdl

--- a/centaur/src/main/resources/standardTestCases/draft3_read_write_functions_papi.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_read_write_functions_papi.test
@@ -1,7 +1,7 @@
 name: draft3_read_write_functions_papi
 testFormat: workflowsuccess
 tags: ["wdl_1.0"]
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 tags: ["wdl_1.0"]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
+++ b/centaur/src/main/resources/standardTestCases/error_10_preemptible.test
@@ -1,6 +1,6 @@
 name: error_10_preemptible
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: error_10_preemptible/error_10_preemptible.wdl

--- a/centaur/src/main/resources/standardTestCases/exhaustive_delete.test
+++ b/centaur/src/main/resources/standardTestCases/exhaustive_delete.test
@@ -2,7 +2,7 @@
 
 name: exhaustive_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/exhaustive_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_jes.test
+++ b/centaur/src/main/resources/standardTestCases/failures.restart_while_failing_jes.test
@@ -1,7 +1,7 @@
 name: failures.restart_while_failing_jes
 testFormat: WorkflowFailureRestartWithRecover
 callMark: restart_while_failing.B1
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 tags: [restart]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/fast_fail_noAddress.test
+++ b/centaur/src/main/resources/standardTestCases/fast_fail_noAddress.test
@@ -1,6 +1,6 @@
 # NB: To request this test by name, make it lowercase, eg sbt "centaur/it:testOnly * -- -n fast_fail_noaddress"
 name: fast_fail_noAddress
-backends: [Papi,Papiv2]
+backends: [Papi,Papiv2, GCPBATCH]
 backendsMode: any
 testFormat: workflowfailure
 

--- a/centaur/src/main/resources/standardTestCases/fast_fail_noAddress.test
+++ b/centaur/src/main/resources/standardTestCases/fast_fail_noAddress.test
@@ -1,6 +1,6 @@
 # NB: To request this test by name, make it lowercase, eg sbt "centaur/it:testOnly * -- -n fast_fail_noaddress"
 name: fast_fail_noAddress
-backends: [Papi,Papiv2, GCPBATCH]
+backends: [Papi,Papiv2]
 backendsMode: any
 testFormat: workflowfailure
 

--- a/centaur/src/main/resources/standardTestCases/fast_fail_noAddress_gcpbatch.test
+++ b/centaur/src/main/resources/standardTestCases/fast_fail_noAddress_gcpbatch.test
@@ -1,0 +1,16 @@
+# NB: To request this test by name, make it lowercase, eg sbt "centaur/it:testOnly * -- -n fast_fail_noaddress_gcpbatch"
+# This is just like the PAPI v2 version except the error message has changed.
+name: fast_fail_noAddress_gcpbatch
+backends: [GCPBATCH]
+backendsMode: any
+testFormat: workflowfailure
+
+files {
+  workflow: fast_fail_noAddress/fast_fail_noAddress.wdl
+}
+
+metadata {
+  workflowName: fast_fail_noAddress
+  "failures.0.causedBy.0.message": "Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: no_external_ip_address field is invalid. both network and subnetwork have to be specified when no_external_ip_address is true). "
+  status: Failed
+}

--- a/centaur/src/main/resources/standardTestCases/final_call_logs_dir_jes.test
+++ b/centaur/src/main/resources/standardTestCases/final_call_logs_dir_jes.test
@@ -1,7 +1,7 @@
 # Tests that a runtime option to save call logs is copying said logs appropriately.
 
 name: final_call_logs_dir_jes
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 testFormat: workflowsuccess
 

--- a/centaur/src/main/resources/standardTestCases/gcs_file_name_with_newline_in_the_middle.test
+++ b/centaur/src/main/resources/standardTestCases/gcs_file_name_with_newline_in_the_middle.test
@@ -1,6 +1,6 @@
 name: gcs_file_name_with_spaces_in_the_middle
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: gcs_file_name_with_newline_in_the_middle/gcs_file_name_with_newline_in_the_middle.wdl

--- a/centaur/src/main/resources/standardTestCases/gcs_path_ending_with_newline.test
+++ b/centaur/src/main/resources/standardTestCases/gcs_path_ending_with_newline.test
@@ -1,6 +1,6 @@
 name: gcs_path_ending_with_newline
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: gcs_path_ending_with_newline/gcs_path_ending_with_newline.wdl

--- a/centaur/src/main/resources/standardTestCases/gcs_underscore_bucket.test
+++ b/centaur/src/main/resources/standardTestCases/gcs_underscore_bucket.test
@@ -1,6 +1,6 @@
 name: gcs_underscore_bucket
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   inputs: gcs_underscore_bucket/gcs_underscore_bucket.inputs

--- a/centaur/src/main/resources/standardTestCases/google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_bad.test
@@ -1,6 +1,6 @@
 name: google_labels_bad
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: google_labels/google_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/google_labels_good.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_good.test
@@ -1,6 +1,6 @@
 name: google_labels_good
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: google_labels/google_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/google_labels_subworkflows.test
+++ b/centaur/src/main/resources/standardTestCases/google_labels_subworkflows.test
@@ -1,6 +1,6 @@
 name: google_labels_sub
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: google_labels/wrapper.wdl

--- a/centaur/src/main/resources/standardTestCases/gpu_cuda_image.test
+++ b/centaur/src/main/resources/standardTestCases/gpu_cuda_image.test
@@ -1,6 +1,6 @@
 name: gpu_cuda_image
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 ignore: true
 
 files {

--- a/centaur/src/main/resources/standardTestCases/gpu_on_papi_invalid.test
+++ b/centaur/src/main/resources/standardTestCases/gpu_on_papi_invalid.test
@@ -1,6 +1,6 @@
 name: gpu_on_papi_invalid
 testFormat: workflowfailure
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: gpu_on_papi/gpu_on_papi.wdl

--- a/centaur/src/main/resources/standardTestCases/gpu_on_papi_valid.test
+++ b/centaur/src/main/resources/standardTestCases/gpu_on_papi_valid.test
@@ -1,6 +1,6 @@
 name: gpu_on_papi_valid
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 ignore: true
 
 files {

--- a/centaur/src/main/resources/standardTestCases/hello_delete.test
+++ b/centaur/src/main/resources/standardTestCases/hello_delete.test
@@ -2,7 +2,7 @@
 
 name: hello_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/hello_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
+++ b/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
@@ -1,6 +1,6 @@
 name: hello_google_legacy_machine_selection
 testFormat: workflowsuccess
-backends: [ Papiv2 ]
+backends: [ Papiv2, GCPBATCH ]
 
 files {
   workflow: wdl_draft3/hello/hello.wdl

--- a/centaur/src/main/resources/standardTestCases/http_inputs.test
+++ b/centaur/src/main/resources/standardTestCases/http_inputs.test
@@ -1,5 +1,5 @@
 name: http_inputs
-backends: [Local, Papiv2]
+backends: [Local, Papiv2, GCPBATCH]
 testFormat: workflowsuccess
 skipDescribeEndpointValidation: true
 

--- a/centaur/src/main/resources/standardTestCases/input_expressions.test
+++ b/centaur/src/main/resources/standardTestCases/input_expressions.test
@@ -1,6 +1,6 @@
 name: input_expressions
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [Papi, Local, GCPBATCH]
 
 files {
   workflow: input_expressions/input_expressions.wdl

--- a/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
+++ b/centaur/src/main/resources/standardTestCases/input_from_bucket_with_requester_pays.test
@@ -1,6 +1,6 @@
 name: input_from_bucket_with_requester_pays
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 ignore: true
 workflowType: WDL
 workflowTypeVersion: 1.0

--- a/centaur/src/main/resources/standardTestCases/invalid_use_reference_disks_specification.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_use_reference_disks_specification.test
@@ -1,6 +1,6 @@
 name: invalid_use_reference_disks_specification
 testFormat: workflowfailure
-backends: [ Papiv2 ]
+backends: [ Papiv2, GCPBATCH ]
 
 files {
   workflow: invalid_use_reference_disks_specification/invalid_use_reference_disks_specification.wdl

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
@@ -1,6 +1,6 @@
 name: invalidate_bad_caches_jes
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches.wdl

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_use_good_jes.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_use_good_jes.test
@@ -1,6 +1,6 @@
 name: invalidate_bad_caches_use_good_jes
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches_use_good.wdl

--- a/centaur/src/main/resources/standardTestCases/jes_labels.test
+++ b/centaur/src/main/resources/standardTestCases/jes_labels.test
@@ -1,7 +1,7 @@
 name: jes_labels
 testFormat: workflowsuccess
 tags: [ labels ]
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: labels/jes_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/large_final_workflow_outputs_dir.test
+++ b/centaur/src/main/resources/standardTestCases/large_final_workflow_outputs_dir.test
@@ -1,6 +1,6 @@
 name: large_final_workflow_outputs_dir
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: large_final_workflow_outputs_dir/large_final_workflow_outputs_dir.wdl

--- a/centaur/src/main/resources/standardTestCases/local_gcs.test
+++ b/centaur/src/main/resources/standardTestCases/local_gcs.test
@@ -1,6 +1,6 @@
 name: local_gcs
 testFormat: workflowsuccess
-backends: [Papi, Local]
+backends: [Papi, Local, GCPBATCH]
 
 files {
   workflow: local_gcs/local_gcs.wdl

--- a/centaur/src/main/resources/standardTestCases/localization_sanity_papi_v2.test
+++ b/centaur/src/main/resources/standardTestCases/localization_sanity_papi_v2.test
@@ -2,7 +2,7 @@ name: localization_sanity_papi_v2
 testFormat: workflowsuccess
 workflowType: WDL
 workflowTypeVersion: 1.0
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: localization_sanity_papi_v2/localization_sanity_papi_v2.wdl

--- a/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/lots_of_inputs_papiv2.test
@@ -4,7 +4,7 @@
 name: lots_of_inputs_papiv2
 testFormat: workflowsuccess
 tags: [ big_metadata ]
-backends: [ Papiv2 ]
+backends: [ Papiv2, GCPBATCH ]
 
 files {
   workflow: lots_of_inputs/lots_of_inputs.wdl

--- a/centaur/src/main/resources/standardTestCases/missing_delete.test
+++ b/centaur/src/main/resources/standardTestCases/missing_delete.test
@@ -2,7 +2,7 @@
 
 name: missing_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/missing_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/missing_input_failure_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/missing_input_failure_papiv2.test
@@ -1,6 +1,6 @@
 name: missing_input_failure_papiv2
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: missing_input_failure/missing_input_failure.wdl

--- a/centaur/src/main/resources/standardTestCases/monitoring_image_script.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_image_script.test
@@ -1,6 +1,6 @@
 name: monitoring_image_script
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: monitoring_image_script/monitoring_image_script.wdl

--- a/centaur/src/main/resources/standardTestCases/monitoring_image_script_with_entrypoints.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_image_script_with_entrypoints.test
@@ -1,6 +1,6 @@
 name: monitoring_image_script_with_entrypoints
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: monitoring_image_script/monitoring_image_script.wdl

--- a/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_log_papiv2.test
@@ -2,7 +2,7 @@
 
 name: monitoring_log
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: monitoring_log/monitoring_log.wdl

--- a/centaur/src/main/resources/standardTestCases/monitoring_script_localization_failure.test
+++ b/centaur/src/main/resources/standardTestCases/monitoring_script_localization_failure.test
@@ -1,6 +1,6 @@
 name: monitoring_script_localization_failure
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: monitoring_script_localization_failure/monitoring_script_localization_failure.wdl

--- a/centaur/src/main/resources/standardTestCases/no_cache_delete.test
+++ b/centaur/src/main/resources/standardTestCases/no_cache_delete.test
@@ -2,7 +2,7 @@
 
 name: no_cache_delete
 testFormat: runtwiceexpectingnocallcaching
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/no_cache_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/no_input_delete.test
+++ b/centaur/src/main/resources/standardTestCases/no_input_delete.test
@@ -2,7 +2,7 @@
 
 name: no_input_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/no_input_delete_setup.wdl

--- a/centaur/src/main/resources/standardTestCases/no_output_delete.test
+++ b/centaur/src/main/resources/standardTestCases/no_output_delete.test
@@ -2,7 +2,7 @@
 
 name: no_output_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/no_output_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/no_task_no_output_delete.test
+++ b/centaur/src/main/resources/standardTestCases/no_task_no_output_delete.test
@@ -2,7 +2,7 @@
 
 name: no_task_no_output_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/no_task_no_output_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
@@ -1,6 +1,6 @@
 name: papi_cpu_platform
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_cpu_platform/papi_cpu_platform.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_delocalization_required_files.test
+++ b/centaur/src/main/resources/standardTestCases/papi_delocalization_required_files.test
@@ -1,6 +1,6 @@
 name: papi_delocalization_required_files
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_delocalization_required_files/papi_delocalization_required_files.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_fail_on_bad_attrs.test
+++ b/centaur/src/main/resources/standardTestCases/papi_fail_on_bad_attrs.test
@@ -1,6 +1,6 @@
 name: papi_fail_on_bad_attrs
 testFormat: workflowfailure
-backends: [Papi] # Only PAPI should object to the malformed disk attribute
+backends: [Papi, GCPBATCH] # Only PAPI should object to the malformed disk attribute
 
 files {
   workflow: papi_fail_on_bad_attrs/papi_fail_on_bad_attrs.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_preemptible_and_max_retries.test
+++ b/centaur/src/main/resources/standardTestCases/papi_preemptible_and_max_retries.test
@@ -1,6 +1,6 @@
 name: papi_preemptible_and_max_retries
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_preemptible_and_max_retries/papi_preemptible_and_max_retries.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_v2_log.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2_log.test
@@ -1,6 +1,6 @@
 name: papi_v2_log
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_v2_log/papi_v2_log.wdl

--- a/centaur/src/main/resources/standardTestCases/papi_v2_plain_detritus.test
+++ b/centaur/src/main/resources/standardTestCases/papi_v2_plain_detritus.test
@@ -1,6 +1,6 @@
 name: papi_v2_plain_detritus
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_v2_plain_detritus/papi_v2_plain_detritus.wdl

--- a/centaur/src/main/resources/standardTestCases/parallel_composite_uploads_off_by_default.test
+++ b/centaur/src/main/resources/standardTestCases/parallel_composite_uploads_off_by_default.test
@@ -3,7 +3,7 @@
 
 name: parallel_composite_uploads_off_by_default
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: parallel_composite_uploads/parallel_composite_uploads_off.wdl

--- a/centaur/src/main/resources/standardTestCases/preemptible_and_memory_retry.test
+++ b/centaur/src/main/resources/standardTestCases/preemptible_and_memory_retry.test
@@ -1,6 +1,6 @@
 name: preemptible_and_memory_retry
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/preemptible_and_memory_retry.wdl

--- a/centaur/src/main/resources/standardTestCases/quota_fail_retry.test
+++ b/centaur/src/main/resources/standardTestCases/quota_fail_retry.test
@@ -1,6 +1,6 @@
 name: quota_fail_retry
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: quota_fail_retry/quota_fail_retry.wdl

--- a/centaur/src/main/resources/standardTestCases/requester_pays_engine_functions_negative.test
+++ b/centaur/src/main/resources/standardTestCases/requester_pays_engine_functions_negative.test
@@ -1,7 +1,7 @@
 name: requester_pays_engine_functions_negative
 testFormat: workflowfailure
 # Papiv2 backend configured SA does not have permission to bill the project, so this workflow should fail
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 workflowType: WDL
 workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]

--- a/centaur/src/main/resources/standardTestCases/requester_pays_localization_negative.test
+++ b/centaur/src/main/resources/standardTestCases/requester_pays_localization_negative.test
@@ -1,7 +1,7 @@
 name: requester_pays_localization_negative
 testFormat: workflowfailure
 # Papiv2 backend configured SA does not have permission to bill the project, so this workflow should fail
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 workflowType: WDL
 workflowTypeVersion: 1.0
 tags: ["wdl_1.0"]

--- a/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
+++ b/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
@@ -1,7 +1,7 @@
 name: restart_jes_with_recover
 testFormat: CromwellRestartWithRecover
 callMark: cromwell_restart.cromwell_killer
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: cromwell_restart/cromwell_restart.wdl

--- a/centaur/src/main/resources/standardTestCases/retry_same_memory_output_failure.test
+++ b/centaur/src/main/resources/standardTestCases/retry_same_memory_output_failure.test
@@ -1,6 +1,6 @@
 name: retry_same_memory_output_failure
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/retry_same_memory_output_failure.wdl

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory.test
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory.test
@@ -1,6 +1,6 @@
 name: retry_with_more_memory
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/retry_with_more_memory.wdl

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory_after_137.test
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory_after_137.test
@@ -1,6 +1,6 @@
 name: retry_with_more_memory_after_137
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/retry_with_more_memory_after_137.wdl

--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory_no_wf_option.test
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory_no_wf_option.test
@@ -1,6 +1,6 @@
 name: retry_with_more_memory_no_wf_option
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: retry_with_more_memory/retry_with_more_memory.wdl

--- a/centaur/src/main/resources/standardTestCases/scatter_delete.test
+++ b/centaur/src/main/resources/standardTestCases/scatter_delete.test
@@ -2,7 +2,7 @@
 
 name: scatter_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/scatter_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/scatter_simples_prepare_scatter_gather_papi.test
+++ b/centaur/src/main/resources/standardTestCases/scatter_simples_prepare_scatter_gather_papi.test
@@ -1,6 +1,6 @@
 name: prepare_scatter_gather_papi
 testFormat: workflowsuccess
-backends: [Papi]
+backends: [Papi, GCPBATCH]
 
 files {
   workflow: scatter_simples/prepare_scatter_gather.wdl

--- a/centaur/src/main/resources/standardTestCases/ssh_access.test
+++ b/centaur/src/main/resources/standardTestCases/ssh_access.test
@@ -1,6 +1,6 @@
 name: ssh_access
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 # CROM-6872: disabling this test because it is consistently failing in our test infrastructure. This
 #   is a community-contributed feature that is not officially supported by the Cromwell development
 #   team at the Broad Institute.

--- a/centaur/src/main/resources/standardTestCases/stdout_delete.test
+++ b/centaur/src/main/resources/standardTestCases/stdout_delete.test
@@ -2,7 +2,7 @@
 
 name: stdout_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/stdout_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/sub_workflow_delete.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_delete.test
@@ -2,7 +2,7 @@
 
 name: sub_workflow_delete
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: delete_intermediates/sub_workflow_delete.wdl

--- a/centaur/src/main/resources/standardTestCases/use_cacheCopy_dir.test
+++ b/centaur/src/main/resources/standardTestCases/use_cacheCopy_dir.test
@@ -1,6 +1,6 @@
 name: use_cache_copy_dir
 testFormat: runtwiceexpectingcallcaching
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: use_cacheCopy_dir/use_cacheCopy_dir.wdl

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: wdl_optional_outputs/wdl_optional_outputs.wdl

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_call_caching.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_call_caching.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs_call_caching
 testFormat: runtwiceexpectingcallcaching
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 # CROM-6807 Don't retry failures, subsequent runs will fail because of unexpected cache hits from the initial run
 retryTestFailures: false

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_draft2.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs_draft2
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: wdl_optional_outputs_draft2/wdl_optional_outputs_draft2.wdl

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs_unsupported
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: wdl_optional_outputs/wdl_optional_outputs_unsupported.wdl

--- a/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported_draft2.test
+++ b/centaur/src/main/resources/standardTestCases/wdl_optional_outputs_unsupported_draft2.test
@@ -1,6 +1,6 @@
 name: wdl_optional_outputs_unsupported_draft2
 testFormat: workflowfailure
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: wdl_optional_outputs_draft2/wdl_optional_outputs_unsupported_draft2.wdl

--- a/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
@@ -1,6 +1,6 @@
 name: workbench_health_monitor_check_papiv2
 testFormat: workflowsuccess
-backends: [Papiv2]
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: workbench_health_monitor_check/workbench_health_monitor_check.wdl


### PR DESCRIPTION
### Description

Turn on 90ish Centaur tests for GCPBATCH. In all but one case this was just adding the GCPBATCH backend to the Centaur .test file. The one exception involved different error message text coming from the Batch system than what we get from Lifesciences.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users