### PR TITLE
AN-613 Make Batch `bootDiskSizeGb` validation work with optional integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Task log files are now included in the group of files copied for call cache hits.
 * Tweak automatic retry of transient errors: retry if task is SCHEDULED but not RUNNING. This should result in more retries, reducing the number of workflows that fail due to transient Batch issues.
 * Fixed an issue that caused WDL tasks to fail when invoking `gcloud` or `gsutil`. Affected tasks returned an error message referencing `python3: not found`.
+* Fixed an issue that could cause a valid WDL using an `Int?` value to fail with an error mentioning `bootDiskSizeGb`.
 
 ## 90 Release Notes
 

--- a/centaur/src/main/resources/standardTestCases/disk_size/disk_size.test
+++ b/centaur/src/main/resources/standardTestCases/disk_size/disk_size.test
@@ -1,0 +1,12 @@
+name: disk_size
+testFormat: workflowsuccess
+backends: [GCPBATCH]
+
+files {
+  workflow: disk_size.wdl
+}
+
+metadata {
+  workflowName: disk_size
+  status: Succeeded
+}

--- a/centaur/src/main/resources/standardTestCases/disk_size/disk_size.test
+++ b/centaur/src/main/resources/standardTestCases/disk_size/disk_size.test
@@ -9,4 +9,8 @@ files {
 metadata {
   workflowName: disk_size
   status: Succeeded
+  "outputs.disk_size.optional_omitted.message": "Disk size is 60 GB"
+  "outputs.disk_size.optional_provided.message": "Disk size is 20 GB"
+  "outputs.disk_size.required_omitted.message": "Disk size is 80 GB"
+  "outputs.disk_size.required_provided.message": "Disk size is 40 GB"
 }

--- a/centaur/src/main/resources/standardTestCases/disk_size/disk_size.wdl
+++ b/centaur/src/main/resources/standardTestCases/disk_size/disk_size.wdl
@@ -1,0 +1,55 @@
+version 1.0
+
+workflow disk_size {
+    call ds_optional as optional_provided {
+        input:
+            disk_size = 20
+    }
+
+    call ds_optional as optional_omitted
+
+    call ds_required as required_provided {
+        input:
+            disk_size = 40
+    }
+
+    call ds_required as required_omitted
+}
+
+task ds_optional {
+    input {
+        Int? disk_size = 60
+    }
+
+    command {
+        echo "Disk size is ${disk_size} GB"
+    }
+
+    output {
+        String message = read_string(stdout())
+    }
+
+    runtime {
+        docker: "ubuntu:latest"
+        bootDiskSizeGb: disk_size
+    }
+}
+
+task ds_required {
+    input {
+        Int disk_size = 80
+    }
+
+    command {
+        echo "Disk size is ${disk_size} GB"
+    }
+
+    output {
+        String message = read_string(stdout())
+    }
+
+    runtime {
+        docker: "ubuntu:latest"
+        bootDiskSizeGb: disk_size
+    }
+}

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -126,7 +126,9 @@ object GcpBatchRuntimeAttributes {
 
   private def bootDiskSizeValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     new BootDiskSizeValidation(runtimeConfig)
-      .withDefault(new BootDiskSizeValidation(runtimeConfig).configDefaultWomValue(runtimeConfig) getOrElse BootDiskDefaultValue)
+      .withDefault(
+        new BootDiskSizeValidation(runtimeConfig).configDefaultWomValue(runtimeConfig) getOrElse BootDiskDefaultValue
+      )
 
   private def noAddressValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Boolean] =
     noAddressValidationInstance

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -126,6 +126,7 @@ object GcpBatchRuntimeAttributes {
 
   private def bootDiskSizeValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     new BootDiskSizeValidation(runtimeConfig)
+      .withDefault(new BootDiskSizeValidation(runtimeConfig).configDefaultWomValue(runtimeConfig) getOrElse BootDiskDefaultValue)
 
   private def noAddressValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Boolean] =
     noAddressValidationInstance


### PR DESCRIPTION
### Description

The code in https://github.com/broadinstitute/cromwell/pull/7701 was very close to working, but did not consider the `Int?` case.

I'm surprised the compiler didn't flag the non-exhaustive match for us, but I didn't dig in to the details.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users