### PR TITLE
AN-614 Increase timeout of logging runnables in GCP Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Tweak automatic retry of transient errors: retry if task is SCHEDULED but not RUNNING. This should result in more retries, reducing the number of workflows that fail due to transient Batch issues.
 * Fixed an issue that caused WDL tasks to fail when invoking `gcloud` or `gsutil`. Affected tasks returned an error message referencing `python3: not found`.
 * Fixed an issue that could cause a valid WDL using an `Int?` value to fail with an error mentioning `bootDiskSizeGb`.
+* Increased timeout for logging runnables in response to a low rate of sporadic timeout errors.
 
 ## 90 Release Notes
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -232,7 +232,7 @@ object RunnableBuilder extends BatchUtilityConversions {
         case (key, value) if key == Key.Tag => Key.Logging -> value
         case (key, value) => key -> value
       }
-    ).withTimeout(timeout = 300.seconds)
+    ).withTimeout(timeout = 30.minutes) // Consider removing this timeout altogether, other runnables don't have them.
 
   def cloudSdkRunnable: Runnable.Builder = Runnable.newBuilder.setContainer(cloudSdkContainerBuilder)
 


### PR DESCRIPTION
### Description

We've seen a low rate of this kind of runnable timing out, try bumping the timeout. These should all be fast, but cloud is cloud.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users