### PR TITLE
AN-224 Fix vmCostPerHour being 10x what it should be

### DIFF
--- a/services/src/main/scala/cromwell/services/cost/GcpCostCatalogService.scala
+++ b/services/src/main/scala/cromwell/services/cost/GcpCostCatalogService.scala
@@ -95,7 +95,7 @@ object GcpCostCatalogService {
       // In practice, from what I've seen, CPU cores and RAM don't have more than a single tier.
       val costPerUnit: Money = pricingInfo.getPricingExpression.getTieredRates(0).getUnitPrice
       val costPerCorePerHour: BigDecimal =
-        costPerUnit.getUnits + (costPerUnit.getNanos * 10e-9) // Same as above, but as a big decimal
+        costPerUnit.getUnits + (costPerUnit.getNanos * 10e-10) // Same as above, but as a big decimal
       val result = costPerCorePerHour * coreCount
       result.validNel
     } else {
@@ -109,7 +109,7 @@ object GcpCostCatalogService {
     if (usageUnit == "GiBy.h") {
       val costPerUnit: Money = pricingInfo.getPricingExpression.getTieredRates(0).getUnitPrice
       val costPerGbHour: BigDecimal =
-        costPerUnit.getUnits + (costPerUnit.getNanos * 10e-9) // Same as above, but as a big decimal
+        costPerUnit.getUnits + (costPerUnit.getNanos * 10e-10) // Same as above, but as a big decimal
       val result = costPerGbHour * ramGbCount
       result.validNel
     } else {

--- a/services/src/test/scala/cromwell/services/cost/GcpCostCatalogServiceSpec.scala
+++ b/services/src/test/scala/cromwell/services/cost/GcpCostCatalogServiceSpec.scala
@@ -249,18 +249,18 @@ class GcpCostCatalogServiceSpec
     // Create BigDecimals from strings to avoid inequality due to floating point shenanigans
     val lookupRows = Table(
       ("instantiatedVmInfo", "costPerHour"),
-      (InstantiatedVmInfo("us-central1", "custom-4-4096", true), BigDecimal(".361")),
-      (InstantiatedVmInfo("us-central1", "n2-custom-4-4096", true), BigDecimal(".42544000000000004")),
-      (InstantiatedVmInfo("us-central1", "n2d-custom-4-4096", true), BigDecimal(".2371600000000000024")),
-      (InstantiatedVmInfo("us-central1", "custom-4-4096", false), BigDecimal("1.43392")),
-      (InstantiatedVmInfo("us-central1", "n2-custom-4-4096", false), BigDecimal("1.50561600000000012")),
-      (InstantiatedVmInfo("us-central1", "n2d-custom-4-4096", false), BigDecimal("1.309896")),
-      (InstantiatedVmInfo("europe-west9", "custom-4-4096", true), BigDecimal(".3501808")),
-      (InstantiatedVmInfo("europe-west9", "n2-custom-4-4096", true), BigDecimal("0.49532")),
-      (InstantiatedVmInfo("europe-west9", "n2d-custom-4-4096", true), BigDecimal("0.30608")),
-      (InstantiatedVmInfo("europe-west9", "custom-4-4096", false), BigDecimal("1.663347200000000016")),
-      (InstantiatedVmInfo("europe-west9", "n2-custom-4-4352", false), BigDecimal("1.75941630500000012")),
-      (InstantiatedVmInfo("europe-west9", "n2d-custom-4-4096", false), BigDecimal("1.51947952"))
+      (InstantiatedVmInfo("us-central1", "custom-4-4096", true), BigDecimal(".0361")),
+      (InstantiatedVmInfo("us-central1", "n2-custom-4-4096", true), BigDecimal(".04254400000000000480")),
+      (InstantiatedVmInfo("us-central1", "n2d-custom-4-4096", true), BigDecimal(".02371600000000000040")),
+      (InstantiatedVmInfo("us-central1", "custom-4-4096", false), BigDecimal(".143392")),
+      (InstantiatedVmInfo("us-central1", "n2-custom-4-4096", false), BigDecimal(".150561600")),
+      (InstantiatedVmInfo("us-central1", "n2d-custom-4-4096", false), BigDecimal(".130989600000000012")),
+      (InstantiatedVmInfo("europe-west9", "custom-4-4096", true), BigDecimal(".035018080000000004")),
+      (InstantiatedVmInfo("europe-west9", "n2-custom-4-4096", true), BigDecimal("0.049532000000000004")),
+      (InstantiatedVmInfo("europe-west9", "n2d-custom-4-4096", true), BigDecimal("0.030608000000000004")),
+      (InstantiatedVmInfo("europe-west9", "custom-4-4096", false), BigDecimal(".1663347200000000040")),
+      (InstantiatedVmInfo("europe-west9", "n2-custom-4-4352", false), BigDecimal(".17594163050")),
+      (InstantiatedVmInfo("europe-west9", "n2d-custom-4-4096", false), BigDecimal(".151947952"))
     )
 
     forAll(lookupRows) { case (instantiatedVmInfo: InstantiatedVmInfo, expectedCostPerHour: BigDecimal) =>


### PR DESCRIPTION
### Description

While it's true that nano units are nine-y, when doing exponential math stuff we need to remember that the 10 contributes one order of magnitude.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users