### PR TITLE
WX-1820 GCP Batch VPC test and doc updates

### DIFF
--- a/centaur/src/main/resources/standardTestCases/gcpbatch_check_network_in_vpc.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_check_network_in_vpc.test
@@ -1,0 +1,20 @@
+name: gcpbatch_check_network_in_vpc
+testFormat: workflowsuccess
+backends: [GCPBATCH-Virtual-Private-Cloud-Labels, GCPBATCH-Virtual-Private-Cloud-Literals]
+
+files {
+  workflow: virtual_private_cloud/gcpbatch_check_network_in_vpc.wdl
+  options: virtual_private_cloud/wf_zone_options.json
+}
+
+metadata {
+  workflowName: check_network_in_vpc
+  status: Succeeded
+
+  "outputs.check_network_in_vpc.network_used_labels": "cromwell-ci-gcpbatch-vpc-network"
+  "outputs.check_network_in_vpc.subnetwork_used_labels": "cromwell-ci-gcpbatch-vpc-network"
+  "outputs.check_network_in_vpc.zone_used_labels": "us-east1-c"
+  "outputs.check_network_in_vpc.network_used_literals": "cromwell-ci-gcpbatch-vpc-network"
+  "outputs.check_network_in_vpc.subnetwork_used_literals": "cromwell-ci-gcpbatch-vpc-network"
+  "outputs.check_network_in_vpc.zone_used_literals": "us-east1-c"
+}

--- a/centaur/src/main/resources/standardTestCases/virtual_private_cloud/gcpbatch_check_network_in_vpc.wdl
+++ b/centaur/src/main/resources/standardTestCases/virtual_private_cloud/gcpbatch_check_network_in_vpc.wdl
@@ -1,0 +1,100 @@
+version 1.0
+
+task get_network_labels_backend {
+  meta { volatile: true }
+  input {
+    Array[String] commandScript
+    String dockerImage
+  }
+  command <<<~{sep="\n" commandScript}>>>
+  runtime {
+    docker: dockerImage
+    backend: "GCPBATCH-Virtual-Private-Cloud-Labels"
+  }
+  output {
+    String networkName = read_string("network")
+    String subnetworkName = read_string("subnetwork")
+    String zone = read_string("zone")
+  }
+}
+
+task get_network_literals_backend {
+  meta { volatile: true }
+  input {
+    Array[String] commandScript
+    String dockerImage
+  }
+  command <<<~{sep="\n" commandScript}>>>
+  runtime {
+    docker: dockerImage
+    backend: "GCPBATCH-Virtual-Private-Cloud-Literals"
+  }
+  output {
+    String networkName = read_string("network")
+    String subnetworkName = read_string("subnetwork")
+    String zone = read_string("zone")
+  }
+}
+
+workflow check_network_in_vpc {
+  # Create a reusable script for multiple backends using workarounds for Cromwell 66:
+  #  - can't pass `backend` as a variable runtime attribute; the call will run on the default backend
+  #  - use an `Array[String]` to simulate a WDL multiline string
+  #  - an escaped backslash `\\` at the end of a WDL string returns a syntax error (maybe from womtool describe?)
+  String backslash = "\u005c"
+  Array[String] commandScript = [
+    "set -euo pipefail",
+    "",
+    "apt-get install --assume-yes jq > /dev/null",
+    "PROJECT=$(",
+    "  curl " + backslash,
+    "    -s \"http://metadata.google.internal/computeMetadata/v1/project/project-id\" " + backslash,
+    "    -H \"Metadata-Flavor: Google\" |",
+    "  sed -E 's!.*/(.*)!\\1!'",
+    ")",
+    "ZONE=$(",
+    "  curl " + backslash,
+    "    -s \"http://metadata.google.internal/computeMetadata/v1/instance/zone\" " + backslash,
+    "    -H \"Metadata-Flavor: Google\" |",
+    "  sed -E 's!.*/(.*)!\\1!'",
+    ")",
+    "INSTANCE=$(",
+    "  curl " + backslash,
+    "    -s \"http://metadata.google.internal/computeMetadata/v1/instance/name\" " + backslash,
+    "    -H \"Metadata-Flavor: Google\"",
+    ")",
+    "TOKEN=$(gcloud auth application-default print-access-token)",
+    "INSTANCE_METADATA=$(",
+    "  curl \"https://www.googleapis.com/compute/v1/projects/$PROJECT/zones/$ZONE/instances/$INSTANCE\" " + backslash,
+    "    -H \"Authorization: Bearer $TOKEN\" " + backslash,
+    "    -H 'Accept: application/json'",
+    ")",
+    "NETWORK_OBJECT=$(echo $INSTANCE_METADATA | jq --raw-output --exit-status '.networkInterfaces[0]')",
+    "echo $NETWORK_OBJECT | jq --exit-status '.network' | sed -E 's!.*/(.*)!\\1!' | sed 's/\"//g' > network",
+    "echo $NETWORK_OBJECT | jq --exit-status '.subnetwork' | sed -E 's!.*/(.*)!\\1!' | sed 's/\"//g' > subnetwork",
+    "echo $ZONE > zone"
+  ]
+  String dockerImage = "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+
+  call get_network_labels_backend {
+    input:
+      commandScript = commandScript,
+      dockerImage = dockerImage
+  }
+
+  call get_network_literals_backend {
+    input:
+      commandScript = commandScript,
+      dockerImage = dockerImage
+  }
+
+   output {
+     String network_used_labels = get_network_labels_backend.networkName
+     String subnetwork_used_labels = get_network_labels_backend.subnetworkName
+     String zone_used_labels = get_network_labels_backend.zone
+     String network_used_literals = get_network_literals_backend.networkName
+     String subnetwork_used_literals = get_network_literals_backend.subnetworkName
+     String zone_used_literals = get_network_literals_backend.zone
+   }
+}
+

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -225,8 +225,9 @@ backend {
 ```
 
 The `network-name` should reference the name of your private network within that network respectively. Note that in the
-PAPI v2 backend `subnetwork-name` was an optional configuration parameter, but `subnetwork-name` does not need to
-specified (and will not be used) in GCP Batch.
+PAPI v2 backend `subnetwork-name` was an optional configuration parameter which accepted a `*` wildcard for choosing the
+appropriate subnetwork region, but in GCP Batch the `subnetwork-name` specification can be omitted
+and GCP Batch will choose the appropriate subnetwork automatically.
 
 For example, if your `virtual-private-cloud` config looks like the one above, then Cromwell will use the value of the
 configuration key, which is `vpc-network` here, as the name of private network and run the jobs on this network.
@@ -267,8 +268,9 @@ backend {
 The `network-label-key` should reference the key in your project's labels whose value is the name of your private network.
 `auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
 Note that in the
-PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter, but `subnetwork-label-key` does not need to
-specified (and will not be used) in GCP Batch.
+PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter which accepted a `*` wildcard for choosing the
+appropriate subnetwork region, but in GCP Batch the `subnetwork-label-key` specification can be omitted
+and GCP Batch will choose the appropriate subnetwork automatically.
 
 For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
 

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -216,6 +216,7 @@ backend {
         ...
         virtual-private-cloud {
           network-name = "vpc-network"
+          subnetwork-name = "vpc-subnetwork"
         }
         ...
       }
@@ -224,22 +225,24 @@ backend {
 }
 ```
 
-The `network-name` should reference the name of your private network within that network respectively. Note that in the
-PAPI v2 backend `subnetwork-name` was an optional configuration parameter, but `subnetwork-name` does not need to
-specified (and will not be used) in GCP Batch.
+The `network-name` and `subnetwork-name` should reference the name of your private network and subnetwork within that
+network respectively. The `subnetwork-name` is an optional config. Note that in the
+PAPI v2 backend `subnetwork-name` was an optional configuration parameter which accepted a `*` wildcard for choosing the
+appropriate subnetwork region, but in GCP Batch the `subnetwork-name` specification can be omitted
+and GCP Batch will choose the appropriate subnetwork automatically.
 
 For example, if your `virtual-private-cloud` config looks like the one above, then Cromwell will use the value of the
 configuration key, which is `vpc-network` here, as the name of private network and run the jobs on this network.
 If the network name is not present in the config Cromwell will fall back to trying to run jobs on the default network.
 
-If `network-name` contains the string `${projectId}` then that value will be replaced
+If the `network-name` or `subnetwork-name` values contain the string `${projectId}` then that value will be replaced
 by Cromwell with the name of the project running GCP Batch.
 
 If the `network-name` does not contain a `/` then it will be prefixed with `projects/${projectId}/global/networks/`.
 
-Cromwell will then pass the network value to GCP Batch. See the documentation for
+Cromwell will then pass the network and subnetwork values to GCP Batch. See the documentation for
 [GCP Batch](https://cloud.google.com/batch/docs/networking-overview)
-for more information on the various formats accepted for `network`.
+for more information on the various formats accepted for `network` and `subnetwork`.
 
 #### Virtual Private Network via Labels
 
@@ -254,6 +257,7 @@ backend {
         ...
         virtual-private-cloud {
           network-label-key = "my-private-network"
+          subnetwork-label-key = "my-private-subnetwork"
           auth = "reference-to-auth-scheme"
         }
         ...
@@ -264,11 +268,12 @@ backend {
 ```
 
 
-The `network-label-key` should reference the key in your project's labels whose value is the name of your private network.
-`auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
-Note that in the
-PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter, but `subnetwork-label-key` does not need to
-specified (and will not be used) in GCP Batch.
+The `network-label-key` and `subnetwork-label-key` should reference the keys in your project's labels whose value is the name of your private network
+and subnetwork within that network respectively. `auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
+The `subnetwork-label-key` is an optional config. Note that in the
+PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter which accepted a `*` wildcard for choosing the
+appropriate subnetwork region, but in GCP Batch the `subnetwork-label-key` specification can be omitted
+and GCP Batch will choose the appropriate subnetwork automatically.
 
 For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
 

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -225,9 +225,8 @@ backend {
 ```
 
 The `network-name` should reference the name of your private network within that network respectively. Note that in the
-PAPI v2 backend `subnetwork-name` was an optional configuration parameter which accepted a `*` wildcard for choosing the
-appropriate subnetwork region, but in GCP Batch the `subnetwork-name` specification can be omitted
-and GCP Batch will choose the appropriate subnetwork automatically.
+PAPI v2 backend `subnetwork-name` was an optional configuration parameter, but `subnetwork-name` does not need to
+specified (and will not be used) in GCP Batch.
 
 For example, if your `virtual-private-cloud` config looks like the one above, then Cromwell will use the value of the
 configuration key, which is `vpc-network` here, as the name of private network and run the jobs on this network.
@@ -268,9 +267,8 @@ backend {
 The `network-label-key` should reference the key in your project's labels whose value is the name of your private network.
 `auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
 Note that in the
-PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter which accepted a `*` wildcard for choosing the
-appropriate subnetwork region, but in GCP Batch the `subnetwork-label-key` specification can be omitted
-and GCP Batch will choose the appropriate subnetwork automatically.
+PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter, but `subnetwork-label-key` does not need to
+specified (and will not be used) in GCP Batch.
 
 For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
 

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -216,7 +216,6 @@ backend {
         ...
         virtual-private-cloud {
           network-name = "vpc-network"
-          subnetwork-name = "vpc-subnetwork"
         }
         ...
       }
@@ -225,21 +224,22 @@ backend {
 }
 ```
 
-The `network-name` and `subnetwork-name` should reference the name of your private network and subnetwork within that
-network respectively. The `subnetwork-name` is an optional config.
+The `network-name` should reference the name of your private network within that network respectively. Note that in the
+PAPI v2 backend `subnetwork-name` was an optional configuration parameter, but `subnetwork-name` does not need to
+specified (and will not be used) in GCP Batch.
 
 For example, if your `virtual-private-cloud` config looks like the one above, then Cromwell will use the value of the
 configuration key, which is `vpc-network` here, as the name of private network and run the jobs on this network.
 If the network name is not present in the config Cromwell will fall back to trying to run jobs on the default network.
 
-If the `network-name` or `subnetwork-name` values contain the string `${projectId}` then that value will be replaced
+If `network-name` contains the string `${projectId}` then that value will be replaced
 by Cromwell with the name of the project running GCP Batch.
 
 If the `network-name` does not contain a `/` then it will be prefixed with `projects/${projectId}/global/networks/`.
 
-Cromwell will then pass the network and subnetwork values to GCP Batch. See the documentation for
+Cromwell will then pass the network value to GCP Batch. See the documentation for
 [GCP Batch](https://cloud.google.com/batch/docs/networking-overview)
-for more information on the various formats accepted for `network` and `subnetwork`.
+for more information on the various formats accepted for `network`.
 
 #### Virtual Private Network via Labels
 
@@ -254,7 +254,6 @@ backend {
         ...
         virtual-private-cloud {
           network-label-key = "my-private-network"
-          subnetwork-label-key = "my-private-subnetwork"
           auth = "reference-to-auth-scheme"
         }
         ...
@@ -265,9 +264,11 @@ backend {
 ```
 
 
-The `network-label-key` and `subnetwork-label-key` should reference the keys in your project's labels whose value is the name of your private network
-and subnetwork within that network respectively. `auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
-The `subnetwork-label-key` is an optional config.
+The `network-label-key` should reference the key in your project's labels whose value is the name of your private network.
+`auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
+Note that in the
+PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter, but `subnetwork-label-key` does not need to
+specified (and will not be used) in GCP Batch.
 
 For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
 

--- a/src/ci/resources/gcp_batch_application.conf
+++ b/src/ci/resources/gcp_batch_application.conf
@@ -23,6 +23,18 @@ backend {
         filesystems.gcs.auth = "requester_pays_service_account"
       }
     }
+    GCPBATCH-Virtual-Private-Cloud-Labels {
+      actor-factory = "cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory"
+      config {
+        include "gcp_batch_provider_config.inc.conf"
+      }
+    }
+    GCPBATCH-Virtual-Private-Cloud-Literals {
+      actor-factory = "cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory"
+      config {
+        include "gcp_batch_provider_config.inc.conf"
+      }
+    }
     GCPBATCHParallelCompositeUploads {
       actor-factory = "cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory"
       config {

--- a/src/ci/resources/gcp_batch_shared_application.inc.conf
+++ b/src/ci/resources/gcp_batch_shared_application.inc.conf
@@ -74,5 +74,44 @@ backend {
         filesystems.http {}
       }
     }
+    GCPBATCH-Virtual-Private-Cloud-Labels {
+      actor-factory = "REPLACEME!"
+      config {
+        # When importing: Remember to also include an appropriate provider_config.inc.conf here.
+
+        genomics.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
+        filesystems.http {}
+        virtual-private-cloud {
+          network-label-key = "cromwell-ci-gcpbatch-network"
+          # For GCP Batch we do not configure the subnetwork name. Batch has to work out the subnetwork for itself in
+          # order to enable running jobs in regions that are different from the region of the GCP Batch to which we send jobs.
+          auth = "service_account"
+        }
+
+        # Have the engine authenticate to docker.io. See BT-141 for more info.
+        include "dockerhub_provider_config_v2.inc.conf"
+      }
+    }
+    GCPBATCH-Virtual-Private-Cloud-Literals {
+      actor-factory = "REPLACEME!"
+      config {
+        # When importing: Remember to also include an appropriate provider_config.inc.conf here.
+
+        genomics.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
+        filesystems.http {}
+        virtual-private-cloud {
+          # integration testing:
+          #  - fully qualified name
+          #  - hardcoded project id
+          #  - does not end with `/`
+          network-name = "projects/broad-dsde-cromwell-dev/global/networks/cromwell-ci-gcpbatch-vpc-network"
+          # For GCP Batch we do not reference the subnetwork name, Batch has to work that out for itself in order to
+          # enable running jobs in regions that are different from the region of the GCP Batch to which we send jobs.
+        }
+
+        # Have the engine authenticate to docker.io. See BT-141 for more info.
+        include "dockerhub_provider_config_v2.inc.conf"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

GCP Batch versions of the VPC tests. Basically the same as their PAPI v2 counterparts with different backend names, different network and label names, and no subnetwork specifications.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users