### PR TITLE
AN-589 CI no longer logs in to Docker 

### DIFF
--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private.test
@@ -1,7 +1,7 @@
 name: docker_hash_dockerhub_private
 testFormat: workflowsuccess
 backendsMode: any
-backends: [Papi, GCPBATCH]
+backends: [GCPBATCH]
 
 files {
   workflow: docker_hash/docker_hash_dockerhub_private.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_usa.test
@@ -1,7 +1,7 @@
 name: docker_hash_dockerhub_private_config_usa_wf_options
 testFormat: workflowsuccess
 # see https://github.com/broadinstitute/cromwell/pull/7515
-backends: [Papiv2USADockerhub, GCPBATCH_ALT]
+backends: [GCPBATCH_ALT]
 
 files {
   workflow: docker_hash/docker_hash_dockerhub_private_usa_dockerhub.wdl

--- a/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
+++ b/centaur/src/main/resources/standardTestCases/docker_hash_dockerhub_private_wf_options.test
@@ -1,7 +1,7 @@
 name: docker_hash_dockerhub_private_wf_options
 testFormat: workflowsuccess
 # see https://github.com/broadinstitute/cromwell/pull/7515
-backends: [Papiv2NoDockerHubConfig, GCPBATCH_USES_SECRET_MANAGER_NOT_KMS]
+backends: [GCPBATCH_USES_SECRET_MANAGER_NOT_KMS]
 
 files {
   workflow: docker_hash/docker_hash_dockerhub_private_no_dockerhub_config.wdl

--- a/centaur/src/main/resources/standardTestCases/hello_docker_image_format_v1.test
+++ b/centaur/src/main/resources/standardTestCases/hello_docker_image_format_v1.test
@@ -1,7 +1,7 @@
 # 'Hello world' for a public image in Docker v1 manifest format.
 name: hello_docker_image_format_v1
 testFormat: workflowsuccess
-backends: [Papiv2, GCPBATCH]
+backends: [GCPBATCH]
 
 # Attempting to pull locally I get an exit code 1, no image pulled, and the following output:
 # % docker pull "ubuntu:utopic-20150319"


### PR DESCRIPTION
### Description

Iteratively sever links to Vault so we can one day remove it entirely. Docker Hub has raised pull limits since the original [BT-143](https://broadworkbench.atlassian.net/browse/WX-143) story. We also have better workarounds available such as GCR mirror.

This PR also removes Life Sciences tests that use the old Docker login mechanism that is being turned off. GCP Batch uses a new mechanism via ~KMS~ Secret Manager and is not affected.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users