### PR TITLE
Add batchJobRoleArn as an optional runtime attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### AWS Batch
 * Added `tagAliases` backend config option, which duplicates engine-generated tags (e.g. `cromwell-workflow-id`) under alternative key names for external systems like cost-tracking tools. See the [Tag Aliases](supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md#tag-aliases) section for configuration details.
+* Added `batchJobRoleArn` runtime attribute, allowing per-task IAM role overrides for AWS Batch job containers. When set, it takes priority over the `aws_batch_job_role_arn` workflow option.
 
 ## 92 Release Notes
 ### WDL 1.1 Support

--- a/docs/backends/AWSBatch.md
+++ b/docs/backends/AWSBatch.md
@@ -10,6 +10,26 @@ This section provides details on how to configure the AWS Batch backend with Cro
 
 Cromwell and AWS Batch recognizes number of runtime attributes, more information can be found in the [customize tasks](/RuntimeAttributes#recognized-runtime-attributes-and-backends) page.
 
+### batchJobRoleArn
+
+The `batchJobRoleArn` runtime attribute allows you to specify an IAM role ARN for a specific task's container. This is useful when individual tasks in a workflow need different permissions — for example, tasks that run on different AWS Batch queues with queue-specific roles.
+
+**Usage:**
+
+```wdl
+task my_task {
+  command { ... }
+  runtime {
+    docker: "ubuntu:latest"
+    batchJobRoleArn: "arn:aws:iam::123456789012:role/MyTaskRole"
+  }
+}
+```
+
+When both `batchJobRoleArn` and the `aws_batch_job_role_arn` workflow option are set, the runtime attribute takes priority. This allows a workflow-level default role to be overridden on a per-task basis.
+
+This attribute is optional. If not specified, the role from the `aws_batch_job_role_arn` workflow option is used instead.
+
 
 ## Running Cromwell on an EC2 instance
 

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchAsyncBackendJobExecutionActor.scala
@@ -235,8 +235,10 @@ class AwsBatchAsyncBackendJobExecutionActor(
     case _ => execScript
   }
 
-  lazy val jobRoleArn =
-    jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn).toOption
+  lazy val jobRoleArn: Option[String] =
+    runtimeAttributes.batchJobRoleArn.orElse {
+      jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.JobRoleArn).toOption
+    }
 
   lazy val scriptBucketPrefix =
     jobDescriptor.workflowDescriptor.workflowOptions.get(AwsBatchWorkflowOptionKeys.ScriptBucketPrefix).toOption

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributes.scala
@@ -99,12 +99,14 @@ case class AwsBatchRuntimeAttributes(cpu: Int Refined Positive,
                                      fuseMount: Boolean,
                                      fileSystem: String = "s3",
                                      tagResources: Boolean = false,
-                                     tagHardware: Boolean = false
+                                     tagHardware: Boolean = false,
+                                     batchJobRoleArn: Option[String] = None
 )
 
 object AwsBatchRuntimeAttributes {
   val Log: Logger = LoggerFactory.getLogger(this.getClass)
   val QueueArnKey = "queueArn"
+  val BatchJobRoleArnKey = "batchJobRoleArn"
 
   val scriptS3BucketKey = "scriptBucketName"
 
@@ -229,6 +231,11 @@ object AwsBatchRuntimeAttributes {
         (throw new RuntimeException("queueArn is required"))
     )
 
+  private val batchJobRoleArnValidationInstance = new StringRuntimeAttributesValidation(BatchJobRoleArnKey)
+  private def batchJobRoleArnValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[String] =
+    batchJobRoleArnValidationInstance
+      .withDefault(batchJobRoleArnValidationInstance.configDefaultWomValue(runtimeConfig) getOrElse WomString(""))
+
   private def awsBatchRetryAttemptsValidation(runtimeConfig: Option[Config]): RuntimeAttributesValidation[Int] =
     AwsBatchRetryAttemptsValidation(awsBatchRetryAttemptsKey).withDefault(
       AwsBatchRetryAttemptsValidation(awsBatchRetryAttemptsKey)
@@ -319,6 +326,7 @@ object AwsBatchRuntimeAttributes {
         dockerValidation,
         containerValidation,
         queueArnValidation(runtimeConfig),
+        batchJobRoleArnValidation(runtimeConfig),
         scriptS3BucketNameValidation(runtimeConfig),
         logGroupNameValidation(runtimeConfig),
         awsBatchRetryAttemptsValidation(runtimeConfig),
@@ -345,6 +353,7 @@ object AwsBatchRuntimeAttributes {
         dockerValidation,
         containerValidation,
         queueArnValidation(runtimeConfig),
+        batchJobRoleArnValidation(runtimeConfig),
         logGroupNameValidation(runtimeConfig),
         awsBatchRetryAttemptsValidation(runtimeConfig),
         awsBatchEvaluateOnExitValidation(runtimeConfig),
@@ -447,6 +456,11 @@ object AwsBatchRuntimeAttributes {
       RuntimeAttributesValidation.extract(jobTimeoutValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
     val fuseMount: Boolean =
       RuntimeAttributesValidation.extract(fuseMountValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+    val batchJobRoleArn: Option[String] = {
+      val raw =
+        RuntimeAttributesValidation.extract(batchJobRoleArnValidation(runtimeAttrsConfig), validatedRuntimeAttributes)
+      if (raw.nonEmpty) Some(raw) else None
+    }
 
     new AwsBatchRuntimeAttributes(
       cpu,
@@ -472,7 +486,8 @@ object AwsBatchRuntimeAttributes {
       fuseMount,
       fileSystem,
       tagResources,
-      tagHardware
+      tagHardware,
+      batchJobRoleArn
     )
   }
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchRuntimeAttributesSpec.scala
@@ -106,7 +106,10 @@ class AwsBatchRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeout
     "/Cromwell/job/",
     Map(),
     false,
-    "local"
+    "local",
+    false,
+    false,
+    None
   )
 
   "AwsBatchRuntimeAttributes" should {


### PR DESCRIPTION
### Description

Adds `batchJobRoleArn` as an optional runtime attribute, allowing individual WDL tasks to specify which IAM role should be used for their AWS Batch job container.

When set, it takes priority over the `aws_batch_job_role_arn` workflow option (#7784), allowing a workflow-level default to be overridden on a per-task basis.

#### Example

```wdl
task my_task {
  command { ... }
  runtime {
    docker: "ubuntu:latest"
    batchJobRoleArn: "arn:aws:iam::123456789012:role/MyTaskRole"
  }
}
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users