### PR TITLE
AN-214 Redirect workflow existence queries from metadata to summary

### DIFF
--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -130,11 +130,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     } yield ()
   }
 
-  override def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean] = {
-    val action = dataAccess.metadataEntryExistsForWorkflowExecutionUuid(workflowExecutionUuid).result
-    runTransaction(action)
-  }
-
   override def metadataSummaryEntryExists(
     workflowExecutionUuid: String
   )(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -95,22 +95,6 @@ trait MetadataEntryComponent {
       }.size
     )
 
-  val metadataEntryExistsForWorkflowExecutionUuid = Compiled((workflowExecutionUuid: Rep[String]) =>
-    (for {
-      metadataEntry <- metadataEntries
-      if metadataEntry.workflowExecutionUuid === workflowExecutionUuid
-    } yield metadataEntry).exists
-  )
-
-  def metadataEntryExistsForWorkflowExecutionUuid(workflowId: Rep[String], key: Rep[String]): Rep[Boolean] =
-    metadataEntries
-      .filter(metadataEntry =>
-        metadataEntry.workflowExecutionUuid === workflowId &&
-          metadataEntry.metadataKey === key &&
-          metadataEntry.metadataValue.isDefined
-      )
-      .exists
-
   val metadataEntriesForWorkflowExecutionUuidAndMetadataKey =
     Compiled((workflowExecutionUuid: Rep[String], metadataKey: Rep[String]) =>
       (for {

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -37,8 +37,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
                          labelMetadataKey: String
   )(implicit ec: ExecutionContext): Future[Unit]
 
-  def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean]
-
   def metadataSummaryEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Future[Boolean]
 
   def queryMetadataEntries(workflowExecutionUuid: String, timeout: Duration)(implicit

--- a/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/MetadataRouteSupport.scala
@@ -237,7 +237,7 @@ object MetadataRouteSupport {
         case FailedToGetArchiveStatusAndEndTime(e) => Future.failed(e)
       }
 
-    validateWorkflowIdInMetadata(possibleWorkflowId, serviceRegistryActor) flatMap { id =>
+    validateWorkflowIdInMetadataSummaries(possibleWorkflowId, serviceRegistryActor) flatMap { id =>
       /*
         for requests made to one of /metadata, /logs or /outputs endpoints, perform an additional check to see
         if metadata for the workflow has been archived and deleted or not (as they interact with metadata table)

--- a/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/wes/WesRouteSupport.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.{Multipart, StatusCode, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.RouteDirectives.complete
 import akka.http.scaladsl.server.{Directive1, Route}
-import akka.pattern.{AskTimeoutException, ask}
+import akka.pattern.{ask, AskTimeoutException}
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import cats.data.NonEmptyList
@@ -16,12 +16,21 @@ import cromwell.engine.instrumentation.HttpInstrumentation
 import cromwell.engine.workflow.WorkflowManagerActor.WorkflowNotFoundException
 import cromwell.engine.workflow.workflowstore.{WorkflowStoreActor, WorkflowStoreSubmitActor}
 import cromwell.server.CromwellShutdown
-import cromwell.services.metadata.MetadataService.{BuildMetadataJsonAction, GetSingleWorkflowMetadataAction, GetStatus, MetadataServiceResponse, StatusLookupFailed}
+import cromwell.services.metadata.MetadataService.{
+  BuildMetadataJsonAction,
+  GetSingleWorkflowMetadataAction,
+  GetStatus,
+  MetadataServiceResponse,
+  StatusLookupFailed
+}
 import cromwell.services.{FailedMetadataJsonResponse, SuccessfulMetadataJsonResponse}
 import cromwell.webservice.PartialWorkflowSources
-import cromwell.webservice.WebServiceUtils.{EnhancedThrowable, completeResponse, materializeFormData}
+import cromwell.webservice.WebServiceUtils.{completeResponse, materializeFormData, EnhancedThrowable}
 import cromwell.webservice.routes.CromwellApiService
-import cromwell.webservice.routes.CromwellApiService.{UnrecognizedWorkflowException, validateWorkflowIdInMetadataSummaries}
+import cromwell.webservice.routes.CromwellApiService.{
+  validateWorkflowIdInMetadataSummaries,
+  UnrecognizedWorkflowException
+}
 import cromwell.webservice.routes.MetadataRouteSupport.{metadataBuilderActorRequest, metadataQueryRequest}
 import cromwell.webservice.routes.wes.WesResponseJsonSupport._
 import cromwell.webservice.routes.wes.WesRouteSupport.{respondWithWesError, _}
@@ -88,9 +97,10 @@ trait WesRouteSupport extends HttpInstrumentation {
               }
             },
             path("runs" / Segment / "status") { possibleWorkflowId =>
-              val response = validateWorkflowIdInMetadataSummaries(possibleWorkflowId, serviceRegistryActor).flatMap(w =>
-                serviceRegistryActor.ask(GetStatus(w)).mapTo[MetadataServiceResponse]
-              )
+              val response =
+                validateWorkflowIdInMetadataSummaries(possibleWorkflowId, serviceRegistryActor).flatMap(w =>
+                  serviceRegistryActor.ask(GetStatus(w)).mapTo[MetadataServiceResponse]
+                )
               // WES can also return a 401 or a 403 but that requires user auth knowledge which Cromwell doesn't currently have
               onComplete(response) {
                 case Success(SuccessfulMetadataJsonResponse(_, jsObject)) =>

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -574,15 +574,13 @@ object CromwellApiServiceSpec {
   val SucceededWorkflowId = WorkflowId.fromString("0cb43b8c-0259-4a19-b7fe-921ced326738")
   val FailedWorkflowId = WorkflowId.fromString("df501790-cef5-4df7-9b48-8760533e3136")
   val SummarizedWorkflowId = WorkflowId.fromString("f0000000-0000-0000-0000-000000000000")
+  val UnsummarizedWorkflowId = WorkflowId.fromString("00001111-aaaa-bbbb-cccc-ddddffffeeee")
   val WorkflowIdExistingOnlyInSummaryTable = WorkflowId.fromString("f0000000-0000-0000-0000-000000000011")
   val ArchivedWorkflowId = WorkflowId.fromString("c4c6339c-2145-47fb-acc5-b5cb8d2809f5")
   val ArchivedAndDeletedWorkflowId = WorkflowId.fromString("abc1234d-2145-47fb-acc5-b5cb8d2809f5")
   val wesWorkflowId = WorkflowId.randomId()
-  val SummarizedWorkflowIds = Set(
-    SummarizedWorkflowId,
-    WorkflowIdExistingOnlyInSummaryTable,
-    ArchivedWorkflowId,
-    ArchivedAndDeletedWorkflowId
+  val UnsummarizedWorkflowIds = Set(
+    UnsummarizedWorkflowId
   )
   val RecognizedWorkflowIds = Set(
     ExistingWorkflowId,
@@ -593,6 +591,7 @@ object CromwellApiServiceSpec {
     SucceededWorkflowId,
     FailedWorkflowId,
     SummarizedWorkflowId,
+    WorkflowIdExistingOnlyInSummaryTable,
     ArchivedWorkflowId,
     ArchivedAndDeletedWorkflowId,
     wesWorkflowId
@@ -685,7 +684,7 @@ object CromwellApiServiceSpec {
         )
         sender() ! response
       case ValidateWorkflowIdInMetadataSummaries(id) =>
-        if (SummarizedWorkflowIds.contains(id)) sender() ! MetadataService.RecognizedWorkflowId
+        if (RecognizedWorkflowIds.contains(id)) sender() ! MetadataService.RecognizedWorkflowId
         else sender() ! MetadataService.UnrecognizedWorkflowId
       case FetchWorkflowMetadataArchiveStatusAndEndTime(id) =>
         id match {

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -684,9 +684,6 @@ object CromwellApiServiceSpec {
           None
         )
         sender() ! response
-      case ValidateWorkflowIdInMetadata(id) =>
-        if (RecognizedWorkflowIds.contains(id)) sender() ! MetadataService.RecognizedWorkflowId
-        else sender() ! MetadataService.UnrecognizedWorkflowId
       case ValidateWorkflowIdInMetadataSummaries(id) =>
         if (SummarizedWorkflowIds.contains(id)) sender() ! MetadataService.RecognizedWorkflowId
         else sender() ! MetadataService.UnrecognizedWorkflowId

--- a/engine/src/test/scala/cromwell/webservice/routes/MetadataRouteSupportSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/MetadataRouteSupportSpec.scala
@@ -573,7 +573,7 @@ class MetadataRouteSupportSpec extends AsyncFlatSpec with ScalatestRouteTest wit
         |}
       """.stripMargin
 
-    val unsummarizedId = CromwellApiServiceSpec.ExistingWorkflowId
+    val unsummarizedId = CromwellApiServiceSpec.UnsummarizedWorkflowId
     Patch(s"/workflows/$version/$unsummarizedId/labels",
           HttpEntity(ContentTypes.`application/json`, validLabelsJson)
     ) ~>

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -130,7 +130,6 @@ object MetadataService {
   case object RefreshSummary extends MetadataServiceAction
   case object SendMetadataTableSizeMetrics extends MetadataServiceAction
 
-  final case class ValidateWorkflowIdInMetadata(possibleWorkflowId: WorkflowId) extends MetadataServiceAction
   final case class ValidateWorkflowIdInMetadataSummaries(possibleWorkflowId: WorkflowId) extends MetadataServiceAction
   final case class FetchWorkflowMetadataArchiveStatusAndEndTime(workflowId: WorkflowId) extends MetadataServiceAction
   final case class FetchFailedJobsMetadataWithWorkflowId(workflowId: WorkflowId) extends BuildWorkflowMetadataJsonAction

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -303,9 +303,6 @@ trait MetadataDatabaseAccess {
       _ map { case (id, labelsForId) => WorkflowId.fromString(id) -> labelsForId }
     }
 
-  def workflowWithIdExistsInMetadata(possibleWorkflowId: String)(implicit ec: ExecutionContext): Future[Boolean] =
-    metadataDatabaseInterface.metadataEntryExists(possibleWorkflowId)
-
   def workflowWithIdExistsInMetadataSummaries(possibleWorkflowId: String)(implicit
     ec: ExecutionContext
   ): Future[Boolean] =

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -194,16 +194,6 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
       None
     }
 
-  private def validateWorkflowIdInMetadata(possibleWorkflowId: WorkflowId, sender: ActorRef): Unit =
-    workflowWithIdExistsInMetadata(possibleWorkflowId.toString) onComplete {
-      case Success(true) => sender ! RecognizedWorkflowId
-      case Success(false) => sender ! UnrecognizedWorkflowId
-      case Failure(e) =>
-        sender ! FailedToCheckWorkflowId(
-          new RuntimeException(s"Failed lookup attempt for workflow ID $possibleWorkflowId", e)
-        )
-    }
-
   private def validateWorkflowIdInMetadataSummaries(possibleWorkflowId: WorkflowId, sender: ActorRef): Unit =
     workflowWithIdExistsInMetadataSummaries(possibleWorkflowId.toString) onComplete {
       case Success(true) => sender ! RecognizedWorkflowId
@@ -258,7 +248,6 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
     case action: PutMetadataActionAndRespond => writeActor forward action
     // Assume that listen messages are directed to the write metadata actor
     case listen: Listen => writeActor forward listen
-    case v: ValidateWorkflowIdInMetadata => validateWorkflowIdInMetadata(v.possibleWorkflowId, sender())
     case v: ValidateWorkflowIdInMetadataSummaries =>
       validateWorkflowIdInMetadataSummaries(v.possibleWorkflowId, sender())
     case g: FetchWorkflowMetadataArchiveStatusAndEndTime =>

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -372,9 +372,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
         Future.failed(WriteMetadataActorSpec.IntermittentException)
       }
 
-    override def metadataEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Nothing =
-      notImplemented()
-
     override def metadataSummaryEntryExists(workflowExecutionUuid: String)(implicit ec: ExecutionContext): Nothing =
       notImplemented()
 


### PR DESCRIPTION
### Description

We make this query constantly, looks like the single most frequent one against metadata. All it does is check whether the workflow ID is valid by checking whether >1 metadatum exists for it.

We already started down the path of checking summary instead of metadata, see https://github.com/broadinstitute/cromwell/pull/4617. It just makes way more sense to me to check a table with 77M rows than 36B.

```
select 
  exists(
    select 
      `CALL_FQN`, 
      `METADATA_KEY`, 
      `WORKFLOW_EXECUTION_UUID`, 
      `METADATA_TIMESTAMP`, 
      `JOB_SCATTER_INDEX`, 
      `METADATA_JOURNAL_ID`, 
      `JOB_RETRY_ATTEMPT`, 
      `METADATA_VALUE_TYPE`, 
      `METADATA_VALUE` 
    from 
      `METADATA_ENTRY` 
    where 
      `WORKFLOW_EXECUTION_UUID` = '602a4913-d666-4182-b2f1-242fbda817d2'
  );
```

It is potentially implicated in the 2021 database migration that failed at the very end, you can see a bunch of them in this screenshot (2021-11-09):

<img width="1792" alt="Screen Shot 2021-11-09 at 1 14 03 AM" src="https://github.com/user-attachments/assets/d3eee3da-9636-4406-a6f9-9862d33cd650">

```
Lock wait timeout exceeded; try restarting transaction
  [for Statement "RENAME TABLE `cromwell`.`METADATA_ENTRY` TO `cromwell`.`_METADATA_ENTRY_old`,
  `cromwell`.`_METADATA_ENTRY_new` TO `cromwell`.`METADATA_ENTRY`"]
  at /usr/bin/pt-online-schema-change line 10922.
```
[Slack link to contemporary discussion.](https://broadinstitute.slack.com/archives/C02LCC8968N/p1636439602084200)
[Contemporary analysis in JIRA.](https://broadworkbench.atlassian.net/browse/WM-906?focusedCommentId=53394)

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users