### PR TITLE
AN-601 Let `gcloud` find its own Python in user containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### GCP Batch
 * Task log files are now included in the group of files copied for call cache hits.
+* Fixed an issue that caused WDL tasks to fail when invoking `gcloud` or `gsutil`. Affected tasks returned an error message referencing `python3: not found`.
 
 ## 90 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/container_tester.wdl
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/container_tester.wdl
@@ -1,0 +1,32 @@
+version 1.0
+
+workflow container_tester {
+    input {
+        String container_image
+    }
+
+    call run_container {
+        input:
+            container_image = container_image
+    }
+}
+
+task run_container {
+    input {
+        String container_image
+    }
+
+    # `gcloud` should successfully find Python, run, and exit (AN-601)
+    command <<<
+        printenv
+        gcloud --version
+    >>>
+
+    runtime {
+        docker: container_image
+    }
+
+    meta {
+        volatile: true
+    }
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/gcpbatch_gcloud_python.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/gcpbatch_gcloud_python.test
@@ -1,0 +1,13 @@
+name: gcpbatch_gcloud_python
+testFormat: workflowsuccess
+backends: [GCPBATCH]
+
+files {
+  workflow: container_tester.wdl
+  inputs: samtools_inputs.json
+}
+
+metadata {
+  workflowName: container_tester
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/samtools_inputs.json
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_gcloud_python/samtools_inputs.json
@@ -1,0 +1,3 @@
+{
+  "container_tester.container_image": "us.gcr.io/broad-dsde-methods/gatk-sv/samtools-cloud:2022-06-10-v0.23-beta-9c6fbf56"
+}

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -181,7 +181,14 @@ object RunnableBuilder extends BatchUtilityConversions {
       Environment
         .newBuilder()
         .putAllVariables(
-          Map("MEM_UNIT" -> memory.unit.toString, "MEM_SIZE" -> memory.amount.toString).asJava
+          Map(
+            "MEM_UNIT" -> memory.unit.toString,
+            "MEM_SIZE" -> memory.amount.toString,
+            // Batch sets `CLOUDSDK_PYTHON=/usr/bin/python3`, which is not compatible with user-provided
+            // images that have Python in a different place. Here we unset the variable so that
+            // `gcloud` can find its own Python. (AN-601, XKCD-1987)
+            "CLOUDSDK_PYTHON" -> ""
+          ).asJava
         )
 
     Runnable


### PR DESCRIPTION
### Description

GCP Batch sets `CLOUDSDK_PYTHON=/usr/bin/python3`, which is not compatible with user containers that have Python in a different location.

This causes `gcloud` to error out with `/opt/google-cloud-sdk/bin/gcloud: 192: exec: /usr/bin/python3: not found`

Just today, three different users have reported this issue with three different Python paths:

```
/usr/local/bin/python3
/opt/conda/envs/lr-mosdepth/bin/python3
/opt/conda/envs/gatk-sv/bin/python3
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users