### PR TITLE
AN-236 Remove PAPIv1 auth file support

### DIFF
--- a/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/authentication/PipelinesApiVMAuthentication.scala
+++ b/supportedBackends/google/pipelines/common/src/main/scala/cromwell/backend/google/pipelines/common/authentication/PipelinesApiVMAuthentication.scala
@@ -6,18 +6,6 @@ import common.validation.ErrorOr._
 import common.validation.Validation._
 import cromwell.cloudsupport.gcp.GoogleConfiguration
 import cromwell.core.DockerCredentials
-import spray.json.{JsString, JsValue}
-
-/**
- * Interface for Authentication information that can be included as a json object in the file uploaded to GCS
- * upon workflow creation and used in the VM.
- */
-sealed trait PipelinesApiAuthObject {
-  def context: String
-  def map: Map[String, JsValue]
-
-  def toMap: Map[String, Map[String, JsValue]] = Map(context -> map)
-}
 
 object PipelinesApiDockerCredentials {
 
@@ -53,10 +41,3 @@ case class PipelinesApiDockerCredentials(override val token: String,
                                          override val keyName: Option[String],
                                          override val authName: Option[String]
 ) extends DockerCredentials(token = token, keyName = keyName, authName = authName)
-    with PipelinesApiAuthObject {
-
-  override val context = "docker"
-  override val map = Map(
-    "token" -> JsString(token)
-  )
-}


### PR DESCRIPTION
### Description

Many years ago, Cromwell stashed credentials in JSON files on GCS that worker VMs would then read and use for authentication. I believe we stopped doing this when we moved to PAPIv2.

I want to get this little change checked in to avoid confusion when I start making the larger changes for call caching metrics.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users