### PR TITLE
Add remaining active national clouds

### DIFF
--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/azure/AzureConfiguration.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/azure/AzureConfiguration.scala
@@ -16,9 +16,11 @@ object AzureConfiguration {
 object AzureEnvironmentConverter {
   val Azure: String = "AzureCloud"
   val AzureGov: String = "AzureUSGovernmentCloud"
+  val AzureChina: String = "AzureChinaCloud"
 
   def fromString(s: String): AzureEnvironment = s match {
     case AzureGov => AzureEnvironment.AZURE_US_GOVERNMENT
+    case AzureChina => AzureEnvironment.AZURE_CHINA
     // a bit redundant, but I want to have a explicit case for Azure for clarity, even though it's the default
     case Azure => AzureEnvironment.AZURE
     case _ => AzureEnvironment.AZURE


### PR DESCRIPTION
### Description

Downstream users of Cromwell may be using any national cloud, not just USGov.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users