### PR TITLE
Add batchJobRoleArn runtime attribute for per-task job role override

### DIFF
--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -235,8 +235,10 @@ class AwsBatchAsyncBackendJobExecutionActor(
     case _ => execScript
   }
 
-  lazy val jobRoleArn =
-    jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn).toOption
+  lazy val jobRoleArn: Option[String] =
+    runtimeAttributes.batchJobRoleArn.orElse {
+      jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn).toOption
+    }
 
   lazy val scriptBucketPrefix =
     jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.ScriptBucketPrefix).toOption

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -99,12 +99,14 @@ case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      fuseMount: Boolean,
                                      fileSystem: String = "s3",
                                      tagResources: Boolean = false,
-                                     tagHardware: Boolean = false
+                                     tagHardware: Boolean = false,
+                                     batchJobRoleArn: Option[String] = None
 )
 
 object AwsBatchRuntimeAttributes {
   val Log: Logger = LoggerFactory.getLogger(this.getClass)
   val QueueArnKey = "queueArn"
+  val BatchJobRoleArnKey = "batchJobRoleArn"
 
   val scriptS3BucketKey = "scriptBucketName"
 
@@ -229,6 +231,11 @@ object AwsBatchRuntimeAttributes {
         (throw new RuntimeException("queueArn is required"))
     )
 
+  private val batchJobRoleArnValidationInstance = new StringRuntimeAttributesValidation(BatchJobRoleArnKey)
+  private def batchJobRoleArnValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[String] =
+    batchJobRoleArnValidationInstance
+      .withDefault(batchJobRoleArnValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse WomString(""))
+
   private def awsBatchRetryAttemptsValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     AwsBatchRetryAttemptsValidation(awsBatchRetryAttemptsKey).withDefault(
       AwsBatchRetryAttemptsValidation(awsBatchRetryAttemptsKey)
@@ -319,6 +326,7 @@ object AwsBatchRuntimeAttributes {
         dockerValidation,
         containerValidation,
         queueArnValidation(runtimeConfig),
+        batchJobRoleArnValidation(runtimeConfig),
         scriptS3BucketNameValidation(runtimeConfig),
         logGroupNameValidation(runtimeConfig),
         awsBatchRetryAttemptsValidation(runtimeConfig),
@@ -345,6 +353,7 @@ object AwsBatchRuntimeAttributes {
         dockerValidation,
         containerValidation,
         queueArnValidation(runtimeConfig),
+        batchJobRoleArnValidation(runtimeConfig),
         logGroupNameValidation(runtimeConfig),
         awsBatchRetryAttemptsValidation(runtimeConfig),
         awsBatchEvaluateOnExitValidation(runtimeConfig),
@@ -447,6 +456,11 @@ object AwsBatchRuntimeAttributes {
       RuntimeAttributesValidation.extract(jobTimeoutValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
     val fuseMount: Boolean =
       RuntimeAttributesValidation.extract(fuseMountValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+    val batchJobRoleArn: Option[String] = {
+      val raw =
+        RuntimeAttributesValidation.extract(batchJobRoleArnValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+      if (raw.nonEmpty) Some(raw) else None
+    }
 
     new AwsBatchRuntimeAttributes(
       cpu,
@@ -472,7 +486,8 @@ object AwsBatchRuntimeAttributes {
       fuseMount,
       fileSystem,
       tagResources,
-      tagHardware
+      tagHardware,
+      batchJobRoleArn
     )
   }
 }


### PR DESCRIPTION
## Summary

Adds `batchJobRoleArn` as an optional runtime attribute, following the same pattern as `queueArn`. This allows individual WDL tasks to specify which IAM role should be used for their AWS Batch job definition.

### Resolution precedence
1. `batchJobRoleArn` runtime attribute (per-task, from WDL runtime block)
2. `aws_batch_job_role_arn` workflow option (per-workflow, added in #7784)

### Example

```wdl
task my_task {
  command { ... }
  runtime {
    docker: "my-image:latest"
    queueArn: "arn:aws:batch:us-east-1:123456789012:job-queue/my-queue"
    batchJobRoleArn: "arn:aws:iam::123456789012:role/MyTaskRole"
  }
}
```

### Use case

When workflows span multiple AWS Batch queues with different IAM role requirements, the workflow-level `aws_batch_job_role_arn` option sets the default, but individual tasks may need a different role. `batchJobRoleArn` provides that per-task override without requiring separate workflow submissions.

## Changes

- `AwsBatchRuntimeAttributes.scala` — adds optional `batchJobRoleArn` runtime attribute with empty string default
- `AwsBatchAsyncBackendJobExecutionActor.scala` — `jobRoleArn` now checks `batchJobRoleArn` runtime attribute first, falling back to the workflow option