### PR TITLE
[AN-333] Prevent infinite DRS download retries

### DIFF
--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
@@ -61,10 +61,10 @@ case class GcsUriDownloader(gcsUrl: String,
       backoff foreach { b => Thread.sleep(b.backoffMillis) }
       logger.warn(s"Attempting download retry $downloadAttempt of $downloadRetries for a GCS url")
       downloadWithRetries(downloadRetries,
-        backoff map {
-          _.next
-        },
-        downloadAttempt + 1
+                          backoff map {
+                            _.next
+                          },
+                          downloadAttempt + 1
       )
     } else {
       IO.raiseError(new RuntimeException(s"Exhausted $downloadRetries resolution retries to download GCS file"))

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
@@ -61,10 +61,9 @@ case class GcsUriDownloader(gcsUrl: String,
     def handleDownloadFailure(t: Throwable): IO[DownloadResult] =
       downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
 
-    logger.info(s"Attempting download attempt $downloadAttempt of $downloadRetries for a GCS url")
-
     if (downloadAttempt < downloadRetries) {
       backoff foreach { b => Thread.sleep(b.backoffMillis) }
+      logger.info(s"Attempting download attempt $downloadAttempt of $downloadRetries for a GCS url")
       runDownloadCommand.redeemWith(
         recover = handleDownloadFailure,
         bind = {

--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/downloaders/GcsUriDownloader.scala
@@ -57,36 +57,30 @@ case class GcsUriDownloader(gcsUrl: String,
                           downloadAttempt: Int = 0
   ): IO[DownloadResult] = {
 
-    if (downloadAttempt < downloadRetries) {
-      backoff foreach { b => Thread.sleep(b.backoffMillis) }
-      logger.warn(s"Attempting download retry $downloadAttempt of $downloadRetries for a GCS url")
-      downloadWithRetries(downloadRetries,
-                          backoff map {
-                            _.next
-                          },
-                          downloadAttempt + 1
-      )
-    } else {
-      IO.raiseError(new RuntimeException(s"Exhausted $downloadRetries resolution retries to download GCS file"))
-    }
-
     // Necessary function to handle the throwable when trying to recover a failed download
     def handleDownloadFailure(t: Throwable): IO[DownloadResult] =
       downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
 
-    runDownloadCommand.redeemWith(
-      recover = handleDownloadFailure,
-      bind = {
-        case s: DownloadSuccess.type =>
-          IO.pure(s)
-        case _: RecognizedRetryableDownloadFailure =>
-          downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
-        case _: UnrecognizedRetryableDownloadFailure =>
-          downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
-        case _ =>
-          downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
-      }
-    )
+    logger.info(s"Attempting download attempt $downloadAttempt of $downloadRetries for a GCS url")
+
+    if (downloadAttempt < downloadRetries) {
+      backoff foreach { b => Thread.sleep(b.backoffMillis) }
+      runDownloadCommand.redeemWith(
+        recover = handleDownloadFailure,
+        bind = {
+          case s: DownloadSuccess.type =>
+            IO.pure(s)
+          case _: RecognizedRetryableDownloadFailure =>
+            downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
+          case _: UnrecognizedRetryableDownloadFailure =>
+            downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
+          case _ =>
+            downloadWithRetries(downloadRetries, backoff, downloadAttempt + 1)
+        }
+      )
+    } else {
+      IO.raiseError(new RuntimeException(s"Exhausted $downloadRetries resolution retries to download GCS file"))
+    }
   }
 
   /**

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GcsUriDownloaderSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GcsUriDownloaderSpec.scala
@@ -100,12 +100,14 @@ class GcsUriDownloaderSpec extends AnyFlatSpec with CromwellTimeoutSpec with Mat
 
   it should "fail to download GCS URL after 5 attempts" in {
     val gcsUrl = "gs://foo/bar.bam"
-    val downloader = spy(new GcsUriDownloader(
-      gcsUrl = gcsUrl,
-      downloadLoc = fakeDownloadLocation,
-      requesterPaysProjectIdOption = Option(fakeRequesterPaysId),
-      serviceAccountJson = None
-    ))
+    val downloader = spy(
+      new GcsUriDownloader(
+        gcsUrl = gcsUrl,
+        downloadLoc = fakeDownloadLocation,
+        requesterPaysProjectIdOption = Option(fakeRequesterPaysId),
+        serviceAccountJson = None
+      )
+    )
 
     val result = downloader.downloadWithRetries(5, None).attempt.unsafeRunSync()
 

--- a/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GcsUriDownloaderSpec.scala
+++ b/cromwell-drs-localizer/src/test/scala/drs/localizer/downloaders/GcsUriDownloaderSpec.scala
@@ -1,6 +1,7 @@
 package drs.localizer.downloaders
 
 import common.assertion.CromwellTimeoutSpec
+import org.mockito.Mockito.{spy, times, verify}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -95,5 +96,26 @@ class GcsUriDownloaderSpec extends AnyFlatSpec with CromwellTimeoutSpec with Mat
          |""".stripMargin
 
     downloader.generateDownloadScript(gcsUrl, Option(fakeSAJsonPath)) shouldBe expectedDownloadScript
+  }
+
+  it should "fail to download GCS URL after 5 attempts" in {
+    val gcsUrl = "gs://foo/bar.bam"
+    val downloader = spy(new GcsUriDownloader(
+      gcsUrl = gcsUrl,
+      downloadLoc = fakeDownloadLocation,
+      requesterPaysProjectIdOption = Option(fakeRequesterPaysId),
+      serviceAccountJson = None
+    ))
+
+    val result = downloader.downloadWithRetries(5, None).attempt.unsafeRunSync()
+
+    result.isLeft shouldBe true
+    // attempts to download the 1st time and the 5th time, but doesn't attempt a 6th
+    verify(downloader, times(1)).downloadWithRetries(5, None, 1)
+    verify(downloader, times(1)).downloadWithRetries(5, None, 5)
+    verify(downloader, times(0)).downloadWithRetries(5, None, 6)
+    // attempts the actual download command 5 times
+    verify(downloader, times(5)).runDownloadCommand
+
   }
 }


### PR DESCRIPTION
### Description

There was a bug in our retry logic that results in DRS downloads infinitely retrying in some cases. To fix this we moved the max retry check and added a test

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users