### PR TITLE
Aning/aws script bucket prefix aws merge

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -10,7 +10,11 @@ import common.util.TryUtil
 import common.validation.ErrorOr.{ErrorOr, ShortCircuitingFlatMap}
 import common.validation.IOChecked._
 import common.validation.Validation._
-import cromwell.backend.BackendJobExecutionActor.{BackendJobExecutionResponse, JobAbortedResponse, JobReconnectionNotSupportedException}
+import cromwell.backend.BackendJobExecutionActor.{
+  BackendJobExecutionResponse,
+  JobAbortedResponse,
+  JobReconnectionNotSupportedException
+}
 import cromwell.backend.BackendLifecycleActor.AbortJobCommand
 import cromwell.backend.BackendLifecycleActorFactory.{FailedRetryCountKey, MemoryMultiplierKey}
 import cromwell.backend.OutputEvaluator._

--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -103,3 +103,43 @@ java -jar cromwell.jar run workflow.wdl -o workflow_options.json
   ]
 }
 ```
+
+### aws_batch_script_bucket_prefix
+
+The `aws_batch_script_bucket_prefix` workflow option allows you to specify a custom prefix (subfolder) within the script bucket where execution scripts will be stored. This enables better organization and isolation of scripts for different workflows, projects, or teams.
+
+**Usage:**
+
+Include this option in your workflow options JSON file:
+
+```json
+{
+  "aws_batch_script_bucket_prefix": "project-x/workflow-123/scripts"
+}
+```
+
+**How it works:**
+- By default (when not specified), scripts are stored in the `scripts/` folder within the configured `scriptBucketName`
+- When you specify a prefix, scripts will be stored directly at that prefix location
+- The prefix should include any subfolder structure you want (including `/scripts` if desired)
+- If no prefix is specified or an empty string is provided, the default `scripts/` location is used
+- A trailing slash will be added automatically if not present to ensure proper S3 key formation (e.g., `my-prefix` becomes `my-prefix/`)
+
+**Example:**
+If your `scriptBucketName` is configured as `my-cromwell-scripts` and you set:
+```json
+{
+  "aws_batch_script_bucket_prefix": "team-alpha/project-genomics/scripts"
+}
+```
+
+Scripts will be stored at: `s3://my-cromwell-scripts/team-alpha/project-genomics/scripts/[script-hash]`
+
+Or for a custom structure without the `scripts` subfolder:
+```json
+{
+  "aws_batch_script_bucket_prefix": "workflows/2024/genomics-pipeline"
+}
+```
+
+Scripts will be stored at: `s3://my-cromwell-scripts/workflows/2024/genomics-pipeline/[script-hash]`

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -248,6 +248,7 @@ class AwsBatchAsyncBackendJobExecutionActor(
       jobPaths,
       Seq.empty[AwsBatchParameter],
       configuration.awsConfig.region,
+      jobDescriptor.workflowDescriptor.workflowOptions,
       Option(configuration.awsAuth),
       configuration.fsxMntPoint,
       configuration.efsMntPoint,

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -99,21 +99,13 @@ final case class AwsBatchJob(
 ) {
 
   val Log: Logger = LoggerFactory.getLogger(AwsBatchJob.getClass)
-  
-  // Debug workflow options
-  Log.info(s"AwsBatchJob created with workflow options: ${workflowOptions.toMap}")
   // this will be the "folder" that scripts will live in (underneath the script bucket)
   // IMPORTANT: We always ensure a trailing slash exists because the script key (MD5 hash) is concatenated
   // directly to this prefix throughout the code (e.g., scriptKeyPrefix + key). Without the trailing slash,
   // we'd get malformed S3 keys like "my-projectabc123" instead of "my-project/abc123".
   val scriptKeyPrefix: String = workflowOptions.getOrElse(AwsBatchWorkflowOptionKeys.ScriptBucketPrefix, "") match {
-    case "" => 
-      Log.info(s"No script bucket prefix found in workflow options, using default 'scripts/'")
-      "scripts/"
-    case prefix => 
-      val prefixWithSlash = if (prefix.endsWith("/")) prefix else s"$prefix/"
-      Log.info(s"Using custom script bucket prefix from workflow options: $prefixWithSlash")
-      prefixWithSlash
+    case "" => "scripts/"
+    case prefix => if (prefix.endsWith("/")) prefix else s"$prefix/"
   }
 
   lazy val batchClient: BatchClient = {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchWorkflowOptionKeys.scala
@@ -2,4 +2,5 @@ package cromwell.backend.impl.aws
 
 object AwsBatchWorkflowOptionKeys {
   val JobRoleArn = "aws_batch_job_role_arn"
+  val ScriptBucketPrefix = "aws_batch_script_bucket_prefix"
 }


### PR DESCRIPTION
### Description

This PR introduces a new workflow option aws_batch_script_bucket_prefix that allows users to specify a custom prefix (subfolder) within the script bucket where execution scripts will be stored.

Currently, all workflow execution scripts are stored in a flat scripts/ folder within the configured S3 bucket. This can become problematic for:

    Multi-tenant environments where different teams need isolated script locations
    Large deployments with many workflows where script organization becomes challenging
    Access control scenarios where IAM policies need to be applied at the prefix level
    Cleanup operations where identifying and removing old workflow scripts is difficult

