### PR TITLE
WX-1885 Fix Bard default behavior

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -596,7 +596,7 @@ services {
     }
   }
   // Bard is used for metrics collection in the Terra SaaS offering and is not applicable outside of it.
-  Bard {
+  BardEventing {
     class = "cromwell.services.metrics.bard.impl.BardEventingActor"
     config {
       enabled = false

--- a/services/src/main/scala/cromwell/services/metrics/bard/impl/BardEventingActor.scala
+++ b/services/src/main/scala/cromwell/services/metrics/bard/impl/BardEventingActor.scala
@@ -24,6 +24,7 @@ class BardEventingActor(serviceConfig: Config, globalConfig: Config, serviceRegi
 
   override def receive: Receive = {
     case BardEventRequest(event) if bardConfig.enabled => bardService.sendEvent(event)
+    case BardEventRequest(_) => // do nothing if Bard not enabled
     // This service currently doesn't do any work on shutdown but the service registry pattern requires it
     // (see https://github.com/broadinstitute/cromwell/issues/2575)
     case ShutdownCommand => context stop self


### PR DESCRIPTION
### Description

This should have no effect on our existing Bard usage, just removes errors logged when NOT using Bard.

 * Base config was incorrect, so Bard was not registered in the Service Registry by default
 * `BardEventingActor.receive` had no handling for receiving a `BardEvent` when eventing was disabled... and also nothing has ever checked for enablement before creating and sending these events.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users