### PR TITLE
CTM-4 Remove metadata query row limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ The key `system.max-subworkflow-launch-count` now controls how many subworkflows
 
 Complements the existing `system.max-workflow-launch-count`, also with a default of 1.
 
-#### Metadata statistics recorder
+#### Metadata
+
+A new configuration key `metadata-row-limit` is introduced with a default of 100,000,000. Workflows are not allowed to exceed this limit (including subworkflows) and will fail with an error.
 
 The `metadata-write-statistics.sub-workflow-bundling` config key is removed. The recorder now always follows the default behavior, which is to bundle subworkflow row counts into their parents. 
+
+The `metadata-read-row-number-safety-threshold` config key is removed. `metadata-row-limit` is its recommended replacement.
 
 ## 92 Release Notes
 ### WDL 1.1 Support

--- a/cromwell.example.backends/cromwell.examples.conf
+++ b/cromwell.example.backends/cromwell.examples.conf
@@ -498,12 +498,6 @@ services {
     #   # See also `akka.http.server.request-timeout`.
     #   metadata-read-query-timeout = "Inf"
     #
-    #   # Limit the number of rows from METADATA_ENTRY that will be fetched to produce metadata responses.
-    #   # This limit takes into account the effects of `includeKey`, `excludeKey` and `includeSubworkflows`
-    #   # request parameters; only the rows required to be retrieved from the database to compose the response
-    #   # count against this limit.
-    #   metadata-read-row-number-safety-threshold = 1000000
-    #
     #   # Remove any UTF-8 mb4 (4 byte) characters from metadata keys in the list.
     #   # These characters (namely emojis) will cause metadata writing to fail in database collations
     #   # that do not support 4 byte UTF-8 characters.

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -280,47 +280,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     runTransaction(action, timeout = timeout)
   }
 
-  override def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
-                                                    metadataKeysToFilterFor: List[String],
-                                                    metadataKeysToFilterOut: List[String],
-                                                    metadataJobQueryValue: MetadataJobQueryValue,
-                                                    expandSubWorkflows: Boolean,
-                                                    timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int] = {
-    val action = metadataJobQueryValue match {
-      case CallQuery(callFqn, jobIndex, jobAttempt) =>
-        dataAccess
-          .countMetadataEntriesForJobWithKeyConstraints(workflowExecutionUuid,
-                                                        metadataKeysToFilterFor,
-                                                        metadataKeysToFilterOut,
-                                                        callFqn,
-                                                        jobIndex,
-                                                        jobAttempt,
-                                                        expandSubWorkflows
-          )
-          .result
-      case WorkflowQuery =>
-        dataAccess
-          .countMetadataEntriesWithKeyConstraints(workflowExecutionUuid,
-                                                  metadataKeysToFilterFor,
-                                                  metadataKeysToFilterOut,
-                                                  requireEmptyJobKey = true,
-                                                  expandSubWorkflows = expandSubWorkflows
-          )
-          .result
-      case CallOrWorkflowQuery =>
-        dataAccess
-          .countMetadataEntriesWithKeyConstraints(workflowExecutionUuid,
-                                                  metadataKeysToFilterFor,
-                                                  metadataKeysToFilterOut,
-                                                  requireEmptyJobKey = false,
-                                                  expandSubWorkflows = expandSubWorkflows
-          )
-          .result
-    }
-    runTransaction(action, timeout = timeout)
-  }
-
   private def updateWorkflowMetadataSummaryEntry(
     buildUpdatedWorkflowMetadataSummaryEntry: (Option[WorkflowMetadataSummaryEntry],
                                                Seq[MetadataEntry]

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -158,33 +158,11 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     database.stream(action)
   }
 
-  override def countMetadataEntries(workflowExecutionUuid: String, expandSubWorkflows: Boolean, timeout: Duration)(
-    implicit ec: ExecutionContext
-  ): Future[Int] = {
-    val action =
-      dataAccess.countMetadataEntriesForWorkflowExecutionUuid((workflowExecutionUuid, expandSubWorkflows)).result
-    runTransaction(action, timeout = timeout)
-  }
-
   override def queryMetadataEntries(workflowExecutionUuid: String, metadataKey: String, timeout: Duration)(implicit
     ec: ExecutionContext
   ): Future[Seq[MetadataEntry]] = {
     val action =
       dataAccess.metadataEntriesForWorkflowExecutionUuidAndMetadataKey((workflowExecutionUuid, metadataKey)).result
-    runTransaction(action, timeout = timeout)
-  }
-
-  override def countMetadataEntries(workflowExecutionUuid: String,
-                                    metadataKey: String,
-                                    expandSubWorkflows: Boolean,
-                                    timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int] = {
-    val action =
-      dataAccess
-        .countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey(
-          (workflowExecutionUuid, metadataKey, expandSubWorkflows)
-        )
-        .result
     runTransaction(action, timeout = timeout)
   }
 
@@ -196,21 +174,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
   )(implicit ec: ExecutionContext): Future[Seq[MetadataEntry]] = {
     val action =
       dataAccess.metadataEntriesForJobKey((workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt)).result
-    runTransaction(action, timeout = timeout)
-  }
-
-  override def countMetadataEntries(workflowExecutionUuid: String,
-                                    callFullyQualifiedName: String,
-                                    jobIndex: Option[Int],
-                                    jobAttempt: Option[Int],
-                                    expandSubWorkflows: Boolean,
-                                    timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int] = {
-    val action = dataAccess
-      .countMetadataEntriesForJobKey(
-        (workflowExecutionUuid, callFullyQualifiedName, jobIndex, jobAttempt, expandSubWorkflows)
-      )
-      .result
     runTransaction(action, timeout = timeout)
   }
 

--- a/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/MetadataSlickDatabase.scala
@@ -227,22 +227,6 @@ class MetadataSlickDatabase(originalDatabaseConfig: Config)
     runTransaction(action, timeout = timeout)
   }
 
-  override def countMetadataEntries(workflowUuid: String,
-                                    metadataKey: String,
-                                    callFullyQualifiedName: String,
-                                    jobIndex: Option[Int],
-                                    jobAttempt: Option[Int],
-                                    expandSubWorkflows: Boolean,
-                                    timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int] = {
-    val action = dataAccess
-      .countMetadataEntriesForJobKeyAndMetadataKey(
-        (workflowUuid, metadataKey, callFullyQualifiedName, jobIndex, jobAttempt, expandSubWorkflows)
-      )
-      .result
-    runTransaction(action, timeout = timeout)
-  }
-
   override def queryMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
                                                     metadataKeysToFilterFor: List[String],
                                                     metadataKeysToFilterOut: List[String],

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/MetadataEntryComponent.scala
@@ -105,22 +105,6 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataEntryId)
   )
 
-  val countMetadataEntriesForWorkflowExecutionUuid =
-    Compiled((rootWorkflowId: Rep[String], expandSubWorkflows: Rep[Boolean]) =>
-      {
-        val targetWorkflowIds = for {
-          summary <- workflowMetadataSummaryEntries
-          // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-          if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-        } yield summary.workflowExecutionUuid
-
-        for {
-          metadata <- metadataEntries
-          if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `IX_METADATA_ENTRY_WEU_MK`
-        } yield metadata
-      }.size
-    )
-
   val metadataEntriesForWorkflowExecutionUuidAndMetadataKey =
     Compiled((workflowExecutionUuid: Rep[String], metadataKey: Rep[String]) =>
       (for {
@@ -131,26 +115,6 @@ trait MetadataEntryComponent {
         if metadataEntry.jobIndex.isEmpty
         if metadataEntry.jobAttempt.isEmpty
       } yield metadataEntry).sortBy(_.metadataTimestamp)
-    )
-
-  val countMetadataEntriesForWorkflowExecutionUuidAndMetadataKey =
-    Compiled((rootWorkflowId: Rep[String], metadataKey: Rep[String], expandSubWorkflows: Rep[Boolean]) =>
-      {
-        val targetWorkflowIds = for {
-          summary <- workflowMetadataSummaryEntries
-          // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-          if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-        } yield summary.workflowExecutionUuid
-
-        for {
-          metadata <- metadataEntries
-          if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `IX_METADATA_ENTRY_WEU_MK`
-          if metadata.metadataKey === metadataKey
-          if metadata.callFullyQualifiedName.isEmpty
-          if metadata.jobIndex.isEmpty
-          if metadata.jobAttempt.isEmpty
-        } yield metadata
-      }.size
     )
 
   val metadataEntriesForJobKey = Compiled(
@@ -168,30 +132,6 @@ trait MetadataEntryComponent {
       } yield metadataEntry).sortBy(_.metadataTimestamp)
   )
 
-  val countMetadataEntriesForJobKey = Compiled(
-    (rootWorkflowId: Rep[String],
-     callFullyQualifiedName: Rep[String],
-     jobIndex: Rep[Option[Int]],
-     jobAttempt: Rep[Option[Int]],
-     expandSubWorkflows: Rep[Boolean]
-    ) =>
-      {
-        val targetWorkflowIds = for {
-          summary <- workflowMetadataSummaryEntries
-          // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-          if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-        } yield summary.workflowExecutionUuid
-
-        for {
-          metadata <- metadataEntries
-          if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `IX_METADATA_ENTRY_WEU_MK`
-          if metadata.callFullyQualifiedName === callFullyQualifiedName
-          if hasSameIndex(metadata, jobIndex)
-          if hasSameAttempt(metadata, jobAttempt)
-        } yield metadata
-      }.size
-  )
-
   val metadataEntriesForJobKeyAndMetadataKey = Compiled(
     (workflowExecutionUuid: Rep[String],
      metadataKey: Rep[String],
@@ -207,32 +147,6 @@ trait MetadataEntryComponent {
         if hasSameIndex(metadataEntry, jobIndex)
         if hasSameAttempt(metadataEntry, jobAttempt)
       } yield metadataEntry).sortBy(_.metadataTimestamp)
-  )
-
-  val countMetadataEntriesForJobKeyAndMetadataKey = Compiled(
-    (rootWorkflowId: Rep[String],
-     metadataKey: Rep[String],
-     callFullyQualifiedName: Rep[String],
-     jobIndex: Rep[Option[Int]],
-     jobAttempt: Rep[Option[Int]],
-     expandSubWorkflows: Rep[Boolean]
-    ) =>
-      {
-        val targetWorkflowIds = for {
-          summary <- workflowMetadataSummaryEntries
-          // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-          if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-        } yield summary.workflowExecutionUuid
-
-        for {
-          metadata <- metadataEntries
-          if metadata.workflowExecutionUuid in targetWorkflowIds // Uses `IX_METADATA_ENTRY_WEU_MK`
-          if metadata.metadataKey === metadataKey
-          if metadata.callFullyQualifiedName === callFullyQualifiedName
-          if hasSameIndex(metadata, jobIndex)
-          if hasSameAttempt(metadata, jobAttempt)
-        } yield metadata
-      }.size
   )
 
   val metadataEntriesForIdRange = Compiled { (minMetadataEntryId: Rep[Long], maxMetadataEntryId: Rep[Long]) =>
@@ -261,32 +175,6 @@ trait MetadataEntryComponent {
     } yield metadataEntry).sortBy(_.metadataTimestamp)
 
   /**
-    * Counts metadata entries that are "like" metadataKeys for the specified workflow.
-    * If requireEmptyJobKey is true, only workflow level keys are counted, otherwise both workflow and call level
-    * keys are counted.
-    */
-  def countMetadataEntriesWithKeyConstraints(rootWorkflowId: String,
-                                             metadataKeysToFilterFor: List[String],
-                                             metadataKeysToFilterOut: List[String],
-                                             requireEmptyJobKey: Boolean,
-                                             expandSubWorkflows: Boolean
-  ) = {
-
-    val targetWorkflowIds = for {
-      summary <- workflowMetadataSummaryEntries
-      // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-    } yield summary.workflowExecutionUuid
-
-    (for {
-      metadataEntry <- metadataEntries
-      if metadataEntry.workflowExecutionUuid in targetWorkflowIds
-      if metadataEntryHasMetadataKeysLike(metadataEntry, metadataKeysToFilterFor, metadataKeysToFilterOut)
-      if metadataEntryHasEmptyJobKey(metadataEntry, requireEmptyJobKey)
-    } yield metadataEntry).size
-  }
-
-  /**
     * Returns metadata entries that are "like" metadataKeys for the specified call.
     * If jobAttempt has no value, all metadata keys for all attempts are returned.
     */
@@ -308,38 +196,6 @@ trait MetadataEntryComponent {
       // regardless of the attempt
       if (metadataEntry.jobAttempt === jobAttempt) || jobAttempt.isEmpty
     } yield metadataEntry).sortBy(_.metadataTimestamp)
-
-  /**
-    * Counts metadata entries that are "like" metadataKeys for the specified call.
-    * If jobAttempt has no value, all metadata keys for all attempts are counted.
-    */
-  def countMetadataEntriesForJobWithKeyConstraints(rootWorkflowId: String,
-                                                   metadataKeysToFilterFor: List[String],
-                                                   metadataKeysToFilterOut: List[String],
-                                                   callFqn: String,
-                                                   jobIndex: Option[Int],
-                                                   jobAttempt: Option[Int],
-                                                   expandSubWorkflows: Boolean
-  ) = {
-
-    val targetWorkflowIds = for {
-      summary <- workflowMetadataSummaryEntries
-      // Uses `IX_WORKFLOW_METADATA_SUMMARY_ENTRY_RWEU`, `UC_WORKFLOW_METADATA_SUMMARY_ENTRY_WEU`
-      if summary.workflowExecutionUuid === rootWorkflowId || ((summary.rootWorkflowExecutionUuid === rootWorkflowId) && expandSubWorkflows)
-    } yield summary.workflowExecutionUuid
-
-    (for {
-      metadataEntry <- metadataEntries
-      if metadataEntry.workflowExecutionUuid in targetWorkflowIds
-      if metadataEntryHasMetadataKeysLike(metadataEntry, metadataKeysToFilterFor, metadataKeysToFilterOut)
-      if metadataEntry.callFullyQualifiedName === callFqn
-      if hasSameIndex(metadataEntry, jobIndex)
-      // Assume that every metadata entry for a call should have a non null attempt value
-      // Because of that, if the jobAttempt parameter is Some(_), make sure it matches, otherwise take all entries
-      // regardless of the attempt
-      if (metadataEntry.jobAttempt === jobAttempt) || jobAttempt.isEmpty
-    } yield metadataEntry).size
-  }
 
   def metadataTableSizeInformation() = {
     val query =

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -98,14 +98,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
                                            timeout: Duration
   )(implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
-  def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
-                                           metadataKeysToFilterFor: List[String],
-                                           metadataKeysToFilterAgainst: List[String],
-                                           metadataJobQueryValue: MetadataJobQueryValue,
-                                           expandSubWorkflows: Boolean,
-                                           timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int]
-
   /**
     * Retrieves next summarizable block of metadata satisfying the specified criteria.
     *

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -45,19 +45,9 @@ trait MetadataSqlDatabase extends SqlDatabase {
 
   def streamMetadataEntries(workflowExecutionUuid: String): DatabasePublisher[MetadataEntry]
 
-  def countMetadataEntries(workflowExecutionUuid: String, expandSubWorkflows: Boolean, timeout: Duration)(implicit
-    ec: ExecutionContext
-  ): Future[Int]
-
   def queryMetadataEntries(workflowExecutionUuid: String, metadataKey: String, timeout: Duration)(implicit
     ec: ExecutionContext
   ): Future[Seq[MetadataEntry]]
-
-  def countMetadataEntries(workflowExecutionUuid: String,
-                           metadataKey: String,
-                           expandSubWorkflows: Boolean,
-                           timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int]
 
   def queryMetadataEntries(workflowExecutionUuid: String,
                            callFullyQualifiedName: String,
@@ -65,14 +55,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            jobAttempt: Option[Int],
                            timeout: Duration
   )(implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
-
-  def countMetadataEntries(workflowExecutionUuid: String,
-                           callFullyQualifiedName: String,
-                           jobIndex: Option[Int],
-                           jobAttempt: Option[Int],
-                           expandSubWorkflows: Boolean,
-                           timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int]
 
   def queryMetadataEntries(workflowUuid: String,
                            metadataKey: String,

--- a/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
+++ b/database/sql/src/main/scala/cromwell/database/sql/MetadataSqlDatabase.scala
@@ -82,15 +82,6 @@ trait MetadataSqlDatabase extends SqlDatabase {
                            timeout: Duration
   )(implicit ec: ExecutionContext): Future[Seq[MetadataEntry]]
 
-  def countMetadataEntries(workflowUuid: String,
-                           metadataKey: String,
-                           callFullyQualifiedName: String,
-                           jobIndex: Option[Int],
-                           jobAttempt: Option[Int],
-                           expandSubWorkflows: Boolean,
-                           timeout: Duration
-  )(implicit ec: ExecutionContext): Future[Int]
-
   def queryMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
                                            metadataKeysToFilterFor: List[String],
                                            metadataKeysToFilterAgainst: List[String],

--- a/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
+++ b/engine/src/main/scala/cromwell/engine/workflow/lifecycle/execution/callcaching/CallCacheDiffActor.scala
@@ -32,23 +32,23 @@ class CallCacheDiffActor(serviceRegistryActor: ActorRef)
   when(WaitingForMetadata) {
     // First Response
     // Response A
-    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery, _), responseJson),
+    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery), responseJson),
                data @ CallCacheDiffWithRequest(queryA, _, None, None, _)
         ) if queryA == originalQuery =>
       stay() using data.copy(responseA = Option(WorkflowMetadataJson(responseJson)))
     // Response B
-    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery, _), responseJson),
+    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery), responseJson),
                data @ CallCacheDiffWithRequest(_, queryB, None, None, _)
         ) if queryB == originalQuery =>
       stay() using data.copy(responseB = Option(WorkflowMetadataJson(responseJson)))
     // Second Response
     // Response A
-    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery, _), responseJson),
+    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery), responseJson),
                CallCacheDiffWithRequest(queryA, queryB, None, Some(responseB), replyTo)
         ) if queryA == originalQuery =>
       buildDiffAndRespond(queryA, queryB, WorkflowMetadataJson(responseJson), responseB, replyTo)
     // Response B
-    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery, _), responseJson),
+    case Event(SuccessfulMetadataJsonResponse(GetMetadataAction(originalQuery), responseJson),
                CallCacheDiffWithRequest(queryA, queryB, Some(responseA), None, replyTo)
         ) if queryB == originalQuery =>
       buildDiffAndRespond(queryA, queryB, responseA, WorkflowMetadataJson(responseJson), replyTo)

--- a/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/MetadataBuilderActorSpec.scala
@@ -36,7 +36,6 @@ class MetadataBuilderActorSpec
 
   behavior of "MetadataBuilderActor"
 
-  val defaultSafetyRowNumberThreshold = 1000000
   val defaultTimeout: FiniteDuration = 5.second.dilated
   implicit val timeout: Timeout = defaultTimeout
 
@@ -51,7 +50,7 @@ class MetadataBuilderActorSpec
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       name = metadataBuilderActorName
     )
 
@@ -71,7 +70,7 @@ class MetadataBuilderActorSpec
   ): Future[Assertion] = {
     val mockReadMetadataWorkerActor = TestProbe("mockReadMetadataWorkerActor")
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(() => mockReadMetadataWorkerActor.props, defaultSafetyRowNumberThreshold),
+      props = MetadataBuilderActor.props(() => mockReadMetadataWorkerActor.props),
       name = metadataBuilderActorName
     )
     val response = mba.ask(action).mapTo[MetadataServiceResponse]
@@ -226,7 +225,7 @@ class MetadataBuilderActorSpec
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       name = "mba-cost-builder"
     )
 
@@ -280,7 +279,7 @@ class MetadataBuilderActorSpec
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       name = "mba-cost-builder"
     )
 
@@ -304,7 +303,7 @@ class MetadataBuilderActorSpec
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       name = "mba-cost-builder"
     )
 
@@ -389,7 +388,7 @@ class MetadataBuilderActorSpec
     // Mock ReadDatabaseMetadataWorkerActor to return the expected metadata results for each query.
     // Would normally have done this with expect/reply on a TestProbe, but that required the messages to
     // be sent in a deterministic order, which is not the case here.
-    class TestReadDatabaseMetadataWorkerActorForCost extends ReadDatabaseMetadataWorkerActor(defaultTimeout, 1000000) {
+    class TestReadDatabaseMetadataWorkerActorForCost extends ReadDatabaseMetadataWorkerActor(defaultTimeout) {
       override def receive: Receive = {
         case GetCost(wfId) if wfId == mainWorkflowId =>
           sender() ! CostResponse(mainWorkflowId, workflowRunningState, MetadataLookupResponse(mainQuery, mainEvents))
@@ -427,7 +426,7 @@ class MetadataBuilderActorSpec
 
     def readMetadataWorkerMaker = () => Props(new TestReadDatabaseMetadataWorkerActorForCost)
     val mba = system.actorOf(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       name = "mba-cost-builder"
     )
 
@@ -983,7 +982,7 @@ class MetadataBuilderActorSpec
     val mainQueryAction = GetMetadataAction(mainQuery)
 
     val subQuery = MetadataQuery(subWorkflowId, None, None, None, None, expandSubWorkflows = true)
-    val subQueryAction = GetMetadataAction(subQuery, checkTotalMetadataRowNumberBeforeQuerying = false)
+    val subQueryAction = GetMetadataAction(subQuery)
 
     val parentProbe = TestProbe("parentProbe")
 
@@ -992,7 +991,7 @@ class MetadataBuilderActorSpec
 
     val metadataBuilder =
       TestActorRef(
-        props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+        props = MetadataBuilderActor.props(readMetadataWorkerMaker),
         supervisor = parentProbe.ref,
         name = s"MetadataActor-$mainWorkflowId"
       )
@@ -1046,7 +1045,7 @@ class MetadataBuilderActorSpec
     def readMetadataWorkerMaker = () => mockReadMetadataWorkerActor.props
 
     val metadataBuilder = TestActorRef(
-      props = MetadataBuilderActor.props(readMetadataWorkerMaker, 1000000),
+      props = MetadataBuilderActor.props(readMetadataWorkerMaker),
       supervisor = parentProbe.ref,
       name = s"MetadataActor-$mainWorkflowId"
     )
@@ -1204,23 +1203,6 @@ class MetadataBuilderActorSpec
     assertMetadataResponse(queryAction, mdQuery, events, expectedRes, "mba-statuses-forward")
     assertMetadataResponse(queryAction, mdQuery, events.reverse, expectedRes, "mba-statuses-reverse")
     assertMetadataResponse(queryAction, mdQuery, Random.shuffle(events), expectedRes, "mba-statuses-random")
-  }
-
-  it should "politely refuse building metadata JSON if metadata number of rows is too large" in {
-    val workflowId = WorkflowId.randomId()
-
-    val mdQuery = MetadataQuery(workflowId, None, None, None, None, expandSubWorkflows = false)
-    val action = GetMetadataAction(mdQuery)
-
-    val metadataRowNumber = 100500
-    val expectedException =
-      new MetadataTooLargeNumberOfRowsException(workflowId, metadataRowNumber, defaultSafetyRowNumberThreshold)
-    assertMetadataFailureResponse(
-      action = action,
-      metadataServiceResponse = MetadataLookupFailedTooLargeResponse(mdQuery, metadataRowNumber),
-      expectedException = expectedException,
-      metadataBuilderActorName = "mba-too-large"
-    )
   }
 
   it should "politely refuse building metadata JSON if timeout occurs on attempt to read metadata from database" in {

--- a/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
+++ b/engine/src/test/scala/cromwell/webservice/routes/CromwellApiServiceSpec.scala
@@ -740,7 +740,7 @@ object CromwellApiServiceSpec {
         )
       case request @ FetchFailedJobsMetadataWithWorkflowId(id) =>
         sender() ! SuccessfulMetadataJsonResponse(request, responseMetadataValues(id, List.empty, List.empty))
-      case request @ GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _), _) =>
+      case request @ GetMetadataAction(MetadataQuery(id, _, _, withKeys, withoutKeys, _)) =>
         val withKeysList = withKeys.map(_.toList).getOrElse(List.empty)
         val withoutKeysList = withoutKeys.map(_.toList).getOrElse(List.empty)
         sender() ! SuccessfulMetadataJsonResponse(request, responseMetadataValues(id, withKeysList, withoutKeysList))

--- a/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
+++ b/server/src/test/scala/cromwell/engine/WorkflowStoreActorSpec.scala
@@ -209,9 +209,7 @@ class WorkflowStoreActorSpec
           eventually(timeout(15.seconds.dilated), interval(500.millis.dilated)) {
             val actorNameUniquificationString = UUID.randomUUID().toString.take(7)
             val readMetadataActor = system.actorOf(
-              ReadDatabaseMetadataWorkerActor.props(metadataReadTimeout = 30 seconds,
-                                                    metadataReadRowNumberSafetyThreshold = 20000
-              ),
+              ReadDatabaseMetadataWorkerActor.props(metadataReadTimeout = 30 seconds),
               s"ReadMetadataActor-FetchEncryptedOptions-$actorNameUniquificationString"
             )
 

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -111,8 +111,7 @@ object MetadataService {
       GetMetadataAction(MetadataQuery(workflowId, None, None, includeKeysOption, excludeKeysOption, expandSubWorkflows))
   }
 
-  final case class GetMetadataAction(key: MetadataQuery)
-      extends BuildWorkflowMetadataJsonWithOverridableSourceAction {
+  final case class GetMetadataAction(key: MetadataQuery) extends BuildWorkflowMetadataJsonWithOverridableSourceAction {
 
     override def workflowId: WorkflowId = key.workflowId
   }

--- a/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
+++ b/services/src/main/scala/cromwell/services/metadata/MetadataService.scala
@@ -111,7 +111,7 @@ object MetadataService {
       GetMetadataAction(MetadataQuery(workflowId, None, None, includeKeysOption, excludeKeysOption, expandSubWorkflows))
   }
 
-  final case class GetMetadataAction(key: MetadataQuery, checkTotalMetadataRowNumberBeforeQuerying: Boolean = true)
+  final case class GetMetadataAction(key: MetadataQuery)
       extends BuildWorkflowMetadataJsonWithOverridableSourceAction {
 
     override def workflowId: WorkflowId = key.workflowId
@@ -145,8 +145,6 @@ object MetadataService {
   final case class MetadataLookupStreamSuccess(id: WorkflowId, result: DatabasePublisher[MetadataEntry])
       extends MetadataServiceResponse
   final case class MetadataLookupStreamFailed(id: WorkflowId, reason: Throwable) extends MetadataServiceResponse
-  final case class MetadataLookupFailedTooLargeResponse(query: MetadataQuery, metadataSizeRows: Int)
-      extends MetadataServiceResponse
   final case class MetadataLookupFailedTimeoutResponse(query: MetadataQuery) extends MetadataServiceResponse
   final case class FetchFailedTasksTimeoutResponse(workflowId: WorkflowId) extends MetadataServiceResponse
   final case class MetadataLookupResponse(query: MetadataQuery, eventList: Seq[MetadataEvent])

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataDatabaseAccess.scala
@@ -140,64 +140,6 @@ trait MetadataDatabaseAccess {
       MetadataEvent(key, value, m.metadataTimestamp.toSystemOffsetDateTime)
     }
 
-  def getMetadataReadRowCount(query: MetadataQuery, timeout: Duration)(implicit ec: ExecutionContext): Future[Int] = {
-
-    def listKeyRequirements(keyRequirementsInput: Option[NonEmptyList[String]]): List[String] =
-      keyRequirementsInput.map(_.toList).toList.flatten.map(_ + "%")
-
-    val uuid = query.workflowId.id.toString
-
-    query match {
-      case q @ MetadataQuery(_, None, None, None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, q.expandSubWorkflows, timeout)
-      case q @ MetadataQuery(_, None, Some(key), None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid, key, q.expandSubWorkflows, timeout)
-      case q @ MetadataQuery(_, Some(jobKey), None, None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid,
-                                                       jobKey.callFqn,
-                                                       jobKey.index,
-                                                       jobKey.attempt,
-                                                       q.expandSubWorkflows,
-                                                       timeout
-        )
-      case q @ MetadataQuery(_, Some(jobKey), Some(key), None, None, _) =>
-        metadataDatabaseInterface.countMetadataEntries(uuid,
-                                                       key,
-                                                       jobKey.callFqn,
-                                                       jobKey.index,
-                                                       jobKey.attempt,
-                                                       q.expandSubWorkflows,
-                                                       timeout
-        )
-      case q @ MetadataQuery(_, None, None, includeKeys, excludeKeys, _) =>
-        val excludeKeyRequirements = listKeyRequirements(excludeKeys)
-        val queryType = if (excludeKeyRequirements.contains("calls%")) WorkflowQuery else CallOrWorkflowQuery
-
-        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid,
-                                                                       listKeyRequirements(includeKeys),
-                                                                       excludeKeyRequirements,
-                                                                       queryType,
-                                                                       q.expandSubWorkflows,
-                                                                       timeout
-        )
-      case q @ MetadataQuery(_,
-                             Some(MetadataQueryJobKey(callFqn, index, attempt)),
-                             None,
-                             includeKeys,
-                             excludeKeys,
-                             _
-          ) =>
-        metadataDatabaseInterface.countMetadataEntryWithKeyConstraints(uuid,
-                                                                       listKeyRequirements(includeKeys),
-                                                                       listKeyRequirements(excludeKeys),
-                                                                       CallQuery(callFqn, index, attempt),
-                                                                       q.expandSubWorkflows,
-                                                                       timeout
-        )
-      case _ => Future.failed(new IllegalArgumentException(s"Invalid MetadataQuery: $query"))
-    }
-  }
-
   def metadataEventsStream(workflowId: WorkflowId): Try[DatabasePublisher[MetadataEntry]] =
     Try(metadataDatabaseInterface.streamMetadataEntries(workflowId.id.toString))
 

--- a/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/MetadataServiceActor.scala
@@ -79,8 +79,6 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
 
   private val metadataReadTimeout: Duration =
     serviceConfig.getOrElse[Duration]("metadata-read-query-timeout", Duration.Inf)
-  private val metadataReadRowNumberSafetyThreshold: Int =
-    serviceConfig.getOrElse[Int]("metadata-read-row-number-safety-threshold", 1000000)
 
   private val metadataTableMetricsInterval: Option[FiniteDuration] =
     serviceConfig.getAs[FiniteDuration]("metadata-table-metrics-interval")
@@ -93,11 +91,11 @@ case class MetadataServiceActor(serviceConfig: Config, globalConfig: Config, ser
 
   def readMetadataWorkerActorProps(): Props =
     ReadDatabaseMetadataWorkerActor
-      .props(metadataReadTimeout, metadataReadRowNumberSafetyThreshold)
+      .props(metadataReadTimeout)
       .withDispatcher(ServiceDispatcher)
 
   def metadataBuilderActorProps(): Props = MetadataBuilderActor
-    .props(readMetadataWorkerActorProps, metadataReadRowNumberSafetyThreshold)
+    .props(readMetadataWorkerActorProps)
     .withDispatcher(ServiceDispatcher)
 
   val readActor = context.actorOf(

--- a/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/ReadDatabaseMetadataWorkerActor.scala
@@ -14,12 +14,12 @@ import scala.concurrent.duration.Duration
 import scala.util.Try
 
 object ReadDatabaseMetadataWorkerActor {
-  def props(metadataReadTimeout: Duration, metadataReadRowNumberSafetyThreshold: Int) =
-    Props(new ReadDatabaseMetadataWorkerActor(metadataReadTimeout, metadataReadRowNumberSafetyThreshold))
+  def props(metadataReadTimeout: Duration) =
+    Props(new ReadDatabaseMetadataWorkerActor(metadataReadTimeout))
       .withDispatcher(ServiceDispatcher)
 }
 
-class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataReadRowNumberSafetyThreshold: Int)
+class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration)
     extends Actor
     with ActorLogging
     with MetadataDatabaseAccess
@@ -30,8 +30,8 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataRea
   def receive = {
     case FetchFailedJobsMetadataWithWorkflowId(w: WorkflowId) =>
       evaluateRespondAndStop(sender(), getFailedJobs(w))
-    case GetMetadataAction(query: MetadataQuery, checkTotalMetadataRowNumberBeforeQuerying: Boolean) =>
-      evaluateRespondAndStop(sender(), getMetadata(query, checkTotalMetadataRowNumberBeforeQuerying))
+    case GetMetadataAction(query: MetadataQuery) =>
+      evaluateRespondAndStop(sender(), queryMetadata(query))
     case GetMetadataStreamAction(workflowId) =>
       evaluateRespondAndStop(sender(), Future.fromTry(getMetadataStream(workflowId)))
     case GetStatus(workflowId) => evaluateRespondAndStop(sender(), getStatus(workflowId))
@@ -61,24 +61,6 @@ class ReadDatabaseMetadataWorkerActor(metadataReadTimeout: Duration, metadataRea
     }
     ()
   }
-
-  private def getMetadata(query: MetadataQuery,
-                          checkResultSizeBeforeQuerying: Boolean
-  ): Future[MetadataServiceResponse] =
-    if (checkResultSizeBeforeQuerying) {
-      getMetadataReadRowCount(query, metadataReadTimeout) flatMap { count =>
-        if (count > metadataReadRowNumberSafetyThreshold) {
-          Future.successful(MetadataLookupFailedTooLargeResponse(query, count))
-        } else {
-          queryMetadata(query)
-        }
-      } recoverWith {
-        case _: SQLTimeoutException => Future.successful(MetadataLookupFailedTimeoutResponse(query))
-        case t => Future.successful(MetadataServiceKeyLookupFailed(query, t))
-      }
-    } else {
-      queryMetadata(query)
-    }
 
   private def getMetadataStream(workflowId: WorkflowId): Try[MetadataServiceResponse] =
     metadataEventsStream(workflowId) map { s =>

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -75,10 +75,9 @@ object MetadataBuilderActor {
   }
 
   def props(readMetadataWorkerMaker: () => Props,
-            metadataReadRowNumberSafetyThreshold: Int,
             isForSubworkflows: Boolean = false
   ) =
-    Props(new MetadataBuilderActor(readMetadataWorkerMaker, metadataReadRowNumberSafetyThreshold, isForSubworkflows))
+    Props(new MetadataBuilderActor(readMetadataWorkerMaker, isForSubworkflows))
 
   val log = LoggerFactory.getLogger("MetadataBuilder")
 
@@ -394,7 +393,6 @@ object MetadataBuilderActor {
 }
 
 class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
-                           metadataReadRowNumberSafetyThreshold: Int,
                            isForSubworkflows: Boolean
 ) extends LoggingFSM[MetadataBuilderActorState, MetadataBuilderActorData]
     with DefaultJsonProtocol {
@@ -437,14 +435,6 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
       processMetadataResponse(query, metadata, target, originalRequest)
     case Event(FetchFailedJobsMetadataLookupResponse(metadata), HasWorkData(target, originalRequest)) =>
       processFailedJobsMetadataResponse(metadata, target, originalRequest)
-    case Event(MetadataLookupFailedTooLargeResponse(query, metadataSizeRows), HasWorkData(target, originalRequest)) =>
-      val metadataTooLargeNumberOfRowsException =
-        new MetadataTooLargeNumberOfRowsException(query.workflowId,
-                                                  metadataSizeRows,
-                                                  metadataReadRowNumberSafetyThreshold
-        )
-      target ! FailedMetadataJsonResponse(originalRequest, metadataTooLargeNumberOfRowsException)
-      allDone()
     case Event(MetadataLookupFailedTimeoutResponse(query), HasWorkData(target, originalRequest)) =>
       val metadataTooLargeTimeoutException = new MetadataTooLargeTimeoutException(query.workflowId)
       target ! FailedMetadataJsonResponse(originalRequest, metadataTooLargeTimeoutException)
@@ -493,7 +483,7 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
 
   def processSubWorkflowMetadata(metadataResponse: MetadataJsonResponse, data: HasReceivedEventsData) =
     metadataResponse match {
-      case SuccessfulMetadataJsonResponse(GetMetadataAction(queryKey, _), js) =>
+      case SuccessfulMetadataJsonResponse(GetMetadataAction(queryKey), js) =>
         val subId: WorkflowId = queryKey.workflowId
         val newData = data.withSubWorkflow(subId.toString, js)
 
@@ -584,14 +574,11 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
         // Otherwise spin up a metadata builder actor for each sub workflow
         subWorkflowIds foreach { subId =>
           val subMetadataBuilder = context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker,
-                                                                              metadataReadRowNumberSafetyThreshold,
                                                                               isForSubworkflows = true
                                                    ),
                                                    uniqueActorName(subId)
           )
-          subMetadataBuilder ! GetMetadataAction(query.copy(workflowId = WorkflowId.fromString(subId)),
-                                                 checkTotalMetadataRowNumberBeforeQuerying = false
-          )
+          subMetadataBuilder ! GetMetadataAction(query.copy(workflowId = WorkflowId.fromString(subId)))
         }
         goto(WaitingForSubWorkflows) using HasReceivedEventsData(target,
                                                                  originalRequest,
@@ -622,7 +609,6 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
       // Otherwise spin up a metadata builder actor for each sub workflow
       subWorkflowIds foreach { subId =>
         val subMetadataBuilder = context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker,
-                                                                            metadataReadRowNumberSafetyThreshold,
                                                                             isForSubworkflows = true
                                                  ),
                                                  uniqueActorName(subId)

--- a/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
+++ b/services/src/main/scala/cromwell/services/metadata/impl/builder/MetadataBuilderActor.scala
@@ -74,9 +74,7 @@ object MetadataBuilderActor {
       this.copy(subWorkflowsMetadata = subWorkflowsMetadata + ((id, metadata)))
   }
 
-  def props(readMetadataWorkerMaker: () => Props,
-            isForSubworkflows: Boolean = false
-  ) =
+  def props(readMetadataWorkerMaker: () => Props, isForSubworkflows: Boolean = false) =
     Props(new MetadataBuilderActor(readMetadataWorkerMaker, isForSubworkflows))
 
   val log = LoggerFactory.getLogger("MetadataBuilder")
@@ -392,9 +390,8 @@ object MetadataBuilderActor {
     }
 }
 
-class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
-                           isForSubworkflows: Boolean
-) extends LoggingFSM[MetadataBuilderActorState, MetadataBuilderActorData]
+class MetadataBuilderActor(readMetadataWorkerMaker: () => Props, isForSubworkflows: Boolean)
+    extends LoggingFSM[MetadataBuilderActorState, MetadataBuilderActorData]
     with DefaultJsonProtocol {
 
   import MetadataBuilderActor._
@@ -573,11 +570,10 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
       else {
         // Otherwise spin up a metadata builder actor for each sub workflow
         subWorkflowIds foreach { subId =>
-          val subMetadataBuilder = context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker,
-                                                                              isForSubworkflows = true
-                                                   ),
-                                                   uniqueActorName(subId)
-          )
+          val subMetadataBuilder =
+            context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker, isForSubworkflows = true),
+                            uniqueActorName(subId)
+            )
           subMetadataBuilder ! GetMetadataAction(query.copy(workflowId = WorkflowId.fromString(subId)))
         }
         goto(WaitingForSubWorkflows) using HasReceivedEventsData(target,
@@ -608,11 +604,10 @@ class MetadataBuilderActor(readMetadataWorkerMaker: () => Props,
     else {
       // Otherwise spin up a metadata builder actor for each sub workflow
       subWorkflowIds foreach { subId =>
-        val subMetadataBuilder = context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker,
-                                                                            isForSubworkflows = true
-                                                 ),
-                                                 uniqueActorName(subId)
-        )
+        val subMetadataBuilder =
+          context.actorOf(MetadataBuilderActor.props(readMetadataWorkerMaker, isForSubworkflows = true),
+                          uniqueActorName(subId)
+          )
         subMetadataBuilder ! GetCost(WorkflowId.fromString(subId))
       }
       goto(WaitingForSubWorkflowCost) using HasReceivedCostEventsData(target,

--- a/services/src/main/scala/cromwell/services/metadata/package.scala
+++ b/services/src/main/scala/cromwell/services/metadata/package.scala
@@ -18,11 +18,6 @@ final case class FailedMetadataJsonResponse(originalRequest: BuildMetadataJsonAc
 
 class MetadataTooLargeException(message: String) extends RuntimeException(message) with NoStackTrace
 
-final class MetadataTooLargeNumberOfRowsException(workflowId: WorkflowId, metadataSizeRows: Int, metadataLimitRows: Int)
-    extends MetadataTooLargeException(
-      s"Metadata for workflow $workflowId exists in database but cannot be served because row count of $metadataSizeRows exceeds configured limit of $metadataLimitRows."
-    )
-
 final class MetadataTooLargeTimeoutException(workflowId: WorkflowId)
     extends MetadataTooLargeException(
       s"Metadata for workflow $workflowId exists in database but retrieval timed out, possibly due to large row count."

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -554,51 +554,6 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with CromwellTimeoutSpec wit
       delete.futureValue(Timeout(10.seconds)) should be(1)
     }
 
-    it should "count up rows" taggedAs DbmsTest in {
-      List(true, false) foreach { expandSubWorkflows =>
-        val expansionFactor = if (expandSubWorkflows) 3 else 1;
-        // Everything
-        {
-          val count =
-            database.countMetadataEntries(rootCountableId, expandSubWorkflows = expandSubWorkflows, 10 seconds)
-          count.futureValue(Timeout(10.seconds)) should be(7 * expansionFactor)
-        }
-
-        // Only includable keys - this looks for workflow level data only
-        {
-          val count = database.countMetadataEntries(rootCountableId,
-                                                    "includableKey",
-                                                    expandSubWorkflows = expandSubWorkflows,
-                                                    10 seconds
-          )
-          count.futureValue(Timeout(10.seconds)) should be(1 * expansionFactor)
-        }
-
-        {
-          val count = database.countMetadataEntries(rootCountableId,
-                                                    "includableCall",
-                                                    Option(0),
-                                                    Option(1),
-                                                    expandSubWorkflows = expandSubWorkflows,
-                                                    10 seconds
-          )
-          count.futureValue(Timeout(10 seconds)) should be(2 * expansionFactor)
-        }
-
-        {
-          val count = database.countMetadataEntries(rootCountableId,
-                                                    "includableKey",
-                                                    "includableCall",
-                                                    Option(0),
-                                                    Option(1),
-                                                    expandSubWorkflows = expandSubWorkflows,
-                                                    10 seconds
-          )
-          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
-        }
-      }
-    }
-
     it should "fetch failed tasks from a failed workflow" taggedAs DbmsTest in {
       database
         .runTestTransaction(

--- a/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
+++ b/services/src/test/scala/cromwell/services/database/MetadataSlickDatabaseSpec.scala
@@ -8,7 +8,6 @@ import cromwell.core.{WorkflowId, WorkflowMetadataKeys}
 import cromwell.database.migration.metadata.table.symbol.MetadataStatement._
 import cromwell.database.slick.MetadataSlickDatabase
 import cromwell.database.slick.MetadataSlickDatabase.SummarizationPartitionedMetadata
-import cromwell.database.sql.joins.{CallOrWorkflowQuery, CallQuery, WorkflowQuery}
 import cromwell.database.sql.tables.{MetadataEntry, WorkflowMetadataSummaryEntry}
 import cromwell.services.metadata.CallMetadataKeys
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
@@ -594,42 +593,6 @@ class MetadataSlickDatabaseSpec extends AnyFlatSpec with CromwellTimeoutSpec wit
                                                     Option(1),
                                                     expandSubWorkflows = expandSubWorkflows,
                                                     10 seconds
-          )
-          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
-        }
-
-        {
-          val count = database.countMetadataEntryWithKeyConstraints(
-            workflowExecutionUuid = rootCountableId,
-            metadataKeysToFilterFor = List("includable%"),
-            metadataKeysToFilterOut = List("excludable%"),
-            CallQuery("includableCall", Option(0), Option(1)),
-            expandSubWorkflows = expandSubWorkflows,
-            10 seconds
-          )
-          count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
-        }
-
-        {
-          val count = database.countMetadataEntryWithKeyConstraints(
-            workflowExecutionUuid = rootCountableId,
-            metadataKeysToFilterFor = List("includable%"),
-            metadataKeysToFilterOut = List("excludable%"),
-            CallOrWorkflowQuery,
-            expandSubWorkflows = expandSubWorkflows,
-            10 seconds
-          )
-          count.futureValue(Timeout(10 seconds)) should be(4 * expansionFactor)
-        }
-
-        {
-          val count = database.countMetadataEntryWithKeyConstraints(
-            workflowExecutionUuid = rootCountableId,
-            metadataKeysToFilterFor = List("includable%"),
-            metadataKeysToFilterOut = List("excludable%"),
-            WorkflowQuery,
-            expandSubWorkflows = expandSubWorkflows,
-            10 seconds
           )
           count.futureValue(Timeout(10 seconds)) should be(1 * expansionFactor)
         }

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -529,15 +529,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
     )(implicit ec: ExecutionContext): Future[Int] =
       notImplemented()
 
-    override def countMetadataEntryWithKeyConstraints(workflowExecutionUuid: String,
-                                                      metadataKeysToFilterFor: List[String],
-                                                      metadataKeysToFilterAgainst: List[String],
-                                                      metadataJobQueryValue: MetadataJobQueryValue,
-                                                      expandSubWorkflows: Boolean,
-                                                      timeout: Duration
-    )(implicit ec: ExecutionContext): Future[Int] =
-      notImplemented()
-
     override def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit
       ec: ExecutionContext
     ): Future[(Option[String], Option[Timestamp])] = notImplemented()

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -498,27 +498,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
     override def getSummaryQueueSize()(implicit ec: ExecutionContext): Future[Int] =
       notImplemented()
 
-    override def countMetadataEntries(workflowExecutionUuid: String, expandSubWorkflows: Boolean, timeout: Duration)(
-      implicit ec: ExecutionContext
-    ): Future[Int] =
-      notImplemented()
-
-    override def countMetadataEntries(workflowExecutionUuid: String,
-                                      metadataKey: String,
-                                      expandSubWorkflows: Boolean,
-                                      timeout: Duration
-    )(implicit ec: ExecutionContext): Future[Int] =
-      notImplemented()
-
-    override def countMetadataEntries(workflowExecutionUuid: String,
-                                      callFullyQualifiedName: String,
-                                      jobIndex: Option[Int],
-                                      jobAttempt: Option[Int],
-                                      expandSubWorkflows: Boolean,
-                                      timeout: Duration
-    )(implicit ec: ExecutionContext): Future[Int] =
-      notImplemented()
-
     override def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit
       ec: ExecutionContext
     ): Future[(Option[String], Option[Timestamp])] = notImplemented()

--- a/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
+++ b/services/src/test/scala/cromwell/services/metadata/impl/WriteMetadataActorSpec.scala
@@ -519,16 +519,6 @@ class WriteMetadataActorSpec extends TestKitSuite with AnyFlatSpecLike with Matc
     )(implicit ec: ExecutionContext): Future[Int] =
       notImplemented()
 
-    override def countMetadataEntries(workflowUuid: String,
-                                      metadataKey: String,
-                                      callFullyQualifiedName: String,
-                                      jobIndex: Option[Int],
-                                      jobAttempt: Option[Int],
-                                      expandSubWorkflows: Boolean,
-                                      timeout: Duration
-    )(implicit ec: ExecutionContext): Future[Int] =
-      notImplemented()
-
     override def getMetadataArchiveStatusAndEndTime(workflowId: String)(implicit
       ec: ExecutionContext
     ): Future[(Option[String], Option[Timestamp])] = notImplemented()

--- a/src/ci/resources/dummy_application.conf
+++ b/src/ci/resources/dummy_application.conf
@@ -49,7 +49,5 @@ backend {
   }
 }
 
-services.MetadataService.config.metadata-read-row-number-safety-threshold = 2000000
-
 # We use this backend to test Metadata of Unusual Size so juice timeouts to unwise levels
 akka.http.server.request-timeout = 5 minutes


### PR DESCRIPTION
### Description

Remove a useful but superseded Cromwell robustness mechanism: count the rows in a hypothetical metadata query, before committing to actually select the rows.

Counting & limiting prevented us from loading 100M row workflows into memory and crashing the application. But we have since imposed upstream limit in https://github.com/broadinstitute/cromwell/pull/7874 that makes the scenario impossible. In practice, I can't recall seeing the row retrieval limit taking effect; there are no instances in the full extent of our logs (90 days?).

**As a bonus:**

Performing a `COUNT` followed by a `SELECT` is very expensive! The real world Prod workflow `4c0c37ac-27b8-4cbe-9035-cb3f642048e4` has logged about 5M rows of metadata and its timings are as follows:

- `COUNT` 6-8s
- `SELECT` 2-3s

So this user may see a 60% reduction in page load times.

Reverts https://github.com/broadinstitute/cromwell/pull/5519

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users