### PR TITLE
[AN-557] Include VM initialization time in cost calculation for Batch jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### GCP Batch
  * Cromwell now supports automatic use of the [GAR Dockerhub mirror](https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images), see [ReadTheDocs](https://cromwell.readthedocs.io/en/develop/backends/GCPBatch/) for details.
+ * VM initialization time in now included in estimated cost calculation for jobs. 
 
 ## 89 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/recursive_imports_cost_batch.test
+++ b/centaur/src/main/resources/standardTestCases/recursive_imports_cost_batch.test
@@ -20,4 +20,4 @@ metadata {
   status: Succeeded
 }
 
-cost: [0.0011, 0.0023]
+cost: [0.0024, 0.0071]

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -178,7 +178,7 @@ object BatchRequestExecutor {
     private def getEventList(events: List[StatusEvent]): List[ExecutionEvent] = {
       // on Batch, when job transitions to SCHEDULED state it indicates that the VM is being initialized. Users are billed for this
       // startup time. Hence, the 'vmStartTime' corresponds to when the job enters the SCHEDULED state.
-      val startedRegex = ".*QUEUED to SCHEDULED.*".r
+      val startedRegex = ".*to SCHEDULED.*".r
 
       // job terminal events can occur in 2 ways:
       //    - job transitions from a RUNNING state to either SUCCEEDED or FAILED state

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -176,7 +176,7 @@ object BatchRequestExecutor {
     }
 
     private def getEventList(events: List[StatusEvent]): List[ExecutionEvent] = {
-      // on Batch, when job transitions to SCHEDULED state it indicates that the VM is being. Users are billed for this
+      // on Batch, when job transitions to SCHEDULED state it indicates that the VM is being initialized. Users are billed for this
       // startup time. Hence, the 'vmStartTime' corresponds to when the job enters the SCHEDULED state.
       val startedRegex = ".*QUEUED to SCHEDULED.*".r
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -176,8 +176,15 @@ object BatchRequestExecutor {
     }
 
     private def getEventList(events: List[StatusEvent]): List[ExecutionEvent] = {
-      val startedRegex = ".*SCHEDULED to RUNNING.*".r
-      val endedRegex = ".*RUNNING to.*".r // can be SUCCEEDED or FAILED
+      // on Batch, when job transitions to SCHEDULED state it indicates that the VM is being. Users are billed for this
+      // startup time. Hence, the 'vmStartTime' corresponds to when the job enters the SCHEDULED state.
+      val startedRegex = ".*QUEUED to SCHEDULED.*".r
+
+      // job terminal events can occur in 2 ways:
+      //    - job transitions from a RUNNING state to either SUCCEEDED or FAILED state
+      //    - job never enters the RUNNING state and instead transitions from SCHEDULED -> SCHEDULED_PENDING_FAILED -> FAILED
+      val endedRegex = ".*RUNNING to.*|.*SCHEDULED_PENDING_FAILED to FAILED.*".r
+
       events.flatMap { e =>
         val time = java.time.Instant
           .ofEpochSecond(e.getEventTime.getSeconds, e.getEventTime.getNanos.toLong)

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/api/BatchRequestExecutorSpec.scala
@@ -236,7 +236,9 @@ class BatchRequestExecutorSpec
 
   it should "send vmStartTime and vmEndTime metadata info along with other events when a workflow fails" in {
     val mockClient =
-      setupBatchClient(jobState = JobStatus.State.FAILED, events = List(schedulingStatusEvent, runningStatusEvent, terminalStatusEvent))
+      setupBatchClient(jobState = JobStatus.State.FAILED,
+                       events = List(schedulingStatusEvent, runningStatusEvent, terminalStatusEvent)
+      )
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())
@@ -263,7 +265,9 @@ class BatchRequestExecutorSpec
 
   it should "send vmStartTime and vmEndTime metadata info along with other events when a job fails to run" in {
     val mockClient =
-      setupBatchClient(jobState = JobStatus.State.FAILED, events = List(schedulingStatusEvent, scheduleFailedStatusEvent))
+      setupBatchClient(jobState = JobStatus.State.FAILED,
+                       events = List(schedulingStatusEvent, scheduleFailedStatusEvent)
+      )
 
     // Create the BatchRequestExecutor
     val batchRequestExecutor = new BatchRequestExecutor.CloudImpl(BatchServiceSettings.newBuilder().build())


### PR DESCRIPTION
### Description

Jira: https://broadworkbench.atlassian.net/browse/AN-557

This PR attempts to fix the underestimation of cost for Batch jobs. On Batch, users incur cost when VM is being initialized. Hence use corresponding events for `vmStartTime` and `vmEndTime` for cost calculations.

Events for a job run locally:
![Screenshot 2025-05-19 at 9 30 28 AM](https://github.com/user-attachments/assets/e2a6298e-1a11-4831-9707-d06cbe5ab3f8)

`vmStartTime` now corresponds to SCHEDULED state:
![Screenshot 2025-05-19 at 9 32 34 AM](https://github.com/user-attachments/assets/8d39655d-b1aa-4421-acbe-86ff8aebf79a)


### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users