### PR TITLE
AN-662 Revert unnecessary GCP auth in github actions

### DIFF
--- a/.github/set_up_cromwell_action/action.yml
+++ b/.github/set_up_cromwell_action/action.yml
@@ -6,10 +6,6 @@ inputs:
   cromwell_repo_token:
     description: "Token used to authenticate while checking out Cromwell."
     required: true
-  gar_login:
-    description: "Whether to authenticate to Google Artifact Registry."
-    required: false
-    default: "true"
 
 runs:
   using: "composite" # <-- this allows these steps to be used by other workflows.
@@ -49,13 +45,3 @@ runs:
         with:
           distribution: temurin
           java-version: 17
-
-      # Must come after checkout step or token file will be deleted
-      - name: Auth to GCP
-        if: ${{ inputs.gar_login == 'true' }}
-        id: 'auth'
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -44,9 +44,6 @@ on:
     branches:
       - develop
 
-permissions:
-  id-token: write
-
 env:
   PUBLISH_CONTRACTS_RUN_NAME: 'publish-contracts-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
   CAN_I_DEPLOY_RUN_NAME: 'can-i-deploy-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
@@ -125,22 +122,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Must come after checkout step or token file will be deleted
-      - name: Auth to GCP
-        id: 'auth'
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
-
       - name: Run consumer tests
         run: |
           docker run --rm -v $PWD:/working \
                           -v jar-cache:/root/.ivy \
                           -v jar-cache:/root/.ivy2 \
-                          -v ${GOOGLE_APPLICATION_CREDENTIALS}:/gha-gcloud-creds.json \
-                          -e GOOGLE_APPLICATION_CREDENTIALS="/gha-gcloud-creds.json" \
                           -w /working \
                           sbtscala/scala-sbt:openjdk-17.0.2_1.7.2_2.13.10 \
                           sbt "project pact4s" clean test

--- a/.github/workflows/cromwell_unit_tests.yml
+++ b/.github/workflows/cromwell_unit_tests.yml
@@ -13,7 +13,6 @@ on:
 
 permissions: 
   contents: read
-  id-token: write
 
 jobs:
   build-and-test: 

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   sbt-build:
@@ -26,15 +25,6 @@ jobs:
           repository: broadinstitute/cromwell
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           path: cromwell
-
-      # Must come after checkout step or token file will be deleted
-      - name: Auth to GCP
-        id: 'auth'
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       - uses: sbt/setup-sbt@v1
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   # Don't run this workflow concurrently on the same branch
@@ -101,7 +100,6 @@ jobs:
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
         cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        gar_login: "false" # Centaur tests handle their own GCP auth.
     # Activate SSH and idle for 30 minutes
 #    - name: Setup tmate session
 #      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/release_community_cromwell.yml
+++ b/.github/workflows/release_community_cromwell.yml
@@ -46,15 +46,6 @@ jobs:
         # related to each other.
         fetch-depth: 0
 
-    # Must come after checkout step or token file will be deleted
-    - name: Auth to GCP
-      id: 'auth'
-      uses: google-github-actions/auth@v2
-      with:
-        token_format: 'access_token'
-        workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-        service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
-
     - name: Merge to master and rev develop
       run: |
         set -e

--- a/.github/workflows/scalafmt-check.yml
+++ b/.github/workflows/scalafmt-check.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   run-scalafmt-check:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,6 @@
 name: dsp-appsec-trivy
 on: [pull_request]
 
-permissions:
-  id-token: write
-
 jobs:
   appsec-trivy:
     # Parse Dockerfile and build, scan image if a "blessed" base image is not used
@@ -20,15 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      # Must come after checkout step or token file will be deleted
-      - name: Auth to GCP
-        id: 'auth'
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       - uses: sbt/setup-sbt@v1
 
       # fetch SBT package


### PR DESCRIPTION
### Description

Followup to #7803, further changes in that PR made this GHA auth unnecessary. We should no longer need to be authed to GCP to build Cromwell.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users