### PR TITLE
AN-714 Accept OCI manifest mediaType for Docker hashing

### DIFF
--- a/centaur/src/main/resources/standardTestCases/cacheBetweenWF/cacheWithDockerOCIManifest.wdl
+++ b/centaur/src/main/resources/standardTestCases/cacheBetweenWF/cacheWithDockerOCIManifest.wdl
@@ -1,0 +1,39 @@
+task getAverage {
+  Int base1 = 9
+  Int base2 = 13
+    command {
+        echo ${(base1*base2)/2}
+    }
+    output {
+        Float average = read_float(stdout())
+    }
+    runtime {
+       docker: "gcr.io/broad-dsde-cromwell-dev/cromwell-oci-manifest-test@sha256:bac1423e2ae5b22a85905abff553cc9f0a7569ef0c1ab0732c821ce5e435a602"
+    }
+}
+
+task heightProduct{
+   Float baseAverage
+   Int height = 7
+
+   command {
+   		echo ${baseAverage*height}
+   }
+   output {
+		Float trapezoidalArea = read_float(stdout())
+   }
+   runtime {
+       docker: "gcr.io/broad-dsde-cromwell-dev/cromwell-oci-manifest-test@sha256:bac1423e2ae5b22a85905abff553cc9f0a7569ef0c1ab0732c821ce5e435a602"
+   }
+}
+
+workflow cacheWithDockerOCIManifest {
+   call getAverage {
+   }
+   call heightProduct {
+      input: baseAverage = getAverage.average
+   }
+   output {
+        heightProduct.trapezoidalArea
+   }
+}

--- a/centaur/src/main/resources/standardTestCases/cacheWithDockerOCIManifest.test
+++ b/centaur/src/main/resources/standardTestCases/cacheWithDockerOCIManifest.test
@@ -1,0 +1,16 @@
+name: cacheWithDockerOCIManifest
+testFormat: runtwiceexpectingcallcaching
+
+files {
+  workflow: cacheBetweenWF/cacheWithDockerOCIManifest.wdl
+  options: common_options/cache_read_off_write_on.options
+  second-options: common_options/cache_read_on_write_on.options
+}
+
+metadata {
+  workflowName: cacheWithDockerOCIManifest
+  status: Succeeded
+  "calls.cacheWithDockerOCIManifest.getAverage.callCaching.result": "Cache Hit: <<CACHE_HIT_UUID>>:cacheWithDockerOCIManifest.getAverage:-1"
+  "calls.cacheWithDockerOCIManifest.heightProduct.callCaching.result": "Cache Hit: <<CACHE_HIT_UUID>>:cacheWithDockerOCIManifest.heightProduct:-1"
+  "outputs.cacheWithDockerOCIManifest.heightProduct.trapezoidalArea": 406.0
+}


### PR DESCRIPTION
### Description

We have recently started seeing this image manifest mediaType in the wild; this enables call caching on images that use it.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users