### PR TITLE
AN-300 Fall back to large Docker image size if we can't find a real one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,9 @@ The index had low cardinality and workflow pickup is faster without it. Migratio
 
 The `IX_METADATA_ENTRY_WEU_MK` index is added to `METADATA_ENTRY`. In pre-release testing, the migration proceeded at about 3 million rows per minute. Please plan downtime accordingly.
 
-### Bug fixes and small changes
+### Reduce errors from boot disk filling up on Google Lifesciences API
 
- * Changed default boot disk size from 10GB to 20GB in PipelinesAPI and Google Batch backends
+ * If Cromwell can't determine the size of the user command Docker image, it will increase Lifesciences API boot disk size by 30GB rather than 0. This should reduce incidence of tasks failing due to boot disk filling up.
 
 #### Improved `size()` function performance on arrays
 

--- a/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_dockerhub.test
@@ -11,8 +11,8 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.docker_size_dockerhub.large_dockerhub_image_with_hash.bootDiskSize": 27
-  "outputs.docker_size_dockerhub.large_dockerhub_image_with_tag.bootDiskSize": 27
+  "outputs.docker_size_dockerhub.large_dockerhub_image_with_hash.bootDiskSize": 17
+  "outputs.docker_size_dockerhub.large_dockerhub_image_with_tag.bootDiskSize": 17
 }
 
 workflowType: WDL

--- a/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
+++ b/centaur/src/main/resources/standardTestCases/docker_size_gcr.test
@@ -11,8 +11,8 @@ files {
 
 metadata {
   status: Succeeded
-  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 27
-  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 27
+  "outputs.docker_size_gcr.large_gcr_image_with_hash.bootDiskSize": 17
+  "outputs.docker_size_gcr.large_gcr_image_with_tag.bootDiskSize": 17
 }
 
 workflowType: WDL

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -60,7 +60,7 @@ object GcpBatchRuntimeAttributes {
 
   val BootDiskSizeKey = "bootDiskSizeGb"
   private val bootDiskValidationInstance = new IntRuntimeAttributesValidation(BootDiskSizeKey)
-  private val BootDiskDefaultValue = WomInteger(20)
+  private val BootDiskDefaultValue = WomInteger(10)
 
   val NoAddressKey = "noAddress"
   private val noAddressValidationInstance = new BooleanRuntimeAttributesValidation(NoAddressKey)

--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/PipelinesApiRuntimeAttributes.scala
@@ -66,7 +66,7 @@ object PipelinesApiRuntimeAttributes {
 
   val BootDiskSizeKey = "bootDiskSizeGb"
   private val bootDiskValidationInstance = new IntRuntimeAttributesValidation(BootDiskSizeKey)
-  private val BootDiskDefaultValue = WomInteger(20)
+  private val BootDiskDefaultValue = WomInteger(10)
 
   val NoAddressKey = "noAddress"
   private val noAddressValidationInstance = new BooleanRuntimeAttributesValidation(NoAddressKey)


### PR DESCRIPTION
### Description

See discussion in AN-300. This should fix cases where we can't find the Docker image size, so we don't bump the boot disk size to account for it, and tasks fail with out-of-disk during `docker pull`.

Batch will be handled in a different ticket.

Includes a revert of https://github.com/broadinstitute/cromwell/pull/7585, since this is a better-targeted fix for the same issue.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users