### PR TITLE
PROD-1000 Increase default boot disk from 10gb to 20gb for GCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,9 @@ The `IX_WORKFLOW_STORE_ENTRY_WS` index is removed from `WORKFLOW_STORE_ENTRY`.
 
 The index had low cardinality and workflow pickup is faster without it. Migration time depends on workflow store size, but should be very fast for most installations. Terminal workflows are removed from the workflow store, so only running workflows contribute to the cost.
 
-### Bug fixes
+### Bug fixes and small changes
+
+ * Changed default boot disk size from 10GB to 20GB in PipelinesAPI and Google Batch backends
 
 #### Improved `size()` function performance on arrays
 

--- a/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
@@ -11,8 +11,8 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.docker_size_dockerhub.large_dockerhub_image_with_hash.bootDiskSize": 17
-  "outputs.docker_size_dockerhub.large_dockerhub_image_with_tag.bootDiskSize": 17
+  "outputs.docker_size_dockerhub.large_dockerhub_image_with_hash.bootDiskSize": 27
+  "outputs.docker_size_dockerhub.large_dockerhub_image_with_tag.bootDiskSize": 27
 }
 
 workflowType: WDL

--- a/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
@@ -11,8 +11,8 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 20
-  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 20
+  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 27
+  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 27
 }
 
 workflowType: WDL

--- a/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
@@ -11,8 +11,8 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 17
-  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 17
+  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 20
+  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 20
 }
 
 workflowType: WDL

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -63,7 +63,7 @@ object GcpBatchRuntimeAttributes {
 
   val BootDiskSizeKey = "bootDiskSizeGb"
   private val bootDiskValidationInstance = new IntRuntimeAttributesValidation(BootDiskSizeKey)
-  private val BootDiskDefaultValue = WomInteger(10)
+  private val BootDiskDefaultValue = WomInteger(20)
 
   val NoAddressKey = "noAddress"
   private val noAddressValidationInstance = new BooleanRuntimeAttributesValidation(NoAddressKey)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
@@ -67,7 +67,7 @@ object PipelinesApiRuntimeAttributes {
 
   val BootDiskSizeKey = "bootDiskSizeGb"
   private val bootDiskValidationInstance = new IntRuntimeAttributesValidation(BootDiskSizeKey)
-  private val BootDiskDefaultValue = WomInteger(10)
+  private val BootDiskDefaultValue = WomInteger(20)
 
   val NoAddressKey = "noAddress"
   private val noAddressValidationInstance = new BooleanRuntimeAttributesValidation(NoAddressKey)


### PR DESCRIPTION
### Description

Increase default boot disk size in response to sudden increase in tasks running out of space on the boot disk.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users