### PR TITLE
CTM-563 Avoid out-of-disk in Github Actions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -102,7 +102,7 @@ jobs:
     # Local backend suite can run out of disk space, probably due to pulling images with the runner's Docker.
     # https://github.com/endersonmenezes/free-disk-space#ubuntu-latest-x86_64
     - name: Free disk space
-      uses: endersonmenezes/free-disk-space@v3.2.2
+      uses: endersonmenezes/free-disk-space@7901478139cff6e9d44df5972fd8ab8fcade4db1 # v3.2.2
       with:
         remove_android: "true"
         remove_dotnet: "true"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,6 +99,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+    # Local backend suite can run out of disk space, probably due to pulling images with the runner's Docker.
+    # https://github.com/endersonmenezes/free-disk-space#ubuntu-latest-x86_64
+    - name: Free disk space
+      uses: endersonmenezes/free-disk-space@v3.2.2
+      with:
+        remove_android: "true"
+        remove_dotnet: "true"
+        remove_haskell: "true"
+        rm_cmd: "rmz"
     - uses: actions/checkout@v3 # checkout the cromwell repo
       with:
         ref: ${{ inputs.target-branch }}


### PR DESCRIPTION
### Description

This error happened a few times while developing https://github.com/broadinstitute/cromwell/pull/7894, finally got a moment to dig in.

[Example failed case.](https://github.com/broadinstitute/cromwell/actions/runs/29509193901/job/87657896585) The log does not seem exceptionally long at 14k lines, so I blame a genuine low disk condition.
```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/2.335.1/_diag/Worker_20260716-150046-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users