### PR TITLE
[AN-605] Construct fully qualified subnetwork path for supporting VPC via Labels on GCP Batch

### DIFF
--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -322,10 +322,11 @@ backend {
 
 The `network-label-key` and `subnetwork-label-key` should reference the keys in your project's labels whose value is the name of your private network
 and subnetwork within that network respectively. `auth` should reference an auth scheme in the `google` stanza which will be used to get the project metadata from Google Cloud.
-The `subnetwork-label-key` is an optional config. Note that in the
-PAPI v2 backend `subnetwork-label-key` was an optional configuration parameter which accepted a `*` wildcard for choosing the
-appropriate subnetwork region, but in GCP Batch the `subnetwork-label-key` specification can be omitted
-and GCP Batch will choose the appropriate subnetwork automatically.
+Cromwell will construct the fully qualified network and subnetwork paths using the network and subnet names.
+
+Note that the `subnetwork-label-key` is an optional config. In the PAPI v2 backend, it was an optional configuration parameter which accepted a `*` wildcard for choosing the
+appropriate subnetwork region. However, in GCP Batch the `subnetwork-label-key` can be omitted _only_ when the network mode is `Auto` -- in this case GCP Batch will automatically choose 
+the appropriate subnetwork. If the network mode is `Custom`, the `subnetwork-label-key` needs to be specified in the configuration, and corresponding label key must exist in project metadata.
 
 For example, if your `virtual-private-cloud` config looks like the one above, and one of the labels in your project is
 

--- a/src/ci/resources/gcp_batch_shared_application.inc.conf
+++ b/src/ci/resources/gcp_batch_shared_application.inc.conf
@@ -98,10 +98,10 @@ backend {
 
         batch.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
         filesystems.http {}
+        # this setup is intended to simulate Terra prod VPC configuration
         virtual-private-cloud {
           network-label-key = "cromwell-ci-gcpbatch-network"
-          # For GCP Batch we do not configure the subnetwork name. Batch has to work out the subnetwork for itself in
-          # order to enable running jobs in regions that are different from the region of the GCP Batch to which we send jobs.
+          subnetwork-label-key = "cromwell-ci-gcbatch-subnetwork"
           auth = "service_account"
         }
 

--- a/src/ci/resources/gcp_batch_shared_application.inc.conf
+++ b/src/ci/resources/gcp_batch_shared_application.inc.conf
@@ -98,7 +98,7 @@ backend {
 
         batch.compute-service-account = "centaur@broad-dsde-cromwell-dev.iam.gserviceaccount.com"
         filesystems.http {}
-        # this setup is intended to simulate Terra prod VPC configuration
+        # this is intended to simulate VPC config used in Terra prod
         virtual-private-cloud {
           network-label-key = "cromwell-ci-gcpbatch-network"
           subnetwork-label-key = "cromwell-ci-gcbatch-subnetwork"

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchInitializationActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchInitializationActor.scala
@@ -210,11 +210,14 @@ class GcpBatchInitializationActor(batchParams: GcpBatchInitializationActorParams
     ): Future[Option[VpcAndSubnetworkProjectLabelValues]] = {
       // Added explicit types to hopefully help future devs who stumble across this two-step code
       val fetchedFromLabels: Future[Option[VpcAndSubnetworkProjectLabelValues]] = vpcConfig.labelsOption match {
-        case Some(labels: VirtualPrivateCloudLabels) => fetchVpcLabelsFromProjectMetadata(labels)
+        case Some(labels: VirtualPrivateCloudLabels) =>
+          println(s"#### FIND ME - labels found")
+          fetchVpcLabelsFromProjectMetadata(labels)
         case None => Future.successful(None)
       }
       fetchedFromLabels map {
         _ orElse {
+          println(s"#### FIND ME - using literals")
           vpcConfig.literalsOption map { literals: VirtualPrivateCloudLiterals =>
             VpcAndSubnetworkProjectLabelValues(literals.network, literals.subnetwork)
           }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchInitializationActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchInitializationActor.scala
@@ -210,14 +210,11 @@ class GcpBatchInitializationActor(batchParams: GcpBatchInitializationActorParams
     ): Future[Option[VpcAndSubnetworkProjectLabelValues]] = {
       // Added explicit types to hopefully help future devs who stumble across this two-step code
       val fetchedFromLabels: Future[Option[VpcAndSubnetworkProjectLabelValues]] = vpcConfig.labelsOption match {
-        case Some(labels: VirtualPrivateCloudLabels) =>
-          println(s"#### FIND ME - labels found")
-          fetchVpcLabelsFromProjectMetadata(labels)
+        case Some(labels: VirtualPrivateCloudLabels) => fetchVpcLabelsFromProjectMetadata(labels)
         case None => Future.successful(None)
       }
       fetchedFromLabels map {
         _ orElse {
-          println(s"#### FIND ME - using literals")
           vpcConfig.literalsOption map { literals: VirtualPrivateCloudLiterals =>
             VpcAndSubnetworkProjectLabelValues(literals.network, literals.subnetwork)
           }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
@@ -10,10 +10,8 @@ final case class VpcAndSubnetworkProjectLabelValues(vpcName: String, subnetNameO
   def networkName(projectId: String): String = {
     val networkNameTemplate =
       if (vpcName.contains("/")) {
-        println(s"#### FIND ME - vpcName already contains '/'")
         vpcName
       } else {
-        println(s"#### FIND ME - fully qualified network path being constructed")
         s"projects/$ProjectIdToken/global/networks/$vpcName"
       }
 
@@ -27,10 +25,8 @@ final case class VpcAndSubnetworkProjectLabelValues(vpcName: String, subnetNameO
   def subnetNameOption(projectId: String, region: String): Option[String] =
     subnetNameOpt map { subnetName =>
       val subnetworkNameTemplate = if (subnetName.contains("/")) {
-        println(s"#### FIND ME - subnetName already contains '/'")
         subnetName
       } else {
-        println(s"#### FIND ME - fully qualified subnetName path being constructed")
         s"projects/$ProjectIdToken/regions/*/subnetworks/$subnetName"
       }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
@@ -10,8 +10,10 @@ final case class VpcAndSubnetworkProjectLabelValues(vpcName: String, subnetNameO
   def networkName(projectId: String): String = {
     val networkNameTemplate =
       if (vpcName.contains("/")) {
+        println(s"#### FIND ME - vpcName already contains '/'")
         vpcName
       } else {
+        println(s"#### FIND ME - fully qualified network path being constructed")
         s"projects/$ProjectIdToken/global/networks/$vpcName"
       }
 
@@ -25,8 +27,10 @@ final case class VpcAndSubnetworkProjectLabelValues(vpcName: String, subnetNameO
   def subnetNameOption(projectId: String, region: String): Option[String] =
     subnetNameOpt map { subnetName =>
       val subnetworkNameTemplate = if (subnetName.contains("/")) {
+        println(s"#### FIND ME - subnetName already contains '/'")
         subnetName
       } else {
+        println(s"#### FIND ME - fully qualified subnetName path being constructed")
         s"projects/$ProjectIdToken/regions/*/subnetworks/$subnetName"
       }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/VpcAndSubnetworkProjectLabelValues.scala
@@ -19,11 +19,19 @@ final case class VpcAndSubnetworkProjectLabelValues(vpcName: String, subnetNameO
   }
 
   /**
-   * Replaces the string `\${projectId}` in the subnet name if found.
-   * Replace wildcard character used in terra configuration for subnetworks with appropriate region
+   * If a subnet name is found, it returns the fully qualified subnet name by replacing \${projectId} and
+   * substituting any wildcard characters used in Terra's subnetwork configuration with the appropriate region.
    */
   def subnetNameOption(projectId: String, region: String): Option[String] =
-    subnetNameOpt map { _.replace(ProjectIdToken, projectId) } map { _.replace(regionWildcard, "regions/" + region) }
+    subnetNameOpt map { subnetName =>
+      val subnetworkNameTemplate = if (subnetName.contains("/")) {
+        subnetName
+      } else {
+        s"projects/$ProjectIdToken/regions/*/subnetworks/$subnetName"
+      }
+
+      subnetworkNameTemplate.replace(ProjectIdToken, projectId).replace(regionWildcard, "regions/" + region)
+    }
 }
 
 object VpcAndSubnetworkProjectLabelValues {

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
@@ -16,7 +16,12 @@ class GcpBatchVpcAndSubnetworkProjectLabelValuesSpec extends AnyFlatSpec with Ma
     ("a network with a slash", "slash/net", None, "slash/net", None),
     ("a network without a slash", "net", None, "projects/my-project/global/networks/net", None),
     ("a subnet with a slash", "slashed/net", Option("slashed/sub"), "slashed/net", Option("slashed/sub")),
-    ("a subnet without a slash", "slashed/net", Option("sub"), "slashed/net", Option("sub")),
+    ("a subnet without a slash",
+     "slashed/net",
+     Option("sub"),
+     "slashed/net",
+     Option("projects/my-project/regions/us-central1/subnetworks/sub")
+    ),
     (
       "a network with a project token",
       s"slashed/$${projectId}/net",
@@ -37,7 +42,13 @@ class GcpBatchVpcAndSubnetworkProjectLabelValuesSpec extends AnyFlatSpec with Ma
       Option(s"slashed/$${projectId}/regions/*/subnet"),
       "slashed/net",
       Option(s"slashed/my-project/regions/us-central1/subnet")
-    )
+    ),
+    ("both network and subnet without slash",
+      "network",
+      Option("subnetwork"),
+      "projects/my-project/global/networks/network",
+      Option("projects/my-project/regions/us-central1/subnetworks/subnetwork")
+    ),
   )
 
   forAll(labelsTests) { (description, network, subnetOption, networkName, subnetNameOption) =>

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
@@ -43,11 +43,12 @@ class GcpBatchVpcAndSubnetworkProjectLabelValuesSpec extends AnyFlatSpec with Ma
       "slashed/net",
       Option(s"slashed/my-project/regions/us-central1/subnet")
     ),
-    ("both network and subnet without slash",
-     "network",
-     Option("subnetwork"),
-     "projects/my-project/global/networks/network",
-     Option("projects/my-project/regions/us-central1/subnetworks/subnetwork")
+    (
+      "both network and subnet without slash",
+      "network",
+      Option("subnetwork"),
+      "projects/my-project/global/networks/network",
+      Option("projects/my-project/regions/us-central1/subnetworks/subnetwork")
     )
   )
 

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchVpcAndSubnetworkProjectLabelValuesSpec.scala
@@ -44,11 +44,11 @@ class GcpBatchVpcAndSubnetworkProjectLabelValuesSpec extends AnyFlatSpec with Ma
       Option(s"slashed/my-project/regions/us-central1/subnet")
     ),
     ("both network and subnet without slash",
-      "network",
-      Option("subnetwork"),
-      "projects/my-project/global/networks/network",
-      Option("projects/my-project/regions/us-central1/subnetworks/subnetwork")
-    ),
+     "network",
+     Option("subnetwork"),
+     "projects/my-project/global/networks/network",
+     Option("projects/my-project/regions/us-central1/subnetworks/subnetwork")
+    )
   )
 
   forAll(labelsTests) { (description, network, subnetOption, networkName, subnetNameOption) =>


### PR DESCRIPTION
### Description

Jira: https://broadworkbench.atlassian.net/browse/AN-605

Related terra-helmfile PR that will merge after this PR merges - https://github.com/broadinstitute/terra-helmfile/pull/6154

To support VPC via Labels Cromwell will construct the fully qualified paths for network (already exists) and subnetwork name (added in this PR).

#### Testing strategy

Tested this PR and [terra-helmfile PR](https://github.com/broadinstitute/terra-helmfile/pull/6154) changes on a BEE on both Batch and LifeSciences backend. 

Workflow used - [gcpbatch_check_network_in_vpc.wdl](https://github.com/broadinstitute/cromwell/blob/develop/centaur/src/main/resources/standardTestCases/virtual_private_cloud/gcpbatch_check_network_in_vpc.wdl)

Network configurations that were tested:
- standard Terra project (terra-xxxxx) configuration:
  - Labels `vpc-network-name` and `vpc-subnetwork-name` exists in the project
  - Network setup:
     - mode: custom
     - network name: network
     - subnet names: subnetwork
- non-standard configuration (as seen in some non terra-xxxx projects):
   - Labels don't exist in project
   - Network setup:
      -  mode: auto
      - network name: default
      - subnet name: default
- rarely seen but this setup was being tested by CI:
  - Only `vpc-network-name` exist in project
  - Network setup:
      -  mode: auto
      - network name: network
      - subnet name: network


### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users