### PR TITLE
Fix WDL 1.1 docker/container runtime attribute on local/SFS backend

### DIFF
--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ContainerDeclarationValidation.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/ContainerDeclarationValidation.scala
@@ -1,0 +1,15 @@
+package cromwell.backend.impl.sfs.config
+
+import cromwell.backend.validation.{Containers, RuntimeAttributesValidation, ValidatedRuntimeAttributes}
+import wdl.draft2.model.Declaration
+import wom.values.{WomString, WomValue}
+
+class ContainerDeclarationValidation(declaration: Declaration,
+                                     instanceValidation: RuntimeAttributesValidation[_]
+) extends DeclarationValidation(declaration, instanceValidation, usedInCallCachingOverride = None) {
+
+  override def extractWdlValueOption(validatedRuntimeAttributes: ValidatedRuntimeAttributes): Option[WomValue] =
+    RuntimeAttributesValidation.extractOption[Containers](instanceValidation.key, validatedRuntimeAttributes) map {
+      containers => WomString(containers.values.head)
+    }
+}

--- a/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
+++ b/supportedBackends/sfs/src/main/scala/cromwell/backend/impl/sfs/config/DeclarationValidation.scala
@@ -31,9 +31,9 @@ object DeclarationValidation {
     declaration.unqualifiedName match {
       // Docker, Container, and CPU are special keys understood by cromwell (docker and container are aliases).
       case name if name == DockerValidation.instance.key =>
-        new DeclarationValidation(declaration, DockerValidation.instance, usedInCallCachingOverride = None)
+        new ContainerDeclarationValidation(declaration, DockerValidation.instance)
       case name if name == ContainerValidation.instance.key =>
-        new DeclarationValidation(declaration, ContainerValidation.instance, usedInCallCachingOverride = None)
+        new ContainerDeclarationValidation(declaration, ContainerValidation.instance)
       case RuntimeAttributesKeys.CpuKey => new CpuDeclarationValidation(declaration, CpuValidation.instance)
       // See MemoryDeclarationValidation for more info
       case name

--- a/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/config/DeclarationValidationSpec.scala
+++ b/supportedBackends/sfs/src/test/scala/cromwell/backend/sfs/config/DeclarationValidationSpec.scala
@@ -2,15 +2,15 @@ package cromwell.backend.sfs.config
 
 import common.assertion.CromwellTimeoutSpec
 import cromwell.backend.impl.sfs.config.DeclarationValidation
-import cromwell.backend.validation.ValidatedRuntimeAttributes
+import cromwell.backend.validation.{Containers, ValidatedRuntimeAttributes}
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineMV
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
 import wdl.draft2.model._
-import wom.types.WomIntegerType
-import wom.values.WomInteger
+import wom.types.{WomIntegerType, WomOptionalType, WomStringType}
+import wom.values.{WomInteger, WomString}
 
 class DeclarationValidationSpec
     extends AnyFlatSpec
@@ -36,5 +36,43 @@ class DeclarationValidationSpec
     )
 
     forAll(keys)(validateCpu)
+  }
+
+  def validateContainer(key: String) = {
+    val expression = WdlExpression.fromString("\"ubuntu:latest\"")
+    val declarationValidation = DeclarationValidation.fromDeclaration(callCachedRuntimeAttributesMap = Map.empty)(
+      Declaration(WomStringType, key, Option(expression), None, null)
+    )
+    declarationValidation.extractWdlValueOption(
+      ValidatedRuntimeAttributes(Map(key -> Containers("ubuntu:latest")))
+    ) shouldBe Some(WomString("ubuntu:latest"))
+  }
+
+  it should "validate docker attribute with Containers type" in {
+    validateContainer("docker")
+  }
+
+  it should "validate container attribute with Containers type" in {
+    validateContainer("container")
+  }
+
+  it should "return None for absent optional docker attribute" in {
+    val expression = WdlExpression.fromString("\"ubuntu:latest\"")
+    val declarationValidation = DeclarationValidation.fromDeclaration(callCachedRuntimeAttributesMap = Map.empty)(
+      Declaration(WomOptionalType(WomStringType), "docker", Option(expression), None, null)
+    )
+    declarationValidation.extractWdlValueOption(
+      ValidatedRuntimeAttributes(Map.empty)
+    ) shouldBe None
+  }
+
+  it should "extract first image when multiple container images are provided" in {
+    val expression = WdlExpression.fromString("\"ubuntu:latest\"")
+    val declarationValidation = DeclarationValidation.fromDeclaration(callCachedRuntimeAttributesMap = Map.empty)(
+      Declaration(WomStringType, "docker", Option(expression), None, null)
+    )
+    declarationValidation.extractWdlValueOption(
+      ValidatedRuntimeAttributes(Map("docker" -> Containers(List("first:1.0", "second:2.0", "third:3.0"))))
+    ) shouldBe Some(WomString("first:1.0"))
   }
 }


### PR DESCRIPTION
Fixes #7846

## Summary

- Add `ContainerDeclarationValidation` to unwrap `Containers` type to `WomString` on the SFS backend
- Wire up `docker` and `container` runtime attribute cases to use the new validation subclass
- Add unit tests for docker/container extraction, optional absence, and multi-image selection

## Problem

Cromwell 92 cannot run WDL 1.1 workflows on the local/shared-filesystem (SFS) backend when `docker` or `container` runtime attributes are specified. The error is:

> No coercion defined from 'image:tag' of type 'cromwell.backend.validation.Containers' to 'String?'

WDL 1.1 introduced a `Containers` wrapper type for the docker/container runtime attribute. Cloud backends (GCP Batch, AWS) were updated to handle this type, but the SFS backend was not. Specifically, `DeclarationValidation.extractWdlValueOption()` tries to coerce a `Containers` object through `WomStringType.coerceRawValue()`, which fails because `WomStringType` has no coercion rule for `Containers`.

CPU and Memory runtime attributes avoid this problem because they have custom `DeclarationValidation` subclasses (`CpuDeclarationValidation`, `MemoryDeclarationValidation`) that override `extractWdlValueOption()` to unwrap their non-WomValue types before coercion.

## Fix

**New file: `ContainerDeclarationValidation.scala`** — A `DeclarationValidation` subclass (15 lines) following the exact pattern of `CpuDeclarationValidation`. It overrides `extractWdlValueOption()` to extract the primary container image string from the `Containers` wrapper and return it as a `WomString`. Uses `containers.values.head` (the first/primary image), consistent with how `Containers.extractContainerOption()` works in cloud backends.

**Edited: `DeclarationValidation.scala`** (2-line change) — Changed the `docker` and `container` match cases in `fromDeclaration()` to instantiate `ContainerDeclarationValidation` instead of the base `DeclarationValidation`.

## Tests

Added 4 unit tests to `DeclarationValidationSpec`:

1. **docker key extraction** — Verifies that a `Containers("ubuntu:latest")` value stored under the `"docker"` key is correctly extracted as `WomString("ubuntu:latest")`
2. **container key extraction** — Same verification for the `"container"` key
3. **absent optional docker** — Verifies that an optional docker attribute absent from `ValidatedRuntimeAttributes` returns `None` (not an error)
4. **multiple container images** — Verifies that `Containers(List("first:1.0", "second:2.0", "third:3.0"))` extracts the first image (`WomString("first:1.0")`)

All 5 tests pass (1 pre-existing + 4 new).

## Files changed

| File | Change |
|------|--------|
| `supportedBackends/sfs/.../config/ContainerDeclarationValidation.scala` | NEW (15 lines) |
| `supportedBackends/sfs/.../config/DeclarationValidation.scala` | 2 lines changed |
| `supportedBackends/sfs/.../config/DeclarationValidationSpec.scala` | 38 lines added |

🤖 Generated with [Claude Code](https://claude.ai/code)