### PR TITLE
Update path to GcpBatch101 doc

### DIFF
--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -5,7 +5,7 @@ Google Cloud Batch is a fully managed service that lets you schedule, queue, and
 
 This section offers detailed configuration instructions for using Cromwell with the Google Cloud Batch in all supported
 authentication modes. Before reading further in this section please see the
-[Getting started on Google Cloud Batch](../tutorials/GcpBatch101) for instructions common to all authentication modes
+[Getting started on Google Cloud Batch](../../tutorials/GcpBatch101) for instructions common to all authentication modes
 and detailed instructions for the application default authentication scheme in particular.
 The instructions below assume you have created a Google Cloud Storage bucket and a Google project enabled for the appropriate APIs.
 


### PR DESCRIPTION
### Description

The [GcpBatch](https://cromwell.readthedocs.io/en/develop/backends/GCPBatch/) page has a broken link to [GcpBatch101](https://cromwell.readthedocs.io/en/develop/tutorials/GcpBatch101/) -> specifically it's pointing at backends/tutorials/GcpBatch101 instead of tutorials/GcpBatch101

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users