### PR TITLE
[AN-473] Widen expected range for PAPI cost test

### DIFF
--- a/centaur/src/main/resources/standardTestCases/recursive_imports_cost_papi.test
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_cost_papi.test
@@ -20,4 +20,4 @@ metadata {
   status: Succeeded
 }
 
-cost: [0.0035,0.0045]
+cost: [0.00,0.01]

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_cost_papi.test
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_cost_papi.test
@@ -20,4 +20,4 @@ metadata {
   status: Succeeded
 }
 
-cost: [0.00,0.01]
+cost: [0.003,0.007]


### PR DESCRIPTION
### Description

This test suite has failed a few times recently because the true cost was slightly out of the expected range for this test (0.0053 instead of 0.0045). 

This change just widens the allowed range a bit

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users