### PR TITLE
[AN-371] Add logs path to batch metadata

### DIFF
--- a/runConfigurations/Repo template_ Cromwell PAPI v2beta.run.xml
+++ b/runConfigurations/Repo template_ Cromwell PAPI v2beta.run.xml
@@ -14,9 +14,18 @@
     <module name="root.cromwell" />
     <option name="PROGRAM_PARAMETERS" value="server" />
     <option name="VM_PARAMETERS" value="-Dconfig.file=target/ci/resources/papi_v2beta_application.conf" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+      </ENTRIES>
+    </extension>
     <method v="2">
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="renderCiResources" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>
 </component>

--- a/runConfigurations/Repo template_ Cromwell PAPI v2beta.run.xml
+++ b/runConfigurations/Repo template_ Cromwell PAPI v2beta.run.xml
@@ -14,18 +14,9 @@
     <module name="root.cromwell" />
     <option name="PROGRAM_PARAMETERS" value="server" />
     <option name="VM_PARAMETERS" value="-Dconfig.file=target/ci/resources/papi_v2beta_application.conf" />
-    <extension name="net.ashald.envfile">
-      <option name="IS_ENABLED" value="false" />
-      <option name="IS_SUBST" value="false" />
-      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
-      <option name="IS_IGNORE_MISSING_FILES" value="false" />
-      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
-      <ENTRIES>
-        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
-      </ENTRIES>
-    </extension>
     <method v="2">
       <option name="Make" enabled="true" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="renderCiResources" run_configuration_type="SbtRunConfiguration" />
     </method>
   </configuration>
 </component>

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
@@ -4,6 +4,7 @@ import cromwell.backend.BackendJobDescriptorKey
 import cromwell.backend.google.batch.runnable.GcpBatchMetadataKeys
 import cromwell.backend.io.JobPaths
 import cromwell.core.path.Path
+import cromwell.services.metadata.CallMetadataKeys
 
 object GcpBatchJobPaths {
 
@@ -40,10 +41,13 @@ case class GcpBatchJobPaths(override val workflowPaths: GcpBatchWorkflowPaths,
   val jesMonitoringLogFilename: String = s"${GcpBatchJobPaths.BatchMonitoringKey}.log"
   lazy val jesMonitoringLogPath: Path = callExecutionRoot.resolve(jesMonitoringLogFilename)
 
-  override lazy val customMetadataPaths =
+  override lazy val customMetadataPaths = Map(
+    CallMetadataKeys.BackendLogsPrefix + ":log" -> batchLogPath
+  ) ++ (
     workflowPaths.monitoringScriptPath map { p =>
       Map(GcpBatchMetadataKeys.MonitoringScript -> p, GcpBatchMetadataKeys.MonitoringLog -> jesMonitoringLogPath)
     } getOrElse Map.empty
+  )
 
   override def standardOutputAndErrorPaths: Map[String, Path] =
     super.standardOutputAndErrorPaths map { case (k, v) =>

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
@@ -7,7 +7,7 @@ import cromwell.core.path.Path
 import cromwell.services.metadata.CallMetadataKeys
 
 object GcpBatchJobPaths {
- val BatchLogPathKey = "log"
+  val BatchLogPathKey = "log"
   val BatchMonitoringKey = "monitoring"
   val BatchMonitoringImageKey = "monitoringImage"
   val BatchExecParamName = "exec"

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchJobPaths.scala
@@ -7,7 +7,7 @@ import cromwell.core.path.Path
 import cromwell.services.metadata.CallMetadataKeys
 
 object GcpBatchJobPaths {
-
+ val BatchLogPathKey = "log"
   val BatchMonitoringKey = "monitoring"
   val BatchMonitoringImageKey = "monitoringImage"
   val BatchExecParamName = "exec"
@@ -47,6 +47,10 @@ case class GcpBatchJobPaths(override val workflowPaths: GcpBatchWorkflowPaths,
     workflowPaths.monitoringScriptPath map { p =>
       Map(GcpBatchMetadataKeys.MonitoringScript -> p, GcpBatchMetadataKeys.MonitoringLog -> jesMonitoringLogPath)
     } getOrElse Map.empty
+  )
+
+  override lazy val customLogPaths: Map[String, Path] = Map(
+    GcpBatchJobPaths.BatchLogPathKey -> batchLogPath
   )
 
   override def standardOutputAndErrorPaths: Map[String, Path] =

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1435,7 +1435,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     val actual = batchBackend.startMetadataKeyValues.safeMapValues(_.toString)
     actual should be(
       Map(
-        //       "backendLogs:log" -> s"$batchGcsRoot/wf_hello/$workflowId/call-goodbye/goodbye.log",
+        "backendLogs:log" -> s"$batchGcsRoot/wf_hello/$workflowId/call-goodbye/goodbye.log",
         "callRoot" -> s"$batchGcsRoot/wf_hello/$workflowId/call-goodbye",
         "gcpBatch:executionBucket" -> batchGcsRoot,
         "gcpBatch:googleProject" -> googleProject,


### PR DESCRIPTION
### Description

Currently, the batch task logs are being generated and are available in GCS but the user is not able to see them in the Job Manager UI. Even after the task has reached terminal state, the log file is not visible. This PR adds the path to the log file to the workflow metadata so that jobmanager can pick it up

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users