### PR TITLE
GCP Batch: Support passing standard machine types to the Google backend by reusing the cpuPlatform field in the RuntimeAttributes

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -234,8 +234,10 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
                                                              googleLegacyMachineSelection = false,
                                                              jobLogger = jobLogger
     )
+    // Don't set cpuPlatform if the field was used to specify standard machine type when submitting the GCP Batch request
+    val cpuPlatformBatchRequest = if (GcpBatchMachineConstraints.isStandardMachineType(cpuPlatform)) "" else cpuPlatform
     val instancePolicy =
-      createInstancePolicy(cpuPlatform = cpuPlatform, spotModel, accelerators, allDisks, machineType = machineType)
+      createInstancePolicy(cpuPlatform = cpuPlatformBatchRequest, spotModel, accelerators, allDisks, machineType = machineType)
     val locationPolicy = LocationPolicy.newBuilder.addAllowedLocations(zones).build
     val allocationPolicy =
       createAllocationPolicy(data, locationPolicy, instancePolicy.build, networkPolicy, gcpSa, accelerators)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchCustomMachineType.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchCustomMachineType.scala
@@ -11,6 +11,8 @@ import wom.format.MemorySize
 
 import scala.math.{log, pow}
 
+case class StandardMachineType(machineType: String) {}
+
 /**
   * Adjusts memory and cpu for custom machine types.
   *

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
@@ -4,22 +4,28 @@ import cromwell.backend.google.batch.models.{
   GcpBatchRuntimeAttributes,
   N1CustomMachineType,
   N2CustomMachineType,
-  N2DCustomMachineType
+  N2DCustomMachineType,
+  StandardMachineType
 }
 import cromwell.core.logging.JobLogger
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
+import scala.util.matching.Regex
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
 object GcpBatchMachineConstraints {
+  private val machineTypePattern: Regex = """^\w{2}\w?-\w+-\w+$""".r
+
   def machineType(memory: MemorySize,
                   cpu: Int Refined Positive,
                   cpuPlatformOption: Option[String],
                   googleLegacyMachineSelection: Boolean,
                   jobLogger: JobLogger
   ): String =
-    if (googleLegacyMachineSelection) {
+    if (isStandardMachineType(cpuPlatformOption.getOrElse(""))) {
+      StandardMachineType(cpuPlatformOption.getOrElse("")).machineType
+    } else if (googleLegacyMachineSelection) {
       s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.intValue()}"
     } else {
       // If someone requests Intel Cascade Lake or Intel Ice Lake as their CPU platform then switch the machine type to n2.
@@ -33,4 +39,6 @@ object GcpBatchMachineConstraints {
         }
       customMachineType.machineType(memory, cpu, jobLogger)
     }
+
+  def isStandardMachineType(machineType: String): Boolean = machineTypePattern.matches(machineType)
 }


### PR DESCRIPTION
### Description

Currently, and as described in https://github.com/broadinstitute/cromwell/issues/7535, only general-purpose machine types are supported in Google Backend, which prevents running wdl workflows on many machine types available on GCP, including those provisioned with modern GPUs.

<!-- What is the purpose of this change? What should reviewers know? -->

As a proof of concept, I thought the simplest and most general solution would be to pass the machine type directly from the wdl configuration to the Google Batch API. The idea is that this approach would be more resilient to machine types being added or deprecated on GCP, as users would only need to update their wdl workflows in such cases. Furthermore, the approach of mapping machine specs  (e.g.: cpu platform and gpu requirements) to standard machine types would potentially introduce an additional layer of maintenance with little benefit.

This PR currently reuses the cpuPlatform field as a proof of concept, but I realize this is less than ideal. I would like to discuss available alternatives with the cromwell team, including adding a new key in the RuntimeAttributes field. Given that some of these attributes are already specific to GCP, would it be possible to support a new standardMachineType attribute?

Please let me know if you have any other suggestions, happy to implement a different approach.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users