### PR TITLE
AN-589 Pre-90 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Security fix
 * Fixed a vulnerability in the repository's Github Actions.
   * We found no evidence of compromise to the source code, so the Cromwell product itself was not impacted.
+  * Forked Cromwell repositories should update immediately from `develop`.
   * Thank you to [Stefano Chierici](https://github.com/darryk10), [Alberto Pellitteri](https://github.com/AlbertoPellitteri), and [Lorenzo Susini](https://github.com/loresuso) for the report.
 
 ## 89 Release Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
  * Fixed a concurrency bug that in rare cases caused tasks to never start.
 
 ### Security fix
-* Fixed a vulnerability in the repository's Github Actions. We found no evidence that the Cromwell product was compromised.
+* Fixed a vulnerability in the repository's Github Actions. We found no evidence that the Cromwell product itself was compromised.
   * Thank you to [Stefano Chierici](https://github.com/darryk10), [Alberto Pellitteri](https://github.com/AlbertoPellitteri), and [Lorenzo Susini](https://github.com/loresuso) for the report.
 
 ## 89 Release Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Bug fixes
  * Fixed a concurrency bug that in rare cases caused tasks to never start.
 
+### Security fix
+* Fixed a vulnerability in the repository's Github Actions. We found no evidence that the Cromwell product was compromised.
+  * Thank you to [Stefano Chierici](https://github.com/darryk10), [Alberto Pellitteri](https://github.com/AlbertoPellitteri), and [Lorenzo Susini](https://github.com/loresuso) for the report.
+
 ## 89 Release Notes
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
  * Fixed a concurrency bug that in rare cases caused tasks to never start.
 
 ### Security fix
-* Fixed a vulnerability in the repository's Github Actions. We found no evidence that the Cromwell product itself was compromised.
+* Fixed a vulnerability in the repository's Github Actions.
+  * We found no evidence of compromise to the source code, so the Cromwell product itself was not impacted.
   * Thank you to [Stefano Chierici](https://github.com/darryk10), [Alberto Pellitteri](https://github.com/AlbertoPellitteri), and [Lorenzo Susini](https://github.com/loresuso) for the report.
 
 ## 89 Release Notes


### PR DESCRIPTION
### Description

We need a new numerical release to refer to as the fixed version to close the security advisory.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users