### PR TITLE
CTM-362 Fix OOMs with large workflows & final outputs copying

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/OutputsLocationHelper.scala
@@ -30,7 +30,7 @@ trait OutputsLocationHelper {
     val useRelativeOutputPaths: Boolean = descriptor.getWorkflowOption(UseRelativeOutputPaths).contains("true")
     val rootAndFiles = for {
       // NOTE: Without .toSeq, outputs in arrays only yield the last output
-      backend <- descriptor.backendAssignments.values.toSeq
+      backend <- descriptor.backendAssignments.values.toSeq.distinct
       config <- BackendConfiguration.backendConfigurationDescriptor(backend).toOption.toSeq
       rootPath <- getBackendRootPath(backend, config, descriptor, backendInitData).toSeq
       outputFiles = findFiles(workflowOutputs).map(_.value)
@@ -54,7 +54,7 @@ trait OutputsLocationHelper {
         }
       }
     }
-    FileRelocationMap(outputFileDestinations.distinct.toMap)
+    FileRelocationMap(outputFileDestinations.toMap)
   }
 
   private def getBackendRootPath(backend: String,


### PR DESCRIPTION
### Description

tl;dr We were creating a tuple in memory for each workflow output (perhaps 10,000) and then duplicating it as many times as the count of tasks in the workflow (perhaps 1,000). Each tuple has two paths, so we are exploding our memory with 10,000 × 1,000 x 2 = 20,000,000 of them.

---

The expression `descriptor.backendAssignments.values` is intended to enumerate the backend(s) employed in this workflow, for the purpose of looking up the `rootPath` to use when constructing copy/move instructions.

The computation is based on the list of (task => backend) assignments, so we inadvertently end up with as many copies of the backend, as there are tasks; in this test WDL, we have 5 tasks:

<img width="482" height="346" alt="Screenshot 2026-03-25 at 17 18 49" src="https://github.com/user-attachments/assets/29b2b57c-466a-43ed-a7e8-e1c182674f90" />

Things get really problematic later. This test workflow has 12 outputs, and we make a copy for each of the 5 duplicate backends:

<img width="480" height="352" alt="Screenshot 2026-03-25 at 17 30 29" src="https://github.com/user-attachments/assets/9a8ee418-d6da-45fe-ba6f-c1f62b84eff8" />

We ultimately did do a `.distinct` at the very end of `outputFilePathMapping`, but that's too late – for large workflows, we probably already crashed with an OOM.

<img width="480" height="352" alt="Screenshot 2026-03-25 at 17 30 38" src="https://github.com/user-attachments/assets/a8a5aef2-e411-49f4-adf0-f2bc27651a2c" />

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users