### PR TITLE
WX-1839 Remove GCS health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,12 @@ The config key `services.HealthMonitor.config.check-dockerhub` is therefore obso
 
 There is no change to any other usage of Docker Hub.
 
+#### Removed GCS health check
+
+Cromwell's health check of GCS has been removed. GCS does not have availability issues of note, and in typical configurations the check does not meaningfully test Cromwell's permissions.
+
+The config keys `services.HealthMonitor.config.check-gcs` and `.gcs-bucket-to-check` are therefore obsolete.
+
 #### Removed Genomics Backend code
 Code relating to the Google Genomics API (aka `v1Alpha`) has been removed since Google has entirely disabled that service.
 Cloud Life Sciences (aka `v2Beta`, deprecated) and Google Batch (aka `batch`, recommended) remain the two viable GCP backends.

--- a/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/workbench_health_monitor_check_papiv2.test
@@ -10,5 +10,5 @@ files {
 metadata {
   workflowName: workbench_health_monitor_check
   status: Succeeded
-  "outputs.workbench_health_monitor_check.out": """{"Engine Database":{"ok":true},"GCS":{"ok":true},"Papi":{"ok":true},"Papi-Caching-No-Copy":{"ok":true},"Papiv2":{"ok":true},"Papiv2-Reference-Disk-Localization":{"ok":true},"Papiv2-Virtual-Private-Cloud-Labels":{"ok":true},"Papiv2-Virtual-Private-Cloud-Literals":{"ok":true},"Papiv2NoDockerHubConfig":{"ok":true},"Papiv2RequesterPays":{"ok":true},"Papiv2USADockerhub":{"ok":true}}"""
+  "outputs.workbench_health_monitor_check.out": """{"Engine Database":{"ok":true},"Papi":{"ok":true},"Papi-Caching-No-Copy":{"ok":true},"Papiv2":{"ok":true},"Papiv2-Reference-Disk-Localization":{"ok":true},"Papiv2-Virtual-Private-Cloud-Labels":{"ok":true},"Papiv2-Virtual-Private-Cloud-Literals":{"ok":true},"Papiv2NoDockerHubConfig":{"ok":true},"Papiv2RequesterPays":{"ok":true},"Papiv2USADockerhub":{"ok":true}}"""
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -562,7 +562,6 @@ services {
     dispatcher = "akka.dispatchers.health-monitor-dispatcher"
     config {
       check-engine-database: false
-      check-gcs: false
       check-papi-backends: []
     }
   }

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -577,9 +577,6 @@ services {
       # NB: requires 'google-auth-name' to be set
       # check-papi-backends: [ PAPIv2 ]
 
-      # If you want to check connection to GCS (NB: requires 'google-auth-name' and 'gcs-bucket-to-check' to be set):
-      # check-gcs: true
-
       # If you want to check database connectivity:
       # check-engine-database: true
 
@@ -605,18 +602,13 @@ services {
       # check-failure-retry-interval = 30 seconds
 
       #####
-      # GCS- and PAPI-specific configuration options:
+      # PAPI-specific configuration options:
       #####
 
-      # The name of an authentication scheme to use for e.g. pinging PAPI and GCS. This should be either an application
+      # The name of an authentication scheme to use for e.g. pinging PAPI. This should be either an application
       # default or service account auth, otherwise things won't work as there'll not be a refresh token where you need
       # them.
       # google-auth-name = application-default
-
-      # A *bucket* in GCS to periodically stat to check for connectivity. This must be accessible by the auth mode
-      # specified by google-auth-name
-      # NB: This is a *bucket name*, not a URL and not an *object*. With 'some-bucket-name', Cromwell would ping gs://some-bucket-name
-      # gcs-bucket-to-check = some-bucket-name
     }
   }
   LoadController {

--- a/services/src/main/scala/cromwell/services/healthmonitor/impl/HealthMonitorServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/healthmonitor/impl/HealthMonitorServiceActor.scala
@@ -11,11 +11,9 @@ final class HealthMonitorServiceActor(serviceConfig: Config, globalConfig: Confi
   override lazy val subsystems: Set[ProtoHealthMonitorServiceActor.MonitoredSubsystem] = {
 
     val engineDatabaseSubsystemOption = if (serviceConfig.getBoolean("check-engine-database")) Some(EngineDb) else None
-    val gcsSubsystemOption = if (serviceConfig.getBoolean("check-gcs")) Some(Gcs) else None
 
     Set(
-      engineDatabaseSubsystemOption,
-      gcsSubsystemOption
+      engineDatabaseSubsystemOption
     ).flatten ++ PapiSubsystems
   }
 }

--- a/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/healthmonitor/HealthMonitorServiceActorSpec.scala
@@ -30,7 +30,6 @@ class HealthMonitorServiceActorSpec
 
     val serviceConfigString =
       """check-engine-database: false
-        |check-gcs: false
         |check-papi-backends: []
         |""".stripMargin
 

--- a/src/ci/resources/gcp_batch_application.inc.conf.ctmpl
+++ b/src/ci/resources/gcp_batch_application.inc.conf.ctmpl
@@ -53,11 +53,9 @@ services {
 	config {
 
       //check-papi-backends: [ Papi ]
-      check-gcs: true
       check-engine-database: true
 
 	  google-auth-name = "service_account"
-	  gcs-bucket-to-check = "cloud-cromwell-dev"
 	}
   }
 }

--- a/src/ci/resources/papi_application.inc.conf.ctmpl
+++ b/src/ci/resources/papi_application.inc.conf.ctmpl
@@ -53,11 +53,9 @@ services {
 	config {
 
       check-papi-backends: [ Papi ]
-      check-gcs: true
       check-engine-database: true
 
 	  google-auth-name = "service_account"
-	  gcs-bucket-to-check = "cloud-cromwell-dev"
 	}
   }
 }


### PR DESCRIPTION
### Description

As part of preparing for the fall 2024 audit, we were asked to fix the permissions on the various healthcheck buckets such as `gs://cromwell-ping-me-dev`.

It would have taken some tinkering to make sure the permissions are secure enough _and_ the healthcheck still works, so I decided to drop the healthcheck. I am not aware of any times it's helped us and doesn't pass the "would we add this today" test.

The only notable bucket we'd want to make sure Cromwell itself has permissions on is the workflow archiver - and it uses [a separate service account from the rest of Cromwell](https://github.com/broadinstitute/terra-helmfile/blob/master/charts/cromwell/templates/config/_cromwell.conf.tpl#L267-L271), so it's not a valid test.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users