### PR TITLE
Make it explicit that the cloud billing API must be enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 This will allow for better grouping of jobs in the Batch UI and ensure deterministic job IDs to prevent duplicates upon Cromwell restart. Example of job ID: `job-e21cbbd3-scatterworkflowmytask-2-1-175f647b`. 
 * Jobs that fail with exit code 50002 before even getting to RUNNING state will now be eligible for automatic transient retries.
 * Set a timeout of 24 hours for many runnables in Batch jobs. This prevents excess spend when localization or other setup steps hang. User command runnables are not affected.
+* Updated cost estimation documentation to make it explicit that the Cloud Billing API must be enabled.
 
 ### AWS Batch
 * Added support for specifying an IAM role for AWS Batch job containers via the `aws_batch_job_role_arn` workflow option. This allows containers to access AWS resources based on the permissions granted to the specified role.

--- a/docs/cromwell_features/CostEstimation.md
+++ b/docs/cromwell_features/CostEstimation.md
@@ -7,7 +7,7 @@ This feature is currently available for **GCP only**. To enable it, add this lin
 services.GcpCostCatalogService.config.enabled = true
 ```
 
-Ensure that your Google credentials are available in your environment via the `GOOGLE_APPLICATION_CREDENTIALS` env var or [another method](https://cloud.google.com/docs/authentication/provide-credentials-adc).
+Ensure that you have [enabled the Cloud Billing API](https://cloud.google.com/billing/v1/how-tos/catalog-api) for your project and that your Google credentials are available in your environment via the `GOOGLE_APPLICATION_CREDENTIALS` env var or [another method](https://cloud.google.com/docs/authentication/provide-credentials-adc).
 
 Workflows run with this functionality enabled will produce non-zero cost when the `/api/workflows/{version}/{workflowId}/cost` endpoint is called. For example:
 ```


### PR DESCRIPTION
### Description

Was talking to @aednichols trying to work out an issue with my Cromwell server not generating cost estimations. Turned out I needed to enable the API but this wasn't made explicit in the docs.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users