### PR TITLE
CTM-518 Resume sending project to DRSHub

### DIFF
--- a/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerMain.scala
+++ b/cromwell-drs-localizer/src/main/scala/drs/localizer/DrsLocalizerMain.scala
@@ -147,10 +147,7 @@ class DrsLocalizerMain(toResolveAndDownload: IO[List[UnresolvedDrsUrl]],
     IO {
       val drsConfig = DrsConfig.fromEnv(sys.env)
       logger.info(s"Using ${drsConfig.drsResolverUrl} to resolve DRS Objects")
-
-      // Temporary revert: set requesterPaysProjectIdOption to `None` while
-      // debugging new passport feature (CTM-494)
-      new DrsPathResolver(drsConfig, drsCredentials, None)
+      new DrsPathResolver(drsConfig, drsCredentials, requesterPaysProjectIdOption)
     }
 
   /**

--- a/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
+++ b/filesystems/drs/src/main/scala/cromwell/filesystems/drs/DrsPathBuilderFactory.scala
@@ -67,8 +67,6 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
               .getBoolean("resolver.preresolve")
           )
 
-      // Temporary revert: set #2 to `None` while debugging new passport feature (CTM-494)
-      //
       // requesterPaysProjectIdOption is passed twice because it is needed in two different DRS resolution paths:
       // 1. To DrsReader.readInterpreter: used by GcsReader when a DRS URI resolves to a gsUri, so that
       //    requester-pays GCS buckets can be accessed.
@@ -79,7 +77,7 @@ class DrsPathBuilderFactory(globalConfig: Config, instanceConfig: Config, single
           singletonConfig.config,
           drsCredentials,
           DrsReader.readInterpreter(googleAuthMode, options, requesterPaysProjectIdOption),
-          None
+          requesterPaysProjectIdOption
         ),
         requesterPaysProjectIdOption,
         preResolve


### PR DESCRIPTION
### Description

Per @snf2ye today, we are good to restore sending project with immediate effect.

Reverts https://github.com/broadinstitute/cromwell/pull/7875
Reverts https://github.com/broadinstitute/cromwell/pull/7876

No related Rawls PR because we deleted all of that code!

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users