### PR TITLE
Always retry VMRecreatedDuringExecution batch errors

### DIFF
--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActor.scala
@@ -1238,16 +1238,20 @@ class GcpBatchAsyncBackendJobExecutionActor(override val standardParams: Standar
   }
 
   // Check whether this failure should be automatically resubmitted without counting against maxRetries.
-  // Guidance: Resubmit if the task has a known-transient failure type and has not yet cost the user money.
+  // Guidance: Resubmit if the task has a known-transient failure type and has not yet cost the user money,
+  // OR if the failure is a GCP-side infrastructure event that is not attributable to user code regardless of
+  // how long the task had been running (e.g. VMRecreatedDuringExecution, which by definition fires only after
+  // the task has started).
   private def isTransientFailure(failed: RunStatus.Failed): Boolean = {
-    lazy val errorTypeIsTransient = List(
+    lazy val errorTypeIsTransientBeforeRunning = List(
       GcpBatchExitCode.VMPreemption,
-      GcpBatchExitCode.VMRecreatedDuringExecution,
       GcpBatchExitCode.VMRebootedDuringExecution,
       GcpBatchExitCode.VMReportingTimeout
     ).contains(failed.errorCode)
+    lazy val errorTypeIsAlwaysTransient =
+      failed.errorCode == GcpBatchExitCode.VMRecreatedDuringExecution
     lazy val taskStartedRunning = failed.eventList.exists(e => executionEventRunningMatcher.matches(e.name))
-    transientErrorRetryable && errorTypeIsTransient && !taskStartedRunning
+    transientErrorRetryable && (errorTypeIsAlwaysTransient || (errorTypeIsTransientBeforeRunning && !taskStartedRunning))
   }
 
   private def handleTransientErrorRetry(failed: RunStatus.Failed, returnCode: Option[Int]) =

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -620,6 +620,12 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
       .isInstanceOf[FailedRetryableExecutionHandle] shouldBe true
     checkFailedResult(GcpBatchExitCode.VMRecreatedDuringExecution) // no VM start time - task has not started
       .isInstanceOf[FailedRetryableExecutionHandle] shouldBe true
+    // VMRecreatedDuringExecution is a GCP infrastructure event and should be retried even after the task
+    // has started running -- by definition it can only fire mid-execution.
+    checkFailedResult(
+      GcpBatchExitCode.VMRecreatedDuringExecution,
+      List(ExecutionEvent("Job state is set from SCHEDULED to RUNNING for job f00b4r", OffsetDateTime.now()))
+    ).isInstanceOf[FailedRetryableExecutionHandle] shouldBe true
     checkFailedResult(GcpBatchExitCode.VMReportingTimeout)
       .isInstanceOf[FailedRetryableExecutionHandle] shouldBe true
     checkFailedResult(
@@ -633,10 +639,6 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
       .isInstanceOf[FailedNonRetryableExecutionHandle] shouldBe true
     checkFailedResult(GcpBatchExitCode.TaskRunsOverMaximumRuntime)
       .isInstanceOf[FailedNonRetryableExecutionHandle] shouldBe true
-    checkFailedResult(
-      GcpBatchExitCode.VMRecreatedDuringExecution,
-      List(ExecutionEvent("Job state is set from SCHEDULED to RUNNING for job f00b4r", OffsetDateTime.now()))
-    ).isInstanceOf[FailedNonRetryableExecutionHandle] shouldBe true
     checkFailedResult(
       GcpBatchExitCode.VMReportingTimeout,
       List(ExecutionEvent("Job state is set from SCHEDULED to RUNNING for job f00bar123", OffsetDateTime.now()))


### PR DESCRIPTION
GCP Batch reports VMRecreatedDuringExecution (50006) when it recreates a VM mid-execution. This is a GCP-side infrastructure event, not a user failure, but it was only retried when the task had not yet started running -- a condition that can never hold for an error that by definition fires during execution. As a result these failures were never retried and workflows failed.

Split the transient-error check so VMRecreatedDuringExecution is always retriable (still bounded by max-transient-error-retries), while the other transient errors keep the existing "not yet running" guard.

### Description

<!-- What is the purpose of this change? What should reviewers know? -->

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [ ] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users