### PR TITLE
AN-428 Reliably recognize preemptible failures

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
 
       # set up SBT cache
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### GCP Batch Updates
  * Add 30 GB default VM boot disk size to user-requested boot disk size; this ensures the VM has room for large user command Docker images.
+ * Fix a bug that caused Cromwell to treat immediate preemptions as failures.
 
 ## 88 Release Notes
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -153,7 +153,7 @@ object BatchRequestExecutor {
       // Get instances that can be created with this AllocationPolicy, only instances[0] is supported
       val instancePolicy = allocationPolicy.getInstances(0).getPolicy
       val machineType = instancePolicy.getMachineType
-      val preemtible = instancePolicy.getProvisioningModelValue == ProvisioningModel.PREEMPTIBLE.getNumber
+      val preemptible = instancePolicy.getProvisioningModelValue == ProvisioningModel.PREEMPTIBLE.getNumber
 
       // location list = [regions/us-central1, zones/us-central1-b], region is the first element
       val location = allocationPolicy.getLocation.getAllowedLocationsList.get(0)
@@ -163,7 +163,7 @@ object BatchRequestExecutor {
         else
           location.split("/").last
 
-      val instantiatedVmInfo = Some(InstantiatedVmInfo(region, machineType, preemtible))
+      val instantiatedVmInfo = Some(InstantiatedVmInfo(region, machineType, preemptible))
 
       if (job.getStatus.getState == JobStatus.State.SUCCEEDED) {
         RunStatus.Success(events, instantiatedVmInfo)


### PR DESCRIPTION
### Description

Fix one cause of frequent task failures on Batch. When a task went from PENDING to FAILED due to preemption rather than going through RUNNING, Cromwell wouldn't recognize the failure as a preemption and wouldn't go through the normal preemption retry process with fallback to dedicated compute.

With this change, all failures due to preemption should be recognized as such.

Also updates the version of `actions/cache` that we use in Trivy checks, v2 became deprecated.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users