### PR TITLE
CTM-292 Build & push server debug image on merge

### DIFF
--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -58,11 +58,16 @@ jobs:
         password: ${{ secrets.DSDEJENKINS_PASSWORD }}
     # Build & push `cromwell`, `womtool`, `cromiam`, and `cromwell-drs-localizer`
     # This step is validated in the GHA 'docker_build_test.yml' without the accompanying docker push
-    - name: Build Cromwell Docker
+    - name: Build & push all images
       run: |
         set -e
         cd cromwell
         sbt -Dproject.isSnapshot=false dockerBuildAndPush
+    - name: Build & push server debug image
+      run: |
+        set -e
+        cd cromwell
+        sbt -Dproject.isDebug=true server/dockerBuildAndPush
     - name: Deploy to dev and board release train (Cromwell)
       uses: broadinstitute/repository-dispatch@master
       with:


### PR DESCRIPTION
### Description

When we have stability issues in Production, we often talk about profiling the server and then don't do it. A leading reason is the 10-20 minute rigamarole of building and uploading an image from the developer's workstation.

By having debug images pre-baked for every deployed build of Cromwell, we decrease the "activation energy" of profiling by about 75% so we're more likely to actually use it.

**Alternative considered:**
- A Github action that builds the debug server image on-demand. This would less convenient, for the benefit of reduced clutter in Docker Hub.
  - If we seriously want to clean up DH, we should consider a larger strategy e.g. delete all non-release builds >1 year old

See also https://github.com/broadinstitute/terra-helmfile/pull/6338

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users