### PR TITLE
AN-702 feat(aws): Added aws_batch_script_bucket_prefix as a AWS Batch Workflow option

### DIFF
--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -103,3 +103,49 @@ java -jar cromwell.jar run workflow.wdl -o workflow_options.json
   ]
 }
 ```
+
+### aws_batch_script_bucket_prefix
+
+The `aws_batch_script_bucket_prefix` workflow option allows you to specify a custom prefix (subfolder) within the script bucket where execution scripts will be stored. This enables better organization and isolation of scripts for different workflows, projects, or teams.
+
+**Usage:**
+
+Include this option in your workflow options JSON file:
+
+```json
+{
+  "aws_batch_script_bucket_prefix": "project-x/workflow-123/scripts"
+}
+```
+
+**How it works:**
+- By default (when not specified), scripts are stored in the `scripts/` folder within the configured `scriptBucketName`
+- When you specify a prefix, scripts will be stored directly at that prefix location
+- The prefix should include any subfolder structure you want (including `/scripts` if desired)
+- If no prefix is specified or an empty string is provided, the default `scripts/` location is used
+- A trailing slash will be added automatically if not present
+
+**Example:**
+If your `scriptBucketName` is configured as `my-cromwell-scripts` and you set:
+```json
+{
+  "aws_batch_script_bucket_prefix": "team-alpha/project-genomics/scripts"
+}
+```
+
+Scripts will be stored at: `s3://my-cromwell-scripts/team-alpha/project-genomics/scripts/[script-hash]`
+
+Or for a custom structure without the `scripts` subfolder:
+```json
+{
+  "aws_batch_script_bucket_prefix": "workflows/2024/genomics-pipeline"
+}
+```
+
+Scripts will be stored at: `s3://my-cromwell-scripts/workflows/2024/genomics-pipeline/[script-hash]`
+
+**Benefits:**
+- **Organization**: Group scripts by workflow, project, team, or any other logical structure
+- **Access Control**: Easier to implement S3 bucket policies based on prefixes
+- **Cleanup**: Simpler to identify and remove old workflow scripts
+- **Multi-tenancy**: Different teams or projects can have isolated script locations

--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -123,7 +123,7 @@ Include this option in your workflow options JSON file:
 - When you specify a prefix, scripts will be stored directly at that prefix location
 - The prefix should include any subfolder structure you want (including `/scripts` if desired)
 - If no prefix is specified or an empty string is provided, the default `scripts/` location is used
-- A trailing slash will be added automatically if not present
+- A trailing slash will be added automatically if not present to ensure proper S3 key formation (e.g., `my-prefix` becomes `my-prefix/`)
 
 **Example:**
 If your `scriptBucketName` is configured as `my-cromwell-scripts` and you set:

--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -143,9 +143,3 @@ Or for a custom structure without the `scripts` subfolder:
 ```
 
 Scripts will be stored at: `s3://my-cromwell-scripts/workflows/2024/genomics-pipeline/[script-hash]`
-
-**Benefits:**
-- **Organization**: Group scripts by workflow, project, team, or any other logical structure
-- **Access Control**: Easier to implement S3 bucket policies based on prefixes
-- **Cleanup**: Simpler to identify and remove old workflow scripts
-- **Multi-tenancy**: Different teams or projects can have isolated script locations

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -188,6 +188,7 @@ class AwsBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       jobPaths,
       Seq.empty[AwsBatchParameter],
       configuration.awsConfig.region,
+      jobDescriptor.workflowDescriptor.workflowOptions,
       Option(configuration.awsAuth)
     )
   /* Tries to abort the job in flight

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -99,6 +99,9 @@ final case class AwsBatchJob(
   val Log: Logger = LoggerFactory.getLogger(AwsBatchJob.getClass)
 
   // this will be the "folder" that scripts will live in (underneath the script bucket)
+  // IMPORTANT: We always ensure a trailing slash exists because the script key (MD5 hash) is concatenated
+  // directly to this prefix throughout the code (e.g., scriptKeyPrefix + key). Without the trailing slash,
+  // we'd get malformed S3 keys like "my-projectabc123" instead of "my-project/abc123".
   val scriptKeyPrefix: String = workflowOptions.getOrElse(AwsBatchWorkflowOptionKeys.ScriptBucketPrefix, "") match {
     case "" => "scripts/"
     case prefix => if (prefix.endsWith("/")) prefix else s"$prefix/"

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
@@ -2,4 +2,5 @@ package cromwell.backend.impl.aws
 
 object AwsBatchWorkflowOptionKeys {
   val JobRoleArn = "aws_batch_job_role_arn"
+  val ScriptBucketPrefix = "aws_batch_script_bucket_prefix"
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -197,6 +197,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
   }
 
   it should "use custom script prefix from workflow options" in {
+    // Test that a custom prefix is used as-is, with a trailing slash automatically added
     val workflowOptionsWithPrefix = WorkflowOptions(
       JsObject(
         Map(
@@ -221,6 +222,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       workflowOptionsWithPrefix
     )
 
+    // Verify the trailing slash is added to ensure proper S3 key formation
     job.scriptKeyPrefix should be("my-project/workflow-123/")
   }
 
@@ -253,6 +255,10 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
   }
 
   it should "preserve trailing slash in custom script prefix" in {
+    // Test that if a user provides a trailing slash, we don't add another one.
+    // This is important because the script key (MD5 hash) is concatenated directly to the prefix.
+    // We want "my-project/scripts/" + "abc123" = "my-project/scripts/abc123"
+    // NOT "my-project/scripts//" + "abc123" = "my-project/scripts//abc123"
     val workflowOptionsWithTrailingSlash = WorkflowOptions(
       JsObject(
         Map(
@@ -277,6 +283,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       workflowOptionsWithTrailingSlash
     )
 
+    // Verify that the existing trailing slash is preserved (not doubled)
     job.scriptKeyPrefix should be("my-project/scripts/")
   }
 }


### PR DESCRIPTION
 This PR introduces a new workflow option `aws_batch_script_bucket_prefix` that allows users to specify a custom prefix (subfolder) within the script bucket where execution scripts will be stored.

Currently, all workflow execution scripts are stored in a flat scripts/ folder within the configured S3 bucket. This can become problematic for:
  - Multi-tenant environments where different teams need isolated script locations
  - Large deployments with many workflows where script organization becomes challenging
  - Access control scenarios where IAM policies need to be applied at the prefix level
  - Cleanup operations where identifying and removing old workflow scripts is difficult

