### PR TITLE
Custom-S3 support and TES improvements

### DIFF
--- a/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
+++ b/backend/src/main/scala/cromwell/backend/standard/StandardAsyncExecutionActor.scala
@@ -450,7 +450,7 @@ trait StandardAsyncExecutionActor
   def commandScriptContents: ErrorOr[String] = {
     val commandString = instantiatedCommand.commandString
     val commandStringAbbreviated = StringUtils.abbreviateMiddle(commandString, "...", abbreviateCommandLength)
-    jobLogger.info(s"`$commandStringAbbreviated`")
+    jobLogger.debug(s"`$commandStringAbbreviated`")
     tellMetadata(Map(CallMetadataKeys.CommandLine -> commandStringAbbreviated))
 
     val cwd = commandDirectory

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/AwsConfiguration.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/AwsConfiguration.scala
@@ -44,9 +44,16 @@ import net.ceedubs.ficus.Ficus._
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.regions.Region
 
+/**
+ * @param endpointUrl optional custom S3-compatible endpoint URL (e.g. "https://s3.gra.io.cloud.ovh.net").
+ *                    When set, all S3 filesystem operations are directed to this endpoint instead
+ *                    of the default AWS S3 endpoint. Corresponds to the `aws.endpoint-url` config key.
+ *                    PR note: added to support non-AWS S3-compatible object stores.
+ */
 final case class AwsConfiguration private (applicationName: String,
                                            authsByName: Map[String, AwsAuthMode],
-                                           strRegion: Option[String]
+                                           strRegion: Option[String],
+                                           endpointUrl: Option[String]
 ) {
 
   def auth(name: String): ErrorOr[AwsAuthMode] =
@@ -82,12 +89,19 @@ object AwsConfiguration {
     val region: Option[String] =
       awsConfig.getAs[String]("region")
 
+    // Optional custom S3-compatible endpoint URL (e.g. OVH Object Storage, MinIO, Ceph).
+    // When set, S3 filesystem operations target this endpoint instead of AWS.
+    // PR note: mirrors the aws.endpoint-url field added to AwsConfiguration.
+    val endpointUrl: Option[String] =
+      awsConfig.getAs[String]("endpoint-url")
+
     def buildAuth(authConfig: Config): ErrorOr[AwsAuthMode] = {
 
       def customKeyAuth(authConfig: Config, name: String, region: Option[String]): ErrorOr[AwsAuthMode] = validate {
         (authConfig.getAs[String]("access-key"), authConfig.getAs[String]("secret-key")) match {
           case (Some(accessKey), Some(secretKey)) =>
-            CustomKeyMode(name, accessKey, secretKey, region)
+            // Pass endpointUrl so CustomKeyMode can skip STS validation for non-AWS endpoints.
+            CustomKeyMode(name, accessKey, secretKey, region, endpointUrl)
           case _ =>
             throw new ConfigException.Generic(
               s"""Access key and/or secret """ +
@@ -159,7 +173,7 @@ object AwsConfiguration {
 
     (appName, errorOrAuthList).flatMapN { (name, list) =>
       uniqueAuthNames(list) map { _ =>
-        AwsConfiguration(name, list map { a => a.name -> a } toMap, region)
+        AwsConfiguration(name, list map { a => a.name -> a } toMap, region, endpointUrl)
       }
     } match {
       case Valid(r) => r

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/AwsConfiguration.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/AwsConfiguration.scala
@@ -48,7 +48,6 @@ import software.amazon.awssdk.regions.Region
  * @param endpointUrl optional custom S3-compatible endpoint URL (e.g. "https://s3.gra.io.cloud.ovh.net").
  *                    When set, all S3 filesystem operations are directed to this endpoint instead
  *                    of the default AWS S3 endpoint. Corresponds to the `aws.endpoint-url` config key.
- *                    PR note: added to support non-AWS S3-compatible object stores.
  */
 final case class AwsConfiguration private (applicationName: String,
                                            authsByName: Map[String, AwsAuthMode],
@@ -91,7 +90,6 @@ object AwsConfiguration {
 
     // Optional custom S3-compatible endpoint URL (e.g. OVH Object Storage, MinIO, Ceph).
     // When set, S3 filesystem operations target this endpoint instead of AWS.
-    // PR note: mirrors the aws.endpoint-url field added to AwsConfiguration.
     val endpointUrl: Option[String] =
       awsConfig.getAs[String]("endpoint-url")
 

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
@@ -116,8 +116,6 @@ object CustomKeyMode
  * When `endpointUrl` is provided the target is NOT AWS: STS-based credential validation is
  * intentionally skipped because AWS STS does not exist on third-party S3-compatible APIs.
  *
- * PR note: endpointUrl + STS-skip added to support non-AWS S3-compatible object stores.
- *
  * @param name        auth entry name from config
  * @param accessKey   static S3 access key
  * @param secretKey   static S3 secret key

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/auth/AwsAuthMode.scala
@@ -110,21 +110,39 @@ case object MockAuthMode extends AwsAuthMode {
 object CustomKeyMode
 
 /**
- * The AwsAuthMode constructed from a 'custom_key' auths scheme.
+ * The AwsAuthMode constructed from the 'custom_keys' auths scheme.
  *
- * @param name
- * @param accessKey static AWS access key
- * @param secretKey static AWS secret key
- * @param region an optional AWS region
+ * Supports both AWS and non-AWS S3-compatible services (e.g. OVH Object Storage, MinIO, Ceph).
+ * When `endpointUrl` is provided the target is NOT AWS: STS-based credential validation is
+ * intentionally skipped because AWS STS does not exist on third-party S3-compatible APIs.
+ *
+ * PR note: endpointUrl + STS-skip added to support non-AWS S3-compatible object stores.
+ *
+ * @param name        auth entry name from config
+ * @param accessKey   static S3 access key
+ * @param secretKey   static S3 secret key
+ * @param region      AWS region string (or S3-compatible region label)
+ * @param endpointUrl optional custom S3-compatible endpoint URL (non-AWS); when set, STS
+ *                    credential validation is skipped.
  */
-final case class CustomKeyMode(override val name: String, accessKey: String, secretKey: String, region: Option[String])
-    extends AwsAuthMode {
+final case class CustomKeyMode(
+    override val name: String,
+    accessKey: String,
+    secretKey: String,
+    region: Option[String],
+    endpointUrl: Option[String] = None
+) extends AwsAuthMode {
   private lazy val _provider: AwsCredentialsProvider = {
-    // make a provider locked to the given access and secret
     val p = StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
-
-    // immediately validate the credentials that the provider will generate before returning the provider
-    validateCredential(p, region)
+    endpointUrl match {
+      case Some(_) =>
+        // Non-AWS S3-compatible endpoint: AWS STS is unavailable on these services.
+        // The caller has explicitly supplied static credentials, so trust them as-is.
+        p
+      case None =>
+        // AWS endpoint: validate via STS GetCallerIdentity as normal.
+        validateCredential(p, region)
+    }
   }
 
   override def provider(): AwsCredentialsProvider = _provider

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
@@ -60,7 +60,6 @@ object S3Storage {
    *                    When set, path-style access is forced automatically because:
    *                    (a) non-AWS services do not support virtual-hosted-style bucket addressing,
    *                    (b) AWS SDK v2 would otherwise prepend the bucket name to the custom hostname.
-   *                    PR note: endpointUri + path-style-force added for non-AWS S3-compatible support.
    */
   def s3Client(
     configuration: S3Configuration,

--- a/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
+++ b/cloudSupport/src/main/scala/cromwell/cloudsupport/aws/s3/S3Storage.scala
@@ -31,6 +31,7 @@
 package cromwell.cloudsupport.aws.s3
 
 import com.typesafe.config.ConfigFactory
+import java.net.URI
 import net.ceedubs.ficus.Ficus._
 import scala.annotation.nowarn
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
@@ -52,11 +53,32 @@ object S3Storage {
     builder.build
   }
 
-  def s3Client(configuration: S3Configuration, provider: AwsCredentialsProvider, region: Option[Region]): S3Client = {
-    val builder = S3Client.builder
-      .serviceConfiguration(configuration)
-      .credentialsProvider(provider)
+  /**
+   * Build an S3Client.
+   *
+   * @param endpointUri optional custom S3-compatible endpoint (e.g. OVH, MinIO).
+   *                    When set, path-style access is forced automatically because:
+   *                    (a) non-AWS services do not support virtual-hosted-style bucket addressing,
+   *                    (b) AWS SDK v2 would otherwise prepend the bucket name to the custom hostname.
+   *                    PR note: endpointUri + path-style-force added for non-AWS S3-compatible support.
+   */
+  def s3Client(
+    configuration: S3Configuration,
+    provider: AwsCredentialsProvider,
+    region: Option[Region],
+    endpointUri: Option[URI] = None
+  ): S3Client = {
+    val builder = S3Client.builder.credentialsProvider(provider)
+    // For a custom endpoint, rebuild the S3Configuration with path-style access enabled.
+    // Non-AWS S3-compatible services require path-style (https://endpoint/bucket/key)
+    // rather than virtual-hosted-style (https://bucket.endpoint/key).
+    val finalConfig = endpointUri match {
+      case Some(_) => configuration.toBuilder.pathStyleAccessEnabled(true).build()
+      case None    => configuration
+    }
+    builder.serviceConfiguration(finalConfig)
     region.foreach(builder.region)
+    endpointUri.foreach(builder.endpointOverride)
     builder.build
   }
 

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/AwsConfigurationSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/AwsConfigurationSpec.scala
@@ -316,4 +316,43 @@ class AwsConfigurationSpec extends AnyFlatSpec with CromwellTimeoutSpec with Mat
       AwsConfiguration(ConfigFactory.parseString(duplicateAuthName))
     } should have message "AWS configuration:\nDuplicate auth names: name-default"
   }
+
+  // endpoint-url: optional custom S3-compatible endpoint (OVH, MinIO, etc.).
+
+  it should "parse an optional endpoint-url" in {
+    val configWithEndpoint =
+      """
+        |aws {
+        |  application-name = "cromwell"
+        |  endpoint-url = "https://s3.gra.io.cloud.ovh.net"
+        |  auths = [
+        |    {
+        |      name = "default"
+        |      scheme = "default"
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+
+    val conf = AwsConfiguration(ConfigFactory.parseString(configWithEndpoint))
+    conf.endpointUrl shouldBe Some("https://s3.gra.io.cloud.ovh.net")
+  }
+
+  it should "have endpointUrl as None when endpoint-url is absent from config" in {
+    val configWithoutEndpoint =
+      """
+        |aws {
+        |  application-name = "cromwell"
+        |  auths = [
+        |    {
+        |      name = "default"
+        |      scheme = "default"
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+
+    val conf = AwsConfiguration(ConfigFactory.parseString(configWithoutEndpoint))
+    conf.endpointUrl shouldBe None
+  }
 }

--- a/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/s3/S3StorageSpec.scala
+++ b/cloudSupport/src/test/scala/cromwell/cloudsupport/aws/s3/S3StorageSpec.scala
@@ -61,6 +61,17 @@ class S3StorageSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers {
     )
   }
 
+  // s3Client overload with custom endpoint: used for non-AWS S3-compatible object stores (OVH, MinIO, etc.).
+  it should "build s3 client with a custom endpoint override" taggedAs S3StorageSpecUtils.AwsTest in {
+    val endpointUri = new java.net.URI("https://s3.gra.io.cloud.ovh.net")
+    S3Storage.s3Client(
+      S3Storage.s3Configuration(),
+      AnonymousCredentialsProvider.create,
+      Option(Region.US_EAST_1),
+      Option(endpointUri)
+    )
+  }
+
 }
 
 object S3StorageSpecUtils {

--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -77,7 +77,6 @@ trait EvenBetterPathMethods {
         // code to run against a GCS Path. Fortunately creating directories in GCS is also unnecessary, so this
         // exception type is just ignored.
         case _: UnsupportedOperationException =>
-        // FIX (upstream PR candidate, companion to S3FileSystemProvider.exists empty-key fix):
         // The S3 filesystem (via better-files) does not support POSIX permissions. Unlike GCS which throws
         // UnsupportedOperationException, better-files' File.permissions() returns null for S3 paths because
         // the underlying NIO attribute view returns null. The subsequent .toSet() call on null produces a

--- a/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
+++ b/core/src/main/scala/cromwell/core/path/EvenBetterPathMethods.scala
@@ -77,6 +77,17 @@ trait EvenBetterPathMethods {
         // code to run against a GCS Path. Fortunately creating directories in GCS is also unnecessary, so this
         // exception type is just ignored.
         case _: UnsupportedOperationException =>
+        // FIX (upstream PR candidate, companion to S3FileSystemProvider.exists empty-key fix):
+        // The S3 filesystem (via better-files) does not support POSIX permissions. Unlike GCS which throws
+        // UnsupportedOperationException, better-files' File.permissions() returns null for S3 paths because
+        // the underlying NIO attribute view returns null. The subsequent .toSet() call on null produces a
+        // NullPointerException. Setting permissions on S3 "directories" is unnecessary (S3 has no POSIX
+        // permission model), so this exception type is safe to ignore here.
+        case _: NullPointerException =>
+        // S3 (and S3-compatible) paths also throw IOException (e.g. NoSuchFileException) from
+        // readAttributes when addPermission is called on a virtual directory or bucket root.
+        // S3 has no POSIX permission model so this is always a no-op; ignore any IOException here.
+        case _: java.io.IOException =>
       }
     }
     this

--- a/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
+++ b/engine/src/main/scala/cromwell/engine/io/RetryableRequestSupport.scala
@@ -28,7 +28,7 @@ object RetryableRequestSupport {
     case ioE: IOException
         if Option(ioE.getMessage).exists(_.contains("Error getting access token for service account")) =>
       true
-    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE) || isGcs504(ioE) || isAws504(ioE)
+    case ioE: IOException => isGcs500(ioE) || isGcs503(ioE) || isGcs504(ioE) || isAws504(ioE) || isNioTransient(ioE)
     case other =>
       // Infinitely retryable is a subset of retryable
       isInfinitelyRetryable(other)
@@ -110,4 +110,31 @@ object RetryableRequestSupport {
       msg.contains("Could not read from s3") &&
         !msg.contains("-rc.txt")
     )
+
+  /**
+    * Transient errors from the local NIO filesystem layer (java.nio / POSIX)
+    * arise when Cromwell reads local or NFS-mounted files (e.g. via sshfs or a Manila PVC)
+    * and the underlying filesystem has a momentary hiccup:
+    *
+    *   - EIO   (Input/output error)  — sshfs/NFS reconnect window, disk glitch
+    *   - ESTALE (Stale file handle)  — NFS server restarted or path re-exported
+    *
+    * All such errors were caught as:
+    *   IOException("Could not read from <path>: <kernel message>", cause)
+    *
+    * They resolve on their own within seconds and are safe to retry up to
+    * `system.io.number-of-attempts` times (default 5, configurable).
+    *
+    * Non-transient errors (file not found, permission denied, etc.) are excluded
+    *
+    * cloud-scheme paths (gs://, s3://, http) are handled by the dedicated
+    * isGcs/isAws matchers above and must NOT match here.
+    */
+  def isNioTransient(failure: Throwable): Boolean =
+    Option(failure.getMessage).exists { msg =>
+      (msg.contains("Input/output error") || msg.contains("Stale file handle")) &&
+      !msg.contains("gs://") &&
+      !msg.contains("s3://") &&
+      !msg.startsWith("http")
+    }
 }

--- a/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/io/IoActorSpec.scala
@@ -294,7 +294,24 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       ),
       new IOException(
         "Some other text. Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-4688/rc: 504 Gateway Timeout"
-      )
+      ),
+
+      // Local / NFS / sshfs transient filesystem errors (EIO = kernel I/O error, ESTALE = stale NFS handle).
+      // These are wrapped by EvenBetterPathMethods.fileIoErrorPf as
+      //   IOException("Could not read from <local-path>: <kernel message>").
+      // They should be retried up to system.io.number-of-attempts times.
+      new IOException(
+        "Could not read from /mnt/shared/gra9/References/genome/hs38DH.amb: Input/output error"
+      ),
+      new IOException(
+        "Could not read from /cromwell-executions/wf/call-task/inputs/Intervals.files.txt: Input/output error"
+      ),
+      new IOException(
+        "Could not read from /mnt/nfs/data/reference.fa: Stale file handle"
+      ),
+      // Bare kernel error messages (no "Could not read from" prefix) — also transient
+      new IOException("Input/output error"),
+      new IOException("Stale file handle")
     )
 
     retryables foreach { e =>
@@ -313,7 +330,15 @@ class IoActorSpec extends TestKitSuite with AnyFlatSpecLike with Matchers with I
       new Exception("5xx HTTP Status Code"),
       new IOException(
         "Could not read from gs://fc-secure-<snip>/JointGenotyping/<snip>/call-HardFilterAndMakeSitesOnlyVcf/shard-500/rc: 404 File Not Found"
-      )
+      ),
+
+      // Permanent local filesystem errors — must NOT be retried
+      new IOException("Could not read from /mnt/shared/file.txt: No such file or directory"),
+      new IOException("Could not read from /mnt/shared/file.txt: Permission denied"),
+
+      // Cloud-scheme paths with EIO-like messages — isNioTransient must not fire for gs:// or s3://
+      new IOException("Could not read from gs://bucket/file.tsv: Input/output error"),
+      new IOException("Could not read from s3://bucket/file.tsv: Input/output error")
     )
 
     nonRetryables foreach { RetryableRequestSupport.isRetryable(_) shouldBe false }

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
@@ -395,12 +395,30 @@ public class S3FileSystemProvider extends FileSystemProvider {
             s3Path.getFileStore().getClient().createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
         }
         // create the object as directory
-        PutObjectRequest.Builder builder = PutObjectRequest.builder();
+        // S3 is a flat namespace — directory marker objects (zero-byte keys ending in "/") are
+        // optional. Some S3-compatible endpoints (e.g. OVH Ceph RadosGW) return 403 Access Denied
+        // for putObject on such markers even when the credentials have full read/write access to
+        // actual objects in the bucket. Swallow S3Exception here: the marker not existing does not
+        // prevent cromwell from writing real objects under this prefix.
+        //
+        // Special case: if s3Path.getKey() is empty we are at the bucket root (e.g. the NIO path
+        // "/bucket/" whose key strips to ""). The bucket root is purely virtual — no marker object
+        // should ever be created for it, and attempting putObject with key "/" causes OVH to 403.
+        // Skip putObject entirely for the bucket root.
         String directoryKey = s3Path.getKey().endsWith("/") ? s3Path.getKey() : s3Path.getKey() + "/";
-        builder.bucket(bucketName)
-                .key(directoryKey)
-                .contentLength(0L);
-        s3Path.getFileStore().getClient().putObject(builder.build(), RequestBody.fromBytes(new byte[0]));
+        if (s3Path.getKey().isEmpty()) {
+            log.info("createDirectory: skipping putObject for bucket root (no marker needed)");
+        } else {
+            PutObjectRequest.Builder builder = PutObjectRequest.builder();
+            builder.bucket(bucketName)
+                    .key(directoryKey)
+                    .contentLength(0L);
+            try {
+                s3Path.getFileStore().getClient().putObject(builder.build(), RequestBody.fromBytes(new byte[0]));
+            } catch (S3Exception e) {
+                log.warning("createDirectory: putObject for directory marker '" + directoryKey + "' returned " + e.statusCode() + " — ignoring (S3 directory markers are optional)");
+            }
+        }
     }
 
     @Override
@@ -834,6 +852,29 @@ public class S3FileSystemProvider extends FileSystemProvider {
      */
     boolean exists(S3Path path) {
         S3Path s3Path = toS3Path(path);
+
+        // FIX : When the S3 key is empty we are at the virtual bucket root.
+        // Calling headObject with an empty key throws SdkClientException("Key cannot be empty") rather
+        // than a catchable S3Exception/NoSuchFileException, so the exception escapes the try-block below
+        // and propagates as an unhandled initialization error.
+        //
+        // This is triggered by cromwell.core.path.EvenBetterPathMethods.createPermissionedDirectories(),
+        // which walks the parent chain all the way to the bucket root when the workflow root directory
+        // does not yet exist (e.g. first run, or a bare-bucket `root` config like "s3://my-bucket").
+        //
+        // Fix: detect the empty-key case early and probe the bucket itself via headBucket instead.
+        // The bucket root is a virtual directory that "exists" iff the bucket is accessible.
+        if (s3Path.getKey().isEmpty()) {
+            try {
+                s3Path.getFileStore().getClient().headBucket(
+                    HeadBucketRequest.builder().bucket(s3Path.getFileStore().name()).build()
+                );
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
         try {
             s3Utils.getS3ObjectSummary(s3Path);
             return true;

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/S3FileSystemProvider.java
@@ -853,7 +853,6 @@ public class S3FileSystemProvider extends FileSystemProvider {
     boolean exists(S3Path path) {
         S3Path s3Path = toS3Path(path);
 
-        // FIX : When the S3 key is empty we are at the virtual bucket root.
         // Calling headObject with an empty key throws SdkClientException("Key cannot be empty") rather
         // than a catchable S3Exception/NoSuchFileException, so the exception escapes the try-block below
         // and propagates as an unhandled initialization error.
@@ -863,7 +862,7 @@ public class S3FileSystemProvider extends FileSystemProvider {
         // does not yet exist (e.g. first run, or a bare-bucket `root` config like "s3://my-bucket").
         //
         // Fix: detect the empty-key case early and probe the bucket itself via headBucket instead.
-        // The bucket root is a virtual directory that "exists" iff the bucket is accessible.
+        // The bucket root is a virtual directory that "exists" if the bucket is accessible.
         if (s3Path.getKey().isEmpty()) {
             try {
                 s3Path.getFileStore().getClient().headBucket(

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
@@ -34,6 +34,15 @@ public class S3Utils {
         String key = s3Path.getKey();
         String bucketName = s3Path.getFileStore().name();
         S3Client client = s3Path.getFileStore().getClient();
+
+        // Guard: empty key means the bucket root virtual directory.
+        // headObject with an empty key causes the AWS SDK marshaller to throw
+        // SdkClientException("Key cannot be empty") before any HTTP call is made.
+        // The bucket root is never a real S3 object, so just signal not-found.
+        if (key.isEmpty()) {
+            throw new NoSuchFileException(bucketName + S3Path.PATH_SEPARATOR);
+        }
+
         // try to find the element with the current key (maybe with end slash or maybe not.)
         try {
             HeadObjectResponse metadata = client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
@@ -56,11 +65,24 @@ public class S3Utils {
 
             return builder.build();
         } catch (S3Exception e) {
-            if (e.statusCode() != 404)
+            // 404 = object not found; fall through to virtual-directory check.
+            // 400 = some S3-compatible endpoints (e.g. OVH Ceph RadosGW) return 400 instead of
+            //       404 for headObject when the key doesn't exist, or when AWS SDK v2 sends a
+            //       header that the service doesn't support.
+            // 403 = OVH Ceph RadosGW also returns 403 ("Forbidden") for headObject on keys that
+            //       do not exist, depending on bucket ACL/policy configuration. This is a Ceph
+            //       quirk: rather than 404 it returns 403 to avoid leaking whether a key exists
+            //       when the caller has only limited bucket permissions.
+            // All three: treat as "not found" and fall through to listObjectsV2 which gives the
+            //       authoritative answer without these ambiguous status codes.
+            // Any other status code (5xx, etc.) is a real error and should propagate.
+            if (e.statusCode() != 404 && e.statusCode() != 400 && e.statusCode() != 403)
                 throw e;
+            if (e.statusCode() != 404)
+                log.debug("headObject returned " + e.statusCode() + " for key '" + key + "' in bucket '" + bucketName + "' — treating as not found and retrying via listObjectsV2 (S3-compatible endpoint quirk)");
         }
 
-        // if not found (404 err) with the original key.
+        // if not found (404, or non-404 from an S3-compatible service) with the original key.
         // try to find the element as a directory.
         try {
             // is a virtual directory (S3 prefix)

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
@@ -36,7 +36,7 @@ public class S3Utils {
         S3Client client = s3Path.getFileStore().getClient();
 
         // Guard: empty key means the bucket root virtual directory.
-        // headObject with an empty key causes the AWS SDK marshaller to throw
+        // headObject with an empty key causes 
         // SdkClientException("Key cannot be empty") before any HTTP call is made.
         // The bucket root is never a real S3 object, so just signal not-found.
         if (key.isEmpty()) {

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -111,7 +111,6 @@ object S3PathBuilder {
 
   /**
    * @param endpointUri optional custom S3-compatible endpoint URI (non-AWS, e.g. OVH, MinIO).
-   *                    PR note: added to support non-AWS S3-compatible object stores.
    */
   def fromAuthMode(authMode: AwsAuthMode,
                    configuration: S3Configuration,
@@ -138,7 +137,7 @@ object S3PathBuilder {
  * Builds S3Path instances for a given credentials provider, region and (optionally) a
  * custom S3-compatible endpoint.
  *
- * PR note: previously this class held only `S3Configuration` and `build()` always fell back
+ * Previously this class held only `S3Configuration` and `build()` always fell back
  * to `System.getenv` / `System.getProperties` for credentials and endpoint, making it
  * impossible to use configured credentials or a non-AWS endpoint. The class now stores the
  * full auth context and injects it into both the s3fs-nio filesystem (for NIO path resolution)
@@ -161,13 +160,13 @@ class S3PathBuilder(
    * Lazily-initialised S3FileSystem backed by our own AWS SDK v2 S3Client.
    * Shared across all build() calls on this builder instance (one builder per workflow).
    *
-   * PR note: s3fs-nio's AmazonS3Factory.getS3Client(URI, Properties) extracts the host from
+   * s3fs-nio's AmazonS3Factory.getS3Client(URI, Properties) extracts the host from
    * the filesystem URI and then calls AWS SDK v2 builder.endpointOverride(uri) passing the
    * full URI — including the s3:// scheme — which the SDK rejects:
    *   "Custom endpoint 's3://...' was not a valid URI"
    * The SDK requires http:// or https:// for endpointOverride.
    *
-   * The fix: S3FileSystemProvider also exposes a 3-arg overload
+   * S3FileSystemProvider also exposes a 3-arg overload
    *   createFileSystem(URI, Properties, S3Client)
    * that constructs S3FileSystem directly from a caller-supplied S3Client, completely
    * bypassing AmazonS3Factory. We pre-build the S3Client via S3Storage.s3Client() which
@@ -219,7 +218,7 @@ case class S3Path private[s3] (nioPath: NioPath, bucket: String, client: S3Clien
 
   override def pathAsString: String = s"s3://$pathWithoutScheme"
 
-  // PR note: was `stripPrefix("s3://s3.amazonaws.com/")` which broke for custom S3-compatible
+  // Previously, this was `stripPrefix("s3://s3.amazonaws.com/")` which broke for custom S3-compatible
   // endpoints (OVH, MinIO, etc.) where s3fs-nio encodes a different host in the path string.
   // Now strips s3://[any-host]/ generically so pathAsString always returns s3://bucket/key.
   override def pathWithoutScheme: String = safeAbsolutePath.replaceFirst("^s3://[^/]*/", "")

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -37,7 +37,8 @@ import cromwell.cloudsupport.aws.auth.AwsAuthMode
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.{NioPath, Path, PathBuilder}
 import cromwell.filesystems.s3.S3PathBuilder._
-import org.lerch.s3fs.{AmazonS3ClientFactory, S3FileSystemProvider}
+import cromwell.cloudsupport.aws.s3.S3Storage
+import org.lerch.s3fs.{S3FileSystem, S3FileSystemProvider}
 import org.lerch.s3fs.util.S3Utils
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
@@ -108,36 +109,101 @@ object S3PathBuilder {
       } else { InvalidScheme(string) }
     } recover { case t => UnparseableS3Path(string, t) } get
 
+  /**
+   * @param endpointUri optional custom S3-compatible endpoint URI (non-AWS, e.g. OVH, MinIO).
+   *                    PR note: added to support non-AWS S3-compatible object stores.
+   */
   def fromAuthMode(authMode: AwsAuthMode,
                    configuration: S3Configuration,
                    options: WorkflowOptions,
-                   storageRegion: Option[Region]
+                   storageRegion: Option[Region],
+                   endpointUri: Option[URI] = None
   )(implicit ec: ExecutionContext): Future[S3PathBuilder] = {
     val provider = authMode.provider()
-
     // Other backends needed retry here. In case we need retry, we'll return
     // a future. This will allow us to add capability without changing signature
-    Future(fromProvider(provider, configuration, options, storageRegion))
+    Future(fromProvider(provider, configuration, options, storageRegion, endpointUri))
   }
 
   def fromProvider(provider: AwsCredentialsProvider,
                    configuration: S3Configuration,
                    options: WorkflowOptions,
-                   storageRegion: Option[Region]
+                   storageRegion: Option[Region],
+                   endpointUri: Option[URI] = None
   ): S3PathBuilder =
-    new S3PathBuilder(configuration)
+    new S3PathBuilder(provider, configuration, storageRegion, endpointUri)
 }
 
-class S3PathBuilder(configuration: S3Configuration) extends PathBuilder {
+/**
+ * Builds S3Path instances for a given credentials provider, region and (optionally) a
+ * custom S3-compatible endpoint.
+ *
+ * PR note: previously this class held only `S3Configuration` and `build()` always fell back
+ * to `System.getenv` / `System.getProperties` for credentials and endpoint, making it
+ * impossible to use configured credentials or a non-AWS endpoint. The class now stores the
+ * full auth context and injects it into both the s3fs-nio filesystem (for NIO path resolution)
+ * and the AWS SDK v2 S3Client (for direct SDK operations stored on S3Path).
+ *
+ * @param provider     AWS SDK v2 credentials provider built from the configured auth mode
+ * @param configuration S3Configuration (accelerate, dual-stack, path-style flags)
+ * @param storageRegion optional region (AWS region or S3-compatible region label)
+ * @param endpointUri  optional custom S3-compatible endpoint; when set, path-style access
+ *                     is forced and the s3fs-nio filesystem is pointed at this host
+ */
+class S3PathBuilder(
+    provider: AwsCredentialsProvider,
+    configuration: S3Configuration,
+    storageRegion: Option[Region],
+    endpointUri: Option[URI]
+) extends PathBuilder {
+
+  /**
+   * Lazily-initialised S3FileSystem backed by our own AWS SDK v2 S3Client.
+   * Shared across all build() calls on this builder instance (one builder per workflow).
+   *
+   * PR note: s3fs-nio's AmazonS3Factory.getS3Client(URI, Properties) extracts the host from
+   * the filesystem URI and then calls AWS SDK v2 builder.endpointOverride(uri) passing the
+   * full URI — including the s3:// scheme — which the SDK rejects:
+   *   "Custom endpoint 's3://...' was not a valid URI"
+   * The SDK requires http:// or https:// for endpointOverride.
+   *
+   * The fix: S3FileSystemProvider also exposes a 3-arg overload
+   *   createFileSystem(URI, Properties, S3Client)
+   * that constructs S3FileSystem directly from a caller-supplied S3Client, completely
+   * bypassing AmazonS3Factory. We pre-build the S3Client via S3Storage.s3Client() which
+   * already calls endpointOverride() with the correct https:// URI.
+   */
+  private lazy val cachedFilesystem: S3FileSystem = {
+    // Build our correctly-configured S3Client (endpointOverride with https:// URI,
+    // pathStyleAccessEnabled forced when endpointUri is set).
+    val s3Client = S3Storage.s3Client(configuration, provider, storageRegion, endpointUri)
+
+    // Build a Properties map with our configured credentials for s3fs-nio's bookkeeping.
+    // s3fs-nio uses s3fs_access_key / s3fs_secret_key as part of the filesystem cache key.
+    // We do not need to copy System.getenv() here because the actual S3 client is already
+    // pre-built (passed as the third argument to createFileSystem); AmazonS3Factory is never
+    // invoked, so only the cache-key fields matter.
+    val creds = provider.resolveCredentials()
+    val props  = new java.util.Properties()
+    props.put("s3fs_access_key", creds.accessKeyId())
+    props.put("s3fs_secret_key", creds.secretAccessKey())
+
+    // The URI is only used to derive the filesystem key; the actual endpoint is
+    // driven by s3Client, not by this URI.
+    val fsUri = endpointUri
+      .map(ep => URI.create(s"s3://${ep.getHost}/"))
+      .getOrElse(URI.create("s3:////"))
+
+    new S3FileSystemProvider().createFileSystem(fsUri, props, s3Client)
+  }
+
   // Tries to create a new S3Path from a String representing an absolute s3 path: s3://<bucket>[/<key>].
   def build(string: String): Try[S3Path] =
     validatePath(string) match {
       case ValidFullS3Path(bucket, path) =>
         Try {
-          val s3Path = new S3FileSystemProvider()
-            .getFileSystem(URI.create("s3:////"), System.getenv)
-            .getPath(s"""/$bucket/$path""")
-          S3Path(s3Path, bucket, new AmazonS3ClientFactory().getS3Client(URI.create("s3:////"), System.getProperties))
+          val nioPath = cachedFilesystem.getPath(s"""/$bucket/$path""")
+          S3Path(nioPath, bucket, cachedFilesystem.getClient())
         }
       case PossiblyValidRelativeS3Path => Failure(new IllegalArgumentException(s"$string does not have a s3 scheme"))
       case invalid: InvalidS3Path => Failure(new IllegalArgumentException(invalid.errorMessage))
@@ -153,7 +219,10 @@ case class S3Path private[s3] (nioPath: NioPath, bucket: String, client: S3Clien
 
   override def pathAsString: String = s"s3://$pathWithoutScheme"
 
-  override def pathWithoutScheme: String = safeAbsolutePath.stripPrefix("s3://s3.amazonaws.com/")
+  // PR note: was `stripPrefix("s3://s3.amazonaws.com/")` which broke for custom S3-compatible
+  // endpoints (OVH, MinIO, etc.) where s3fs-nio encodes a different host in the path string.
+  // Now strips s3://[any-host]/ generically so pathAsString always returns s3://bucket/key.
+  override def pathWithoutScheme: String = safeAbsolutePath.replaceFirst("^s3://[^/]*/", "")
 
   def key: String = safeAbsolutePath
 
@@ -182,5 +251,28 @@ case class S3Path private[s3] (nioPath: NioPath, bucket: String, client: S3Clien
       case '/' => s3Path.toAbsolutePath.toString
       case _ => s3Path.resolve(s"/$bucket/$originalPath").toAbsolutePath.toString
     }
+  }
+
+  /**
+   * Override createDirectories() as a no-op for S3 paths.
+   *
+   * S3 is a flat key-value namespace — "directories" are a purely virtual concept defined
+   * by key prefixes. There is no API call required (or meaningful) to "create" a directory.
+   * The base BetterFileMethods.createDirectories() delegates to better-files which calls the
+   * s3fs-nio NIO FileSystemProvider.createDirectory(), which attempts to PUT a zero-byte
+   * object with a trailing slash as a "directory marker". S3-compatible endpoints such as
+   * OVH Ceph RadosGW reject these putObject calls with 403 Access Denied.
+   *
+   * Since directories don't physically exist in S3, creating them is unnecessary.
+   * Cromwell's actual workflow files are written directly at their full key paths later;
+   * those writes succeed without any parent "directory" having been pre-created.
+   *
+   * The subsequent addPermission() call in createPermissionedDirectories() will throw
+   * IOException (S3 has no POSIX permission model), which is already caught and ignored
+   * by EvenBetterPathMethods.createPermissionedDirectories().
+   */
+  override def createDirectories()(implicit attributes: better.files.File.Attributes = better.files.File.Attributes.default): this.type = {
+    // S3 directories are virtual — no-op.
+    this
   }
 }

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilderFactory.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilderFactory.scala
@@ -39,6 +39,7 @@ import cromwell.cloudsupport.aws.auth.AwsAuthMode
 import cromwell.cloudsupport.aws.s3.S3Storage
 import cromwell.core.WorkflowOptions
 import cromwell.core.path.PathBuilderFactory
+import java.net.URI
 import net.ceedubs.ficus.Ficus._
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
@@ -55,13 +56,16 @@ final case class S3PathBuilderFactory private (globalConfig: Config, instanceCon
   val authModeValidation: ErrorOr[AwsAuthMode] = conf.auth(authModeAsString)
   val authMode = authModeValidation.unsafe(s"Failed to get authentication mode for $authModeAsString")
 
+  // conf.endpointUrl is Some(url) for non-AWS S3-compatible services (OVH, MinIO, etc.)
+  private val endpointUri: Option[URI] = conf.endpointUrl.map(URI.create)
+
   def withOptions(options: WorkflowOptions)(implicit as: ActorSystem, ec: ExecutionContext): Future[S3PathBuilder] =
-    S3PathBuilder.fromAuthMode(authMode, S3Storage.DefaultConfiguration, options, conf.region)
+    S3PathBuilder.fromAuthMode(authMode, S3Storage.DefaultConfiguration, options, conf.region, endpointUri)
 
   // Ignores the authMode and creates an S3PathBuilder using the passed credentials directly.
   // Can be used when the Credentials are already available.
   def fromProvider(options: WorkflowOptions, provider: AwsCredentialsProvider): S3PathBuilder =
-    S3PathBuilder.fromProvider(provider, S3Storage.DefaultConfiguration, options, conf.region)
+    S3PathBuilder.fromProvider(provider, S3Storage.DefaultConfiguration, options, conf.region, endpointUri)
 }
 
 object S3PathBuilderFactory {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -549,22 +549,23 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
    */
   private def checkStderrForOOM: Future[Boolean] = {
     val stderr = jobPaths.standardPaths.error
-    jobLogger.info(s"[OOM-check] memoryRetryRequested=$memoryRetryRequested memoryRetryFactor=$memoryRetryFactor keys=$memoryRetryErrorKeys stderr=$stderr")
+    jobLogger.debug(s"[OOM-check] memoryRetryRequested=$memoryRetryRequested memoryRetryFactor=$memoryRetryFactor keys=$memoryRetryErrorKeys stderr=$stderr")
     memoryRetryErrorKeys match {
       case None | Some(Nil) =>
-        jobLogger.info(s"[OOM-check] no keys configured, skipping OOM check")
+        jobLogger.debug(s"[OOM-check] no keys configured, skipping OOM check")
         Future.successful(false)
       case Some(keys) =>
         for {
           exists <- asyncIo.existsAsync(stderr)
-          _ = jobLogger.info(s"[OOM-check] stderr exists=$exists at $stderr")
+          _ = jobLogger.debug(s"[OOM-check] stderr exists=$exists at $stderr")
           contentOpt <-
             if (exists)
               asyncIo.contentAsStringAsync(stderr, None, failOnOverflow = false).map(Option(_))
             else
               Future.successful(None)
           result = contentOpt.exists(content => keys.exists(content.contains))
-          _ = jobLogger.info(s"[OOM-check] result=$result contentLen=${contentOpt.map(_.length)} keys=$keys")
+          _ = if (result) jobLogger.warn(s"[OOM-check] OOM kill detected — contentLen=${contentOpt.map(_.length)} matchedKeys=$keys")
+              else jobLogger.debug(s"[OOM-check] result=$result contentLen=${contentOpt.map(_.length)} keys=$keys")
         } yield result
     }
   }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesAsyncBackendJobExecutionActor.scala
@@ -13,13 +13,20 @@ import cats.implicits._
 import common.exception.AggregatedMessageException
 import common.validation.ErrorOr.ErrorOr
 import common.validation.Validation._
+import eu.timepit.refined.refineV
+import cromwell.core.WorkflowOptions
 import cromwell.backend.async.{
   AbortedExecutionHandle,
   ExecutionHandle,
   FailedNonRetryableExecutionHandle,
-  PendingExecutionHandle
+  PendingExecutionHandle,
+  ReturnCodeIsNotAnInt,
+  RetryWithMoreMemory,
+  StderrNonEmpty,
+  WrongReturnCode
 }
 import cromwell.backend.impl.tes.TesAsyncBackendJobExecutionActor._
+import cromwell.backend.standard.retry.memory.MemoryRetryResult
 import cromwell.backend.impl.tes.TesResponseJsonFormatter._
 import cromwell.backend.standard.{StandardAsyncExecutionActor, StandardAsyncExecutionActorParams, StandardAsyncJob}
 import cromwell.backend.{BackendJobLifecycleActor, Platform}
@@ -36,7 +43,7 @@ import wom.values.WomFile
 import java.io.FileNotFoundException
 import java.nio.file.FileAlreadyExistsException
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 case class TesVmCostData(startTime: Option[String], endTime: Option[String], vmCost: Option[String]) {
   val fullyPopulated: Boolean = startTime.nonEmpty && vmCost.nonEmpty
@@ -238,6 +245,28 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     jobDescriptor.maybeCallCachingEligible.dockerHash.getOrElse(runtimeAttributes.dockerImage)
   override lazy val dockerImageUsed: Option[String] = Option(realDockerImageUsed)
 
+  // Override memoryRetryFactor to read from the runtime attribute (set via backend config default-runtime-attributes
+  // or per-task WDL runtime block), falling back to the standard workflow-option mechanism.
+  override lazy val memoryRetryFactor: Option[MemoryRetryMultiplierRefined] = {
+    val fromRuntimeAttr: Option[MemoryRetryMultiplierRefined] =
+      runtimeAttributes.memoryRetryMultiplier.flatMap { v =>
+        refineV[MemoryRetryMultiplier](v) match {
+          case Right(refined) => Some(refined)
+          case Left(e) =>
+            jobLogger.warn(s"[OOM-check] Invalid memory_retry_multiplier value $v (must be 1.0..99.0): $e")
+            None
+        }
+      }
+    // Fall back to the workflow-option mechanism (reads memory_retry_multiplier from workflow options JSON)
+    fromRuntimeAttr.orElse {
+      jobDescriptor.workflowDescriptor.getWorkflowOption(WorkflowOptions.MemoryRetryMultiplier).flatMap { value =>
+        scala.util.Try(value.toDouble).toOption.flatMap { v =>
+          refineV[MemoryRetryMultiplier](v).toOption
+        }
+      }
+    }
+  }
+
   private val tesEndpoint = workflowDescriptor.workflowOptions.getOrElse("endpoint", tesConfiguration.endpointURL)
 
   override lazy val jobTag: String = jobDescriptor.key.tag
@@ -263,14 +292,19 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
     )
 
   override def mapCommandLineJobInputWomFile(womFile: WomFile): WomFile =
-    womFile.mapFile(value =>
-      getPath(value) match {
-        case Success(path: Path) =>
-          TesAsyncBackendJobExecutionActor.mapInputPath(path, tesJobPaths, commandDirectory)
-        case _ =>
-          value
-      }
-    )
+    womFile.mapFile { value =>
+      // Paths under the configured shared filesystem mount point are already available
+      // inside the container – pass them through unchanged so the command script sees
+      // the original path. Mount point is read from `filesystems.local.local-root` config.
+      if (TesBackendFileHashingActor.isLocalPath(value, tesConfiguration.localRoot)) value
+      else
+        getPath(value) match {
+          case Success(path: Path) =>
+            TesAsyncBackendJobExecutionActor.mapInputPath(path, tesJobPaths, commandDirectory)
+          case _ =>
+            value
+        }
+    }
 
   override lazy val commandDirectory: Path =
     runtimeAttributes.dockerWorkingDir match {
@@ -507,6 +541,125 @@ class TesAsyncBackendJobExecutionActor(override val standardParams: StandardAsyn
           Unmarshal(response.entity).to[A]
         }
     } yield data
+
+  /**
+   * Checks if the task's stderr contains any of the configured memory-retry-error-keys.
+   * For TES/nerdctl, an OOM-killed container produces "Killed" in stderr (via bash set -e)
+   * and exits with rc=137.
+   */
+  private def checkStderrForOOM: Future[Boolean] = {
+    val stderr = jobPaths.standardPaths.error
+    jobLogger.info(s"[OOM-check] memoryRetryRequested=$memoryRetryRequested memoryRetryFactor=$memoryRetryFactor keys=$memoryRetryErrorKeys stderr=$stderr")
+    memoryRetryErrorKeys match {
+      case None | Some(Nil) =>
+        jobLogger.info(s"[OOM-check] no keys configured, skipping OOM check")
+        Future.successful(false)
+      case Some(keys) =>
+        for {
+          exists <- asyncIo.existsAsync(stderr)
+          _ = jobLogger.info(s"[OOM-check] stderr exists=$exists at $stderr")
+          contentOpt <-
+            if (exists)
+              asyncIo.contentAsStringAsync(stderr, None, failOnOverflow = false).map(Option(_))
+            else
+              Future.successful(None)
+          result = contentOpt.exists(content => keys.exists(content.contains))
+          _ = jobLogger.info(s"[OOM-check] result=$result contentLen=${contentOpt.map(_.length)} keys=$keys")
+        } yield result
+    }
+  }
+
+  /**
+   * Override handleExecutionResult to add TES-specific memory retry detection.
+   * When nerdctl kills a container at its cgroup memory limit, bash's set -e propagates
+   * rc=137 and writes "Killed" to stderr. We detect this by scanning stderr for the
+   * configured memory-retry-error-keys and retry with a larger memory allocation.
+   */
+  override def handleExecutionResult(
+    status: StandardAsyncRunState,
+    oldHandle: StandardAsyncPendingExecutionHandle
+  ): Future[ExecutionHandle] = {
+    val stderr = jobPaths.standardPaths.error
+    lazy val stderrAsOption: Option[Path] = Option(stderr)
+
+    val stderrSizeAndReturnCodeAndMemoryRetry = for {
+      returnCodeAsString <- asyncIo.contentAsStringAsync(jobPaths.returnCode, None, failOnOverflow = false)
+      stderrSize <- if (failOnStdErr) asyncIo.sizeAsync(stderr) else Future.successful(0L)
+      retryWithMoreMemory <- checkStderrForOOM
+    } yield (stderrSize, returnCodeAsString, retryWithMoreMemory)
+
+    stderrSizeAndReturnCodeAndMemoryRetry flatMap { case (stderrSize, returnCodeAsString, retryWithMoreMemory) =>
+      val tryReturnCodeAsInt = Try(returnCodeAsString.trim.toInt)
+      if (isDone(status)) {
+        tryReturnCodeAsInt match {
+          case Success(returnCodeAsInt) if failOnStdErr && stderrSize.intValue > 0 =>
+            val executionHandle = Future.successful(
+              FailedNonRetryableExecutionHandle(StderrNonEmpty(jobDescriptor.key.tag, stderrSize, stderrAsOption),
+                                                Option(returnCodeAsInt),
+                                                None
+              )
+            )
+            retryElseFail(executionHandle)
+          case Success(returnCodeAsInt) if continueOnReturnCode.continueFor(returnCodeAsInt) =>
+            handleExecutionSuccess(status, oldHandle, returnCodeAsInt)
+          // Important: check OOM before isAbort — rc=137 can be either; OOM takes priority.
+          case Success(returnCodeAsInt) if retryWithMoreMemory && memoryRetryRequested =>
+            jobLogger.info(s"Memory retry triggered for TES job (rc=$returnCodeAsInt, stderr contains OOM key)")
+            val executionHandle = Future.successful(
+              FailedNonRetryableExecutionHandle(
+                RetryWithMoreMemory(jobDescriptor.key.tag, stderrAsOption, memoryRetryErrorKeys, log),
+                Option(returnCodeAsInt),
+                None
+              )
+            )
+            retryElseFail(executionHandle,
+                          MemoryRetryResult(retryWithMoreMemory, memoryRetryFactor, previousMemoryMultiplier)
+            )
+          case Success(returnCodeAsInt) if isAbort(returnCodeAsInt) =>
+            Future.successful(AbortedExecutionHandle)
+          case Success(returnCodeAsInt) =>
+            val executionHandle = Future.successful(
+              FailedNonRetryableExecutionHandle(WrongReturnCode(jobDescriptor.key.tag, returnCodeAsInt, stderrAsOption),
+                                                Option(returnCodeAsInt),
+                                                None
+              )
+            )
+            retryElseFail(executionHandle)
+          case Failure(_) =>
+            Future.successful(
+              FailedNonRetryableExecutionHandle(
+                ReturnCodeIsNotAnInt(jobDescriptor.key.tag, returnCodeAsString, stderrAsOption),
+                kvPairsToSave = None
+              )
+            )
+        }
+      } else {
+        tryReturnCodeAsInt match {
+          case Success(returnCodeAsInt)
+              if retryWithMoreMemory && memoryRetryRequested && !continueOnReturnCode.continueFor(returnCodeAsInt) =>
+            val executionHandle = Future.successful(
+              FailedNonRetryableExecutionHandle(
+                RetryWithMoreMemory(jobDescriptor.key.tag, stderrAsOption, memoryRetryErrorKeys, log),
+                Option(returnCodeAsInt),
+                None
+              )
+            )
+            retryElseFail(executionHandle,
+                          MemoryRetryResult(retryWithMoreMemory, memoryRetryFactor, previousMemoryMultiplier)
+            )
+          case _ =>
+            val failureStatus = handleExecutionFailure(status, tryReturnCodeAsInt.toOption)
+            retryElseFail(failureStatus)
+        }
+      }
+    } recoverWith { case exception =>
+      if (isDone(status)) Future.successful(FailedNonRetryableExecutionHandle(exception, kvPairsToSave = None))
+      else {
+        val failureStatus = handleExecutionFailure(status, None)
+        retryElseFail(failureStatus)
+      }
+    }
+  }
 
   override def platform: Option[Platform] = tesConfiguration.platform
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendFileHashingActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendFileHashingActor.scala
@@ -1,0 +1,116 @@
+package cromwell.backend.impl.tes
+
+import akka.actor.Props
+import com.typesafe.config.Config
+import cromwell.backend.standard.callcaching.StandardFileHashingActor.SingleFileHashRequest
+import cromwell.backend.standard.callcaching.{StandardFileHashingActor, StandardFileHashingActorParams}
+import net.ceedubs.ficus.Ficus._
+import org.apache.commons.codec.digest.DigestUtils
+
+import java.nio.file.{Files, Paths}
+import scala.util.{Failure, Try, Using}
+
+object TesBackendFileHashingActor {
+  def props(standardParams: StandardFileHashingActorParams): Props =
+    Props(new TesBackendFileHashingActor(standardParams))
+
+  /**
+    * Returns true for an absolute, non-cloud path that belongs to the shared filesystem
+    * inside a TES worker container.
+    *
+    * When `localRoot` is provided (from `filesystems.local.local-root` config), only
+    * paths under that specific mount point are considered local. This avoids accidentally
+    * treating any absolute path (e.g. `/etc/hostname`) as a shared-filesystem file.
+    *
+    * When `localRoot` is None (default), falls back to the previous generic behaviour:
+    * any path starting with "/" that has no URI scheme is considered local.
+    * This preserves backward compatibility with deployments that do not set local-root.
+    *
+    * PR note: `localRoot` parameter added so the shared-FS mount point is driven by
+    * `filesystems.local.local-root` config rather than being an implicit convention.
+    */
+  def isLocalPath(value: String, localRoot: Option[String] = None): Boolean = {
+    val isAbsoluteLocal = value.startsWith("/") && !value.startsWith("//") && !value.contains("://")
+    localRoot match {
+      case Some(root) => isAbsoluteLocal && value.startsWith(root)
+      case None       => isAbsoluteLocal
+    }
+  }
+}
+
+/**
+  * Custom file-hashing actor for the TES backend.
+  *
+  * For local-style paths (absolute paths without a URI scheme, e.g. /mnt/efs/…):
+  *   - If `filesystems.local.caching.check-sibling-md5 = true` and a sibling
+  *     `<file>.md5` exists, the content of that file is returned as the hash.
+  *   - Otherwise the file is hashed with MD5.
+  *
+  * For cloud / HTTP / DRS / … paths the method returns `None` so the base-class
+  * async IO hashing takes over (S3 ETags, GCS CRC32, …).
+  */
+class TesBackendFileHashingActor(standardParams: StandardFileHashingActorParams)
+    extends StandardFileHashingActor(standardParams) {
+
+  // Use the default IoCommandBuilder – cloud paths are handled by the super-class.
+  override val ioCommandBuilder = cromwell.core.io.DefaultIoCommandBuilder
+
+  /** Read check-sibling-md5 from the backend configuration. */
+  lazy val checkSiblingMd5: Boolean =
+    configurationDescriptor.backendConfig
+      .as[Option[Config]]("filesystems.local.caching")
+      .flatMap(_.as[Option[Boolean]]("check-sibling-md5"))
+      .getOrElse(false)
+
+  /**
+    * Mount point of the shared filesystem inside TES worker containers.
+    * Reads `filesystems.local.local-root` (preferred) with backward-compat fallback
+    * to legacy key `filesystems.local.efs`.
+    * When set, only paths under this root are hashed locally; other absolute paths are
+    * treated as cloud paths and handed to the base-class async IO hashing.
+    * PR note: replaces the implicit /mnt/efs convention.
+    */
+  lazy val localRoot: Option[String] =
+    configurationDescriptor.backendConfig
+      .as[Option[String]]("filesystems.local.local-root")
+      .orElse(configurationDescriptor.backendConfig.as[Option[String]]("filesystems.local.efs"))
+
+  /**
+    * Called before async IO hashing.  Returning `Some(result)` short-circuits
+    * the async path; returning `None` falls through to it.
+    */
+  override def customHashStrategy(fileRequest: SingleFileHashRequest): Option[Try[String]] = {
+    val rawValue = fileRequest.file.valueString
+    if (TesBackendFileHashingActor.isLocalPath(rawValue, localRoot)) {
+      Some(hashLocalFile(rawValue))
+    } else {
+      // Cloud / HTTP / DRS paths → let the base class handle them asynchronously.
+      None
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private def hashLocalFile(pathStr: String): Try[String] = {
+    val nioPath = Paths.get(pathStr)
+
+    if (!Files.exists(nioPath))
+      return Failure(new java.io.FileNotFoundException(s"Local file not found for hashing: $pathStr"))
+
+    if (checkSiblingMd5) {
+      val md5SiblingPath = Paths.get(pathStr + ".md5")
+      if (Files.exists(md5SiblingPath)) {
+        log.debug(s"[TES-hash] Using sibling .md5 file for: $pathStr")
+        Try(new String(Files.readAllBytes(md5SiblingPath)).trim)
+      } else {
+        log.debug(s"[TES-hash] No sibling .md5 found, computing MD5 for: $pathStr")
+        Using(Files.newInputStream(nioPath))(DigestUtils.md5Hex)
+      }
+    } else {
+      log.debug(s"[TES-hash] Computing MD5 for: $pathStr")
+      Using(Files.newInputStream(nioPath))(DigestUtils.md5Hex)
+    }
+  }
+}

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendFileHashingActor.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendFileHashingActor.scala
@@ -25,9 +25,6 @@ object TesBackendFileHashingActor {
     * When `localRoot` is None (default), falls back to the previous generic behaviour:
     * any path starting with "/" that has no URI scheme is considered local.
     * This preserves backward compatibility with deployments that do not set local-root.
-    *
-    * PR note: `localRoot` parameter added so the shared-FS mount point is driven by
-    * `filesystems.local.local-root` config rather than being an implicit convention.
     */
   def isLocalPath(value: String, localRoot: Option[String] = None): Boolean = {
     val isAbsoluteLocal = value.startsWith("/") && !value.startsWith("//") && !value.contains("://")

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendLifecycleActorFactory.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesBackendLifecycleActorFactory.scala
@@ -3,6 +3,7 @@ package cromwell.backend.impl.tes
 import akka.actor.ActorRef
 import cromwell.backend._
 import cromwell.backend.standard._
+import cromwell.backend.standard.callcaching.StandardFileHashingActor
 import wom.graph.CommandCallNode
 
 case class TesBackendLifecycleActorFactory(name: String, configurationDescriptor: BackendConfigurationDescriptor)
@@ -25,4 +26,9 @@ case class TesBackendLifecycleActorFactory(name: String, configurationDescriptor
                                                  restarting: Boolean
   ): StandardInitializationActorParams =
     TesInitializationActorParams(workflowDescriptor, calls, tesConfiguration, serviceRegistryActor)
+
+  // Use our custom hashing actor so that local-style paths (/mnt/efs/…, /some/path)
+  // are hashed with sibling-MD5 support instead of the default async IO hash.
+  override lazy val fileHashingActorClassOption: Option[Class[_ <: StandardFileHashingActor]] =
+    Option(classOf[TesBackendFileHashingActor])
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
@@ -19,6 +19,23 @@ class TesConfiguration(val configurationDescriptor: BackendConfigurationDescript
       .as[Option[Boolean]](TesConfiguration.useBackendParametersKey)
       .getOrElse(false)
 
+  /**
+   * Mount point of the shared filesystem inside TES worker containers (e.g. /mnt/shared for
+   * Manila NFS, /mnt/efs for AWS EFS). Configured via `filesystems.local.local-root`.
+   * Legacy key `filesystems.local.efs` is accepted for backward compatibility.
+   *
+   * When set, only paths under this root are treated as "already present on the shared
+   * filesystem" and excluded from TES input localisation. When absent, any absolute path
+   * without a URI scheme is treated as local (previous behaviour).
+   *
+   * PR note: makes the shared-FS mount point an explicit config value instead of
+   * an implicit /mnt/efs convention inherited from AWS deployments.
+   */
+  val localRoot: Option[String] =
+    configurationDescriptor.backendConfig
+      .as[Option[String]]("filesystems.local.local-root")
+      .orElse(configurationDescriptor.backendConfig.as[Option[String]]("filesystems.local.efs"))
+
   val pollBackoff =
     configurationDescriptor.backendConfig
       .as[Option[Config]]("poll-backoff")

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesConfiguration.scala
@@ -27,9 +27,6 @@ class TesConfiguration(val configurationDescriptor: BackendConfigurationDescript
    * When set, only paths under this root are treated as "already present on the shared
    * filesystem" and excluded from TES input localisation. When absent, any absolute path
    * without a URI scheme is treated as local (previous behaviour).
-   *
-   * PR note: makes the shared-FS mount point an explicit config value instead of
-   * an implicit /mnt/efs convention inherited from AWS deployments.
    */
   val localRoot: Option[String] =
     configurationDescriptor.backendConfig

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesExpressionFunctions.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesExpressionFunctions.scala
@@ -6,7 +6,7 @@ import cromwell.backend.standard.StandardExpressionFunctionsParams
 class TesExpressionFunctions(standardParams: StandardExpressionFunctionsParams)
     extends SharedFileSystemExpressionFunctions(standardParams) {
 
-  // FIX : The original check only passed through local absolute paths ("/...")
+  // The original check only passed through local absolute paths ("/...")
   // and FTP URIs, sending everything else through callContext.root.resolve(str). For cloud-backed TES
   // deployments (S3, GCS, Azure, …) the output paths returned by the TES server are already fully-
   // qualified URIs (e.g. "s3://bucket/key"). Resolving a URI-scheme string against an S3Path doubles

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesExpressionFunctions.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesExpressionFunctions.scala
@@ -6,7 +6,14 @@ import cromwell.backend.standard.StandardExpressionFunctionsParams
 class TesExpressionFunctions(standardParams: StandardExpressionFunctionsParams)
     extends SharedFileSystemExpressionFunctions(standardParams) {
 
+  // FIX : The original check only passed through local absolute paths ("/...")
+  // and FTP URIs, sending everything else through callContext.root.resolve(str). For cloud-backed TES
+  // deployments (S3, GCS, Azure, …) the output paths returned by the TES server are already fully-
+  // qualified URIs (e.g. "s3://bucket/key"). Resolving a URI-scheme string against an S3Path doubles
+  // the path (s3://…execution/s3:/…execution/stdout) because S3Path.resolve(String) treats any string
+  // that does not start with "/" as relative.
+  // Fix: treat any string that contains "://" as already-absolute and return it unchanged.
   override def preMapping(str: String) =
-    if (str.startsWith("/") || str.startsWith("ftp://")) str
+    if (str.startsWith("/") || str.contains("://")) str
     else standardParams.callContext.root.resolve(str).toString
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesJobCachingActorHelper.scala
@@ -16,8 +16,15 @@ trait TesJobCachingActorHelper extends StandardCachingActorHelper {
 
   lazy val tesConfiguration: TesConfiguration = initializationData.tesConfiguration
 
-  lazy val runtimeAttributes =
-    TesRuntimeAttributes(validatedRuntimeAttributes, jobDescriptor.runtimeAttributes, tesConfiguration)
+  lazy val runtimeAttributes = {
+    val raw = jobDescriptor.runtimeAttributes
+    jobLogger.debug(s"[backoff_limit] raw runtimeAttributes keys: ${raw.keys.mkString(", ")}")
+    jobLogger.debug(s"[backoff_limit] raw runtimeAttributes values: ${raw.map { case (k, v) => s"$k=${v.toWomString}" }.mkString(", ")}")
+    jobLogger.debug(s"[backoff_limit] useBackendParameters=${tesConfiguration.useBackendParameters}")
+    val attrs = TesRuntimeAttributes(validatedRuntimeAttributes, raw, tesConfiguration)
+    jobLogger.debug(s"[backoff_limit] resulting backendParameters: ${attrs.backendParameters}")
+    attrs
+  }
   override protected def nonStandardMetadata: Map[String, Any] =
     super.nonStandardMetadata ++ tesJobPaths.azureLogPathsForMetadata
 

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesResponseJsonFormatter.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesResponseJsonFormatter.scala
@@ -8,8 +8,37 @@ final case class CancelTaskResponse()
 
 object TesResponseJsonFormatter extends DefaultJsonProtocol {
 
-  /** OutputFileLog is partly defined by size_byte: Int which is supplied as string as described by the TES spec.
-   * We create a custom deserializer to read the size_byte string and turn it into the Int Cromwell expects
+  /** FIX (: Spray-json serializes Scala `None` as JSON `null`.
+   * Protobuf3's JSON parser rejects null for string/message fields:
+   *   "invalid value for string field value: null"
+   * Omitting the key entirely is the correct proto3-compliant behaviour — missing
+   * fields are treated as their default value (empty string / zero / etc.).
+   *
+   * Two sources of null in the TES payload:
+   *   1. Top-level Option fields on Task/Input/Output/etc. (e.g. Task.id, Input.content)
+   *   2. Map[String, Option[String]] values inside `tags` and `backend_parameters`
+   *      (e.g. Task.tags["parent_workflow_id"] = None for top-level workflows)
+   *
+   * We use a deep recursive strip so that nulls are removed at every nesting level.
+   * Reading is unaffected: spray-json already maps missing JSON keys to `None`.
+   */
+  private def deepStripNulls(json: JsValue): JsValue = json match {
+    case o: JsObject =>
+      JsObject(o.fields.filterNot(_._2 == JsNull).map { case (k, v) => k -> deepStripNulls(v) })
+    case a: JsArray =>
+      JsArray(a.elements.filterNot(_ == JsNull).map(deepStripNulls))
+    case other => other
+  }
+
+  private def nullFreeFormat[T](fmt: RootJsonFormat[T]): RootJsonFormat[T] =
+    new RootJsonFormat[T] {
+      def read(json: JsValue): T = fmt.read(json)
+      def write(obj: T): JsValue = deepStripNulls(fmt.write(obj))
+    }
+
+  /** OutputFileLog is partly defined by size_bytes: Long which is supplied as string as described by the TES spec.
+   * We create a custom deserializer to read the size_bytes string and turn it into the Long Cromwell expects.
+   * NOTE: size_bytes must be Long, not Int — output files can exceed 2 GB (Int.MaxValue = 2,147,483,647).
    */
   implicit object customJsonFormatOutputFileLog extends RootJsonFormat[OutputFileLog] {
     def write(obj: OutputFileLog): JsValue =
@@ -22,19 +51,20 @@ object TesResponseJsonFormatter extends DefaultJsonProtocol {
     def read(value: JsValue): OutputFileLog =
       value.asJsObject.getFields("url", "path", "size_bytes") match {
         case Seq(JsString(url), JsString(path), JsString(size_bytes)) =>
-          OutputFileLog(url, path, size_bytes.toInt)
-        case Seq(JsString(url), JsString(path)) => OutputFileLog(url, path, 0)
+          OutputFileLog(url, path, size_bytes.toLong)
+        case Seq(JsString(url), JsString(path)) => OutputFileLog(url, path, 0L)
         case _ => throw DeserializationException("Cannot deserialize OutputFileLog")
       }
   }
-  implicit val resourcesFormat = jsonFormat6(Resources)
-  implicit val inputFormat = jsonFormat6(Input)
-  implicit val outputFormat = jsonFormat5(Output)
-  implicit val executorFormat = jsonFormat7(Executor)
-  implicit val executorLogFormat = jsonFormat5(ExecutorLog)
-  implicit val taskLogFormat = jsonFormat6(TaskLog)
-  implicit val taskFormat = jsonFormat11(Task)
-  implicit val minimalTaskView = jsonFormat2(MinimalTaskView)
+
+  implicit val resourcesFormat          = nullFreeFormat(jsonFormat6(Resources))
+  implicit val inputFormat              = nullFreeFormat(jsonFormat6(Input))
+  implicit val outputFormat             = nullFreeFormat(jsonFormat5(Output))
+  implicit val executorFormat           = nullFreeFormat(jsonFormat7(Executor))
+  implicit val executorLogFormat        = nullFreeFormat(jsonFormat5(ExecutorLog))
+  implicit val taskLogFormat            = nullFreeFormat(jsonFormat6(TaskLog))
+  implicit val taskFormat               = nullFreeFormat(jsonFormat11(Task))
+  implicit val minimalTaskView          = jsonFormat2(MinimalTaskView)
   implicit val createTaskResponseFormat = jsonFormat1(CreateTaskResponse)
   implicit val cancelTaskResponseFormat = jsonFormat0(CancelTaskResponse)
 }

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesResponseJsonFormatter.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesResponseJsonFormatter.scala
@@ -8,8 +8,8 @@ final case class CancelTaskResponse()
 
 object TesResponseJsonFormatter extends DefaultJsonProtocol {
 
-  /** FIX (: Spray-json serializes Scala `None` as JSON `null`.
-   * Protobuf3's JSON parser rejects null for string/message fields:
+  /**Spray-json serializes Scala `None` as JSON `null`.
+   * Protobuf3's JSON parser (eg in Funnel/TES) rejects null for string/message fields:
    *   "invalid value for string field value: null"
    * Omitting the key entirely is the correct proto3-compliant behaviour — missing
    * fields are treated as their default value (empty string / zero / etc.).

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
@@ -43,7 +43,10 @@ object TesRuntimeAttributes {
   val BackoffLimitKey = "backoff_limit"
 
   private def cpuValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[Int Refined Positive] =
-    CpuValidation.optional
+    CpuValidation.configDefaultWomValue(runtimeConfig) match {
+      case Some(default) => CpuValidation.instance.withDefault(default).optional
+      case None          => CpuValidation.optional
+    }
 
   private def failOnStderrValidation(runtimeConfig: Option[Config]) = FailOnStderrValidation.default(runtimeConfig)
 
@@ -51,7 +54,10 @@ object TesRuntimeAttributes {
     ContinueOnReturnCodeValidation.default(runtimeConfig)
 
   private def diskSizeValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[MemorySize] =
-    MemoryValidation.optional(DiskSizeKey)
+    MemoryValidation.configDefaultString(DiskSizeKey, runtimeConfig) match {
+      case Some(default) => MemoryValidation.withDefaultMemory(DiskSizeKey, default).optional
+      case None          => MemoryValidation.optional(DiskSizeKey)
+    }
 
   private def diskSizeCompatValidation(
     runtimeConfig: Option[Config]
@@ -59,7 +65,10 @@ object TesRuntimeAttributes {
     DisksValidation.optional
 
   private def memoryValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[MemorySize] =
-    MemoryValidation.optional(RuntimeAttributesKeys.MemoryKey)
+    MemoryValidation.configDefaultString(RuntimeAttributesKeys.MemoryKey, runtimeConfig) match {
+      case Some(default) => MemoryValidation.withDefaultMemory(RuntimeAttributesKeys.MemoryKey, default).optional
+      case None          => MemoryValidation.optional(RuntimeAttributesKeys.MemoryKey)
+    }
 
   // As of WDL 1.1 these two are aliases of each other
   private val dockerValidation: OptionalRuntimeAttributesValidation[Containers] = DockerValidation.instance

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
@@ -123,7 +123,7 @@ object TesRuntimeAttributes {
                             keysToExclude: Set[String],
                             config: TesConfiguration
   ): Map[String, Option[String]] = {
-    // PR note: unknownKeys was declared but never used (compiler error with -Wunused).
+    // unknownKeys was declared but never used (compiler error with -Wunused).
     // Log at debug so callers can see which runtime attributes are being forwarded as
     // TES backend_parameters (useful for diagnosing Funnel/TES 1.1 passthrough issues).
     val unknownKeys = runtimeAttributes.keySet -- keysToExclude

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesRuntimeAttributes.scala
@@ -17,6 +17,7 @@ import wom.types.{WomIntegerType, WomStringType}
 import wom.values._
 
 import java.util.regex.Pattern
+import org.slf4j.LoggerFactory
 
 case class TesRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode,
                                 dockerImage: String,
@@ -27,14 +28,19 @@ case class TesRuntimeAttributes(continueOnReturnCode: ContinueOnReturnCode,
                                 disk: Option[MemorySize],
                                 preemptible: Boolean,
                                 localizedSasEnvVar: Option[String],
-                                backendParameters: Map[String, Option[String]]
+                                backendParameters: Map[String, Option[String]],
+                                memoryRetryMultiplier: Option[Double]
 )
 
 object TesRuntimeAttributes {
+  private val log = LoggerFactory.getLogger(getClass.getSimpleName)
+
   val DockerWorkingDirKey = "dockerWorkingDir"
   val DiskSizeKey = "disk"
   val PreemptibleKey = "preemptible"
   val LocalizedSasKey = "azureSasEnvironmentVariable"
+  val MemoryRetryMultiplierKey = "memory_retry_multiplier"
+  val BackoffLimitKey = "backoff_limit"
 
   private def cpuValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[Int Refined Positive] =
     CpuValidation.optional
@@ -64,6 +70,26 @@ object TesRuntimeAttributes {
   private def preemptibleValidation(runtimeConfig: Option[Config]) = PreemptibleValidation.default(runtimeConfig)
   private def localizedSasValidation: OptionalRuntimeAttributesValidation[String] = LocalizedSasValidation.optional
 
+  private def memoryRetryMultiplierValidation(
+    runtimeConfig: Option[Config]
+  ): OptionalRuntimeAttributesValidation[Double] = {
+    val instance = new FloatRuntimeAttributesValidation(MemoryRetryMultiplierKey)
+    instance.configDefaultWomValue(runtimeConfig) match {
+      case Some(default) => instance.withDefault(default).optional
+      case None          => instance.optional
+    }
+  }
+
+  private def backoffLimitValidation(
+    runtimeConfig: Option[Config]
+  ): OptionalRuntimeAttributesValidation[String] = {
+    val instance = new BackoffLimitValidation
+    instance.configDefaultWomValue(runtimeConfig) match {
+      case Some(default) => instance.withDefault(default).optional
+      case None          => instance.optional
+    }
+  }
+
   def runtimeAttributesBuilder(backendRuntimeConfig: Option[Config]): StandardValidatedRuntimeAttributesBuilder =
     // !! NOTE !! If new validated attributes are added to TesRuntimeAttributes, be sure to include
     // their validations here so that they will be handled correctly with backendParameters.
@@ -79,13 +105,23 @@ object TesRuntimeAttributes {
         containerValidation,
         dockerWorkingDirValidation,
         preemptibleValidation(backendRuntimeConfig),
-        localizedSasValidation
+        localizedSasValidation,
+        memoryRetryMultiplierValidation(backendRuntimeConfig),
+        backoffLimitValidation(backendRuntimeConfig)
       )
 
   def makeBackendParameters(runtimeAttributes: Map[String, WomValue],
                             keysToExclude: Set[String],
                             config: TesConfiguration
-  ): Map[String, Option[String]] =
+  ): Map[String, Option[String]] = {
+    // PR note: unknownKeys was declared but never used (compiler error with -Wunused).
+    // Log at debug so callers can see which runtime attributes are being forwarded as
+    // TES backend_parameters (useful for diagnosing Funnel/TES 1.1 passthrough issues).
+    val unknownKeys = runtimeAttributes.keySet -- keysToExclude
+    if (unknownKeys.nonEmpty)
+      log.debug("makeBackendParameters: forwarding non-standard runtime keys as TES backend_parameters: {}",
+                unknownKeys.mkString(", "))
+
     if (config.useBackendParameters)
       runtimeAttributes.view
         .filterKeys(k => !keysToExclude.contains(k))
@@ -98,6 +134,7 @@ object TesRuntimeAttributes {
         .toMap
     else
       Map.empty
+  }
 
   private def detectDiskFormat(backendRuntimeConfig: Option[Config],
                                validatedRuntimeAttributes: ValidatedRuntimeAttributes
@@ -176,13 +213,31 @@ object TesRuntimeAttributes {
       failOnStderrValidation(backendRuntimeConfig),
       continueOnReturnCodeValidation(backendRuntimeConfig),
       preemptibleValidation(backendRuntimeConfig),
-      localizedSasValidation
+      localizedSasValidation,
+      memoryRetryMultiplierValidation(backendRuntimeConfig),
+      backoffLimitValidation(backendRuntimeConfig)
     )
+
+    val memoryRetryMultiplier: Option[Double] =
+      RuntimeAttributesValidation.extractOption(memoryRetryMultiplierValidation(backendRuntimeConfig).key, validatedRuntimeAttributes)
+
+    // Extract backoff_limit from validated attributes (covers both default-runtime-attributes
+    // config defaults and per-task runtime { backoff_limit: "N" } declarations).
+    val backoffLimit: Option[String] =
+      RuntimeAttributesValidation.extractOption(backoffLimitValidation(backendRuntimeConfig).key, validatedRuntimeAttributes)
+    println(s"[backoff_limit] apply: extracted backoffLimit from validatedRuntimeAttributes = $backoffLimit")
+    println(s"[backoff_limit] apply: rawRuntimeAttributes keys = ${rawRuntimeAttributes.keys.mkString(", ")}")
 
     // BT-458 any strings included in runtime attributes that aren't otherwise used should be
     // passed through to the TES server as part of backend_parameters
     val keysToExclude = validations map { _.key }
-    val backendParameters = makeBackendParameters(rawRuntimeAttributes, keysToExclude, config)
+    val rawBackendParameters = makeBackendParameters(rawRuntimeAttributes, keysToExclude, config)
+    // Inject backoff_limit from validated attributes (handles the config-default path, since
+    // default-runtime-attributes values don't appear in rawRuntimeAttributes for unknown keys).
+    val backendParameters = if (config.useBackendParameters)
+      backoffLimit.fold(rawBackendParameters)(v => rawBackendParameters + (BackoffLimitKey -> Option(v)))
+    else rawBackendParameters
+    println(s"[backoff_limit] apply: final backendParameters = $backendParameters")
 
     new TesRuntimeAttributes(
       continueOnReturnCode,
@@ -194,7 +249,8 @@ object TesRuntimeAttributes {
       disk,
       preemptible,
       localizedSas,
-      backendParameters
+      backendParameters,
+      memoryRetryMultiplier
     )
   }
 }
@@ -256,6 +312,18 @@ class PreemptibleValidation extends BooleanRuntimeAttributesValidation(TesRuntim
 
   override protected def missingValueMessage: String =
     s"Expecting $key runtime attribute to be an Integer, Boolean, or a String with values of 'true' or 'false'"
+}
+
+object BackoffLimitValidation {
+  lazy val instance: RuntimeAttributesValidation[String] = new BackoffLimitValidation
+  lazy val optional: OptionalRuntimeAttributesValidation[String] = instance.optional
+}
+
+class BackoffLimitValidation extends StringRuntimeAttributesValidation(TesRuntimeAttributes.BackoffLimitKey) {
+  override protected def validateValue: PartialFunction[WomValue, ErrorOr[String]] = {
+    case WomString(value)  => value.validNel
+    case WomInteger(value) => value.toString.validNel
+  }
 }
 
 object LocalizedSasValidation {

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -76,12 +76,30 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
       _.collectAsSeq { case w: WomFile => w }
     }
 
+  // Shared filesystem mount point. Reads `filesystems.local.local-root` with legacy fallback
+  // to `filesystems.local.efs`. Passed to isLocalPath() to restrict shared-FS detection to
+  // paths under this root rather than accepting any absolute path.
+  // PR note: replaces the implicit /mnt/efs convention.
+  private val localRoot: Option[String] =
+    configurationDescriptor.backendConfig
+      .as[Option[String]]("filesystems.local.local-root")
+      .orElse(configurationDescriptor.backendConfig.as[Option[String]]("filesystems.local.efs"))
+
   lazy val inputs: Seq[Input] = {
+    val allInputs =
+      TesTask.buildTaskInputs(callInputFiles ++ writeFunctionFiles, workflowName, mapCommandLineWomFile)
+
+    // Paths under the shared filesystem mount point are already present inside the worker
+    // container. Passing them to TES as Input entries would cause Funnel (or another TES
+    // executor) to attempt a redundant local-file copy. Filter them out so only cloud / HTTP
+    // / DRS inputs are localised. The mount point is configured via
+    // `filesystems.local.local-root` (falls back to any absolute path when unset).
     val result =
-      TesTask.buildTaskInputs(callInputFiles ++ writeFunctionFiles, workflowName, mapCommandLineWomFile) ++ Seq(
-        commandScript
-      )
-    jobLogger.info(
+      allInputs.filterNot { input =>
+        input.url.exists(url => TesBackendFileHashingActor.isLocalPath(url, localRoot))
+      } ++ Seq(commandScript)
+
+    jobLogger.debug(
       s"Calculated TES inputs (found ${result.size}): " + result.mkString(System.lineSeparator(),
                                                                           System.lineSeparator(),
                                                                           System.lineSeparator()
@@ -209,7 +227,7 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
       case OutputMode.ROOT => List(cwdOutput) ++ additionalGlobOutput
     }
 
-    jobLogger.info(
+    jobLogger.debug(
       s"Calculated TES outputs (found ${result.size}): " + result.mkString(System.lineSeparator(),
                                                                            System.lineSeparator(),
                                                                            System.lineSeparator()
@@ -246,6 +264,19 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
 }
 
 object TesTask {
+  /**
+    * Returns true for an input URL that represents a path on the shared filesystem
+    * inside a TES worker container (absolute path without a URI scheme,
+    * e.g. "/mnt/shared/data/file.bam"). Such inputs are already present
+    * on the mounted filesystem and must not be localised by the TES executor.
+    *
+    * @param localRoot optional mount point from `filesystems.local.local-root` config;
+    *                  when set, only paths under this root are considered local.
+    *                  Defaults to None (any absolute path without a URI scheme).
+    */
+  def isLocalStyleUrl(url: String, localRoot: Option[String] = None): Boolean =
+    TesBackendFileHashingActor.isLocalPath(url, localRoot)
+
   // Helper to determine which source to use for a workflowExecutionIdentity
   def getPreferredWorkflowExecutionIdentity(configIdentity: Option[WorkflowExecutionIdentityConfig],
                                             workflowOptionsIdentity: Option[WorkflowExecutionIdentityOption]
@@ -390,7 +421,7 @@ final case class Resources(cpu_cores: Option[Int],
                            backend_parameters: Option[Map[String, Option[String]]]
 )
 
-final case class OutputFileLog(url: String, path: String, size_bytes: Int)
+final case class OutputFileLog(url: String, path: String, size_bytes: Long)
 
 final case class TaskLog(start_time: Option[String],
                          end_time: Option[String],

--- a/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
+++ b/supportedBackends/tes/src/main/scala/cromwell/backend/impl/tes/TesTask.scala
@@ -79,7 +79,6 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
   // Shared filesystem mount point. Reads `filesystems.local.local-root` with legacy fallback
   // to `filesystems.local.efs`. Passed to isLocalPath() to restrict shared-FS detection to
   // paths under this root rather than accepting any absolute path.
-  // PR note: replaces the implicit /mnt/efs convention.
   private val localRoot: Option[String] =
     configurationDescriptor.backendConfig
       .as[Option[String]]("filesystems.local.local-root")
@@ -90,7 +89,8 @@ final case class TesTask(jobDescriptor: BackendJobDescriptor,
       TesTask.buildTaskInputs(callInputFiles ++ writeFunctionFiles, workflowName, mapCommandLineWomFile)
 
     // Paths under the shared filesystem mount point are already present inside the worker
-    // container. Passing them to TES as Input entries would cause Funnel (or another TES
+    // container (if workers are properly configured...). 
+    // Passing them to TES as Input entries would cause Funnel (or another TES
     // executor) to attempt a redundant local-file copy. Filter them out so only cloud / HTTP
     // / DRS inputs are localised. The mount point is configured via
     // `filesystems.local.local-root` (falls back to any absolute path when unset).

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesConfigurationSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesConfigurationSpec.scala
@@ -48,4 +48,21 @@ class TesConfigurationSpec extends AnyFlatSpec with Matchers {
   it should "fail if user defines an invalid backoff" in {
     assertThrows[ConfigException.Missing](makeTesConfig(TesTestConfig.backendConfigWithInvalidBackoffs))
   }
+
+  // localRoot: shared filesystem mount point used to skip TES localisation for already-present files.
+
+  it should "read localRoot from filesystems.local.local-root" in {
+    val tesConfig = makeTesConfig(TesTestConfig.backendConfigWithLocalRoot)
+    tesConfig.localRoot shouldBe Some("/mnt/shared")
+  }
+
+  it should "fall back to filesystems.local.efs for localRoot when local-root is absent" in {
+    val tesConfig = makeTesConfig(TesTestConfig.backendConfigWithLegacyEfs)
+    tesConfig.localRoot shouldBe Some("/mnt/efs")
+  }
+
+  it should "return None for localRoot when neither filesystems.local.local-root nor filesystems.local.efs is configured" in {
+    val tesConfig = makeTesConfig(TesTestConfig.backendConfig)
+    tesConfig.localRoot shouldBe None
+  }
 }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesRuntimeAttributesSpec.scala
@@ -21,12 +21,13 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
     "ubuntu:latest",
     None,
     false,
-    None,
-    None,
-    None,
+    Option(refineMV[Positive](1)),              // cpu default from backendConfig
+    Option(MemorySize.parse("2 GB").get),       // memory default from backendConfig
+    Option(MemorySize.parse("2 GB").get),       // disk default from backendConfig
     false,
     None,
-    Map.empty
+    Map.empty,
+    None                                        // memoryRetryMultiplier
   )
 
   val expectedDefaultsPlusUbuntuDocker = expectedDefaults.copy(dockerImage = "ubuntu:latest")
@@ -331,6 +332,65 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
       val expectedRuntimeAttributes = expectedDefaults.copy(backendParameters = Map("foo" -> None))
       assertSuccess(runtimeAttributes, expectedRuntimeAttributes, tesConfig = mockTesConfigWithBackendParams)
     }
+
+    // memory_retry_multiplier: optional per-task float that multiplies the memory allocation on OOM retry.
+    "validate a valid memory_retry_multiplier entry" in {
+      val runtimeAttributes =
+        Map("docker" -> WomString("ubuntu:latest"),
+            TesRuntimeAttributes.MemoryRetryMultiplierKey -> WomFloat(1.5)
+        )
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(memoryRetryMultiplier = Option(1.5))
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes)
+    }
+
+    "use memory_retry_multiplier config default when not set per-task" in {
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"))
+      val expectedRuntimeAttributes = expectedDefaultsPlusUbuntuDocker.copy(memoryRetryMultiplier = Option(2.0))
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes, tesConfig = mockTesConfigWithMemoryRetry)
+    }
+
+    // backoff_limit: forwarded as a TES backend_parameter; accepts both string and integer values.
+    "validate a valid backoff_limit string entry" in {
+      val runtimeAttributes =
+        Map("docker" -> WomString("ubuntu:latest"),
+            TesRuntimeAttributes.BackoffLimitKey -> WomString("3")
+        )
+      // With useBackendParameters = false the key is silently dropped — validation must not fail.
+      assertSuccess(runtimeAttributes, expectedDefaultsPlusUbuntuDocker)
+    }
+
+    "validate a backoff_limit provided as WomInteger" in {
+      val runtimeAttributes =
+        Map("docker" -> WomString("ubuntu:latest"),
+            TesRuntimeAttributes.BackoffLimitKey -> WomInteger(5)
+        )
+      assertSuccess(runtimeAttributes, expectedDefaultsPlusUbuntuDocker)
+    }
+
+    "include task-level backoff_limit in backend_parameters when useBackendParameters is true" in {
+      val runtimeAttributes =
+        Map("docker" -> WomString("ubuntu:latest"),
+            TesRuntimeAttributes.BackoffLimitKey -> WomString("3")
+        )
+      val expectedRuntimeAttributes =
+        expectedDefaultsPlusUbuntuDocker.copy(
+          backendParameters = Map(TesRuntimeAttributes.BackoffLimitKey -> Option("3"))
+        )
+      assertSuccess(runtimeAttributes, expectedRuntimeAttributes, tesConfig = mockTesConfigWithBackendParams)
+    }
+
+    "inject config-default backoff_limit into backend_parameters when useBackendParameters is true" in {
+      // backoff_limit is not set per-task; the value comes from default-runtime-attributes in the backend config.
+      val runtimeAttributes = Map("docker" -> WomString("ubuntu:latest"))
+      val expectedRuntimeAttributes =
+        expectedDefaultsPlusUbuntuDocker.copy(
+          backendParameters = Map(TesRuntimeAttributes.BackoffLimitKey -> Option("5"))
+        )
+      assertSuccess(runtimeAttributes,
+                    expectedRuntimeAttributes,
+                    tesConfig = mockTesConfigWithBackendParamsAndBackoffLimit
+      )
+    }
   }
 
   private val mockConfigurationDescriptor =
@@ -338,6 +398,12 @@ class TesRuntimeAttributesSpec extends AnyWordSpecLike with CromwellTimeoutSpec 
   private val mockTesConfiguration = new TesConfiguration(mockConfigurationDescriptor)
   private val mockTesConfigWithBackendParams = new TesConfiguration(
     mockConfigurationDescriptor.copy(backendConfig = TesTestConfig.backendConfigWithBackendParams)
+  )
+  private val mockTesConfigWithMemoryRetry = new TesConfiguration(
+    mockConfigurationDescriptor.copy(backendConfig = TesTestConfig.backendConfigWithMemoryRetryMultiplier)
+  )
+  private val mockTesConfigWithBackendParamsAndBackoffLimit = new TesConfiguration(
+    mockConfigurationDescriptor.copy(backendConfig = TesTestConfig.backendConfigWithBackendParamsAndBackoffLimit)
   )
 
   private def assertSuccess(runtimeAttributes: Map[String, WomValue],

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTaskSpec.scala
@@ -27,7 +27,8 @@ class TesTaskSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers wit
     None,
     false,
     None,
-    Map.empty
+    Map.empty,
+    None // memoryRetryMultiplier
   )
   val internalPathPrefix = Option("mock/path/to/tes/task")
   val expectedTuple = "internal_path_prefix" -> internalPathPrefix
@@ -246,5 +247,34 @@ class TesTaskSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers wit
     )
 
     input.toString shouldBe "cromwell.backend.impl.tes.Input(Some(asdf),Some(asdf),None,asdf,Some(asdf),Some(asdf))"
+  }
+
+  // isLocalStyleUrl: identifies paths on the shared filesystem that must not be localised by the TES executor.
+
+  it should "treat an absolute path without a URI scheme as local when no localRoot is configured" in {
+    TesTask.isLocalStyleUrl("/mnt/shared/data/file.bam") shouldBe true
+    TesTask.isLocalStyleUrl("/cromwell-executions/task/inputs/file.txt") shouldBe true
+  }
+
+  it should "not treat cloud or HTTP paths as local" in {
+    TesTask.isLocalStyleUrl("gs://bucket/file.bam") shouldBe false
+    TesTask.isLocalStyleUrl("s3://bucket/file.bam") shouldBe false
+    TesTask.isLocalStyleUrl("http://host/file.bam") shouldBe false
+    TesTask.isLocalStyleUrl("https://host/file.bam") shouldBe false
+    TesTask.isLocalStyleUrl("drs://host/id") shouldBe false
+  }
+
+  it should "treat a path under the configured localRoot as local" in {
+    TesTask.isLocalStyleUrl("/mnt/shared/file.bam", Some("/mnt/shared")) shouldBe true
+    TesTask.isLocalStyleUrl("/mnt/shared/sub/dir/file.bam", Some("/mnt/shared")) shouldBe true
+  }
+
+  it should "not treat an absolute path outside the configured localRoot as local" in {
+    TesTask.isLocalStyleUrl("/cromwell-executions/task/file.txt", Some("/mnt/shared")) shouldBe false
+    TesTask.isLocalStyleUrl("/etc/hostname", Some("/mnt/shared")) shouldBe false
+  }
+
+  it should "not treat a UNC path (starting with //) as local" in {
+    TesTask.isLocalStyleUrl("//server/share/file.bam") shouldBe false
   }
 }

--- a/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
+++ b/supportedBackends/tes/src/test/scala/cromwell/backend/impl/tes/TesTestConfig.scala
@@ -111,4 +111,88 @@ object TesTestConfig {
       |""".stripMargin
 
   val backendConfigWithInvalidBackoffs = ConfigFactory.parseString(backendConfigStringWithInvalidBackoffs)
+
+  // Configures a shared filesystem mount point via the canonical `filesystems.local.local-root` key.
+  private val backendConfigStringWithLocalRoot =
+    """
+      |root = "local-cromwell-executions"
+      |dockerRoot = "/cromwell-executions"
+      |endpoint = "http://127.0.0.1:9000/v1/jobs"
+      |
+      |filesystems.local.local-root = "/mnt/shared"
+      |
+      |default-runtime-attributes {
+      |  cpu: 1
+      |  failOnStderr: false
+      |  continueOnReturnCode: 0
+      |  memory: "2 GB"
+      |  disk: "2 GB"
+      |  preemptible: false
+      |}
+      |""".stripMargin
+
+  val backendConfigWithLocalRoot = ConfigFactory.parseString(backendConfigStringWithLocalRoot)
+
+  // Configures the shared filesystem mount point via the legacy `filesystems.local.efs` key.
+  private val backendConfigStringWithLegacyEfs =
+    """
+      |root = "local-cromwell-executions"
+      |dockerRoot = "/cromwell-executions"
+      |endpoint = "http://127.0.0.1:9000/v1/jobs"
+      |
+      |filesystems.local.efs = "/mnt/efs"
+      |
+      |default-runtime-attributes {
+      |  cpu: 1
+      |  failOnStderr: false
+      |  continueOnReturnCode: 0
+      |  memory: "2 GB"
+      |  disk: "2 GB"
+      |  preemptible: false
+      |}
+      |""".stripMargin
+
+  val backendConfigWithLegacyEfs = ConfigFactory.parseString(backendConfigStringWithLegacyEfs)
+
+  // Provides a default memory_retry_multiplier via default-runtime-attributes.
+  private val backendConfigStringWithMemoryRetryMultiplier =
+    """
+      |root = "local-cromwell-executions"
+      |dockerRoot = "/cromwell-executions"
+      |endpoint = "http://127.0.0.1:9000/v1/jobs"
+      |
+      |default-runtime-attributes {
+      |  cpu: 1
+      |  failOnStderr: false
+      |  continueOnReturnCode: 0
+      |  memory: "2 GB"
+      |  disk: "2 GB"
+      |  preemptible: false
+      |  memory_retry_multiplier: 2.0
+      |}
+      |""".stripMargin
+
+  val backendConfigWithMemoryRetryMultiplier = ConfigFactory.parseString(backendConfigStringWithMemoryRetryMultiplier)
+
+  // Enables TES 1.1 backend_parameters pass-through AND supplies a default backoff_limit.
+  private val backendConfigStringWithBackendParamsAndBackoffLimit =
+    """
+      |root = "local-cromwell-executions"
+      |dockerRoot = "/cromwell-executions"
+      |endpoint = "http://127.0.0.1:9000/v1/jobs"
+      |use_tes_11_preview_backend_parameters = true
+      |
+      |default-runtime-attributes {
+      |  cpu: 1
+      |  failOnStderr: false
+      |  continueOnReturnCode: 0
+      |  memory: "2 GB"
+      |  disk: "2 GB"
+      |  preemptible: false
+      |  backoff_limit: "5"
+      |}
+      |""".stripMargin
+
+  val backendConfigWithBackendParamsAndBackoffLimit =
+    ConfigFactory.parseString(backendConfigStringWithBackendParamsAndBackoffLimit)
 }


### PR DESCRIPTION
### Description

Base commit: 0232cbdfa95b8075ff47db0a4b8de32f78542a42
All work described below is on top of that revision.

I set up a cromwell-tes-k8s infrastructure on AWS and OVHcloud.   Issues encountered along the way were fixed in multiple layers.  This PR reflects the changes needed in cromwell.  

See : https://geertvandeweyer.github.io/ 

#### Support for Custom-S3 endpoints 

Cromwell S3FS provider does not handle non AWS s3 locations (eg OVH). Fixes included:
   - Added `aws.endpoint-url` config and propagated to AwsConfiguration, AwsAuthMode, and S3 client builder.
   - Endpoint-URL aware logic: skip STS validation for non-AWS endpoints; force path-style access; handle custom URI in S3PathBuilder/Factory.
   - Hardening fixes for S3 filesystem provider:
     * Ignore errors creating "directory marker" objects.
     * Handle empty key (bucket root) specially in exists() and S3Utils.
     * Tolerate 400/403 responses from S3-compatible services when checking existence.
   - Miscellaneous path handling tweaks (permissions NPE, createDirectories() no-op, generic pathWithoutScheme).
   - Introduced extensive documentation comments to explain non-AWS behaviour.
   

#### TES backend improvements

Various fixes to improve interaction of TES backend with TES providers (tested on funnel):
   - Support non-aws deployments (see above)
   - Add OOM handlin with memory-retry logic to scale memory requirements
   - Shared filesystem support (EFS / NFS manilla / ... ) , including hashin through sibling files
   - max-retries : in TES, this is supported as backoff-limit parameter
   

#### Tests

Tests were added and passed (locally) for the altered functionality. 

#### Disclaimer:
Changes were drafted with the help of claude sonnet 4.6
   
