### PR TITLE
CTM-409 New setting for subworkflow start rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Cromwell Change Log
 
+## 93 Release Notes
 ### AWS Batch
 * Added `tagAliases` backend config option, which duplicates engine-generated tags (e.g. `cromwell-workflow-id`) under alternative key names for external systems like cost-tracking tools. See the [Tag Aliases](supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md#tag-aliases) section for configuration details.
+
+### General
+
+#### Configurable subworkflow launch rate
+
+The key `system.max-subworkflow-launch-count` now controls how many subworkflows launch per batch, with a default of 1.
+
+Complements the existing `system.max-workflow-launch-count`, also with a default of 1.
 
 ## 92 Release Notes
 ### WDL 1.1 Support

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -125,6 +125,10 @@ system {
   # Deviating from 1 is not recommended for multi-runner setups due to possible deadlocks. [BW-962]
   max-workflow-launch-count = 1
 
+  # Subworkflows launch like jobs from the execution store, but are expensive like workflows. Allow separate
+  # regulation, recommended to match workflow launch count. (CTM-409)
+  max-subworkflow-launch-count = 1
+
   # Workflows will be grouped by the value of the specified field in their workflow options.
   #
   # Currently, hog-safety will limit concurrent jobs within a hog group:

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -47,6 +47,9 @@ system {
   # Cromwell will launch up to N submitted workflows at a time, regardless of how many open workflow slots exist
   #max-workflow-launch-count = 50
 
+  # Subworkflows launch like jobs from the execution store, but are expensive like workflows.
+  #max-subworkflow-launch-count = 1
+
   # Number of seconds between workflow launches
   #new-workflow-poll-rate = 20
 

--- a/docs/Configuring.md
+++ b/docs/Configuring.md
@@ -148,6 +148,14 @@ On every poll, Cromwell will take at limited number of new submissions, provided
 system.max-workflow-launch-count = 1
 ```
 
+**Max Subworkflow Launch Count**
+
+When starting new work, Cromwell applies a separate rate to jobs and subworkflows, as the latter are considerably more expensive.
+
+```hocon
+system.max-subworkflow-launch-count = 1
+```
+
 ***Abort configuration***
 
 Cromwell will scan for abort requests using default configuration values equivalent to those below. In most circumstances

--- a/docs/Scaling.md
+++ b/docs/Scaling.md
@@ -39,6 +39,9 @@ system {
   # Cromwell will launch up to N submitted workflows at a time, regardless of how many open workflow slots exist
   # Set this to 0 for a non-runner.
   max-workflow-launch-count = 1
+  
+  # Cromwell will launch up to N submitted workflows at a time, regardless of how many open workflow slots exist
+  max-subworkflow-launch-count = 1
 
   # The maximum number of workflows to run concurrently.
   # Set this to 0 for a non-runner.
@@ -56,4 +59,3 @@ Cromwell instances should not require any configuration changes to operate in th
 Cromwell instance is not intended to operate in the front end role then requests should not be directed to
 that instance. If there are multiple front end instances then it may be desirable to configure a load balancer
 in front of these instances to direct requests to the front end instances only.
-

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -81,10 +81,14 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
 
   private val DefaultTotalMaxJobsPerRootWf = 1000000
   private val DefaultMaxScatterSize = 1000000
+  private val DefaultMaxSubWorkflowsToLaunch = 1
   private val TotalMaxJobsPerRootWf =
     params.rootConfig.getOrElse("system.total-max-jobs-per-root-workflow", DefaultTotalMaxJobsPerRootWf)
   private val MaxScatterWidth =
     params.rootConfig.getOrElse("system.max-scatter-width-per-scatter", DefaultMaxScatterSize)
+  // Harmonize subworkflow launch rate to the rate for top-level workflows (CTM-409)
+  private val MaxSubWorkflowsToLaunch =
+    params.rootConfig.getOrElse("system.max-workflow-launch-count", DefaultMaxSubWorkflowsToLaunch)
   private val FileHashBatchSize: Int = params.rootConfig.as[Int]("system.file-hash-batch-size")
 
   private val backendFactories: Map[String, BackendLifecycleActorFactory] = {
@@ -647,7 +651,7 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
       } else updatedData.mergeExecutionDiffs(diffs)
     }
 
-    val DataStoreUpdate(runnableKeys, _, updatedData) = data.executionStoreUpdate
+    val DataStoreUpdate(runnableKeys, _, updatedData) = data.executionStoreUpdate(MaxSubWorkflowsToLaunch)
     val runnableCalls = runnableKeys.view
       .collect { case k: BackendJobDescriptorKey => k }
       .groupBy(_.node)

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActor.scala
@@ -86,9 +86,8 @@ case class WorkflowExecutionActor(params: WorkflowExecutionActorParams)
     params.rootConfig.getOrElse("system.total-max-jobs-per-root-workflow", DefaultTotalMaxJobsPerRootWf)
   private val MaxScatterWidth =
     params.rootConfig.getOrElse("system.max-scatter-width-per-scatter", DefaultMaxScatterSize)
-  // Harmonize subworkflow launch rate to the rate for top-level workflows (CTM-409)
   private val MaxSubWorkflowsToLaunch =
-    params.rootConfig.getOrElse("system.max-workflow-launch-count", DefaultMaxSubWorkflowsToLaunch)
+    params.rootConfig.getOrElse("system.max-subworkflow-launch-count", DefaultMaxSubWorkflowsToLaunch)
   private val FileHashBatchSize: Int = params.rootConfig.as[Int]("system.file-hash-batch-size")
 
   private val backendFactories: Map[String, BackendLifecycleActorFactory] = {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/WorkflowExecutionActorData.scala
@@ -145,8 +145,8 @@ case class WorkflowExecutionActorData(workflowDescriptor: EngineWorkflowDescript
   def jobExecutionMap: JobExecutionMap =
     downstreamExecutionMap updated (workflowDescriptor.backendDescriptor, executionStore.startedJobs)
 
-  def executionStoreUpdate: DataStoreUpdate = {
-    val update = executionStore.update
+  def executionStoreUpdate(maxSubWorkflowsToLaunch: Int): DataStoreUpdate = {
+    val update = executionStore.update(maxSubWorkflowsToLaunch)
     DataStoreUpdate(update.runnableKeys, update.statusChanges, this.copy(executionStore = update.updatedStore))
   }
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -304,8 +304,8 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     // Filter for unstarted keys. `LazyList.filter` preserves laziness, we only evaluate as many elements as we take.
     val readyToStart: LazyList[JobKey] = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
-    // Subworkflows are considerably more expensive to start than any other key. Harmonize their start rate
-    // to the same low rate we configure for top-level workflows. (CTM-409)
+    // Subworkflows are considerably more expensive to start than any other key. Start them at a customized,
+    // lower rate. (CTM-409)
     val subWorkflowKeys = readyToStart.filter(isSubworkflow).take(maxSubWorkflowsToLaunch).toList
     val otherJobKeys = readyToStart.filterNot(isSubworkflow).take(MaxJobsToStartPerTick).toList
 

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -282,7 +282,7 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     *
     * This method can be expensive to run for very large workflows if needsUpdate is true.
     */
-  def update: ExecutionStoreUpdate = if (needsUpdate) {
+  def update(maxSubWorkflowsToLaunch: Int): ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     var internalUpdates = Map.empty[JobKey, ExecutionStatus]
 
@@ -299,14 +299,21 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
       runnable
     }
 
+    def isSubworkflow(key: JobKey): Boolean = key.isInstanceOf[SubWorkflowKey]
+
     // Filter for unstarted keys. `LazyList.filter` preserves laziness, we only evaluate as many elements as we take.
     val readyToStart: LazyList[JobKey] = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
-    // Compute the first N runnable keys
-    val keysToStart = readyToStart.take(MaxJobsToStartPerTick).toList
+    // Subworkflows are considerably more expensive to start than any other key. Harmonize their start rate
+    // to the same low rate we configure for top-level workflows. (CTM-409)
+    val subWorkflowKeys = readyToStart.filter(isSubworkflow).take(maxSubWorkflowsToLaunch).toList
+    val otherJobKeys = readyToStart.filterNot(isSubworkflow).take(MaxJobsToStartPerTick).toList
+
+    val keysToStart = subWorkflowKeys ++ otherJobKeys
 
     // If we can take more keys (N + 1) than we are processing now (N), then we need more passes.
-    def truncated: Boolean = keysToStart.size < readyToStart.take(MaxJobsToStartPerTick + 1).size
+    def truncated: Boolean =
+      keysToStart.size < readyToStart.take(MaxJobsToStartPerTick + maxSubWorkflowsToLaunch + 1).size
 
     // If we found unstartable keys, update their status, and set needsUpdate to true (it might unblock other keys)
     val updated = if (internalUpdates.nonEmpty) {

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -299,14 +299,14 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
       runnable
     }
 
-    // Filter for unstarted keys:
-    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
+    // Filter for unstarted keys. `LazyList.filter` preserves laziness, we only evaluate as many elements as we take.
+    val readyToStart: LazyList[JobKey] = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
-    // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
-    val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList
+    // Compute the first N runnable keys
+    val keysToStart = readyToStart.take(MaxJobsToStartPerTick).toList
 
-    // Will be true if the result is truncated, in which case we'll need to do another pass later
-    val truncated = keysToStartPlusOne.size > MaxJobsToStartPerTick
+    // If we can take more keys (N + 1) than we are processing now (N), then we need more passes.
+    def truncated: Boolean = keysToStart.size < readyToStart.take(MaxJobsToStartPerTick + 1).size
 
     // If we found unstartable keys, update their status, and set needsUpdate to true (it might unblock other keys)
     val updated = if (internalUpdates.nonEmpty) {
@@ -318,6 +318,6 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     } else withNeedsUpdateFalse
 
     // Only take the first ExecutionStore.MaxJobsToStartPerTick from the above list.
-    ExecutionStoreUpdate(keysToStartPlusOne.take(MaxJobsToStartPerTick), updated, internalUpdates)
+    ExecutionStoreUpdate(keysToStart, updated, internalUpdates)
   } else ExecutionStoreUpdate(List.empty, this, Map.empty)
 }

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStore.scala
@@ -240,7 +240,7 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     }
   }
 
-  private def keysWithStatus(status: ExecutionStatus) = store.getOrElse(status, List.empty)
+  private def keysWithStatus(status: ExecutionStatus): List[JobKey] = store.getOrElse(status, List.empty)
 
   /**
     * We're done when all the keys have a terminal status,
@@ -278,18 +278,18 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     * In the process, identifies and updates the status of keys that are unstartable.
     * Returns an ExecutionStoreUpdate which is the list of runnable keys and an updated execution store.
     *
-    * If needsUpdate, returns an empty list of runnable keys and this instance of the store.
+    * If needsUpdate is false, returns an empty list of runnable keys and this instance of the store.
     *
-    * This method can expansive to run for very large workflows if needsUpdate is true.
+    * This method can be expensive to run for very large workflows if needsUpdate is true.
     */
   def update: ExecutionStoreUpdate = if (needsUpdate) {
     // When looking for runnable keys, keep track of the ones that are unstartable so we can mark them as such
     var internalUpdates = Map.empty[JobKey, ExecutionStatus]
 
     // Returns true if a key should be run now. Update its status if necessary
-    def filterFunction(key: JobKey): Boolean = {
+    def isRunnable(key: JobKey): Boolean = {
       // A key is runnable if all its dependencies are Done
-      val runnable = key.allDependenciesAreIn(doneStatus)
+      val runnable: Boolean = key.allDependenciesAreIn(doneStatus)
 
       // If the key is not runnable, but all its dependencies are in a terminal status, then it's unreachable
       if (!runnable && key.allDependenciesAreIn(terminalStatus)) {
@@ -300,7 +300,7 @@ sealed abstract class ExecutionStore private[stores] (statusStore: Map[JobKey, E
     }
 
     // Filter for unstarted keys:
-    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(filterFunction)
+    val readyToStart = keysWithStatus(NotStarted).to(LazyList).filter(isRunnable)
 
     // Compute the first ExecutionStore.MaxJobsToStartPerTick + 1 runnable keys
     val keysToStartPlusOne = readyToStart.take(MaxJobsToStartPerTick + 1).toList

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/ExecutionStoreBenchmark.scala
@@ -68,7 +68,7 @@ object ExecutionStoreBenchmark extends Bench[Double] with DefaultJsonProtocol {
     measure method "update" in {
       val sizes: Gen[Int] = Gen.range("size")(from = 1000, upto = 10000, hop = 1000)
       using(stores(sizes)) in { es =>
-        es.update
+        es.update(1)
       }
     }
 

--- a/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
+++ b/engine/src/test/scala/cromwell/engine/workflow/lifecycle/execution/stores/ExecutionStoreSpec.scala
@@ -30,7 +30,7 @@ class ExecutionStoreSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
       store.store.getOrElse(QueuedInCromwell, List.empty).size should be(
         iterationNumber * ExecutionStore.MaxJobsToStartPerTick
       )
-      val update = store.update
+      val update = store.update(1)
       store = update.updatedStore.updateKeys(update.runnableKeys.map(_ -> QueuedInCromwell).toMap)
       iterationNumber = iterationNumber + 1
     }


### PR DESCRIPTION
### Description

We are seeing OOMs as Cromwell tries to start approximately 7,000 subworkflows instantaneously.

The current logic saturates system resources by requesting 1,000 subs at once. The application chugs for more than the one-second wait until the next clock tick; so it is constantly falling behind. I believe we are seeing the issue with this workflow specifically because it has a lot of inputs.

Going from 1,000 subworkflows per second to 1 per second is a dramatic change, but it is reasonable within the product behavior envelope. It will now take 7,000 seconds to launch 7,000 workflows, or 1 hour 57 minutes; which is not super consequential for workflows that take many hours to run.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [x] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users