### PR TITLE
CTM-490, CTM-496 CVE updates

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   private val kittensV = "2.3.2"
   private val liquibaseV = "4.8.0"
   private val logbackV = "1.2.13"
-  private val lz4JavaV = "1.8.0"
+  private val lz4JavaV = "1.11.0"
   private val mariadbV = "2.7.4"
   /*
   The StatsD reporter for DropWizard's (Code Hale's) Metrics 3.x still works with Metrics 4.x.
@@ -512,7 +512,7 @@ object Dependencies {
   val tesBackendDependencies: List[ModuleID] = akkaHttpDependencies
 
   val sfsBackendDependencies = List (
-    "org.lz4" % "lz4-java" % lz4JavaV
+    "at.yawk.lz4" % "lz4-java" % lz4JavaV
   )
   val scalaTest = "org.scalatest" %% "scalatest" % scalatestV
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -76,7 +76,7 @@ object Dependencies {
   https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-29.html#mysqld-8-0-29-charset
    */
   private val mysqlV = "8.0.28"
-  private val nettyV = "4.2.12.Final"
+  private val nettyV = "4.2.14.Final"
   private val postgresV = "42.4.4"
   private val pprintV = "0.7.3"
   private val rdf4jV = "3.7.1"

--- a/src/ci/bin/testCentaurTes.sh
+++ b/src/ci/bin/testCentaurTes.sh
@@ -26,7 +26,7 @@ startup_funnel() {
         curl \
             --location \
             --output "${funnel_tar_gz}" \
-            "https://github.com/ohsu-comp-bio/funnel/releases/download/0.5.0/${funnel_tar_gz}"
+            "https://github.com/calypr/funnel/releases/download/0.5.0/${funnel_tar_gz}"
         tar xzf "${funnel_tar_gz}"
     fi
 


### PR DESCRIPTION
### Description

The only notable observation is that `lz4-java` became abandonware in its original incarnation, but there is a community fork created to continue security patches. Thus, we switch to the fork.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users