### PR TITLE
[AN-517] Fix overestimation of cost for Batch jobs using preemptible machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  * Automatically retry tasks that fail with transient Batch errors before the VM has started running (that is, before the task has cost the user money). These retries do not count against `maxRetries`.
  * Symlink to `/cromwell_root` - In LifeSciences, the Cromwell root directory that user scripts are run from is located at `/cromwell_root`, but in the Batch backend it has moved to `/mnt/disk/cromwell_root`. To ensure WDLs that rely on the original 
 path don't break when run on the Batch, and to also maintain forward compatibility we have created a symlink between `/mnt/disk/cromwell_root` and `/cromwell_root`.
+ * Fixed a bug that caused Cromwell to over estimate the workflow cost for Batch jobs that used preemptible machines. 
 
 ### Other Changes
 * Removes a database index `METADATA_WORKFLOW_IDX` that is now redundant since the introduction of `IX_METADATA_ENTRY_WEU_MK`. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
  * Automatically retry tasks that fail with transient Batch errors before the VM has started running (that is, before the task has cost the user money). These retries do not count against `maxRetries`.
  * Symlink to `/cromwell_root` - In LifeSciences, the Cromwell root directory that user scripts are run from is located at `/cromwell_root`, but in the Batch backend it has moved to `/mnt/disk/cromwell_root`. To ensure WDLs that rely on the original 
 path don't break when run on the Batch, and to also maintain forward compatibility we have created a symlink between `/mnt/disk/cromwell_root` and `/cromwell_root`.
- * Fixed a bug that caused Cromwell to over estimate the workflow cost for Batch jobs that used preemptible machines. 
+ * Fixed a bug that caused Cromwell to overestimate the workflow cost for Batch jobs that used preemptible machines. 
 
 ### Other Changes
 * Removes a database index `METADATA_WORKFLOW_IDX` that is now redundant since the introduction of `IX_METADATA_ENTRY_WEU_MK`. 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -144,6 +144,8 @@ object BatchRequestExecutor {
       // Get instances that can be created with this AllocationPolicy, only instances[0] is supported
       val instancePolicy = allocationPolicy.getInstances(0).getPolicy
       val machineType = instancePolicy.getMachineType
+
+      // SPOT VM is used as preemptible VM instances in Batch
       val preemptible = instancePolicy.getProvisioningModelValue == ProvisioningModel.SPOT.getNumber
 
       // location list = [regions/us-central1, zones/us-central1-b], region is the first element

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -145,8 +145,9 @@ object BatchRequestExecutor {
       val instancePolicy = allocationPolicy.getInstances(0).getPolicy
       val machineType = instancePolicy.getMachineType
 
-      // SPOT VM is used as preemptible VM instances in Batch
-      val preemptible = instancePolicy.getProvisioningModelValue == ProvisioningModel.SPOT.getNumber
+      // SPOT VM is used as preemptible VM instances in Batch. Check for both SPOT or PREEMPTIBLE just to be safe
+      val preemptible = (instancePolicy.getProvisioningModelValue == ProvisioningModel.SPOT.getNumber) ||
+        (instancePolicy.getProvisioningModelValue == ProvisioningModel.PREEMPTIBLE.getNumber)
 
       // location list = [regions/us-central1, zones/us-central1-b], region is the first element
       val location = allocationPolicy.getLocation.getAllowedLocationsList.get(0)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -144,7 +144,7 @@ object BatchRequestExecutor {
       // Get instances that can be created with this AllocationPolicy, only instances[0] is supported
       val instancePolicy = allocationPolicy.getInstances(0).getPolicy
       val machineType = instancePolicy.getMachineType
-      val preemptible = instancePolicy.getProvisioningModelValue == ProvisioningModel.PREEMPTIBLE.getNumber
+      val preemptible = instancePolicy.getProvisioningModelValue == ProvisioningModel.SPOT.getNumber
 
       // location list = [regions/us-central1, zones/us-central1-b], region is the first element
       val location = allocationPolicy.getLocation.getAllowedLocationsList.get(0)

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
@@ -68,7 +68,7 @@ class BatchRequestExecutorSpec
     val instancePolicy = InstancePolicy
       .newBuilder()
       .setMachineType(machineType)
-      .setProvisioningModel(ProvisioningModel.PREEMPTIBLE)
+      .setProvisioningModel(ProvisioningModel.SPOT)
       .build()
 
     val allocationPolicy = AllocationPolicy


### PR DESCRIPTION
### Description

Jira ticket: https://broadworkbench.atlassian.net/browse/AN-517

<!-- What is the purpose of this change? What should reviewers know? -->

Previously - Cost Catalog would use SKU `N1 Predefined Instance Core running in Americas` even when calculating cost for jobs that used preemptible machines. And preemptible would be `false` for that VM (see last property in `InstantiatedVmInfo`) 
```
Calculated vmCostPerHour of 0.0400850 (CPU 0.031611 for 1 cores [N1 Predefined Instance Core running in Americas], 
RAM 0.0084740 for 2.0 Gb [N1 Predefined Instance Ram running in Americas]) for InstantiatedVmInfo(us-central1,custom-1-2048,false)
``` 

After - Cost Catalog correctly uses SKU `Spot Preemptible N1 Predefined Instance Core running in Americas` when calculating cost. And preemptible is correctly `true` in `InstantiatedVmInfo`
```
Calculated vmCostPerHour of 0.010480 (CPU 0.00834 for 1 cores [Spot Preemptible N1 Predefined Instance Core running in Americas], 
RAM 0.002140 for 2.0 Gb [Spot Preemptible N1 Predefined Instance Ram running in Americas]) for InstantiatedVmInfo(us-central1,custom-1-2048,true)
```

**Testing:** 
I ran a simple wdl (sleeps for 10 mins then prints hello world) locally against LifeSciences & Batch and below are the estimated costs

Machine type in all cases: custom-1-2048


  | LifeSciences | Batch (develop branch) | Batch (with PR changes)
-- | -- | -- | --
Standard machine | $0.008044513898611112 | $0.007254672377777777 | $0.007254716916666667
Preemptible machine | $0.0020746877555555556 | **$0.0071492599625** | **$0.0018883795555555557**

Estimated cost is similar (and in this case lesser) to that of LifeSciences.




### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users