### PR TITLE
AN-465 Retry all transient GCP Batch failures, but not forever

### DIFF
--- a/centaur/src/main/resources/standardTestCases/recursive_imports_cost_batch.test
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_cost_batch.test
@@ -20,4 +20,4 @@ metadata {
   status: Succeeded
 }
 
-cost: [0.0015, 0.0019]
+cost: [0.0011, 0.0023]

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableMap
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend._
 import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{
+  autoRetryCountKey,
   preemptionCountKey,
   robustBuildAttributes,
   unexpectedRetryCountKey
@@ -35,7 +36,8 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
 ) extends StandardLifecycleActorFactory
     with GcpPlatform {
 
-  override val requestedKeyValueStoreKeys: Seq[String] = Seq(preemptionCountKey, unexpectedRetryCountKey)
+  override val requestedKeyValueStoreKeys: Seq[String] =
+    Seq(preemptionCountKey, unexpectedRetryCountKey, autoRetryCountKey)
 
   override def jobIdKey: String = "__gcp_batch"
   protected val googleConfig: GoogleConfiguration = GoogleConfiguration(configurationDescriptor.globalConfig)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
@@ -140,6 +140,7 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
 object GcpBatchBackendLifecycleActorFactory extends StrictLogging {
   val preemptionCountKey = "PreemptionCount"
   val unexpectedRetryCountKey = "UnexpectedRetryCount"
+  val autoRetryCountKey = "AutoRetryCount"
 
   private[batch] def robustBuildAttributes(buildAttributes: () => GcpBatchConfigurationAttributes,
                                            maxAttempts: Int = 3,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/GcpBatchBackendLifecycleActorFactory.scala
@@ -8,9 +8,9 @@ import com.google.common.collect.ImmutableMap
 import com.typesafe.scalalogging.StrictLogging
 import cromwell.backend._
 import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{
-  autoRetryCountKey,
   preemptionCountKey,
   robustBuildAttributes,
+  transientRetryCountKey,
   unexpectedRetryCountKey
 }
 import cromwell.backend.google.batch.actors._
@@ -37,7 +37,7 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
     with GcpPlatform {
 
   override val requestedKeyValueStoreKeys: Seq[String] =
-    Seq(preemptionCountKey, unexpectedRetryCountKey, autoRetryCountKey)
+    Seq(preemptionCountKey, unexpectedRetryCountKey, transientRetryCountKey)
 
   override def jobIdKey: String = "__gcp_batch"
   protected val googleConfig: GoogleConfiguration = GoogleConfiguration(configurationDescriptor.globalConfig)
@@ -142,7 +142,7 @@ class GcpBatchBackendLifecycleActorFactory(override val name: String,
 object GcpBatchBackendLifecycleActorFactory extends StrictLogging {
   val preemptionCountKey = "PreemptionCount"
   val unexpectedRetryCountKey = "UnexpectedRetryCount"
-  val autoRetryCountKey = "AutoRetryCount"
+  val transientRetryCountKey = "TransientRetryCount"
 
   private[batch] def robustBuildAttributes(buildAttributes: () => GcpBatchConfigurationAttributes,
                                            maxAttempts: Int = 3,

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -188,7 +188,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     PreviousRetryReasons.tryApply(jobDescriptor.prefetchedKvStoreEntries, jobDescriptor.key.attempt)
 
   override lazy val preemptible: Boolean = previousRetryReasons match {
-    case Valid(PreviousRetryReasons(p, _)) => p < maxPreemption
+    case Valid(PreviousRetryReasons(p, _, _)) => p < maxPreemption
     case _ => false
   }
 
@@ -1108,10 +1108,10 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         runStatus match {
           case _: RunStatus.Aborted => AbortedExecutionHandle
           case failedStatus: RunStatus.Failed =>
-            if (failedStatus.errorCode == GcpBatchExitCode.VMPreemption && preemptible) {
-              handlePreemption(failedStatus, returnCode)
-            } else if (shouldAutoRetryFailure(failedStatus)) {
+            if (shouldAutoRetryFailure(failedStatus)) {
               handleAutoRetry(failedStatus, returnCode)
+            } else if (failedStatus.errorCode == GcpBatchExitCode.VMPreemption && preemptible) {
+              handlePreemption(failedStatus, returnCode)
             } else
               handleFailedRunStatus(failedStatus, returnCode)
           case unknown =>
@@ -1123,12 +1123,15 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     }
   }
 
-  private def nextAttemptPreemptedAndUnexpectedRetryCountsToKvPairs(p: Int, ur: Int): Seq[KvPair] =
+  private def nextAttemptRetryCountsToKvPairs(p: Int, ur: Int, ar: Int): Seq[KvPair] =
     Seq(
       KvPair(ScopedKey(workflowId, futureKvJobKey, GcpBatchBackendLifecycleActorFactory.unexpectedRetryCountKey),
              ur.toString
       ),
-      KvPair(ScopedKey(workflowId, futureKvJobKey, GcpBatchBackendLifecycleActorFactory.preemptionCountKey), p.toString)
+      KvPair(ScopedKey(workflowId, futureKvJobKey, GcpBatchBackendLifecycleActorFactory.preemptionCountKey),
+             p.toString
+      ),
+      KvPair(ScopedKey(workflowId, futureKvJobKey, GcpBatchBackendLifecycleActorFactory.autoRetryCountKey), ar.toString)
     )
 
   private def handlePreemption(
@@ -1139,13 +1142,12 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
 
     val errorCode: GcpBatchExitCode = runStatus.errorCode
     previousRetryReasons match {
-      case Valid(PreviousRetryReasons(p, ur)) =>
+      case Valid(PreviousRetryReasons(p, ur, ar)) =>
         val thisPreemption = p + 1
         val taskName = s"${workflowDescriptor.id}:${call.localName}"
         val baseMsg = s"Task $taskName was preempted for the ${thisPreemption.toOrdinal} time."
 
-        val preemptionAndUnexpectedRetryCountsKvPairs =
-          nextAttemptPreemptedAndUnexpectedRetryCountsToKvPairs(thisPreemption, ur)
+        val retryCountsKvPairs = nextAttemptRetryCountsToKvPairs(thisPreemption, ur, ar)
         if (thisPreemption < maxPreemption) {
           // Increment preemption count and unexpectedRetryCount stays the same
           val msg =
@@ -1154,7 +1156,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           FailedRetryableExecutionHandle(
             StandardException(errorCode, msg, jobTag, jobReturnCode, standardPaths.error),
             jobReturnCode,
-            kvPairsToSave = Option(preemptionAndUnexpectedRetryCountsKvPairs)
+            kvPairsToSave = Option(retryCountsKvPairs)
           )
         } else {
           val msg = s"$baseMsg The maximum number of preemptible attempts ($maxPreemption) has been reached. The " +
@@ -1162,7 +1164,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           FailedRetryableExecutionHandle(
             StandardException(errorCode, msg, jobTag, jobReturnCode, standardPaths.error),
             jobReturnCode,
-            kvPairsToSave = Option(preemptionAndUnexpectedRetryCountsKvPairs)
+            kvPairsToSave = Option(retryCountsKvPairs)
           )
         }
       case Invalid(_) =>
@@ -1183,6 +1185,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   // Guidance: Resubmit if the task has a known-transient failure type and has not yet cost the user money.
   private def shouldAutoRetryFailure(failed: RunStatus.Failed): Boolean = {
     val errorTypeIsAutoRetryable = List(
+      GcpBatchExitCode.VMPreemption,
       GcpBatchExitCode.VMRecreatedDuringExecution,
       GcpBatchExitCode.VMRebootedDuringExecution
     ).contains(failed.errorCode)
@@ -1190,15 +1193,32 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     errorTypeIsAutoRetryable && taskFailedBeforeStarting
   }
 
-  private def handleAutoRetry(failed: RunStatus.Failed, returnCode: Option[Int]) = {
-    // This message doesn't contain information about which error because that's added inside StandardException
-    val msg = "Task failed immediately due to a transient GCP Batch error and will be resubmitted."
-    FailedRetryableExecutionHandle(
-      StandardException(failed.errorCode, msg, jobTag, returnCode, standardPaths.error),
-      returnCode,
-      kvPairsToSave = None
-    )
-  }
+  private def handleAutoRetry(failed: RunStatus.Failed, returnCode: Option[Int]) =
+    previousRetryReasons match {
+      case Valid(PreviousRetryReasons(p, ur, ar)) =>
+        val thisAutoRetry = ar + 1
+        val retryCountsKvPairs =
+          nextAttemptRetryCountsToKvPairs(p, ur, thisAutoRetry)
+
+        // This message doesn't contain information about which error because that's added inside StandardException
+        val msg = "Task failed immediately due to a transient GCP Batch error and will be resubmitted."
+        FailedRetryableExecutionHandle(
+          StandardException(failed.errorCode, msg, jobTag, returnCode, standardPaths.error),
+          returnCode,
+          kvPairsToSave = Option(retryCountsKvPairs)
+        )
+      case Invalid(_) =>
+        FailedNonRetryableExecutionHandle(
+          StandardException(failed.errorCode,
+                            "Job failed due to preemption, couldn't get information about previous retry attempts.",
+                            jobTag,
+                            returnCode,
+                            standardPaths.error
+          ),
+          returnCode,
+          None
+        )
+    }
 
   override lazy val startMetadataKeyValues: Map[String, Any] =
     super[GcpBatchJobCachingActorHelper].startMetadataKeyValues

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchConfigurationAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchConfigurationAttributes.scala
@@ -55,7 +55,8 @@ case class GcpBatchConfigurationAttributes(
   batchRequestTimeoutConfiguration: BatchRequestTimeoutConfiguration,
   referenceFileToDiskImageMappingOpt: Option[Map[String, GcpBatchReferenceFilesDisk]],
   checkpointingInterval: FiniteDuration,
-  logsPolicy: GcpBatchLogsPolicy
+  logsPolicy: GcpBatchLogsPolicy,
+  maxAutoTaskRetries: Int
 )
 
 object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOperations with StrictLogging {
@@ -109,6 +110,7 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
     "concurrent-job-limit",
     "request-workers",
     "batch-timeout",
+    "max-auto-task-retries",
     "batch-requests.timeouts.read",
     "batch-requests.timeouts.connect",
     "default-runtime-attributes.bootDiskSizeGb",
@@ -300,6 +302,9 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
 
     val checkpointingInterval: FiniteDuration = backendConfig.getOrElse(checkpointingIntervalKey, 10.minutes)
 
+    val maxAutoTaskRetries: Int =
+      backendConfig.as[Option[Int]]("max-auto-task-retries").getOrElse(10)
+
     def authGoogleConfigForBatchConfigurationAttributes(
       project: String,
       bucket: String,
@@ -341,7 +346,8 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
           batchRequestTimeoutConfiguration = batchRequestTimeoutConfiguration,
           referenceFileToDiskImageMappingOpt = generatedReferenceFilesMappingOpt,
           checkpointingInterval = checkpointingInterval,
-          logsPolicy = logsPolicy
+          logsPolicy = logsPolicy,
+          maxAutoTaskRetries = maxAutoTaskRetries
         )
       }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchConfigurationAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchConfigurationAttributes.scala
@@ -56,7 +56,7 @@ case class GcpBatchConfigurationAttributes(
   referenceFileToDiskImageMappingOpt: Option[Map[String, GcpBatchReferenceFilesDisk]],
   checkpointingInterval: FiniteDuration,
   logsPolicy: GcpBatchLogsPolicy,
-  maxAutoTaskRetries: Int
+  maxTransientErrorRetries: Int
 )
 
 object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOperations with StrictLogging {
@@ -110,7 +110,7 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
     "concurrent-job-limit",
     "request-workers",
     "batch-timeout",
-    "max-auto-task-retries",
+    "max-transient-error-retries",
     "batch-requests.timeouts.read",
     "batch-requests.timeouts.connect",
     "default-runtime-attributes.bootDiskSizeGb",
@@ -302,8 +302,8 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
 
     val checkpointingInterval: FiniteDuration = backendConfig.getOrElse(checkpointingIntervalKey, 10.minutes)
 
-    val maxAutoTaskRetries: Int =
-      backendConfig.as[Option[Int]]("max-auto-task-retries").getOrElse(10)
+    val maxTransientErrorRetries: Int =
+      backendConfig.as[Option[Int]]("max-transient-error-retries").getOrElse(10)
 
     def authGoogleConfigForBatchConfigurationAttributes(
       project: String,
@@ -347,7 +347,7 @@ object GcpBatchConfigurationAttributes extends GcpBatchReferenceFilesMappingOper
           referenceFileToDiskImageMappingOpt = generatedReferenceFilesMappingOpt,
           checkpointingInterval = checkpointingInterval,
           logsPolicy = logsPolicy,
-          maxAutoTaskRetries = maxAutoTaskRetries
+          maxTransientErrorRetries = maxTransientErrorRetries
         )
       }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
@@ -4,15 +4,15 @@ import cats.syntax.apply._
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
 import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{
-  autoRetryCountKey,
   preemptionCountKey,
+  transientRetryCountKey,
   unexpectedRetryCountKey
 }
 import cromwell.services.keyvalue.KeyValueServiceActor._
 
 import scala.util.{Failure, Success, Try}
 
-case class PreviousRetryReasons(preempted: Int, unexpectedRetry: Int, autoRetry: Int)
+case class PreviousRetryReasons(preempted: Int, unexpectedRetry: Int, transientRetry: Int)
 
 object PreviousRetryReasons {
 
@@ -20,22 +20,25 @@ object PreviousRetryReasons {
     val validatedPreemptionCount = validatedKvResponse(prefetchedKvEntries.get(preemptionCountKey), preemptionCountKey)
     val validatedUnexpectedRetryCount =
       validatedKvResponse(prefetchedKvEntries.get(unexpectedRetryCountKey), unexpectedRetryCountKey)
-    val validatedAutoRetryCount =
-      validatedKvResponse(prefetchedKvEntries.get(autoRetryCountKey), autoRetryCountKey)
+    val validatedTransientRetryCount =
+      validatedKvResponse(prefetchedKvEntries.get(transientRetryCountKey), transientRetryCountKey)
 
-    (validatedPreemptionCount, validatedUnexpectedRetryCount, validatedAutoRetryCount) mapN PreviousRetryReasons.apply
+    (validatedPreemptionCount,
+     validatedUnexpectedRetryCount,
+     validatedTransientRetryCount
+    ) mapN PreviousRetryReasons.apply
   }
 
   def apply(knownPreemptedCount: Int,
             knownUnexpectedRetryCount: Int,
-            knownAutoRetryCount: Int,
+            knownTransientRetryCount: Int,
             attempt: Int
   ): PreviousRetryReasons = {
     // If we have anything unaccounted for, we can top up the unexpected retry count.
     // NB: 'attempt' is 1-indexed, so, magic number:
     // NB2: for sanity's sake, I won't let this unaccounted for drop below 0, just in case...
     val unaccountedFor = Math.max(attempt - 1 - knownPreemptedCount - knownUnexpectedRetryCount, 0)
-    PreviousRetryReasons(knownPreemptedCount, knownUnexpectedRetryCount + unaccountedFor, knownAutoRetryCount)
+    PreviousRetryReasons(knownPreemptedCount, knownUnexpectedRetryCount + unaccountedFor, knownTransientRetryCount)
   }
 
   private def validatedKvResponse(r: Option[KvResponse], fromKey: String): ErrorOr[Int] = r match {

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
@@ -3,7 +3,11 @@ package cromwell.backend.google.batch.models
 import cats.syntax.apply._
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
-import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{autoRetryCountKey, preemptionCountKey, unexpectedRetryCountKey}
+import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{
+  autoRetryCountKey,
+  preemptionCountKey,
+  unexpectedRetryCountKey
+}
 import cromwell.services.keyvalue.KeyValueServiceActor._
 
 import scala.util.{Failure, Success, Try}
@@ -22,7 +26,11 @@ object PreviousRetryReasons {
     (validatedPreemptionCount, validatedUnexpectedRetryCount, validatedAutoRetryCount) mapN PreviousRetryReasons.apply
   }
 
-  def apply(knownPreemptedCount: Int, knownUnexpectedRetryCount: Int, knownAutoRetryCount: Int, attempt: Int): PreviousRetryReasons = {
+  def apply(knownPreemptedCount: Int,
+            knownUnexpectedRetryCount: Int,
+            knownAutoRetryCount: Int,
+            attempt: Int
+  ): PreviousRetryReasons = {
     // If we have anything unaccounted for, we can top up the unexpected retry count.
     // NB: 'attempt' is 1-indexed, so, magic number:
     // NB2: for sanity's sake, I won't let this unaccounted for drop below 0, just in case...

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/PreviousRetryReasons.scala
@@ -3,12 +3,12 @@ package cromwell.backend.google.batch.models
 import cats.syntax.apply._
 import cats.syntax.validated._
 import common.validation.ErrorOr.ErrorOr
-import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{preemptionCountKey, unexpectedRetryCountKey}
+import cromwell.backend.google.batch.GcpBatchBackendLifecycleActorFactory.{autoRetryCountKey, preemptionCountKey, unexpectedRetryCountKey}
 import cromwell.services.keyvalue.KeyValueServiceActor._
 
 import scala.util.{Failure, Success, Try}
 
-case class PreviousRetryReasons(preempted: Int, unexpectedRetry: Int)
+case class PreviousRetryReasons(preempted: Int, unexpectedRetry: Int, autoRetry: Int)
 
 object PreviousRetryReasons {
 
@@ -16,16 +16,18 @@ object PreviousRetryReasons {
     val validatedPreemptionCount = validatedKvResponse(prefetchedKvEntries.get(preemptionCountKey), preemptionCountKey)
     val validatedUnexpectedRetryCount =
       validatedKvResponse(prefetchedKvEntries.get(unexpectedRetryCountKey), unexpectedRetryCountKey)
+    val validatedAutoRetryCount =
+      validatedKvResponse(prefetchedKvEntries.get(autoRetryCountKey), autoRetryCountKey)
 
-    (validatedPreemptionCount, validatedUnexpectedRetryCount) mapN PreviousRetryReasons.apply
+    (validatedPreemptionCount, validatedUnexpectedRetryCount, validatedAutoRetryCount) mapN PreviousRetryReasons.apply
   }
 
-  def apply(knownPreemptedCount: Int, knownUnexpectedRetryCount: Int, attempt: Int): PreviousRetryReasons = {
+  def apply(knownPreemptedCount: Int, knownUnexpectedRetryCount: Int, knownAutoRetryCount: Int, attempt: Int): PreviousRetryReasons = {
     // If we have anything unaccounted for, we can top up the unexpected retry count.
     // NB: 'attempt' is 1-indexed, so, magic number:
     // NB2: for sanity's sake, I won't let this unaccounted for drop below 0, just in case...
     val unaccountedFor = Math.max(attempt - 1 - knownPreemptedCount - knownUnexpectedRetryCount, 0)
-    PreviousRetryReasons(knownPreemptedCount, knownUnexpectedRetryCount + unaccountedFor)
+    PreviousRetryReasons(knownPreemptedCount, knownUnexpectedRetryCount + unaccountedFor, knownAutoRetryCount)
   }
 
   private def validatedKvResponse(r: Option[KvResponse], fromKey: String): ErrorOr[Int] = r match {

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchBackendLifecycleActorFactorySpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchBackendLifecycleActorFactorySpec.scala
@@ -35,7 +35,7 @@ class GcpBatchBackendLifecycleActorFactorySpec extends AnyFlatSpecLike with Matc
       referenceFileToDiskImageMappingOpt = None,
       checkpointingInterval = 1 second,
       logsPolicy = GcpBatchLogsPolicy.CloudLogging,
-      maxAutoTaskRetries = 10
+      maxTransientErrorRetries = 10
     )
 
     GcpBatchBackendLifecycleActorFactory.robustBuildAttributes(() => attributes) shouldBe attributes

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchBackendLifecycleActorFactorySpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchBackendLifecycleActorFactorySpec.scala
@@ -34,7 +34,8 @@ class GcpBatchBackendLifecycleActorFactorySpec extends AnyFlatSpecLike with Matc
       batchRequestTimeoutConfiguration = null,
       referenceFileToDiskImageMappingOpt = None,
       checkpointingInterval = 1 second,
-      logsPolicy = GcpBatchLogsPolicy.CloudLogging
+      logsPolicy = GcpBatchLogsPolicy.CloudLogging,
+      maxAutoTaskRetries = 10
     )
 
     GcpBatchBackendLifecycleActorFactory.robustBuildAttributes(() => attributes) shouldBe attributes

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/callcaching/BatchBackendCacheHitCopyingActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/callcaching/BatchBackendCacheHitCopyingActorSpec.scala
@@ -435,7 +435,7 @@ class BatchBackendCacheHitCopyingActorSpec
       referenceFileToDiskImageMappingOpt = None,
       checkpointingInterval = 10.minutes,
       logsPolicy = GcpBatchLogsPolicy.CloudLogging,
-      maxAutoTaskRetries = 10
+      maxTransientErrorRetries = 10
     )
 
     val batchConfiguration = mockWithDefaults[GcpBatchConfiguration]

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/callcaching/BatchBackendCacheHitCopyingActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/callcaching/BatchBackendCacheHitCopyingActorSpec.scala
@@ -434,7 +434,8 @@ class BatchBackendCacheHitCopyingActorSpec
       batchRequestTimeoutConfiguration = null,
       referenceFileToDiskImageMappingOpt = None,
       checkpointingInterval = 10.minutes,
-      logsPolicy = GcpBatchLogsPolicy.CloudLogging
+      logsPolicy = GcpBatchLogsPolicy.CloudLogging,
+      maxAutoTaskRetries = 10
     )
 
     val batchConfiguration = mockWithDefaults[GcpBatchConfiguration]


### PR DESCRIPTION
### Description

Updates retry behavior in GCP Batch backend. When a task fails:
 * If it's a known transient GCP Batch error (VM preemption, VM recreation, VM restart) and the task has not started running on the VM (costing the user money) yet, retry up to 10 times by default, retry count configurable.
 * Otherwise, fall back to the standard `preemptible` and `maxRetries` handling.

Note that these retry types can be interleaved, we can have auto-retried transient failures among the other types.

The specific changes this PR makes are:
 * VM preemption added to the list of error types that will automatically retry if the task hasn't started running yet
 * Automatic retry attempts capped at a configurable number

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users