### PR TITLE
AN-617 Don't write backendLogs metadata if there is no backend log

### DIFF
--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -1549,7 +1549,6 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     val actual = batchBackend.startMetadataKeyValues.safeMapValues(_.toString)
     actual should be(
       Map(
-        "backendLogs:log" -> s"$batchGcsRoot/wf_hello/$workflowId/call-goodbye/goodbye.log",
         "callRoot" -> s"$batchGcsRoot/wf_hello/$workflowId/call-goodbye",
         "gcpBatch:executionBucket" -> batchGcsRoot,
         "gcpBatch:googleProject" -> googleProject,

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchJobPathsSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchJobPathsSpec.scala
@@ -4,7 +4,13 @@ import com.google.cloud.NoCredentials
 import common.collections.EnhancedCollections._
 import cromwell.backend.BackendSpec
 import cromwell.backend.google.batch.actors.GcpBatchInitializationActor
-import cromwell.backend.google.batch.models.GcpBatchTestConfig.{gcpBatchConfiguration, pathBuilders}
+import cromwell.backend.google.batch.models.GcpBatchTestConfig.{
+  batchAttributes,
+  gcpBatchConfiguration,
+  googleConfiguration,
+  pathBuilders,
+  BatchBackendConfigurationDescriptor
+}
 import cromwell.backend.io.JobPathsSpecHelper._
 import cromwell.core.TestKitSuite
 import cromwell.util.SampleWdl
@@ -99,4 +105,61 @@ class GcpBatchJobPathsSpec extends TestKitSuite with AnyFlatSpecLike with Matche
       be(s"gs://my-cromwell-workflows-bucket/wf_hello/${workflowDescriptor.id}/call-hello/stderr")
   }
 
+  it should "include the backend log path in metadata and detritus when the file is configured to exist" in {
+    val workflowDescriptor = buildWdlWorkflowDescriptor(
+      SampleWdl.HelloWorld.workflowSource(),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+    )
+    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+
+    val configWithPathLogsPolicy =
+      new GcpBatchConfiguration(BatchBackendConfigurationDescriptor,
+                                googleConfiguration,
+                                batchAttributes.copy(logsPolicy = GcpBatchLogsPolicy.Path)
+      )
+
+    val workflowPaths = GcpBatchWorkflowPaths(
+      workflowDescriptor,
+      NoCredentials.getInstance(),
+      NoCredentials.getInstance(),
+      configWithPathLogsPolicy,
+      pathBuilders(),
+      GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper
+    )
+
+    val callPaths = GcpBatchJobPaths(workflowPaths, jobDescriptorKey)
+
+    callPaths.customMetadataPaths should contain(
+      "backendLogs:log" -> callPaths.batchLogPath
+    )
+    callPaths.customDetritusPaths should contain(
+      "log" -> callPaths.batchLogPath
+    )
+  }
+
+  it should "not include the backend log path in metadata and detritus when the file is not configured to exist" in {
+    val workflowDescriptor = buildWdlWorkflowDescriptor(
+      SampleWdl.HelloWorld.workflowSource(),
+      inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.safeMapValues(JsString.apply)).compactPrint)
+    )
+    val jobDescriptorKey = firstJobDescriptorKey(workflowDescriptor)
+
+    val workflowPaths = GcpBatchWorkflowPaths(
+      workflowDescriptor,
+      NoCredentials.getInstance(),
+      NoCredentials.getInstance(),
+      gcpBatchConfiguration,
+      pathBuilders(),
+      GcpBatchInitializationActor.defaultStandardStreamNameToFileNameMetadataMapper
+    )
+
+    val callPaths = GcpBatchJobPaths(workflowPaths, jobDescriptorKey)
+
+    callPaths.customMetadataPaths shouldNot contain(
+      "backendLogs:log" -> callPaths.batchLogPath
+    )
+    callPaths.customDetritusPaths shouldNot contain(
+      "log" -> callPaths.batchLogPath
+    )
+  }
 }


### PR DESCRIPTION
### Description

Ensure that metadata correctly reflects the existence of the backend log file for GCP Batch tasks.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users