### PR TITLE
CTM-655 Cloud SDK to 583.0.0, previous image expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 * The `disks` WDL runtime attribute size is now honored on EC2 Batch compute environments. Previously, the size component (e.g. `500` in `local-disk 500 HDD`) was silently discarded and tasks shared whatever EBS was attached to the host instance. When a size greater than zero is specified, each task now receives a dedicated gp3 EBS volume of exactly the requested size, provisioned before the task runs and deleted on exit — matching the per-task disk lifecycle of the GCP Batch backend. This requires an AMI built with the `cromwell-disk-utils` bundle at `/usr/local/cromwell-disk-utils` and IAM permissions for `ec2:CreateVolume`, `ec2:AttachVolume`, `ec2:DetachVolume`, `ec2:DeleteVolume`, `ec2:DescribeVolumes`, and `ec2:CreateTags` on the batch instance role. Tasks with no `disks` attribute or a zero-size disk are unaffected.
 * Added support for non-glibc-based docker images (Alpine Linux, etc.)s
 
+### GCP Batch
+
+The default Cloud SDK helper image is now `gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-alpine`. Google applied a one-year retention policy to that repository in August 2026 and deleted the previously pinned `461.0.0-alpine` tag, which made every GCP Batch task fail at its first runnable with no stderr or return code reaching GCS.
+
+Cromwell now also blanks `CLOUDSDK_PYTHON` on the runnables it builds from this image, as it already did for user runnables. Batch sets that variable to `/usr/bin/python3`, but current alpine Cloud SDK images ship Python at `/usr/local/bin/python3` only, so `gsutil` would otherwise exit 127 during localization. Blanking it lets `gcloud` and `gsutil` find their own interpreter, so a custom `cloud-sdk-image-url` may point at any variant that provides `python3` and `gsutil`.
+
+Because Google keeps tags for only a year, this pin will expire again. The `cloud-sdk-image-url` configuration key overrides it; see [Custom Google Cloud SDK container](https://cromwell.readthedocs.io/en/stable/backends/GCPBatch/#custom-google-cloud-sdk-container).
+
 ### General
 
 #### Configurable subworkflow launch rate

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -347,10 +347,14 @@ Own repository can be used by adding `cloud-sdk-image-url` reference to used con
 ```
 google {
   ...
-  cloud-sdk-image-url = "eu.gcr.io/your-project-id/cloudsdktool/cloud-sdk:354.0.0-alpine"
+  cloud-sdk-image-url = "eu.gcr.io/your-project-id/cloudsdktool/cloud-sdk:583.0.0-alpine"
   cloud-sdk-image-size-gb = 1
 }
 ```
+
+Note that Google deletes tags from `gcr.io/google.com/cloudsdktool/cloud-sdk` one year after they are published, so the version Cromwell defaults to will eventually disappear and every task will fail at its first runnable. If that happens before you can upgrade Cromwell, set `cloud-sdk-image-url` to a tag that still exists.
+
+The replacement image must provide `python3` on the `PATH` and a working `gsutil`. Cromwell's helper scripts are base64-encoded and decoded with `python3`, so the `stable` variant, which ships no `python3` at all, will not work. Cromwell blanks `CLOUDSDK_PYTHON` on its own runnables so that `gcloud` and `gsutil` find whichever interpreter their image provides, which means the `alpine`, `slim`, and `debian_component_based` variants are all viable.
 
 ### Parallel Composite Uploads 
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/CheckpointingRunnable.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/CheckpointingRunnable.scala
@@ -12,7 +12,7 @@ trait CheckpointingRunnable {
           createParameters.checkpointingConfiguration.checkpointingCommand(checkpointFilename,
                                                                            RunnableCommands.multiLineBinBashCommand
           )
-        val checkpointingEnvironment = Map.empty[String, String]
+        val checkpointingEnvironment = RunnableUtils.CloudSdkEnvironment
 
         // Initial sync from cloud:
         val initialCheckpointSyncRunnable = RunnableBuilder.cloudSdkShellRunnable(

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/Delocalization.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/Delocalization.scala
@@ -35,6 +35,7 @@ trait Delocalization {
 
     RunnableBuilder
       .withImage(womOutputRuntimeExtractor.dockerImage.getOrElse(CloudSdkImage))
+      .withEnvironment(CloudSdkEnvironment)
       .withCommand(commands: _*)
       .withEntrypointCommand("/bin/bash")
       .withLabels(Map(Key.Tag -> Value.Delocalization))

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -235,7 +235,8 @@ object RunnableBuilder extends BatchUtilityConversions {
       timeout = 30.minutes
     )
 
-  def cloudSdkRunnable: Runnable.Builder = Runnable.newBuilder.setContainer(cloudSdkContainerBuilder)
+  def cloudSdkRunnable: Runnable.Builder =
+    Runnable.newBuilder.setContainer(cloudSdkContainerBuilder).withEnvironment(CloudSdkEnvironment)
 
   // Set a default timeout of 24 hours for these runnables. They are typically used for running
   // localization, delocalization, small shell commands, etc. These processes occasionally hang and
@@ -247,6 +248,7 @@ object RunnableBuilder extends BatchUtilityConversions {
   ): Runnable.Builder =
     Runnable.newBuilder
       .setContainer(cloudSdkContainerBuilder)
+      .withEnvironment(CloudSdkEnvironment)
       .withVolumes(volumes)
       .withLabels(labels)
       .withEntrypointCommand(

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -14,9 +14,20 @@ object RunnableUtils {
   /**
     * An image with the Google Cloud SDK installed.
     * http://gcr.io/google.com/cloudsdktool/cloud-sdk
+    *
+    * Google deletes tags from this repository one year after they are published, so this pin needs periodic bumping.
+    * When it expires, every runnable below fails to pull and jobs die before producing any output.
     */
   val CloudSdkImage: String =
-    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:461.0.0-alpine")
+    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-alpine")
+
+  /**
+    * Batch sets `CLOUDSDK_PYTHON=/usr/bin/python3` on every runnable, but the alpine Cloud SDK image ships Python at
+    * /usr/local/bin/python3 only, so `gsutil` there dies with exit 127 before writing anything to stderr. Blanking the
+    * variable lets `gcloud` and `gsutil` locate their own interpreter, which works regardless of which image (or which
+    * operator-supplied `cloud-sdk-image-url`) we end up running. (AN-601, XKCD-1987)
+    */
+  val CloudSdkEnvironment: Map[String, String] = Map("CLOUDSDK_PYTHON" -> "")
 
   /** Quotes a string such that it's compatible as a string argument in the shell. */
   def shellEscaped(any: Any): String = {


### PR DESCRIPTION
### Description

Google applied a one-year retention policy to `gcr.io/google.com/cloudsdktool/cloud-sdk` and deleted the pinned `461.0.0-alpine` tag. Every GCP Batch task now fails at its first runnable, before any stderr or return code reaches GCS. Reported in #7899.

`develop`'s nightly has been red since 2026-09-02, and only the three GCP Batch suites are failing. 


This bumps the default to `583.0.0-alpine` (published 2026-09-01, so roughly a year of runway).

This also overrides the Batch injection of `CLOUDSDK_PYTHON=/usr/bin/python3` into every runnable. Alpine Cloud SDK images ship Python at `/usr/local/bin/python3` only, so `gsutil` would exit 127 during localization with nothing written to stderr. Blanking the variable makes the `gcloud` wrapper fall back to its own interpreter discovery, which executes and version-checks each candidate before selecting it, same as the AN-601 fix.

#### `CHANGELOG.md`
 - [x] I updated `CHANGELOG.md` in this PR
 - [ ] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users