### PR TITLE
CTM-292 Optimize resolution of `localization_optional` DRS files

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -272,7 +272,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
     )
 
   // TODO: There is an AWS version of this that looks functionally identical. Consider unifying.
-  override def inputsToNotLocalize: Set[WomFile] = {
+  override lazy val inputsToNotLocalize: Set[WomFile] = {
     val loFiles: Set[WomFile] =
       if (noLocalizationForTask)
         jobDescriptor.allInputFiles


### PR DESCRIPTION
### Description

**Before**

Users can supply a mix of DRS and GCS files in the `localization_optional` section. We run all of the files through a "cloud resolve" function that attempts to resolve DRS files to GCS.

This is wasteful because cloud resolving GCS to GCS is an expensive no-op.

**After**

Partition files based on their scheme. Cloud resolve only the `drs://` files.

Memoize the result of the call, instead of doing it twice.

**DRS + GCS background**

Only TDR's DRS files have a GCS path associated with them. Other DRS providers have dropped GCS paths in favor of signed URLs.

There are many and growing datasets in TDR, so it's worth providing an optimization path for those computing with them.

Michael Baumann and I were previously not aware of this optimization, but it's useful enough to keep around.

**Why do we care about this now**

The process of trying to DRS-resolve an extreme amount (7M) of `localization_optional` files caused Cromwell outages the week of 2025-12-08. It turns out we shouldn't be doing that anyway.

<img width="500" height="281" alt="Screenshot 2025-12-11 at 15 55 53" src="https://github.com/user-attachments/assets/903319c9-cf83-4ea8-9b81-b7437ba2cd75" />

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users