### PR TITLE
[WX-1835] Scheduled logging for list of groups experiencing quota exhaustion

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
@@ -23,11 +23,11 @@ class GroupMetricsActor(engineDbInterface: EngineSqlDatabase,
 
   implicit val ec: MessageDispatcher = context.system.dispatchers.lookup(Dispatcher.EngineDispatcher)
 
-  // initial schedule for logging exhausted groups
-  context.system.scheduler.scheduleOnce(loggingInterval)(self ! LogQuotaExhaustedGroups)
   log.info(
     s"${this.getClass.getSimpleName} configured to log groups experiencing quota exhaustion at interval ${loggingInterval.toString()}."
   )
+  // initial schedule for logging exhausted groups
+  context.system.scheduler.scheduleOnce(loggingInterval)(self ! LogQuotaExhaustedGroups)
 
   override def receive: Receive = {
     case RecordGroupQuotaExhaustion(group) =>

--- a/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
@@ -24,7 +24,7 @@ class GroupMetricsActor(engineDbInterface: EngineSqlDatabase,
   implicit val ec: MessageDispatcher = context.system.dispatchers.lookup(Dispatcher.EngineDispatcher)
 
   log.info(
-    s"${this.getClass.getSimpleName} configured to log groups experiencing quota exhaustion at interval ${loggingInterval.toString()}."
+    s"${this.getClass.getSimpleName} configured to log groups experiencing quota exhaustion at interval of ${loggingInterval.toString()}."
   )
   // initial schedule for logging exhausted groups
   context.system.scheduler.scheduleOnce(loggingInterval)(self ! LogQuotaExhaustedGroups)

--- a/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
@@ -44,7 +44,8 @@ class GroupMetricsActor(engineDbInterface: EngineSqlDatabase,
       getQuotaExhaustedGroups() onComplete {
         case Success(quotaExhaustedGroups) =>
           log.info(
-            s"Hog groups currently experiencing quota exhaustion: ${quotaExhaustedGroups.length}. Group IDs: ${quotaExhaustedGroups.toList.toString()}"
+            s"Hog groups currently experiencing quota exhaustion: ${quotaExhaustedGroups.length}. Group IDs: [${quotaExhaustedGroups.toList
+                .mkString(", ")}]."
           )
         case Failure(exception) =>
           log.info(

--- a/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
@@ -11,13 +11,19 @@ import cromwell.database.sql.SqlConverters.OffsetDateTimeToSystemTimestamp
 import cromwell.database.sql.tables.GroupMetricsEntry
 
 import java.time.OffsetDateTime
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
-class GroupMetricsActor(engineDbInterface: EngineSqlDatabase, quotaExhaustionThresholdInMins: Long)
+class GroupMetricsActor(engineDbInterface: EngineSqlDatabase, quotaExhaustionThresholdInMins: Long, loggingInterval: FiniteDuration)
     extends Actor
     with ActorLogging {
 
   implicit val ec: MessageDispatcher = context.system.dispatchers.lookup(Dispatcher.EngineDispatcher)
+
+  // initial schedule for logging exhausted groups
+  context.system.scheduler.scheduleOnce(loggingInterval)(self ! LogQuotaExhaustedGroups)
+  log.info(s"${this.getClass.getSimpleName} configured to log groups experiencing quota exhaustion at interval ${loggingInterval.toString()}.")
 
   override def receive: Receive = {
     case RecordGroupQuotaExhaustion(group) =>
@@ -26,18 +32,30 @@ class GroupMetricsActor(engineDbInterface: EngineSqlDatabase, quotaExhaustionThr
       ()
     case GetQuotaExhaustedGroups =>
       val respondTo: ActorRef = sender()
-
-      // for a group in the GROUP_METRICS_ENTRY table, if the 'quota_exhaustion_detected' timestamp hasn't
-      // been updated in last X minutes it is no longer experiencing cloud quota exhaustion
-      val currentTimestampMinusDelay = OffsetDateTime.now().minusMinutes(quotaExhaustionThresholdInMins)
-      engineDbInterface.getQuotaExhaustedGroups(currentTimestampMinusDelay.toSystemTimestamp) onComplete {
+      getQuotaExhaustedGroups() onComplete {
         case Success(quotaExhaustedGroups) => respondTo ! GetQuotaExhaustedGroupsSuccess(quotaExhaustedGroups.toList)
         case Failure(exception) => respondTo ! GetQuotaExhaustedGroupsFailure(exception.getMessage)
       }
+    case LogQuotaExhaustedGroups => getQuotaExhaustedGroups() onComplete {
+        case Success(quotaExhaustedGroups) =>
+          log.info(s"Hog groups currently experiencing quota exhaustion: ${quotaExhaustedGroups.length}. Group IDs: ${quotaExhaustedGroups.toList.toString()}")
+        case Failure(exception) =>
+          log.info(s"Something went wrong when fetching quota exhausted groups for logging. Will retry in ${loggingInterval.toString()}. Exception: ${exception.getMessage}")
+      }
+      // schedule next logging
+      context.system.scheduler.scheduleOnce(loggingInterval)(self ! LogQuotaExhaustedGroups)
+      ()
     case other =>
       log.error(
         s"Programmer Error: Unexpected message ${other.toPrettyElidedString(1000)} received by ${this.self.path.name}."
       )
+  }
+
+  private def getQuotaExhaustedGroups(): Future[Seq[String]] = {
+    // for a group in the GROUP_METRICS_ENTRY table, if the 'quota_exhaustion_detected' timestamp hasn't
+    // been updated in last X minutes it is no longer experiencing cloud quota exhaustion
+    val currentTimestampMinusDelay = OffsetDateTime.now().minusMinutes(quotaExhaustionThresholdInMins)
+    engineDbInterface.getQuotaExhaustedGroups(currentTimestampMinusDelay.toSystemTimestamp)
   }
 }
 
@@ -47,12 +65,13 @@ object GroupMetricsActor {
   sealed trait GroupMetricsActorMessage
   case class RecordGroupQuotaExhaustion(group: String) extends GroupMetricsActorMessage
   case object GetQuotaExhaustedGroups extends GroupMetricsActorMessage
+  case object LogQuotaExhaustedGroups extends GroupMetricsActorMessage
 
   // Responses
   sealed trait GetQuotaExhaustedGroupsResponse
   case class GetQuotaExhaustedGroupsSuccess(quotaExhaustedGroups: List[String]) extends GetQuotaExhaustedGroupsResponse
   case class GetQuotaExhaustedGroupsFailure(errorMsg: String) extends GetQuotaExhaustedGroupsResponse
 
-  def props(engineDbInterface: EngineSqlDatabase, quotaExhaustionThresholdInMins: Long): Props =
-    Props(new GroupMetricsActor(engineDbInterface, quotaExhaustionThresholdInMins)).withDispatcher(EngineDispatcher)
+  def props(engineDbInterface: EngineSqlDatabase, quotaExhaustionThresholdInMins: Long, loggingInterval: FiniteDuration): Props =
+    Props(new GroupMetricsActor(engineDbInterface, quotaExhaustionThresholdInMins, loggingInterval)).withDispatcher(EngineDispatcher)
 }

--- a/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
@@ -3,7 +3,12 @@ package cromwell.backend.standard
 import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.{Config, ConfigFactory}
-import cromwell.backend.standard.GroupMetricsActor.{GetQuotaExhaustedGroups, GetQuotaExhaustedGroupsSuccess, LogQuotaExhaustedGroups, RecordGroupQuotaExhaustion}
+import cromwell.backend.standard.GroupMetricsActor.{
+  GetQuotaExhaustedGroups,
+  GetQuotaExhaustedGroupsSuccess,
+  LogQuotaExhaustedGroups,
+  RecordGroupQuotaExhaustion
+}
 import cromwell.database.slick.EngineSlickDatabase
 import cromwell.database.sql.tables.GroupMetricsEntry
 import cromwell.services.EngineServicesStore

--- a/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
@@ -3,11 +3,7 @@ package cromwell.backend.standard
 import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.{Config, ConfigFactory}
-import cromwell.backend.standard.GroupMetricsActor.{
-  GetQuotaExhaustedGroups,
-  GetQuotaExhaustedGroupsSuccess,
-  RecordGroupQuotaExhaustion
-}
+import cromwell.backend.standard.GroupMetricsActor.{GetQuotaExhaustedGroups, GetQuotaExhaustedGroupsSuccess, LogQuotaExhaustedGroups, RecordGroupQuotaExhaustion}
 import cromwell.database.slick.EngineSlickDatabase
 import cromwell.database.sql.tables.GroupMetricsEntry
 import cromwell.services.EngineServicesStore
@@ -47,7 +43,7 @@ class GroupMetricsActorSpec extends AnyFlatSpec with Matchers {
 
   it should "receive new quota exhaustion message and call database function" in {
     val db = databaseInterface()
-    val mockGroupMetricsActor = TestActorRef(GroupMetricsActor.props(db, 15))
+    val mockGroupMetricsActor = TestActorRef(GroupMetricsActor.props(db, 15, 5.minutes))
 
     mockGroupMetricsActor.tell(RecordGroupQuotaExhaustion(testHogGroup), TestProbe().ref)
 
@@ -58,7 +54,7 @@ class GroupMetricsActorSpec extends AnyFlatSpec with Matchers {
 
   it should "respond with groups in quota exhaustion" in {
     val db = databaseInterface()
-    val mockGroupMetricsActor = TestActorRef(GroupMetricsActor.props(db, 15))
+    val mockGroupMetricsActor = TestActorRef(GroupMetricsActor.props(db, 15, 5.minutes))
     val requestActor = TestProbe()
 
     mockGroupMetricsActor.tell(GetQuotaExhaustedGroups, requestActor.ref)

--- a/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
+++ b/backend/src/test/scala/cromwell/backend/standard/GroupMetricsActorSpec.scala
@@ -6,7 +6,6 @@ import com.typesafe.config.{Config, ConfigFactory}
 import cromwell.backend.standard.GroupMetricsActor.{
   GetQuotaExhaustedGroups,
   GetQuotaExhaustedGroupsSuccess,
-  LogQuotaExhaustedGroups,
   RecordGroupQuotaExhaustion
 }
 import cromwell.database.slick.EngineSlickDatabase

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -277,6 +277,8 @@ system {
     # threshold (in minutes) after which a group in GROUP_METRICS_ENTRY table is no longer considered to be
     # actively experiencing quota exhaustion
     threshold-minutes = 15
+    # logging interval for which groups are in active quota exhaustion state
+    logging-interval = 5 minutes
   }
 
   workflow-heartbeats {

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -210,9 +210,11 @@ abstract class CromwellRootActor(terminator: CromwellTerminator,
     systemConfig.as[Option[Boolean]]("quota-exhaustion-job-start-control.enabled").getOrElse(false)
   private lazy val quotaExhaustionThresholdInMins: Long =
     systemConfig.as[Option[Long]]("quota-exhaustion-job-start-control.threshold-minutes").getOrElse(15)
+  private lazy val quotaExhaustionLoggingInterval: FiniteDuration =
+    systemConfig.as[Option[FiniteDuration]]("quota-exhaustion-job-start-control.logging-interval").getOrElse(5.minutes)
   private lazy val groupMetricsActor: ActorRef =
     context.actorOf(
-      GroupMetricsActor.props(EngineServicesStore.engineDatabaseInterface, quotaExhaustionThresholdInMins)
+      GroupMetricsActor.props(EngineServicesStore.engineDatabaseInterface, quotaExhaustionThresholdInMins, quotaExhaustionLoggingInterval)
     )
   private lazy val groupMetricsActorForJTDA: Option[ActorRef] =
     if (quotaExhaustionJobControlEnabled) Option(groupMetricsActor) else None

--- a/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
+++ b/engine/src/main/scala/cromwell/server/CromwellRootActor.scala
@@ -214,7 +214,10 @@ abstract class CromwellRootActor(terminator: CromwellTerminator,
     systemConfig.as[Option[FiniteDuration]]("quota-exhaustion-job-start-control.logging-interval").getOrElse(5.minutes)
   private lazy val groupMetricsActor: ActorRef =
     context.actorOf(
-      GroupMetricsActor.props(EngineServicesStore.engineDatabaseInterface, quotaExhaustionThresholdInMins, quotaExhaustionLoggingInterval)
+      GroupMetricsActor.props(EngineServicesStore.engineDatabaseInterface,
+                              quotaExhaustionThresholdInMins,
+                              quotaExhaustionLoggingInterval
+      )
     )
   private lazy val groupMetricsActorForJTDA: Option[ActorRef] =
     if (quotaExhaustionJobControlEnabled) Option(groupMetricsActor) else None

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobTokenDispenserActorSpec.scala
@@ -3,7 +3,11 @@ package cromwell.engine.workflow.tokens
 import akka.actor.{ActorRef, PoisonPill, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import cromwell.backend.standard.GroupMetricsActor
-import cromwell.backend.standard.GroupMetricsActor.{GetQuotaExhaustedGroups, GetQuotaExhaustedGroupsSuccess, LogQuotaExhaustedGroups}
+import cromwell.backend.standard.GroupMetricsActor.{
+  GetQuotaExhaustedGroups,
+  GetQuotaExhaustedGroupsSuccess,
+  LogQuotaExhaustedGroups
+}
 import cromwell.core.JobToken.JobTokenType
 import cromwell.core.{HogGroup, TestKitSuite}
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.{Rate, TokensAvailable}

--- a/engine/src/test/scala/cromwell/engine/workflow/tokens/JobTokenDispenserActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/tokens/JobTokenDispenserActorSpec.scala
@@ -3,7 +3,7 @@ package cromwell.engine.workflow.tokens
 import akka.actor.{ActorRef, PoisonPill, Props}
 import akka.testkit.{ImplicitSender, TestActorRef, TestProbe}
 import cromwell.backend.standard.GroupMetricsActor
-import cromwell.backend.standard.GroupMetricsActor.{GetQuotaExhaustedGroups, GetQuotaExhaustedGroupsSuccess}
+import cromwell.backend.standard.GroupMetricsActor.{GetQuotaExhaustedGroups, GetQuotaExhaustedGroupsSuccess, LogQuotaExhaustedGroups}
 import cromwell.core.JobToken.JobTokenType
 import cromwell.core.{HogGroup, TestKitSuite}
 import cromwell.engine.workflow.tokens.DynamicRateLimiter.{Rate, TokensAvailable}
@@ -572,8 +572,9 @@ object JobTokenDispenserActorSpec {
   val LimitedTo5Tokens: JobTokenType = limitedTokenType(5)
 }
 
-class TestGroupMetricsActorForJTDA extends GroupMetricsActor(engineDatabaseInterface, 15) {
-  override def receive: Receive = { case GetQuotaExhaustedGroups =>
-    sender() ! GetQuotaExhaustedGroupsSuccess(List(quotaExhaustedHogGroup.value))
+class TestGroupMetricsActorForJTDA extends GroupMetricsActor(engineDatabaseInterface, 15, 10.minutes) {
+  override def receive: Receive = {
+    case GetQuotaExhaustedGroups => sender() ! GetQuotaExhaustedGroupsSuccess(List(quotaExhaustedHogGroup.value))
+    case LogQuotaExhaustedGroups => ()
   }
 }


### PR DESCRIPTION
### Description

Jira: https://broadworkbench.atlassian.net/browse/WX-1835

Note: the scheduled logging will happen even if `quota-exhaustion-job-start-control` is disabled. This is because even if JobTokenDispenser doesn't account for quota exhausted groups, Cromwell is always recording which groups are in quota exhaustion. And scheduled logging will help easily see that list even if the feature `quota-exhaustion-job-start-control` is disabled.

Example logs at different times:
```
2024-09-12 18:32:11 cromwell-system-akka.dispatchers.engine-dispatcher-24 INFO  - GroupMetricsActor configured to log groups experiencing quota exhaustion at interval of 5 minutes.
2024-09-12 18:37:11 cromwell-system-akka.dispatchers.engine-dispatcher-58 INFO  - Hog groups currently experiencing quota exhaustion: 3. Group IDs: [cromwell-dev, sshah-test-1, sshah-test-2].
....
2024-09-12 18:42:11 cromwell-system-akka.dispatchers.engine-dispatcher-71 INFO  - Hog groups currently experiencing quota exhaustion: 1. Group IDs: [cromwell-dev].
....
2024-09-12 19:02:12 cromwell-system-akka.dispatchers.engine-dispatcher-60 INFO  - Hog groups currently experiencing quota exhaustion: 0. Group IDs: [].
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users