### PR TITLE
[#7674] Add support for AWS batch retry limit

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -432,12 +432,17 @@ final case class AwsBatchJob(
           // See:
           //
           // http://aws-java-sdk-javadoc.s3-website-us-west-2.amazonaws.com/latest/software/amazon/awssdk/services/batch/model/RegisterJobDefinitionRequest.Builder.html
-          val definitionRequest = RegisterJobDefinitionRequest.builder
+          val definitionBuilder = RegisterJobDefinitionRequest.builder
             .containerProperties(jobDefinition.containerProperties)
             .jobDefinitionName(jobDefinitionName)
             // See https://stackoverflow.com/questions/24349517/scala-method-named-type
             .`type`(JobDefinitionType.CONTAINER)
-            .build
+          if (jobDefinitionContext.runtimeAttributes.batchRetry > 0) {
+           definitionBuilder.retryStrategy(
+              RetryStrategy.builder.attempts(jobDefinitionContext.runtimeAttributes.batchRetry).build
+            )
+          }
+          val definitionRequest = definitionBuilder.build
 
           Log.debug(s"Submitting definition request: $definitionRequest")
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobCachingActorHelper.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobCachingActorHelper.scala
@@ -53,7 +53,7 @@ trait AwsBatchJobCachingActorHelper extends StandardCachingActorHelper {
   lazy val callPaths: AwsBatchJobPaths = jobPaths.asInstanceOf[AwsBatchJobPaths]
 
   lazy val runtimeAttributes: AwsBatchRuntimeAttributes =
-    AwsBatchRuntimeAttributes(validatedRuntimeAttributes, configuration.runtimeConfig, configuration.fileSystem)
+    AwsBatchRuntimeAttributes(validatedRuntimeAttributes, configuration)
 
   lazy val workingDisk: AwsBatchVolume = runtimeAttributes.disks
     .find(x =>

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -132,12 +132,13 @@ trait AwsBatchJobDefinitionBuilder {
       )
 
     def buildName(imageName: String,
+                  batchRetries: Int,
                   packedCommand: String,
                   volumes: List[Volume],
                   mountPoints: List[MountPoint],
                   env: Seq[KeyValuePair]
     ): String = {
-      val str = s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints
+      val str = s"$imageName:$batchRetries:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints
           .map(_.toString)
           .mkString(",")}:${env.map(_.toString).mkString(",")}"
 
@@ -161,6 +162,7 @@ trait AwsBatchJobDefinitionBuilder {
     val mountPoints = buildMountPoints(context.runtimeAttributes.disks)
     val jobDefinitionName = buildName(
       context.runtimeAttributes.dockerImage,
+      context.runtimeAttributes.batchRetry,
       packedCommand.mkString(","),
       volumes,
       mountPoints,

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -112,6 +112,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
     continueOnReturnCode = ContinueOnReturnCodeFlag(false),
     noAddress = false,
     scriptS3BucketName = "script-bucket",
+    batchRetry = 1,
     fileSystem = "s3"
   )
 

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -69,7 +69,8 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     false,
     ContinueOnReturnCodeSet(Set(0)),
     false,
-    "my-stuff"
+    "my-stuff",
+    1,
   )
 
   val expectedDefaultsLocalFS = new AwsBatchRuntimeAttributes(
@@ -83,6 +84,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     ContinueOnReturnCodeSet(Set(0)),
     false,
     "",
+    0,
     "local"
   )
 
@@ -495,7 +497,7 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
         runtimeAttributes
       )
     val validatedRuntimeAttributes = runtimeAttributesBuilder.build(defaultedAttributes, NOPLogger.NOP_LOGGER)
-    AwsBatchRuntimeAttributes(validatedRuntimeAttributes, configuration.runtimeConfig, configuration.fileSystem)
+    AwsBatchRuntimeAttributes(validatedRuntimeAttributes, configuration)
   }
 
   private val emptyWorkflowOptions = WorkflowOptions.fromMap(Map.empty).get


### PR DESCRIPTION
### Description

When submitting jobs to AWS Batch, Cromwell dynamically creates job definitions based on the job configuration. However, the current implementation does not provide a way for users to configure the Batch retry limit in the job definition.

This PR introduces a new batchRetry parameter in the configuration, allowing users to specify a default retry limit for AWS Batch jobs. The parameter is also included in the job runtime settings. By default, batchRetry is set to 0, effectively disabling retries unless explicitly configured by the user.
