### PR TITLE
AN-532 Finite DRS timeout

### DIFF
--- a/centaur/src/main/scala/centaur/test/CentaurTestException.scala
+++ b/centaur/src/main/scala/centaur/test/CentaurTestException.scala
@@ -19,7 +19,8 @@ case class CentaurTestException private (message: String,
                                          workflowIdOption: Option[String],
                                          metadataJsonOption: Option[String],
                                          causeOption: Option[Exception]
-) extends RuntimeException(message, causeOption.orNull) with NoStackTrace
+) extends RuntimeException(message, causeOption.orNull)
+    with NoStackTrace
 
 object CentaurTestException {
 

--- a/centaur/src/main/scala/centaur/test/CentaurTestException.scala
+++ b/centaur/src/main/scala/centaur/test/CentaurTestException.scala
@@ -3,6 +3,8 @@ package centaur.test
 import centaur.test.workflow.Workflow
 import cromwell.api.model.{SubmittedWorkflow, WorkflowMetadata}
 
+import scala.util.control.NoStackTrace
+
 /**
   * An exception with information about a centaur test failure.
   *
@@ -17,7 +19,7 @@ case class CentaurTestException private (message: String,
                                          workflowIdOption: Option[String],
                                          metadataJsonOption: Option[String],
                                          causeOption: Option[Exception]
-) extends RuntimeException(message, causeOption.orNull)
+) extends RuntimeException(message, causeOption.orNull) with NoStackTrace
 
 object CentaurTestException {
 

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
@@ -58,7 +58,7 @@ object DrsConfig {
   def toEnv(drsConfig: DrsConfig): Map[String, String] =
     Map(
       EnvDrsResolverUrl -> drsConfig.drsResolverUrl,
-      EnvDrsResolverRequestTimeout -> s"${drsConfig.requestTimeout}",
+      EnvDrsResolverRequestTimeout -> s"${drsConfig.requestTimeout.toSeconds}",
       EnvDrsResolverNumRetries -> s"${drsConfig.numRetries}",
       EnvDrsResolverWaitInitialSeconds -> s"${drsConfig.waitInitial.toSeconds}",
       EnvDrsResolverWaitMaximumSeconds -> s"${drsConfig.waitMaximum.toSeconds}",

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsConfig.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 final case class DrsConfig(drsResolverUrl: String,
+                           requestTimeout: FiniteDuration,
                            numRetries: Int,
                            waitInitial: FiniteDuration,
                            waitMaximum: FiniteDuration,
@@ -16,6 +17,7 @@ final case class DrsConfig(drsResolverUrl: String,
 
 object DrsConfig {
   // If you update these values also update Filesystems.md!
+  private val DefaultRequestTimeout = 60 seconds
   private val DefaultNumRetries = 3
   private val DefaultWaitInitial = 30 seconds
   private val DefaultWaitMaximum = 60 seconds
@@ -23,6 +25,7 @@ object DrsConfig {
   private val DefaultWaitRandomizationFactor = 0.1
 
   private val EnvDrsResolverUrl = "DRS_RESOLVER_URL"
+  private val EnvDrsResolverRequestTimeout = "DRS_RESOLVER_REQUEST_TIMEOUT"
   private val EnvDrsResolverNumRetries = "DRS_RESOLVER_NUM_RETRIES"
   private val EnvDrsResolverWaitInitialSeconds = "DRS_RESOLVER_WAIT_INITIAL_SECONDS"
   private val EnvDrsResolverWaitMaximumSeconds = "DRS_RESOLVER_WAIT_MAXIMUM_SECONDS"
@@ -32,6 +35,7 @@ object DrsConfig {
   def fromConfig(drsResolverConfig: Config): DrsConfig =
     DrsConfig(
       drsResolverUrl = drsResolverConfig.getString("url"),
+      requestTimeout = drsResolverConfig.getOrElse("request-timeout", DefaultRequestTimeout),
       numRetries = drsResolverConfig.getOrElse("num-retries", DefaultNumRetries),
       waitInitial = drsResolverConfig.getOrElse("wait-initial", DefaultWaitInitial),
       waitMaximum = drsResolverConfig.getOrElse("wait-maximum", DefaultWaitMaximum),
@@ -42,6 +46,7 @@ object DrsConfig {
   def fromEnv(env: Map[String, String]): DrsConfig =
     DrsConfig(
       drsResolverUrl = env(EnvDrsResolverUrl),
+      requestTimeout = env.get(EnvDrsResolverRequestTimeout).map(_.toLong.seconds).getOrElse(DefaultRequestTimeout),
       numRetries = env.get(EnvDrsResolverNumRetries).map(_.toInt).getOrElse(DefaultNumRetries),
       waitInitial = env.get(EnvDrsResolverWaitInitialSeconds).map(_.toLong.seconds).getOrElse(DefaultWaitInitial),
       waitMaximum = env.get(EnvDrsResolverWaitMaximumSeconds).map(_.toLong.seconds).getOrElse(DefaultWaitMaximum),
@@ -53,6 +58,7 @@ object DrsConfig {
   def toEnv(drsConfig: DrsConfig): Map[String, String] =
     Map(
       EnvDrsResolverUrl -> drsConfig.drsResolverUrl,
+      EnvDrsResolverRequestTimeout -> s"${drsConfig.requestTimeout}",
       EnvDrsResolverNumRetries -> s"${drsConfig.numRetries}",
       EnvDrsResolverWaitInitialSeconds -> s"${drsConfig.waitInitial.toSeconds}",
       EnvDrsResolverWaitMaximumSeconds -> s"${drsConfig.waitMaximum.toSeconds}",

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -6,7 +6,7 @@ import cats.effect.{IO, Resource}
 import cats.implicits._
 import cloud.nio.impl.drs.DrsPathResolver.{FatalRetryDisposition, RegularRetryDisposition}
 import cloud.nio.impl.drs.DrsResolverResponseSupport._
-import common.exception.{toIO, AggregatedMessageException}
+import common.exception.{AggregatedMessageException, toIO}
 import common.validation.ErrorOr.ErrorOr
 import io.circe._
 import io.circe.generic.semiauto._
@@ -14,6 +14,7 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import mouse.boolean._
 import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.{HttpGet, HttpPost}
 import org.apache.http.entity.{ContentType, StringEntity}
 import org.apache.http.impl.client.HttpClientBuilder
@@ -61,12 +62,23 @@ class DrsPathResolver(drsConfig: DrsConfig, drsCredentials: DrsCredentials) {
           postRequest.setEntity(new StringEntity(requestJson, ContentType.APPLICATION_JSON))
           postRequest.setHeader("Authorization", s"Bearer $token")
           postRequest.setHeader("X-App-ID", "cromwell_drs_localizer")
+          postRequest.setConfig(timeoutConfig)
           postRequest
         }
       case Invalid(errors) =>
         IO.raiseError(AggregatedMessageException("Error getting access token", errors.toList))
     }
     Resource.eval(io)
+  }
+
+  private lazy val timeoutConfig: RequestConfig = {
+    // Infinite timeout bad, can exhaust Akka threads. [AN-532]
+    val requestTimeoutMillis = drsConfig.requestTimeout.toMillis.toInt
+    RequestConfig.custom()
+      .setConnectionRequestTimeout(requestTimeoutMillis / 4) // Obtain connection from the pool
+      .setConnectTimeout(requestTimeoutMillis)               // Max time to first byte from server
+      .setSocketTimeout(requestTimeoutMillis / 4)            // Max time between subsequent bytes
+      .build()
   }
 
   private def httpResponseToDrsResolverResponse(

--- a/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/main/scala/cloud/nio/impl/drs/DrsPathResolver.scala
@@ -6,7 +6,7 @@ import cats.effect.{IO, Resource}
 import cats.implicits._
 import cloud.nio.impl.drs.DrsPathResolver.{FatalRetryDisposition, RegularRetryDisposition}
 import cloud.nio.impl.drs.DrsResolverResponseSupport._
-import common.exception.{AggregatedMessageException, toIO}
+import common.exception.{toIO, AggregatedMessageException}
 import common.validation.ErrorOr.ErrorOr
 import io.circe._
 import io.circe.generic.semiauto._
@@ -74,10 +74,11 @@ class DrsPathResolver(drsConfig: DrsConfig, drsCredentials: DrsCredentials) {
   private lazy val timeoutConfig: RequestConfig = {
     // Infinite timeout bad, can exhaust Akka threads. [AN-532]
     val requestTimeoutMillis = drsConfig.requestTimeout.toMillis.toInt
-    RequestConfig.custom()
+    RequestConfig
+      .custom()
       .setConnectionRequestTimeout(requestTimeoutMillis / 4) // Obtain connection from the pool
-      .setConnectTimeout(requestTimeoutMillis)               // Max time to first byte from server
-      .setSocketTimeout(requestTimeoutMillis / 4)            // Max time between subsequent bytes
+      .setConnectTimeout(requestTimeoutMillis) // Max time to first byte from server
+      .setSocketTimeout(requestTimeoutMillis / 4) // Max time between subsequent bytes
       .build()
   }
 

--- a/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsPaths.scala
+++ b/cloud-nio/cloud-nio-impl-drs/src/test/scala/cloud/nio/impl/drs/MockDrsPaths.scala
@@ -1,11 +1,12 @@
 package cloud.nio.impl.drs
 
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 object MockDrsPaths {
   val drsResolverUrl = "http://mock.drshub"
 
-  val mockDrsConfig: DrsConfig = DrsConfig(MockDrsPaths.drsResolverUrl, 1, 1.seconds, 1.seconds, 1d, 0d)
+  val mockDrsConfig: DrsConfig = DrsConfig(MockDrsPaths.drsResolverUrl, 5 seconds, 1, 1 seconds, 1 seconds, 1d, 0d)
 
   val mockToken = "mock.token"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,10 +12,13 @@ coverage:
         base: pr
         target: 50%
         threshold: 5%
-    patch:
+    patch: # coverage report for the PR changes only
       default:
         base: pr
         target: 50%
-        threshold: 5%
+        threshold: 0% # no required threshold for patch
 
 comment: off
+
+github_checks:
+  annotations: false

--- a/docs/filesystems/Filesystems.md
+++ b/docs/filesystems/Filesystems.md
@@ -20,6 +20,9 @@ filesystems {
         config {
           resolver {
             url = https://drshub-url-here"
+            # How long to wait for the server to start responding
+            # Default is the informal standard around the DRS ecosystem
+            request-timeout = 60 seconds
             # The number of times to retry failures connecting or HTTP 429 or HTTP 5XX responses, default 3.
             num-retries = 3
             # How long to wait between retrying HTTP 429 or HTTP 5XX responses, default 10 seconds.


### PR DESCRIPTION
### Description

Apache HTTP client has an unsafe infinite timeout. Mitigate the risk by adding finite timeouts to important request phases.

There is still a possible infinite request scenario:
- The server sends a slow trickle of bytes
- The interval between bytes is less than the socket timeout
- Client waits forever
 
I don't think this is a risk with DRS, but something to mitigate in a future PR.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users