### PR TITLE
CORE-40: Honor WDL disks size in AWS Batch backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 93 Release Notes
 ### AWS Batch
 * Added `tagAliases` backend config option, which duplicates engine-generated tags (e.g. `cromwell-workflow-id`) under alternative key names for external systems like cost-tracking tools. See the [Tag Aliases](supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/README.md#tag-aliases) section for configuration details.
+* The `disks` WDL runtime attribute size is now honored on EC2 Batch compute environments. Previously, the size component (e.g. `500` in `local-disk 500 HDD`) was silently discarded and tasks shared whatever EBS was attached to the host instance. When a size greater than zero is specified, each task now receives a dedicated gp3 EBS volume of exactly the requested size, provisioned before the task runs and deleted on exit — matching the per-task disk lifecycle of the GCP Batch backend. This requires an AMI built with the `cromwell-disk-utils` bundle at `/usr/local/cromwell-disk-utils` and IAM permissions for `ec2:CreateVolume`, `ec2:AttachVolume`, `ec2:DetachVolume`, `ec2:DeleteVolume`, `ec2:DescribeVolumes`, and `ec2:CreateTags` on the batch instance role. Tasks with no `disks` attribute or a zero-size disk are unaffected.
 
 ### General
 

--- a/docs/RuntimeAttributes.md
+++ b/docs/RuntimeAttributes.md
@@ -213,7 +213,7 @@ They are specified as a comma separated list of disks. Each disk is further sepa
 
 All tasks launched on Google Cloud *must* have a `local-disk`.  If one is not specified in the runtime section of the task, then a default of `local-disk 10 SSD` will be used.  The `local-disk` will be mounted to `/cromwell_root`.
 
-For the AWS Batch backend, the disk volume is managed by AWS EBS with autoscaling capabilities.  As such, the Disk size and disk type will be ignored. If provided, the mount point will be verified at runtime.
+For the AWS Batch backend (EC2 compute environments), the disk size is honored: when a size greater than zero is specified, each task receives a dedicated gp3 EBS volume of exactly the requested size, provisioned before the task runs and deleted on exit. The disk type field is ignored. If no size is specified (e.g. bare `local-disk`), the task uses the EBS volume already attached to the host instance.
 
 
 The Disk type must be one of "LOCAL", "SSD", or "HDD". When set to "LOCAL", the size of the drive is constrained to 375 GB intervals so intermediate values will be rounded up to the next 375 GB. All disks are set to auto-delete after the job completes.

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -82,10 +82,9 @@ trait AwsBatchJobDefinitionBuilder {
    */
   def containerPropertiesBuilder(context: AwsBatchJobDefinitionContext): (ContainerProperties.Builder, String) = {
 
-    val workingDiskSizeGb: Int = context.runtimeAttributes.disks
+    val workingDiskSizeGb: Option[Int] = context.runtimeAttributes.disks
       .find(_.name == AwsBatchWorkingDisk.Name)
-      .map(_.sizeGb)
-      .getOrElse(0)
+      .flatMap(_.sizeGb)
 
     def buildVolumes(disks: Seq[AwsBatchVolume], fsx: Option[List[String]]): List[Volume] = {
 
@@ -95,7 +94,7 @@ trait AwsBatchJobDefinitionBuilder {
         case false => List()
       }
 
-      val diskProvisioningVolumes: List[Volume] = if (workingDiskSizeGb > 0) {
+      val diskProvisioningVolumes: List[Volume] = if (workingDiskSizeGb.isDefined) {
         List(
           Volume
             .builder()
@@ -136,7 +135,7 @@ trait AwsBatchJobDefinitionBuilder {
         case false => List()
       }
 
-      val diskProvisioningMounts: List[MountPoint] = if (workingDiskSizeGb > 0) {
+      val diskProvisioningMounts: List[MountPoint] = if (workingDiskSizeGb.isDefined) {
         List(
           MountPoint
             .builder()
@@ -210,9 +209,11 @@ trait AwsBatchJobDefinitionBuilder {
           .toInt}:${fuseMount.toString}:${jobTimeout}:$roleArnStr"
     }
 
-    val environment: List[KeyValuePair] = if (workingDiskSizeGb > 0) {
-      List(KeyValuePair.builder().name("CROMWELL_DISK_GB").value(workingDiskSizeGb.toString).build())
-    } else List.empty[KeyValuePair]
+    val environment: List[KeyValuePair] = workingDiskSizeGb
+      .map { gb =>
+        List(KeyValuePair.builder().name("CROMWELL_DISK_GB").value(gb.toString).build())
+      }
+      .getOrElse(List.empty)
     val cmdName = context.runtimeAttributes.fileSystem match {
       case AWSBatchStorageSystems.s3 => "/var/scratch/fetch_and_run.sh"
       case _ => context.commandText
@@ -272,7 +273,7 @@ trait AwsBatchJobDefinitionBuilder {
     }
 
     val linuxParameters = linuxParametersBuilder.build()
-    val privileged = context.runtimeAttributes.fuseMount || workingDiskSizeGb > 0
+    val privileged = context.runtimeAttributes.fuseMount || workingDiskSizeGb.isDefined
 
     val builderWithBasicProperties = ContainerProperties
       .builder()

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -32,7 +32,7 @@
 package cromwell.backend.impl.aws
 
 import cromwell.backend.BackendJobDescriptor
-import cromwell.backend.impl.aws.io.AwsBatchVolume
+import cromwell.backend.impl.aws.io.{AwsBatchVolume, AwsBatchWorkingDisk}
 import cromwell.backend.io.JobPaths
 import org.apache.commons.lang3.builder.{ToStringBuilder, ToStringStyle}
 import org.slf4j.{Logger, LoggerFactory}
@@ -82,6 +82,11 @@ trait AwsBatchJobDefinitionBuilder {
    */
   def containerPropertiesBuilder(context: AwsBatchJobDefinitionContext): (ContainerProperties.Builder, String) = {
 
+    val workingDiskSizeGb: Int = context.runtimeAttributes.disks
+      .find(_.name == AwsBatchWorkingDisk.Name)
+      .map(_.sizeGb)
+      .getOrElse(0)
+
     def buildVolumes(disks: Seq[AwsBatchVolume], fsx: Option[List[String]]): List[Volume] = {
 
       val fsx_volumes = fsx.isDefined match {
@@ -89,6 +94,16 @@ trait AwsBatchJobDefinitionBuilder {
           fsx.get.map(mnt => Volume.builder().name(mnt).host(Host.builder().sourcePath(s"/$mnt").build()).build())
         case false => List()
       }
+
+      val diskProvisioningVolumes: List[Volume] = if (workingDiskSizeGb > 0) {
+        List(
+          Volume
+            .builder()
+            .name("cromwellDiskUtils")
+            .host(Host.builder().sourcePath("/usr/local/cromwell-disk-utils").build())
+            .build()
+        )
+      } else List()
 
       // all the configured disks plus the fetch and run volume and the aws-cli volume
       disks.map(d => d.toVolume()).toList ++ List(
@@ -110,7 +125,7 @@ trait AwsBatchJobDefinitionBuilder {
           .name("instanceId")
           .host(Host.builder().sourcePath("/var/lib/cloud/data/instance-id").build())
           .build()
-      ) ++ fsx_volumes
+      ) ++ fsx_volumes ++ diskProvisioningVolumes
     }
 
     def buildMountPoints(disks: Seq[AwsBatchVolume], fsx: Option[List[String]]): List[MountPoint] = {
@@ -120,6 +135,17 @@ trait AwsBatchJobDefinitionBuilder {
           fsx.get.map(mnt => MountPoint.builder().readOnly(false).sourceVolume(mnt).containerPath(s"/$mnt").build())
         case false => List()
       }
+
+      val diskProvisioningMounts: List[MountPoint] = if (workingDiskSizeGb > 0) {
+        List(
+          MountPoint
+            .builder()
+            .readOnly(true)
+            .sourceVolume("cromwellDiskUtils")
+            .containerPath("/usr/local/cromwell-disk-utils")
+            .build()
+        )
+      } else List()
 
       // all the configured disks plus the fetch and run mount point and the AWS cli mount point
       disks.map(_.toMountPoint).toList ++ List(
@@ -143,7 +169,7 @@ trait AwsBatchJobDefinitionBuilder {
           .sourceVolume("instanceId")
           .containerPath("/var/lib/cloud/data/instance-id")
           .build()
-      ) ++ fsx_disks
+      ) ++ fsx_disks ++ diskProvisioningMounts
     }
 
     def buildUlimits(ulimits: Seq[Map[String, String]]): List[Ulimit] =
@@ -184,7 +210,9 @@ trait AwsBatchJobDefinitionBuilder {
           .toInt}:${fuseMount.toString}:${jobTimeout}:$roleArnStr"
     }
 
-    val environment = List.empty[KeyValuePair]
+    val environment: List[KeyValuePair] = if (workingDiskSizeGb > 0) {
+      List(KeyValuePair.builder().name("CROMWELL_DISK_GB").value(workingDiskSizeGb.toString).build())
+    } else List.empty[KeyValuePair]
     val cmdName = context.runtimeAttributes.fileSystem match {
       case AWSBatchStorageSystems.s3 => "/var/scratch/fetch_and_run.sh"
       case _ => context.commandText
@@ -244,8 +272,7 @@ trait AwsBatchJobDefinitionBuilder {
     }
 
     val linuxParameters = linuxParametersBuilder.build()
-    // simple true / false for now, depending on a single attribute
-    val privileged = context.runtimeAttributes.fuseMount
+    val privileged = context.runtimeAttributes.fuseMount || workingDiskSizeGb > 0
 
     val builderWithBasicProperties = ContainerProperties
       .builder()

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/AwsBatchJobDefinition.scala
@@ -273,6 +273,9 @@ trait AwsBatchJobDefinitionBuilder {
     }
 
     val linuxParameters = linuxParametersBuilder.build()
+    // privileged grants CAP_SYS_ADMIN (required for mount) and unrestricted block device
+    // access (required to reach the attached EBS volume). Both fuseMount and per-task disk
+    // provisioning need this; either condition activates it.
     val privileged = context.runtimeAttributes.fuseMount || workingDiskSizeGb.isDefined
 
     val builderWithBasicProperties = ContainerProperties

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
@@ -60,7 +60,7 @@ object AwsBatchVolume {
         Valid(AwsBatchWorkingDisk())
       case MountedDiskPattern(mountPoint) =>
         Valid(AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint)))
-      // Fall back to PAPI-style patterns and capture the size
+      // Fall back to standard WDL disk patterns (size and type) and capture the size
       case DiskPatterns.WorkingDiskPattern(sizeStr, _) =>
         Valid(AwsBatchWorkingDisk(sizeGb = Try(sizeStr.toInt).toOption.filter(_ > 0)))
       case DiskPatterns.MountedDiskPattern(mountPoint, sizeStr, fsType) =>

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
@@ -62,10 +62,13 @@ object AwsBatchVolume {
         Valid(AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint)))
       // Fall back to PAPI-style patterns and capture the size
       case DiskPatterns.WorkingDiskPattern(sizeStr, _) =>
-        Valid(AwsBatchWorkingDisk(sizeGb = Try(sizeStr.toInt).getOrElse(0)))
+        Valid(AwsBatchWorkingDisk(sizeGb = Try(sizeStr.toInt).toOption.filter(_ > 0)))
       case DiskPatterns.MountedDiskPattern(mountPoint, sizeStr, fsType) =>
         Valid(
-          AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint), fsType, sizeGb = Try(sizeStr.toInt).getOrElse(0))
+          AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint),
+                                   fsType,
+                                   sizeGb = Try(sizeStr.toInt).toOption.filter(_ > 0)
+          )
         )
       case _ =>
         s"Disk strings should be of the format 'local-disk' or '/mount/point' but got: '$s'".invalidNel
@@ -87,7 +90,7 @@ trait AwsBatchVolume {
   def name: String
   def mountPoint: Path
   def fsType: String
-  def sizeGb: Int
+  def sizeGb: Option[Int]
   def getHostPath(id: Option[String]): String =
     id match {
       case Some(id) => mountPoint.toAbsolutePath.pathAsString + "/" + id
@@ -105,10 +108,11 @@ trait AwsBatchVolume {
       .build
 }
 
-case class AwsBatchEmptyMountedDisk(mountPoint: Path, ftype: String = "ebs", sizeGb: Int = 0) extends AwsBatchVolume {
+case class AwsBatchEmptyMountedDisk(mountPoint: Path, ftype: String = "ebs", sizeGb: Option[Int] = None)
+    extends AwsBatchVolume {
   val name = s"d-${mountPoint.pathAsString.md5Sum}"
   val fsType = ftype.toLowerCase
-  override def toString: String = s"$name $mountPoint $sizeGb"
+  override def toString: String = sizeGb.fold(s"$name $mountPoint")(gb => s"$name $mountPoint $gb")
 }
 
 object AwsBatchWorkingDisk {
@@ -118,9 +122,9 @@ object AwsBatchWorkingDisk {
   val Default = AwsBatchWorkingDisk()
 }
 
-case class AwsBatchWorkingDisk(sizeGb: Int = 0) extends AwsBatchVolume {
+case class AwsBatchWorkingDisk(sizeGb: Option[Int] = None) extends AwsBatchVolume {
   val mountPoint = AwsBatchWorkingDisk.MountPoint
   val name = AwsBatchWorkingDisk.Name
   val fsType = AwsBatchWorkingDisk.fsType
-  override def toString: String = s"$name $mountPoint $sizeGb"
+  override def toString: String = sizeGb.fold(s"$name $mountPoint")(gb => s"$name $mountPoint $gb")
 }

--- a/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
+++ b/supportedBackends/aws/src/main/scala/cromwell/backend/impl/aws/io/AwsBatchVolume.scala
@@ -60,11 +60,13 @@ object AwsBatchVolume {
         Valid(AwsBatchWorkingDisk())
       case MountedDiskPattern(mountPoint) =>
         Valid(AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint)))
-      // In addition to the AWS-specific patterns above, we can also fall back to PAPI-style patterns and ignore the size
-      case DiskPatterns.WorkingDiskPattern(_, _) =>
-        Valid(AwsBatchWorkingDisk())
-      case DiskPatterns.MountedDiskPattern(mountPoint, _, fsType) =>
-        Valid(AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint), fsType))
+      // Fall back to PAPI-style patterns and capture the size
+      case DiskPatterns.WorkingDiskPattern(sizeStr, _) =>
+        Valid(AwsBatchWorkingDisk(sizeGb = Try(sizeStr.toInt).getOrElse(0)))
+      case DiskPatterns.MountedDiskPattern(mountPoint, sizeStr, fsType) =>
+        Valid(
+          AwsBatchEmptyMountedDisk(DefaultPathBuilder.get(mountPoint), fsType, sizeGb = Try(sizeStr.toInt).getOrElse(0))
+        )
       case _ =>
         s"Disk strings should be of the format 'local-disk' or '/mount/point' but got: '$s'".invalidNel
 
@@ -85,6 +87,7 @@ trait AwsBatchVolume {
   def name: String
   def mountPoint: Path
   def fsType: String
+  def sizeGb: Int
   def getHostPath(id: Option[String]): String =
     id match {
       case Some(id) => mountPoint.toAbsolutePath.pathAsString + "/" + id
@@ -102,10 +105,10 @@ trait AwsBatchVolume {
       .build
 }
 
-case class AwsBatchEmptyMountedDisk(mountPoint: Path, ftype: String = "ebs") extends AwsBatchVolume {
+case class AwsBatchEmptyMountedDisk(mountPoint: Path, ftype: String = "ebs", sizeGb: Int = 0) extends AwsBatchVolume {
   val name = s"d-${mountPoint.pathAsString.md5Sum}"
   val fsType = ftype.toLowerCase
-  override def toString: String = s"$name $mountPoint"
+  override def toString: String = s"$name $mountPoint $sizeGb"
 }
 
 object AwsBatchWorkingDisk {
@@ -115,9 +118,9 @@ object AwsBatchWorkingDisk {
   val Default = AwsBatchWorkingDisk()
 }
 
-case class AwsBatchWorkingDisk() extends AwsBatchVolume {
+case class AwsBatchWorkingDisk(sizeGb: Int = 0) extends AwsBatchVolume {
   val mountPoint = AwsBatchWorkingDisk.MountPoint
   val name = AwsBatchWorkingDisk.Name
   val fsType = AwsBatchWorkingDisk.fsType
-  override def toString: String = s"$name $mountPoint"
+  override def toString: String = s"$name $mountPoint $sizeGb"
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttachedDiskSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttachedDiskSpec.scala
@@ -32,7 +32,7 @@
 package cromwell.backend.impl.aws
 
 import common.assertion.CromwellTimeoutSpec
-import cromwell.backend.impl.aws.io.{AwsBatchEmptyMountedDisk, AwsBatchWorkingDisk}
+import cromwell.backend.impl.aws.io.{AwsBatchEmptyMountedDisk, AwsBatchVolume, AwsBatchWorkingDisk}
 import cromwell.core.path.DefaultPathBuilder
 import org.scalatest.TryValues
 import org.scalatest.flatspec.AnyFlatSpec
@@ -41,40 +41,49 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
 
 class AwsBatchAttachedDiskSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with TryValues {
-  val validTable = Table(
-    ("unparsed", "parsed"),
-    // AwsBatchEmptyMountedDisk has a toString override that uses the MD5sum of
-    // the mount path in the return value, so these values are deterministic
-    ("d-39de0dbcfb68c8735bd088c62fa061a4 /mnt", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"))),
-    ("d-753b3ff55ce6e29b10951ad6190f7c84 /mnt/my_path",
-     AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt/my_path"))
+
+  // toString includes sizeGb so tasks with different disk sizes produce different job definition hashes
+  val stringifyTable = Table(
+    ("disk", "expected"),
+    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt")), "d-39de0dbcfb68c8735bd088c62fa061a4 /mnt 0"),
+    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt/my_path")),
+     "d-753b3ff55ce6e29b10951ad6190f7c84 /mnt/my_path 0"
     ),
-    ("local-disk /cromwell_root", AwsBatchWorkingDisk())
+    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "ssd", 200),
+     "d-39de0dbcfb68c8735bd088c62fa061a4 /mnt 200"
+    ),
+    (AwsBatchWorkingDisk(), "local-disk /cromwell_root 0"),
+    (AwsBatchWorkingDisk(sizeGb = 500), "local-disk /cromwell_root 500")
   )
 
-  // TODO: Work through this syntax
-  // it should "parse" in {
-  //   forAll(validTable) { (unparsed, parsed) =>
-  //     AwsBatchAttachedDisk.parse(unparsed).get shouldEqual parsed
-  //   }
-  // }
-
-  it should "stringify" in {
-    forAll(validTable) { (unparsed, parsed) =>
-      parsed.toString shouldEqual unparsed
+  it should "stringify including sizeGb" in {
+    forAll(stringifyTable) { (disk, expected) =>
+      disk.toString shouldEqual expected
     }
   }
 
-  val invalidTable = Table(
-    "unparsed",
-    "BAD",
-    "foobar"
+  val parseTable = Table(
+    ("wdlString", "expected"),
+    // AWS-specific short-form (no size): sizeGb = 0, no EBS provisioning
+    ("local-disk", AwsBatchWorkingDisk()),
+    ("/mnt", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"))),
+    // PAPI-style with explicit size: sizeGb is captured for per-task EBS provisioning
+    ("local-disk 500 HDD", AwsBatchWorkingDisk(sizeGb = 500)),
+    ("local-disk 0 HDD", AwsBatchWorkingDisk(sizeGb = 0)),
+    ("/mnt 200 SSD", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "SSD", sizeGb = 200))
   )
 
-  // TODO: Work through this syntax
-  // it should "reject malformed disk mounts" in {
-  //   forAll(invalidTable) { (unparsed) =>
-  //     AwsBatchAttachedDisk.parse(unparsed) should be(a[Failure[_]])
-  //   }
-  // }
+  it should "parse WDL disk strings, capturing explicit sizes" in {
+    forAll(parseTable) { (wdlString, expected) =>
+      AwsBatchVolume.parse(wdlString).success.value shouldEqual expected
+    }
+  }
+
+  val invalidTable = Table("unparsed", "BAD", "foobar")
+
+  it should "reject malformed disk mounts" in {
+    forAll(invalidTable) { unparsed =>
+      AwsBatchVolume.parse(unparsed).isFailure should be(true)
+    }
+  }
 }

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttachedDiskSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchAttachedDiskSpec.scala
@@ -42,21 +42,21 @@ import org.scalatest.prop.Tables.Table
 
 class AwsBatchAttachedDiskSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers with TryValues {
 
-  // toString includes sizeGb so tasks with different disk sizes produce different job definition hashes
+  // toString includes sizeGb when present so tasks with different disk sizes produce different job definition hashes
   val stringifyTable = Table(
     ("disk", "expected"),
-    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt")), "d-39de0dbcfb68c8735bd088c62fa061a4 /mnt 0"),
+    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt")), "d-39de0dbcfb68c8735bd088c62fa061a4 /mnt"),
     (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt/my_path")),
-     "d-753b3ff55ce6e29b10951ad6190f7c84 /mnt/my_path 0"
+     "d-753b3ff55ce6e29b10951ad6190f7c84 /mnt/my_path"
     ),
-    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "ssd", 200),
+    (AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "ssd", Some(200)),
      "d-39de0dbcfb68c8735bd088c62fa061a4 /mnt 200"
     ),
-    (AwsBatchWorkingDisk(), "local-disk /cromwell_root 0"),
-    (AwsBatchWorkingDisk(sizeGb = 500), "local-disk /cromwell_root 500")
+    (AwsBatchWorkingDisk(), "local-disk /cromwell_root"),
+    (AwsBatchWorkingDisk(sizeGb = Some(500)), "local-disk /cromwell_root 500")
   )
 
-  it should "stringify including sizeGb" in {
+  it should "stringify including sizeGb when present" in {
     forAll(stringifyTable) { (disk, expected) =>
       disk.toString shouldEqual expected
     }
@@ -64,13 +64,12 @@ class AwsBatchAttachedDiskSpec extends AnyFlatSpec with CromwellTimeoutSpec with
 
   val parseTable = Table(
     ("wdlString", "expected"),
-    // AWS-specific short-form (no size): sizeGb = 0, no EBS provisioning
+    // AWS-specific short-form (no size): sizeGb = None, no EBS provisioning
     ("local-disk", AwsBatchWorkingDisk()),
     ("/mnt", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"))),
     // PAPI-style with explicit size: sizeGb is captured for per-task EBS provisioning
-    ("local-disk 500 HDD", AwsBatchWorkingDisk(sizeGb = 500)),
-    ("local-disk 0 HDD", AwsBatchWorkingDisk(sizeGb = 0)),
-    ("/mnt 200 SSD", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "SSD", sizeGb = 200))
+    ("local-disk 500 HDD", AwsBatchWorkingDisk(sizeGb = Some(500))),
+    ("/mnt 200 SSD", AwsBatchEmptyMountedDisk(DefaultPathBuilder.get("/mnt"), "SSD", sizeGb = Some(200)))
   )
 
   it should "parse WDL disk strings, capturing explicit sizes" in {
@@ -79,7 +78,7 @@ class AwsBatchAttachedDiskSpec extends AnyFlatSpec with CromwellTimeoutSpec with
     }
   }
 
-  val invalidTable = Table("unparsed", "BAD", "foobar")
+  val invalidTable = Table("unparsed", "BAD", "foobar", "local-disk 0 HDD")
 
   it should "reject malformed disk mounts" in {
     forAll(invalidTable) { unparsed =>

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -264,7 +264,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
       containerProperties.volumes().asScala.map(_.name()) should contain("cromwellDiskUtils")
       containerProperties.mountPoints().asScala.map(_.sourceVolume()) should contain("cromwellDiskUtils")
       containerProperties.mountPoints().asScala.map(_.containerPath()) should contain("/usr/local/cromwell-disk-utils")
-      containerProperties.privileged() should be(true)
+      containerProperties.privileged() shouldBe true
     }
 
     "not mount cromwellDiskUtils volume and not set privileged when working disk sizeGb is 0" in {
@@ -273,7 +273,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
 
       containerProperties.volumes().asScala.map(_.name()) should not contain "cromwellDiskUtils"
       containerProperties.mountPoints().asScala.map(_.sourceVolume()) should not contain "cromwellDiskUtils"
-      containerProperties.privileged() should be(false)
+      containerProperties.privileged() shouldBe false
     }
 
     "produce distinct job definition names for different working disk sizes" in {

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -238,7 +238,7 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
     }
 
     "set CROMWELL_DISK_GB environment variable when working disk sizeGb > 0" in {
-      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = Some(500)))))
       val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
       val envNames = containerProperties.environment().asScala.map(_.name())
 
@@ -251,14 +251,14 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
     }
 
     "not set CROMWELL_DISK_GB environment variable when working disk sizeGb is 0" in {
-      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 0))))
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk())))
       val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
 
       containerProperties.environment().asScala.map(_.name()) should not contain "CROMWELL_DISK_GB"
     }
 
     "mount cromwellDiskUtils volume and set privileged when working disk sizeGb > 0" in {
-      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = Some(500)))))
       val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
 
       containerProperties.volumes().asScala.map(_.name()) should contain("cromwellDiskUtils")
@@ -277,8 +277,8 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
     }
 
     "produce distinct job definition names for different working disk sizes" in {
-      val context100 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 100))))
-      val context500 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+      val context100 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = Some(100)))))
+      val context500 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = Some(500)))))
 
       val name100 = StandardAwsBatchJobDefinitionBuilder.build(context100).name
       val name500 = StandardAwsBatchJobDefinitionBuilder.build(context500).name

--- a/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
+++ b/supportedBackends/aws/src/test/scala/cromwell/backend/impl/aws/AwsBatchJobDefinitionSpec.scala
@@ -2,6 +2,7 @@ package cromwell.backend.impl.aws
 
 import common.mock.MockSugar
 import cromwell.backend.BackendSpec._
+import cromwell.backend.impl.aws.io.AwsBatchWorkingDisk
 import cromwell.backend.io.JobPaths
 import cromwell.backend.{BackendJobDescriptor, BackendJobDescriptorKey, BackendWorkflowDescriptor}
 import cromwell.core.callcaching.NoDocker
@@ -14,6 +15,8 @@ import spray.json.{JsObject, JsString}
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 import wom.graph.CommandCallNode
+
+import scala.jdk.CollectionConverters._
 
 class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockSugar {
 
@@ -67,6 +70,26 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
 
   // Mock job paths for testing
   val mockJobPaths: JobPaths = mock[JobPaths]
+
+  private def buildContext(attrs: AwsBatchRuntimeAttributes): AwsBatchJobDefinitionContext =
+    AwsBatchJobDefinitionContext(
+      runtimeAttributes = attrs,
+      commandText = "echo hello",
+      dockerRcPath = "/tmp/rc.txt",
+      dockerStdoutPath = "/tmp/stdout.log",
+      dockerStderrPath = "/tmp/stderr.log",
+      jobDescriptor = jobDescriptor,
+      jobPaths = mockJobPaths,
+      inputs = Set.empty,
+      outputs = Set.empty,
+      fsxMntPoint = None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None
+    )
 
   "AwsBatchJobDefinition StandardAwsBatchJobDefinitionBuilder" should {
 
@@ -212,6 +235,55 @@ class AwsBatchJobDefinitionSpec extends AnyWordSpecLike with Matchers with MockS
 
       // Verify no job role ARN is set when not provided
       Option(containerProperties.jobRoleArn()).isEmpty should be(true)
+    }
+
+    "set CROMWELL_DISK_GB environment variable when working disk sizeGb > 0" in {
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+      val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
+      val envNames = containerProperties.environment().asScala.map(_.name())
+
+      envNames should contain("CROMWELL_DISK_GB")
+      containerProperties
+        .environment()
+        .asScala
+        .find(_.name() == "CROMWELL_DISK_GB")
+        .map(_.value()) shouldEqual Some("500")
+    }
+
+    "not set CROMWELL_DISK_GB environment variable when working disk sizeGb is 0" in {
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 0))))
+      val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
+
+      containerProperties.environment().asScala.map(_.name()) should not contain "CROMWELL_DISK_GB"
+    }
+
+    "mount cromwellDiskUtils volume and set privileged when working disk sizeGb > 0" in {
+      val context = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+      val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
+
+      containerProperties.volumes().asScala.map(_.name()) should contain("cromwellDiskUtils")
+      containerProperties.mountPoints().asScala.map(_.sourceVolume()) should contain("cromwellDiskUtils")
+      containerProperties.mountPoints().asScala.map(_.containerPath()) should contain("/usr/local/cromwell-disk-utils")
+      containerProperties.privileged() should be(true)
+    }
+
+    "not mount cromwellDiskUtils volume and not set privileged when working disk sizeGb is 0" in {
+      val context = buildContext(runtimeAttributes)
+      val containerProperties = StandardAwsBatchJobDefinitionBuilder.build(context).containerProperties
+
+      containerProperties.volumes().asScala.map(_.name()) should not contain "cromwellDiskUtils"
+      containerProperties.mountPoints().asScala.map(_.sourceVolume()) should not contain "cromwellDiskUtils"
+      containerProperties.privileged() should be(false)
+    }
+
+    "produce distinct job definition names for different working disk sizes" in {
+      val context100 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 100))))
+      val context500 = buildContext(runtimeAttributes.copy(disks = Seq(AwsBatchWorkingDisk(sizeGb = 500))))
+
+      val name100 = StandardAwsBatchJobDefinitionBuilder.build(context100).name
+      val name500 = StandardAwsBatchJobDefinitionBuilder.build(context500).name
+
+      name100 should not equal name500
     }
   }
 }


### PR DESCRIPTION
Ticket: https://manifoldai.atlassian.net/browse/CORE-40

## Summary

Fixes CORE-40: the AWS Batch backend was silently discarding the disk size from WDL \`disks\` runtime attributes (e.g. \`local-disk 500 HDD\`), causing all tasks to use whatever EBS was attached to the EC2 host rather than the size the workflow requested.

This brings AWS Batch to GCP Batch parity: each task gets a dedicated EBS volume of exactly the requested size, provisioned at task start and deleted on exit.

## Why container-side provisioning is necessary

A native AWS Batch EBS-per-task API would be preferable. We verified that none exists. The AWS Batch SDK \`Volume\` class was inspected across versions:

| SDK version | Volume types supported |
|---|---|
| 2.29.20 (currently used) | \`host\`, \`efsVolumeConfiguration\` |
| 2.45.1 (latest as of June 2026) | \`host\`, \`efsVolumeConfiguration\`, \`s3filesVolumeConfiguration\` |

No \`ebsVolumeConfiguration\` exists in either version. \`EphemeralStorage\` does allow specifying a size but is explicitly documented as Fargate-only and capped at 200 GiB. Amazon ECS gained native per-task EBS attachment at re:Invent 2023, but AWS Batch has not yet surfaced this capability in its own API.

This implementation is designed to be forward-compatible: if AWS adds native EBS to the Batch SDK, \`sizeGb: Option[Int]\` in \`AwsBatchVolume\` stays unchanged and the container-side provisioning block in \`AwsBatchJobDefinition\` is replaced with a \`Volume.builder().ebsVolumeConfiguration(...)\` call.

## Changes

**\`AwsBatchVolume.scala\`**
- Added \`sizeGb: Option[Int]\` to the \`AwsBatchVolume\` trait and both concrete classes (\`AwsBatchWorkingDisk\`, \`AwsBatchEmptyMountedDisk\`)
- \`parse()\` now captures the size from PAPI-style patterns instead of discarding it with \`_\`; bare \`local-disk\` (no size) and zero-size strings parse to \`None\`
- \`toString\` includes \`sizeGb\` when present so tasks with different disk sizes produce distinct job definition hashes (no stale cache hits)

**\`AwsBatchJobDefinition.scala\`**
- Computes \`workingDiskSizeGb: Option[Int]\` from \`runtimeAttributes.disks\`
- When \`workingDiskSizeGb.isDefined\`:
  - Sets \`CROMWELL_DISK_GB\` environment variable (read by \`fetch_and_run.sh\` on the AMI)
  - Adds a read-only bind-mount of \`/usr/local/cromwell-disk-utils\` from the host into the container (provides portable \`mkfs.ext4\`, \`mount\`, \`umount\` that work in any Docker image)
  - Sets \`privileged = true\` so the container has \`CAP_SYS_ADMIN\` (required for \`mount\`) and unrestricted block device access (required to reach the attached EBS volume)

## Infrastructure companion (science-cloud repo)

The companion PR https://github.com/manifoldai/science-cloud/pull/23360 provides:
- AMI bootstrap script building the \`cromwell-disk-utils\` portable binary bundle
- \`fetch_and_run.sh\` rewritten to provision/mount/delete an EBS volume when \`CROMWELL_DISK_GB\` is set
- IAM policy granting the batch instance role the six EC2 permissions needed for the EBS lifecycle

## Test plan

- [ ] Unit: \`AwsBatchAttachedDiskSpec\` — parse and stringify tests for \`sizeGb\`
- [ ] Unit: \`AwsBatchJobDefinitionSpec\` — \`CROMWELL_DISK_GB\` env var, \`cromwellDiskUtils\` volume/mount, \`privileged\` flag present when disk size set; absent when not
- [ ] End-to-end: submit a WDL workflow with \`disks: "local-disk 100 HDD"\`; confirm a 100 GiB gp3 volume is created, mounted at \`/cromwell_root\`, and deleted after the task completes
- [ ] Regression: submit a WDL workflow with no \`disks\` attribute; confirm no EBS activity and behaviour is unchanged