### PR TITLE
[AN-174] Add centaur test for 4-byte unicode chars in stderr for GCP Batch

### DIFF
--- a/centaur/src/main/resources/standardTestCases/emoji_in_stderr/emoji_in_stderr.wdl
+++ b/centaur/src/main/resources/standardTestCases/emoji_in_stderr/emoji_in_stderr.wdl
@@ -1,0 +1,17 @@
+version 1.0
+
+task makeAnEmoji {
+    command {
+        AN_EMOJI='\360\237\246\204\n'
+        echo "This is my stdout file"
+        echo "This is my stderr file" >&2
+        printf $AN_EMOJI >&2
+    }
+    runtime {
+        docker: 'ubuntu:latest'
+    }
+}
+
+workflow emoji_in_stderr {
+    call makeAnEmoji {}
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_emoji_in_stderr.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_emoji_in_stderr.test
@@ -1,0 +1,12 @@
+name: gcpbatch_emoji_in_stderr
+testFormat: workflowsuccess
+backends: [GCPBATCH]
+
+files {
+  workflow: emoji_in_stderr/emoji_in_stderr.wdl
+}
+
+metadata {
+  workflowName: emoji_in_stderr
+  status: Succeeded
+}


### PR DESCRIPTION
### Description

https://broadworkbench.atlassian.net/browse/AN-174

This PR adds a centaur test for ensuring GCP Batch doesn't make a workflow fail when there are 4-byte unicode characters in stderr. Currently GCP Batch doesn't seem to include stderr content in `statusEvents` in operations metadata and hence there is no need to add special handling for these characters. But if in future this behavior is changed the centaur test should warn us of it when it starts failing.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users