### PR TITLE
AN-595 SBT 1.8.1 => 1.8.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # scala-steward:off
-sbt.version=1.8.1
+sbt.version=1.8.2


### PR DESCRIPTION
### Description

Running just `sbt` on the command line produced the following error, though SBT seemed to mostly work fine afterwards.

This was reported and fixed in https://github.com/sbt/sbt/issues/7117

```
Exception in thread "sbt-socket-server" java.lang.NoClassDefFoundError: Could not initialize class org.scalasbt.ipcsocket.JNIUnixDomainSocketLibraryProvider
	at org.scalasbt.ipcsocket.UnixDomainSocketLibraryProvider.get(UnixDomainSocketLibraryProvider.java:26)
	at org.scalasbt.ipcsocket.UnixDomainSocketLibraryProvider.maxSocketLength(UnixDomainSocketLibraryProvider.java:31)
	at sbt.internal.server.Server$$anon$1$$anon$2.$anonfun$run$1(Server.scala:75)
	at scala.util.Try$.apply(Try.scala:213)
	at sbt.internal.server.Server$$anon$1$$anon$2.run(Server.scala:63)
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: darwin/aarch64/libsbtipcsocket.dylib not found on classpath [in thread "main"]
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users