### PR TITLE
SCP-1594: Enable Additional System Tag Keys with TagAlias for AWS Batch Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Cromwell Change Log
 
+### AWS Batch
+* Added `tagAliases` backend config option, which duplicates engine-generated tags (e.g. `cromwell-workflow-id`) under alternative key names for external systems like cost-tracking tools. See the [Tag Aliases](supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md#tag-aliases) section for configuration details.
+
 ## 92 Release Notes
 ### WDL 1.1 Support
 * Cromwell now fully supports WDL 1.1. Users can specify `Version: "1.1"` in their workflow options to use WDL 1.1 features. See the [WDL 1.1 Spec](https://github.com/openwdl/wdl/blob/wdl-1.1/SPEC.md)

--- a/centaur/src/main/resources/standardTestCases/aws_label_propagation.test
+++ b/centaur/src/main/resources/standardTestCases/aws_label_propagation.test
@@ -16,4 +16,6 @@ metadata {
   "outputs.CheckAwsLabelPropagation.job_tags.label-key-2": "label-value-2"
   "outputs.CheckAwsLabelPropagation.job_tags.only-key": ""
   "outputs.CheckAwsLabelPropagation.job_tags.fc-id": "0123-abcd-4567-efgh"
+  # test a tag with a predictable value (unlike cromwell-workflow-id)
+  "outputs.CheckAwsLabelPropagation.job_tags.alias-workflow-name": "CheckAwsLabelPropagation"
 }

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_gpu_on_papi_invalid.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_gpu_on_papi_invalid.test
@@ -10,5 +10,5 @@ files {
 metadata {
   status: Failed
 
-  "calls.gpu_on_papi.task_with_gpu.failures.0.message": "Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: machine_type field is invalid. machine type custom-1-2048 is not compatible with accelerators [type:\"nonsense value\"  count:1] error: generic::invalid_argument: Accelerator field is invalid. Accelerator with type nonsense value is not supported for Batch now. Please make sure that the type is lowercase formatted as name field in command `gcloud compute accelerator-types list` shows if it exists in the list.). "
+  "calls.gpu_on_papi.task_with_gpu.failures.0.message": "Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: machine_type field is invalid. machine type custom-1-2048 is not compatible with accelerators [type:\"nonsense value\" count:1] error: generic::invalid_argument: Accelerator field is invalid. Accelerator with type nonsense value is not supported for Batch now. Please make sure that the type is lowercase formatted as name field in command `gcloud compute accelerator-types list` shows if it exists in the list.). "
 }

--- a/services/src/test/scala/cromwell/services/database/QueryTimeoutSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/QueryTimeoutSpec.scala
@@ -106,7 +106,7 @@ class QueryTimeoutSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matcher
                  */
                 case (major, minor) if (major >= 10 && minor >= 3) || major >= 11 =>
                   RegexErrorMessage(
-                    """(\(conn=\d+\) )?Query execution was interrupted \(max_statement_time exceeded\)""".r
+                    """(\(conn=\d+\) )?Query (execution )?was interrupted(: execution time limit \d+(\.\d+)? sec exceeded| \(max_statement_time exceeded\))""".r
                   )
                 case _ => IntErrorMessage(1)
               }

--- a/src/ci/resources/aws_tag_resources_application.conf
+++ b/src/ci/resources/aws_tag_resources_application.conf
@@ -1,3 +1,6 @@
 include "aws_application.conf"
 
 backend.providers.AWSBATCH.config.tagResources=true
+backend.providers.AWSBATCH.config.tagAliases={
+    "cromwell-root-workflow-name" = "alias-workflow-name"
+}

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -263,6 +263,7 @@ class AwsBatchAsyncBackendJobExecutionActor(
       Option(runtimeAttributes.efsDelocalize),
       configuration.tagResources,
       configuration.tagHardware,
+      configuration.tagAliases,
       runtimeAttributes.logGroupName,
       runtimeAttributes.additionalTags,
       scriptBucketPrefix

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAttributes.scala
@@ -68,6 +68,7 @@ case class AwsBatchAttributes(fileSystem: String,
                               efsDelocalize: Option[Boolean],
                               tagResources: Option[Boolean],
                               tagHardware: Option[Boolean],
+                              tagAliases: Map[String, String],
                               globLinkCommand: Option[String],
                               checkSiblingMd5: Option[Boolean]
 )
@@ -102,6 +103,7 @@ object AwsBatchAttributes {
     "efsMakeMD5",
     "tagResources",
     "tagHardware",
+    "tagAliases",
     "maxRetries",
     "glob-link-command"
   )
@@ -214,6 +216,11 @@ object AwsBatchAttributes {
         case false => None
       }
     }
+    val tagAliases: ErrorOr[Map[String, String]] = validate(
+      backendConfig
+        .as[Option[Map[String, String]]]("tagAliases")
+        .getOrElse(Map.empty)
+    )
     // from config if set.
     val globLinkCommand: ErrorOr[Option[String]] = validate {
       backendConfig.hasPath("glob-link-command") match {
@@ -242,6 +249,7 @@ object AwsBatchAttributes {
       efsDelocalize,
       tagResources,
       tagHardware,
+      tagAliases,
       globLinkCommand,
       checkSiblingMd5
     ).tupled.map((AwsBatchAttributes.apply _).tupled) match {

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchConfiguration.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchConfiguration.scala
@@ -66,6 +66,7 @@ class AwsBatchConfiguration(val configurationDescriptor: BackendConfigurationDes
   val checkSiblingMd5 = batchAttributes.checkSiblingMd5
   val tagResources = batchAttributes.tagResources
   val tagHardware = batchAttributes.tagHardware
+  val tagAliases = batchAttributes.tagAliases
 
 }
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJob.scala
@@ -94,6 +94,7 @@ final case class AwsBatchJob(
   efsDelocalize: Option[Boolean],
   tagResources: Option[Boolean],
   tagHardware: Option[Boolean],
+  tagAliases: Map[String, String],
   logGroupName: String,
   additionalTags: Map[String, String],
   scriptBucketPrefix: Option[String]
@@ -715,8 +716,12 @@ final case class AwsBatchJob(
           )
         )
 
-        // Combine both maps - Tags will override customLabels if there are duplicate keys
-        val allTags: Map[String, String] = customLabels ++ Tags
+        // Expand tag aliases: duplicate engine tag values under alias keys
+        val aliasedTags: Map[String, String] = tagAliases.flatMap { case (sourceKey, aliasKey) =>
+          Tags.get(sourceKey).map(value => aliasKey -> value)
+        }
+        // Combine all maps - Tags override customLabels, aliases come last
+        val allTags: Map[String, String] = customLabels ++ Tags ++ aliasedTags
         submitJobRequest = submitJobRequest.tags(allTags.asJava).propagateTags(true)
       }
       // JobTimeout provided (positive value) : add to request

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md
@@ -668,6 +668,36 @@ backend {
 
 ```
 
+#### Tag Aliases
+
+When `tagResources` is enabled, Cromwell sets five engine-generated tags on each AWS Batch job:
+
+- `cromwell-workflow-name`
+- `cromwell-workflow-id`
+- `cromwell-task-id`
+- `cromwell-root-workflow-name`
+- `cromwell-root-workflow-id`
+
+The `tagAliases` option lets you duplicate any of these engine tags under a second key name. This is useful when you need the same value exposed under a different tag key for external systems (e.g. cost-tracking or orchestration tools). Each entry maps a source engine tag key to an alias key. The alias receives the same (already sanitized) value as the source tag.
+
+```
+backend {
+    providers {
+        AWSBatch {
+            config{
+                tagResources = true
+                tagAliases {
+                    "cromwell-workflow-id" = "alias:workflow-run-id"
+                    "cromwell-workflow-name" = "alias:pipeline-name"
+                }
+            }
+        }
+    }
+}
+```
+
+This configuration is optional. When omitted, no aliases are produced. Only the five engine tag keys listed above are valid as source keys; any entry whose source key does not match an engine tag is silently ignored.
+
 Additional, custom tags can be added to jobs, using the "additionalTags" parameter in the "default-runtime-attributes" section of the job definition:
 
 ```

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttributesSpec.scala
@@ -55,6 +55,7 @@ class AwsBatchAttributesSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
     attributes.executionBucket should be("s3://myBucket")
     attributes.tagResources should be(Some(true))
     attributes.tagHardware should be(Some(true))
+    attributes.tagAliases should be(Map("cromwell-workflow-id" -> "alias:workflow-run-id"))
   }
 
   it should "not parse invalid config" taggedAs IntegrationTest in {
@@ -80,7 +81,9 @@ class AwsBatchAttributesSpec extends AnyFlatSpec with CromwellTimeoutSpec with M
        |   numCreateDefinitionAttempts = 6
        |   tagResources = true
        |   tagHardware = true
-       |
+       |   tagAliases {
+       |     "cromwell-workflow-id" = "alias:workflow-run-id"
+       |   }
        |
        |   filesystems = {
        |     local {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobSpec.scala
@@ -189,6 +189,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       None
@@ -218,6 +219,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       None
@@ -247,6 +249,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       None
@@ -679,6 +682,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       Some("my-project/workflow-123")
@@ -711,6 +715,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       Some("")
@@ -745,6 +750,7 @@ class AwsBatchJobSpec extends TestKitSuite with AnyFlatSpecLike with Matchers wi
       None,
       None,
       None,
+      Map.empty,
       "",
       Map.empty,
       Some("my-project/scripts/")


### PR DESCRIPTION
### Description

This PR is based on @LizBaldo 's example https://github.com/broadinstitute/cromwell/pull/7818

  - Add tagAliases configuration option to the AWS Batch backend, allowing engine-generated tags to be duplicated under additional key names
  - When tagResources = true, any entry in tagAliases maps a source engine tag (e.g. `cromwell-workflow-id`) to an alias key (e.g. `alias:workflow-run-id`), emitting the same sanitized value under both keys
  - The option is optional and defaults to an empty map when omitted

## Testing

Output from the `Tag Alias` test (added in this PR) confirming new tags:

```json
{
  "CheckAwsLabelAliasing.result": "Label aliasing check complete",
  "CheckAwsLabelAliasing.job_tags": {
    "only-key": "",
    "fc-id": "0123-abcd-4567-efgh",
    "alias:workflow-run-id": "258192e9-8063-4fa1-9f15-5fd170fce5bf",
    "label-key-2": "label-value-2",
    "cromwell-root-workflow-name": "CheckAwsLabelAliasing",
    "cromwell-workflow-id": "258192e9-8063-4fa1-9f15-5fd170fce5bf",
    "cromwell-root-workflow-id": "258192e9-8063-4fa1-9f15-5fd170fce5bf",
    "cromwell-workflow-name": "CheckAwsLabelAliasing",
    "cromwell-task-id": "CheckAwsLabelAliasing.CheckLabels-None-1",
    "label-key-1": "label-value-1"
  },
  "CheckAwsLabelAliasing.job_info": "s3://cromwell-centaur-execution-9-25/cromwell-execution/CheckAwsLabelAliasing/258192e9-8063-4fa1-9f15-5fd170fce5bf/call-CheckLabels/CheckLabels-stdout.log"
}
```

Compare to the output in the `Tag Resources` test, we can see that just one new tag (10 total), `"alias:workflow-run-id"`, is added (and it has the same value as `"cromwell-workflow-id"`).

Below we have 9 tags:

```json
{
  "CheckAwsLabelPropagation.job_info": "s3://cromwell-centaur-execution-9-25/cromwell-execution/CheckAwsLabelPropagation/0b18a9c0-d150-476f-a9ba-546117d77934/call-CheckLabels/CheckLabels-stdout.log",
  "CheckAwsLabelPropagation.job_tags": {
    "only-key": "",
    "fc-id": "0123-abcd-4567-efgh",
    "label-key-2": "label-value-2",
    "cromwell-root-workflow-name": "CheckAwsLabelPropagation",
    "cromwell-workflow-id": "0b18a9c0-d150-476f-a9ba-546117d77934",
    "cromwell-root-workflow-id": "0b18a9c0-d150-476f-a9ba-546117d77934",
    "cromwell-workflow-name": "CheckAwsLabelPropagation",
    "cromwell-task-id": "CheckAwsLabelPropagation.CheckLabels-None-1",
    "label-key-1": "label-value-1"
  },
  "CheckAwsLabelPropagation.result": "Label propagation check complete"
}
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users