### PR TITLE
CTM-399 Upgrade Netty to latest stable

### DIFF
--- a/centaur/src/main/resources/standardTestCases/gcpbatch_gpu_on_papi_invalid.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_gpu_on_papi_invalid.test
@@ -10,5 +10,5 @@ files {
 metadata {
   status: Failed
 
-  "calls.gpu_on_papi.task_with_gpu.failures.0.message": "Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: machine_type field is invalid. machine type custom-1-2048 is not compatible with accelerators [type:\"nonsense value\" count:1] error: generic::invalid_argument: Accelerator field is invalid. Accelerator with type nonsense value is not supported for Batch now. Please make sure that the type is lowercase formatted as name field in command `gcloud compute accelerator-types list` shows if it exists in the list.). "
+  "calls.gpu_on_papi.task_with_gpu.failures.0.message": "Unable to complete Batch request due to a problem with the request (io.grpc.StatusRuntimeException: INVALID_ARGUMENT: machine_type field is invalid."~~
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html#mysqld-8-0-29-charset
    */
   private val mysqlV = "8.0.28"
-  private val nettyV = "4.1.119.Final"
+  private val nettyV = "4.2.12.Final"
   private val postgresV = "42.4.4"
   private val pprintV = "0.7.3"
   private val rdf4jV = "3.7.1"


### PR DESCRIPTION
### Description

This addresses [CVE-2025-58056](https://nvd.nist.gov/vuln/detail/CVE-2025-58056)

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users