### PR TITLE
CTM-655 Fix CI issues with gcloud CLI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -40,6 +40,9 @@ jobs:
           - build_type: centaurGcpBatchRestart
             build_mysql: 8.4
             friendly_name: Centaur GCP Batch (restart)
+          - build_type: centaurGcpBatchRestartCallCaching
+            build_mysql: 8.4
+            friendly_name: Centaur GCP Batch (restart, call caching)
           - build_type: dbms
             friendly_name: DBMS
           - build_type: centaurTes

--- a/centaur/src/main/resources/standardTestCases/dummy_backend/35k_scatter_success.test
+++ b/centaur/src/main/resources/standardTestCases/dummy_backend/35k_scatter_success.test
@@ -14,4 +14,4 @@ metadata {
   "outputs.dummy_scatter.results_count": 35000
 }
 
-maximumTime = 12 minutes
+maximumTime = 15 minutes

--- a/docs/backends/GCPBatch.md
+++ b/docs/backends/GCPBatch.md
@@ -341,13 +341,14 @@ network labels, and then fall back to running on the default network.
 
 ### Custom Google Cloud SDK container
 
-Cromwell can't use Google's container registry if VPC Perimeter is used in project.
-Own repository can be used by adding `cloud-sdk-image-url` reference to used container:
+Cromwell uses `cloud-sdk:alpine` by default. If you require a static Cloud SDK version, set a custom value like `cloud-sdk:584.0.0-alpine` for `cloud-sdk-image-url`. Note that GCP [deletes tags after 1 year](https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy), so any custom tag requires recurring updates.
+
+Cromwell can't use Google's container registry if VPC Perimeter is used in project. Work around by re-hosting within the project and setting `cloud-sdk-image-url`.
 
 ```
 google {
   ...
-  cloud-sdk-image-url = "eu.gcr.io/your-project-id/cloudsdktool/cloud-sdk:354.0.0-alpine"
+  cloud-sdk-image-url = "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
   cloud-sdk-image-size-gb = 1
 }
 ```

--- a/src/ci/bin/test.inc.sh
+++ b/src/ci/bin/test.inc.sh
@@ -190,6 +190,9 @@ cromwell::private::create_build_variables() {
         centaurHoricromtalGcpBatch*)
             CROMWELL_BUILD_CROMWELL_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/gcp_batch_horicromtal_application.conf"
             ;;
+        centaurGcpBatchRestartCallCaching)
+            CROMWELL_BUILD_CROMWELL_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/gcp_batch_restart_application.conf"
+            ;;
         *)
             CROMWELL_BUILD_CROMWELL_CONFIG="${CROMWELL_BUILD_RESOURCES_DIRECTORY}/${CROMWELL_BUILD_BACKEND_TYPE}_application.conf"
             ;;

--- a/src/ci/bin/testCentaurGcpBatchRestart.sh
+++ b/src/ci/bin/testCentaurGcpBatchRestart.sh
@@ -12,6 +12,9 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
+# No DRS tests in this suite. Set a placeholder image so we do not spend time building the DRS localizer.
+export CROMWELL_BUILD_BATCH_DOCKER_IMAGE_DRS="mirror.gcr.io/almalinux:latest"
+
 cromwell::build::batch::setup_batch_centaur_environment
 
 cromwell::build::assemble_jars

--- a/src/ci/bin/testCentaurGcpBatchRestartCallCaching.sh
+++ b/src/ci/bin/testCentaurGcpBatchRestartCallCaching.sh
@@ -16,9 +16,11 @@ cromwell::build::batch::setup_batch_centaur_environment
 
 cromwell::build::assemble_jars
 
+# Split out of testCentaurGcpBatchRestart.sh, which excludes this test. Restart tests are
+# serialized because they kill and restart the shared Cromwell, and this one runs about as
+# long as the other three combined.
 cromwell::build::run_centaur \
     -p 100 \
-    -i restart \
-    -e call_cache_cha_cha_batch \
+    -i call_cache_cha_cha_batch \
 
 cromwell::build::generate_code_coverage

--- a/src/ci/bin/testCentaurGcpBatchRestartCallCaching.sh
+++ b/src/ci/bin/testCentaurGcpBatchRestartCallCaching.sh
@@ -12,6 +12,9 @@ cromwell::build::setup_common_environment
 
 cromwell::build::setup_centaur_environment
 
+# No DRS tests in this suite. Set a placeholder image so we do not spend time building the DRS localizer.
+export CROMWELL_BUILD_BATCH_DOCKER_IMAGE_DRS="mirror.gcr.io/almalinux:latest"
+
 cromwell::build::batch::setup_batch_centaur_environment
 
 cromwell::build::assemble_jars

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/CheckpointingRunnable.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/CheckpointingRunnable.scala
@@ -12,7 +12,7 @@ trait CheckpointingRunnable {
           createParameters.checkpointingConfiguration.checkpointingCommand(checkpointFilename,
                                                                            RunnableCommands.multiLineBinBashCommand
           )
-        val checkpointingEnvironment = Map.empty[String, String]
+        val checkpointingEnvironment = RunnableUtils.CloudSdkEnvironment
 
         // Initial sync from cloud:
         val initialCheckpointSyncRunnable = RunnableBuilder.cloudSdkShellRunnable(

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/Delocalization.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/Delocalization.scala
@@ -35,6 +35,7 @@ trait Delocalization {
 
     RunnableBuilder
       .withImage(womOutputRuntimeExtractor.dockerImage.getOrElse(CloudSdkImage))
+      .withEnvironment(CloudSdkEnvironment)
       .withCommand(commands: _*)
       .withEntrypointCommand("/bin/bash")
       .withLabels(Map(Key.Tag -> Value.Delocalization))

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -238,7 +238,6 @@ object RunnableBuilder extends BatchUtilityConversions {
   def cloudSdkRunnable: Runnable.Builder =
     Runnable.newBuilder.setContainer(cloudSdkContainerBuilder).withEnvironment(CloudSdkEnvironment)
 
-
   // Set a default timeout of 24 hours for these runnables. They are typically used for running
   // localization, delocalization, small shell commands, etc. These processes occasionally hang and
   // cost the user money, don't let them hang for the full timeout period of the high-level job.

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableBuilder.scala
@@ -235,7 +235,9 @@ object RunnableBuilder extends BatchUtilityConversions {
       timeout = 30.minutes
     )
 
-  def cloudSdkRunnable: Runnable.Builder = Runnable.newBuilder.setContainer(cloudSdkContainerBuilder)
+  def cloudSdkRunnable: Runnable.Builder =
+    Runnable.newBuilder.setContainer(cloudSdkContainerBuilder).withEnvironment(CloudSdkEnvironment)
+
 
   // Set a default timeout of 24 hours for these runnables. They are typically used for running
   // localization, delocalization, small shell commands, etc. These processes occasionally hang and
@@ -247,6 +249,7 @@ object RunnableBuilder extends BatchUtilityConversions {
   ): Runnable.Builder =
     Runnable.newBuilder
       .setContainer(cloudSdkContainerBuilder)
+      .withEnvironment(CloudSdkEnvironment)
       .withVolumes(volumes)
       .withLabels(labels)
       .withEntrypointCommand(

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -18,6 +18,12 @@ object RunnableUtils {
   val CloudSdkImage: String =
     config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine")
 
+  /**
+   * Batch sets a `CLOUDSDK_PYTHON` value that is incorrect for some images.
+   * Erase it so that Cloud SDK self-discovers the right Python within its image.
+   */
+  val CloudSdkEnvironment: Map[String, String] = Map("CLOUDSDK_PYTHON" -> "")
+
   /** Quotes a string such that it's compatible as a string argument in the shell. */
   def shellEscaped(any: Any): String = {
     val str = String.valueOf(any)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/runnable/RunnableUtils.scala
@@ -16,7 +16,7 @@ object RunnableUtils {
     * http://gcr.io/google.com/cloudsdktool/cloud-sdk
     */
   val CloudSdkImage: String =
-    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:461.0.0-alpine")
+    config.getOrElse("cloud-sdk-image-url", "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine")
 
   /** Quotes a string such that it's compatible as a string argument in the shell. */
   def shellEscaped(any: Any): String = {


### PR DESCRIPTION
### Description

I think a floating tag is a safer bet to keep CI working without forced annual updates. We do offer the escape hatch of custom tag for customers who want to configure it.

Terra already has a pinned version that lasts forever, we use the non-expiring Docker Hub copy of CloudSDK, accessed via the GCR public mirror: https://github.com/broadinstitute/terra-helmfile/pull/6114

Closes https://github.com/broadinstitute/cromwell/issues/7899

### Release Notes Confirmation

#### `CHANGELOG.md`
 - [ ] I updated `CHANGELOG.md` in this PR
 - [x] I assert that this change shouldn't be included in `CHANGELOG.md` because it doesn't impact community users

#### Terra Release Notes
 - [ ] I added a suggested release notes entry in this Jira ticket
 - [x] I assert that this change doesn't need Jira release notes because it doesn't impact Terra users