### PR TITLE
[AN-531] Fix flaky 'gcpbatch_preemptible_and_memory_retry' Centaur test

### DIFF
--- a/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/preemptible_and_memory_retry.wdl
+++ b/centaur/src/main/resources/standardTestCases/retry_with_more_memory/gcpbatch/preemptible_and_memory_retry.wdl
@@ -19,7 +19,7 @@ task imitate_oom_error_on_preemptible {
       zone=$(basename "$fully_qualified_zone")
 
       gcloud beta compute instances simulate-maintenance-event $(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/name" -H "Metadata-Flavor: Google") --zone=$zone -q
-      sleep 60
+      sleep 300
     fi
 
     # Should reach here on the second attempt


### PR DESCRIPTION
### Description

Jira: https://broadworkbench.atlassian.net/browse/AN-531

I had noticed in my previous PR that `gcpbatch_preemptible_and_memory_retry` Centaur test would either fail in some of the builds or be have to retried 3 times and pass on the 3rd attempt. Upon inspection it seemed that sleeping for only 1 minute after running the `simulate-maintenance-event` to "preempt" the VM wasn't enough. As a result, in the first attempt of the task `imitate_oom_error_on_preemptible` itself Cromwell would detect out of memory key and then retry with more memory. This would essentially fail the test. Increasing the sleep amount allows the `simulate-maintenance-event` to finish and have the VM preempted successfully.

<!-- What is the purpose of this change? What should reviewers know? -->

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users