### PR TITLE
AN-634 Update expectation for `noAddress` network/subnetwork error

### DIFF
--- a/centaur/src/main/resources/standardTestCases/gcpbatch_fast_fail_noAddress.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_fast_fail_noAddress.test
@@ -10,6 +10,6 @@ files {
 
 metadata {
   workflowName: fast_fail_noAddress
-  "failures.0.causedBy.0.message": ~~"Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: no_external_ip_address field is invalid. both network and subnetwork have to be specified when no_external_ip_address is true)."
+  "failures.0.causedBy.0.message": ~~"Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: no_external_ip_address field is invalid. either network or subnetwork have to be specified when no_external_ip_address is true)."
   status: Failed
 }


### PR DESCRIPTION
### Description

We started seeing this CI failure on the morning of Tuesday 6/17. Bartosz confirmed it is a recent change.

This PR obviously doesn't fix the users' workflows, but we know the change is intentional and we want working CI.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users