### PR TITLE
batch: add on-demand retry for preemption

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
@@ -7,6 +7,9 @@ import com.google.cloud.batch.v1.BatchServiceSettings
 import com.google.common.collect.ImmutableMap
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend._
+import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{
+  preemptionCountKey
+}
 import cromwell.backend.google.batch.actors._
 import cromwell.backend.google.batch.api.request.{BatchRequestExecutor, RequestHandler}
 import cromwell.backend.google.batch.authentication.GcpBatchDockerCredentials
@@ -30,6 +33,7 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
 ) extends StandardLifecycleActorFactory
     with GcpPlatform {
 
+  override val requestedKeyValueStoreKeys: Seq[String] = Seq(preemptionCountKey)
   import GcpBatchBackendLifecycleActorFactory._
 
   override def jobIdKey: String = "__gcp_batch"
@@ -133,6 +137,7 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
 }
 
 object GcpBatchBackendLifecycleActorFactory extends StrictLogging {
+  val preemptionCountKey = "PreemptionCount"
 
   private[batch] def robustBuildAttributes(buildAttributes: () => GcpBatchConfigurationAttributes,
                                            maxAttempts: Int = 3,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchJobCachingActorHelper.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchJobCachingActorHelper.scala
@@ -25,6 +25,8 @@ trait GcpBatchJobCachingActorHelper extends StandardCachingActorHelper {
     batchConfiguration.runtimeConfig
   )
 
+  val preemptible: Int
+
   lazy val workingDisk: GcpBatchAttachedDisk = runtimeAttributes.disks.find(_.name == GcpBatchWorkingDisk.Name).get
 
   lazy val callRootPath: Path = gcpBatchCallPaths.callExecutionRoot
@@ -75,9 +77,10 @@ trait GcpBatchJobCachingActorHelper extends StandardCachingActorHelper {
       .get(WorkflowOptionKeys.GoogleProject)
       .getOrElse(batchAttributes.project)
 
-    Map[String, String](
+    Map[String, Any](
       GcpBatchMetadataKeys.GoogleProject -> googleProject,
-      GcpBatchMetadataKeys.ExecutionBucket -> initializationData.workflowPaths.executionRootString
+      GcpBatchMetadataKeys.ExecutionBucket -> initializationData.workflowPaths.executionRootString,
+      "preemptible" -> preemptible
     ) ++ originalLabelEvents
   }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
@@ -78,6 +78,7 @@ object GcpBatchRequestFactory {
                                       projectId: String,
                                       computeServiceAccount: String,
                                       googleLabels: Seq[GcpLabel],
+                                      preemptible: Int,
                                       batchTimeout: FiniteDuration,
                                       jobShell: String,
                                       privateDockerKeyAndEncryptedToken: Option[CreateBatchDockerKeyAndToken],


### PR DESCRIPTION
The Batch backend currently doesn’t retry preempted jobs with on-demand VMs, which is problematic since our goal is to save costs and avoid failing large tasks due to a few preempted machines. This patch reintroduces, in part, functionality removed in commit 49d675dbb95d7, enabling the job to restart on a STANDARD VM after encountering a VMPreemption error.

We have tested this initially and it seems to work, after preemption tries have gone, the job is restarted in standard VM.

Probably you notice that I'm a newbie in scala, so please just review and point out the stupidities, or just do a rewrite (patch is quite small). Anyway this is desperately needed in our project, thank you.