### PR TITLE
WX-1835 Tweak to quota exhaustion logging

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/GroupMetricsActor.scala
@@ -43,10 +43,11 @@ class GroupMetricsActor(engineDbInterface: EngineSqlDatabase,
     case LogQuotaExhaustedGroups =>
       getQuotaExhaustedGroups() onComplete {
         case Success(quotaExhaustedGroups) =>
-          log.info(
-            s"Hog groups currently experiencing quota exhaustion: ${quotaExhaustedGroups.length}. Group IDs: [${quotaExhaustedGroups.toList
-                .mkString(", ")}]."
-          )
+          if (quotaExhaustedGroups.nonEmpty)
+            log.info(
+              s"Hog groups currently experiencing quota exhaustion: ${quotaExhaustedGroups.length}. Group IDs: [${quotaExhaustedGroups.toList
+                  .mkString(", ")}]."
+            )
         case Failure(exception) =>
           log.info(
             s"Something went wrong when fetching quota exhausted groups for logging. Will retry in ${loggingInterval


### PR DESCRIPTION
### Description

I found myself crafting the following query to make the logging more information-dense.
```
"Hog groups currently experiencing quota exhaustion"
  AND ( NOT "Hog groups currently experiencing quota exhaustion: 0" )
```

Before:

<img width="876" alt="Screenshot 2024-09-26 at 15 47 10" src="https://github.com/user-attachments/assets/8475d8da-ae1b-439c-b8d8-be012cc627c7">

After:

<img width="876" alt="Screenshot 2024-09-26 at 15 43 40" src="https://github.com/user-attachments/assets/973e33d3-1f4d-4e90-afe7-86728598c30f">


### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users