### PR TITLE
AN-349 AN-358 Fix cost status

### DIFF
--- a/.github/workflows/cromwell_unit_tests.yml
+++ b/.github/workflows/cromwell_unit_tests.yml
@@ -22,6 +22,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3 # checkout the cromwell repo
+    - uses: sbt/setup-sbt@v1
     - uses: ./.github/set_up_cromwell_action #Exectute this reusable github action. It will set up java/sbt/git-secrets/cromwell.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -25,6 +25,7 @@ jobs:
           repository: broadinstitute/cromwell
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           path: cromwell
+      - uses: sbt/setup-sbt@v1
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -93,9 +93,9 @@ jobs:
             friendly_name: Centaur Engine Upgrade Local with MySQL 5.7
           - build_type: referenceDiskManifestBuilderApp
             friendly_name: Reference Disk Manifest Builder App
-          - build_type: centaurSlurm
-            build_mysql: 5.7
-            friendly_name: "Centaur Slurm with MySQL 5.7"
+#          - build_type: centaurSlurm
+#            build_mysql: 5.7
+#            friendly_name: "Centaur Slurm with MySQL 5.7"
           - build_type: centaurBlob
             build_mysql: 5.7
             friendly_name: Centaur Blob

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -114,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+    - uses: sbt/setup-sbt@v1
     - uses: actions/checkout@v3 # checkout the cromwell repo
       with:
         ref: ${{ inputs.target-branch }}

--- a/.github/workflows/scalafmt-check.yml
+++ b/.github/workflows/scalafmt-check.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: sbt/setup-sbt@v1
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.target-branch }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: sbt/setup-sbt@v1
 
       # fetch SBT package
       - uses: actions/setup-java@v4

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -347,7 +347,8 @@ class MetadataBuilderActorSpec
     val subWorkflow1aId = WorkflowId(UUID.fromString("1a1a1a1a-f76d-4af3-b371-5ba580916729"))
     val subWorkflow1bId = WorkflowId(UUID.fromString("1b1b1b1b-f76d-4af3-b371-5ba580916729"))
 
-    val workflowState = WorkflowSucceeded
+    val workflowSucceededState = WorkflowSucceeded
+    val workflowRunningState = WorkflowRunning
 
     val mainEvents = List(
       MetadataEvent(MetadataKey(mainWorkflowId, Option(MetadataJobKey("wfMain", None, 1)), "subWorkflowId"),
@@ -391,19 +392,25 @@ class MetadataBuilderActorSpec
     class TestReadDatabaseMetadataWorkerActorForCost extends ReadDatabaseMetadataWorkerActor(defaultTimeout, 1000000) {
       override def receive: Receive = {
         case GetCost(wfId) if wfId == mainWorkflowId =>
-          sender() ! CostResponse(mainWorkflowId, workflowState, MetadataLookupResponse(mainQuery, mainEvents))
+          sender() ! CostResponse(mainWorkflowId, workflowRunningState, MetadataLookupResponse(mainQuery, mainEvents))
           ()
         case GetCost(wfId) if wfId == subWorkflow1Id =>
-          sender() ! CostResponse(subWorkflow1Id, workflowState, MetadataLookupResponse(sub1Query, sub1Events))
+          sender() ! CostResponse(subWorkflow1Id, workflowSucceededState, MetadataLookupResponse(sub1Query, sub1Events))
           ()
         case GetCost(wfId) if wfId == subWorkflow2Id =>
-          sender() ! CostResponse(subWorkflow2Id, workflowState, MetadataLookupResponse(sub2Query, sub2Events))
+          sender() ! CostResponse(subWorkflow2Id, workflowSucceededState, MetadataLookupResponse(sub2Query, sub2Events))
           ()
         case GetCost(wfId) if wfId == subWorkflow1aId =>
-          sender() ! CostResponse(subWorkflow1aId, workflowState, MetadataLookupResponse(sub1aQuery, sub1aEvents))
+          sender() ! CostResponse(subWorkflow1aId,
+                                  workflowSucceededState,
+                                  MetadataLookupResponse(sub1aQuery, sub1aEvents)
+          )
           ()
         case GetCost(wfId) if wfId == subWorkflow1bId =>
-          sender() ! CostResponse(subWorkflow1bId, workflowState, MetadataLookupResponse(sub1bQuery, sub1bEvents))
+          sender() ! CostResponse(subWorkflow1bId,
+                                  workflowSucceededState,
+                                  MetadataLookupResponse(sub1bQuery, sub1bEvents)
+          )
           ()
         case _ => ()
       }
@@ -414,7 +421,7 @@ class MetadataBuilderActorSpec
          |"cost": 7,
          |"currency": "USD",
          |"id": "${mainWorkflowId}",
-         |"status": "${workflowState.toString}",
+         |"status": "${workflowRunningState.toString}",
          |"errors": ["Couldn't find valid vmCostPerHour for call1aA.-1.1"]
          |}""".stripMargin
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -36,6 +36,10 @@ object MetadataBuilderActor {
   final case class HasWorkData(target: ActorRef, originalRequest: BuildMetadataJsonAction)
       extends MetadataBuilderActorData
 
+  // Classes extending this trait are used to track state when the actor has launched child
+  // actors to collect metadata for subworkflows. This class aggregates data as it comes in,
+  // and builds the complete output when all subworkflow data is present. There's one child
+  // class for plain metadata queries and one for cost queries.
   sealed trait EventsCollectorData extends MetadataBuilderActorData {
     val target: ActorRef
     val originalRequest: BuildMetadataJsonAction
@@ -46,6 +50,7 @@ object MetadataBuilderActor {
 
     def isComplete = subWorkflowsMetadata.size == waitFor
   }
+
   final case class HasReceivedEventsData(target: ActorRef,
                                          originalRequest: BuildMetadataJsonAction,
                                          originalQuery: MetadataQuery,

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -543,6 +543,8 @@ cromwell::private::pip_install() {
 
 cromwell::private::upgrade_pip() {
     sudo apt-get install -y python3-pip
+    # as of ubuntu 23 need to pass --user flag
+    # https://mail.openvswitch.org/pipermail/ovs-dev/2024-June/414969.html
     cromwell::private::pip_install pip --upgrade --user pip
     cromwell::private::pip_install requests[security] --ignore-installed
 }

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -543,7 +543,7 @@ cromwell::private::pip_install() {
 
 cromwell::private::upgrade_pip() {
     sudo apt-get install -y python3-pip
-    cromwell::private::pip_install pip --upgrade
+    cromwell::private::pip_install pip --upgrade --user pip
     cromwell::private::pip_install requests[security] --ignore-installed
 }
 


### PR DESCRIPTION
### Description

Fixes a bug that caused an incorrect workflow status to be returned in the `/cost` response when subworkflows were present. This happened because subworkflow status was leaking into the parent workflow response.

Also fixes some build issues resulting from GHA runners upgrading to Ubuntu 24.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [X] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [X] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users