### PR TITLE
CTM-653 Add call caching creation date index

### DIFF
--- a/database/migration/src/main/resources/changelog.xml
+++ b/database/migration/src/main/resources/changelog.xml
@@ -95,6 +95,7 @@
     <include file="changesets/add_group_metrics_unique_constraint.xml" relativeToChangelogFile="true" />
     <include file="changesets/enlarge_job_key_value_entry_id.xml" relativeToChangelogFile="true" />
     <include file="changesets/add_timestamp_in_call_caching.xml" relativeToChangelogFile="true" />
+    <include file="changesets/call_caching_index_add_created_at.xml" relativeToChangelogFile="true" />
     <!-- WARNING!
       This changeset should always be last.
       It is always run (and should always run last) to set table ownership correctly.

--- a/database/migration/src/main/resources/changesets/call_caching_index_add_created_at.xml
+++ b/database/migration/src/main/resources/changesets/call_caching_index_add_created_at.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog objectQuotingStrategy="QUOTE_ALL_OBJECTS"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="call_caching_index_add_created_at" author="anichols" dbms="hsqldb,mariadb,mysql,postgresql">
+        <createIndex indexName="IX_CALL_CACHING_ENTRY_CA" tableName="CALL_CACHING_ENTRY">
+            <column name="CREATED_AT"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
+++ b/database/sql/src/main/scala/cromwell/database/slick/tables/CallCachingEntryComponent.scala
@@ -42,6 +42,8 @@ trait CallCachingEntryComponent {
             (workflowExecutionUuid, callFullyQualifiedName, jobIndex),
             unique = true
       )
+
+    def ixCallCachingEntryCa = index("IX_CALL_CACHING_ENTRY_CA", createdAt, unique = false)
   }
 
   protected val callCachingEntries = TableQuery[CallCachingEntries]


### PR DESCRIPTION
### Description

We are looking to delete call caching records at 90 days. We do have the date stored but date queries do not return in a timely manner.

This index creates in 8-10 minutes on a Prod clone, meaning it's cheaper than a single un-indexed query! I view this as fast enough to run during our normal deploy window, but we could certainly do an off-cycle release from Beehive.

```
-- 10-20 minutes
SELECT * FROM CALL_CACHING_ENTRY
    -- column added 2026-01
    WHERE CREATED_AT >= '2026-02-01'
    AND CREATED_AT <= '2026-08-01'
    LIMIT 10;
```

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users