### PR TITLE
CTM-362 Fix hotspot in copying final outputs logic

### DIFF
--- a/core/src/main/scala/cromwell/core/path/FileRelocationMap.scala
+++ b/core/src/main/scala/cromwell/core/path/FileRelocationMap.scala
@@ -15,5 +15,5 @@ case class FileRelocationMap(map: Map[Path, Path]) {
 }
 
 object FileRelocationMap {
-  val empty: FileRelocationMap = FileRelocationMap(Map.empty)
+  lazy val empty: FileRelocationMap = FileRelocationMap(Map.empty)
 }

--- a/core/src/main/scala/cromwell/core/path/FileRelocationMap.scala
+++ b/core/src/main/scala/cromwell/core/path/FileRelocationMap.scala
@@ -1,0 +1,19 @@
+package cromwell.core.path
+
+/**
+ * Defines source/destination relationships for files being copied with the final outputs location feature
+ * @param map all files to be copied for this workflow
+ */
+case class FileRelocationMap(map: Map[Path, Path]) {
+
+  /**
+   * We do NOT want to recompute this every time (CTM-362)
+   */
+  lazy val stringified: Map[String, String] = map map { case (src: Path, dst: Path) =>
+    src.pathAsString -> dst.pathAsString
+  }
+}
+
+object FileRelocationMap {
+  val empty: FileRelocationMap = FileRelocationMap(Map.empty)
+}

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
@@ -1,21 +1,11 @@
 package cromwell.engine.workflow.lifecycle
 
-import cromwell.backend.{
-  AllBackendInitializationData,
-  BackendConfigurationDescriptor,
-  BackendInitializationData,
-  BackendLifecycleActorFactory
-}
+import cromwell.backend.{AllBackendInitializationData, BackendConfigurationDescriptor, BackendInitializationData, BackendLifecycleActorFactory}
 import cromwell.core.WorkflowOptions.UseRelativeOutputPaths
-import cromwell.core.path.{Path, PathCopier, PathFactory}
+import cromwell.core.path.{FileRelocationMap, Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendConfiguration, CromwellBackends}
-import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
 import wom.values.{WomSingleFile, WomValue}
-
-object OutputsLocationHelper {
-  type FileRelocationMap = Map[Path, Path]
-}
 
 trait OutputsLocationHelper {
 
@@ -59,7 +49,7 @@ trait OutputsLocationHelper {
         }
       }
     }
-    outputFileDestinations.distinct.toMap
+    FileRelocationMap(outputFileDestinations.distinct.toMap)
   }
 
   private def getBackendRootPath(backend: String,

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
@@ -1,6 +1,11 @@
 package cromwell.engine.workflow.lifecycle
 
-import cromwell.backend.{AllBackendInitializationData, BackendConfigurationDescriptor, BackendInitializationData, BackendLifecycleActorFactory}
+import cromwell.backend.{
+  AllBackendInitializationData,
+  BackendConfigurationDescriptor,
+  BackendInitializationData,
+  BackendLifecycleActorFactory
+}
 import cromwell.core.WorkflowOptions.UseRelativeOutputPaths
 import cromwell.core.path.{FileRelocationMap, Path, PathCopier, PathFactory}
 import cromwell.engine.EngineWorkflowDescriptor

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/CallMetadataHelper.scala
@@ -1,12 +1,11 @@
 package cromwell.engine.workflow.lifecycle.execution
 
 import java.time.OffsetDateTime
-
 import akka.actor.ActorRef
 import cromwell.backend.async.JobAlreadyFailedInJobStore
 import cromwell.core.ExecutionStatus._
 import cromwell.core._
-import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
+import cromwell.core.path.FileRelocationMap
 import cromwell.services.metadata.MetadataService._
 import cromwell.services.metadata._
 import wdl.draft2.model._

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -30,10 +30,17 @@ import cromwell.engine.backend.{BackendSingletonCollection, CromwellBackends}
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData.DataStoreUpdate
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor
-import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{ExpressionEvaluationFailedResponse, ExpressionEvaluationSucceededResponse}
+import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{
+  ExpressionEvaluationFailedResponse,
+  ExpressionEvaluationSucceededResponse
+}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.{ActiveExecutionStore, ExecutionStore}
-import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, EngineLifecycleActorAbortedResponse, OutputsLocationHelper}
+import cromwell.engine.workflow.lifecycle.{
+  EngineLifecycleActorAbortCommand,
+  EngineLifecycleActorAbortedResponse,
+  OutputsLocationHelper
+}
 import cromwell.engine.workflow.workflowstore.{RestartableAborting, StartableState}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.instrumentation.CromwellInstrumentation

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -24,24 +24,16 @@ import cromwell.core.WorkflowOptions.Destination
 import cromwell.core._
 import cromwell.core.io.AsyncIo
 import cromwell.core.logging.WorkflowLogging
-import cromwell.core.path.Path
+import cromwell.core.path.FileRelocationMap
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.backend.{BackendSingletonCollection, CromwellBackends}
-import cromwell.engine.workflow.lifecycle.OutputsLocationHelper.FileRelocationMap
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActor._
 import cromwell.engine.workflow.lifecycle.execution.WorkflowExecutionActorData.DataStoreUpdate
 import cromwell.engine.workflow.lifecycle.execution.job.EngineJobExecutionActor
-import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{
-  ExpressionEvaluationFailedResponse,
-  ExpressionEvaluationSucceededResponse
-}
+import cromwell.engine.workflow.lifecycle.execution.keys.ExpressionKey.{ExpressionEvaluationFailedResponse, ExpressionEvaluationSucceededResponse}
 import cromwell.engine.workflow.lifecycle.execution.keys._
 import cromwell.engine.workflow.lifecycle.execution.stores.{ActiveExecutionStore, ExecutionStore}
-import cromwell.engine.workflow.lifecycle.{
-  EngineLifecycleActorAbortCommand,
-  EngineLifecycleActorAbortedResponse,
-  OutputsLocationHelper
-}
+import cromwell.engine.workflow.lifecycle.{EngineLifecycleActorAbortCommand, EngineLifecycleActorAbortedResponse, OutputsLocationHelper}
 import cromwell.engine.workflow.workflowstore.{RestartableAborting, StartableState}
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
 import cromwell.services.instrumentation.CromwellInstrumentation
@@ -419,12 +411,9 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       val fileMap: FileRelocationMap =
         (workflowDescriptor.finalWorkflowOutputsDir, workflowDescriptor.finalWorkflowOutputsDirMetadata) match {
           case (Some(outputDir), Destination) =>
-            outputFilePathMapping(outputDir, workflowDescriptor, params.initializationData, outputs.values.toSeq) map {
-              case (src, dst) =>
-                (src, dst)
-            }
+            outputFilePathMapping(outputDir, workflowDescriptor, params.initializationData, outputs.values.toSeq)
           case _ =>
-            Map.empty[Path, Path]
+            FileRelocationMap.empty
         }
 
       val fullyQualifiedOutputs = outputs map { case (outputNode, value) =>

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -3,7 +3,12 @@ package cromwell.engine.workflow.lifecycle.finalization
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.event.LoggingReceive
 import cromwell.backend.BackendLifecycleActor.BackendWorkflowLifecycleActorResponse
-import cromwell.backend.BackendWorkflowFinalizationActor.{FinalizationFailed, FinalizationResponse, FinalizationSuccess, Finalize}
+import cromwell.backend.BackendWorkflowFinalizationActor.{
+  FinalizationFailed,
+  FinalizationResponse,
+  FinalizationSuccess,
+  Finalize
+}
 import cromwell.backend.AllBackendInitializationData
 import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core._

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/finalization/CopyWorkflowOutputsActor.scala
@@ -3,17 +3,12 @@ package cromwell.engine.workflow.lifecycle.finalization
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.event.LoggingReceive
 import cromwell.backend.BackendLifecycleActor.BackendWorkflowLifecycleActorResponse
-import cromwell.backend.BackendWorkflowFinalizationActor.{
-  FinalizationFailed,
-  FinalizationResponse,
-  FinalizationSuccess,
-  Finalize
-}
+import cromwell.backend.BackendWorkflowFinalizationActor.{FinalizationFailed, FinalizationResponse, FinalizationSuccess, Finalize}
 import cromwell.backend.AllBackendInitializationData
 import cromwell.core.Dispatcher.IoDispatcher
 import cromwell.core._
 import cromwell.core.io.AsyncIoActorClient
-import cromwell.core.path.Path
+import cromwell.core.path.{FileRelocationMap, Path}
 import cromwell.engine.EngineWorkflowDescriptor
 import cromwell.engine.workflow.lifecycle.OutputsLocationHelper
 import cromwell.filesystems.gcs.batch.GcsBatchCommandBuilder
@@ -81,12 +76,12 @@ class CopyWorkflowOutputsActor(workflowId: WorkflowId,
   }
 
   private def copyWorkflowOutputs(outputsDir: String): Future[Seq[Unit]] = {
-    val outputFilePaths =
+    val outputFilePaths: FileRelocationMap =
       outputFilePathMapping(outputsDir, workflowDescriptor, initializationData, workflowOutputs.outputs.values.toSeq)
 
-    markDuplicates(outputFilePaths)
+    markDuplicates(outputFilePaths.map)
 
-    val copies = outputFilePaths.toList map { case (srcPath, dstPath) =>
+    val copies = outputFilePaths.map.toList map { case (srcPath, dstPath) =>
       asyncIo.copyAsync(srcPath, dstPath)
     }
 

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -6,7 +6,7 @@ import cats.data.NonEmptyList
 import cromwell.core._
 import cromwell.services.ServiceRegistryActor.{ListenToMessage, ServiceRegistryMessage}
 import common.exception.{MessageAggregation, ThrowableAggregation}
-import cromwell.core.path.Path
+import cromwell.core.path.FileRelocationMap
 import cromwell.database.sql.tables.MetadataEntry
 import slick.basic.DatabasePublisher
 import wom.core._
@@ -202,7 +202,7 @@ object MetadataService {
   final case class WorkflowQueryFailure(reason: Throwable) extends MetadataQueryResponse
 
   implicit private class EnhancedWomTraversable(val womValues: Iterable[WomValue]) extends AnyVal {
-    def toEvents(metadataKey: MetadataKey, fileMap: Map[Path, Path]): List[MetadataEvent] = if (womValues.isEmpty) {
+    def toEvents(metadataKey: MetadataKey, fileMap: FileRelocationMap): List[MetadataEvent] = if (womValues.isEmpty) {
       List(MetadataEvent.empty(metadataKey.copy(key = s"${metadataKey.key}[]")))
     } else {
       womValues.toList.zipWithIndex
@@ -221,7 +221,7 @@ object MetadataService {
     */
   def womValueToMetadataEvents(metadataKey: MetadataKey,
                                womValue: WomValue,
-                               fileMap: Map[Path, Path] = Map.empty
+                               fileMap: FileRelocationMap = FileRelocationMap.empty
   ): Iterable[MetadataEvent] = womValue match {
     case WomArray(_, valueSeq) => valueSeq.toEvents(metadataKey, fileMap)
     case WomMap(_, valueMap) =>
@@ -247,11 +247,7 @@ object MetadataService {
         womValueToMetadataEvents(metadataKey.copy(key = metadataKey.key + ":right"), right, fileMap)
     case file: WomSingleFile =>
       // Our lookup key is a string; to avoid exceptions, stringify paths instead of pathifying the string
-      val stringifiedMap: Map[String, String] = fileMap map { case (src: Path, dst: Path) =>
-        src.pathAsString -> dst.pathAsString
-      }
-      // Why? When we copy/move final outputs, we need to map the original file to the destination file.
-      val mappedFile: WomSingleFile = stringifiedMap.get(file.valueString) match {
+      val mappedFile: WomSingleFile = fileMap.stringified.get(file.valueString) match {
         case Some(dst) =>
           WomSingleFile(dst)
         case None =>


### PR DESCRIPTION
### Description

This [bug](https://broadworkbench.atlassian.net/browse/CTM-362) uses up a lot of CPU and/or memory on Cromwell runners. It certainly was the sole cause of restarts last month, and current profiling shows that it is at least _part_ of the current instability.

Take note of the prominent `OutputsLocationHelper.outputFilePathMapping` entries in the flame graph below, captured on Tuesday March 24.
<img width="600" alt="CPU-flame-graph6 copy" src="https://github.com/user-attachments/assets/e3eec4b4-704e-4959-b2b0-7801244b68e1" />
### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users