### PR TITLE
CTM-409 Prepare `ExecutionStore.scala` for enhancement

### DIFF
--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -299,14 +299,14 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
       runnable
     }
 
-    // Filter for unstarted keys:
-    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
+    // Filter for unstarted keys. `LazyList.filter` preserves laziness, we only evaluate as many elements as we take.
+    val readyToStart: LazyList[JobKey] = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
-    // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
-    val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList
+    // Compute the first N runnable keys
+    val keysToStart = readyToStart.take(MaxJobsToStartPerTick).toList
 
-    // Will be true if the result is truncated, in which case we'll need to do another pass later
-    val truncated = keysToStartPlusOne.size > MaxJobsToStartPerTick
+    // If we can take more keys (N + 1) than we are processing now (N), then we need more passes.
+    def truncated: Boolean = keysToStart.size < readyToStart.take(MaxJobsToStartPerTick + 1).size
 
     // If we found unstartable keys, update their status, and set needsUpdate to true (it might unblock other keys)
     val updated = if (internalUpdates.nonEmpty) {
@@ -318,6 +318,6 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     } else withNeedsUpdateFalse
 
     // Only take the first ExecutionStore.MaxJobsToStartPerTick from the above list.
-    ExecutionStoreUpdate(keysToStartPlusOne.take(MaxJobsToStartPerTick), updated, internalUpdates)
+    ExecutionStoreUpdate(keysToStart, updated, internalUpdates)
   } else ExecutionStoreUpdate(List.empty, this, Map.empty)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -240,7 +240,7 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     }
   }
 
-  private def keysWithStatus(status: ExecutionStatus) = store.getOrElse(status, List.empty)
+  private def keysWithStatus(status: ExecutionStatus): List[JobKey] = store.getOrElse(status, List.empty)
 
   /**
     * We're done when all the keys have a terminal status,
@@ -278,18 +278,18 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     * In the process, identifies and updates the status of keys that are unstartable.
     * Returns an ExecutionStoreUpdate which is the list of runnable keys and an updated execution store.
     *
-    * If needsUpdate, returns an empty list of runnable keys and this instance of the store.
+    * If needsUpdate is false, returns an empty list of runnable keys and this instance of the store.
     *
-    * This method can expansive to run for very large workflows if needsUpdate is true.
+    * This method can be expensive to run for very large workflows if needsUpdate is true.
     */
   def update: ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     var internalUpdates = Map.empty[JobKey, ExecutionStatus]
 
     // Returns true if a key should be run now. Update its status if necessary
-    def filterFunction(key: JobKey): Boolean = {
+    def isRunnable(key: JobKey): Boolean = {
       // A key is runnable if all its dependencies are Done
-      val runnable = key.allDependenciesAreIn(doneStatus)
+      val runnable: Boolean = key.allDependenciesAreIn(doneStatus)
 
       // If the key is not runnable, but all its dependencies are in a terminal status, then it's unreachable
       if (!runnable && key.allDependenciesAreIn(terminalStatus)) {
@@ -300,7 +300,7 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     }
 
     // Filter for unstarted keys:
-    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(filterFunction)
+    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
     val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList


### PR DESCRIPTION
### Description

I am enhancing this function to filter out subworkflow keys and start them at a much lower rate, `.take(1)`.

In advance of that, here is a "pre-factor" that adjusts things closer to how my brain works.

Efficiency should be identical, both LHS and RHS of the diff have one `filter()` and two `take()`.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users