### PR TITLE
womtool: add support for sub wdls

### DIFF
--- a/engine/src/main/scala/cromwell/webservice/routes/WomtoolRouteSupport.scala
+++ b/engine/src/main/scala/cromwell/webservice/routes/WomtoolRouteSupport.scala
@@ -60,6 +60,7 @@ trait WomtoolRouteSupport extends WebServiceUtils with GithubAuthVendingSupport 
     val workflowInputs = data.get("workflowInputs").map(_.utf8String)
     val workflowType = data.get("workflowType").map(_.utf8String)
     val workflowVersion = data.get("workflowTypeVersion").map(_.utf8String)
+    val workflowDependencies = data.get("workflowDependencies").map(_.toArray)
 
     val wsfc = WorkflowSourceFilesCollection(
       workflowSource,
@@ -70,7 +71,7 @@ trait WomtoolRouteSupport extends WebServiceUtils with GithubAuthVendingSupport 
       workflowInputs.getOrElse(""),
       workflowOptions = WorkflowOptions.empty,
       labelsJson = "",
-      importsFile = None,
+      importsFile = workflowDependencies,
       workflowOnHold = false,
       warnings = Seq.empty,
       requestedWorkflowId = None


### PR DESCRIPTION
We would like to use the womtool for wdl validation, but it is missing the support for sub wdls. Thus add support for sub wdls for womtool. Ran with curl -X POST http://localhost:8000/api/womtool/v1/describe   -F workflowSource=@main.wdl   -F workflowDependencies=@deps.zip, so zipping the subwdls...