### PR TITLE
CTM-467 Trigger workflow failure when reaching max metadata

### DIFF
--- a/centaur/src/main/resources/standardTestCases/dummy_backend/35k_scatter_success.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/35k_scatter_success.test
@@ -1,4 +1,4 @@
-name: dummy_scatter
+name: 35k_scatter_success
 testFormat: workflowsuccessandtimedoutputs
 backends: [Dummy]
 tags: [Dummy]

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
@@ -3,6 +3,7 @@ testFormat: workflowsuccessandtimedoutputs
 backends: [Dummy]
 tags: [Dummy]
 
+# Produces about 1.3M rows of metadata
 files {
   workflow: dummy_scatter.wdl
 }

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
@@ -4,7 +4,7 @@ backends: [Dummy]
 tags: [Dummy]
 
 files {
-  workflow: dummy_scatter/dummy_scatter.wdl
+  workflow: dummy_scatter.wdl
 }
 
 metadata {

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
@@ -2,6 +2,7 @@ name: dummy_scatter
 testFormat: workflowsuccessandtimedoutputs
 backends: [Dummy]
 tags: [Dummy]
+retryTestFailures: false
 
 # Produces about 1.3M rows of metadata
 files {

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.test
@@ -4,11 +4,12 @@ backends: [Dummy]
 tags: [Dummy]
 retryTestFailures: false
 
-# Produces about 1.3M rows of metadata
 files {
   workflow: dummy_scatter.wdl
 }
 
+# Produces about 1.3M rows of metadata
+# Test how we fly: harmonized to Terra Prod limit set in `_cromwell.conf.tpl`
 metadata {
   "outputs.dummy_scatter.results_count": 35000
 }

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.wdl
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter.wdl
@@ -1,7 +1,10 @@
 version 1.0
 
 workflow dummy_scatter {
-  scatter (x in range(35000)) {
+  input {
+    Int scatter_width = 35000
+  }
+  scatter (x in range(scatter_width)) {
     call dummy_scattered_task
   }
   output {

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -9,9 +9,11 @@ files {
   inputs: fail_inputs.json
 }
 
-# Produces >1.5M rows of metadata
-metadata {
-  workflowName: dummy_scatter
-  status: Failed
-  "failures.0.message": ~~"metadata, exceeding limit of 1500000."
-}
+# Produces >1.5M rows of metadata.
+# Unfortunately Centaur insists on retrieving all of the metadata at once and times out.
+# This case relies exclusively on the `workflowfailure` assertion for now.
+# metadata {
+#   workflowName: dummy_scatter
+#   status: Failed
+#   "failures.0.message": ~~"metadata, exceeding limit of 1500000."
+# }

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -1,0 +1,17 @@
+name: dummy_scatter
+testFormat: workflowfailure
+backends: [Dummy]
+tags: [Dummy]
+
+files {
+  workflow: dummy_scatter.wdl
+  inputs: fail_inputs.json
+}
+
+metadata {
+  workflowName: dummy_scatter
+  status: Failed
+  "failures.0.message": ~~"metadata, exceeding limit of 500000."
+}
+
+maximumTime = 5 minutes

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -8,8 +8,9 @@ files {
   inputs: fail_inputs.json
 }
 
+# Produces >1.5M rows of metadata
 metadata {
   workflowName: dummy_scatter
   status: Failed
-  "failures.0.message": ~~"metadata, exceeding limit of 1000000."
+  "failures.0.message": ~~"metadata, exceeding limit of 1500000."
 }

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -10,10 +10,8 @@ files {
 }
 
 # Produces >1.5M rows of metadata.
-# Unfortunately Centaur insists on retrieving all of the metadata at once and times out.
-# This case relies exclusively on the `workflowfailure` assertion for now.
-# metadata {
-#   workflowName: dummy_scatter
-#   status: Failed
-#   "failures.0.message": ~~"metadata, exceeding limit of 1500000."
-# }
+metadata {
+  workflowName: dummy_scatter
+  status: Failed
+  "failures.0.message": ~~"metadata, exceeding limit of 1500000."
+}

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -11,7 +11,5 @@ files {
 metadata {
   workflowName: dummy_scatter
   status: Failed
-  "failures.0.message": ~~"metadata, exceeding limit of 500000."
+  "failures.0.message": ~~"metadata, exceeding limit of 1000000."
 }
-
-maximumTime = 5 minutes

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -2,6 +2,7 @@ name: dummy_scatter_fail
 testFormat: workflowfailure
 backends: [Dummy]
 tags: [Dummy]
+retryTestFailures: false
 
 files {
   workflow: dummy_scatter.wdl

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/dummy_scatter_fail.test
@@ -1,4 +1,4 @@
-name: dummy_scatter
+name: dummy_scatter_fail
 testFormat: workflowfailure
 backends: [Dummy]
 tags: [Dummy]

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/fail_inputs.json
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/fail_inputs.json
@@ -1,3 +1,3 @@
 {
-  "dummy_scatter.scatter_width": 500000
+  "dummy_scatter.scatter_width": 60000
 }

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/fail_inputs.json
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/fail_inputs.json
@@ -1,0 +1,3 @@
+{
+  "dummy_scatter.scatter_width": 500000
+}

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/too_much_metadata_fail.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/too_much_metadata_fail.test
@@ -1,4 +1,4 @@
-name: dummy_scatter_fail
+name: too_much_metadata_fail
 testFormat: workflowfailure
 backends: [Dummy]
 tags: [Dummy]

--- a/centaur/src/main/resources/standardTestCases/gcp_machine_type/gpu_inputs.json
+++ b/centaur/src/main/resources/standardTestCases/gcp_machine_type/gpu_inputs.json
@@ -1,4 +1,4 @@
 {
   "minimal_hello_world.machine_type": "g2-standard-4",
-  "minimal_hello_world.zones": "us-east4-a us-east4-c"
+  "minimal_hello_world.zones": "northamerica-northeast1-a northamerica-northeast1-b northamerica-northeast1-c"
 }

--- a/core/src/main/scala/cromwell/core/events/Metadata.scala
+++ b/core/src/main/scala/cromwell/core/events/Metadata.scala
@@ -1,0 +1,10 @@
+package cromwell.core.events
+
+import cromwell.core.WorkflowId
+
+sealed trait MetadataAlert {
+  def workflowId: WorkflowId
+  def count: Long
+}
+final case class HeavyMetadataAlert(workflowId: WorkflowId, count: Long) extends MetadataAlert
+final case class MaxMetadataAlert(workflowId: WorkflowId, count: Long, limit: Long) extends MetadataAlert

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -614,7 +614,7 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
       stay() using data.copy(effectiveStartableState = RestartableAborting)
     case Event(FailWorkflowWithExceptionCommand(e), data) =>
       goto(WorkflowFailedState) using data.copy(lastStateReached =
-        StateCheckpoint(data.lastStateReached.state, Option(List(e)))
+        data.lastStateReached.copy(state = stateName, failures = Option(List(e)))
       )
     case Event(msg @ EngineStatsActor.JobCountQuery, data) =>
       data.currentLifecycleStateActor match {

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowActor.scala
@@ -80,6 +80,7 @@ object WorkflowActor {
   case object StartWorkflowCommand extends WorkflowActorCommand
   case object AbortWorkflowCommand extends WorkflowActorCommand
   final case class AbortWorkflowWithExceptionCommand(exception: Throwable) extends WorkflowActorCommand
+  final case class FailWorkflowWithExceptionCommand(exception: Throwable) extends WorkflowActorCommand
   case object SendWorkflowHeartbeatCommand extends WorkflowActorCommand
   case object AwaitMetadataIntegrity
 
@@ -611,6 +612,10 @@ class WorkflowActor(workflowToStart: WorkflowToStart,
     // If the workflow is being restarted, then we have to keep going to try and reconnect to the jobs - but remember that workflow is now in abort mode
     case Event(AbortWorkflowCommand, data: WorkflowActorData) if restarting =>
       stay() using data.copy(effectiveStartableState = RestartableAborting)
+    case Event(FailWorkflowWithExceptionCommand(e), data) =>
+      goto(WorkflowFailedState) using data.copy(lastStateReached =
+        StateCheckpoint(data.lastStateReached.state, Option(List(e)))
+      )
     case Event(msg @ EngineStatsActor.JobCountQuery, data) =>
       data.currentLifecycleStateActor match {
         case Some(a) => a forward msg

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -283,7 +283,7 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
       for {
         actor <- stateData.actorForId(id)
       } yield actor ! WorkflowActor.FailWorkflowWithExceptionCommand(
-        new Exception(s"Workflow $id produced $count metadata rows, exceeding limit of $limit.") with NoStackTrace
+        new Exception(s"Workflow $id produced $count metadata, exceeding limit of $limit.") with NoStackTrace
       )
       stay()
     case Event(PreventNewWorkflowsFromStarting, _) =>

--- a/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/WorkflowManagerActor.scala
@@ -1,7 +1,6 @@
 package cromwell.engine.workflow
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor._
 import akka.event.Logging
@@ -11,6 +10,7 @@ import common.exception.ThrowableAggregation
 import cromwell.backend.async.KnownJobFailureException
 import cromwell.backend.standard.callcaching.{CallCachingBlacklistManager, RootWorkflowFileHashCacheActor}
 import cromwell.core.Dispatcher.EngineDispatcher
+import cromwell.core.events.MaxMetadataAlert
 import cromwell.core.{WorkflowId, WorkflowState}
 import cromwell.engine.SubWorkflowStart
 import cromwell.engine.backend.BackendSingletonCollection
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.Try
+import scala.util.control.NoStackTrace
 
 object WorkflowManagerActor {
   val DefaultMaxWorkflowsToRun = 5000
@@ -111,6 +112,8 @@ object WorkflowManagerActor {
   case class WorkflowManagerData(workflows: Map[WorkflowId, ActorRef], subWorkflows: Set[ActorRef]) {
     def idFromActor(actor: ActorRef): Option[WorkflowId] = workflows.collectFirst { case (id, a) if a == actor => id }
 
+    def actorForId(id: WorkflowId): Option[ActorRef] = workflows.get(id)
+
     def withAddition(entries: NonEmptyList[WorkflowIdToActorRef]): WorkflowManagerData = {
       val entryTuples = entries map { e => e.workflowId -> e.workflowActor }
       this.copy(workflows = workflows ++ entryTuples.toList)
@@ -171,6 +174,8 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
     timers.startSingleTimer(RetrieveNewWorkflowsKey, RetrieveNewWorkflows, Duration.Zero)
     // Listen on subworkflow start events to inform our decision to pick up new root workflows from the workflow store.
     context.system.eventStream.subscribe(self, classOf[SubWorkflowStart])
+    // Listen for workflows that have exceeded the metadata limit (CTM-467)
+    context.system.eventStream.subscribe(self, classOf[MaxMetadataAlert])
     ()
   }
 
@@ -271,8 +276,15 @@ class WorkflowManagerActor(params: WorkflowManagerActorParams)
     case Event(AbortWorkflowsCommand(ids), stateData) =>
       for {
         id <- ids
-        actor <- stateData.workflows.get(id)
+        actor <- stateData.actorForId(id)
       } yield actor ! WorkflowActor.AbortWorkflowCommand
+      stay()
+    case Event(MaxMetadataAlert(id, count, limit), stateData) =>
+      for {
+        actor <- stateData.actorForId(id)
+      } yield actor ! WorkflowActor.FailWorkflowWithExceptionCommand(
+        new Exception(s"Workflow $id produced $count metadata rows, exceeding limit of $limit.") with NoStackTrace
+      )
       stay()
     case Event(PreventNewWorkflowsFromStarting, _) =>
       timers.cancel(RetrieveNewWorkflowsKey)

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
@@ -2,25 +2,20 @@ package cromwell.services.metadata.impl
 
 import java.util.UUID
 import java.util.concurrent.Callable
-
 import com.google.common.cache.CacheBuilder
 import cromwell.core.WorkflowId
 import cromwell.services.metadata.{MetadataEvent, MetadataKey, MetadataString, MetadataValue}
+
 import java.time.{Duration => JDuration}
 import net.ceedubs.ficus.Ficus._
 import com.typesafe.config.Config
+import cromwell.core.events.{HeavyMetadataAlert, MaxMetadataAlert, MetadataAlert}
 import cromwell.services.metadata.impl.MetadataStatisticsRecorder._
 
 import scala.concurrent.duration._
 import scala.util.Try
 
 object MetadataStatisticsRecorder {
-  sealed trait MetadataAlert {
-    def workflowId: WorkflowId
-    def count: Long
-  }
-  final case class HeavyMetadataAlert(workflowId: WorkflowId, count: Long) extends MetadataAlert
-  final case class MaxMetadataAlert(workflowId: WorkflowId, count: Long) extends MetadataAlert
   final case class WorkflowMetadataWriteStatistics(workflowId: WorkflowId,
                                                    totalWrites: Long,
                                                    lastLogged: Long,
@@ -117,7 +112,7 @@ final class ActiveMetadataStatisticsRecorder(workflowCacheSize: Long, metadataAl
       // Otherwise we would continuously spam the alert once its condition becomes true.
       // After we fail the workflow it should never reach its next interval.
       val maxAlert = if (writesForWorkflow > metadataLimit) {
-        Vector(MaxMetadataAlert(workflowWriteStats.workflowId, writesForWorkflow))
+        Vector(MaxMetadataAlert(workflowWriteStats.workflowId, writesForWorkflow, metadataLimit))
       } else Vector.empty
 
       heavyAlert ++ maxAlert

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
@@ -41,9 +41,9 @@ object MetadataStatisticsRecorder {
     }
 
   object MetadataStatisticsRecorderSettings {
-    val defaultCacheSize = 20000L
-    val defaultAlertInterval = 100000L
-    val defaultLimit = 100000000L
+    private val defaultCacheSize = 20000L
+    private val defaultAlertInterval = 100000L
+    private val defaultLimit = 100000000L
 
     def apply(configSection: Option[Config]): MetadataStatisticsRecorderSettings =
       (configSection flatMap { conf: Config =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataStatisticsRecorder.scala
@@ -50,7 +50,7 @@ object MetadataStatisticsRecorder {
         if (conf.as[Option[Boolean]]("enabled").forall(identity)) {
           val cacheSize: Long = conf.getOrElse("cache-size", defaultCacheSize)
           val metadataAlertInterval: Long = conf.getOrElse("metadata-row-alert-interval", defaultAlertInterval)
-          val metadataLimit: Long = conf.getOrElse("metadata-row-limit", defaultAlertInterval)
+          val metadataLimit: Long = conf.getOrElse("metadata-row-limit", defaultLimit)
           Option(MetadataStatisticsEnabled(cacheSize, metadataAlertInterval, metadataLimit))
         } else None
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -5,14 +5,11 @@ import cats.data.NonEmptyVector
 import cromwell.core.Dispatcher.ServiceDispatcher
 import cromwell.core.Mailbox.PriorityMailbox
 import cromwell.core.WorkflowId
+import cromwell.core.events.{HeavyMetadataAlert, MaxMetadataAlert}
 import cromwell.core.instrumentation.InstrumentationPrefixes
 import cromwell.services.metadata.{MetadataEvent, MetadataString, MetadataValue}
 import cromwell.services.metadata.MetadataService._
-import cromwell.services.metadata.impl.MetadataStatisticsRecorder.{
-  HeavyMetadataAlert,
-  MaxMetadataAlert,
-  MetadataStatisticsRecorderSettings
-}
+import cromwell.services.metadata.impl.MetadataStatisticsRecorder.MetadataStatisticsRecorderSettings
 import cromwell.services.{EnhancedBatchActor, MetadataServicesStore}
 import wdl.util.StringUtil
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/WriteMetadataActor.scala
@@ -38,6 +38,7 @@ class WriteMetadataActor(override val batchSize: Int,
         log.warning(s"${a.workflowId} has logged a heavy amount of metadata (${a.count} rows)")
       case a: MaxMetadataAlert =>
         log.error(s"${a.workflowId} has logged too much metadata and will fail (${a.count} rows)")
+        context.system.eventStream.publish(a)
     }
 
     dbAction onComplete {

--- a/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/MetadataStatisticsRecorderSpec.scala
@@ -1,11 +1,10 @@
 package cromwell.services.metadata
 
 import java.util.UUID
-
 import common.assertion.ManyTimes.intWithTimes
 import cromwell.core.WorkflowId
+import cromwell.core.events.HeavyMetadataAlert
 import cromwell.services.metadata.impl.ActiveMetadataStatisticsRecorder
-import cromwell.services.metadata.impl.MetadataStatisticsRecorder.HeavyMetadataAlert
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import wom.values.{WomInteger, WomString}

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -56,7 +56,7 @@ services.MetadataService.config.metadata-write-statistics {
   enabled = true
   cache-size = 20000
   metadata-row-alert-interval = 5000 # Quite low... but we don't expect much metadata from test workflows, right?
-  metadata-row-limit = 1000000 # Chosen to pass `dummy_scatter.test` and fail `dummy_scatter_fail.test`
+  metadata-row-limit = 1500000 # Chosen to pass `dummy_scatter.test` and fail `dummy_scatter_fail.test`
 }
 
 # Make the shutdown timeout conspicuously long, so that if it hangs, it is an obvious problem in CI.

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -56,7 +56,7 @@ services.MetadataService.config.metadata-write-statistics {
   enabled = true
   cache-size = 20000
   metadata-row-alert-interval = 5000 # Quite low... but we don't expect much metadata from test workflows, right?
-  metadata-row-limit = 100000
+  metadata-row-limit = 500000 # Chosen to pass `dummy_scatter.test` and fail `dummy_scatter_fail.test`
 }
 
 # Make the shutdown timeout conspicuously long, so that if it hangs, it is an obvious problem in CI.

--- a/src/ci/resources/build_application.inc.conf
+++ b/src/ci/resources/build_application.inc.conf
@@ -56,7 +56,7 @@ services.MetadataService.config.metadata-write-statistics {
   enabled = true
   cache-size = 20000
   metadata-row-alert-interval = 5000 # Quite low... but we don't expect much metadata from test workflows, right?
-  metadata-row-limit = 500000 # Chosen to pass `dummy_scatter.test` and fail `dummy_scatter_fail.test`
+  metadata-row-limit = 1000000 # Chosen to pass `dummy_scatter.test` and fail `dummy_scatter_fail.test`
 }
 
 # Make the shutdown timeout conspicuously long, so that if it hangs, it is an obvious problem in CI.

--- a/src/ci/resources/centaur_application.conf
+++ b/src/ci/resources/centaur_application.conf
@@ -1,7 +1,8 @@
 include required(classpath("application.conf"))
 
+# Allow Centaur to handle large metadata responses received from Cromwell,
+# such as `dummy_scatter` / `dummy_scatter_fail`
 akka.http.client.parsing.max-content-length = 134217728 # 128 MiB
-akka.http.routing.decode-max-size           = 134217728 # 128 MiB
 
 centaur {
   log-request-failures: true

--- a/src/ci/resources/centaur_application.conf
+++ b/src/ci/resources/centaur_application.conf
@@ -1,8 +1,7 @@
 include required(classpath("application.conf"))
 
-# Set high enough to be able to read metadata from PAPIv2 CRON jobs
-# Roughly twice what the last failure showed in terms of size
-akka.http.client.parsing.max-content-length = 20971520 # 20MiB
+akka.http.client.parsing.max-content-length = 134217728 # 128 MiB
+akka.http.routing.decode-max-size           = 134217728 # 128 MiB
 
 centaur {
   log-request-failures: true

--- a/src/ci/resources/dummy_application.conf
+++ b/src/ci/resources/dummy_application.conf
@@ -50,4 +50,6 @@ backend {
 }
 
 services.MetadataService.config.metadata-read-row-number-safety-threshold = 2000000
-akka.http.server.request-timeout = 10 minutes
+
+# We use this backend to test Metadata of Unusual Size so juice timeouts to unwise levels
+akka.http.server.request-timeout = 5 minutes

--- a/src/ci/resources/dummy_application.conf
+++ b/src/ci/resources/dummy_application.conf
@@ -50,3 +50,4 @@ backend {
 }
 
 services.MetadataService.config.metadata-read-row-number-safety-threshold = 2000000
+akka.http.server.request-timeout = 10 minutes


### PR DESCRIPTION
### Description

1. `WriteMetadataActor` publishes to event stream
2. `WorkflowManagerActor` subscribes to the event
3. WMA then locates the appropriate `WorkflowActor` and tells it to fail its workflow

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users