### PR TITLE
AN-345 Ensure Batch boot disk is large enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Cromwell Change Log
 
+## 89 Release Notes
+
+### GCP Batch Updates
+ * Add default VM boot disk size to user-requested boot disk size; this ensures the VM has room for large user command Docker images.
+
 ## 88 Release Notes
 
 ### Important Upgrade Note: Database Schema Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 89 Release Notes
 
 ### GCP Batch Updates
- * Add default VM boot disk size to user-requested boot disk size; this ensures the VM has room for large user command Docker images.
+ * Add 30 GB default VM boot disk size to user-requested boot disk size; this ensures the VM has room for large user command Docker images.
 
 ## 88 Release Notes
 

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1431,7 +1431,6 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
 
     val batchBackend = testActorRef.underlyingActor
 
-    // NOTE: The commented lines are not provided by batch yet, we need to check whether those are necessary
     val actual = batchBackend.startMetadataKeyValues.safeMapValues(_.toString)
     actual should be(
       Map(
@@ -1442,7 +1441,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
         "labels:cromwell-workflow-id" -> s"cromwell-$workflowId",
         "labels:wdl-task-name" -> "goodbye",
         "preemptible" -> "false",
-        "runtimeAttributes:bootDiskSizeGb" -> "10",
+        "runtimeAttributes:bootDiskSizeGb" -> "30",
         "runtimeAttributes:continueOnReturnCode" -> "0",
         "runtimeAttributes:cpu" -> "1",
         "runtimeAttributes:disks" -> "local-disk 200 SSD",

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributesSpec.scala
@@ -140,7 +140,7 @@ final class GcpBatchRuntimeAttributesSpec
 
     "validate a valid bootDiskSizeGb entry" in {
       val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"), "bootDiskSizeGb" -> WomInteger(4))
-      val expectedRuntimeAttributes = expectedDefaults.copy(bootDiskSize = 4)
+      val expectedRuntimeAttributes = expectedDefaults.copy(bootDiskSize = 34)
       assertBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes, expectedRuntimeAttributes)
     }
 
@@ -278,7 +278,7 @@ trait GcpBatchRuntimeAttributesSpecsMixin {
     gpuResource = None,
     zones = Vector("us-central1-b", "us-central1-a"),
     preemptible = 0,
-    bootDiskSize = 10,
+    bootDiskSize = 30,
     memory = MemorySize(2, MemoryUnit.GB),
     disks = Vector(GcpBatchWorkingDisk(DiskType.SSD, 10)),
     dockerImage = "ubuntu:latest",

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchTestConfig.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchTestConfig.scala
@@ -33,7 +33,7 @@ object GcpBatchTestConfig {
       |    continueOnReturnCode: 0
       |    docker: "ubuntu:latest"
       |    memory: "2048 MB"
-      |    bootDiskSizeGb: 10
+      |    bootDiskSizeGb: 30
       |    disks: "local-disk 10 SSD"
       |    noAddress: false
       |    preemptible: 0


### PR DESCRIPTION
### Description

See [AN-345](https://broadworkbench.atlassian.net/browse/AN-345) for justification. This should eliminate edge cases where a WDL that worked on PAPI fails on Batch due to the user command Docker image filling up the VM boot disk.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users

[AN-345]: https://broadworkbench.atlassian.net/browse/AN-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ