### PR TITLE
WX-927 GCP Batch picks a bigger boot disk size and that's okay

### DIFF
--- a/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
@@ -1,5 +1,8 @@
 name: docker_size_dockerhub
 testFormat: workflowsuccess
+# Not testing this for GCP Batch since Batch seems to give us a 30 GiB boot volume even when we ask for 10 GiB.
+# Honestly that's fine, 30 GiB should be big enough to keep us out of trouble with large Docker images without being
+# noticeably more expensive.
 backends: [Papiv2]
 
 files {

--- a/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
@@ -1,5 +1,8 @@
 name: docker_size_gcr
 testFormat: workflowsuccess
+# Not testing this for GCP Batch since Batch seems to give us a 30 GiB boot volume even when we ask for 10 GiB.
+# Honestly that's fine, 30 GiB should be big enough to keep us out of trouble with large Docker images without being
+# noticeably more expensive.
 backends: [Papiv2]
 
 files {


### PR DESCRIPTION
### Description

Rationalize the non-testing of boot disk sizes for GCP Batch

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users