### PR TITLE
AN-428 Automatically resubmit some types of Batch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### GCP Batch Updates
  * Add 30 GB default VM boot disk size to user-requested boot disk size; this ensures the VM has room for large user command Docker images.
  * Fix a bug that caused Cromwell to treat immediate preemptions as failures.
+ * Automatically retry tasks that fail with transient Batch errors before the VM has started running (that is, before the task has cost the user money). These retries do not count against `maxRetries`.
 
 ## 88 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_papi_delocalization_required_files.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_papi_delocalization_required_files.test
@@ -11,5 +11,5 @@ metadata {
   "calls.required_files.check_it.executionStatus": "Done"
   "calls.required_files.do_it.executionStatus": "Failed"
   "calls.required_files.do_it.retryableFailure": "false"
-  "calls.required_files.do_it.failures.0.message": ~~"Job exited without an error, exit code 0. Batch error code 0. Job failed with an unknown reason"
+  "calls.required_files.do_it.failures.0.message": ~~"Job exited without an error, exit code 0. GCP Batch task exited with Success(0)."
 }

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
@@ -14,5 +14,5 @@ metadata {
   workflowName: requester_pays_localization
   status: Failed
   "failures.0.message": "Workflow failed"
-  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. Job exited without an error, exit code 0. GCP Batch task exited with Success(0)."
+  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. GCP Batch task exited with Success(0)."
 }

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
@@ -14,5 +14,5 @@ metadata {
   workflowName: requester_pays_localization
   status: Failed
   "failures.0.message": "Workflow failed"
-  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. Batch error code 0. Job failed with an unknown reason"
+  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. Job exited without an error, exit code 0. GCP Batch task exited with Success(0)."
 }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1094,7 +1094,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       FailedNonRetryableExecutionHandle(
         StandardException(
           runStatus.errorCode,
-          "",
+          "", // We have no additional context to provide beyond what's already included by StandardException
           jobTag,
           returnCode,
           standardPaths.error

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1191,9 +1191,8 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   }
 
   private def handleAutoRetry(failed: RunStatus.Failed, returnCode: Option[Int]) = {
-    val msg =
-      "Task failed immediately due to a transient GCP Batch error " +
-        s"${failed.errorCode}(${failed.errorCode.code}) and will be resubmitted."
+    // This message doesn't contain information about which error because that's added inside StandardException
+    val msg = "Task failed immediately due to a transient GCP Batch error and will be resubmitted."
     FailedRetryableExecutionHandle(
       StandardException(failed.errorCode, msg, jobTag, returnCode, standardPaths.error),
       returnCode,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1186,7 +1186,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       GcpBatchExitCode.VMRecreatedDuringExecution,
       GcpBatchExitCode.VMRebootedDuringExecution
     ).contains(failed.errorCode)
-    val taskFailedBeforeStarting = failed.eventList.exists(_.name == CallMetadataKeys.VmStartTime)
+    val taskFailedBeforeStarting = !failed.eventList.exists(_.name == CallMetadataKeys.VmStartTime)
     errorTypeIsAutoRetryable && taskFailedBeforeStarting
   }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
@@ -1,0 +1,37 @@
+package cromwell.backend.google.batch.models
+
+sealed abstract class GcpBatchExitCode(val code: Int) extends Product with Serializable
+
+/**
+ * Represents the possible exit codes from Batch.
+ *
+ * See: https://cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes
+ */
+object GcpBatchExitCode {
+  case object VMPreemption extends GcpBatchExitCode(50001)
+
+  case object VMReportingTimeout extends GcpBatchExitCode(50002)
+
+  case object VMRebootedDuringExecution extends GcpBatchExitCode(50003)
+
+  case object VMAndTaskAreUnresponsive extends GcpBatchExitCode(50004)
+
+  case object TaskRunsOverMaximumRuntime extends GcpBatchExitCode(50005)
+
+  case object VMRecreatedDuringExecution extends GcpBatchExitCode(50006)
+
+  val values: List[GcpBatchExitCode] = List(
+    VMPreemption,
+    VMReportingTimeout,
+    VMRebootedDuringExecution,
+    VMAndTaskAreUnresponsive,
+    TaskRunsOverMaximumRuntime,
+    VMRecreatedDuringExecution
+  )
+
+  def fromEventMessage(message: String): Option[GcpBatchExitCode] =
+    values.find { target =>
+      message.contains(s"exit code ${target.code}")
+    }
+
+}

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
@@ -20,7 +20,8 @@ object GcpBatchExitCode {
 
   case object VMRecreatedDuringExecution extends GcpBatchExitCode(50006)
 
-  val values: List[GcpBatchExitCode] = List(
+  // Includes the above codes that correspond to Batch errors, intentionally excludes the Success code below
+  val batchErrorCodes: List[GcpBatchExitCode] = List(
     VMPreemption,
     VMReportingTimeout,
     VMRebootedDuringExecution,
@@ -34,7 +35,8 @@ object GcpBatchExitCode {
   case object Success extends GcpBatchExitCode(0)
 
   def fromEventMessage(message: String): Option[GcpBatchExitCode] =
-    values.find { target =>
+    // Note that this will never return Success, because we don't get Success explicitly from GCP.
+    batchErrorCodes.find { target =>
       message.contains(s"exit code ${target.code}")
     }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
@@ -29,6 +29,10 @@ object GcpBatchExitCode {
     VMRecreatedDuringExecution
   )
 
+  // Special case non-error code - this does not correspond to any messages we get from Batch,
+  // this is what we use for tasks that don't error out at the Batch layer.
+  case object Success extends GcpBatchExitCode(0)
+
   def fromEventMessage(message: String): Option[GcpBatchExitCode] =
     values.find { target =>
       message.contains(s"exit code ${target.code}")

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/RunStatus.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/RunStatus.scala
@@ -1,7 +1,6 @@
 package cromwell.backend.google.batch.models
 
 import cromwell.core.ExecutionEvent
-import io.grpc.Status
 import cromwell.services.cost.InstantiatedVmInfo
 
 sealed trait RunStatus {
@@ -31,30 +30,20 @@ object RunStatus {
     override def toString = "Success"
   }
 
-  sealed trait UnsuccessfulRunStatus extends TerminalRunStatus {
-    val errorCode: Status
-  }
+  sealed trait UnsuccessfulRunStatus extends TerminalRunStatus
 
   final case class Failed(
-    errorCode: Status,
+    errorCode: GcpBatchExitCode,
     eventList: Seq[ExecutionEvent],
     instantiatedVmInfo: Option[InstantiatedVmInfo] = Option.empty
   ) extends UnsuccessfulRunStatus {
     override def toString = "Failed"
   }
 
-  final case class Aborted(errorCode: Status, instantiatedVmInfo: Option[InstantiatedVmInfo] = Option.empty)
+  final case class Aborted(instantiatedVmInfo: Option[InstantiatedVmInfo] = Option.empty)
       extends UnsuccessfulRunStatus {
     override def toString = "Aborted"
 
     override def eventList: Seq[ExecutionEvent] = List.empty
-  }
-
-  final case class Preempted(
-    errorCode: Status,
-    eventList: Seq[ExecutionEvent],
-    instantiatedVmInfo: Option[InstantiatedVmInfo] = Option.empty
-  ) extends UnsuccessfulRunStatus {
-    override def toString = "Preempted"
   }
 }

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
@@ -2,15 +2,6 @@ package cromwell.backend.google.batch.api.request
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import com.google.cloud.batch.v1.{
-  AllocationPolicy,
-  BatchServiceClient,
-  BatchServiceSettings,
-  GetJobRequest,
-  Job,
-  JobStatus,
-  StatusEvent
-}
 import com.google.cloud.batch.v1.AllocationPolicy.{
   InstancePolicy,
   InstancePolicyOrTemplate,
@@ -18,6 +9,7 @@ import com.google.cloud.batch.v1.AllocationPolicy.{
   ProvisioningModel
 }
 import com.google.cloud.batch.v1.JobStatus.State
+import com.google.cloud.batch.v1._
 import com.google.protobuf.Timestamp
 import common.mock.MockSugar
 import cromwell.backend.google.batch.api.BatchApiResponse
@@ -28,6 +20,8 @@ import org.scalatest.PrivateMethodTester
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import scala.jdk.CollectionConverters._
+
 class BatchRequestExecutorSpec
     extends TestKit(ActorSystem("BatchRequestExecutorSpec"))
     with AnyFlatSpecLike
@@ -35,9 +29,41 @@ class BatchRequestExecutorSpec
     with MockSugar
     with PrivateMethodTester {
 
+  val startStatusEvent = StatusEvent
+    .newBuilder()
+    .setType("STATUS_CHANGED")
+    .setEventTime(Timestamp.newBuilder().setSeconds(1).build())
+    .setDescription("Job state is set from SCHEDULED to RUNNING for job...")
+    .build()
+
+  val endStatusEvent = StatusEvent
+    .newBuilder()
+    .setType("STATUS_CHANGED")
+    .setEventTime(Timestamp.newBuilder().setSeconds(2).build())
+    .setDescription("Job state is set from RUNNING to SOME_OTHER_STATUS for job...")
+    .build()
+
+  val schedulingStatusEvent = StatusEvent
+    .newBuilder()
+    .setType("STATUS_CHANGED")
+    .setEventTime(Timestamp.newBuilder().setSeconds(3).build())
+    .setDescription("Job state is set from QUEUED to SCHEDULED for job...")
+    .build()
+
+  val preemptionError = "Job state is set from SCHEDULED to FAILED for job projects/....Job failed due to task " +
+    "failure. Specifically, task with index 0 failed due to the following task event: \"Task state is updated " +
+    "from PENDING to FAILED on zones/... due to Spot VM preemption with exit code 50001.\""
+  val preemptionStatusEvent = StatusEvent
+    .newBuilder()
+    .setType("STATUS_CHANGED")
+    .setEventTime(Timestamp.newBuilder().setSeconds(4).build())
+    .setDescription(preemptionError)
+    .build()
+
   def setupBatchClient(machineType: String = "n1-standard-1",
                        location: String = "regions/us-central1",
-                       jobState: State = JobStatus.State.SUCCEEDED
+                       jobState: State = JobStatus.State.SUCCEEDED,
+                       events: List[StatusEvent]
   ): BatchServiceClient = {
     val instancePolicy = InstancePolicy
       .newBuilder()
@@ -51,25 +77,10 @@ class BatchRequestExecutorSpec
       .addInstances(InstancePolicyOrTemplate.newBuilder().setPolicy(instancePolicy))
       .build()
 
-    val startStatusEvent = StatusEvent
-      .newBuilder()
-      .setType("STATUS_CHANGED")
-      .setEventTime(Timestamp.newBuilder().setSeconds(1).build())
-      .setDescription("Job state is set from SCHEDULED to RUNNING for job...")
-      .build()
-
-    val endStatusEvent = StatusEvent
-      .newBuilder()
-      .setType("STATUS_CHANGED")
-      .setEventTime(Timestamp.newBuilder().setSeconds(2).build())
-      .setDescription("Job state is set from RUNNING to SOME_OTHER_STATUS for job...")
-      .build()
-
     val jobStatus = JobStatus
       .newBuilder()
       .setState(jobState)
-      .addStatusEvents(startStatusEvent)
-      .addStatusEvents(endStatusEvent)
+      .addAllStatusEvents(events.asJava)
       .build()
 
     val job = Job.newBuilder().setAllocationPolicy(allocationPolicy).setStatus(jobStatus).build()
@@ -83,9 +94,48 @@ class BatchRequestExecutorSpec
 
   behavior of "BatchRequestExecutor"
 
+  it should "create a schedule status event correctly" in {
+
+    val mockClient = setupBatchClient(jobState = JobStatus.State.QUEUED, events = List(schedulingStatusEvent))
+    val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
+
+    // testing a private method see https://www.scalatest.org/user_guide/using_PrivateMethodTester
+    val internalGetHandler = PrivateMethod[BatchApiResponse.StatusQueried](Symbol("internalGetHandler"))
+    val result = batchRequestExecutor invokePrivate internalGetHandler(mockClient, GetJobRequest.newBuilder().build())
+
+    // Verify the event
+    result.status match {
+      case RunStatus.Initializing(events, _) =>
+        events.length shouldBe 1
+        events.map(_.name).head shouldBe "Job state is set from QUEUED to SCHEDULED for job..."
+        events.map(_.offsetDateTime.toString).head shouldBe "1970-01-01T00:00:03Z"
+      case _ => fail("Expected RunStatus.Initializing with events")
+    }
+  }
+
+  it should "handle an immediate preemption correctly" in {
+
+    val mockClient = setupBatchClient(jobState = JobStatus.State.FAILED, events = List(preemptionStatusEvent))
+    val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
+
+    // testing a private method see https://www.scalatest.org/user_guide/using_PrivateMethodTester
+    val internalGetHandler = PrivateMethod[BatchApiResponse.StatusQueried](Symbol("internalGetHandler"))
+    val result = batchRequestExecutor invokePrivate internalGetHandler(mockClient, GetJobRequest.newBuilder().build())
+
+    // Verify the event
+    result.status match {
+      case RunStatus.Preempted(_, events, _) =>
+        events.length shouldBe 1
+        events.map(_.name).head shouldBe preemptionError
+        events.map(_.offsetDateTime.toString).head shouldBe "1970-01-01T00:00:04Z"
+      case _ => fail("Expected RunStatus.Preempted with events")
+    }
+  }
+
   it should "create instantiatedVmInfo correctly" in {
 
-    val mockClient = setupBatchClient(jobState = JobStatus.State.RUNNING)
+    val mockClient =
+      setupBatchClient(jobState = JobStatus.State.RUNNING, events = List(startStatusEvent, endStatusEvent))
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
 
@@ -105,7 +155,10 @@ class BatchRequestExecutorSpec
 
   it should "create instantiatedVmInfo correctly with different location info" in {
 
-    val mockClient = setupBatchClient(location = "zones/us-central1-a", jobState = JobStatus.State.RUNNING)
+    val mockClient = setupBatchClient(location = "zones/us-central1-a",
+                                      jobState = JobStatus.State.RUNNING,
+                                      events = List(startStatusEvent, endStatusEvent)
+    )
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
@@ -126,7 +179,8 @@ class BatchRequestExecutorSpec
 
   it should "create instantiatedVmInfo correctly with missing location info" in {
 
-    val mockClient = setupBatchClient(jobState = JobStatus.State.RUNNING)
+    val mockClient =
+      setupBatchClient(jobState = JobStatus.State.RUNNING, events = List(startStatusEvent, endStatusEvent))
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
@@ -147,7 +201,7 @@ class BatchRequestExecutorSpec
 
   it should "send vmStartTime and vmEndTime metadata info when a workflow succeeds" in {
 
-    val mockClient = setupBatchClient()
+    val mockClient = setupBatchClient(events = List(startStatusEvent, endStatusEvent))
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
@@ -168,7 +222,8 @@ class BatchRequestExecutorSpec
   }
 
   it should "send vmStartTime and vmEndTime metadata info along with other events when a workflow fails" in {
-    val mockClient = setupBatchClient(jobState = JobStatus.State.FAILED)
+    val mockClient =
+      setupBatchClient(jobState = JobStatus.State.FAILED, events = List(startStatusEvent, endStatusEvent))
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchExitCodeSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchExitCodeSpec.scala
@@ -1,0 +1,52 @@
+package cromwell.backend.google.batch.models
+
+import org.scalatest.OptionValues._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class GcpBatchExitCodeSpec extends AnyWordSpec with Matchers {
+
+  "fromEventMessage" should {
+    "detect VMPreemption error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to Spot Preemption with exit code 50001."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.VMPreemption)
+    }
+
+    "detect VMReportingTimeout error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to Batch no longer receives VM updates with exit code 50002."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.VMReportingTimeout)
+    }
+
+    "detect VMRebootedDuringExecution error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to VM is rebooted during task execution with exit code 50003."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.VMRebootedDuringExecution)
+    }
+
+    "detect VMAndTaskAreUnresponsive error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to tasks cannot be canceled with exit code 50004."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.VMAndTaskAreUnresponsive)
+    }
+
+    "detect TaskRunsOverMaximumRuntime error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to task runs over the maximum runtime with exit code 50005."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.TaskRunsOverMaximumRuntime)
+    }
+
+    "detect VMRecreatedDuringExecution error" in {
+      val msg =
+        "Task state is updated from PRE-STATE to FAILED on zones/ZONE/instances/INSTANCE_ID due to VM is recreated during task execution with exit code 50006."
+      val result = GcpBatchExitCode.fromEventMessage(msg)
+      result.value should be(GcpBatchExitCode.VMRecreatedDuringExecution)
+    }
+  }
+}


### PR DESCRIPTION
### Description

The primary goal of this work is to automatically (without counting against `maxRetries`) resubmit failed tasks when:
 * The job has not yet cost the user money (the VM hasn't started running)
 * The error is known to be a transient Batch problem

To make that change easier I plumbed `GcpBatchExitCode` through our `Failed` run status. This had the side effect of making it possible for our error messages to be more helpful. For example, an error that used to say:

`Task my_workflow.my_task:NA:14 failed. The job was stopped before the command finished. Batch error code 0. Job failed with an unknown reason`

...will now say:

`Task my_workflow.my_task:NA:14 failed. The job was stopped before the command finished. GCP Batch task exited with VMRecreatedDuringExecution(50006).`

Unfortunately we can't test this behavior with a Centaur test because there's no way to trigger a task to fail before its VM starts running.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users