### PR TITLE
AN-702 feat(aws): Added support for AWS jobRoleARN override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Job IDs will be derived from workflow and call details with a hash generated using call name. 
 This will allow for better grouping of jobs in the Batch UI and ensure deterministic job IDs to prevent duplicates upon Cromwell restart. Example of job ID: `job-e21cbbd3-scatterworkflowmytask-2-1-175f647b`
 
+### AWS Batch
+* Added support for specifying an IAM role for AWS Batch job containers via the `aws_batch_job_role_arn` workflow option. This allows containers to access AWS resources based on the permissions granted to the specified role.
+
 ### Other changes
 * Removed unused code related to Azure cloud services.
 

--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -57,3 +57,49 @@ AWS Batch allows the use of private Docker containers by providing `dockerhub` c
 
 * `(backend.providers.AWSBatch.config.)concurrent-job-limit` specifies the number of jobs that Cromwell will allow to be running in AWS at the same time. Tune this parameter based on how many nodes are in the compute environment.
 * `(backend.providers.AWSBatch.config.)root` points to the S3 bucket where workflow outputs are stored. This becomes a path on the root instance, and by default is cromwell_root. This is monitored by preinstalled daemon that expands drive space on the host, ie AWS EBS autoscale.  This path is used as the 'local-disk' for containers.
+
+## Workflow Options
+
+The AWS Batch backend supports the following workflow options:
+
+### aws_batch_job_role_arn
+
+The `aws_batch_job_role_arn` workflow option allows you to specify an IAM role ARN that will be associated with the AWS Batch job's container. This enables the container to assume the specified role and access AWS resources according to the permissions granted to that role.
+
+**Usage:**
+
+Include this option in your workflow options JSON file:
+
+```json
+{
+  "aws_batch_job_role_arn": "arn:aws:iam::123456789012:role/MyJobRole"
+}
+```
+
+Or specify it on the command line:
+
+```bash
+java -jar cromwell.jar run workflow.wdl -o workflow_options.json
+```
+
+**Example use cases:**
+- Accessing S3 buckets with specific permissions
+- Invoking other AWS services (e.g., Lambda, SNS, SQS)
+- Cross-account resource access
+
+**Note:** The IAM role must have a trust relationship that allows the AWS Batch service to assume it. The role should include the following trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -400,7 +400,8 @@ final case class AwsBatchJob(
           jobDescriptor = jobDescriptor,
           jobPaths = jobPaths,
           inputs = inputs,
-          outputs = outputs
+          outputs = outputs,
+          workflowOptions = jobDescriptor.workflowDescriptor.workflowOptions
         )
 
         val jobDefinitionBuilder = StandardAwsBatchJobDefinitionBuilder

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -172,33 +172,31 @@ trait AwsBatchJobDefinitionBuilder {
       context.workflowOptions
     )
 
-    {
-      val builderWithBasicProperties = builder
-        .command(packedCommand.asJava)
-        .resourceRequirements(
-          ResourceRequirement
-            .builder()
-            .`type`(ResourceType.MEMORY)
-            .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
-            .build(),
-          ResourceRequirement
-            .builder()
-            .`type`(ResourceType.VCPU)
-            .value(context.runtimeAttributes.cpu.value.toString)
-            .build()
-        )
-        .volumes(volumes.asJava)
-        .mountPoints(mountPoints.asJava)
-        .environment(environment.asJava)
+    val builderWithBasicProperties = builder
+      .command(packedCommand.asJava)
+      .resourceRequirements(
+        ResourceRequirement
+          .builder()
+          .`type`(ResourceType.MEMORY)
+          .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
+          .build(),
+        ResourceRequirement
+          .builder()
+          .`type`(ResourceType.VCPU)
+          .value(context.runtimeAttributes.cpu.value.toString)
+          .build()
+      )
+      .volumes(volumes.asJava)
+      .mountPoints(mountPoints.asJava)
+      .environment(environment.asJava)
 
-      // Add job role ARN if specified
-      val finalBuilder = context.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
-        case Success(roleArn) => builderWithBasicProperties.jobRoleArn(roleArn)
-        case _ => builderWithBasicProperties
-      }
-
-      (finalBuilder, jobDefinitionName)
+    // Add job role ARN if specified
+    val finalBuilder = context.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
+      case Success(roleArn) => builderWithBasicProperties.jobRoleArn(roleArn)
+      case _ => builderWithBasicProperties
     }
+
+    (finalBuilder, jobDefinitionName)
   }
 
   private def packCommand(shell: String, options: String, mainCommand: String): Seq[String] = {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -140,10 +140,7 @@ trait AwsBatchJobDefinitionBuilder {
                   env: Seq[KeyValuePair],
                   workflowOptions: WorkflowOptions
     ): String = {
-      val roleArnStr = workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
-        case Success(roleArn) => roleArn
-        case _ => ""
-      }
+      val roleArnStr = workflowOptions.getOrElse(AwsBatchWorkflowOptionKeys.JobRoleArn, "")
       val str = s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints
           .map(_.toString)
           .mkString(",")}:${env.map(_.toString).mkString(",")}:$roleArnStr"

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -193,13 +193,13 @@ trait AwsBatchJobDefinitionBuilder {
         .volumes(volumes.asJava)
         .mountPoints(mountPoints.asJava)
         .environment(environment.asJava)
-      
+
       // Add job role ARN if specified
       val finalBuilder = context.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
         case Success(roleArn) => builderWithBasicProperties.jobRoleArn(roleArn)
         case _ => builderWithBasicProperties
       }
-      
+
       (finalBuilder, jobDefinitionName)
     }
   }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -34,6 +34,7 @@ package cromwell.backend.impl.aws
 import scala.collection.mutable.ListBuffer
 import cromwell.backend.BackendJobDescriptor
 import cromwell.backend.io.JobPaths
+import cromwell.core.WorkflowOptions
 import software.amazon.awssdk.services.batch.model.{
   ContainerProperties,
   Host,
@@ -50,6 +51,7 @@ import java.security.MessageDigest
 import org.apache.commons.lang3.builder.{ToStringBuilder, ToStringStyle}
 import org.slf4j.{Logger, LoggerFactory}
 import wdl4s.parser.MemoryUnit
+import scala.util.Success
 
 /**
   * Responsible for the creation of the job definition.
@@ -135,11 +137,16 @@ trait AwsBatchJobDefinitionBuilder {
                   packedCommand: String,
                   volumes: List[Volume],
                   mountPoints: List[MountPoint],
-                  env: Seq[KeyValuePair]
+                  env: Seq[KeyValuePair],
+                  workflowOptions: WorkflowOptions
     ): String = {
+      val roleArnStr = workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
+        case Success(roleArn) => roleArn
+        case _ => ""
+      }
       val str = s"$imageName:$packedCommand:${volumes.map(_.toString).mkString(",")}:${mountPoints
           .map(_.toString)
-          .mkString(",")}:${env.map(_.toString).mkString(",")}"
+          .mkString(",")}:${env.map(_.toString).mkString(",")}:$roleArnStr"
 
       val sha1 = MessageDigest
         .getInstance("SHA-1")
@@ -164,28 +171,37 @@ trait AwsBatchJobDefinitionBuilder {
       packedCommand.mkString(","),
       volumes,
       mountPoints,
-      environment
+      environment,
+      context.workflowOptions
     )
 
-    (builder
-       .command(packedCommand.asJava)
-       .resourceRequirements(
-         ResourceRequirement
-           .builder()
-           .`type`(ResourceType.MEMORY)
-           .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
-           .build(),
-         ResourceRequirement
-           .builder()
-           .`type`(ResourceType.VCPU)
-           .value(context.runtimeAttributes.cpu.value.toString)
-           .build()
-       )
-       .volumes(volumes.asJava)
-       .mountPoints(mountPoints.asJava)
-       .environment(environment.asJava),
-     jobDefinitionName
-    )
+    {
+      val builderWithBasicProperties = builder
+        .command(packedCommand.asJava)
+        .resourceRequirements(
+          ResourceRequirement
+            .builder()
+            .`type`(ResourceType.MEMORY)
+            .value(context.runtimeAttributes.memory.to(MemoryUnit.MB).amount.toInt.toString)
+            .build(),
+          ResourceRequirement
+            .builder()
+            .`type`(ResourceType.VCPU)
+            .value(context.runtimeAttributes.cpu.value.toString)
+            .build()
+        )
+        .volumes(volumes.asJava)
+        .mountPoints(mountPoints.asJava)
+        .environment(environment.asJava)
+      
+      // Add job role ARN if specified
+      val finalBuilder = context.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn) match {
+        case Success(roleArn) => builderWithBasicProperties.jobRoleArn(roleArn)
+        case _ => builderWithBasicProperties
+      }
+      
+      (finalBuilder, jobDefinitionName)
+    }
   }
 
   private def packCommand(shell: String, options: String, mainCommand: String): Seq[String] = {
@@ -229,7 +245,8 @@ case class AwsBatchJobDefinitionContext(runtimeAttributes: AwsBatchRuntimeAttrib
                                         jobDescriptor: BackendJobDescriptor,
                                         jobPaths: JobPaths,
                                         inputs: Set[AwsBatchInput],
-                                        outputs: Set[AwsBatchFileOutput]
+                                        outputs: Set[AwsBatchFileOutput],
+                                        workflowOptions: WorkflowOptions
 ) {
 
   override def toString: String =
@@ -243,5 +260,6 @@ case class AwsBatchJobDefinitionContext(runtimeAttributes: AwsBatchRuntimeAttrib
       .append("jobPaths", jobPaths)
       .append("inputs", inputs)
       .append("outputs", outputs)
+      .append("workflowOptions", workflowOptions)
       .build
 }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
@@ -1,34 +1,3 @@
-/*
- * Copyright 2018 Amazon.com, Inc. or its affiliates.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *
- *  1. Redistributions of source code must retain the above copyright notice,
- *  this list of conditions and the following disclaimer.
- *
- *  2. Redistributions in binary form must reproduce the above copyright
- *  notice, this list of conditions and the following disclaimer in the
- *  documentation and/or other materials provided with the distribution.
- *
- *  3. Neither the name of the copyright holder nor the names of its
- *  contributors may be used to endorse or promote products derived from
- *  this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
- *  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
- *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
- *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- *  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- *  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- */
-
 package cromwell.backend.impl.aws
 
 object AwsBatchWorkflowOptionKeys {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ *  BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ *  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ *  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ *  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ *  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package cromwell.backend.impl.aws
+
+object AwsBatchWorkflowOptionKeys {
+  val JobRoleArn = "aws_batch_job_role_arn"
+}

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -178,7 +178,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
       val containerProperties = jobDefinition.containerProperties
 
       // Verify no job role ARN is set when not provided
-      containerProperties.jobRoleArn() should be(null)
+      Option(containerProperties.jobRoleArn()).isEmpty should be(true)
     }
 
     "correctly use getOrElse method for jobRoleArn retrieval" in {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -2,6 +2,7 @@ package cromwell.backend.impl.aws
 
 import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.backend.BackendSpec._
+import cromwell.backend.io.JobPaths
 import cromwell.core.WorkflowOptions
 import cromwell.core.callcaching.NoDocker
 import cromwell.util.SampleWdl
@@ -13,8 +14,9 @@ import spray.json.{JsObject, JsString}
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 import wom.graph.CommandCallNode
+import common.mock.MockSugar
 
-class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
+class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockSugar {
 
   import AwsBatchWorkflowOptionKeys._
 
@@ -55,6 +57,9 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
     fileSystem = "s3"
   )
 
+  // Mock job paths for testing
+  val mockJobPaths: JobPaths = mock[JobPaths]
+
   "AwsBatchJobDefinition StandardAwsBatchJobDefinitionBuilder" should {
 
     "build a job definition name without jobRoleArn when not provided" in {
@@ -67,7 +72,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
         dockerStdoutPath = "/tmp/stdout.log",
         dockerStderrPath = "/tmp/stderr.log",
         jobDescriptor = jobDescriptor,
-        jobPaths = null,
+        jobPaths = mockJobPaths,
         inputs = Set.empty,
         outputs = Set.empty,
         workflowOptions = workflowOptions
@@ -99,7 +104,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
         dockerStdoutPath = "/tmp/stdout.log",
         dockerStderrPath = "/tmp/stderr.log",
         jobDescriptor = jobDescriptor,
-        jobPaths = null,
+        jobPaths = mockJobPaths,
         inputs = Set.empty,
         outputs = Set.empty,
         workflowOptions = workflowOptions
@@ -122,7 +127,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
         dockerStdoutPath = "/tmp/stdout.log",
         dockerStderrPath = "/tmp/stderr.log",
         jobDescriptor = jobDescriptor,
-        jobPaths = null,
+        jobPaths = mockJobPaths,
         inputs = Set.empty,
         outputs = Set.empty,
         workflowOptions = workflowOptionsNoRole
@@ -145,7 +150,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
         dockerStdoutPath = "/tmp/stdout.log",
         dockerStderrPath = "/tmp/stderr.log",
         jobDescriptor = jobDescriptor,
-        jobPaths = null,
+        jobPaths = mockJobPaths,
         inputs = Set.empty,
         outputs = Set.empty,
         workflowOptions = workflowOptions
@@ -168,7 +173,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
         dockerStdoutPath = "/tmp/stdout.log",
         dockerStderrPath = "/tmp/stderr.log",
         jobDescriptor = jobDescriptor,
-        jobPaths = null,
+        jobPaths = mockJobPaths,
         inputs = Set.empty,
         outputs = Set.empty,
         workflowOptions = workflowOptions

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -1,0 +1,197 @@
+package cromwell.backend.impl.aws
+
+import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
+import cromwell.backend.BackendSpec._
+import cromwell.core.WorkflowOptions
+import cromwell.core.callcaching.NoDocker
+import cromwell.util.SampleWdl
+import eu.timepit.refined.refineMV
+import eu.timepit.refined.numeric.Positive
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import spray.json.{JsObject, JsString}
+import wdl4s.parser.MemoryUnit
+import wom.format.MemorySize
+import wom.graph.CommandCallNode
+
+class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers {
+
+  import AwsBatchWorkflowOptionKeys._
+
+  // Create a simple workflow descriptor for testing
+  val workflowDescriptor: BackendWorkflowDescriptor = buildWdlWorkflowDescriptor(
+    SampleWdl.HelloWorld.workflowSource(),
+    inputFileAsJson = Option(JsObject(SampleWdl.HelloWorld.rawInputs.map { case (k, v) =>
+      k -> JsString(v)
+    }).compactPrint)
+  )
+
+  val call: CommandCallNode = workflowDescriptor.callable.taskCallNodes.head
+  val jobKey: BackendJobDescriptorKey = BackendJobDescriptorKey(call, None, 1)
+
+  // Mock job descriptor for testing
+  val jobDescriptor: BackendJobDescriptor = BackendJobDescriptor(
+    workflowDescriptor,
+    jobKey,
+    Map.empty,
+    Map.empty,
+    NoDocker,
+    None,
+    Map.empty
+  )
+
+  // Test runtime attributes
+  val runtimeAttributes = AwsBatchRuntimeAttributes(
+    cpu = refineMV[Positive](1),
+    zones = Vector("us-east-1a"),
+    memory = MemorySize(2.0, MemoryUnit.GB),
+    disks = Seq.empty,
+    dockerImage = "ubuntu:latest",
+    queueArn = "arn:aws:batch:us-east-1:123456789:job-queue/test-queue",
+    failOnStderr = false,
+    continueOnReturnCode = cromwell.backend.validation.ContinueOnReturnCodeSet(Set(0)),
+    noAddress = false,
+    scriptS3BucketName = "test-bucket",
+    fileSystem = "s3"
+  )
+
+  "AwsBatchJobDefinition StandardAwsBatchJobDefinitionBuilder" should {
+
+    "build a job definition name without jobRoleArn when not provided" in {
+      val workflowOptions = WorkflowOptions(JsObject.empty)
+
+      val context = AwsBatchJobDefinitionContext(
+        runtimeAttributes = runtimeAttributes,
+        commandText = "echo hello",
+        dockerRcPath = "/tmp/rc.txt",
+        dockerStdoutPath = "/tmp/stdout.log",
+        dockerStderrPath = "/tmp/stderr.log",
+        jobDescriptor = jobDescriptor,
+        jobPaths = null,
+        inputs = Set.empty,
+        outputs = Set.empty,
+        workflowOptions = workflowOptions
+      )
+
+      val jobDefinition = StandardAwsBatchJobDefinitionBuilder.build(context)
+
+      // Job definition name should be deterministic based on inputs
+      // The colon in "ubuntu:latest" gets replaced with underscore
+      jobDefinition.name should startWith("cromwell_ubuntu_latest")
+      // The name should contain the SHA1 hash at the end
+      jobDefinition.name should fullyMatch regex """cromwell_ubuntu_latest[a-f0-9]{40}"""
+
+      // Verify no roleArn is included in hash calculation by checking it matches expected pattern
+      val roleArnStr = workflowOptions.getOrElse(JobRoleArn, "")
+      roleArnStr should be("")
+    }
+
+    "build a job definition name with jobRoleArn when provided" in {
+      // This test makes sure that the Job Definition is rebuilt correctly
+      // if the user submits a workflow with different JobRoleARN.
+      val roleArn = "arn:aws:iam::123456789012:role/MyJobRole"
+      val workflowOptions = WorkflowOptions(JsObject(Map(JobRoleArn -> JsString(roleArn))))
+
+      val context = AwsBatchJobDefinitionContext(
+        runtimeAttributes = runtimeAttributes,
+        commandText = "echo hello",
+        dockerRcPath = "/tmp/rc.txt",
+        dockerStdoutPath = "/tmp/stdout.log",
+        dockerStderrPath = "/tmp/stderr.log",
+        jobDescriptor = jobDescriptor,
+        jobPaths = null,
+        inputs = Set.empty,
+        outputs = Set.empty,
+        workflowOptions = workflowOptions
+      )
+
+      val jobDefinitionWithRole = StandardAwsBatchJobDefinitionBuilder.build(context)
+
+      // Job definition name should be different when roleArn is included
+      // The colon in "ubuntu:latest" gets replaced with underscore
+      jobDefinitionWithRole.name should startWith("cromwell_ubuntu_latest")
+      // The name should contain the SHA1 hash at the end
+      jobDefinitionWithRole.name should fullyMatch regex """cromwell_ubuntu_latest[a-f0-9]{40}"""
+
+      // Create the same job definition without roleArn to compare
+      val workflowOptionsNoRole = WorkflowOptions(JsObject.empty)
+      val contextNoRole = AwsBatchJobDefinitionContext(
+        runtimeAttributes = runtimeAttributes,
+        commandText = "echo hello",
+        dockerRcPath = "/tmp/rc.txt",
+        dockerStdoutPath = "/tmp/stdout.log",
+        dockerStderrPath = "/tmp/stderr.log",
+        jobDescriptor = jobDescriptor,
+        jobPaths = null,
+        inputs = Set.empty,
+        outputs = Set.empty,
+        workflowOptions = workflowOptionsNoRole
+      )
+
+      val jobDefinitionNoRole = StandardAwsBatchJobDefinitionBuilder.build(contextNoRole)
+
+      // The two names should be different because roleArn is included in the hash
+      jobDefinitionWithRole.name should not equal jobDefinitionNoRole.name
+    }
+
+    "apply jobRoleArn to container properties when provided" in {
+      val roleArn = "arn:aws:iam::123456789012:role/MyJobRole"
+      val workflowOptions = WorkflowOptions(JsObject(Map(JobRoleArn -> JsString(roleArn))))
+
+      val context = AwsBatchJobDefinitionContext(
+        runtimeAttributes = runtimeAttributes,
+        commandText = "echo hello",
+        dockerRcPath = "/tmp/rc.txt",
+        dockerStdoutPath = "/tmp/stdout.log",
+        dockerStderrPath = "/tmp/stderr.log",
+        jobDescriptor = jobDescriptor,
+        jobPaths = null,
+        inputs = Set.empty,
+        outputs = Set.empty,
+        workflowOptions = workflowOptions
+      )
+
+      val jobDefinition = StandardAwsBatchJobDefinitionBuilder.build(context)
+      val containerProperties = jobDefinition.containerProperties
+
+      // Verify the job role ARN is set on the container properties
+      containerProperties.jobRoleArn() should equal(roleArn)
+    }
+
+    "not set jobRoleArn on container properties when not provided" in {
+      val workflowOptions = WorkflowOptions(JsObject.empty)
+
+      val context = AwsBatchJobDefinitionContext(
+        runtimeAttributes = runtimeAttributes,
+        commandText = "echo hello",
+        dockerRcPath = "/tmp/rc.txt",
+        dockerStdoutPath = "/tmp/stdout.log",
+        dockerStderrPath = "/tmp/stderr.log",
+        jobDescriptor = jobDescriptor,
+        jobPaths = null,
+        inputs = Set.empty,
+        outputs = Set.empty,
+        workflowOptions = workflowOptions
+      )
+
+      val jobDefinition = StandardAwsBatchJobDefinitionBuilder.build(context)
+      val containerProperties = jobDefinition.containerProperties
+
+      // Verify no job role ARN is set when not provided
+      containerProperties.jobRoleArn() should be(null)
+    }
+
+    "correctly use getOrElse method for jobRoleArn retrieval" in {
+      val workflowOptions = WorkflowOptions(JsObject.empty)
+
+      // Test that getOrElse returns default value when key is not present
+      val roleArnStr = workflowOptions.getOrElse(JobRoleArn, "default-value")
+      roleArnStr should be("default-value")
+
+      // Test that getOrElse returns the actual value when key is present
+      val workflowOptionsWithRole = WorkflowOptions(JsObject(Map(JobRoleArn -> JsString("my-role-arn"))))
+      val roleArnStrWithValue = workflowOptionsWithRole.getOrElse(JobRoleArn, "default-value")
+      roleArnStrWithValue should be("my-role-arn")
+    }
+  }
+}


### PR DESCRIPTION
### Description

This PR added a workflow option for the AWS Batch backend to override the `jobRoleARN` in the Batch definition.

For example, you can submit the workflow with the field `aws_batch_job_role_arn`. The AWS Batch backend will propagate this field to the JobDefinition.
```bash
curl -X POST "http://localhost:8000/api/workflows/v1" \
  -H "accept: application/json" \
  -F "workflowSource=@hello_world.wdl" \
  -F "workflowInputs={}" \
  -F 'workflowOptions={"aws_batch_job_role_arn": "arn:aws:iam::$account:role/your-role-name"}'
```