### PR TITLE
[AN-199] Stop codecov warning annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,3 +19,6 @@ coverage:
         threshold: 5%
 
 comment: off
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Description

This disables the `Added line #L252 was not covered by tests` annotations on PRs showing which lines aren't covered by tests. These annotations clutter the files changed and the same information can be found by clicking on the codecov action if someone wants to find it.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users