### PR TITLE
AN-587 Resolve vulnerably jetty-server version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -217,7 +217,7 @@ object Dependencies {
     "com.azure" % "azure-core" % "1.51.0",
     "com.azure" % "azure-storage-blob" % "12.23.0-beta.1",
     "com.azure" % "azure-storage-common" % "12.22.0-beta.1",
-    "com.azure" % "azure-core-test" % "1.26.2",
+    "com.azure" % "azure-core-test" % "1.27.0-beta.8",
     "org.junit.jupiter" % "junit-jupiter-params" % "5.9.3",
     "org.junit.jupiter" % "junit-jupiter-engine" % "5.9.3",
     "org.junit.jupiter" % "junit-jupiter-api" % "5.9.3",


### PR DESCRIPTION
### Description

This package upgrade results in us no longer pulling in `jetty-server`. We were already never using it.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users