### PR TITLE
WX-927 No JES machine types in GCP Batch

### DIFF
--- a/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
+++ b/centaur/src/main/resources/standardTestCases/hello_google_legacy_machine_selection.test
@@ -1,7 +1,11 @@
 name: hello_google_legacy_machine_selection
 testFormat: workflowsuccess
-# Explicitly turned this off in my machine contraint wiring-in PR. Do we still care about this?
-backends: [ Papiv2, GCPBATCH_FAIL ]
+
+# Legacy PAPI v1 (aka JES) machine types not supported on GCP Batch.
+# Task wf_hello.hello:NA:1 failed: Job failed when Batch tries to schedule it:
+# Batch Error: code - CODE_MACHINE_TYPE_NOT_FOUND, description -
+# machine type predefined-1-2048 for job job-xyz, project 8675309, region us-central1, zones (if any) us-central1-b is not available.
+backends: [ Papiv2, GCPBATCH_LEGACY_MACHINE_TYPES_NOT_SUPPORTED ]
 
 files {
   workflow: wdl_draft3/hello/hello.wdl

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -231,7 +231,6 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val machineType = GcpBatchMachineConstraints.machineType(runtimeAttributes.memory,
                                                              runtimeAttributes.cpu,
                                                              cpuPlatformOption = runtimeAttributes.cpuPlatform,
-                                                             googleLegacyMachineSelection = false,
                                                              jobLogger = jobLogger
     )
     val instancePolicy =

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/WorkflowOptionKeys.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/WorkflowOptionKeys.scala
@@ -8,5 +8,4 @@ object WorkflowOptionKeys {
   val GoogleProject = "google_project"
   val GoogleComputeServiceAccount = "google_compute_service_account"
   val EnableFuse = "enable_fuse"
-  val GoogleLegacyMachineSelection = "google_legacy_machine_selection"
 }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
@@ -1,6 +1,11 @@
 package cromwell.backend.google.batch.util
 
-import cromwell.backend.google.batch.models.{GcpBatchRuntimeAttributes, N1CustomMachineType, N2CustomMachineType, N2DCustomMachineType}
+import cromwell.backend.google.batch.models.{
+  GcpBatchRuntimeAttributes,
+  N1CustomMachineType,
+  N2CustomMachineType,
+  N2DCustomMachineType
+}
 import cromwell.core.logging.JobLogger
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
@@ -1,36 +1,26 @@
 package cromwell.backend.google.batch.util
 
-import cromwell.backend.google.batch.models.{
-  GcpBatchRuntimeAttributes,
-  N1CustomMachineType,
-  N2CustomMachineType,
-  N2DCustomMachineType
-}
+import cromwell.backend.google.batch.models.{GcpBatchRuntimeAttributes, N1CustomMachineType, N2CustomMachineType, N2DCustomMachineType}
 import cromwell.core.logging.JobLogger
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
 object GcpBatchMachineConstraints {
   def machineType(memory: MemorySize,
                   cpu: Int Refined Positive,
                   cpuPlatformOption: Option[String],
-                  googleLegacyMachineSelection: Boolean,
                   jobLogger: JobLogger
-  ): String =
-    if (googleLegacyMachineSelection) {
-      s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.intValue()}"
-    } else {
-      // If someone requests Intel Cascade Lake or Intel Ice Lake as their CPU platform then switch the machine type to n2.
-      // Similarly, CPU platform of AMD Rome corresponds to the machine type n2d.
-      val customMachineType =
-        cpuPlatformOption match {
-          case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelCascadeLakeValue) => N2CustomMachineType
-          case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelIceLakeValue) => N2CustomMachineType
-          case Some(GcpBatchRuntimeAttributes.CpuPlatformAMDRomeValue) => N2DCustomMachineType
-          case _ => N1CustomMachineType
-        }
-      customMachineType.machineType(memory, cpu, jobLogger)
-    }
+  ): String = {
+    // If someone requests Intel Cascade Lake or Intel Ice Lake as their CPU platform then switch the machine type to n2.
+    // Similarly, CPU platform of AMD Rome corresponds to the machine type n2d.
+    val customMachineType =
+      cpuPlatformOption match {
+        case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelCascadeLakeValue) => N2CustomMachineType
+        case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelIceLakeValue) => N2CustomMachineType
+        case Some(GcpBatchRuntimeAttributes.CpuPlatformAMDRomeValue) => N2DCustomMachineType
+        case _ => N1CustomMachineType
+      }
+    customMachineType.machineType(memory, cpu, jobLogger)
+  }
 }

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
@@ -24,78 +24,77 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
 
   it should "generate valid machine types" in {
     val validTypes = Table(
-      ("memory", "cpu", "cpuPlatformOption", "googleLegacyMachineSelection", "machineTypeString"),
+      ("memory", "cpu", "cpuPlatformOption", "machineTypeString"),
       // Already ok tuple
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, "custom-1-1024"),
       // CPU must be even (except if it's 1)
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, false, "custom-4-4096"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, "custom-4-4096"),
       // Memory must be a multiple of 256
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, "custom-1-1024"),
       // Memory / cpu ratio must be > 0.9GB, increase memory
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, false, "custom-4-3840"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, false, "custom-16-14848"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, "custom-4-3840"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, "custom-16-14848"),
       // Memory / cpu ratio must be < 6.5GB, increase CPU
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, false, "custom-4-14080"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, "custom-4-14080"),
       // Memory should be an int
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1536"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, "custom-1-1536"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, "custom-1-1024"),
       // Increase to a cpu selection not valid for n2 below
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, false, "custom-34-31488"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, "custom-34-31488"),
 
       // Same tests as above but with legacy machine type selection (cpu and memory as specified. No 'custom machine
       // requirement' adjustments are expected this time, except float->int)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, true, "predefined-3-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, true, "predefined-4-1024"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, true, "predefined-16-14336"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-13977"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1520"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, true, "predefined-33-2048"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1024"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, "predefined-3-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, "predefined-1-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, "predefined-4-1024"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, "predefined-16-14336"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, "predefined-1-13977"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1520"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1024"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, "predefined-33-2048"),
 
       // Same tests but with cascade lake (n2)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascadeLake, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascadeLake, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascadeLake, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascadeLake, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascadeLake, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascadeLake, "n2-custom-36-36864"),
 
       // Same tests, but with ice lake. Should produce same results as cascade lake since they're both n2.
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, "n2-custom-36-36864"),
 
       // Same tests but with AMD Rome (n2d) #cpu > 16 are in increments of 16
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2dOption, false, "n2d-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2dOption, false, "n2d-custom-4-2048"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2dOption, false, "n2d-custom-16-14336"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1536"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2dOption, false, "n2d-custom-48-24576"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](81), n2dOption, false, "n2d-custom-96-49152"),
-      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, false, "n2d-custom-96-262144")
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, "n2d-custom-2-1024"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2dOption, "n2d-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2dOption, "n2d-custom-2-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2dOption, "n2d-custom-4-2048"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2dOption, "n2d-custom-16-14336"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2dOption, "n2d-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2dOption, "n2d-custom-2-1536"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2dOption, "n2d-custom-2-1024"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2dOption, "n2d-custom-48-24576"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](81), n2dOption, "n2d-custom-96-49152"),
+      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, "n2d-custom-96-262144")
     )
 
-    forAll(validTypes) { (memory, cpu, cpuPlatformOption, googleLegacyMachineSelection, expected) =>
+    forAll(validTypes) { (memory, cpu, cpuPlatformOption, expected) =>
       GcpBatchMachineConstraints.machineType(
         memory = memory,
         cpu = cpu,
         cpuPlatformOption = cpuPlatformOption,
-        googleLegacyMachineSelection = googleLegacyMachineSelection,
         jobLogger = mock[JobLogger]
       ) shouldBe expected
     }

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
@@ -42,18 +42,6 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
       // Increase to a cpu selection not valid for n2 below
       (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, "custom-34-31488"),
 
-      // Same tests as above but with legacy machine type selection (cpu and memory as specified. No 'custom machine
-      // requirement' adjustments are expected this time, except float->int)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1024"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, "predefined-3-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, "predefined-1-1024"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, "predefined-4-1024"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, "predefined-16-14336"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, "predefined-1-13977"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1520"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, "predefined-1-1024"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, "predefined-33-2048"),
-
       // Same tests but with cascade lake (n2)
       (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, "n2-custom-2-2048"),
       (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, "n2-custom-4-4096"),


### PR DESCRIPTION
### Description

The `google_legacy_machine_selection` workflow option that exists on PAPI v2 to pick JES-shaped machines was not completely wired in to the GCP Batch backend. However when I completed the wiring job and ran the `hello_google_legacy_machine_selection` Centaur test I got this:

```
Task wf_hello.hello:NA:1 failed: Job failed when Batch tries to schedule it:
Batch Error: code - CODE_MACHINE_TYPE_NOT_FOUND, description - 
machine type predefined-1-2048 for job job-xyz, project 8675309, region us-central1, zones (if any) us-central1-b is not available.
```

So basically `google_legacy_machine_selection` does not seem to work on GCP Batch. If anyone is using this undocumented feature to emulate the behavior of JES from many years ago, we should let them know that this support is going to be dropped when GCP Batch is rolled out. 

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users