### PR TITLE
AN-696 Set default timeout of 24 hours for GCP Batch cloud sdk shell runnables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Job IDs will be derived from workflow and call details with a hash generated using call name. 
 This will allow for better grouping of jobs in the Batch UI and ensure deterministic job IDs to prevent duplicates upon Cromwell restart. Example of job ID: `job-e21cbbd3-scatterworkflowmytask-2-1-175f647b`. 
 * Jobs that fail with exit code 50002 before even getting to RUNNING state will now be eligible for automatic transient retries.
+* Set a timeout of 24 hours for many runnables in Batch jobs. This prevents jobs from hanging indefinitely when localization or other setup steps fail. User command runnables are not affected.
 
 ### AWS Batch
 * Added support for specifying an IAM role for AWS Batch job containers via the `aws_batch_job_role_arn` workflow option. This allows containers to access AWS resources based on the permissions granted to the specified role.

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -230,16 +230,20 @@ object RunnableBuilder extends BatchUtilityConversions {
       flags,
       labels = runnableLabels collect {
         case (key, value) if key == Key.Tag => Key.Logging -> value
-        case (key, value) => key -> value
-      }
-    ).withTimeout(timeout = 30.minutes) // Consider removing this timeout altogether, other runnables don't have them.
+        case (key, value) => key -> value,
+      },
+      timeout = 30.minutes
+    )
 
   def cloudSdkRunnable: Runnable.Builder = Runnable.newBuilder.setContainer(cloudSdkContainerBuilder)
 
+  // Set a default timeout of 24 hours for these runnables. They are typically used for running
+  // localization, delocalization, small shell commands, etc. These processes occasionally hang and
+  // cost the user money, don't let them hang for the full timeout period of the high-level job.
   def cloudSdkShellRunnable(shellCommand: String)(volumes: List[Volume],
                                                   flags: List[RunnableFlag],
                                                   labels: Map[String, String],
-                                                  timeout: Duration = Duration.Inf
+                                                  timeout: Duration = 24.hours
   ): Runnable.Builder =
     Runnable.newBuilder
       .setContainer(cloudSdkContainerBuilder)


### PR DESCRIPTION
### Description

See comment in diff for explanation of change. The high-level outcome we want here is to fail rather than letting hung localization operations (and other related ops) run forever.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [X] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users