### PR TITLE
AN-343 Begrudgingly test with real objects

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1243,7 +1243,6 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         case batchOutput if batchOutput.name == makeSafeReferenceName(path) =>
           val pathAsString = batchOutput.cloudPath.pathAsString
 
-          // TODO: batchOutput.cloudPath.exists invokes GCP, which causes a test ported from papi-common to fail
           if (batchOutput.isFileParameter && !batchOutput.cloudPath.exists) {
             // This is not an error if the path represents a `File?` optional output (the Batch delocalization script
             // should have failed if this file output was not optional but missing). Throw to produce the correct "empty

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1086,58 +1086,57 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
   // Cause: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
   // Will be addressed by another ticket
   it should "convert local Paths back to corresponding GCS paths in BatchOutputs" in {
-    pending
 
     val batchOutputs = Set(
       GcpBatchFileOutput(
-        s"$MountPoint/path/to/file1",
-        gcsPath("gs://path/to/file1"),
-        DefaultPathBuilder.get(s"$MountPoint/path/to/file1"),
+        s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1",
+        gcsPath("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"),
+        DefaultPathBuilder.get(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPoint/path/to/file2",
-        gcsPath("gs://path/to/file2"),
-        DefaultPathBuilder.get(s"$MountPoint/path/to/file2"),
+        s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2",
+        gcsPath("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"),
+        DefaultPathBuilder.get(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPoint/path/to/file3",
-        gcsPath("gs://path/to/file3"),
-        DefaultPathBuilder.get(s"$MountPoint/path/to/file3"),
+        s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3",
+        gcsPath("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"),
+        DefaultPathBuilder.get(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPoint/path/to/file4",
-        gcsPath("gs://path/to/file4"),
-        DefaultPathBuilder.get(s"$MountPoint/path/to/file4"),
+        s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4",
+        gcsPath("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4"),
+        DefaultPathBuilder.get(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4"),
         workingDisk,
         optional = false,
         secondary = false
       ),
       GcpBatchFileOutput(
-        s"$MountPoint/path/to/file5",
-        gcsPath("gs://path/to/file5"),
-        DefaultPathBuilder.get(s"$MountPoint/path/to/file5"),
+        s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5",
+        gcsPath("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5"),
+        DefaultPathBuilder.get(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5"),
         workingDisk,
         optional = false,
         secondary = false
       )
     )
     val outputValues = Seq(
-      WomSingleFile(s"$MountPoint/path/to/file1"),
+      WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"),
       WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile(s"$MountPoint/path/to/file2"), WomSingleFile(s"$MountPoint/path/to/file3"))
+               Seq(WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"), WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"))
       ),
       WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
              Map(
-               WomSingleFile(s"$MountPoint/path/to/file4") -> WomSingleFile(s"$MountPoint/path/to/file5")
+               WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4") -> WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5")
              )
       )
     )
@@ -1177,15 +1176,15 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
 
     val result = outputValues map wdlValueToGcsPath(batchOutputs)
     result should have size 3
-    result should contain(WomSingleFile("gs://path/to/file1"))
+    result should contain(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"))
     result should contain(
       WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile("gs://path/to/file2"), WomSingleFile("gs://path/to/file3"))
+               Seq(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"), WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"))
       )
     )
     result should contain(
       WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
-             Map(WomSingleFile("gs://path/to/file4") -> WomSingleFile("gs://path/to/file5"))
+             Map(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4") -> WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5"))
       )
     )
   }

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1082,9 +1082,6 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     }
   }
 
-  // TODO: FIXME
-  // Cause: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
-  // Will be addressed by another ticket
   it should "convert local Paths back to corresponding GCS paths in BatchOutputs" in {
 
     val batchOutputs = Set(

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1128,13 +1128,20 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     )
     val outputValues = Seq(
       WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"),
-      WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"), WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"))
+      WomArray(
+        WomArrayType(WomSingleFileType),
+        Seq(
+          WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"),
+          WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3")
+        )
       ),
-      WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
-             Map(
-               WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4") -> WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5")
-             )
+      WomMap(
+        WomMapType(WomSingleFileType, WomSingleFileType),
+        Map(
+          WomSingleFile(
+            s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4"
+          ) -> WomSingleFile(s"$MountPoint/centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5")
+        )
       )
     )
 
@@ -1175,13 +1182,22 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     result should have size 3
     result should contain(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file1"))
     result should contain(
-      WomArray(WomArrayType(WomSingleFileType),
-               Seq(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"), WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3"))
+      WomArray(
+        WomArrayType(WomSingleFileType),
+        Seq(
+          WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file2"),
+          WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file3")
+        )
       )
     )
     result should contain(
-      WomMap(WomMapType(WomSingleFileType, WomSingleFileType),
-             Map(WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4") -> WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5"))
+      WomMap(
+        WomMapType(WomSingleFileType, WomSingleFileType),
+        Map(
+          WomSingleFile("gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file4") -> WomSingleFile(
+            "gs://centaur-ci-public/GcpBatchAsyncBackendJobExecutionActorSpec/file5"
+          )
+        )
       )
     )
   }


### PR DESCRIPTION
### Description

This test had been disabled for the whole existence of the Batch backend.

The Life Sciences version of the test, `PipelinesApiAsyncBackendJobExecutionActorSpec.scala`, called a very basic default implementation with no side effects:
```
cromwell.backend.google.pipelines.common.PipelinesApiAsyncBackendJobExecutionActor#womFileToGcsPath
```

Its override, which we actually use for that backend, checks for existence of real files:
```
cromwell.backend.google.pipelines.v2beta.PipelinesApiAsyncBackendJobExecutionActor#womFileToGcsPath
```

The factoring of Batch does not include a default/override, so this fallback is no longer possible. The test always wants to call the real function with side-effects:
```
cromwell.backend.google.batch.actors.GcpBatchAsyncBackendJobExecutionActor#womFileToGcsPath
```

This seems desirable to me, because we're testing the code we use instead of the code we override.

#### The following additional issues are annoying:
- The code is called from the GCP backend actor, where it is not possible to inject alternate mock filesystems
- The test seems to spin up the actor in a way that does not set up Google auth, so I had to make the 0-byte test objects public

#### Alternate idea considered:
- Create a base class for `GcpBatchAsyncBackendJobExecutionActor` that has a trivial implementation of `womFileToGcsPath`

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users