### PR TITLE
AN-486 Turn off Life Sciences test suites

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,9 +33,6 @@ jobs:
         # Batch test fixes to land later
         include:
           - build_type: centaurGcpBatch
-            build_mysql: 8.0
-            friendly_name: GCP Batch, MySQL 8.0
-          - build_type: centaurGcpBatch
             build_mysql: 8.4
             friendly_name: GCP Batch, MySQL 8.4 (Terra production)
           - build_type: centaurGcpBatchRestart

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,21 +32,12 @@ jobs:
       matrix:
         # Batch test fixes to land later
         include:
-          - build_type: centaurPapiV2beta
-            build_mysql: 8.0
-            friendly_name: Life Sciences, MySQL 8.0
-          - build_type: centaurPapiV2beta
-            build_mysql: 8.4
-            friendly_name: Life Sciences, MySQL 8.4 (current Terra production)
           - build_type: centaurGcpBatch
             build_mysql: 8.0
             friendly_name: GCP Batch, MySQL 8.0
           - build_type: centaurGcpBatch
             build_mysql: 8.4
             friendly_name: GCP Batch, MySQL 8.4
-          - build_type: centaurPapiV2betaRestart
-            build_mysql: 8.4
-            friendly_name: Centaur Papi V2 Beta (restart)
           - build_type: centaurGcpBatchRestart
             build_mysql: 8.4
             friendly_name: Centaur GCP Batch (restart)
@@ -66,9 +57,6 @@ jobs:
           - build_type: centaurDummy
             build_mysql: 8.4
             friendly_name: Centaur Dummy with MySQL 8.4
-          - build_type: centaurHoricromtalPapiV2beta
-            build_mysql: 8.4
-            friendly_name: Centaur Horicromtal PapiV2 Beta with MySQL 8.4
           - build_type: centaurHoricromtalGcpBatch
             build_mysql: 8.4
             friendly_name: Centaur Horicromtal GCP Batch with MySQL 8.4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,7 +37,7 @@ jobs:
             friendly_name: GCP Batch, MySQL 8.0
           - build_type: centaurGcpBatch
             build_mysql: 8.4
-            friendly_name: GCP Batch, MySQL 8.4
+            friendly_name: GCP Batch, MySQL 8.4 (Terra production)
           - build_type: centaurGcpBatchRestart
             build_mysql: 8.4
             friendly_name: Centaur GCP Batch (restart)


### PR DESCRIPTION
### Description

- Stop testing Life Sciences
- Update Terra production designation
- MySQL 8.4 has been out for >1 year now, we can stop testing its predecessor

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users