### PR TITLE
CTM-535 Minor test fixup

### DIFF
--- a/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
+++ b/centaur/src/main/resources/standardTestCases/abort.restart_abort_jes.test
@@ -3,6 +3,7 @@ name: abort.restart_abort_jes
 testFormat: ScheduledAbortWithRestart
 callMark: scheduled_abort.aborted
 backends: [GCPBATCH]
+tags: [restart]
 
 files {
   workflow: abort/scheduled_abort.wdl

--- a/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/call_cache_capoeira_jes.test
@@ -2,6 +2,7 @@ name: call_cache_capoeira_jes
 testFormat: workflowsuccess
 backends: [GCPBATCH]
 retryTestFailures: false
+tags: [slowpoke]
 
 files {
   workflow: call_cache_capoeira/call_cache_capoeira_jes.wdl

--- a/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
+++ b/centaur/src/main/resources/standardTestCases/draft3_call_cache_capoeira_jes.test
@@ -4,8 +4,8 @@ backendsMode: all
 backends: [Local, GCPBATCH]
 workflowType: WDL
 workflowTypeVersion: 1.0
-tags: ["wdl_1.0"]
 retryTestFailures: false
+tags: ["wdl_1.0", "slowpoke"]
 
 files {
   workflow: wdl_draft3/call_cache_capoeira/draft3_call_cache_capoeira_jes.wdl

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_google_labels_bad.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_google_labels_bad.test
@@ -1,6 +1,7 @@
 name: gcpbatch_google_labels_bad
 testFormat: workflowfailure
 backends: [GCPBATCH]
+tags: [slowpoke]
 
 files {
   workflow: google_labels/google_labels.wdl

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_invalidate_bad_caches_jes_no_copy.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_invalidate_bad_caches_jes_no_copy.test
@@ -4,6 +4,7 @@ backends: [GCPBATCH-Caching-No-Copy,]
 
 # No point retrying failures since they'll just end up colliding with previous results:
 retryTestFailures: false
+tags: [slowpoke]
 
 files {
   workflow: invalidate_bad_caches/gcpbatch_invalidate_bad_caches_no_copy.wdl

--- a/centaur/src/main/resources/standardTestCases/gcpbatch_papi_preemptible_and_max_retries.test
+++ b/centaur/src/main/resources/standardTestCases/gcpbatch_papi_preemptible_and_max_retries.test
@@ -1,6 +1,7 @@
 name: gcpbatch_papi_preemptible_and_max_retries
 testFormat: workflowfailure
 backends: [GCPBATCH]
+tags: [slowpoke]
 
 files {
   workflow: papi_preemptible_and_max_retries/gcpbatch_papi_preemptible_and_max_retries.wdl

--- a/centaur/src/main/resources/standardTestCases/invalid_runtime_attributes.test
+++ b/centaur/src/main/resources/standardTestCases/invalid_runtime_attributes.test
@@ -1,5 +1,6 @@
 name: invalid_runtime_attributes
 testFormat: workflowfailure
+tags: [slowpoke]
 
 files {
   workflow: invalid_runtime_attributes/invalid_runtime_attributes.wdl

--- a/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
+++ b/centaur/src/main/resources/standardTestCases/invalidate_bad_caches_jes.test
@@ -1,6 +1,7 @@
 name: invalidate_bad_caches_jes
 testFormat: workflowsuccess
 backends: [GCPBATCH]
+tags: [slowpoke]
 
 files {
   workflow: invalidate_bad_caches/invalidate_bad_caches.wdl

--- a/centaur/src/main/resources/standardTestCases/readFromCacheFalse.test
+++ b/centaur/src/main/resources/standardTestCases/readFromCacheFalse.test
@@ -1,5 +1,6 @@
 name: readFromCacheFalse
 testFormat: runtwiceexpectingnocallcaching
+tags: [slowpoke]
 
 files {
   workflow: readFromCacheFalse/readFromCache.wdl

--- a/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
+++ b/centaur/src/main/resources/standardTestCases/restart.restart_jes_with_recover.test
@@ -2,6 +2,7 @@ name: restart_jes_with_recover
 testFormat: CromwellRestartWithRecover
 callMark: cromwell_restart.cromwell_killer
 backends: [GCPBATCH]
+tags: [restart]
 
 files {
   workflow: cromwell_restart/cromwell_restart.wdl

--- a/centaur/src/main/resources/standardTestCases/sub_workflow_interactions.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_interactions.test
@@ -1,6 +1,6 @@
 name: sub_workflow_interactions
 testFormat: workflowsuccess
-tags: [subworkflow]
+tags: [subworkflow, slowpoke]
 
 files {
   workflow: sub_workflow_interactions/sub_workflow_interactions.wdl

--- a/centaur/src/main/resources/standardTestCases/sub_workflow_interactions_scatter.test
+++ b/centaur/src/main/resources/standardTestCases/sub_workflow_interactions_scatter.test
@@ -1,6 +1,6 @@
 name: sub_workflow_interactions_scatter
 testFormat: workflowsuccess
-tags: [subworkflow]
+tags: [subworkflow, slowpoke]
 
 files {
   workflow: sub_workflow_interactions_scatter/sub_workflow_interactions_scatter.wdl

--- a/src/ci/bin/testCentaurHoricromtalGcpBatch.sh
+++ b/src/ci/bin/testCentaurHoricromtalGcpBatch.sh
@@ -26,6 +26,7 @@ cromwell::build::run_centaur \
     -e standard_output_paths_colliding_prevented \
     -e papi_v2alpha1_gcsa \
     -e restart \
+    -e slowpoke \
     -e lots_of_inputs_papiv2 \
     # Due to Centaur changes in WX-1629, lots_of_inputs_papiv2 times out due to the large number of inputs. Instead,
     # we run lots_of_inputs, which tests 400 inputs instead of the 10,000 in lots_of_inputs_papiv2


### PR DESCRIPTION
### Description

Some cleanup that I found and deferred while battling long CI runs in https://github.com/broadinstitute/cromwell/pull/7890

1. `restart` tests actually trigger a reboot of the Cromwell server. This is disruptive and inflates runtimes, so they should run only in the restart suite.
2. "Horicromtal" a.k.a. "horizontal Cromwell" suite is intended to test 2 runners consuming from a shared queue. The test wants many small cases that run quickly, so exclude `slowpoke` tests that run >15 minutes.

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users