### PR TITLE
WX-1712 Much more complete metadata file location remapping

### DIFF
--- a/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/gcpWdlResultsMoving.test
+++ b/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/gcpWdlResultsMoving.test
@@ -17,16 +17,42 @@ metadata {
   "outputs.simpleWorkflow.outGlob.0": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-"~~
   "outputs.simpleWorkflow.outGlob.1": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-"~~
   "outputs.simpleWorkflow.outGlob.2": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-"~~
+
+  # TODO: Centaur's JSON flattening does not support nested arrays (`centaur.json.JsonUtils`)
+  # Consider a `files.metadata` key that simply supplies metadata JSON expectations as JSON.
+  # "outputs.simpleWorkflow.nested_array.0.0": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest1.txt"
+  # "outputs.simpleWorkflow.nested_array.0.1": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest2.txt"
+  # "outputs.simpleWorkflow.nested_array.1.0": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest3.txt"
+
+  "outputs.simpleWorkflow.myFoo.complex.right.t": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/object_out.txt"
 }
 
 # The `centaur-ci-us-east1` bucket is in a different region than the workflow runs
 fileSystemCheck: "gcs"
 outputExpectations: {
+    ### Destination
+
     "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/output.txt": 1
+
     # We don't currently have a way to check for glob contents, so do the next best thing by asserting the expected count
-    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/": 4
+    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/": 8
     # "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-3860fac5129fd76b802f49dcd7f9a9f6/foo.zardoz": 1
     # "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-3860fac5129fd76b802f49dcd7f9a9f6/bar.zardoz": 1
     # "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-3860fac5129fd76b802f49dcd7f9a9f6/baz.zardoz": 1
+
+    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest1.txt": 1
+    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest2.txt": 1
+    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest3.txt": 1
+
+    "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/object_out.txt": 1
+
+    ### Source
+
     "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/output.txt": 0
+
+    "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest1.txt": 0
+    "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest2.txt": 0
+    "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/simpleWorkflow<<UUID>>/call-simpleStdoutTask/arraytest3.txt": 0
+
+    "gs://cloud-cromwell-dev-self-cleaning/cromwell_execution/ci/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/object_out.txt": 0
 }

--- a/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/gcpWdlResultsMoving.test
+++ b/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/gcpWdlResultsMoving.test
@@ -19,7 +19,7 @@ metadata {
   "outputs.simpleWorkflow.outGlob.2": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/glob-"~~
 
   # TODO: Centaur's JSON flattening does not support nested arrays (`centaur.json.JsonUtils`)
-  # Consider a `files.metadata` key that simply supplies metadata JSON expectations as JSON.
+  # Consider using JsonPath (XPath for JSON) to traverse the tree, or check in a JSON file to use as expectation.
   # "outputs.simpleWorkflow.nested_array.0.0": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest1.txt"
   # "outputs.simpleWorkflow.nested_array.0.1": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest2.txt"
   # "outputs.simpleWorkflow.nested_array.1.0": "gs://centaur-ci-us-east1/move_destination/simpleWorkflow/<<UUID>>/call-simpleStdoutTask/arraytest3.txt"

--- a/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/wdlResultsCopying/simpleWorkflow.wdl
+++ b/centaur/src/main/resources/standardTestCases/resultsCopyingTestCases/wdlResultsCopying/simpleWorkflow.wdl
@@ -1,19 +1,37 @@
+version 1.0
+
 workflow simpleWorkflow {
     call simpleStdoutTask {}
     output {
         File outFile = simpleStdoutTask.outFile
         Array[File] outGlob = simpleStdoutTask.outGlob
+        FooStruct myFoo = object {
+            simple: 5,
+            complex: ([42], { "t": simpleStdoutTask.objectOutputFile })
+        }
+        Array[Array[File]] nested_array = [[simpleStdoutTask.arraytest1, simpleStdoutTask.arraytest2], [simpleStdoutTask.arraytest3]]
     }
+}
+
+struct FooStruct {
+  Int simple
+  Pair[Array[Int], Map[String, File]] complex
 }
 
 task simpleStdoutTask {
   String outputFileName = "output.txt"
+  String objectOutputFileName = "object_out.txt"
 
   command {
     echo 'Hello world' > ${outputFileName}
+    echo 'Hello world' > ${objectOutputFileName}
     echo 'foo' > "foo.zardoz"
     echo 'bar' > "bar.zardoz"
     echo 'baz' > "baz.zardoz"
+
+    echo "arraytest1" > "arraytest1.txt"
+    echo "arraytest2" > "arraytest2.txt"
+    echo "arraytest3" > "arraytest3.txt"
   }
 
   runtime {
@@ -24,6 +42,10 @@ task simpleStdoutTask {
 
   output {
     File outFile = outputFileName
+    File objectOutputFile = objectOutputFileName
     Array[File] outGlob = glob("*.zardoz")
+    File arraytest1 = "arraytest1.txt"
+    File arraytest2 = "arraytest2.txt"
+    File arraytest3 = "arraytest3.txt"
   }
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
@@ -1,6 +1,11 @@
 package cromwell.engine.workflow.lifecycle
 
-import cromwell.backend.{AllBackendInitializationData, BackendConfigurationDescriptor, BackendInitializationData, BackendLifecycleActorFactory}
+import cromwell.backend.{
+  AllBackendInitializationData,
+  BackendConfigurationDescriptor,
+  BackendInitializationData,
+  BackendLifecycleActorFactory
+}
 import cromwell.core.WorkflowOptions.UseRelativeOutputPaths
 import cromwell.core.path.{Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
@@ -1,16 +1,16 @@
 package cromwell.engine.workflow.lifecycle
 
-import cromwell.backend.{
-  AllBackendInitializationData,
-  BackendConfigurationDescriptor,
-  BackendInitializationData,
-  BackendLifecycleActorFactory
-}
+import cromwell.backend.{AllBackendInitializationData, BackendConfigurationDescriptor, BackendInitializationData, BackendLifecycleActorFactory}
 import cromwell.core.WorkflowOptions.UseRelativeOutputPaths
 import cromwell.core.path.{Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
+import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
 import wom.values.{WomSingleFile, WomValue}
+
+object OutputsLocationHelper {
+  type FileRelocationMap = Map[Path, Path]
+}
 
 trait OutputsLocationHelper {
 
@@ -25,7 +25,7 @@ trait OutputsLocationHelper {
                                       descriptor: EngineWorkflowDescriptor,
                                       backendInitData: AllBackendInitializationData,
                                       workflowOutputs: Seq[WomValue]
-  ): Map[Path, Path] = {
+  ): FileRelocationMap = {
     val workflowOutputsPath = PathFactory.buildPath(outputsDir, descriptor.pathBuilders)
     val useRelativeOutputPaths: Boolean = descriptor.getWorkflowOption(UseRelativeOutputPaths).contains("true")
     val rootAndFiles = for {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorRef
 import cromwell.backend.async.JobAlreadyFailedInJobStore
 import cromwell.core.ExecutionStatus._
 import cromwell.core._
+import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import wdl.draft2.model._
@@ -65,14 +66,15 @@ trait CallMetadataHelper {
     }
   }
 
-  def pushWorkflowOutputMetadata(outputs: Map[LocallyQualifiedName, WomValue]) = {
+  def pushWorkflowOutputMetadata(outputs: Map[LocallyQualifiedName, WomValue], fileMap: FileRelocationMap) = {
     val events = if (outputs.isEmpty) {
       List(MetadataEvent.empty(MetadataKey(workflowIdForCallMetadata, None, WorkflowMetadataKeys.Outputs)))
     } else {
       outputs flatMap { case (outputName, outputValue) =>
         womValueToMetadataEvents(
           MetadataKey(workflowIdForCallMetadata, None, s"${WorkflowMetadataKeys.Outputs}:$outputName"),
-          outputValue
+          outputValue,
+          fileMap
         )
       }
     }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -31,10 +31,17 @@ import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMa
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData.DataStoreUpdate
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor
-import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{ExpressionEvaluationFailedResponse, ExpressionEvaluationSucceededResponse}
+import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{
+  ExpressionEvaluationFailedResponse,
+  ExpressionEvaluationSucceededResponse
+}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.{ActiveExecutionStore, ExecutionStore}
-import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, EngineLifecycleActorAbortedResponse, OutputsLocationHelper}
+import cromwell.engine.workflow.lifecycle.{
+  EngineLifecycleActorAbortCommand,
+  EngineLifecycleActorAbortedResponse,
+  OutputsLocationHelper
+}
 import cromwell.engine.workflow.workflowstore.{RestartableAborting, StartableState}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.instrumentation.CromwellInstrumentation

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -24,22 +24,17 @@ import cromwell.core.WorkflowOptions.Move
 import cromwell.core._
 import cromwell.core.io.AsyncIo
 import cromwell.core.logging.WorkflowLogging
+import cromwell.core.path.Path
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendSingletonCollection, CromwellBackends}
+import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData.DataStoreUpdate
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor
-import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{
-  ExpressionEvaluationFailedResponse,
-  ExpressionEvaluationSucceededResponse
-}
+import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{ExpressionEvaluationFailedResponse, ExpressionEvaluationSucceededResponse}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.{ActiveExecutionStore, ExecutionStore}
-import cromwell.engine.workflow.lifecycle.{
-  EngineLifecycleActorAbortCommand,
-  EngineLifecycleActorAbortedResponse,
-  OutputsLocationHelper
-}
+import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, EngineLifecycleActorAbortedResponse, OutputsLocationHelper}
 import cromwell.engine.workflow.workflowstore.{RestartableAborting, StartableState}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.instrumentation.CromwellInstrumentation
@@ -414,34 +409,19 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
     import spray.json._
 
     def handleSuccessfulWorkflowOutputs(outputs: Map[GraphOutputNode, WomValue]) = {
-      val mapping: Map[String, String] =
+      val fileMap: FileRelocationMap =
         (workflowDescriptor.finalWorkflowOutputsDir, workflowDescriptor.finalWorkflowOutputsMode) match {
           case (Some(outputDir), Move) =>
             outputFilePathMapping(outputDir, workflowDescriptor, params.initializationData, outputs.values.toSeq) map {
               case (src, dst) =>
-                (src.pathAsString, dst.pathAsString)
+                (src, dst)
             }
           case _ =>
-            Map.empty[String, String]
-        }
-
-      def moveOrIdentity(value: WomValue): WomValue =
-        value match {
-          case single: WomSingleFile =>
-            mapping.get(single.valueString) match {
-              case Some(dst) =>
-                WomSingleFile(dst)
-              case None =>
-                single
-            }
-          case array: WomArray =>
-            WomArray(array.value.map(moveOrIdentity))
-          case nonFileValue =>
-            nonFileValue
+            Map.empty[Path, Path]
         }
 
       val fullyQualifiedOutputs = outputs map { case (outputNode, value) =>
-        outputNode.identifier.fullyQualifiedName.value -> moveOrIdentity(value)
+        outputNode.identifier.fullyQualifiedName.value -> value
       }
       // Publish fully qualified workflow outputs to log and metadata
       workflowLogger.info(
@@ -450,7 +430,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       )
 
       // Fully qualified to match `CALL_FQN` column in metadata table
-      pushWorkflowOutputMetadata(fullyQualifiedOutputs)
+      pushWorkflowOutputMetadata(fullyQualifiedOutputs, fileMap)
 
       val localOutputs = CallOutputs(outputs map { case (outputNode, value) =>
         outputNode.graphOutputPort -> value

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -208,6 +208,13 @@ object MetadataService {
     }
   }
 
+  /**
+    * @param metadataKey Coordinates uniquely identifying what this event describes, such as `outputs:my_workflow.file_array[5]`.
+    * @param womValue The value to be serialized into event(s). Complex types are flattened into multiple individual events.
+    * @param fileMap Files that copy/move after the workflow completes need to have their new location in metadata.
+    *                When creating events for files only, check the map for a possible new location, or empty map for no-op.
+    * @return Flat list of metadata events ready to be written to the database.
+    */
   def womValueToMetadataEvents(metadataKey: MetadataKey,
                                womValue: WomValue,
                                fileMap: Map[Path, Path] = Map.empty

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -208,7 +208,10 @@ object MetadataService {
     }
   }
 
-  def womValueToMetadataEvents(metadataKey: MetadataKey, womValue: WomValue, fileMap: Map[Path, Path] = Map.empty): Iterable[MetadataEvent] = womValue match {
+  def womValueToMetadataEvents(metadataKey: MetadataKey,
+                               womValue: WomValue,
+                               fileMap: Map[Path, Path] = Map.empty
+  ): Iterable[MetadataEvent] = womValue match {
     case WomArray(_, valueSeq) => valueSeq.toEvents(metadataKey, fileMap)
     case WomMap(_, valueMap) =>
       if (valueMap.isEmpty) {
@@ -233,8 +236,8 @@ object MetadataService {
         womValueToMetadataEvents(metadataKey.copy(key = metadataKey.key + ":right"), right, fileMap)
     case file: WomSingleFile =>
       // Our lookup key is a string; to avoid exceptions, stringify paths instead of pathifying the string
-      val stringifiedMap: Map[String, String] = fileMap map {
-        case (src: Path, dst: Path) => src.pathAsString -> dst.pathAsString
+      val stringifiedMap: Map[String, String] = fileMap map { case (src: Path, dst: Path) =>
+        src.pathAsString -> dst.pathAsString
       }
       // Why? When we copy/move final outputs, we need to map the original file to the destination file.
       val mappedFile: WomSingleFile = stringifiedMap.get(file.valueString) match {


### PR DESCRIPTION
### Description

While testing on Dev, I discovered that the Wom traversal in `moveOrIdentity` is woefully inadequate. We need to support structs, maps, pairs, etc. to call this feature complete.

In researching how to address this, I discovered `womValueToMetadataEvents` which seems like a much better pre-existing piece of code that already traverses all Wom types.

After [cleaning it up](https://github.com/broadinstitute/cromwell/pull/7499/files#diff-854b47290dea5287619fbe2c8cbcc3db06552b4a84d3456552e261efd086ad8cL246-L266) in https://github.com/broadinstitute/cromwell/pull/7499, this PR enhances it with file location mapping.

The Centaur test verifies mapping of a file in a map in a pair in a struct. Recursion!

```
struct FooStruct {
  Int simple
  Pair[Array[Int], Map[String, File]] complex
}
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users