### PR TITLE
docs: remove the `oliver` repository

### DIFF
--- a/docs/Ecosystem.md
+++ b/docs/Ecosystem.md
@@ -3,4 +3,3 @@
 Many community projects have been created to support the use of the core Cromwell engine. Check them out to make your Cromwell experience even better!
 
 * [Cromshell](https://github.com/broadinstitute/cromshell): Shell script for interacting with cromwell servers created at the [Broad Institute](https://github.com/broadinstitute).
-* [Oliver](https://github.com/stjudecloud/oliver): An opinionated Cromwell orchestration manager created by the [St. Jude Cloud team](https://github.com/stjudecloud).


### PR DESCRIPTION
### Description

`oliver` has been not been actively worked on in about 4 years and has been officially archived for over 2 years publicly. We should also remove it from the Cromwell documentation.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users