### PR TITLE
AN-138 Enable cost endpoint in CromIAM

### DIFF
--- a/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
+++ b/CromIAM/src/main/scala/cromiam/webservice/CromIamApiService.scala
@@ -81,7 +81,7 @@ trait CromIamApiService
 
   val workflowRoutes: Route = queryGetRoute ~ queryPostRoute ~ workflowOutputsRoute ~ submitRoute ~
     workflowLogsRoute ~ abortRoute ~ metadataRoute ~ timingRoute ~ statusRoute ~ backendRoute ~ labelPatchRoute ~
-    callCacheDiffRoute ~ labelGetRoute ~ releaseHoldRoute
+    callCacheDiffRoute ~ labelGetRoute ~ releaseHoldRoute ~ costRoute
 
   val allRoutes: Route = handleExceptions(CromIamExceptionHandler)(workflowRoutes ~ engineRoutes ~ womtoolRoutes)
 
@@ -114,6 +114,7 @@ trait CromIamApiService
   def timingRoute: Route = workflowGetRouteWithId("timing")
   def statusRoute: Route = workflowGetRouteWithId("status")
   def labelGetRoute: Route = workflowGetRouteWithId(Labels)
+  def costRoute: Route = workflowGetRouteWithId("cost")
 
   def labelPatchRoute: Route =
     path("api" / "workflows" / Segment / Segment / Labels) { (_, workflowId) =>


### PR DESCRIPTION
### Description

Enables calling the workflow cost endpoint through CromIAM. Deliberately omitting Swagger change, that will be done in AN-145 once we are ready to advertise this feature.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users