### PR TITLE
CTM-503 Fix confusing task error message

### DIFF
--- a/centaur/src/main/resources/standardTestCases/gcp_machine_type/gcp_machine_type_fail.test
+++ b/centaur/src/main/resources/standardTestCases/gcp_machine_type/gcp_machine_type_fail.test
@@ -9,5 +9,5 @@ files {
 
 # Batch rejects the task and Cromwell fails it in an orderly manner
 metadata {
-  "failures.0.causedBy.0.message": ~~"GCP Batch task exited with Success(0). "
+  "failures.0.causedBy.0.message": ~~" Check GCP Batch job logs for details."
 }

--- a/centaur/src/main/resources/standardTestCases/gcp_machine_type/gcp_machine_type_gpu.test
+++ b/centaur/src/main/resources/standardTestCases/gcp_machine_type/gcp_machine_type_gpu.test
@@ -2,6 +2,9 @@ name: gcp_machine_type_gpu
 testFormat: workflowsuccess
 backends: [GCPBATCH]
 
+# The mechanics of this test work fine but as of 2026-05 there there are constant stockouts of GPUs
+ignore: true
+
 # Creates a `g2-standard-4` VM: 1 NVIDIA L4 GPU, 4 vCPUs, 16GB RAM
 # This is the cheapest machine type under the new type-based GPU model, replacing the older machine type + gpu type scheme.
 # For more information, see https://broadworkbench.atlassian.net/browse/AN-758

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_papi_delocalization_required_files.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_papi_delocalization_required_files.test
@@ -11,5 +11,5 @@ metadata {
   "calls.required_files.check_it.executionStatus": "Done"
   "calls.required_files.do_it.executionStatus": "Failed"
   "calls.required_files.do_it.retryableFailure": "false"
-  "calls.required_files.do_it.failures.0.message": ~~"Job exited without an error, exit code 0. GCP Batch task exited with Success(0)."
+  "calls.required_files.do_it.failures.0.message": ~~"Job exited without an error, exit code 0. Check GCP Batch job logs for details."
 }

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_requester_pays_localization_negative.test
@@ -14,5 +14,5 @@ metadata {
   workflowName: requester_pays_localization
   status: Failed
   "failures.0.message": "Workflow failed"
-  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. GCP Batch task exited with Success(0)."
+  "failures.0.causedBy.0.message": ~~"The job was stopped before the command finished. Check GCP Batch job logs for details."
 }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -67,11 +67,11 @@ import scala.util.{Failure, Success, Try}
 
 object GcpBatchAsyncBackendJobExecutionActor {
 
-  def StandardException(errorCode: GcpBatchExitCode,
-                        message: String,
-                        jobTag: String,
-                        returnCodeOption: Option[Int],
-                        stderrPath: Path
+  private def StandardException(errorCode: GcpBatchExitCode,
+                                message: Option[String],
+                                jobTag: String,
+                                returnCodeOption: Option[Int],
+                                stderrPath: Path
   ): Exception = {
     val returnCodeMessage = returnCodeOption match {
       case Some(returnCode) if returnCode == 0 => "Job exited without an error, exit code 0."
@@ -79,8 +79,17 @@ object GcpBatchAsyncBackendJobExecutionActor {
       case None => "The job was stopped before the command finished."
     }
 
+    val batchCodeMessage =
+      if (errorCode == GcpBatchExitCode.GenericFailure) "Check GCP Batch job logs for details."
+      else s"GCP Batch task exited with $errorCode(${errorCode.code})."
+
+    val contextMessage = message match {
+      case Some(msg) => s" $msg"
+      case None => ""
+    }
+
     new Exception(
-      s"Task $jobTag failed. $returnCodeMessage GCP Batch task exited with ${errorCode}(${errorCode.code}). ${message}"
+      s"Task $jobTag failed. $returnCodeMessage $batchCodeMessage$contextMessage"
     ) with NoStackTrace
   }
 
@@ -1148,7 +1157,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       FailedNonRetryableExecutionHandle(
         StandardException(
           runStatus.errorCode,
-          "", // We have no additional context to provide beyond what's already included by StandardException
+          None, // We have no additional context to provide beyond what's already included by StandardException
           jobTag,
           returnCode,
           standardPaths.error
@@ -1210,7 +1219,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
             s"$baseMsg The call will be restarted with another preemptible VM (max preemptible attempts number is " +
               s"$maxPreemption)."
           FailedRetryableExecutionHandle(
-            StandardException(errorCode, msg, jobTag, jobReturnCode, standardPaths.error),
+            StandardException(errorCode, Option(msg), jobTag, jobReturnCode, standardPaths.error),
             jobReturnCode,
             kvPairsToSave = Option(retryCountsKvPairs)
           )
@@ -1218,7 +1227,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
           val msg = s"$baseMsg The maximum number of preemptible attempts ($maxPreemption) has been reached. The " +
             s"call will be restarted with a non-preemptible VM."
           FailedRetryableExecutionHandle(
-            StandardException(errorCode, msg, jobTag, jobReturnCode, standardPaths.error),
+            StandardException(errorCode, Option(msg), jobTag, jobReturnCode, standardPaths.error),
             jobReturnCode,
             kvPairsToSave = Option(retryCountsKvPairs)
           )
@@ -1226,7 +1235,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
       case Invalid(_) =>
         FailedNonRetryableExecutionHandle(
           StandardException(errorCode,
-                            "Job failed due to preemption, couldn't get information about previous retry attempts.",
+                            Option("Job failed due to preemption, couldn't get information about previous retry attempts."),
                             jobTag,
                             jobReturnCode,
                             standardPaths.error
@@ -1262,7 +1271,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         val msg =
           s"Task failed immediately due to a transient GCP Batch error and will be automatically resubmitted up to ${remainingTransientRetries} more times."
         FailedRetryableExecutionHandle(
-          StandardException(failed.errorCode, msg, jobTag, returnCode, standardPaths.error),
+          StandardException(failed.errorCode, Option(msg), jobTag, returnCode, standardPaths.error),
           returnCode,
           kvPairsToSave = Option(retryCountsKvPairs)
         )
@@ -1270,7 +1279,7 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         FailedNonRetryableExecutionHandle(
           StandardException(
             failed.errorCode,
-            "Job failed due to transient GCP Batch error, couldn't get information about previous retry attempts.",
+            Option("Job failed due to transient GCP Batch error, couldn't get information about previous retry attempts."),
             jobTag,
             returnCode,
             standardPaths.error

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1234,11 +1234,12 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         }
       case Invalid(_) =>
         FailedNonRetryableExecutionHandle(
-          StandardException(errorCode,
-                            Option("Job failed due to preemption, couldn't get information about previous retry attempts."),
-                            jobTag,
-                            jobReturnCode,
-                            standardPaths.error
+          StandardException(
+            errorCode,
+            Option("Job failed due to preemption, couldn't get information about previous retry attempts."),
+            jobTag,
+            jobReturnCode,
+            standardPaths.error
           ),
           jobReturnCode,
           None
@@ -1279,7 +1280,9 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
         FailedNonRetryableExecutionHandle(
           StandardException(
             failed.errorCode,
-            Option("Job failed due to transient GCP Batch error, couldn't get information about previous retry attempts."),
+            Option(
+              "Job failed due to transient GCP Batch error, couldn't get information about previous retry attempts."
+            ),
             jobTag,
             returnCode,
             standardPaths.error

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/request/BatchRequestExecutor.scala
@@ -178,7 +178,7 @@ object BatchRequestExecutor {
             events
               .flatMap(e => GcpBatchExitCode.fromEventMessage(e.name))
               .headOption
-              .getOrElse(GcpBatchExitCode.Success)
+              .getOrElse(GcpBatchExitCode.GenericFailure)
           RunStatus.Failed(batchExitCode, events, instantiatedVmInfo)
         case JobStatus.State.CANCELLED => RunStatus.Aborted(events, instantiatedVmInfo)
         case _ => RunStatus.Initializing(events, instantiatedVmInfo)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchExitCode.scala
@@ -30,9 +30,11 @@ object GcpBatchExitCode {
     VMRecreatedDuringExecution
   )
 
-  // Special case non-error code - this does not correspond to any messages we get from Batch,
-  // this is what we use for tasks that don't error out at the Batch layer.
-  case object Success extends GcpBatchExitCode(0)
+  // Special case non-error code - this does not correspond to any Batch error code [0],
+  // this is what we use for tasks that error out at the user layer.
+  //
+  // [0] https://docs.cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes
+  case object GenericFailure extends GcpBatchExitCode(0)
 
   def fromEventMessage(message: String): Option[GcpBatchExitCode] =
     // Note that this will never return Success, because we don't get Success explicitly from GCP.

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -502,7 +502,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     val handle = new GcpBatchPendingExecutionHandle(null, runId, None, None)
 
     val failedStatus = RunStatus.Failed(
-      GcpBatchExitCode.Success,
+      GcpBatchExitCode.GenericFailure,
       Seq.empty
     )
     val executionResult = batchBackend.handleExecutionResult(failedStatus, handle)
@@ -629,7 +629,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
       .isInstanceOf[FailedRetryableExecutionHandle] shouldBe true
 
     // Should not retry
-    checkFailedResult(GcpBatchExitCode.Success)
+    checkFailedResult(GcpBatchExitCode.GenericFailure)
       .isInstanceOf[FailedNonRetryableExecutionHandle] shouldBe true
     checkFailedResult(GcpBatchExitCode.TaskRunsOverMaximumRuntime)
       .isInstanceOf[FailedNonRetryableExecutionHandle] shouldBe true


### PR DESCRIPTION
### Description

Users have been reasonably confused by the following statement, which reports failure and success in the same breath.

> "Task bamToKallisto.namesortBam:NA:1 failed. The job was stopped before the command finished. GCP Batch task exited with Success(0). "

Update it with some friendler and more helpful language:

> "Task bamToKallisto.namesortBam:NA:1 failed. The job was stopped before the command finished. Check Batch job logs for details."

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users