### PR TITLE
AN-273 Fix integration tests impacted by varying GCS message

### DIFF
--- a/centaur/src/main/resources/standardTestCases/missing_input_failure_papiv2.test
+++ b/centaur/src/main/resources/standardTestCases/missing_input_failure_papiv2.test
@@ -11,5 +11,6 @@ metadata {
     workflowName: missing_input_failure
     status: Failed
     "failures.0.message": "Workflow failed"
-    "failures.0.causedBy.0.message": "Failed to evaluate 'missing_input_failure.hello.addressee' (reason 1 of 1): Evaluating read_string(wf_hello_input) failed: [Attempted 1 time(s)] - IOException: Could not read from gs://nonexistingbucket/path/doesnt/exist: File not found: gs://nonexistingbucket/path/doesnt/exist"
+    # The GCS error message occasionally varies for unknown reasons. Do not try to assert on it, just make sure we get the right Cromwell exception. (AN-273)
+    "failures.0.causedBy.0.message": "Failed to evaluate 'missing_input_failure.hello.addressee' (reason 1 of 1): Evaluating read_string(wf_hello_input) failed: [Attempted 1 time(s)] - IOException: Could not read from gs://nonexistingbucket/path/doesnt/exist"~~
 }


### PR DESCRIPTION
### Description

Centaur added trailing `~~` support in August via https://github.com/broadinstitute/cromwell/pull/7483, we didn't have that the last time(s) this happened.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users